### PR TITLE
Issue #16 : E2E GUI tests shall use SAML-IDP for SSO 

### DIFF
--- a/e2e/gui/default.conf
+++ b/e2e/gui/default.conf
@@ -28,3 +28,5 @@ e2e.ui.image.luigi=
 e2e.ui.storage.prefix=
 e2e.ui.default.instance.type=
 e2e.ui.nfs.prefix=
+e2e.ui.default.instance.price.type=
+e2e.ui.cloud.provider=

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/DetachedConfigurationsTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/DetachedConfigurationsTest.java
@@ -93,7 +93,7 @@ public class DetachedConfigurationsTest
     private final String pipelineDefaultProfile = "default";
     private final String defaultDisk = "21";
     private final String defaultInstanceType = C.DEFAULT_INSTANCE;
-    private final String defaultPriceType = "Spot";
+    private final String defaultPriceType = C.DEFAULT_INSTANCE_PRICE_TYPE;
 
     private final String pipelineCustomProfile = "custom-pipe-conf";
     private final String customDisk = "22";
@@ -257,7 +257,7 @@ public class DetachedConfigurationsTest
                 .ensure(PIPELINE, empty)
                 .ensure(IMAGE, empty)
                 .ensure(INSTANCE_TYPE, Condition.or("Empty or placeholder", empty, text("Instance type")))
-                .ensure(PRICE_TYPE, text("Spot"))
+                .ensure(PRICE_TYPE, text(defaultPriceType))
                 .ensure(DISK, empty)
         );
     }
@@ -427,7 +427,7 @@ public class DetachedConfigurationsTest
                     .ensure(hintOf(priceType()), visible)
                     .ensure(hintOf(timeout()), visible)
                     .ensure(hintOf(startIdle()), visible)
-                    .ensure(priceType(), text("Spot"))
+                    .ensure(priceType(), text(defaultPriceType))
             );
     }
 

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/LaunchClusterTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/LaunchClusterTest.java
@@ -85,7 +85,7 @@ public class LaunchClusterTest extends AbstractAutoRemovingPipelineRunningTest {
                 .stopRunIfPresent(getRunId());
     }
 
-    @Test
+    @Test(priority = 1)
     @TestCase({"EPMCMBIBPC-2620"})
     public void invalidValuesOnConfigureClusterPopUp() {
         library()

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/PipelineDockerCommitTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/PipelineDockerCommitTest.java
@@ -48,7 +48,7 @@ public class PipelineDockerCommitTest
     private final String toolVersion = "latest";
     private final String diskSize = "19";
     private final String instanceType = C.DEFAULT_INSTANCE;
-    private final String priceType = "Spot";
+    private final String priceType = C.DEFAULT_INSTANCE_PRICE_TYPE;
 
     @BeforeClass
     public void removeTool() {

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/RunToolsInSandBoxTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/RunToolsInSandBoxTest.java
@@ -44,7 +44,7 @@ public class RunToolsInSandBoxTest
     private final String command = "nginx -g \"daemon off;\"";
     private final String type = C.DEFAULT_INSTANCE;
     private final String disk = "15";
-    private final String price = "Spot";
+    private final String price = C.DEFAULT_INSTANCE_PRICE_TYPE;
     private final String registry = C.DEFAULT_REGISTRY;
     private final String tool = C.TESTING_TOOL_NAME;
     private final String group = C.DEFAULT_GROUP;

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/RunToolsInSandboxCheckDataStorageTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/RunToolsInSandboxCheckDataStorageTest.java
@@ -36,7 +36,7 @@ public class RunToolsInSandboxCheckDataStorageTest
     private final String defaultCommand = "/start.sh";
     private final String type = C.DEFAULT_INSTANCE;
     private final String disk = "15";
-    private final String price = "Spot";
+    private final String price = C.DEFAULT_INSTANCE_PRICE_TYPE;
     private final String registry = C.DEFAULT_REGISTRY;
     private final String tool = C.TESTING_TOOL_NAME;
     private final String group = C.DEFAULT_GROUP;

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/SamplesMetadataTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/SamplesMetadataTest.java
@@ -30,6 +30,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 import static com.codeborne.selenide.CollectionCondition.sizeGreaterThanOrEqual;
@@ -84,7 +85,7 @@ public class SamplesMetadataTest
 
     private final String instanceDisk = "20";
     private final String instanceType = C.DEFAULT_INSTANCE;
-    private final String priceType = "Spot";
+    private final String priceType = C.DEFAULT_INSTANCE_PRICE_TYPE;
 
     private final String configJson = "/sample-metadata-config.json";
     private final String launchScript = "singlesamplevariantcalling.sh";
@@ -386,9 +387,13 @@ public class SamplesMetadataTest
                 .firstVersion()
                 .codeTab()
                 .clickOnFile("config.json")
-                .editFile(configuration -> Utils.readResourceFully(configJson)
-                        .replace("{{docker_image}}", dockerImage)
-                        .replace("{{instance_type}}", C.DEFAULT_INSTANCE))
+                .editFile(configuration -> {
+                    final boolean isSpot = Objects.equals(priceType, "Spot");
+                    return Utils.readResourceFully(configJson)
+                            .replace("{{docker_image}}", dockerImage)
+                            .replace("{{instance_type}}", C.DEFAULT_INSTANCE)
+                            .replace("{{is_spot}}", String.valueOf(isSpot));
+                })
                 .deleteExtraBrackets(110)
                 .saveAndCommitWithMessage("test: sample metadata")
                 .click(DELETE)

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/AuthenticationPageAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/AuthenticationPageAO.java
@@ -22,7 +22,7 @@ import static com.codeborne.selenide.Selenide.$;
 
 public class AuthenticationPageAO {
     public AuthenticationPageAO login(String login) {
-        $(byId("userNameInput"))
+        $(byId("userName"))
                 .shouldBe(visible)
                 .setValue(login)
                 .shouldHave(value(login));
@@ -30,7 +30,7 @@ public class AuthenticationPageAO {
     }
 
     public AuthenticationPageAO password(String password) {
-        $(byId("passwordInput"))
+        $(byId("password"))
                 .shouldBe(visible)
                 .setValue(password)
                 .shouldHave(value(password));
@@ -38,7 +38,7 @@ public class AuthenticationPageAO {
     }
 
     public NavigationMenuAO signIn() {
-        $(byId("submitButton"))
+        $(byId("btn-sign-in"))
                 .shouldBe(visible)
                 .click();
 

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/mixins/Tools.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/mixins/Tools.java
@@ -35,7 +35,7 @@ public interface Tools extends Navigation {
     String defaultCommand = "/start.sh";
     String defaultInstanceType = C.DEFAULT_INSTANCE;
     String defaultDiskSize = "20";
-    String defaultPriceType = "Spot";
+    String defaultPriceType = C.DEFAULT_INSTANCE_PRICE_TYPE;
 
     default void fallbackToToolDefaultState(final String registryName,
                                             final String groupName,

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/utils/C.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/utils/C.java
@@ -65,6 +65,8 @@ public class C {
         STORAGE_PREFIX = conf.getProperty("e2e.ui.storage.prefix");
         DEFAULT_INSTANCE = conf.getProperty("e2e.ui.default.instance.type");
         NFS_PREFIX = conf.getProperty("e2e.ui.nfs.prefix");
+        DEFAULT_INSTANCE_PRICE_TYPE = conf.getProperty("e2e.ui.default.instance.price.type");
+        CLOUD_PROVIDER = conf.getProperty("e2e.ui.cloud.provider");
     }
 
     public static final int DEFAULT_TIMEOUT;
@@ -107,4 +109,6 @@ public class C {
     public static final String NFS_PREFIX;
 
     public static final String DEFAULT_INSTANCE;
+    public static final String DEFAULT_INSTANCE_PRICE_TYPE;
+    public static final String CLOUD_PROVIDER;
 }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/utils/listener/Cloud.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/utils/listener/Cloud.java
@@ -13,15 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.epam.pipeline.autotests.utils;
+package com.epam.pipeline.autotests.utils.listener;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+public enum Cloud {
+    AWS("aws"),
+    AZURE("azure");
 
-@Target(ElementType.METHOD)
-@Retention(RetentionPolicy.RUNTIME)
-public @interface TestCase {
-    String[] value();
+    public final String cloudProvider;
+
+    Cloud(final String cloudProvider) {
+        this.cloudProvider = cloudProvider;
+    }
 }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/utils/listener/CloudProviderOnly.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/utils/listener/CloudProviderOnly.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.epam.pipeline.autotests.utils;
+package com.epam.pipeline.autotests.utils.listener;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -22,6 +22,6 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface TestCase {
-    String[] value();
+public @interface CloudProviderOnly {
+    Cloud value();
 }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/utils/listener/ConditionalTestAnalyzer.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/utils/listener/ConditionalTestAnalyzer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.epam.pipeline.autotests.utils.listener;
+
+import com.epam.pipeline.autotests.utils.C;
+import org.testng.IInvokedMethod;
+import org.testng.IInvokedMethodListener;
+import org.testng.ITestResult;
+import org.testng.SkipException;
+
+import java.lang.reflect.Method;
+
+public class ConditionalTestAnalyzer implements IInvokedMethodListener {
+
+    @Override
+    public void beforeInvocation(final IInvokedMethod method, final ITestResult testResult) {
+        final Method resultMethod = testResult.getMethod().getConstructorOrMethod().getMethod();
+        if (resultMethod.isAnnotationPresent(CloudProviderOnly.class) &&
+                !resultMethod.getAnnotation(CloudProviderOnly.class).value().name().toLowerCase()
+                        .equals(C.CLOUD_PROVIDER)) {
+            throw new SkipException("These tests should be run in AWS only");
+        }
+    }
+
+    @Override
+    public void afterInvocation(final IInvokedMethod method, final ITestResult testResult) {
+        // no op
+    }
+}

--- a/e2e/gui/src/test/resources/sample-metadata-config.json
+++ b/e2e/gui/src/test/resources/sample-metadata-config.json
@@ -36,5 +36,5 @@
     },
     "is_spot" : true
   },
-  "default" : true
+  "default" : "{{is_spot}}"
 } ]


### PR DESCRIPTION
E2E GUI tests use SAML-IDP for user login. Tests was unified for azure and aws stands by introducing the provider and cloud annotation likewise. Resolves #16 