### PR TITLE
Fix child runs launch on parent node

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/execution/PipelineExecutor.java
+++ b/api/src/main/java/com/epam/pipeline/manager/execution/PipelineExecutor.java
@@ -81,12 +81,13 @@ public class PipelineExecutor {
             Map<String, String> nodeSelector = new HashMap<>();
 
             if (preferenceManager.getPreference(SystemPreferences.CLUSTER_ENABLE_AUTOSCALING)) {
+                String runIdLabel = String.valueOf(run.getId());
                 nodeSelector.put("runid", nodeIdLabel);
                 // id pod ip == pipeline id we have a root pod, otherwise we prefer to skip pod in autoscaler
-                if (run.getPodId().equals(pipelineId)) {
+                if (run.getPodId().equals(pipelineId) && nodeIdLabel.equals(runIdLabel)) {
                     labels.put("type", "pipeline");
                 }
-                labels.put("runid", nodeIdLabel);
+                labels.put("runid", runIdLabel);
             } else {
                 nodeSelector.put("skill", "luigi");
             }

--- a/pipe-cli/src/api/pipeline.py
+++ b/pipe-cli/src/api/pipeline.py
@@ -164,7 +164,6 @@ class Pipeline(API):
                 params[key] = {'value': parameter_value[0], 'type': parameter_value[1]}
             payload['params'] = params
         data = json.dumps(payload)
-        print(str(data))
         response_data = api.call('run', data)
         return PipelineRunModel.load(response_data['payload'])
 

--- a/pipe-cli/src/api/pipeline.py
+++ b/pipe-cli/src/api/pipeline.py
@@ -21,6 +21,7 @@ from ..model.pipeline_run_parameters_model import PipelineRunParametersModel
 from ..model.pipeline_run_model import PipelineRunModel, PriceType
 from ..model.datastorage_rule_model import DataStorageRuleModel
 from ..model.instance_price import InstancePrice
+from ..api.pipeline_run import PipelineRun
 
 TYPE_VALUE_DELIMITER = '?'
 TYPE_DEFAULT = 'string'
@@ -125,15 +126,17 @@ class Pipeline(API):
         if region_id is not None:
             payload['cloudRegionId'] = region_id
         if parent_node is not None:
-            payload['parentNodeId'] = parent_node
+            cls.__add_parent_node_params(payload, parent_node)
         data = json.dumps(payload)
+        print(str(data))
         response_data = api.call('run', data)
         return PipelineRunModel.load(response_data['payload'])
 
     @classmethod
     def launch_command(cls, instance_disk, instance_type,
                        docker_image, cmd_template, parameters,
-                       timeout=None, instance_count=None, price_type=None):
+                       timeout=None, instance_count=None, price_type=None,
+                       region_id=None, parent_node=None):
         api = cls.instance()
         payload = {}
         if instance_disk is not None:
@@ -150,6 +153,10 @@ class Pipeline(API):
             payload['nodeCount'] = instance_count
         if price_type:
             payload['isSpot'] = price_type == PriceType.SPOT
+        if region_id is not None:
+            payload['cloudRegionId'] = region_id
+        if parent_node is not None:
+            cls.__add_parent_node_params(payload, parent_node)
         if parameters is not None:
             params = {}
             for key in parameters.keys():
@@ -157,6 +164,7 @@ class Pipeline(API):
                 params[key] = {'value': parameter_value[0], 'type': parameter_value[1]}
             payload['params'] = params
         data = json.dumps(payload)
+        print(str(data))
         response_data = api.call('run', data)
         return PipelineRunModel.load(response_data['payload'])
 
@@ -185,3 +193,25 @@ class Pipeline(API):
             api_url += '&config={}'.format(config_name)
         response_data = api.call(api_url, json.dumps(data))
         return InstancePrice.load(response_data['payload'])
+
+    @classmethod
+    def __add_parent_node_params(cls, params, parent_node):
+        run_model = PipelineRun.get(parent_node)
+        for ins_param in run_model.instance:
+            if ins_param[0] == 'nodeDisk':
+                params['hddSize'] = ins_param[1]
+            elif ins_param[0] == 'nodeType':
+                params['instanceType'] = ins_param[1]
+        params['parentRunId'] = parent_node
+        params['parentNodeId'] = parent_node
+
+    @classmethod
+    def __add_parent_node_params(cls, params, parent_node):
+        run_model = PipelineRun.get(parent_node)
+        for ins_param in run_model.instance:
+            if ins_param[0] == 'nodeDisk':
+                params['hddSize'] = ins_param[1]
+            elif ins_param[0] == 'nodeType':
+                params['instanceType'] = ins_param[1]
+        params['parentRunId'] = parent_node
+        params['parentNodeId'] = parent_node

--- a/pipe-cli/src/api/pipeline.py
+++ b/pipe-cli/src/api/pipeline.py
@@ -205,13 +205,3 @@ class Pipeline(API):
         params['parentRunId'] = parent_node
         params['parentNodeId'] = parent_node
 
-    @classmethod
-    def __add_parent_node_params(cls, params, parent_node):
-        run_model = PipelineRun.get(parent_node)
-        for ins_param in run_model.instance:
-            if ins_param[0] == 'nodeDisk':
-                params['hddSize'] = ins_param[1]
-            elif ins_param[0] == 'nodeType':
-                params['instanceType'] = ins_param[1]
-        params['parentRunId'] = parent_node
-        params['parentNodeId'] = parent_node

--- a/pipe-cli/src/utilities/pipeline_run_operations.py
+++ b/pipe-cli/src/utilities/pipeline_run_operations.py
@@ -189,7 +189,7 @@ class PipelineRunOperations(object):
             elif parameters:
                 if not quiet:
                     click.echo('You must specify pipeline for listing parameters', err=True)
-            elif docker_image is None or instance_type is None or instance_disk is None:
+            elif docker_image is None or parent_node is None and (instance_type is None or instance_disk is None):
                 if not quiet:
                     click.echo('Docker image, instance type and instance disk are required parameters '
                                'if pipeline was not provided.')
@@ -214,7 +214,9 @@ class PipelineRunOperations(object):
                                                              run_params_dict,
                                                              timeout,
                                                              instance_count=instance_count,
-                                                             price_type=price_type)
+                                                             price_type=price_type,
+                                                             region_id=region_id,
+                                                             parent_node=parent_node)
                 pipeline_run_id = pipeline_run_model.identifier
                 if not quiet:
                     click.echo('Pipeline run scheduled with RunId: {}'.format(pipeline_run_id))


### PR DESCRIPTION
This PR enables launching of child runs via `pipe run` command for tools.