### PR TITLE
Implement STS credentials for GCP

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -88,7 +88,9 @@ dependencies {
     compile group: "com.google.api-client", name: "google-api-client", version: "1.23.0"
     compile "com.google.apis:google-api-services-compute:v1-rev210-1.25.0"
     compile "com.google.apis:google-api-services-cloudbilling:v1-rev30-1.25.0"
-
+    compile "com.google.apis:google-api-services-iamcredentials:v1-rev32-1.25.0"
+    compile "com.google.cloud:google-cloud-storage:1.64.0"
+    
     testCompile group: "org.springframework.security", name: "spring-security-test", version: "4.2.2.RELEASE"
     testCompile group: "com.github.tomakehurst", name: "wiremock", version: "2.14.0"
 

--- a/api/src/main/java/com/epam/pipeline/entity/datastorage/AbstractDataStorageFactory.java
+++ b/api/src/main/java/com/epam/pipeline/entity/datastorage/AbstractDataStorageFactory.java
@@ -19,6 +19,7 @@ package com.epam.pipeline.entity.datastorage;
 import com.epam.pipeline.controller.vo.DataStorageVO;
 import com.epam.pipeline.entity.datastorage.aws.S3bucketDataStorage;
 import com.epam.pipeline.entity.datastorage.azure.AzureBlobStorage;
+import com.epam.pipeline.entity.datastorage.gcp.GSBucketStorage;
 import com.epam.pipeline.entity.datastorage.nfs.NFSDataStorage;
 import com.epam.pipeline.entity.region.CloudProvider;
 
@@ -78,10 +79,16 @@ public abstract class AbstractDataStorageFactory {
                     storage.setFileShareMountId(fileShareMountId);
                     return storage;
                 case AZ:
-                    AzureBlobStorage blobStorage = new AzureBlobStorage(id, name, path, policy, mountPoint);
+                    final AzureBlobStorage blobStorage = new AzureBlobStorage(id, name, path, policy, mountPoint);
                     blobStorage.setStoragePolicy(null);
                     blobStorage.setRegionId(regionId);
                     return blobStorage;
+                case GS:
+                    final GSBucketStorage gsBucketStorage = new GSBucketStorage(id, name, path, policy,
+                            mountPoint);
+                    gsBucketStorage.setStoragePolicy(null);
+                    gsBucketStorage.setRegionId(regionId);
+                    return gsBucketStorage;
                 default:
                     throw new IllegalArgumentException("Unsupported data storage type: " + type);
             }

--- a/api/src/main/java/com/epam/pipeline/entity/datastorage/gcp/GSBucketStorage.java
+++ b/api/src/main/java/com/epam/pipeline/entity/datastorage/gcp/GSBucketStorage.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.datastorage.gcp;
+
+import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
+import com.epam.pipeline.entity.datastorage.DataStorageType;
+import com.epam.pipeline.entity.datastorage.StoragePolicy;
+import com.epam.pipeline.manager.datastorage.providers.ProviderUtils;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class GSBucketStorage extends AbstractDataStorage {
+
+    private Long regionId;
+
+    public GSBucketStorage(final Long id, final String name, final String path, final StoragePolicy policy,
+                           final String mountPoint) {
+        super(id, name, ProviderUtils.normalizeBucketName(path), DataStorageType.GS, policy, mountPoint);
+    }
+
+    @Override
+    public String getDelimiter() {
+        return ProviderUtils.DELIMITER;
+    }
+
+    @Override
+    public String getPathMask() {
+        return String.format("gs://%s", getPath());
+    }
+
+    @Override
+    public boolean isPolicySupported() {
+        return false;
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/entity/datastorage/gcp/GSBucketStorage.java
+++ b/api/src/main/java/com/epam/pipeline/entity/datastorage/gcp/GSBucketStorage.java
@@ -46,6 +46,6 @@ public class GSBucketStorage extends AbstractDataStorage {
 
     @Override
     public boolean isPolicySupported() {
-        return false;
+        return true;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPClient.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPClient.java
@@ -24,6 +24,7 @@ import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.cloudbilling.Cloudbilling;
 import com.google.api.services.compute.Compute;
+import com.google.api.services.iamcredentials.v1.IAMCredentials;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
@@ -41,6 +42,7 @@ public class GCPClient {
             Collections.singletonList("https://www.googleapis.com/auth/compute");
     private static final List<String> BILLING_SCOPES =
             Collections.singletonList("https://www.googleapis.com/auth/cloud-platform");
+    private static final List<String> IAM_SCOPES = Collections.singletonList("https://www.googleapis.com/auth/iam");
 
     private final HttpTransport httpTransport;
     private final JsonFactory jsonFactory;
@@ -62,6 +64,13 @@ public class GCPClient {
         final GoogleCredential credentials = buildCredentials(region);
         return new Cloudbilling.Builder(httpTransport, jsonFactory, credentials.createScoped(BILLING_SCOPES))
 //                .setApplicationName(region.getApplicationName())
+                .build();
+    }
+
+    public IAMCredentials buildIAMCredentialsClient(final GCPRegion region) throws IOException {
+        final GoogleCredential credentials = buildCredentials(region).createScoped(IAM_SCOPES);
+        return new IAMCredentials.Builder(httpTransport, jsonFactory, credentials)
+                .setApplicationName(region.getApplicationName())
                 .build();
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPTemporaryCredentialGenerator.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPTemporaryCredentialGenerator.java
@@ -28,6 +28,7 @@ import com.epam.pipeline.manager.region.CloudRegionManager;
 import com.google.api.services.iamcredentials.v1.IAMCredentials;
 import com.google.api.services.iamcredentials.v1.model.GenerateAccessTokenRequest;
 import com.google.api.services.iamcredentials.v1.model.GenerateAccessTokenResponse;
+import com.google.api.services.storage.StorageScopes;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
@@ -43,10 +44,6 @@ import java.util.List;
 @RequiredArgsConstructor
 public class GCPTemporaryCredentialGenerator implements TemporaryCredentialsGenerator<GSBucketStorage> {
     private static final String ACCOUNT_NAME_REQUEST_FORMAT = "projects/-/serviceAccounts/%s";
-    private static final List<String> READ_ONLY_STORAGE_SCOPE = Collections
-            .singletonList("https://www.googleapis.com/auth/devstorage.read_only");
-    private static final List<String> WRITE_STORAGE_SCOPE = Collections
-            .singletonList("https://www.googleapis.com/auth/devstorage.read_write");
 
     private final CloudRegionManager cloudRegionManager;
     private final PreferenceManager preferenceManager;
@@ -107,7 +104,7 @@ public class GCPTemporaryCredentialGenerator implements TemporaryCredentialsGene
     private List<String> buildScope(final List<DataStorageAction> actions) {
         return actions.stream()
                 .filter(action -> action.isWrite() || action.isWriteVersion()).findAny()
-                .map(action -> WRITE_STORAGE_SCOPE)
-                .orElse(READ_ONLY_STORAGE_SCOPE);
+                .map(action -> Collections.singletonList(StorageScopes.DEVSTORAGE_READ_WRITE))
+                .orElse(Collections.singletonList(StorageScopes.DEVSTORAGE_READ_ONLY));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPTemporaryCredentialGenerator.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPTemporaryCredentialGenerator.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cloud.gcp;
+
+import com.epam.pipeline.entity.datastorage.DataStorageAction;
+import com.epam.pipeline.entity.datastorage.DataStorageType;
+import com.epam.pipeline.entity.datastorage.TemporaryCredentials;
+import com.epam.pipeline.entity.datastorage.gcp.GSBucketStorage;
+import com.epam.pipeline.entity.region.GCPRegion;
+import com.epam.pipeline.manager.cloud.TemporaryCredentialsGenerator;
+import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.epam.pipeline.manager.preference.SystemPreferences;
+import com.epam.pipeline.manager.region.CloudRegionManager;
+import com.google.api.services.iamcredentials.v1.IAMCredentials;
+import com.google.api.services.iamcredentials.v1.model.GenerateAccessTokenRequest;
+import com.google.api.services.iamcredentials.v1.model.GenerateAccessTokenResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Provides short-lived service account credentials for operations on data storages.
+ */
+@Service
+@RequiredArgsConstructor
+public class GCPTemporaryCredentialGenerator implements TemporaryCredentialsGenerator<GSBucketStorage> {
+    private static final String ACCOUNT_NAME_REQUEST_FORMAT = "projects/-/serviceAccounts/%s";
+    private static final List<String> READ_ONLY_STORAGE_SCOPE = Collections
+            .singletonList("https://www.googleapis.com/auth/devstorage.read_only");
+    private static final List<String> WRITE_STORAGE_SCOPE = Collections
+            .singletonList("https://www.googleapis.com/auth/devstorage.read_write");
+
+    private final CloudRegionManager cloudRegionManager;
+    private final PreferenceManager preferenceManager;
+    private final GCPClient gcpClient;
+
+    @Override
+    public DataStorageType getStorageType() {
+        return DataStorageType.GS;
+    }
+
+    /**
+     * Generates temporary access credentials. Returns full read access to all data storages if all actions require
+     * only read access. If at least one action requires write access returns full write access to all data storages.
+     * @param actions to be performed on storage(s)
+     * @param dataStorage to get additional info
+     * @return access token, project ID and expiration time
+     */
+    @Override
+    public TemporaryCredentials generate(final List<DataStorageAction> actions, final GSBucketStorage dataStorage) {
+        try {
+            final GCPRegion region = getRegion(dataStorage);
+            final IAMCredentials credentials = gcpClient.buildIAMCredentialsClient(region);
+
+            final GenerateAccessTokenRequest generateAccessTokenRequest = new GenerateAccessTokenRequest()
+                    .setLifetime(buildDuration())
+                    .setScope(buildScope(actions));
+
+            final GenerateAccessTokenResponse tokenResponse = credentials
+                    .projects()
+                    .serviceAccounts()
+                    .generateAccessToken(String.format(ACCOUNT_NAME_REQUEST_FORMAT, region.getImpersonatedAccount()),
+                            generateAccessTokenRequest)
+                    .execute();
+
+            return TemporaryCredentials.builder()
+                    .token(tokenResponse.getAccessToken())
+                    .expirationTime(tokenResponse.getExpireTime())
+                    .accessKey(region.getProject())
+                    .build();
+        } catch (IOException e) {
+            throw new IllegalArgumentException(String.format("An error occurred during generating temporary " +
+                    "credentials for %s storage %s", dataStorage.getType(), dataStorage.getPath()));
+        }
+    }
+
+    @Override
+    public GCPRegion getRegion(final GSBucketStorage dataStorage) {
+        return cloudRegionManager.getGCPRegion(dataStorage);
+    }
+
+    private String buildDuration() {
+        final Integer duration =
+                preferenceManager.getPreference(SystemPreferences.DATA_STORAGE_TEMP_CREDENTIALS_DURATION);
+        Assert.notNull(duration, "Data storage temporary credential duration must be specified");
+        return String.format("%ds", duration);
+    }
+
+    private List<String> buildScope(final List<DataStorageAction> actions) {
+        return actions.stream()
+                .filter(action -> action.isWrite() || action.isWriteVersion()).findAny()
+                .map(action -> WRITE_STORAGE_SCOPE)
+                .orElse(READ_ONLY_STORAGE_SCOPE);
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageHelper.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.datastorage.providers.gcp;
+
+import com.epam.pipeline.common.MessageConstants;
+import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.entity.datastorage.gcp.GSBucketStorage;
+import com.epam.pipeline.entity.region.GCPRegion;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageClass;
+import com.google.cloud.storage.StorageOptions;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.util.Assert;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+@Slf4j
+@RequiredArgsConstructor
+public class GSBucketStorageHelper {
+    private static final String EMPTY_PREFIX = "";
+
+    private final MessageHelper messageHelper;
+    private final GCPRegion region;
+
+    public String createGoogleStorage(final GSBucketStorage storage) {
+        final Storage client = getClient();
+        final Bucket bucket = client.create(BucketInfo.newBuilder(storage.getPath())
+                .setStorageClass(StorageClass.REGIONAL)
+                .setLocation(region.getRegionCode())
+                .build());
+        return bucket.getName();
+    }
+
+    public void deleteGoogleStorage(final String bucketName) {
+        final Storage client = getClient();
+        checkBucketExists(bucketName);
+        final Iterable<Blob> blobs = client.list(bucketName, Storage.BlobListOption.prefix(EMPTY_PREFIX)).iterateAll();
+        blobs.forEach(blob -> blob.delete());
+        final boolean deleted = client.delete(bucketName);
+
+        if (!deleted) {
+            throw new IllegalArgumentException(String.format("Failed to delete google data storage %s", bucketName));
+        }
+    }
+
+    private Storage getClient() {
+        if (StringUtils.isBlank(region.getAuthFile())) {
+            return StorageOptions.getDefaultInstance().getService();
+        }
+        try (InputStream stream = new FileInputStream(region.getAuthFile())) {
+            final GoogleCredentials sourceCredentials = ServiceAccountCredentials
+                    .fromStream(stream);
+            return StorageOptions.newBuilder()
+                    .setProjectId(region.getProject())
+                    .setCredentials(sourceCredentials)
+                    .build()
+                    .getService();
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Failed to retrieve google storage client");
+        }
+    }
+
+    private void checkBucketExists(final String bucketName) {
+        final Storage client = getClient();
+        Assert.notNull(client.get(bucketName), messageHelper.getMessage(
+                MessageConstants.ERROR_DATASTORAGE_NOT_FOUND_BY_NAME));
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageProvider.java
@@ -131,8 +131,8 @@ public class GSBucketStorageProvider implements StorageProvider<GSBucketStorage>
     }
 
     @Override
-    public boolean checkStorage(GSBucketStorage dataStorage) {
-        return true;
+    public boolean checkStorage(final GSBucketStorage dataStorage) {
+        return getHelper(dataStorage).checkStorageExists(dataStorage.getPath());
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageProvider.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.datastorage.providers.gcp;
+
+import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.entity.datastorage.DataStorageDownloadFileUrl;
+import com.epam.pipeline.entity.datastorage.DataStorageException;
+import com.epam.pipeline.entity.datastorage.DataStorageFile;
+import com.epam.pipeline.entity.datastorage.DataStorageFolder;
+import com.epam.pipeline.entity.datastorage.DataStorageItemContent;
+import com.epam.pipeline.entity.datastorage.DataStorageListing;
+import com.epam.pipeline.entity.datastorage.DataStorageStreamingContent;
+import com.epam.pipeline.entity.datastorage.DataStorageType;
+import com.epam.pipeline.entity.datastorage.gcp.GSBucketStorage;
+import com.epam.pipeline.entity.region.GCPRegion;
+import com.epam.pipeline.manager.datastorage.providers.StorageProvider;
+import com.epam.pipeline.manager.region.CloudRegionManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Set;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GSBucketStorageProvider implements StorageProvider<GSBucketStorage> {
+
+    private final CloudRegionManager cloudRegionManager;
+    private final MessageHelper messageHelper;
+
+    @Override
+    public DataStorageType getStorageType() {
+        return DataStorageType.GS;
+    }
+
+    @Override
+    public String createStorage(final GSBucketStorage storage) throws DataStorageException {
+        return getHelper(storage).createGoogleStorage(storage);
+    }
+
+    @Override
+    public void deleteStorage(final GSBucketStorage dataStorage) throws DataStorageException {
+        getHelper(dataStorage).deleteGoogleStorage(dataStorage.getPath());
+    }
+
+    @Override
+    public void applyStoragePolicy(GSBucketStorage dataStorage) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void restoreFileVersion(GSBucketStorage dataStorage, String path, String version)
+            throws DataStorageException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DataStorageListing getItems(GSBucketStorage dataStorage, String path, Boolean showVersion,
+                                       Integer pageSize, String marker) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DataStorageDownloadFileUrl generateDownloadURL(GSBucketStorage dataStorage, String path,
+                                                          String version) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DataStorageDownloadFileUrl generateDataStorageItemUploadUrl(GSBucketStorage dataStorage,
+                                                                       String path) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DataStorageFile createFile(GSBucketStorage dataStorage, String path, byte[] contents)
+            throws DataStorageException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DataStorageFile createFile(GSBucketStorage dataStorage, String path, InputStream dataStream)
+            throws DataStorageException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DataStorageFolder createFolder(GSBucketStorage dataStorage, String path)
+            throws DataStorageException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void deleteFile(GSBucketStorage dataStorage, String path, String version,
+                           Boolean totally) throws DataStorageException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void deleteFolder(GSBucketStorage dataStorage, String path, Boolean totally) throws DataStorageException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DataStorageFile moveFile(GSBucketStorage dataStorage, String oldPath, String newPath)
+            throws DataStorageException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DataStorageFolder moveFolder(GSBucketStorage dataStorage, String oldPath, String newPath)
+            throws DataStorageException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean checkStorage(GSBucketStorage dataStorage) {
+        return true;
+    }
+
+    @Override
+    public Map<String, String> updateObjectTags(GSBucketStorage dataStorage, String path, Map<String, String> tags,
+                                                String version) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, String> listObjectTags(GSBucketStorage dataStorage, String path, String version) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, String> deleteObjectTags(GSBucketStorage dataStorage, String path, Set<String> tagsToDelete,
+                                                String version) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DataStorageItemContent getFile(GSBucketStorage dataStorage, String path, String version,
+                                          Long maxDownloadSize) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DataStorageStreamingContent getStream(GSBucketStorage dataStorage, String path, String version) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String buildFullStoragePath(GSBucketStorage dataStorage, String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getDefaultMountOptions(GSBucketStorage dataStorage) {
+        return null;
+    }
+
+    private GSBucketStorageHelper getHelper(final GSBucketStorage storage) {
+        final GCPRegion gcpRegion = cloudRegionManager.getGCPRegion(storage);
+        return new GSBucketStorageHelper(messageHelper, gcpRegion);
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/region/CloudRegionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/region/CloudRegionManager.java
@@ -24,12 +24,14 @@ import com.epam.pipeline.entity.AbstractSecuredEntity;
 import com.epam.pipeline.entity.datastorage.FileShareMount;
 import com.epam.pipeline.entity.datastorage.aws.S3bucketDataStorage;
 import com.epam.pipeline.entity.datastorage.azure.AzureBlobStorage;
+import com.epam.pipeline.entity.datastorage.gcp.GSBucketStorage;
 import com.epam.pipeline.entity.region.AbstractCloudRegion;
+import com.epam.pipeline.entity.region.AbstractCloudRegionCredentials;
 import com.epam.pipeline.entity.region.AwsRegion;
 import com.epam.pipeline.entity.region.AzureRegion;
 import com.epam.pipeline.entity.region.AzureRegionCredentials;
 import com.epam.pipeline.entity.region.CloudProvider;
-import com.epam.pipeline.entity.region.AbstractCloudRegionCredentials;
+import com.epam.pipeline.entity.region.GCPRegion;
 import com.epam.pipeline.entity.security.acl.AclClass;
 import com.epam.pipeline.entity.utils.DateUtils;
 import com.epam.pipeline.manager.datastorage.FileShareMountManager;
@@ -244,6 +246,10 @@ public class CloudRegionManager implements SecuredEntityManager {
 
     public AzureRegion getAzureRegion(final AzureBlobStorage dataStorage) {
         return (AzureRegion) getCloudRegion(CloudProvider.AZURE, dataStorage.getRegionId());
+    }
+
+    public GCPRegion getGCPRegion(final GSBucketStorage dataStorage) {
+        return (GCPRegion) getCloudRegion(CloudProvider.GCP, dataStorage.getRegionId());
     }
 
     private AbstractCloudRegion getCloudRegion(final CloudProvider provider, final Long regionId) {

--- a/core/src/main/java/com/epam/pipeline/entity/datastorage/DataStorageType.java
+++ b/core/src/main/java/com/epam/pipeline/entity/datastorage/DataStorageType.java
@@ -25,7 +25,8 @@ import java.util.stream.Collectors;
 public enum DataStorageType {
     S3("S3"),
     NFS("NFS"),
-    AZ("AZ");
+    AZ("AZ"),
+    GS("GS");
 
     private String id;
     private static Map<String, DataStorageType> idMap;
@@ -71,6 +72,7 @@ public enum DataStorageType {
         switch (provider) {
             case AWS: return S3;
             case AZURE: return AZ;
+            case GCP: return GS;
             default: throw new IllegalArgumentException("Unsupported provider for object storage: " + provider);
         }
     }


### PR DESCRIPTION
resolves #15 

Provides short-lived service account credentials generation for operations on data storages according to 
`projects.serviceAccounts.generateAccessToken`  Google API. Includes initial implementation of `StorageProvider` (create/delete data storages only)