### PR TITLE
Allow default admin to manage users via Web GUI

### DIFF
--- a/deploy/contents/install/app/install.sh
+++ b/deploy/contents/install/app/install.sh
@@ -296,7 +296,9 @@ if is_service_requested cp-idp; then
 
         print_info "-> Waiting for IdP to initialize"
         wait_for_deployment "cp-idp"
-        CP_INSTALL_SUMMARY="$CP_INSTALL_SUMMARY\ncp-idp: https://$CP_IDP_EXTERNAL_HOST:$CP_IDP_EXTERNAL_PORT"
+        CP_INSTALL_SUMMARY="$CP_INSTALL_SUMMARY\ncp-idp:"
+        CP_INSTALL_SUMMARY="$CP_INSTALL_SUMMARY\nUsers auth:     https://$CP_IDP_EXTERNAL_HOST:$CP_IDP_EXTERNAL_PORT"
+        CP_INSTALL_SUMMARY="$CP_INSTALL_SUMMARY\nAdministrating: https://$CP_IDP_EXTERNAL_HOST:$CP_IDP_EXTERNAL_PORT/admin"
     fi
     echo
 fi

--- a/deploy/docker/cp-idp/Dockerfile
+++ b/deploy/docker/cp-idp/Dockerfile
@@ -25,7 +25,7 @@ RUN yum install gcc-c++ \
 RUN cd /opt && \
     git clone https://github.com/rodichenko/saml-idp.git && \
     cd saml-idp && \
-    git checkout tags/v1.2.1 && \
+    git checkout tags/v1.2.3 && \
     npm install --global
 
 ADD config.js /opt/saml-idp/

--- a/deploy/docker/cp-idp/init
+++ b/deploy/docker/cp-idp/init
@@ -29,6 +29,7 @@ fi
 default_admin_name=${CP_DEFAULT_ADMIN_NAME:-pipe_admin}
 default_admin_pass=${CP_DEFAULT_ADMIN_PASS:-pipe_admin}
 default_admin_email=${CP_DEFAULT_ADMIN_EMAIL:-"pipe_admin@nowhere.com"}
+default_admin_group="ROLE_ADMIN"
 
 echo "Adding default admin user as:"
 echo "-> Name: $default_admin_name"
@@ -39,7 +40,9 @@ saml-idp add-user   "$default_admin_name" \
                     "$default_admin_pass" \
                     --firstName "$default_admin_name" \
                     --lastName "$default_admin_name" \
-                    --email "$default_admin_email"
+                    --email "$default_admin_email" \
+                    --groups "$default_admin_group"
+
 
 echo "Starting IdP:"
 saml-idp    --cert  "$CP_IDP_CERT_DIR/idp-public-cert.pem" \
@@ -48,5 +51,6 @@ saml-idp    --cert  "$CP_IDP_CERT_DIR/idp-public-cert.pem" \
             --check \
             --https \
             --httpsPrivateKey "$CP_IDP_CERT_DIR/ssl-private-key.pem" \
-            --httpsCert "$CP_IDP_CERT_DIR/ssl-public-cert.pem"
+            --httpsCert "$CP_IDP_CERT_DIR/ssl-public-cert.pem" \
+            --admins "$default_admin_group"
             


### PR DESCRIPTION
# Summary

If a basic authentication option is used to deploy Cloud Pipeline - *embedded* SAML provider will be used.

Now, this option supports GUI-based users management (previously only IdP CLI was available).

# How it works

1. During IdP process startup - define which group will be considered as an `Administators` group via `--admins <admin_group>`, e.g.: `--admins ROLE_ADMIN`
2. Register a user with `--groups <admin_group>`, e.g. for pipe_admin: `--groups ROLE_ADMIN`
3. Navigate to `https://<idp-host>:<idp-port>/admin`
4. View/Edit/Add users:
![image](https://user-images.githubusercontent.com/20998291/55345596-f2754c80-54b8-11e9-95f6-20f0b6b91e80.png)

# Notes

Basic authentication option using the *embedded* SAML provider shall be used only for PoC and small/isolated deployments. For any production-like environments - some of the mature IdPs shall be considered