### PR TITLE
Support GCP in pipe cli storage tests

### DIFF
--- a/e2e/cli/README.md
+++ b/e2e/cli/README.md
@@ -1,30 +1,35 @@
 # CP CLI integration tests
 
-CP CLI integration tests can be launched for several cloud providers. 
-It is specified in `CP_PROVIDER` environment variable:
+## Storage tests
+
+CP CLI integration storage tests can be launched with all supported cloud providers. Cloud provider
+is specified in `CP_PROVIDER` environment variable:
 
 - `S3` for Aws cloud provider,
 - `AZ` for Azure cloud provider,
 - `GS` for Google cloud provider.
 
-## Providers
+```bash
+cd buckets
+pytest -s -v
+```
 
-### Aws
+### Credentials
 
-Aws default credentials is required to launch integration tests with Aws cloud provider.
+Storage integration tests require provider-specific credentials to be configured.
 
-### Azure
+#### Aws
 
-Several environment variables is required to launch integration tests with Azure cloud provider.
+Aws cloud provider default credentials should be configured to launch integration tests.
+
+#### Azure
 
 | variable | description |
 | -------- | ----------- |
 | **AZURE_STORAGE_ACCOUNT** | Azure storage account name. |
 | **AZURE_ACCOUNT_KEY** | Azure storage account access key. |
 
-### Google
-
-Several environment variables is required to launch integration tests with Google cloud provider.
+#### Google
 
 | variable | description |
 | -------- | ----------- |

--- a/e2e/cli/README.md
+++ b/e2e/cli/README.md
@@ -1,0 +1,31 @@
+# CP CLI integration tests
+
+CP CLI integration tests can be launched for several cloud providers. 
+It is specified in `CP_PROVIDER` environment variable:
+
+- `S3` for Aws cloud provider,
+- `AZ` for Azure cloud provider,
+- `GS` for Google cloud provider.
+
+## Providers
+
+### Aws
+
+Aws default credentials is required to launch integration tests with Aws cloud provider.
+
+### Azure
+
+Several environment variables is required to launch integration tests with Azure cloud provider.
+
+| variable | description |
+| -------- | ----------- |
+| **AZURE_STORAGE_ACCOUNT** | Azure storage account name. |
+| **AZURE_ACCOUNT_KEY** | Azure storage account access key. |
+
+### Google
+
+Several environment variables is required to launch integration tests with Google cloud provider.
+
+| variable | description |
+| -------- | ----------- |
+| **GOOGLE_APPLICATION_CREDENTIALS** | Local path to Google service account credentials json file. |

--- a/e2e/cli/buckets/cp/test_cp_with_files.py
+++ b/e2e/cli/buckets/cp/test_cp_with_files.py
@@ -272,7 +272,7 @@ class TestCopyWithFiles(object):
         self.upload_file_to_bucket(source)
         try:
             error = pipe_storage_cp(source, destination, force=True, expected_status=1)[1]
-            assert_error_message_is_present(error, 'Error: Supported schemes for datastorage are: "cp", "s3", "az".')
+            assert_error_message_is_present(error, 'Error: Supported schemes for datastorage are: "cp", "s3", "az", "gs".')
         except AssertionError as e:
             pytest.fail("Test case {} failed. {}".format("EPMCMBIBPC-655", e.message))
 

--- a/e2e/cli/buckets/ls/test_list_folder.py
+++ b/e2e/cli/buckets/ls/test_list_folder.py
@@ -189,7 +189,7 @@ class TestLsFolder(object):
     def test_list_with_wrong_scheme(self):
         try:
             error = pipe_storage_ls("s4://{}/".format(self.bucket_name), recursive=True, expected_status=1)[1]
-            assert_error_message_is_present(error, 'Supported schemes for datastorage are: "cp", "s3", "az".')
+            assert_error_message_is_present(error, 'Supported schemes for datastorage are: "cp", "s3", "az", "gs".')
         except AssertionError as e:
             pytest.fail("Test case {} failed. {}".format(self.epam_test_case_ls_wrong_scheme, e.message))
 

--- a/e2e/cli/buckets/mkdir_mvtodir/test_mkdir_mvtodir.py
+++ b/e2e/cli/buckets/mkdir_mvtodir/test_mkdir_mvtodir.py
@@ -18,7 +18,7 @@ from buckets.utils.listing import *
 from common_utils.entity_managers import EntityManager
 from common_utils.pipe_cli import *
 
-ERROR_MESSAGE = "An error accrued in case "
+ERROR_MESSAGE = "An error occurred in case "
 
 
 class TestMkdirMvtodir(object):

--- a/e2e/cli/buckets/mv/test_mv_with_files.py
+++ b/e2e/cli/buckets/mv/test_mv_with_files.py
@@ -251,7 +251,7 @@ class TestMoveWithFiles(object):
         self.upload_file_to_bucket(source)
         try:
             error = pipe_storage_mv(source, destination, force=True, expected_status=1)[1]
-            assert_error_message_is_present(error, 'Error: Supported schemes for datastorage are: "cp", "s3", "az".')
+            assert_error_message_is_present(error, 'Error: Supported schemes for datastorage are: "cp", "s3", "az", "gs".')
         except AssertionError as e:
             pytest.fail("Test case {} failed. {}".format("EPMCMBIBPC-679", e.message))
 

--- a/e2e/cli/buckets/policy/test_policy.py
+++ b/e2e/cli/buckets/policy/test_policy.py
@@ -1,5 +1,3 @@
-import pytest
-import os
 # Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,9 +12,11 @@ import os
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from time import sleep
+import pytest
+import os
 
 from buckets.utils.cloud.azure_client import AzureClient
+from buckets.utils.cloud.google_client import GsClient
 from buckets.utils.cloud.utilities import assert_policy
 from buckets.utils.utilities_for_test import delete_buckets, create_buckets, create_bucket
 from common_utils.cmd_utils import get_test_prefix
@@ -26,6 +26,7 @@ ERROR_MESSAGE = "An error occurred in case "
 
 
 @pytest.mark.skipif(os.environ['CP_PROVIDER'] == AzureClient.name, reason="Storage policy is not supported for AZURE provider")
+@pytest.mark.skipif(os.environ['CP_PROVIDER'] == GsClient.name, reason="Storage policy is not available for GOOGLE provider yet")
 class TestPolicy(object):
     bucket_name = "epmcmbibpc-it-policy{}".format(get_test_prefix())
 

--- a/e2e/cli/buckets/policy/test_policy.py
+++ b/e2e/cli/buckets/policy/test_policy.py
@@ -16,7 +16,6 @@ import pytest
 import os
 
 from buckets.utils.cloud.azure_client import AzureClient
-from buckets.utils.cloud.google_client import GsClient
 from buckets.utils.cloud.utilities import assert_policy
 from buckets.utils.utilities_for_test import delete_buckets, create_buckets, create_bucket
 from common_utils.cmd_utils import get_test_prefix
@@ -26,7 +25,6 @@ ERROR_MESSAGE = "An error occurred in case "
 
 
 @pytest.mark.skipif(os.environ['CP_PROVIDER'] == AzureClient.name, reason="Storage policy is not supported for AZURE provider")
-@pytest.mark.skipif(os.environ['CP_PROVIDER'] == GsClient.name, reason="Storage policy is not available for GOOGLE provider yet")
 class TestPolicy(object):
     bucket_name = "epmcmbibpc-it-policy{}".format(get_test_prefix())
 

--- a/e2e/cli/buckets/rm/test_remove_files_folders.py
+++ b/e2e/cli/buckets/rm/test_remove_files_folders.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..utils.listing import get_pipe_listing, get_aws_listing, compare_listing
 from common_utils.pipe_cli import *
 from ..utils.listing import get_pipe_listing, compare_listing, f
 from ..utils.assertions_utils import *
@@ -160,7 +159,7 @@ class TestRmFileFolder(object):
     def test_remove_from_wrong_scheme(self):
         try:
             error = pipe_storage_rm("s4://{}/test.txt".format(self.bucket_name), expected_status=1)[1]
-            assert_error_message_is_present(error, 'Error: Supported schemes for datastorage are: "cp", "s3", "az".')
+            assert_error_message_is_present(error, 'Error: Supported schemes for datastorage are: "cp", "s3", "az", "gs".')
         except AssertionError as e:
             pytest.fail("Test case {} failed. {}".format(self.epam_test_case_rm_wrong_scheme, e.message))
 

--- a/e2e/cli/buckets/tag/test_tag.py
+++ b/e2e/cli/buckets/tag/test_tag.py
@@ -20,18 +20,19 @@ from common_utils.entity_managers import EntityManager
 ERROR_MESSAGE = "An error occurred in case "
 
 
-class TestS3Tagging(object):
+class TestTagging(object):
     test_file = "test-tag1.txt"
     test_file2 = "test-tag2.txt"
     test_file_in_folder = "tags/" + test_file
     test_file2_in_folder = "tags/" + test_file2
-    bucket = 'epmcmbibpc-s3-tagging-{}'.format(get_test_prefix()).lower()
+    bucket = 'epmcmbibpc-storage-tagging-{}'.format(get_test_prefix()).lower()
     path_to_bucket = 'cp://{}'.format(bucket)
     tag1 = ("key1", "value1")
     tag2 = ("key2", "value2")
     tag3 = ("key3", "value3")
     owner_token = os.environ['USER_TOKEN']
     owner = os.environ['TEST_USER']
+    versioning_providers = [S3Client.name, GsClient.name]
 
     @classmethod
     def setup_class(cls):
@@ -40,8 +41,10 @@ class TestS3Tagging(object):
         try:
             folder_id = manager.create(cls.bucket)
             set_acl_permissions(cls.owner, str(folder_id), 'folder', allow='rw')
-            create_data_storage(cls.bucket, versioning=os.environ['CP_PROVIDER'] == S3Client.name,
-                                token=cls.owner_token, folder=folder_id)
+            create_data_storage(cls.bucket,
+                                versioning=os.environ['CP_PROVIDER'] in TestTagging.versioning_providers,
+                                token=cls.owner_token,
+                                folder=folder_id)
             create_test_file(os.path.abspath(cls.test_file), TestFiles.DEFAULT_CONTENT)
         except BaseException as e:
             if folder_id is not None:
@@ -140,7 +143,7 @@ class TestS3Tagging(object):
          2. error message
      """
     test_case_for_non_existing = [
-        ('cp://non_exisitng/{}'.format(test_file), 'data storage with id: \'non_exisitng\' was not found'),
+        ('cp://non_existing/{}'.format(test_file), 'data storage with id: \'non_existing\' was not found'),
         ('cp://{}/non_existing'.format(bucket), 'Path \'non_existing\' doesn\'t exist')
     ]
 
@@ -224,4 +227,4 @@ class TestS3Tagging(object):
         pipe_storage_rm(path, args=self.rm_arguments())
 
     def rm_arguments(self):
-        return ['--hard-delete'] if os.environ['CP_PROVIDER'] == S3Client.name else []
+        return ['--hard-delete'] if os.environ['CP_PROVIDER'] in TestTagging.versioning_providers else []

--- a/e2e/cli/buckets/tag/test_tag.py
+++ b/e2e/cli/buckets/tag/test_tag.py
@@ -170,7 +170,7 @@ class TestTagging(object):
             set_storage_tags(path, [self.tag1])
 
             stderr = delete_storage_tags(path, [self.tag2[1]], expected_status=1)[1]
-            assert_error_message_is_present(stderr, 'Tag \'{}\' doesn\'t exist'.format(self.tag2[1]))
+            assert_error_message_is_present(stderr, 'Tag \'{}\' does not exist'.format(self.tag2[1]))
 
             assert_tags_listing(self.bucket, path, [self.tag1])
             pipe_storage_rm(path, args=self.rm_arguments())

--- a/e2e/cli/buckets/tag/test_tag.py
+++ b/e2e/cli/buckets/tag/test_tag.py
@@ -144,7 +144,7 @@ class TestTagging(object):
      """
     test_case_for_non_existing = [
         ('cp://non_existing/{}'.format(test_file), 'data storage with id: \'non_existing\' was not found'),
-        ('cp://{}/non_existing'.format(bucket), 'Path \'non_existing\' doesn\'t exist')
+        ('cp://{}/non_existing'.format(bucket), 'path \'non_existing\' for bucket \'{}\' does not exist'.format(bucket))
     ]
 
     @pytest.mark.parametrize("path,message", test_case_for_non_existing)

--- a/e2e/cli/buckets/utils/cloud/aws_client.py
+++ b/e2e/cli/buckets/utils/cloud/aws_client.py
@@ -41,14 +41,21 @@ class S3Client(CloudClient):
         assert actual_policy['backupDuration'] == backup_duration, "Backup Duration assertion failed"
 
     def get_modification_date(self, path):
-        listing = self.get_listing(path)
+        listing = self._get_listing(path)
         if not listing:
             raise RuntimeError('Storage path %s wasn\'t found.' % path)
         return listing[0].last_modified
 
-    def get_versions(self, path):
-        # TODO 01.04.19: Method is not implemented yet.
-        raise RuntimeError('Method is not implemented yet.')
+    def _get_listing(self, path, recursive=False, expected_status=0):
+        args = []
+        if recursive:
+            args.append("--recursive")
+        cmd_output = self.s3_ls(path, args, expected_status)
+        return self.parse_aws_listing(cmd_output)
+
+    def get_versions(self, bucket_name, key):
+        file_versions = get_aws_object_version_listing(bucket_name, key)
+        return [version.version_id for version in file_versions]
 
     def wait_for_bucket_creation(self, bucket_name):
         waiter = boto3.client('s3').get_waiter('bucket_exists')

--- a/e2e/cli/buckets/utils/cloud/aws_client.py
+++ b/e2e/cli/buckets/utils/cloud/aws_client.py
@@ -22,13 +22,6 @@ class S3Client(CloudClient):
     def folder_exists(self, bucket_name, key):
         return len(self.list_s3_folder(bucket_name, key)) > 0
 
-    def get_listing(self, path, recursive=False, expected_status=0):
-        args = []
-        if recursive:
-            args.append("--recursive")
-        cmd_output = self.s3_ls(path, args, expected_status)
-        return self.parse_aws_listing(cmd_output)
-
     def list_object_tags(self, bucket, key, version=None, args=None):
         command = ['aws', 's3api', 'get-object-tagging', '--bucket', bucket, '--key', key]
         if version:
@@ -52,6 +45,10 @@ class S3Client(CloudClient):
         if not listing:
             raise RuntimeError('Storage path %s wasn\'t found.' % path)
         return listing[0].last_modified
+
+    def get_versions(self, path):
+        # TODO 01.04.19: Method is not implemented yet.
+        raise RuntimeError('Method is not implemented yet.')
 
     def wait_for_bucket_creation(self, bucket_name):
         waiter = boto3.client('s3').get_waiter('bucket_exists')

--- a/e2e/cli/buckets/utils/cloud/azure_client.py
+++ b/e2e/cli/buckets/utils/cloud/azure_client.py
@@ -47,6 +47,9 @@ class AzureClient(CloudClient):
         last_modified = bucket_entries[0].properties.last_modified
         return last_modified.astimezone(get_localzone()).replace(tzinfo=None)
 
+    def get_versions(self, path):
+        raise RuntimeError('Versioning is not supported by Azure cloud provider.')
+
     def _get_bucket_entries(self, bucket_name, key):
         return list(self._get_client().list_blobs(bucket_name, key))
 

--- a/e2e/cli/buckets/utils/cloud/azure_client.py
+++ b/e2e/cli/buckets/utils/cloud/azure_client.py
@@ -47,7 +47,7 @@ class AzureClient(CloudClient):
         last_modified = bucket_entries[0].properties.last_modified
         return last_modified.astimezone(get_localzone()).replace(tzinfo=None)
 
-    def get_versions(self, path):
+    def get_versions(self, bucket_name, key):
         raise RuntimeError('Versioning is not supported by Azure cloud provider.')
 
     def _get_bucket_entries(self, bucket_name, key):

--- a/e2e/cli/buckets/utils/cloud/cloud_client.py
+++ b/e2e/cli/buckets/utils/cloud/cloud_client.py
@@ -26,7 +26,7 @@ class CloudClient(object):
         pass
 
     @abstractmethod
-    def get_versions(self, path):
+    def get_versions(self, bucket_name, key):
         pass
 
     @abstractmethod

--- a/e2e/cli/buckets/utils/cloud/cloud_client.py
+++ b/e2e/cli/buckets/utils/cloud/cloud_client.py
@@ -26,6 +26,10 @@ class CloudClient(object):
         pass
 
     @abstractmethod
+    def get_versions(self, path):
+        pass
+
+    @abstractmethod
     def wait_for_bucket_creation(self, bucket_name):
         pass
 

--- a/e2e/cli/buckets/utils/cloud/cloud_client.py
+++ b/e2e/cli/buckets/utils/cloud/cloud_client.py
@@ -1,4 +1,5 @@
 from abc import ABCMeta, abstractmethod
+from time import sleep
 
 
 class CloudClient(object):
@@ -31,3 +32,10 @@ class CloudClient(object):
     @abstractmethod
     def wait_for_bucket_deletion(self, bucket_name):
         pass
+
+    def _wait_unless(self, is_ready, attempts=20, delay=3):
+        for attempt in range(attempts):
+            if is_ready():
+                return True
+            sleep(delay)
+        return False

--- a/e2e/cli/buckets/utils/cloud/google_client.py
+++ b/e2e/cli/buckets/utils/cloud/google_client.py
@@ -43,6 +43,10 @@ class GsClient(CloudClient):
         last_modified = blob.updated
         return last_modified.astimezone(get_localzone()).replace(tzinfo=None, microsecond=0)
 
+    def get_versions(self, path):
+        # TODO 01.04.19: Method is not implemented yet.
+        raise RuntimeError('Method is not implemented yet.')
+
     def wait_for_bucket_creation(self, bucket_name):
         if self._wait_unless(lambda: self._get_client().bucket(bucket_name).exists()):
             return

--- a/e2e/cli/buckets/utils/cloud/google_client.py
+++ b/e2e/cli/buckets/utils/cloud/google_client.py
@@ -1,20 +1,12 @@
-import os
-
-from azure.storage.blob import BlockBlobService
+from google.cloud.storage import Client
 from tzlocal import get_localzone
 
 from buckets.utils.cloud.cloud_client import CloudClient
 
 
-class AzureClient(CloudClient):
+class GsClient(CloudClient):
 
-    name = 'AZ'
-    _ACCOUNT_NAME = ''
-    _ACCOUNT_KEY = ''
-
-    def __init__(self):
-        AzureClient._ACCOUNT_NAME = os.getenv('AZURE_STORAGE_ACCOUNT')
-        AzureClient._ACCOUNT_KEY = os.getenv('AZURE_ACCOUNT_KEY')
+    name = 'GS'
 
     def object_exists(self, bucket_name, key):
         bucket_entries = self._get_bucket_entries(bucket_name, key)
@@ -33,33 +25,36 @@ class AzureClient(CloudClient):
         return result
 
     def list_object_tags(self, bucket, key, version=None, args=None):
-        return self._get_client().get_blob_metadata(bucket, key)
+        # TODO 29.03.19: Use version to retrieve required metadata
+        blob = self._get_client().bucket(bucket).blob(key)
+        blob.reload()
+        return blob.metadata
 
     def assert_policy(self, bucket_name, sts, lts, backup_duration):
-        # TODO 15.02.19: Method is not implemented yet.
+        # TODO 29.03.19: Method is not implemented yet.
         raise RuntimeError('Method is not implemented yet.')
 
     def get_modification_date(self, path):
         path_elements = path.replace('cp://', '').split('/')
         bucket_name = path_elements[0]
         blob_name = '/'.join(path_elements[1:])
-        bucket_entries = self._get_bucket_entries(bucket_name, blob_name)
-        last_modified = bucket_entries[0].properties.last_modified
-        return last_modified.astimezone(get_localzone()).replace(tzinfo=None)
-
-    def _get_bucket_entries(self, bucket_name, key):
-        return list(self._get_client().list_blobs(bucket_name, key))
+        blob = self._get_client().bucket(bucket_name).blob(blob_name)
+        blob.reload()
+        last_modified = blob.updated
+        return last_modified.astimezone(get_localzone()).replace(tzinfo=None, microsecond=0)
 
     def wait_for_bucket_creation(self, bucket_name):
-        if self._wait_unless(lambda: self._get_client().exists(bucket_name)):
+        if self._wait_unless(lambda: self._get_client().bucket(bucket_name).exists()):
             return
-        raise RuntimeError('Azure storage with name=%s wasn\'t created.' % bucket_name)
+        raise RuntimeError('Google storage with name=%s wasn\'t created.' % bucket_name)
 
     def wait_for_bucket_deletion(self, bucket_name):
-        if self._wait_unless(lambda: not self._get_client().exists(bucket_name)):
+        if self._wait_unless(lambda: not self._get_client().bucket(bucket_name).exists()):
             return
-        raise RuntimeError('Azure storage with name=%s wasn\'t deleted.' % bucket_name)
+        raise RuntimeError('Google storage with name=%s wasn\'t deleted.' % bucket_name)
+
+    def _get_bucket_entries(self, bucket_name, key):
+        return list(self._get_client().get_bucket(bucket_name).list_blobs(prefix=key))
 
     def _get_client(self):
-        return BlockBlobService(account_name=AzureClient._ACCOUNT_NAME,
-                                account_key=AzureClient._ACCOUNT_KEY)
+        return Client()

--- a/e2e/cli/buckets/utils/cloud/utilities.py
+++ b/e2e/cli/buckets/utils/cloud/utilities.py
@@ -26,10 +26,6 @@ def folder_exists(bucket_name, key):
     return get_client().folder_exists(bucket_name, key)
 
 
-def get_listing(path, recursive=False, expected_status=0):
-    return get_client().get_listing(path, recursive, expected_status)
-
-
 def list_object_tags(bucket, key, version=None, args=None):
     return get_client().list_object_tags(bucket, key, version, args)
 

--- a/e2e/cli/buckets/utils/cloud/utilities.py
+++ b/e2e/cli/buckets/utils/cloud/utilities.py
@@ -1,10 +1,12 @@
 from buckets.utils.cloud.aws_client import S3Client
 from buckets.utils.cloud.azure_client import AzureClient
+from buckets.utils.cloud.google_client import GsClient
 from common_utils.cmd_utils import *
 
 _clients = {
     S3Client.name: S3Client,
-    AzureClient.name: AzureClient
+    AzureClient.name: AzureClient,
+    GsClient.name: GsClient
 }
 
 

--- a/e2e/cli/buckets/utils/cloud/utilities.py
+++ b/e2e/cli/buckets/utils/cloud/utilities.py
@@ -22,6 +22,10 @@ def object_exists(bucket_name, key):
     return get_client().object_exists(bucket_name, key)
 
 
+def get_versions(bucket_name, key):
+    return get_client().get_versions(bucket_name, key)
+
+
 def folder_exists(bucket_name, key):
     return get_client().folder_exists(bucket_name, key)
 

--- a/e2e/cli/buckets/utils/listing.py
+++ b/e2e/cli/buckets/utils/listing.py
@@ -161,14 +161,15 @@ def get_pipe_listing(path, show_details=True, recursive=False, token=None, versi
 
 
 def compare_listing(actual_listing, expected_listing, expected_length, show_details=True, check_last_modified=False,
-                    check_version=False):
+                    check_version=False, sort=True):
     assert len(actual_listing) == expected_length, \
         "Length of listing [{}] doesn't match expected value [{}]".format(len(actual_listing), expected_length)
     assert len(actual_listing) == len(expected_listing), \
         "Length of listing results differ between pipe ls [{}] and cloud ls [{}]" \
                 .format(len(actual_listing), len(expected_listing))
-    actual_listing = sorted(actual_listing, key=lambda tup: (tup.type, tup.name, tup.size, tup.last_modified))
-    expected_listing = sorted(expected_listing, key=lambda tup: (tup.type, tup.name, tup.size, tup.last_modified))
+    if sort:
+        actual_listing = sorted(actual_listing, key=lambda tup: (tup.type, tup.name, tup.size, tup.last_modified))
+        expected_listing = sorted(expected_listing, key=lambda tup: (tup.type, tup.name, tup.size, tup.last_modified))
     for actual_item, expected_item in zip(actual_listing, expected_listing):
         if show_details:
             assert actual_item.equals(expected_item, check_last_modified=check_last_modified,

--- a/e2e/cli/buckets/utils/object_info.py
+++ b/e2e/cli/buckets/utils/object_info.py
@@ -2,9 +2,16 @@ import os
 
 import boto3
 from azure.storage.blob import BlockBlobService
+from google.cloud.storage import Client
 from tzlocal import get_localzone
 
 from buckets.utils.file_utils import file_last_modified_time
+
+_object_infos = {
+    'S3': lambda *args: S3ObjectInfo(False).build(*args),
+    'AZ': lambda *args: AzureObjectInfo(False).build(*args),
+    'GS': lambda *args: GsObjectInfo(False).build(*args)
+}
 
 
 class ObjectInfo(object):
@@ -20,11 +27,11 @@ class ObjectInfo(object):
         if self.is_local:
             return LocalFileInfo(self.is_local).build(args[0])
         else:
-            if os.environ['CP_PROVIDER'] == 'AZ':
-                return AzureObjectInfo(False).build(*args)
-            if os.environ['CP_PROVIDER'] == 'S3':
-                return S3ObjectInfo(False).build(*args)
-        raise RuntimeError('Provider must be one of %s' % ['AZ', 'S3'])
+            provider = os.environ['CP_PROVIDER']
+            if provider in _object_infos:
+                return _object_infos[provider](*args)
+            else:
+                raise RuntimeError('Provider must be one of %s' % _object_infos.keys())
 
 
 class S3ObjectInfo(ObjectInfo):
@@ -64,7 +71,28 @@ class AzureObjectInfo(ObjectInfo):
             self.exists = False
             return self
         self.size = bucket_entry[0].properties.content_length
-        self.last_modified = bucket_entry[0].properties.last_modified.astimezone(get_localzone()).replace(tzinfo=None)
+        self.last_modified = bucket_entry[0].properties.last_modified.astimezone(
+            get_localzone()).replace(tzinfo=None)
+        return self
+
+
+class GsObjectInfo(ObjectInfo):
+
+    def __init__(self, is_local):
+        super(GsObjectInfo, self).__init__(is_local)
+
+    def build(self, bucket_name, key):
+        self.path = "cp://" + os.path.join(bucket_name, key)
+        client = Client()
+        bucket_entry = list(client.bucket(bucket_name).list_blobs(prefix=key))
+        if len(bucket_entry) > 0 and bucket_entry[0].name == key:
+            self.exists = True
+        else:
+            self.exists = False
+            return self
+        self.size = bucket_entry[0].size
+        self.last_modified = bucket_entry[0].updated.astimezone(get_localzone()).replace(
+            tzinfo=None)
         return self
 
 

--- a/e2e/cli/buckets/utils/tag_assertion_utils.py
+++ b/e2e/cli/buckets/utils/tag_assertion_utils.py
@@ -20,9 +20,8 @@ def assert_tags_listing(bucket, path, expected_tags, version=None, token=None):
     stdout, stderr = get_storage_tags(path, version=version, token=token)
     output = parse_tag_table(stdout)
     compare_tags('pipe storage', expected_tags, output)
-    # TODO 29.03.19: Rename variables in a cloud-agnostic notation
-    aws_tags = list_object_tags(bucket, path[len(bucket) + 6:], version=version)
-    compare_tags('aws get-object-tagging', expected_tags, aws_tags)
+    actual_tags = list_object_tags(bucket, path[len(bucket) + 6:], version=version)
+    compare_tags('Getting object tags', expected_tags, actual_tags)
 
 
 def compare_tags(name, expected_tags, output):

--- a/e2e/cli/buckets/utils/tag_assertion_utils.py
+++ b/e2e/cli/buckets/utils/tag_assertion_utils.py
@@ -1,4 +1,3 @@
-from buckets.utils.cloud.utilities import *
 # Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,7 @@ from buckets.utils.cloud.utilities import *
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from buckets.utils.aws.utilities import *
+from buckets.utils.cloud.utilities import *
 from common_utils.pipe_cli import *
 
 
@@ -21,6 +20,7 @@ def assert_tags_listing(bucket, path, expected_tags, version=None, token=None):
     stdout, stderr = get_storage_tags(path, version=version, token=token)
     output = parse_tag_table(stdout)
     compare_tags('pipe storage', expected_tags, output)
+    # TODO 29.03.19: Rename variables in a cloud-agnostic notation
     aws_tags = list_object_tags(bucket, path[len(bucket) + 6:], version=version)
     compare_tags('aws get-object-tagging', expected_tags, aws_tags)
 

--- a/e2e/cli/buckets/versioning/test_data_storage_versioning.py
+++ b/e2e/cli/buckets/versioning/test_data_storage_versioning.py
@@ -21,7 +21,7 @@ from buckets.utils.listing import *
 from buckets.utils.file_utils import *
 from common_utils.pipe_cli import *
 
-ERROR_MESSAGE = "An error accrued in case "
+ERROR_MESSAGE = "An error occurred in case "
 
 
 @pytest.mark.skipif(os.environ['CP_PROVIDER'] == AzureClient.name, reason="Versioning is not supported for AZURE provider")

--- a/e2e/cli/buckets/versioning/test_data_storage_versioning.py
+++ b/e2e/cli/buckets/versioning/test_data_storage_versioning.py
@@ -333,7 +333,7 @@ class TestDataStorageVersioning(object):
             pipe_storage_cp(self.test_file_2, destination, force=True, token=self.token, expected_status=0)
             actual_output = get_pipe_listing(self.path_to_bucket, token=self.token)
             expected_output = [
-                f(self.test_file_1, 10)
+                f(self.test_file_1, 14)
             ]
             compare_listing(actual_output, expected_output, 1)
             actual_output = pipe_storage_ls(self.path_to_bucket, expected_status=1, token=self.token, versioning=True)[1]

--- a/e2e/cli/buckets/versioning/test_data_storage_versioning.py
+++ b/e2e/cli/buckets/versioning/test_data_storage_versioning.py
@@ -14,9 +14,8 @@
 
 import pytest
 
-from buckets.utils.cloud.aws_client import get_aws_object_version_listing
 from buckets.utils.cloud.azure_client import AzureClient
-from buckets.utils.cloud.utilities import object_exists, get_listing
+from buckets.utils.cloud.utilities import object_exists
 from buckets.utils.listing import *
 from buckets.utils.file_utils import *
 from common_utils.pipe_cli import *
@@ -68,12 +67,15 @@ class TestDataStorageVersioning(object):
         try:
             pipe_storage_cp(self.test_file_1, destination)
             pipe_storage_rm(destination)
-            pipe_output = get_pipe_listing(self.path_to_bucket)
-            assert len(pipe_output) == 0
-            pipe_output = assert_and_filter_first_versioned_listing_line(
+            actual_output = get_pipe_listing(self.path_to_bucket)
+            assert len(actual_output) == 0
+            actual_output = assert_and_filter_first_versioned_listing_line(
                 get_pipe_listing(self.path_to_bucket, versioning=True))
-            aws_output = get_aws_object_version_listing(self.bucket, self.test_file_1)
-            compare_listing(pipe_output, aws_output, 2)
+            expected_output = [
+                f(self.test_file_1, deleted=True, latest=True),
+                f(self.test_file_1, 10, added=True)
+            ]
+            compare_listing(actual_output, expected_output, 2)
         except BaseException as e:
             pytest.fail(ERROR_MESSAGE + "epmcmbibpc-877:" + "\n" + e.message)
 
@@ -84,14 +86,19 @@ class TestDataStorageVersioning(object):
             pipe_storage_rm(destination)
             output = pipe_storage_ls(self.path_to_bucket, show_details=False)[0]
             assert len(output) == 0
-            pipe_output = assert_and_filter_first_versioned_listing_line(
+            actual_output = assert_and_filter_first_versioned_listing_line(
                 get_pipe_listing(self.path_to_bucket, versioning=True))
-            aws_output = get_aws_object_version_listing(self.bucket, self.test_file_1)
-            compare_listing(pipe_output, aws_output, 2)
+            expected_output = [
+                f(self.test_file_1, deleted=True, latest=True),
+                f(self.test_file_1, 10, added=True)
+            ]
+            compare_listing(actual_output, expected_output, 2)
             pipe_storage_restore(destination)
-            pipe_output = get_pipe_listing(self.path_to_bucket)
-            aws_output = get_listing(self.bucket)
-            compare_listing(pipe_output, aws_output, 1)
+            actual_output = get_pipe_listing(self.path_to_bucket)
+            expected_output = [
+                f(self.test_file_1, 10)
+            ]
+            compare_listing(actual_output, expected_output, 1)
         except BaseException as e:
             pytest.fail(ERROR_MESSAGE + "epmcmbibpc-881:" + "\n" + e.message)
 
@@ -100,13 +107,18 @@ class TestDataStorageVersioning(object):
         try:
             pipe_storage_cp(self.test_file_1, destination)
             pipe_storage_cp(self.test_file_2, destination, force=True)  # another file with same name
-            pipe_output = get_pipe_listing(self.path_to_bucket)
-            aws_output = get_listing(self.bucket, self.test_file_1)
-            compare_listing(pipe_output, aws_output, 1)
-            pipe_output = assert_and_filter_first_versioned_listing_line(
+            actual_output = get_pipe_listing(self.path_to_bucket)
+            expected_output = [
+                f(self.test_file_1, 14)
+            ]
+            compare_listing(actual_output, expected_output, 1)
+            actual_output = assert_and_filter_first_versioned_listing_line(
                 get_pipe_listing(self.path_to_bucket, versioning=True))
-            aws_output = get_aws_object_version_listing(self.bucket, self.test_file_1)
-            compare_listing(pipe_output, aws_output, 2)
+            expected_output = [
+                f(self.test_file_1, 14, added=True, latest=True),
+                f(self.test_file_1, 10, added=True)
+            ]
+            compare_listing(actual_output, expected_output, 2)
         except BaseException as e:
             pytest.fail(ERROR_MESSAGE + "epmcmbibpc-882:" + "\n" + e.message)
 
@@ -116,16 +128,22 @@ class TestDataStorageVersioning(object):
             pipe_storage_cp(self.test_file_1, destination)
             pipe_storage_cp(self.test_file_2, destination, force=True)
             pipe_storage_rm(destination)
-            pipe_output = assert_and_filter_first_versioned_listing_line(
+            actual_output = assert_and_filter_first_versioned_listing_line(
                 get_pipe_listing(self.path_to_bucket, versioning=True))
-            aws_output = get_aws_object_version_listing(self.bucket, self.test_file_1)
-            compare_listing(pipe_output, aws_output, 3)
-            version = get_non_latest_version(pipe_output)
+            expected_output = [
+                f(self.test_file_1, deleted=True, latest=True),
+                f(self.test_file_1, 14, added=True),
+                f(self.test_file_1, 10, added=True)
+            ]
+            compare_listing(actual_output, expected_output, 3)
+            version = get_non_latest_version(actual_output)
             assert version, "No version available to restore."
             pipe_storage_restore(destination, version=version)
-            pipe_output = get_pipe_listing(self.path_to_bucket)
-            aws_output = get_listing(self.bucket)
-            compare_listing(pipe_output, aws_output, 1)
+            actual_output = get_pipe_listing(self.path_to_bucket)
+            expected_output = [
+                f(self.test_file_1, 10)
+            ]
+            compare_listing(actual_output, expected_output, 1)
         except BaseException as e:
             pytest.fail(ERROR_MESSAGE + "epmcmbibpc-883:" + "\n" + e.message)
 
@@ -134,10 +152,10 @@ class TestDataStorageVersioning(object):
         try:
             pipe_storage_cp(os.path.abspath(self.test_file_1), destination)
             pipe_storage_rm(destination, args=['--hard-delete'])
-            pipe_output = assert_and_filter_first_versioned_listing_line(
+            actual_output = assert_and_filter_first_versioned_listing_line(
                 get_pipe_listing(self.path_to_bucket, versioning=True), result_not_empty=False)
-            aws_output = get_aws_object_version_listing(self.bucket, self.test_file_1)
-            compare_listing(pipe_output, aws_output, 0)
+            expected_output = []
+            compare_listing(actual_output, expected_output, 0)
         except BaseException as e:
             pytest.fail(ERROR_MESSAGE + "epmcmbibpc-884:" + "\n" + e.message)
 
@@ -146,15 +164,18 @@ class TestDataStorageVersioning(object):
         try:
             pipe_storage_cp(os.path.abspath(self.test_file_1), destination)
             pipe_storage_rm(destination)
-            pipe_output = assert_and_filter_first_versioned_listing_line(
+            actual_output = assert_and_filter_first_versioned_listing_line(
                 get_pipe_listing(self.path_to_bucket, versioning=True))
-            aws_output = get_aws_object_version_listing(self.bucket, self.test_file_1)
-            compare_listing(pipe_output, aws_output, 2)
+            expected_output = [
+                f(self.test_file_1, deleted=True, latest=True),
+                f(self.test_file_1, 10, added=True),
+            ]
+            compare_listing(actual_output, expected_output, 2)
             pipe_storage_rm(destination, args=['--hard-delete'], recursive=True)
-            pipe_output = assert_and_filter_first_versioned_listing_line(
+            actual_output = assert_and_filter_first_versioned_listing_line(
                 get_pipe_listing(self.path_to_bucket, versioning=True), result_not_empty=False)
-            aws_output = get_aws_object_version_listing(self.bucket, self.test_file_1)
-            compare_listing(pipe_output, aws_output, 0)
+            expected_output = []
+            compare_listing(actual_output, expected_output, 0)
         except BaseException as e:
             pytest.fail(ERROR_MESSAGE + "epmcmbibpc-993:" + "\n" + e.message)
 
@@ -163,21 +184,27 @@ class TestDataStorageVersioning(object):
         try:
             pipe_storage_cp(os.path.abspath(self.test_file_1), destination_1)
             pipe_storage_rm(destination_1, recursive=True)
-            pipe_output = get_pipe_listing(self.path_to_bucket)
-            assert len(pipe_output) == 0
-            pipe_output = get_pipe_listing(self.path_to_bucket, versioning=True)
-            assert len(pipe_output) == 1 and self.test_folder_1 in pipe_output[0].name
-            pipe_output = assert_and_filter_first_versioned_listing_line(
+            actual_output = get_pipe_listing(self.path_to_bucket)
+            assert len(actual_output) == 0
+            actual_output = get_pipe_listing(self.path_to_bucket, versioning=True)
+            assert len(actual_output) == 1 and self.test_folder_1 in actual_output[0].name
+            actual_output = assert_and_filter_first_versioned_listing_line(
                 get_pipe_listing('cp://{}/{}'.format(self.bucket, self.test_folder_1), versioning=True, recursive=True))
-            aws_output = get_aws_object_version_listing(self.bucket, "/".join([self.test_folder_1, self.test_file_1]))
-            compare_listing(pipe_output, aws_output, 2)
-            pipe_storage_restore('cp://{}/{}'.format(self.bucket, self.test_folder_1))
-            pipe_output = get_pipe_listing(self.path_to_bucket)
-            assert len(pipe_output) == 1 and self.test_folder_1 in pipe_output[0].name
-            pipe_output = assert_and_filter_first_versioned_listing_line(
+            expected_output = [
+                f('{}/{}'.format(self.test_folder_1, self.test_file_1), deleted=True, latest=True),
+                f('{}/{}'.format(self.test_folder_1, self.test_file_1), 10, added=True)
+            ]
+            compare_listing(actual_output, expected_output, 2)
+            pipe_storage_restore('cp://{}/{}'.format(self.bucket, self.test_folder_1), expected_status=0)
+            actual_output = get_pipe_listing(self.path_to_bucket)
+            assert len(actual_output) == 1 and self.test_folder_1 in actual_output[0].name
+            actual_output = assert_and_filter_first_versioned_listing_line(
                 get_pipe_listing('cp://{}/{}'.format(self.bucket, self.test_folder_1), versioning=True, recursive=True))
-            aws_output = get_aws_object_version_listing(self.bucket, "/".join([self.test_folder_1, self.test_file_1]))
-            compare_listing(pipe_output, aws_output, 1)
+            expected_output = [
+                f('{}/{}'.format(self.test_folder_1, self.test_file_1), 10, added=True),
+                f('{}/{}'.format(self.test_folder_1, self.test_file_1), 10, added=True, latest=True)
+            ]
+            compare_listing(actual_output, expected_output, 2)
         except BaseException as e:
             pytest.fail(ERROR_MESSAGE + "epmcmbibpc-885-886:" + "\n" + e.message)
 
@@ -189,13 +216,13 @@ class TestDataStorageVersioning(object):
             pipe_storage_cp(os.path.abspath(self.test_file_1), destination_2)
             pipe_storage_rm('cp://{}/{}'.format(self.bucket, self.test_folder_1), args=['--hard-delete'],
                             recursive=True)
-            pipe_output = get_pipe_listing('cp://{}/{}'.format(self.bucket, self.test_folder_1))
-            assert len(pipe_output) == 0
-            pipe_output = assert_and_filter_first_versioned_listing_line(
+            actual_output = get_pipe_listing('cp://{}/{}'.format(self.bucket, self.test_folder_1))
+            assert len(actual_output) == 0
+            actual_output = assert_and_filter_first_versioned_listing_line(
                 get_pipe_listing('cp://{}/{}'.format(self.bucket, self.test_folder_1), versioning=True),
                 result_not_empty=False)
-            aws_output = get_aws_object_version_listing(self.bucket, "/".join([self.test_folder_1, self.test_file_1]))
-            compare_listing(pipe_output, aws_output, 0)
+            expected_output = []
+            compare_listing(actual_output, expected_output, 0)
         except BaseException as e:
             pytest.fail(ERROR_MESSAGE + "epmcmbibpc-887:" + "\n" + e.message)
 
@@ -206,24 +233,30 @@ class TestDataStorageVersioning(object):
             pipe_storage_cp(os.path.abspath(self.test_file_1), destination_1)
             pipe_storage_cp(os.path.abspath(self.test_file_1), destination_2)
             pipe_storage_rm('cp://{}/{}'.format(self.bucket, self.test_folder_1), recursive=True)
-            pipe_output = get_pipe_listing(self.path_to_bucket)
-            assert len(pipe_output) == 0
-            pipe_output = get_pipe_listing(self.path_to_bucket, versioning=True)
-            assert len(pipe_output) == 1 and self.test_folder_1 in pipe_output[0].name
-            pipe_output = assert_and_filter_first_versioned_listing_line(
+            actual_output = get_pipe_listing(self.path_to_bucket)
+            assert len(actual_output) == 0
+            actual_output = get_pipe_listing(self.path_to_bucket, versioning=True)
+            assert len(actual_output) == 1 and self.test_folder_1 in actual_output[0].name
+            actual_output = assert_and_filter_first_versioned_listing_line(
                 get_pipe_listing('cp://{}/{}'.format(self.bucket, self.test_folder_1), versioning=True, recursive=True))
-            aws_output = get_aws_object_version_listing(self.bucket, self.test_folder_1)
-            compare_listing(pipe_output, aws_output, 4)
+            expected_output = [
+                f('{}/{}'.format(self.test_folder_1, self.test_file_1), deleted=True, latest=True),
+                f('{}/{}'.format(self.test_folder_1, self.test_file_1), 10, added=True),
+                f('{}/{}/{}'.format(self.test_folder_1, self.test_folder_2, self.test_file_1),
+                  deleted=True, latest=True),
+                f('{}/{}/{}'.format(self.test_folder_1, self.test_folder_2, self.test_file_1), 10, added=True)
+            ]
+            compare_listing(actual_output, expected_output, 4)
 
             pipe_storage_rm('cp://{}/{}'.format(self.bucket, self.test_folder_1), args=['--hard-delete'],
                             recursive=True)
-            pipe_output = get_pipe_listing('cp://{}/{}'.format(self.bucket, self.test_folder_1))
-            assert len(pipe_output) == 0
-            pipe_output = assert_and_filter_first_versioned_listing_line(
+            actual_output = get_pipe_listing('cp://{}/{}'.format(self.bucket, self.test_folder_1))
+            assert len(actual_output) == 0
+            actual_output = assert_and_filter_first_versioned_listing_line(
                 get_pipe_listing('cp://{}/{}'.format(self.bucket, self.test_folder_1), versioning=True),
                 result_not_empty=False)
-            aws_output = get_aws_object_version_listing(self.bucket, "/".join([self.test_folder_1, self.test_file_1]))
-            compare_listing(pipe_output, aws_output, 0)
+            expected_output = []
+            compare_listing(actual_output, expected_output, 0)
         except BaseException as e:
             pytest.fail(ERROR_MESSAGE + "epmcmbibpc-998:" + "\n" + e.message)
 
@@ -259,7 +292,7 @@ class TestDataStorageVersioning(object):
         try:
             pipe_storage_cp(self.test_file_1, destination)
             error_message = pipe_storage_restore(destination, expected_status=1)[1]
-            assert 'Error: Latest version in the buckets is not a delete marker. Please specify "--version" parameter.'\
+            assert 'Error: Latest file version is not deleted. Please specify "--version" parameter.'\
                    in error_message[0]
         except BaseException as e:
             pytest.fail(ERROR_MESSAGE + "epmcmbibpc-948:" + "\n" + e.message)
@@ -271,7 +304,7 @@ class TestDataStorageVersioning(object):
             pipe_output = assert_and_filter_first_versioned_listing_line(
                 get_pipe_listing(destination, versioning=True))
             version_id = get_latest_version(pipe_output)
-            error_message = pipe_storage_restore(destination, version=version_id, expected_status=0)[1]
+            error_message = pipe_storage_restore(destination, version=version_id, expected_status=1)[1]
             assert 'Version "{}" is already the latest version'.format(version_id)\
                    in error_message[0]
         except BaseException as e:
@@ -298,11 +331,13 @@ class TestDataStorageVersioning(object):
             set_storage_permission(self.user, self.bucket, allow='w')
             pipe_storage_cp(self.test_file_1, destination, token=self.token, expected_status=0)
             pipe_storage_cp(self.test_file_2, destination, force=True, token=self.token, expected_status=0)
-            pipe_output = get_pipe_listing(self.path_to_bucket, token=self.token)
-            aws_output = get_listing(self.bucket, self.test_file_1)
-            compare_listing(pipe_output, aws_output, 1)
-            pipe_output = pipe_storage_ls(self.path_to_bucket, expected_status=1, token=self.token, versioning=True)[1]
-            assert "Access is denied" in pipe_output[0]
+            actual_output = get_pipe_listing(self.path_to_bucket, token=self.token)
+            expected_output = [
+                f(self.test_file_1, 10)
+            ]
+            compare_listing(actual_output, expected_output, 1)
+            actual_output = pipe_storage_ls(self.path_to_bucket, expected_status=1, token=self.token, versioning=True)[1]
+            assert "Access is denied" in actual_output[0]
         except BaseException as e:
             pytest.fail(ERROR_MESSAGE + "epmcmbibpc-891:" + "\n" + e.message)
 

--- a/e2e/cli/common_utils/pipe_cli.py
+++ b/e2e/cli/common_utils/pipe_cli.py
@@ -79,12 +79,12 @@ def pipe_storage_rm(source, recursive=False, args=None, expected_status=0, token
 
 
 def create_data_storage(bucket_name, path=None, versioning=False, token=None, expected_status=0,
-                        folder=None, sts="", lts="", backup_duration=""):
+                        folder=None, sts="", lts="", backup_duration="", region_id="default"):
     provider = os.environ['CP_PROVIDER']
     path = path if path else bucket_name
     command = ['pipe', 'storage', 'create', '--name', bucket_name, '-c', '--path', path,
                "-d", "The test bucket for integration testing", "-sts", sts, "-lts", lts, "-t", provider,
-               "-b", backup_duration]
+               "-b", backup_duration, "-r", region_id]
     if folder:
         command.extend(["-f", str(folder)])
     else:

--- a/e2e/cli/requirements.txt
+++ b/e2e/cli/requirements.txt
@@ -1,3 +1,5 @@
 pytest
 boto3
-azure==4.0.0
+azure-storage-blob==1.5.0
+google-cloud-storage==1.14.0
+tzlocal==1.5.1

--- a/e2e/cli/tag/test_tag.py
+++ b/e2e/cli/tag/test_tag.py
@@ -18,7 +18,7 @@ from assertion_utils import *
 from common_utils.entity_managers import EntityManager
 from common_utils.pipe_cli import *
 
-ERROR_MESSAGE = "An error accrued in case "
+ERROR_MESSAGE = "An error occurred in case "
 PIPELINE = 'pipeline'
 FOLDER = 'folder'
 DATA_STORAGE = 'data_storage'

--- a/pipe-cli/src/api/data_storage.py
+++ b/pipe-cli/src/api/data_storage.py
@@ -65,6 +65,8 @@ class DataStorage(API):
             return None
         storages = DataStorage.list()
         for storage in storages:
+            if storage.name is not None and storage.name.lower() == name.lower():
+                return storage
             if storage.path is not None and storage.path.lower() == name.lower():
                 return storage
         raise ValueError("Datastorage with name {} does not exist!".format(name))

--- a/pipe-cli/src/utilities/storage/s3.py
+++ b/pipe-cli/src/utilities/storage/s3.py
@@ -298,7 +298,7 @@ class RestoreManager(StorageItemManager, AbstractRestoreManager):
             for item in page['DeleteMarkers']:
                 if 'IsLatest' in item and item['IsLatest']:
                     return item
-        raise RuntimeError('Latest version in the buckets is not a delete marker. Please specify "--version" parameter.')
+        raise RuntimeError('Latest file version is not deleted. Please specify "--version" parameter.')
 
 
 class DeleteManager(StorageItemManager, AbstractDeleteManager):


### PR DESCRIPTION
# Summary

Resolves #42 and fixes #104.

Brings support for Google Cloud Provider in pipe-cli storage operations tests. Also it fixes storage deletion issue #104.