### PR TITLE
WDL 'Multiple links into one input are prohibited' error fixed

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,7 @@
     "mobx-react-router": "^3.1.2",
     "moment": "^2.18.1",
     "papaparse": "^4.3.6",
-    "pipeline-builder": "0.3.10-dev.304",
+    "pipeline-builder": "0.3.10-dev.308",
     "prop-types": "^15.5.8",
     "react": "^15.4.2",
     "react-day-picker": "^5.5.3",


### PR DESCRIPTION
This PR fixes 'Multiple links into one input are prohibited' error while editing following workflows:

- gatk/haplotypecaller-gvcf-gatk4
- gatk/processing-for-variant-discovery-gatk4
- gatk/joint-discovery-gatk4
- gatk/pre-processing-hg38-gatk4
- gatk/pre-processing-b37-gatk4

Error occurred for task's input with expressions:
<pre>
workflow WorkflowName {
    ...
    String v1
    String v2
    String v3
    call TaskA {
        input:
            varA = <b>v1 + v2 + v3</b>
    }
    ....
}
....
</pre>

Steps to reproduce:
1. Open such a workflow;
2. Select any task;
3. Open 'Properties' pane;
4. Rename task.

