### PR TITLE
Unified error message for storage tags operations

### DIFF
--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -178,6 +178,8 @@ public final class MessageConstants {
     public static final String ERROR_SHARED_ROOT_URL_IS_NOT_SET = "error.shared.root.url.is.not.set";
     public static final String ERROR_DATASTORAGE_USED_AS_DEFAULT = "error.datastorage.is.used.default";
     public static final String ERROR_DATASTORAGE_FILE_TAG_NOT_EXIST = "error.datastorage.file.tag.not.exist";
+    public static final String ERROR_DATASTORAGE_PATH_NOT_FOUND = "error.datastorage.path.not.found";
+    public static final String ERROR_DATASTORAGE_PATH_ALREADY_EXISTS = "error.datastorage.path.already.exists";
 
     // NFS
     public static final String ERROR_DATASTORAGE_NFS_MOUNT = "error.datastorage.nfs.mount";
@@ -410,19 +412,12 @@ public final class MessageConstants {
     public static final String ERROR_AZURE_INSTANCE_NOT_RUNNING = "error.azure.instance.not.running";
     public static final String ERROR_DATASTORAGE_AZURE_INVALID_ACCOUNT_KEY =
             "error.datastorage.azure.invalid.account.key";
-    public static final String ERROR_DATASTORAGE_AZURE_ITEM_DELETE_FAILED =
-            "error.datastorage.azure.item.delete.failed";
-    public static final String ERROR_DATASTORAGE_AZURE_ITEM_ALREADY_EXISTS =
-            "error.datastorage.azure.item.already.exists";
     public static final String ERROR_DATASTORAGE_AZURE_CREATE_FILE = "error.datastorage.azure.create.file";
 
     //GCP
     public static final String ERROR_GCP_PROJECT_REQUIRED = "error.gcp.project.required";
     public static final String ERROR_GCP_IMP_ACC_REQUIRED = "error.gcp.impersonate.account";
     public static final String ERROR_GCP_SSH_KEY_REQUIRED = "error.gcp.ssh.key.required";
-
-    public static final String ERROR_GCP_STORAGE_PATH_NOT_FOUND = "error.gcp.storage.path.not.found";
-    public static final String ERROR_GCP_STORAGE_PATH_ALREADY_EXISTS = "error.gcp.storage.path.already.exists";
 
     public static final String ERROR_GCP_INSTANCE_NOT_RUNNING = "error.gcp.instance.not.running";
     public static final String ERROR_GCP_INSTANCE_NOT_FOUND = "error.gcp.instance.not.found";

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/RegionAwareS3Helper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/RegionAwareS3Helper.java
@@ -18,6 +18,7 @@ package com.epam.pipeline.manager.datastorage.providers.aws.s3;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.entity.region.AwsRegion;
 import com.epam.pipeline.manager.cloud.aws.AWSUtils;
 
@@ -28,7 +29,8 @@ public class RegionAwareS3Helper extends S3Helper {
 
     private final AwsRegion region;
 
-    public RegionAwareS3Helper(final AwsRegion region) {
+    public RegionAwareS3Helper(final AwsRegion region, final MessageHelper messageHelper) {
+        super(messageHelper);
         this.region = region;
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3Helper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3Helper.java
@@ -59,6 +59,8 @@ import com.amazonaws.services.s3.model.lifecycle.LifecycleFilter;
 import com.amazonaws.services.s3.model.lifecycle.LifecyclePrefixPredicate;
 import com.amazonaws.util.IOUtils;
 import com.amazonaws.util.StringUtils;
+import com.epam.pipeline.common.MessageConstants;
+import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorageItem;
 import com.epam.pipeline.entity.datastorage.DataStorageDownloadFileUrl;
@@ -73,6 +75,7 @@ import com.epam.pipeline.entity.datastorage.StoragePolicy;
 import com.epam.pipeline.entity.region.AwsRegion;
 import com.epam.pipeline.manager.datastorage.providers.ProviderUtils;
 import com.epam.pipeline.utils.FileContentUtils;
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.slf4j.Logger;
@@ -103,6 +106,7 @@ import java.util.stream.Collectors;
  * Util class providing methods to interact with AWS S3 API.
  * Uses Default Credential Provider Chain for AWS authorization.
  */
+@RequiredArgsConstructor
 public class S3Helper {
     private static final Logger LOGGER = LoggerFactory.getLogger(S3Helper.class);
 
@@ -114,6 +118,8 @@ public class S3Helper {
     private static final String LTS_RULE_ID = "Long term storage rule";
     private static final String PATH_SHOULD_NOT_BE_EMPTY_MESSAGE = "Path should not be empty";
     private static final Long URL_EXPIRATION = 24 * 60 * 60 * 1000L;
+
+    private final MessageHelper messageHelper;
 
     public AmazonS3 getDefaultS3Client() {
         return AmazonS3ClientBuilder.defaultClient();
@@ -467,7 +473,8 @@ public class S3Helper {
         }
         AmazonS3 client = getDefaultS3Client();
         if (!StringUtils.hasValue(version) && !totally && !itemExists(client, bucket, path, false)) {
-            throw new DataStorageException("File does not exist");
+            throw new DataStorageException(messageHelper
+                    .getMessage(MessageConstants.ERROR_DATASTORAGE_PATH_NOT_FOUND, path, bucket));
         }
         try {
             if (!StringUtils.hasValue(version) && totally) {
@@ -529,10 +536,12 @@ public class S3Helper {
         }
         AmazonS3 client = getDefaultS3Client();
         if (!itemExists(client, bucket, oldPath, false)) {
-            throw new DataStorageException(String.format("File '%s' does not exist", oldPath));
+            throw new DataStorageException(messageHelper
+                    .getMessage(MessageConstants.ERROR_DATASTORAGE_PATH_NOT_FOUND, oldPath, bucket));
         }
         if (itemExists(client, bucket, newPath, false)) {
-            throw new DataStorageException(String.format("File '%s' already exists", newPath));
+            throw new DataStorageException(messageHelper
+                    .getMessage(MessageConstants.ERROR_DATASTORAGE_PATH_ALREADY_EXISTS, newPath, bucket));
         }
         if (fileSizeExceedsLimit(client, bucket, oldPath)) {
             throw new DataStorageException(String.format("File '%s' moving was aborted because " +
@@ -840,7 +849,8 @@ public class S3Helper {
             return convertAwsTagsToMap(client.getObjectTagging(getTaggingRequest).getTagSet());
         } catch (AmazonS3Exception e) {
             if (e.getStatusCode() == NOT_FOUND) {
-                throw new DataStorageException(String.format("Path '%s' doesn't exist", path));
+                throw new DataStorageException(messageHelper
+                        .getMessage(MessageConstants.ERROR_DATASTORAGE_PATH_NOT_FOUND, path, dataStorage.getPath()));
             } else {
                 throw new DataStorageException(e.getMessage(), e);
             }
@@ -850,9 +860,8 @@ public class S3Helper {
     public Map<String, String> deleteObjectTags(AbstractDataStorage dataStorage, String path, Set<String> tagKeys,
                                                 String version) {
         Map<String, String> existingTags = listObjectTags(dataStorage, path, version);
-        tagKeys.forEach(tag -> {
-            Assert.isTrue(existingTags.containsKey(tag), String.format("Tag '%s' doesn't exist", tag));
-        });
+        tagKeys.forEach(tag -> Assert.isTrue(existingTags.containsKey(tag), messageHelper.getMessage(
+                MessageConstants.ERROR_DATASTORAGE_FILE_TAG_NOT_EXIST, tag)));
         existingTags.keySet().removeAll(tagKeys);
         updateObjectTags(dataStorage, path, existingTags, version);
         return existingTags;
@@ -868,7 +877,8 @@ public class S3Helper {
             return downloadContent(maxDownloadSize, objectPortion);
         } catch (AmazonS3Exception e) {
             if (e.getStatusCode() == NOT_FOUND) {
-                throw new DataStorageException(String.format("File '%s' doesn't exist", path));
+                throw new DataStorageException(messageHelper
+                        .getMessage(MessageConstants.ERROR_DATASTORAGE_PATH_NOT_FOUND, path, dataStorage.getPath()));
             } else if (e.getStatusCode() == INVALID_RANGE) {
                 // is thrown in case of en empty file
                 LOGGER.debug(e.getMessage(), e);
@@ -890,7 +900,8 @@ public class S3Helper {
             return new DataStorageStreamingContent(object.getObjectContent(), object.getKey());
         } catch (AmazonS3Exception e) {
             if (e.getStatusCode() == NOT_FOUND) {
-                throw new DataStorageException(String.format("File '%s' doesn't exist", path));
+                throw new DataStorageException(messageHelper
+                        .getMessage(MessageConstants.ERROR_DATASTORAGE_PATH_NOT_FOUND, path, dataStorage.getPath()));
             } else {
                 throw new DataStorageException(e.getMessage(), e);
             }
@@ -951,7 +962,8 @@ public class S3Helper {
         } else if (!listing.getObjectSummaries().isEmpty()) {
             return DataStorageItemType.File;
         } else {
-            throw new IllegalArgumentException(String.format("Path '%s' does not exist", path));
+            throw new IllegalArgumentException(messageHelper
+                    .getMessage(MessageConstants.ERROR_DATASTORAGE_PATH_NOT_FOUND, path, bucket));
         }
     }
 
@@ -967,7 +979,8 @@ public class S3Helper {
         } else if (!listing.getVersionSummaries().isEmpty()) {
             return DataStorageItemType.File;
         } else {
-            throw new IllegalArgumentException(String.format("Path '%s' does not exist", path));
+            throw new IllegalArgumentException(messageHelper
+                    .getMessage(MessageConstants.ERROR_DATASTORAGE_PATH_NOT_FOUND, path, bucket));
         }
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3StorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3StorageProvider.java
@@ -218,7 +218,7 @@ public class S3StorageProvider implements StorageProvider<S3bucketDataStorage> {
 
     public S3Helper getS3Helper(S3bucketDataStorage dataStorage) {
         AwsRegion region = getAwsRegion(dataStorage);
-        return new RegionAwareS3Helper(region);
+        return new RegionAwareS3Helper(region, messageHelper);
     }
 
     private AwsRegion getAwsRegion(S3bucketDataStorage dataStorage) {

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureStorageHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureStorageHelper.java
@@ -398,11 +398,11 @@ public class AzureStorageHelper {
     private void validatePath(final AzureBlobStorage storage, final String path, final boolean exist) {
         validatePath(path);
         if (exist) {
-            Assert.state(blobExists(storage, path),
-                    messageHelper.getMessage(MessageConstants.ERROR_DATASTORAGE_AZURE_ITEM_DELETE_FAILED, path));
+            Assert.state(blobExists(storage, path), messageHelper
+                    .getMessage(MessageConstants.ERROR_DATASTORAGE_PATH_NOT_FOUND, path, storage.getPath()));
         } else {
-            Assert.state(!blobExists(storage, path),
-                    messageHelper.getMessage(MessageConstants.ERROR_DATASTORAGE_AZURE_ITEM_ALREADY_EXISTS, path));
+            Assert.state(!blobExists(storage, path), messageHelper
+                    .getMessage(MessageConstants.ERROR_DATASTORAGE_PATH_ALREADY_EXISTS, path, storage.getPath()));
         }
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageHelper.java
@@ -324,8 +324,8 @@ public class GSBucketStorageHelper {
     public Map<String, String> deleteMetadata(final GSBucketStorage storage, final String path,
                                               final Set<String> tagsToDelete, final String version) {
         final Map<String, String> existingTags = listMetadata(storage, path, version);
-        tagsToDelete.forEach(tag ->
-            Assert.isTrue(existingTags.containsKey(tag), String.format("Tag '%s' doesn't exist", tag))
+        tagsToDelete.forEach(tag -> Assert.isTrue(existingTags.containsKey(tag), messageHelper.getMessage(
+                MessageConstants.ERROR_DATASTORAGE_FILE_TAG_NOT_EXIST, tag))
         );
         existingTags.keySet().removeAll(tagsToDelete);
         updateMetadata(storage, path, existingTags, version);
@@ -451,14 +451,14 @@ public class GSBucketStorageHelper {
         final BlobId blobId = BlobId.of(bucketName, blobPath,
                 StringUtils.isNotBlank(version) ? Long.valueOf(version) : null);
         final Blob blob = client.get(blobId);
-        Assert.notNull(blob, messageHelper.getMessage(MessageConstants.ERROR_GCP_STORAGE_PATH_NOT_FOUND, blobPath,
+        Assert.notNull(blob, messageHelper.getMessage(MessageConstants.ERROR_DATASTORAGE_PATH_NOT_FOUND, blobPath,
                 bucketName));
         return blob;
     }
 
     private void checkBlobDoesNotExist(final String bucketName, final String blobPath, final Storage client) {
         final Blob blob = client.get(bucketName, blobPath);
-        Assert.isNull(blob, messageHelper.getMessage(MessageConstants.ERROR_GCP_STORAGE_PATH_ALREADY_EXISTS, blobPath,
+        Assert.isNull(blob, messageHelper.getMessage(MessageConstants.ERROR_DATASTORAGE_PATH_ALREADY_EXISTS, blobPath,
                 bucketName));
     }
 

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -174,6 +174,8 @@ error.datastorage.create.failed=Failed to create a new storage: ''{0}''.
 error.datastorage.delete.failed=Failed to delete a storage: ''{0}''.
 error.datastorage.type.not.specified=Data Storage type is not specified for data storage ''{0}''.
 error.datastorage.file.tag.not.exist=Tag ''{0}'' does not exist.
+error.datastorage.path.not.found=Storage path ''{0}'' for bucket ''{1}'' does not exist.
+error.datastorage.path.already.exists=Storage path ''{0}'' for bucket ''{1}'' already exists.
 
 error.datastorage.nfs.mount=Could not mount nfs ''{0}'' with path: ''{1}''
 error.datastorage.nfs.mount.2=Could not mount nfs: ''{0}'' : ''{1}''
@@ -383,17 +385,12 @@ error.azure.storage.key.required=Storage account key must be specified.
 error.azure.instance.not.found=Failed to find Azure instance with id {0}.
 error.azure.instance.not.running=Azure instance {0} is not in active state. Current state: {1}.
 error.datastorage.azure.invalid.account.key=Azure account key for account name ''{0}'' is invalid.
-error.datastorage.azure.item.delete.failed=Azure item ''{0}'' does not exist.
-error.datastorage.azure.item.already.exists=Error: azure item ''{0}'' already exists.
 error.datastorage.azure.create.file=Could not create a file in azure: {0}.
 
 #GCP
 error.gcp.project.required=Project id must be specified for GCP region.
 error.gcp.ssh.key.required=Path to public SSH key must be specified for GCP region.
 error.gcp.impersonate.account=Impersonated account for temporary credentials must be specified.
-
-error.gcp.storage.path.not.found=Google Storage path ''{0}'' for bucket ''{1}'' not found
-error.gcp.storage.path.already.exists=Google Storage path ''{0}'' for bucket ''{1}'' already exists
 
 error.gcp.instance.not.running=GCP instance ''{0}'' is not in active state. Current state: ''{1}''
 error.gcp.instance.not.found=Instance with label ''{0}'' not found!

--- a/api/src/test/java/com/epam/pipeline/manager/MockS3Helper.java
+++ b/api/src/test/java/com/epam/pipeline/manager/MockS3Helper.java
@@ -26,6 +26,10 @@ import java.util.Map;
 
 public class MockS3Helper extends S3Helper {
 
+    public MockS3Helper() {
+        super(null);
+    }
+
     @Override public String createS3Bucket(String name,
                                            String policy,
                                            List<CORSRule> corsRulesFile,

--- a/api/src/test/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3HelperTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3HelperTest.java
@@ -23,6 +23,7 @@ import com.amazonaws.services.s3.model.ListObjectsRequest;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.entity.datastorage.DataStorageException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -56,7 +57,8 @@ public class S3HelperTest {
     private static final String SIZE_EXCEEDS_EXCEPTION_MESSAGE = "size exceeds the limit";
 
     private final AmazonS3 amazonS3 = mock(AmazonS3.class);
-    private final S3Helper helper = spy(new S3Helper());
+    private final MessageHelper messageHelper = mock(MessageHelper.class);
+    private final S3Helper helper = spy(new S3Helper(messageHelper));
 
     @Before
     public void setUp() {
@@ -100,7 +102,7 @@ public class S3HelperTest {
                                                       "8.10.249.0/24", "77.75.64.0/23", "77.75.66.0/23",
                                                       "193.202.91.0/24");
 
-        S3Helper helper = new S3Helper();
+        S3Helper helper = new S3Helper(messageHelper);
         ObjectMapper objectMapper = new ObjectMapper();
 
         String populatedPolicyString = helper.populateBucketPolicy("testBucket", policyStr, testAllowedCidrs, true);


### PR DESCRIPTION
Resolves issue #76 
The common message `Storage path 'not_existing_path' for bucket 'bucket_name' does not exist` for all providers introduced.