### PR TITLE
NPE on missing cmd template

### DIFF
--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -133,6 +133,7 @@ public final class MessageConstants {
     public static final String ERROR_RUN_PRETTY_URL_IN_USE = "error.pipeline.run.pretty.url.in.use";
     public static final String ERROR_EXCEED_MAX_RESTART_RUN_COUNT = "error.exceed.max.restart.run.count";
     public static final String ERROR_GET_NODE_STAT = "error.get.node.stat";
+    public static final String ERROR_CMD_TEMPLATE_NOT_RESOLVED = "error.cmd.template.not.resolved";
 
     // PodMonitor messages
     public static final String DEBUG_MONITOR_CHECK_RUNNING = "debug.monitor.check.running";

--- a/api/src/main/java/com/epam/pipeline/manager/execution/PipelineLauncher.java
+++ b/api/src/main/java/com/epam/pipeline/manager/execution/PipelineLauncher.java
@@ -16,6 +16,8 @@
 
 package com.epam.pipeline.manager.execution;
 
+import com.epam.pipeline.common.MessageConstants;
+import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.config.Constants;
 import com.epam.pipeline.entity.cluster.EnvVarsSettings;
 import com.epam.pipeline.entity.configuration.PipelineConfiguration;
@@ -40,6 +42,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 import java.text.SimpleDateFormat;
@@ -90,6 +93,9 @@ public class PipelineLauncher {
     @Autowired
     private CloudFacade cloudFacade;
 
+    @Autowired
+    private MessageHelper messageHelper;
+
     private final SimpleDateFormat dateFormat = new SimpleDateFormat(Constants.SIMPLE_DATE_FORMAT);
     private final SimpleDateFormat timeFormat = new SimpleDateFormat(Constants.SIMPLE_TIME_FORMAT);
 
@@ -112,6 +118,8 @@ public class PipelineLauncher {
         List<EnvVar> envVars = EnvVarsBuilder.buildEnvVars(run, configuration, systemParams,
                 buildRegionSpecificEnvVars(run.getInstance().getCloudRegionId()));
 
+        Assert.isTrue(!StringUtils.isEmpty(configuration.getCmdTemplate()), messageHelper.getMessage(
+                MessageConstants.ERROR_CMD_TEMPLATE_NOT_RESOLVED));
         String pipelineCommand = commandBuilder.build(configuration, systemParams);
         String gitCloneUrl = Optional.ofNullable(gitCredentials).map(GitCredentials::getUrl)
                 .orElse(run.getRepository());

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -101,6 +101,7 @@ error.pipeline.run.pretty.url.in.use=Url ''{0}'' is already used for run ''{1}''
 error.exceed.max.restart.run.count=Error: exceeded allowed number of restart for run ''{0}''.
 error.get.node.stat=Failed to get node stat for node ''{0}''
 error.run.instance.disk.not.enough=Not enough instance disk to save docker images.
+error.cmd.template.not.resolved=No cmd template was resolved for the run.
 
 #Tools
 error.tool.not.found=Tool with requested id: ''{0}'' was not found.

--- a/pipe-cli/src/utilities/pipeline_run_operations.py
+++ b/pipe-cli/src/utilities/pipeline_run_operations.py
@@ -189,10 +189,11 @@ class PipelineRunOperations(object):
             elif parameters:
                 if not quiet:
                     click.echo('You must specify pipeline for listing parameters', err=True)
-            elif docker_image is None or parent_node is None and (instance_type is None or instance_disk is None):
+            elif docker_image is None or parent_node is None \
+                    and (instance_type is None or instance_disk is None or cmd_template is None):
                 if not quiet:
-                    click.echo('Docker image, instance type and instance disk are required parameters '
-                               'if pipeline was not provided.')
+                    click.echo('Docker image, instance type, instance disk and cmd template '
+                               'are required parameters if pipeline was not provided.')
                 else:
                     required_parameters = []
                     if docker_image is None:
@@ -201,6 +202,8 @@ class PipelineRunOperations(object):
                         required_parameters.append('instance_type')
                     if instance_disk is None:
                         required_parameters.append('instance_disk')
+                    if cmd_template is None:
+                        required_parameters.append('cmd_template')
                     click.echo(', '.join(required_parameters))
                     sys.exit(1)
             else:

--- a/pipe-cli/tests/test_pipe.py
+++ b/pipe-cli/tests/test_pipe.py
@@ -336,7 +336,8 @@ class TestRun(object):
                   text=mock_price(instance_disk, instance_type))
         mock.post(mocked_url('run'), text=mock_run(pipeline_id, docker_image=docker_image, identifier=run_id))
         expected_stdout = \
-            "Docker image, instance type and instance disk are required parameters if pipeline was not provided.\n"
+            "Docker image, instance type, instance disk and cmd template are required parameters " \
+            "if pipeline was not provided.\n"
         actual_stdout = get_stdout_string(
             lambda: PipelineRunOperations.run(None, None, self.parameters, self.yes, self.run_params,
                                               None, None, None, self.cmd_template, self.timeout,


### PR DESCRIPTION
## Summary

Resolves #88.

The pull request makes the `cmd` argument mandatory for launching tools in `pipe-cli`. Also it adds proper error message on backend if launching tool does not have default `cmd_template` and it is not given explicitly.