### PR TITLE
GCP extended custom memory price

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPResourceType.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPResourceType.java
@@ -19,6 +19,12 @@ package com.epam.pipeline.manager.cloud.gcp;
 public enum GCPResourceType {
     CPU,
     RAM,
+    EXTENDED_RAM {
+        @Override
+        public String alias() {
+            return super.alias().replace("_", "");
+        }
+    },
     GPU,
     DISK {
         @Override

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/extractor/GCPCustomMachineExtractor.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/extractor/GCPCustomMachineExtractor.java
@@ -35,24 +35,29 @@ import java.util.stream.Collectors;
 @Component
 public class GCPCustomMachineExtractor implements GCPObjectExtractor {
 
+    private static final int MEGABYTES_IN_GIGABYTE = 1024;
     private static final String CUSTOM_FAMILY = "custom";
+    private static final double EXTENDED_FACTOR = 6.5;
 
     @Override
     public List<AbstractGCPObject> extract(final GCPRegion region) {
         return CollectionUtils.emptyIfNull(region.getCustomInstanceTypes())
                 .stream()
                 .filter(type -> type.getCpu() > 0 && type.getRam() >= 0)
-                .map(type -> {
-                    if (type.getGpu() > 0 && StringUtils.isNotBlank(type.getGpuType())) {
-                        final String name = gpuCustomGpuMachine(type);
-                        return new GCPMachine(name, CUSTOM_FAMILY, type.getCpu(), type.getRam(), type.getGpu(),
-                                type.getGpuType());
-                    } else {
-                        final String name = customCpuMachine(type);
-                        return new GCPMachine(name, CUSTOM_FAMILY, type.getCpu(), type.getRam(), 0, null);
-                    }
-                })
+                .map(this::toGcpMachine)
                 .collect(Collectors.toList());
+    }
+
+    private GCPMachine toGcpMachine(final GCPCustomInstanceType type) {
+        final String name = type.getGpu() > 0 && StringUtils.isNotBlank(type.getGpuType())
+                ? gpuCustomGpuMachine(type)
+                : customCpuMachine(type);
+        final double extendedMemory = type.getRam() / type.getCpu() > EXTENDED_FACTOR
+                ? type.getRam() - type.getCpu() * EXTENDED_FACTOR
+                : 0.0;
+        final double defaultMemory = type.getRam() - extendedMemory;
+        return new GCPMachine(name, CUSTOM_FAMILY, type.getCpu(), defaultMemory, extendedMemory,
+                type.getGpu(), type.getGpuType());
     }
 
     private String gpuCustomGpuMachine(final GCPCustomInstanceType type) {
@@ -61,6 +66,6 @@ public class GCPCustomMachineExtractor implements GCPObjectExtractor {
     }
 
     private String customCpuMachine(final GCPCustomInstanceType type) {
-        return String.format("%s-%s-%s", CUSTOM_FAMILY, type.getCpu(), (int) (type.getRam() * 1024));
+        return String.format("%s-%s-%s", CUSTOM_FAMILY, type.getCpu(), (int) (type.getRam() * MEGABYTES_IN_GIGABYTE));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/extractor/GCPPredefinedMachineExtractor.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/extractor/GCPPredefinedMachineExtractor.java
@@ -80,7 +80,7 @@ public class GCPPredefinedMachineExtractor implements GCPObjectExtractor {
         final String name = machineType.getName();
         final String family = elements[1];
         if (elements.length == 2) {
-            return Optional.of(new GCPMachine(name, family, 1, 0, 0, null));
+            return Optional.of(GCPMachine.withCpu(name, family, 1, 0, 0));
         }
         if (elements.length == 3) {
             try {
@@ -88,7 +88,7 @@ public class GCPPredefinedMachineExtractor implements GCPObjectExtractor {
                 final double memory = new BigDecimal((double) machineType.getMemoryMb() / 1024)
                         .setScale(2, RoundingMode.HALF_EVEN)
                         .doubleValue();
-                return Optional.of(new GCPMachine(name, family, cpu, memory, 0, null));
+                return Optional.of(GCPMachine.withCpu(name, family, cpu, memory, 0));
             } catch (NumberFormatException e) {
                 log.warn(String.format("GCP Machine Type name '%s' parsing has failed.", machineType), e);
                 return Optional.empty();

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/resource/GCPMachine.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/resource/GCPMachine.java
@@ -21,27 +21,54 @@ import com.epam.pipeline.manager.cloud.CloudInstancePriceService;
 import com.epam.pipeline.manager.cloud.gcp.GCPBilling;
 import com.epam.pipeline.manager.cloud.gcp.GCPResourcePrice;
 import com.epam.pipeline.manager.cloud.gcp.GCPResourceType;
-import lombok.Getter;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.text.WordUtils;
 
 import java.util.Date;
 import java.util.List;
 
-@Getter
+@Value
+@EqualsAndHashCode(callSuper = true)
 public class GCPMachine extends AbstractGCPObject {
     private final int cpu;
     private final double ram;
+    private final double extendedRam;
     private final int gpu;
     private final String gpuType;
 
-    public GCPMachine(final String name, final String family, final int cpu, final double ram, final int gpu,
+    public GCPMachine(final String name,
+                      final String family,
+                      final int cpu,
+                      final double ram,
+                      final double extendedRam,
+                      final int gpu,
                       final String gpuType) {
         super(name, family);
         this.cpu = cpu;
         this.ram = ram;
+        this.extendedRam = extendedRam;
         this.gpu = gpu;
         this.gpuType = gpuType;
+    }
+
+    public static GCPMachine withCpu(final String name,
+                                     final String family,
+                                     final int cpu,
+                                     final double ram,
+                                     final double extendedRam) {
+        return new GCPMachine(name, family, cpu, ram, extendedRam, 0, null);
+    }
+
+    public static GCPMachine withGpu(final String name,
+                                     final String family,
+                                     final int cpu,
+                                     final double ram,
+                                     final double extendedRam,
+                                     final int gpu,
+                                     final String gpuType) {
+        return new GCPMachine(name, family, cpu, ram, extendedRam, gpu, gpuType);
     }
 
     @Override
@@ -73,6 +100,8 @@ public class GCPMachine extends AbstractGCPObject {
                 return cpu > 0;
             case RAM:
                 return ram > 0;
+            case EXTENDED_RAM:
+                return extendedRam > 0;
             case GPU:
                 return gpu > 0 && StringUtils.isNotBlank(gpuType);
             default:
@@ -89,6 +118,8 @@ public class GCPMachine extends AbstractGCPObject {
                             return cpu * price.getNanos();
                         case RAM:
                             return Math.round(ram * price.getNanos());
+                        case EXTENDED_RAM:
+                            return Math.round(extendedRam * price.getNanos());
                         case GPU:
                             return gpu * price.getNanos();
                         default:

--- a/api/src/test/java/com/epam/pipeline/manager/cloud/gcp/CustomGCPObjectExtractorTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cloud/gcp/CustomGCPObjectExtractorTest.java
@@ -35,14 +35,21 @@ import static org.junit.Assert.assertThat;
 public class CustomGCPObjectExtractorTest {
 
     private static final double DELTA = 0.01;
+    private static final int CPU = 1;
+    private static final double RAM = 2.0;
+    private static final double EXTENDED_RAM = 2.0;
+    private static final double EXTENDED_RAM_FACTOR = 6.5;
+    private static final int GPU = 3;
+    private static final String K_80 = "K80";
+    public static final String CUSTOM_FAMILY = "custom";
 
     private final GCPObjectExtractor extractor = new GCPCustomMachineExtractor();
 
     @Test
     public void testCustomCpuMachineExtraction() {
         final GCPRegion region = new GCPRegion();
-        region.setCustomInstanceTypes(Collections.singletonList(GCPCustomInstanceType.withCpu(1, 2)));
-        final GCPMachine expectedMachine = GCPMachine.withCpu("custom-1-2048", "custom", 1, 2.0, 0);
+        region.setCustomInstanceTypes(Collections.singletonList(GCPCustomInstanceType.withCpu(CPU, RAM)));
+        final GCPMachine expectedMachine = GCPMachine.withCpu("custom-1-2048", CUSTOM_FAMILY, CPU, RAM, 0);
 
         final List<AbstractGCPObject> actualMachines = extractor.extract(region);
 
@@ -55,8 +62,9 @@ public class CustomGCPObjectExtractorTest {
     @Test
     public void testCustomGpuMachineExtraction() {
         final GCPRegion region = new GCPRegion();
-        region.setCustomInstanceTypes(Collections.singletonList(GCPCustomInstanceType.withGpu(1, 2, 3, "K80")));
-        final GCPMachine expectedMachine = GCPMachine.withGpu("gpu-custom-1-2048-k80-3", "custom", 1, 2, 0, 3, "K80");
+        region.setCustomInstanceTypes(Collections.singletonList(GCPCustomInstanceType.withGpu(CPU, RAM, GPU, K_80)));
+        final GCPMachine expectedMachine = GCPMachine.withGpu("gpu-custom-1-2048-k80-3", CUSTOM_FAMILY, CPU, RAM, 0,
+                GPU, K_80);
 
         final List<AbstractGCPObject> actualMachines = extractor.extract(region);
 
@@ -69,8 +77,10 @@ public class CustomGCPObjectExtractorTest {
     @Test
     public void testExtendedCustomMachineExtraction() {
         final GCPRegion region = new GCPRegion();
-        region.setCustomInstanceTypes(Collections.singletonList(GCPCustomInstanceType.withCpu(2, 15)));
-        final GCPMachine expectedMachine = GCPMachine.withCpu("gpu-custom-1-2048-k80-3", "custom", 2, 13, 2);
+        region.setCustomInstanceTypes(Collections.singletonList(GCPCustomInstanceType.withCpu(2 * CPU,
+                EXTENDED_RAM_FACTOR * 2 + EXTENDED_RAM)));
+        final GCPMachine expectedMachine = GCPMachine.withCpu("gpu-custom-1-2048-k80-3", CUSTOM_FAMILY, 2 * CPU,
+                EXTENDED_RAM_FACTOR * 2, EXTENDED_RAM);
 
         final List<AbstractGCPObject> actualMachines = extractor.extract(region);
 

--- a/api/src/test/java/com/epam/pipeline/manager/cloud/gcp/CustomGCPObjectExtractorTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cloud/gcp/CustomGCPObjectExtractorTest.java
@@ -27,36 +27,63 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.List;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class CustomGCPObjectExtractorTest {
 
-    private GCPObjectExtractor extractor = new GCPCustomMachineExtractor();
+    private static final double DELTA = 0.01;
+
+    private final GCPObjectExtractor extractor = new GCPCustomMachineExtractor();
 
     @Test
     public void testCustomCpuMachineExtraction() {
         final GCPRegion region = new GCPRegion();
         region.setCustomInstanceTypes(Collections.singletonList(GCPCustomInstanceType.withCpu(1, 2)));
-        final List<GCPMachine> expectedMachines = Collections.singletonList(
-                new GCPMachine("custom-1-2048", "custom", 1, 2, 0, null));
+        final GCPMachine expectedMachine = GCPMachine.withCpu("custom-1-2048", "custom", 1, 2.0, 0);
 
         final List<AbstractGCPObject> actualMachines = extractor.extract(region);
 
         assertThat(actualMachines.size(), is(1));
-        assertThat(actualMachines, is(expectedMachines));
+        final AbstractGCPObject actualObject = actualMachines.get(0);
+        assertThat(actualObject, instanceOf(GCPMachine.class));
+        assertMachineEquals(expectedMachine, (GCPMachine) actualObject);
     }
 
     @Test
     public void testCustomGpuMachineExtraction() {
         final GCPRegion region = new GCPRegion();
         region.setCustomInstanceTypes(Collections.singletonList(GCPCustomInstanceType.withGpu(1, 2, 3, "K80")));
-        final List<GCPMachine> expectedMachines = Collections.singletonList(
-                new GCPMachine("gpu-custom-1-2048-k80-3", "custom", 1, 2, 3, "K80"));
+        final GCPMachine expectedMachine = GCPMachine.withGpu("gpu-custom-1-2048-k80-3", "custom", 1, 2, 0, 3, "K80");
 
         final List<AbstractGCPObject> actualMachines = extractor.extract(region);
 
         assertThat(actualMachines.size(), is(1));
-        assertThat(actualMachines, is(expectedMachines));
+        final AbstractGCPObject actualObject = actualMachines.get(0);
+        assertThat(actualObject, instanceOf(GCPMachine.class));
+        assertMachineEquals(expectedMachine, (GCPMachine) actualObject);
+    }
+
+    @Test
+    public void testExtendedCustomMachineExtraction() {
+        final GCPRegion region = new GCPRegion();
+        region.setCustomInstanceTypes(Collections.singletonList(GCPCustomInstanceType.withCpu(2, 15)));
+        final GCPMachine expectedMachine = GCPMachine.withCpu("gpu-custom-1-2048-k80-3", "custom", 2, 13, 2);
+
+        final List<AbstractGCPObject> actualMachines = extractor.extract(region);
+
+        assertThat(actualMachines.size(), is(1));
+        final AbstractGCPObject actualObject = actualMachines.get(0);
+        assertThat(actualObject, instanceOf(GCPMachine.class));
+        assertMachineEquals(expectedMachine, (GCPMachine) actualObject);
+    }
+
+    private void assertMachineEquals(final GCPMachine expectedMachine, final GCPMachine actualMachine) {
+        assertEquals(actualMachine.getCpu(), expectedMachine.getCpu());
+        assertEquals(actualMachine.getRam(), expectedMachine.getRam(), DELTA);
+        assertEquals(actualMachine.getExtendedRam(), expectedMachine.getExtendedRam(), DELTA);
+        assertEquals(actualMachine.getGpu(), expectedMachine.getGpu());
     }
 }

--- a/deploy/contents/install/cloud-configs/gcp/other/gcp.sku.mapping.json
+++ b/deploy/contents/install/cloud-configs/gcp/other/gcp.sku.mapping.json
@@ -55,6 +55,10 @@
     "prefix": "Custom Instance Ram",
     "group": "RAM"
   },
+  "extendedram_ondemand_custom": {
+    "prefix": "Custom Extended Instance Ram",
+    "group": "RAM"
+  },
   "gpu_ondemand_t4": {
     "prefix": "Nvidia Tesla T4 GPU running",
     "group": "GPU"
@@ -129,6 +133,10 @@
   },
   "ram_preemptible_custom": {
     "prefix": "Preemptible Custom Instance Ram",
+    "group": "RAM"
+  },
+  "extendedram_preemptible_custom": {
+    "prefix": "Preemptible Custom Extended Instance Ram",
     "group": "RAM"
   },
   "gpu_preemptible_t4": {


### PR DESCRIPTION
## Summary

Resolves #101.

The pull request improves billing for custom instance types with extended memory. Additional billing resource type was added `extendedram`. Therefore `gcp.sku.mapping` preference should be updated including mappings for extended ram billings.

Example of an extended memory mappings:
```
{
    ...
    "extendedram_ondemand_custom": {
        "prefix": "Custom Extended Instance Ram",
        "group": "RAM"
    },
    "extendedram_preemptible_custom": {
        "prefix": "Preemptible Custom Extended Instance Ram",
        "group": "RAM"
    }
}
```