### PR TITLE
Add resource monitoring security context

### DIFF
--- a/api/src/main/java/com/epam/pipeline/app/AppMVCConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/AppMVCConfiguration.java
@@ -37,9 +37,9 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 public class AppMVCConfiguration extends WebMvcConfigurerAdapter {
 
     private static final String[] CACHED_RESOURCES_PATH =
-            {"/iconfont/**", "/static/css/*.css", "/static/js/*.js"};
+        {"/iconfont/**", "/static/css/*.css", "/static/js/*.js"};
     private static final String[] CACHED_RESOURCES_LOCATION =
-            {"classpath:static/iconfont/", "classpath:static/static/css/", "classpath:static/static/js/"};
+        {"classpath:static/iconfont/", "classpath:static/static/css/", "classpath:static/static/js/"};
 
     @Override
     public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -90,6 +90,8 @@ public final class MessageConstants {
     public static final String DEBUG_DOCKER_REGISTRY_AUTO_ENABLE = "debug.docker.registry.auto.enable";
     public static final String DEBUG_DOCKER_REGISTRY_AUTO_ENABLE_SUCCESS = "debug.docker.registry.auto.enable.success";
     public static final String ERROR_DOCKER_REGISTRY_NO_EXTERNAL = "error.docker.registry.no.external";
+    public static final String ERROR_DOCKER_REGISTRY_AUTHENTICATION_REQUIRED =
+            "error.docker.registry.authentication.required";
     // Registry access
     public static final String ERROR_REGISTRY_IS_NOT_ALLOWED = "error.registry.not.allowed";
     public static final String ERROR_REGISTRY_ACTION_IS_NOT_ALLOWED = "error.registry.action.not.allowed";

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
@@ -30,12 +30,14 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import javax.annotation.PostConstruct;
 
-import lombok.RequiredArgsConstructor;
+import com.epam.pipeline.manager.preference.PreferenceManager;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.math3.util.Precision;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -65,7 +67,6 @@ import io.reactivex.Observable;
  */
 @Service
 @ConditionalOnProperty("monitoring.elasticsearch.url")
-@RequiredArgsConstructor
 @Slf4j
 public class ResourceMonitoringManager extends AbstractSchedulingManager {
     private static final int MILLIS = 1000;
@@ -77,6 +78,23 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
     private final InstanceOfferManager instanceOfferManager;
     private final MonitoringESDao monitoringDao;
     private final MessageHelper messageHelper;
+
+    @Autowired
+    public ResourceMonitoringManager(PipelineRunManager pipelineRunManager,
+                                     PreferenceManager preferenceManager,
+                                     NotificationManager notificationManager,
+                                     InstanceOfferManager instanceOfferManager,
+                                     MonitoringESDao monitoringDao,
+                                     TaskScheduler scheduler,
+                                     MessageHelper messageHelper) {
+        this.pipelineRunManager = pipelineRunManager;
+        this.messageHelper = messageHelper;
+        this.preferenceManager = preferenceManager;
+        this.notificationManager = notificationManager;
+        this.instanceOfferManager = instanceOfferManager;
+        this.monitoringDao = monitoringDao;
+        this.scheduler = scheduler;
+    }
 
     private Map<String, InstanceType> instanceTypeMap = new HashMap<>();
 

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
@@ -30,14 +30,12 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import javax.annotation.PostConstruct;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.math3.util.Precision;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -52,7 +50,6 @@ import com.epam.pipeline.entity.utils.DateUtils;
 import com.epam.pipeline.manager.cluster.InstanceOfferManager;
 import com.epam.pipeline.manager.notification.NotificationManager;
 import com.epam.pipeline.manager.pipeline.PipelineRunManager;
-import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.manager.scheduling.AbstractSchedulingManager;
 import io.reactivex.Observable;
@@ -68,36 +65,20 @@ import io.reactivex.Observable;
  */
 @Service
 @ConditionalOnProperty("monitoring.elasticsearch.url")
+@RequiredArgsConstructor
+@Slf4j
 public class ResourceMonitoringManager extends AbstractSchedulingManager {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ResourceMonitoringManager.class);
-
     private static final int MILLIS = 1000;
     private static final double PERCENT = 100.0;
     private static final double ONE_THOUSANDTH = 0.001;
 
-    private PipelineRunManager pipelineRunManager;
-    private NotificationManager notificationManager;
-    private InstanceOfferManager instanceOfferManager;
-    private MonitoringESDao monitoringDao;
-    private MessageHelper messageHelper;
+    private final PipelineRunManager pipelineRunManager;
+    private final NotificationManager notificationManager;
+    private final InstanceOfferManager instanceOfferManager;
+    private final MonitoringESDao monitoringDao;
+    private final MessageHelper messageHelper;
 
     private Map<String, InstanceType> instanceTypeMap = new HashMap<>();
-
-    @Autowired
-    public ResourceMonitoringManager(PipelineRunManager pipelineRunManager,
-                                     PreferenceManager preferenceManager,
-                                     NotificationManager notificationManager,
-                                     InstanceOfferManager instanceOfferManager,
-                                     MonitoringESDao monitoringDao,
-                                     TaskScheduler scheduler, MessageHelper messageHelper) {
-        this.pipelineRunManager = pipelineRunManager;
-        this.messageHelper = messageHelper;
-        this.preferenceManager = preferenceManager;
-        this.notificationManager = notificationManager;
-        this.instanceOfferManager = instanceOfferManager;
-        this.monitoringDao = monitoringDao;
-        this.scheduler = scheduler;
-    }
 
     @PostConstruct
     public void init() {
@@ -106,8 +87,8 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
         instanceTypesObservable.subscribe(instanceTypes -> instanceTypeMap = instanceTypes.stream()
                 .collect(Collectors.toMap(InstanceType::getName, t -> t, (t1, t2) -> t1)));
 
-        scheduleFixedDelay(this::monitorResourceUsage, SystemPreferences.SYSTEM_RESOURCE_MONITORING_PERIOD,
-                           "Resource Usage Monitoring");
+        scheduleFixedDelaySecured(this::monitorResourceUsage, SystemPreferences.SYSTEM_RESOURCE_MONITORING_PERIOD,
+                "Resource Usage Monitoring");
     }
 
     @Scheduled(cron = "0 0 0 ? * *")
@@ -122,7 +103,7 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
             .filter(r -> DateUtils.nowUTC().isAfter(r.getProlongedAtTime().plus(idleTimeout, ChronoUnit.MINUTES)))
             .collect(Collectors.toMap(PipelineRun::getPodId, r -> r));
 
-        LOGGER.debug("Checking cpu stats for pipelines: " + running.keySet().stream()
+        log.debug("Checking cpu stats for pipelines: " + running.keySet().stream()
             .collect(Collectors.joining(", ")));
 
         LocalDateTime now = DateUtils.nowUTC();
@@ -131,7 +112,7 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
             now.minusMinutes(idleTimeout),
             now);
 
-        LOGGER.debug("CPU Metrics received: " + cpuMetrics.entrySet().stream().map(e -> e.getKey() + ":" + e.getValue())
+        log.debug("CPU Metrics received: " + cpuMetrics.entrySet().stream().map(e -> e.getKey() + ":" + e.getValue())
             .collect(Collectors.joining(", ")));
 
         double idleCpuLevel = preferenceManager.getPreference(SYSTEM_IDLE_CPU_THRESHOLD_PERCENT) / PERCENT;
@@ -178,7 +159,7 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
             run.setLastIdleNotificationTime(DateUtils.nowUTC());
             runsToUpdate.add(run);
             pipelinesToNotify.add(new ImmutablePair<>(run, cpuUsageRate));
-            LOGGER.info(messageHelper.getMessage(MessageConstants.INFO_RUN_IDLE_NOTIFY, run.getPodId(), cpuUsageRate));
+            log.info(messageHelper.getMessage(MessageConstants.INFO_RUN_IDLE_NOTIFY, run.getPodId(), cpuUsageRate));
         } else { // run was already notified - we need to take some action
             performActionOnIdleRun(run, action, cpuUsageRate, actionTimeout, pipelinesToNotify, runsToUpdate);
         }
@@ -188,7 +169,7 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
                                         List<Pair<PipelineRun, Double>> pipelinesToNotify,
                                         List<PipelineRun> runsToUpdate) {
         if (run.getLastIdleNotificationTime().isBefore(DateUtils.nowUTC().minusMinutes(actionTimeout))) {
-            LOGGER.info(messageHelper.getMessage(MessageConstants.INFO_RUN_IDLE_ACTION, run.getPodId(), cpuUsageRate,
+            log.info(messageHelper.getMessage(MessageConstants.INFO_RUN_IDLE_ACTION, run.getPodId(), cpuUsageRate,
                                                  action));
             switch (action) {
                 case PAUSE:

--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerAuthService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerAuthService.java
@@ -20,6 +20,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import com.epam.pipeline.common.MessageConstants;
+import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.entity.security.JwtRawToken;
 import com.epam.pipeline.entity.security.JwtTokenClaims;
 import com.epam.pipeline.exception.docker.DockerAuthorizationException;
@@ -52,13 +53,14 @@ public class DockerAuthService {
     private final JwtTokenVerifier jwtTokenVerifier;
     private final JwtTokenGenerator jwtTokenGenerator;
     private final PreferenceManager preferenceManager;
+    private final MessageHelper messageHelper;
 
     public JwtRawToken issueDockerToken(UserContext user, String service, List<DockerRegistryClaim> claims) {
         Long jwtExpirationSeconds = preferenceManager.getPreference(
                 SystemPreferences.DOCKER_SECURITY_TOOL_JWT_TOKEN_EXPIRATION);
         long expitationTime = jwtExpirationSeconds != null && jwtExpirationSeconds > 0
                 ? jwtExpirationSeconds : TOKEN_EXPIRATION;
-        Assert.notNull(user, MessageConstants.ERROR_DOCKER_REGISTRY_AUTHENTICATION_REQUIRED);
+        Assert.notNull(user, messageHelper.getMessage(MessageConstants.ERROR_DOCKER_REGISTRY_AUTHENTICATION_REQUIRED));
         return new JwtRawToken(jwtTokenGenerator.issueDockerToken(user.toClaims(), expitationTime, service, claims));
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/docker/scan/ToolScanScheduler.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/scan/ToolScanScheduler.java
@@ -35,6 +35,7 @@ import com.epam.pipeline.manager.scheduling.AbstractSchedulingManager;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.concurrent.DelegatingSecurityContextCallable;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -60,13 +61,26 @@ import java.util.concurrent.Future;
 public class ToolScanScheduler extends AbstractSchedulingManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(ToolScanScheduler.class);
 
-    private final DockerRegistryDao dockerRegistryDao;
-    private final ToolScanManager toolScanManager;
-    private final ToolManager toolManager;
-    private final MessageHelper messageHelper;
-    private final ToolVersionManager toolVersionManager;
-    private final DockerClientFactory dockerClientFactory;
-    private final DockerRegistryManager dockerRegistryManager;
+    @Autowired
+    private DockerRegistryDao dockerRegistryDao;
+
+    @Autowired
+    private ToolScanManager toolScanManager;
+
+    @Autowired
+    private ToolManager toolManager;
+
+    @Autowired
+    private MessageHelper messageHelper;
+
+    @Autowired
+    private ToolVersionManager toolVersionManager;
+
+    @Autowired
+    private DockerClientFactory dockerClientFactory;
+
+    @Autowired
+    private DockerRegistryManager dockerRegistryManager;
 
     /**
      * A single thread executor to run force scans

--- a/api/src/main/java/com/epam/pipeline/manager/scheduling/AbstractSchedulingManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/scheduling/AbstractSchedulingManager.java
@@ -16,21 +16,25 @@
 
 package com.epam.pipeline.manager.scheduling;
 
+import java.util.Optional;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.epam.pipeline.manager.preference.AbstractSystemPreference.StringPreference;
 import com.epam.pipeline.manager.preference.AbstractSystemPreference.IntPreference;
 import com.epam.pipeline.manager.preference.PreferenceManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.epam.pipeline.manager.security.AuthManager;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.support.CronTrigger;
+import org.springframework.security.concurrent.DelegatingSecurityContextRunnable;
 
 /**
  * A base class for application components, that have a scheduled task
  */
+@Slf4j
 public abstract class AbstractSchedulingManager {
-    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractSchedulingManager.class);
 
     @Autowired
     protected TaskScheduler scheduler;
@@ -38,7 +42,10 @@ public abstract class AbstractSchedulingManager {
     @Autowired
     protected PreferenceManager preferenceManager;
 
-    protected AtomicReference<ScheduledFuture<?>> scheduledFuture = new AtomicReference<>();
+    @Autowired
+    protected AuthManager authManager;
+
+    protected final AtomicReference<ScheduledFuture<?>> scheduledFuture = new AtomicReference<>();
 
     /**
      * Schedule a task with a fixed delay, that is being fetched from a AbstractSystemPreference
@@ -48,16 +55,68 @@ public abstract class AbstractSchedulingManager {
      */
     protected void scheduleFixedDelay(Runnable task, IntPreference delayPreference, String taskName) {
         Integer statusUpdateRate = preferenceManager.getPreference(delayPreference);
-        LOGGER.info("Scheduled {} with a rate of {} ms", taskName, statusUpdateRate);
+        log.info("Scheduled {} with a rate of {} ms", taskName, statusUpdateRate);
 
         ScheduledFuture<?> future = scheduler.scheduleWithFixedDelay(task, statusUpdateRate);
         scheduledFuture.set(future);
 
         preferenceManager.getObservablePreference(delayPreference)
             .subscribe(rate -> scheduledFuture.updateAndGet(f -> {
-                LOGGER.debug("Rescheduling {} with a new rate of {} ms", taskName, rate);
+                log.debug("Rescheduling {} with a new rate of {} ms", taskName, rate);
                 f.cancel(false);
                 return scheduler.scheduleWithFixedDelay(task, rate.longValue());
             }));
+    }
+
+    /**
+     * Schedule a task with a fixed delay, that is being fetched from an AbstractSystemPreference.
+     *
+     * A task will be executed in a security context of a default admin.
+     *
+     * @param task            a task to schedule.
+     * @param delayPreference a preference containing execution rate.
+     * @param taskName        a name of the task.
+     */
+    protected void scheduleFixedDelaySecured(final Runnable task,
+                                             final IntPreference delayPreference,
+                                             final String taskName) {
+        final DelegatingSecurityContextRunnable secureRunnable = new DelegatingSecurityContextRunnable(task,
+                authManager.createSchedulerSecurityContext());
+        final Integer rate = Optional.ofNullable(preferenceManager.getPreference(delayPreference)).orElse(0);
+
+        log.info("Scheduled {} at {}", taskName, rate);
+        scheduledFuture.set(scheduler.scheduleWithFixedDelay(secureRunnable, rate));
+        preferenceManager.getObservablePreference(delayPreference)
+                .subscribe(newRate -> scheduledFuture.updateAndGet(f -> {
+                    log.info("Rescheduling {} at {}", taskName, newRate);
+                    f.cancel(false);
+                    return scheduler.scheduleWithFixedDelay(secureRunnable, newRate);
+                }));
+    }
+
+    /**
+     * Schedule a task with a cron delay, that is being fetched from an AbstractSystemPreference.
+     *
+     * A task will be executed in a security context of a default admin.
+     *
+     * @param task           a task to schedule.
+     * @param cronPreference a preference containing cron expression.
+     * @param taskName       a name of the task.
+     */
+    protected void scheduleSecured(final Runnable task,
+                                   final StringPreference cronPreference,
+                                   final String taskName) {
+        final DelegatingSecurityContextRunnable secureRunnable = new DelegatingSecurityContextRunnable(task,
+                authManager.createSchedulerSecurityContext());
+        final String cron = Optional.ofNullable(preferenceManager.getPreference(cronPreference)).orElse("");
+
+        log.info("Scheduled {} at {}", taskName, cron);
+        scheduledFuture.set(scheduler.schedule(secureRunnable, new CronTrigger(cron)));
+        preferenceManager.getObservablePreference(cronPreference)
+                .subscribe(newCron -> scheduledFuture.updateAndGet(f -> {
+                    log.info("Rescheduling {} at {}", taskName, newCron);
+                    f.cancel(false);
+                    return scheduler.schedule(secureRunnable, new CronTrigger(newCron));
+                }));
     }
 }

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -131,6 +131,7 @@ error.registry.could.not.get.manifest=Could not get manifest for image ''{0}''
 debug.docker.registry.auto.enable=Tool with name ''{0}'' will be automatically enabled by docker registry notification.
 debug.docker.registry.auto.enable.success=Tool with name ''{0}'' successfully enabled by docker registry notification.
 error.docker.registry.no.external=Docker registry ''{0}'' does not have external URL.
+error.docker.registry.authentication.required=Authentication is required to generate docker registry jwt token.
 
 # Docker Registry access
 error.registry.unauthorized=Authorization failed for registry ''{0}''.


### PR DESCRIPTION
# Summary

Is related to #146.

Adds default security context for resource monitoring operations the same way it was done for tool scanning in `ToolScanScheduler`.