### PR TITLE
Issue #144: Allow `force` deletion of a ToolGroup object

### DIFF
--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -102,6 +102,7 @@ public final class MessageConstants {
     public static final String ERROR_TOOL_GROUP_IS_NOT_PROVIDED = "error.tool.group.is.not.provided";
     public static final String ERROR_TOOL_GROUP_BY_NAME_NOT_FOUND = "error.tool.group.by.name.not.found";
     public static final String ERROR_PRIVATE_TOOL_GROUP_NOT_FOUND = "error.private.tool.group.not.found";
+    public static final String ERROR_TOOL_GROUP_NOT_EMPTY = "error.tool.group.not.empty";
 
     //PipelineLauncher
     public static final String ERROR_INVALID_CMD_TEMPLATE = "error.invalid.cmd.template";

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/ToolGroupController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/ToolGroupController.java
@@ -88,7 +88,8 @@ public class ToolGroupController extends AbstractRestController {
     }
 
     @RequestMapping(value = TOOL_GROUP_URL, method = RequestMethod.DELETE)
-    public Result<ToolGroup> delete(@RequestParam String id) {
-        return Result.success(toolGroupApiService.delete(id));
+    public Result<ToolGroup> delete(@RequestParam String id, 
+                                    @RequestParam(defaultValue = "false") boolean force) {
+        return Result.success(force ? toolGroupApiService.deleteForce(id) : toolGroupApiService.delete(id));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerRegistryManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerRegistryManager.java
@@ -258,8 +258,7 @@ public class DockerRegistryManager implements SecuredEntityManager {
         if (force) {
             //remove all tools from registry to avoid DataIntegrityViolationException
             // But do not delete actual tools from registry
-            registry.getTools().forEach(tool -> toolManager.delete(tool.getRegistry(), tool.getImage(), false));
-            toolGroupManager.loadByRegistryId(id).forEach(g -> toolGroupManager.delete(g.getId().toString()));
+            toolGroupManager.loadByRegistryId(id).forEach(g -> toolGroupManager.delete(g.getId().toString(), force));
         }
         if (StringUtils.isNotBlank(registry.getSecretName())) {
             kubernetesManager.deleteSecret(registry.getSecretName());

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/ToolGroupApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/ToolGroupApiService.java
@@ -82,6 +82,12 @@ public class ToolGroupApiService {
     @PreAuthorize("hasRole('ADMIN') or (hasRole('TOOL_GROUP_MANAGER') AND "
             + "@grantPermissionManager.toolGroupPermission(#id, 'WRITE'))")
     public ToolGroup delete(String id) {
-        return toolGroupManager.delete(id);
+        return toolGroupManager.delete(id, false);
+    }
+
+    @PreAuthorize("hasRole('ADMIN') or (hasRole('TOOL_GROUP_MANAGER') AND "
+            + "@grantPermissionManager.toolGroupChildPermission(#id, 'WRITE'))")
+    public ToolGroup deleteForce(String id) {
+        return toolGroupManager.delete(id, true);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/ToolGroupManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/ToolGroupManager.java
@@ -118,8 +118,9 @@ public class ToolGroupManager implements SecuredEntityManager {
     }
 
     @Transactional(propagation = Propagation.REQUIRED)
-    public ToolGroup delete(String id) {
-        ToolGroup group = loadByNameOrId(id);
+    public ToolGroup delete(final String id, final boolean force) {
+        final ToolGroup group = loadByNameOrId(id);
+        handleChildTools(group, force);
         toolGroupDao.deleteToolGroup(group.getId());
         return group;
     }
@@ -345,5 +346,13 @@ public class ToolGroupManager implements SecuredEntityManager {
         String userName = authManager.getAuthorizedUser();
         String groupName = userName.trim().toLowerCase();
         return groupName.replaceAll("[^a-z0-9\\-]+", "-");
+    }
+
+    private void handleChildTools(final ToolGroup group, final boolean force) {
+        if (CollectionUtils.isEmpty(group.getTools())) {
+            return;
+        }
+        Assert.isTrue(force, messageHelper.getMessage(MessageConstants.ERROR_TOOL_GROUP_NOT_EMPTY));
+        toolManager.deleteToolsInGroup(group);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/ToolManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/ToolManager.java
@@ -351,30 +351,17 @@ public class ToolManager implements SecuredEntityManager {
     @Transactional(propagation = Propagation.REQUIRED)
     public Tool delete(String registry, final String image, boolean hard) {
         Tool tool = loadTool(registry, image);
-        if (hard) {
-            DockerRegistry dockerRegistry = dockerRegistryManager.load(tool.getRegistryId());
-            List<String> tags = dockerRegistryManager.loadImageTags(dockerRegistry, image);
-
-            for (String tag : tags) {
-                Optional<ManifestV2> manifestOpt =
-                        dockerRegistryManager.deleteImage(dockerRegistry, tool.getImage(), tag);
-                manifestOpt.ifPresent(manifest -> {
-                    dockerRegistryManager.deleteLayer(dockerRegistry, image, manifest.getConfig().getDigest());
-
-                    Collections.reverse(manifest.getLayers());
-                    for (ManifestV2.Config layer : manifest.getLayers()) {
-                        dockerRegistryManager.deleteLayer(dockerRegistry, image, layer.getDigest());
-                    }
-                });
-            }
-        }
-        toolVulnerabilityDao.loadAllToolVersionScans(tool.getId())
-                .values()
-                .forEach(versionScan -> deleteToolVersionScan(tool.getId(), versionScan.getVersion()));
-        toolDao.deleteToolIcon(tool.getId());
-        toolVersionManager.deleteToolVersions(tool.getId());
-        toolDao.deleteTool(tool.getId());
+        deleteToolWithDependent(tool, image, hard);
         return tool;
+    }
+
+    /**
+     * Deletes all tools from a group
+     * @param toolGroup to clean
+     */
+    public void deleteToolsInGroup(final ToolGroup toolGroup) {
+        ListUtils.emptyIfNull(toolGroup.getTools())
+                .forEach(tool -> deleteToolWithDependent(tool, tool.getImage(), false));
     }
 
     /**
@@ -689,5 +676,32 @@ public class ToolManager implements SecuredEntityManager {
         return !StringUtils.hasText(instanceType)
                 || instanceOfferManager.isToolInstanceAllowedInAnyRegion(instanceType, resource);
     }
+
+    private void deleteToolWithDependent(final Tool tool, final String image, final boolean hard) {
+        if (hard) {
+            DockerRegistry dockerRegistry = dockerRegistryManager.load(tool.getRegistryId());
+            List<String> tags = dockerRegistryManager.loadImageTags(dockerRegistry, image);
+
+            for (String tag : tags) {
+                Optional<ManifestV2> manifestOpt =
+                        dockerRegistryManager.deleteImage(dockerRegistry, tool.getImage(), tag);
+                manifestOpt.ifPresent(manifest -> {
+                    dockerRegistryManager.deleteLayer(dockerRegistry, image, manifest.getConfig().getDigest());
+
+                    Collections.reverse(manifest.getLayers());
+                    for (ManifestV2.Config layer : manifest.getLayers()) {
+                        dockerRegistryManager.deleteLayer(dockerRegistry, image, layer.getDigest());
+                    }
+                });
+            }
+        }
+        toolVulnerabilityDao.loadAllToolVersionScans(tool.getId())
+                .values()
+                .forEach(versionScan -> deleteToolVersionScan(tool.getId(), versionScan.getVersion()));
+        toolDao.deleteToolIcon(tool.getId());
+        toolVersionManager.deleteToolVersions(tool.getId());
+        toolDao.deleteTool(tool.getId());
+    }
+
 
 }

--- a/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionManager.java
@@ -548,6 +548,13 @@ public class GrantPermissionManager {
         return permissionsHelper.isAllowed(permissionName, group);
     }
 
+    public boolean toolGroupChildPermission(String groupId, String permissionName) {
+        ToolGroup group = toolGroupManager.loadByNameOrId(groupId);
+        return permissionsHelper.isAllowed(permissionName, group) &&
+                ListUtils.emptyIfNull(group.getTools()).stream()
+                        .allMatch(tool -> permissionsHelper.isAllowed(permissionName, tool));
+    }
+
     public boolean runPermission(PipelineRun run, String permissionName) {
         if (permissionsHelper.isOwner(run)) {
             run.setMask(AbstractSecuredEntity.ALL_PERMISSIONS_MASK);

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -122,6 +122,7 @@ error.tool.group.by.name.not.found=Tool group with requested name: ''{0}'' was n
 error.private.tool.group.not.found=Private Tool Group was not found in the requested registry ''{0}''.
 error.tool.copy.between.registries=Cannot copy tools between registries
 error.tool.image.unavailable=Tool image ''{0}'' does not exist in docker registry.
+error.tool.group.not.empty=Tool group ''{0}'' is not empty. Pass force flag to delete tool group with all child tools.
 
 # Docker Registry
 error.registry.not.found=Registry with name ''{0}'' not found


### PR DESCRIPTION
This PR adds `force` parameter to delete tool group request. 

If `force` parameter is set to `true` all child tools will be deleted before parent tool group. 

If `force` parameter is `false` and tool group is not empty - and error with appropriate message is thrown.