### PR TITLE
'Remove child tools' flag added to 'Remove tool group' confirm dialog

### DIFF
--- a/client/src/models/tools/ToolsGroupDelete.js
+++ b/client/src/models/tools/ToolsGroupDelete.js
@@ -17,7 +17,7 @@
 import Remote from '../basic/Remote';
 
 export default class ToolsGroupDelete extends Remote {
-  constructor (id) {
+  constructor (id, force = false) {
     super();
     this.constructor.fetchOptions = {
       headers: {
@@ -27,6 +27,6 @@ export default class ToolsGroupDelete extends Remote {
       credentials: 'include',
       method: 'DELETE'
     };
-    this.url = `/toolGroup?id=${id}`;
+    this.url = `/toolGroup?id=${id}&force=${force}`;
   }
 }


### PR DESCRIPTION
This PR fixes #144 issue.
'Remove child tools' flag added to confirmation dialog. This flag is displayed only for groups with child tools.