### PR TITLE
Pre/Post-commit hooks implementation

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/cloud/commands/AbstractCommand.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/commands/AbstractCommand.java
@@ -16,11 +16,16 @@
 
 package com.epam.pipeline.manager.cloud.commands;
 
-public abstract class AbstractClusterCommand extends AbstractCommand {
+import java.util.List;
+import java.util.stream.Collectors;
 
-    public static final String EXECUTABLE = "python";
-    protected static final String RUN_ID_PARAMETER = "--run_id";
-    protected static final String REGION_PARAMETER = "--region_id";
-    protected static final String INTERNAL_IP_PARAMETER = "--internal_ip";
-    protected static final String NODE_NAME_PARAMETER = "--node_name";
+public abstract class AbstractCommand {
+    private static final String ARG_DELIMITER = " ";
+
+    public String getCommand() {
+        return buildCommandArguments().stream()
+                .collect(Collectors.joining(ARG_DELIMITER));
+    }
+
+    protected abstract List<String> buildCommandArguments();
 }

--- a/api/src/main/java/com/epam/pipeline/manager/docker/AbstractDockerCommand.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/AbstractDockerCommand.java
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.manager.cloud.commands;
+package com.epam.pipeline.manager.docker;
 
-public abstract class AbstractClusterCommand extends AbstractCommand {
+import com.epam.pipeline.manager.cloud.commands.AbstractCommand;
 
-    public static final String EXECUTABLE = "python";
-    protected static final String RUN_ID_PARAMETER = "--run_id";
-    protected static final String REGION_PARAMETER = "--region_id";
-    protected static final String INTERNAL_IP_PARAMETER = "--internal_ip";
-    protected static final String NODE_NAME_PARAMETER = "--node_name";
+public abstract class AbstractDockerCommand extends AbstractCommand {
+
+    public String getDockerCommand(final String template, final String runScriptUrl) {
+        return String.format(template, runScriptUrl, getCommand());
+    }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerCommitCommand.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerCommitCommand.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.docker;
+
+import lombok.Builder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Builder
+public class DockerCommitCommand extends AbstractDockerCommand {
+    private static final String COMMIT_COMMAND_TEMPLATE = "curl -k -s \"%s\" | sudo -E /bin/bash " +
+            "--login /dev/stdin %s &> ~/commit_pipeline.log &";
+
+    private final String api;
+    private final String apiToken;
+    private final String commitDistributionUrl;
+    private final String distributionUrl;
+    private final String runId;
+    private final String containerId;
+    private final String cleanUp;
+    private final String stopPipeline;
+    private final String timeout;
+    private final String registryToPush;
+    private final String registryToPushId;
+    private final String toolGroupId;
+    private final String newImageName;
+    private final String dockerLogin;
+    private final String dockerPassword;
+    private final String isPipelineAuth;
+    private final String preCommitCommand;
+    private final String postCommitCommand;
+
+    private final String runScriptUrl;
+
+    @Override
+    public String getCommand() {
+        return getDockerCommand(COMMIT_COMMAND_TEMPLATE, runScriptUrl);
+    }
+
+    @Override
+    protected List<String> buildCommandArguments() {
+        final List<String> command = new ArrayList<>();
+        command.add(api);
+        command.add(apiToken);
+        command.add(commitDistributionUrl);
+        command.add(distributionUrl);
+        command.add(runId);
+        command.add(containerId);
+        command.add(cleanUp);
+        command.add(stopPipeline);
+        command.add(timeout);
+        command.add(registryToPush);
+        command.add(registryToPushId);
+        command.add(toolGroupId);
+        command.add(newImageName);
+        command.add(dockerLogin);
+        command.add(dockerPassword);
+        command.add(isPipelineAuth);
+        command.add(preCommitCommand);
+        command.add(postCommitCommand);
+        return command;
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerContainerOperationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerContainerOperationManager.java
@@ -72,9 +72,9 @@ public class DockerContainerOperationManager {
     private static final String GLOBAL_KNOWN_HOSTS_FILE = "GlobalKnownHostsFile=/dev/null";
     private static final String USER_KNOWN_HOSTS_FILE = "UserKnownHostsFile=/dev/null";
     private static final String COMMIT_COMMAND_TEMPLATE = "curl -k -s \"%s\" | sudo -E /bin/bash " +
-            "--login /dev/stdin %s %s %s %s %d %s %b %b %d %s %d %d %s %s %s %b &> ~/commit_pipeline.log &";
+            "--login /dev/stdin %s %s %s %s %d %s %b %b %d %s %d %d %s %s %s %b %s %s &> ~/commit_pipeline.log &";
     private static final String PAUSE_COMMAND_TEMPLATE = "curl -k -s \"%s\" | sudo -E /bin/bash " +
-            "--login /dev/stdin %s %s %s %s %d %s %d %s %s &> ~/pause_pipeline.log";
+            "--login /dev/stdin %s %s %s %s %d %s %d %s %s %s &> ~/pause_pipeline.log";
     private static final String COMMIT_COMMAND_DESCRIPTION = "ssh session to commit pipeline run";
     private static final String PAUSE_COMMAND_DESCRIPTION = "Error is occured during to pause pipeline run";
     private static final String REJOIN_COMMAND_DESCRIPTION = "Error is occured during to resume pipeline run";
@@ -174,7 +174,9 @@ public class DockerContainerOperationManager {
                     newImageName,
                     dockerLogin,
                     dockerPassword,
-                    registry.isPipelineAuth()
+                    registry.isPipelineAuth(),
+                    preferenceManager.getPreference(SystemPreferences.PRE_COMMIT_COMMAND_PATH),
+                    preferenceManager.getPreference(SystemPreferences.POST_COMMIT_COMMAND_PATH)
             );
 
             Process sshConnection = submitCommandViaSSH(run.getInstance().getNodeIP(), commitContainerCommand);
@@ -215,7 +217,8 @@ public class DockerContainerOperationManager {
                     containerId,
                     preferenceManager.getPreference(SystemPreferences.COMMIT_TIMEOUT),
                     run.getDockerImage(),
-                    run.getTaskName()
+                    run.getTaskName(),
+                    preferenceManager.getPreference(SystemPreferences.PRE_COMMIT_COMMAND_PATH)
             );
 
             RunInstance instance = run.getInstance();

--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerPauseCommand.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerPauseCommand.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.docker;
+
+import lombok.Builder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Builder
+public class DockerPauseCommand extends AbstractDockerCommand {
+    private static final String PAUSE_COMMAND_TEMPLATE = "curl -k -s \"%s\" | sudo -E /bin/bash " +
+            "--login /dev/stdin %s &> ~/pause_pipeline.log";
+
+    private final String api;
+    private final String apiToken;
+    private final String pauseDistributionUrl;
+    private final String distributionUrl;
+    private final String runId;
+    private final String containerId;
+    private final String timeout;
+    private final String newImageName;
+    private final String defaultTaskName;
+    private final String preCommitCommand;
+
+    private final String runPauseScriptUrl;
+
+    @Override
+    public String getCommand() {
+        return getDockerCommand(PAUSE_COMMAND_TEMPLATE, runPauseScriptUrl);
+    }
+
+    @Override
+    protected List<String> buildCommandArguments() {
+        final List<String> command = new ArrayList<>();
+        command.add(api);
+        command.add(apiToken);
+        command.add(pauseDistributionUrl);
+        command.add(distributionUrl);
+        command.add(runId);
+        command.add(containerId);
+        command.add(timeout);
+        command.add(newImageName);
+        command.add(defaultTaskName);
+        command.add(preCommitCommand);
+        return command;
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -97,6 +97,11 @@ public class SystemPreferences {
                                                                          isGreaterThan(0));
     public static final StringPreference COMMIT_USERNAME = new StringPreference("commit.username", null,
                                                                          COMMIT_GROUP, PreferenceValidators.isNotBlank);
+    public static final StringPreference PRE_COMMIT_COMMAND_PATH = new StringPreference("commit.pre.command.path",
+            "/root/pre_commit.sh", COMMIT_GROUP, PreferenceValidators.isNotBlank);
+    public static final StringPreference POST_COMMIT_COMMAND_PATH = new StringPreference("commit.post.command.path",
+            "/root/post_commit.sh", COMMIT_GROUP, PreferenceValidators.isNotBlank);
+
     // DATA_STORAGE_GROUP
     public static final IntPreference DATA_STORAGE_MAX_DOWNLOAD_SIZE = new IntPreference(
         "storage.max.download.size", 10000, DATA_STORAGE_GROUP, isGreaterThan(0));

--- a/deploy/docker/cp-tools/base/rstudio/Dockerfile
+++ b/deploy/docker/cp-tools/base/rstudio/Dockerfile
@@ -90,4 +90,4 @@ RUN export ADD=shiny && \
 RUN rm -f /etc/cont-init.d/userconf
 
 ADD    post_commit.sh /root/post_commit.sh
-RUN    chmod 777 /root/post_commit.sh
+RUN    chmod +x /root/post_commit.sh

--- a/deploy/docker/cp-tools/base/rstudio/Dockerfile
+++ b/deploy/docker/cp-tools/base/rstudio/Dockerfile
@@ -88,3 +88,6 @@ RUN export ADD=shiny && \
     chmod g+rwx /srv -R
 
 RUN rm -f /etc/cont-init.d/userconf
+
+ADD    post_commit.sh /root/post_commit.sh
+RUN    chmod 777 /root/post_commit.sh

--- a/deploy/docker/cp-tools/base/rstudio/post_commit.sh
+++ b/deploy/docker/cp-tools/base/rstudio/post_commit.sh
@@ -15,7 +15,9 @@
 
 if [[ -f /etc/cp_env.sh ]]; then
     source /etc/cp_env.sh
-    rm -rf $OWNER_HOME/.rstudio/sessions/active/session-*
-else
+fi
+if [[ -z $OWNER_HOME ]]; then
     rm -rf /home/*/.rstudio/sessions/active/session-*
+else
+    rm -rf $OWNER_HOME/.rstudio/sessions/active/session-*
 fi

--- a/deploy/docker/cp-tools/base/rstudio/post_commit.sh
+++ b/deploy/docker/cp-tools/base/rstudio/post_commit.sh
@@ -1,0 +1,18 @@
+# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/env bash
+
+owner_home_path=`cat /etc/cp_env.sh | grep OWNER_HOME | sed 's/.*\"\([^]]*\)\".*/\1/g'`
+rm -rf $owner_home_path/.rstudio/sessions/active/session-*

--- a/deploy/docker/cp-tools/base/rstudio/post_commit.sh
+++ b/deploy/docker/cp-tools/base/rstudio/post_commit.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/usr/bin/env bash
-
-owner_home_path=`cat /etc/cp_env.sh | grep OWNER_HOME | sed 's/.*\"\([^]]*\)\".*/\1/g'`
-rm -rf $owner_home_path/.rstudio/sessions/active/session-*
+if [[ -f /etc/cp_env.sh ]]; then
+    source /etc/cp_env.sh
+    rm -rf $OWNER_HOME/.rstudio/sessions/active/session-*
+else
+    rm -rf /home/*/.rstudio/sessions/active/session-*
+fi

--- a/scripts/commit-run-scripts/commit_run.sh
+++ b/scripts/commit-run-scripts/commit_run.sh
@@ -14,19 +14,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+commit_hook() {
+    container_id=${1}
+    prefix=${2}
+    hook_command_path=${3}
+
+    if [[ ! -z "${hook_command_path}" ]]; then
+        docker exec ${container_id} test -f ${hook_command_path} > /dev/null 2> /dev/null
+        if [[ $? -eq 0 ]]; then
+            pipe_log_info "[INFO] Run ${prefix}-commit command from path ${hook_command_path}" "$TASK_NAME"
+            pipe_exec "docker exec ${container_id} sh -c '${hook_command_path} ${CLEAN_UP} ${STOP_PIPELINE}'" "$TASK_NAME"
+            check_last_exit_code $? "[ERROR] There are some troubles while executing ${prefix}-commit script." \
+                    "[INFO] ${prefix}-commit operations were successfully performed."
+        else
+            pipe_log_info "[INFO] ${prefix}-commit script ${hook_command_path} not found" "$TASK_NAME"
+        fi
+    fi
+}
+
 SCRIPT_PATH="$SCRIPTS_DIR/common_commit_initialization.sh"
 . $SCRIPT_PATH
 
-if [[ ! -z "${PRE_COMMIT_COMMAND}" ]]; then
-    pipe_log_info "[INFO] Pre-commit command found by path ${PRE_COMMIT_COMMAND}" "$TASK_NAME"
-    pipe_exec "docker exec ${CONTAINER_ID} ls ${PRE_COMMIT_COMMAND} > /dev/null" "$TASK_NAME"
-    if [[ $? -eq 0 ]]; then
-        pipe_log_info "[INFO] Run pre-commit command" "$TASK_NAME"
-        pipe_exec "docker exec ${CONTAINER_ID} sh -c '${PRE_COMMIT_COMMAND} ${CLEAN_UP} ${STOP_PIPELINE}'" "$TASK_NAME"
-        check_last_exit_code $? "[ERROR] There are some troubles while executing pre-commit script." \
-                        "[INFO] Pre-commit operations were successfully performed."
-    fi
-fi
+commit_hook ${CONTAINER_ID} "pre" ${PRE_COMMIT_COMMAND}
 
 commit_file $FULL_NEW_IMAGE_NAME
 check_last_exit_code $? "[ERROR] Error occurred while committing temporary container" \
@@ -35,16 +44,7 @@ check_last_exit_code $? "[ERROR] Error occurred while committing temporary conta
 
 export tmp_container=`docker run --entrypoint "/bin/sleep" -d ${FULL_NEW_IMAGE_NAME} 1d`
 
-if [[ ! -z "${POST_COMMIT_COMMAND}" ]]; then
-    pipe_log_info "[INFO] Post-commit command found by path ${POST_COMMIT_COMMAND}" "$TASK_NAME"
-    pipe_exec "docker exec ${tmp_container} ls ${POST_COMMIT_COMMAND} > /dev/null" "$TASK_NAME"
-    if [[ $? -eq 0 ]]; then
-        pipe_log_info "[INFO] Run post-commit command" "$TASK_NAME"
-        pipe_exec "docker exec ${tmp_container} sh -c '${POST_COMMIT_COMMAND} ${CLEAN_UP} ${STOP_PIPELINE}'" "$TASK_NAME"
-        check_last_exit_code $? "[ERROR] There are some troubles while executing post-commit script." \
-                        "[INFO] Post-commit operations were successfully performed."
-    fi
-fi
+commit_hook ${tmp_container} "post" ${POST_COMMIT_COMMAND}
 
 pipe_log_info "[INFO] Clean up container with env vars and files ..." "$TASK_NAME"
 docker cp $SCRIPTS_DIR/cleanup_container.sh "${tmp_container}":/

--- a/scripts/commit-run-scripts/commit_run_starter.sh
+++ b/scripts/commit-run-scripts/commit_run_starter.sh
@@ -46,9 +46,12 @@ if [[ "$#" -ge 15 ]]; then
     export DOCKER_PASSWORD=${15}
 fi
 
-if [[ "$#" -eq 16 ]]; then
+if [[ "$#" -ge 16 ]]; then
     export IS_PIPELINE_AUTH=${16}
 fi
+
+export PRE_COMMIT_COMMAND=${17}
+export POST_COMMIT_COMMAND=${18}
 
 export TASK_NAME="CommitPipelineRun"
 

--- a/scripts/commit-run-scripts/pause_run.sh
+++ b/scripts/commit-run-scripts/pause_run.sh
@@ -77,6 +77,7 @@ export CONTAINER_ID=${6}
 TIMEOUT=${7}
 export NEW_IMAGE_NAME=${8}
 export DEFAULT_TASK_NAME=${9}
+export PRE_COMMIT_COMMAND=${10}
 
 export TASK_NAME="PausePipelineRun"
 export CP_PYTHON2_PATH=python


### PR DESCRIPTION
Provide implementation for #165 

Provides the following changes for `commit` and `pause` operations:
1. Two preferences are introduced:
- `commit.pre.command.path`: specified a path to a script within a docker image, that will be executed in a currently running container, **BEFORE** `docker commit` occurs. (default: `/root/pre_commit.sh`). 
  - This option is useful if any operations shall be performed with the running processes (e.g. send a signal), because in the subsequent `post` operation - only filesystem operations will be available. 
  - *Note* that any changes done at this stage will affect the running container.
- `commit.post.command.path`: specified a path to a script within a docker image, that will be executed in a committed image, **AFTER** `docker commit` occurs. (default: `/root/post_commit.sh`). 
  - This hook can be used to perform any filesystem cleanup or other operations, that shall not affect the currently running processes.

2. Those scripts will be passed to the corresponding commit/pause scripts:
- `commit_run_starter.sh` script: both preferences are passed via `PRE_COMMIT_COMMAND` and `POST_COMMIT_COMMAND` parameters
- `pause_run.sh` script:  only `commit.pre.command.path` value is passed to the `PRE_COMMIT_COMMAND` parameter

3. If a corresponding pre/post script is not found in the docker image - it will not be executed


