### PR TITLE
WDL visualization now supports `import` statements

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,7 @@
     "mobx-react-router": "^3.1.2",
     "moment": "^2.18.1",
     "papaparse": "^4.3.6",
-    "pipeline-builder": "0.3.10-dev.308",
+    "pipeline-builder": "0.3.10-dev.313",
     "prop-types": "^15.5.8",
     "react": "^15.4.2",
     "react-day-picker": "^5.5.3",


### PR DESCRIPTION
Previously we were unable to modify WDL workflows with `import` statements. New version of `pipeline-builder` (v313) fixes this.