### PR TITLE
Allow to configure swap file for aws/azure

### DIFF
--- a/scripts/autoscaling/aws/nodeup.py
+++ b/scripts/autoscaling/aws/nodeup.py
@@ -32,19 +32,6 @@ from distutils.version import LooseVersion
 import fnmatch
 import sys
 
-
-#############################
-### TODO
-### This section corresponds to pipeline logging, so that we will get nodeup logs in GUI as a separate task
-### But current implementation is almost a hack (e.g. relies on application.config location)
-### It shall be completely rewritten once Python scripts are moved to Java
-### How to make sure this will work:
-### 1. application.config shall be located in ../config/application.config
-### 2. application.config shall contain valid values for:
-###     - api.host
-###     - server.api.token
-### 3. Latest "pipeline" package shall be installed using "pip install"
-
 NETWORKS_PARAM = "cluster.networks.config"
 NODEUP_TASK = "InitializeNode"
 
@@ -145,13 +132,9 @@ def get_security_groups(aws_region):
     if not config:
         raise RuntimeError('Security group setting is required to run an instance')
     return config
-
-def get_proxies(aws_region):
-    return get_cloud_config_section(aws_region, "proxies")
     
 def get_well_known_hosts(aws_region):
     return get_cloud_config_section(aws_region, "well_known_hosts")
-
 
 def get_allowed_instance_image(aws_region, instance_type, default_image):
     default_init_script = os.path.dirname(os.path.abspath(__file__)) + '/init.sh'
@@ -369,25 +352,31 @@ def get_well_known_hosts_string(aws_region):
         return ''
     return ' && '.join(entries)
 
-def replace_proxies(aws_region, init_script):
-    pipe_log('Setting proxy settings for an instance in {} region'.format(aws_region))
-    proxies_list = get_proxies(aws_region)
-    if not proxies_list:
+def replace_common_params(aws_region, init_script, config_section):
+    pipe_log('Configuring {} settings for an instance in {} region'.format(config_section, aws_region))
+    common_list = get_cloud_config_section(aws_region, config_section)
+    if not common_list:
         return init_script
 
-    for proxy_item in proxies_list:
-        if not 'name' in proxy_item or not 'path' in proxy_item:
+    for common_item in common_list:
+        if not 'name' in common_item or not 'path' in common_item:
             continue
-        proxy_name = proxy_item['name']
-        proxy_path = proxy_item['path']
-        if not proxy_name:
+        item_name = common_item['name']
+        item_path = common_item['path']
+        if not item_name:
             continue
-        if proxy_path == None:
-            proxy_path = ''
-        init_script = init_script.replace('@' + proxy_name +  '@', proxy_path)
-        pipe_log('-> {}={}'.format(proxy_name, proxy_path))
+        if item_path == None:
+            item_path = ''
+        init_script = init_script.replace('@' + item_name +  '@', item_path)
+        pipe_log('-> {}={}'.format(item_name, item_path))
     
     return init_script
+
+def replace_proxies(aws_region, init_script):
+    return replace_common_params(aws_region, init_script, "proxies")
+
+def replace_swap(aws_region, init_script):
+    return replace_common_params(aws_region, init_script, "swap")
 
 def get_user_data_script(aws_region, ins_type, ins_img, kube_ip, kubeadm_token):
     allowed_instance = get_allowed_instance_image(aws_region, ins_type, ins_img)
@@ -398,6 +387,7 @@ def get_user_data_script(aws_region, ins_type, ins_img, kube_ip, kubeadm_token):
         well_known_string = get_well_known_hosts_string(aws_region)
         init_script.close()
         user_data_script = replace_proxies(aws_region, user_data_script)
+        user_data_script = replace_swap(aws_region, user_data_script)
         return user_data_script.replace('@DOCKER_CERTS@', certs_string)\
             .replace('@WELL_KNOWN_HOSTS@', well_known_string)\
             .replace('@KUBE_IP@', kube_ip)\

--- a/scripts/autoscaling/init_multicloud.sh
+++ b/scripts/autoscaling/init_multicloud.sh
@@ -58,6 +58,67 @@ function update_nameserver {
   fi
 }
 
+function setup_swap {
+  local default_swap_file="/ebs/swap/swapfile"
+  local swap_ratio="${1:-0}"
+  local swap_file="${2:-$default_swap_file}"
+  
+  # If swap_ratio/swap_file are not set at all - they will appear with @ in the beginning and the end
+  # Consider that as default values
+  if [[ "$swap_ratio" != "@"*"@" ]]; then
+    swap_ratio=0
+  fi
+  if [[ "$swap_file" != "@"*"@" ]]; then
+    swap_file=$default_swap_file
+  fi
+
+  # If explicitely set to 0 - do not do anything
+  if [ -z "$swap_ratio" ] || [ "$swap_ratio" == "0" ]; then
+    echo "Swap ratio is not set of equals to 0"
+    return 0
+  fi
+
+  # If swap file already exists - fallback, as it may be a paused run
+  if [ -f "$swap_file" ]; then
+    echo "Swap file already exists at ${swap_file}. Refusing to proceed with the swap configuration"
+    return 1
+  fi
+
+  local physical_ram_kb=$(grep MemTotal /proc/meminfo | awk '{print $2}')
+  local swap_size_gb=$(echo "$physical_ram_kb * $swap_ratio / 1024 / 1024" | bc)
+  if [ $? -ne 0 ] || [ "$swap_size_gb" == "0" ]; then
+    echo "Unable to compute swap size. physical_ram_kb: $physical_ram_kb swap_ratio: $swap_ratio swap_size_gb: $swap_size_gb"
+    return 1
+  fi
+
+  mkdir -p $(dirname $swap_file)
+
+  echo "$swap_size_gb Gb swap file will be create at $swap_file"
+  dd if=/dev/zero of=$swap_file bs=1G count=$swap_size_gb
+  if [ $? -ne 0 ]; then
+    echo "Unable to create a swapfile at $swap_file"
+    rm -f "$swap_file"
+    return 1
+  fi
+
+  chmod 600 $swap_file
+  mkswap $swap_file
+  if [ $? -ne 0 ]; then
+    echo "Unable to mkswap at $swap_file"
+    rm -f "$swap_file"
+    return 1
+  fi
+
+  swapon $swap_file
+  if [ $? -ne 0 ]; then
+    echo "Unable to swapon at $swap_file"
+    rm -f "$swap_file"
+    return 1
+  fi
+
+  return 0
+}
+
 # Mount all drives that do not have mount points yet. Each drive will be mounted to /ebsN folder (N is a number of a drive)
 UNMOUNTED_DRIVES=$(lsblk -sdrpn -o NAME,TYPE,MOUNTPOINT | awk '$2 == "disk" && $3 == "" { print $1 }')
 DRIVE_NUM=0
@@ -90,6 +151,11 @@ do
   rm -rf $MOUNT_POINT/lost+found/   
  
 done
+
+# Setup swap configuration
+swap_ratio="@swap_ratio@"
+swap_location="@swap_location@"
+setup_swap "${swap_ratio:-0}" "${swap_location:-/ebs/swap/swapfile}"
 
 # Stop docker if it is running and clean any remaining default directories
 systemctl stop docker
@@ -178,7 +244,7 @@ fi
 # This will be replaced by "echo {IP} {HOSTNAME} >> /etc/hosts" in nodeup.py
 @WELL_KNOWN_HOSTS@
 
-# Setup proxies for a current AWS region
+# Setup proxies for a current region
 nameserver_val="@dns_proxy@"
 nameserver_post_val="@dns_proxy_post@"
 http_proxy_val="@http_proxy@"


### PR DESCRIPTION
Addresses issue #199.

# Summary

If `swap` entry is defined in the `cluster.networks.config` preference - it's value will be used to configure the swap behavior for the compute node being initialized.
Two options can be used for that purpose:
1. `swap_location`:
- Defines the location of the swap file
- If not set - default location `/ebs/swap/swapfile` will be used
- If that file already exists - swap will not be configured
2. `swap_ratio`:
- Total node RAM will be multiplied by this parameter
- The resulting value will be used to create a swap file of a computed size
- If not set or set to `0` - swap will not be used

# Example

E.g. consider the following configuration of the `cluster.networks.config`:
```
{
   "regions": [
    {
        "name": "us-east-1",
        "swap": [
            {
                "name": "swap_ratio",
                "path": "0.5"
            }
        ]
    },
    {
        "name": "westeurope",
        "swap": [
            {
                "name": "swap_location",
                "path": "/mnt/resource/swapfile"
            },
            {
                "name": "swap_ratio",
                "path": "1"
            }
        ]
    }
}
```

This config contains both options for the `swap` configuration. It will result in the following swap setup:
1. If a node is run in the AWS `us-east-1` region:
- Size of the swap file will be half of the physical RAM
- Default value `/ebs/swap/swapfile` will be used as a swap file location
2. If a node is run in the Azure `westeurope` region:
- Size of the swap file will be equal to the physical RAM
- Swap file will be located in the `Azure Temporary` storage (typically mounted to `/mnt/resource` directory for CentOS host OS)
