### PR TITLE
Resolve E2E GUI test issues from 24.04.19

### DIFF
--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/AutopauseTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/AutopauseTest.java
@@ -79,7 +79,7 @@ public class AutopauseTest extends AbstractSeveralPipelineRunningTest implements
 
         launchTool(onDemand, enabled);
 
-        if (Cloud.AZURE.name().toLowerCase().equals(C.CLOUD_PROVIDER.toLowerCase())) {
+        if (Cloud.AZURE.name().equalsIgnoreCase(C.CLOUD_PROVIDER)) {
             runsMenu()
                     .activeRuns()
                     .ensure(runWithId(getLastRunId()), visible)
@@ -107,7 +107,7 @@ public class AutopauseTest extends AbstractSeveralPipelineRunningTest implements
 
         launchTool(onDemand, enabled);
 
-        if (Cloud.AZURE.name().toLowerCase().equals(C.CLOUD_PROVIDER.toLowerCase())) {
+        if (Cloud.AZURE.name().equalsIgnoreCase(C.CLOUD_PROVIDER)) {
             runsMenu()
                     .activeRuns()
                     .waitUntilResumeButtonAppear(getLastRunId())

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/AutopauseTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/AutopauseTest.java
@@ -112,6 +112,7 @@ public class AutopauseTest extends AbstractSeveralPipelineRunningTest implements
                     .waitUntilResumeButtonAppear(getLastRunId())
                     .validateStatus(getLastRunId(), LogAO.Status.PAUSED)
                     .resume(getLastRunId(), getToolName())
+                    .waitUntilStopButtonAppear(getLastRunId())
                     .stopRun(getLastRunId());
             return;
         }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/AutopauseTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/AutopauseTest.java
@@ -79,7 +79,7 @@ public class AutopauseTest extends AbstractSeveralPipelineRunningTest implements
 
         launchTool(onDemand, enabled);
 
-        if (Cloud.AZURE.name().equals(C.CLOUD_PROVIDER)) {
+        if (Cloud.AZURE.name().toLowerCase().equals(C.CLOUD_PROVIDER.toLowerCase())) {
             runsMenu()
                     .activeRuns()
                     .ensure(runWithId(getLastRunId()), visible)
@@ -107,7 +107,7 @@ public class AutopauseTest extends AbstractSeveralPipelineRunningTest implements
 
         launchTool(onDemand, enabled);
 
-        if (Cloud.AZURE.name().equals(C.CLOUD_PROVIDER)) {
+        if (Cloud.AZURE.name().toLowerCase().equals(C.CLOUD_PROVIDER.toLowerCase())) {
             runsMenu()
                     .activeRuns()
                     .waitUntilResumeButtonAppear(getLastRunId())

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/AutopauseTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/AutopauseTest.java
@@ -26,12 +26,8 @@ import com.epam.pipeline.autotests.mixins.Tools;
 import com.epam.pipeline.autotests.utils.C;
 import com.epam.pipeline.autotests.utils.TestCase;
 import com.epam.pipeline.autotests.utils.Utils;
-import com.epam.pipeline.autotests.utils.listener.Cloud;
-import com.epam.pipeline.autotests.utils.listener.CloudProviderOnly;
-import com.epam.pipeline.autotests.utils.listener.ConditionalTestAnalyzer;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 import java.util.function.Function;
@@ -42,8 +38,8 @@ import static com.codeborne.selenide.Condition.visible;
 import static com.epam.pipeline.autotests.ao.Primitive.AUTO_PAUSE;
 import static com.epam.pipeline.autotests.ao.Primitive.OK;
 import static com.epam.pipeline.autotests.utils.PipelineSelectors.runWithId;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
-@Listeners(value = ConditionalTestAnalyzer.class)
 public class AutopauseTest extends AbstractSeveralPipelineRunningTest implements Tools, Authorization {
 
     private final String tool = C.TESTING_TOOL_NAME;
@@ -80,9 +76,18 @@ public class AutopauseTest extends AbstractSeveralPipelineRunningTest implements
         setSystemPreferences("2", "2", "30", "STOP");
         relogin();
 
-        launchTool(defaultPriceType, hidden);
         launchTool(onDemand, enabled);
 
+        if ("azure".equals(C.CLOUD_PROVIDER)) {
+            runsMenu()
+                    .activeRuns()
+                    .ensure(runWithId(getLastRunId()), visible)
+                    .waitForCompletion(getLastRunId())
+                    .completedRuns()
+                    .ensure(runWithId(getLastRunId()), visible);
+            return;
+        }
+        launchTool(defaultPriceType, hidden);
         runsMenu()
                 .activeRuns()
                 .ensure(runWithId(getLastRunId()), visible)
@@ -93,16 +98,24 @@ public class AutopauseTest extends AbstractSeveralPipelineRunningTest implements
                 .ensure(runWithId(String.valueOf(Integer.parseInt(getLastRunId()) - 1)), visible);
     }
 
-    @CloudProviderOnly(Cloud.AWS)
     @Test
     @TestCase({"EPMCMBIBPC-2634"})
     public void autopauseValidationPauseOrStop() {
         setSystemPreferences("2", "2", "30", "PAUSE_OR_STOP");
         relogin();
 
-        launchTool(defaultPriceType, hidden);
         launchTool(onDemand, enabled);
 
+        if ("azure".equals(C.CLOUD_PROVIDER)) {
+            runsMenu()
+                    .activeRuns()
+                    .waitUntilResumeButtonAppear(getLastRunId())
+                    .validateStatus(getLastRunId(), LogAO.Status.PAUSED)
+                    .resume(getLastRunId(), getToolName())
+                    .stopRun(getLastRunId());
+            return;
+        }
+        launchTool(defaultPriceType, hidden);
         runsMenu()
                 .activeRuns()
                 .waitUntilResumeButtonAppear(getLastRunId())
@@ -157,6 +170,7 @@ public class AutopauseTest extends AbstractSeveralPipelineRunningTest implements
                         .setIdleCpuThreshold(idleCpuThreshold)
                         .setIdleAction(idleAction)
                         .save()
+                        .sleep(2, SECONDS)
                         .click(OK)
         );
     }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/AutopauseTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/AutopauseTest.java
@@ -26,6 +26,7 @@ import com.epam.pipeline.autotests.mixins.Tools;
 import com.epam.pipeline.autotests.utils.C;
 import com.epam.pipeline.autotests.utils.TestCase;
 import com.epam.pipeline.autotests.utils.Utils;
+import com.epam.pipeline.autotests.utils.listener.Cloud;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -78,7 +79,7 @@ public class AutopauseTest extends AbstractSeveralPipelineRunningTest implements
 
         launchTool(onDemand, enabled);
 
-        if ("azure".equals(C.CLOUD_PROVIDER)) {
+        if (Cloud.AZURE.name().equals(C.CLOUD_PROVIDER)) {
             runsMenu()
                     .activeRuns()
                     .ensure(runWithId(getLastRunId()), visible)
@@ -106,7 +107,7 @@ public class AutopauseTest extends AbstractSeveralPipelineRunningTest implements
 
         launchTool(onDemand, enabled);
 
-        if ("azure".equals(C.CLOUD_PROVIDER)) {
+        if (Cloud.AZURE.name().equals(C.CLOUD_PROVIDER)) {
             runsMenu()
                     .activeRuns()
                     .waitUntilResumeButtonAppear(getLastRunId())

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ObjectMetadataFileTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ObjectMetadataFileTest.java
@@ -21,8 +21,12 @@ import com.epam.pipeline.autotests.mixins.Authorization;
 import com.epam.pipeline.autotests.utils.C;
 import com.epam.pipeline.autotests.utils.TestCase;
 import com.epam.pipeline.autotests.utils.Utils;
+import com.epam.pipeline.autotests.utils.listener.Cloud;
+import com.epam.pipeline.autotests.utils.listener.CloudProviderOnly;
+import com.epam.pipeline.autotests.utils.listener.ConditionalTestAnalyzer;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -34,7 +38,7 @@ import static com.epam.pipeline.autotests.ao.Primitive.*;
 import static com.epam.pipeline.autotests.utils.Utils.sleep;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-
+@Listeners(value = ConditionalTestAnalyzer.class)
 public class ObjectMetadataFileTest extends AbstractBfxPipelineTest implements Authorization {
 
     private final String bucket = "file-metadata-test-bucket-" + Utils.randomSuffix();
@@ -150,6 +154,7 @@ public class ObjectMetadataFileTest extends AbstractBfxPipelineTest implements A
                 .assertValueIs(value2);
     }
 
+    @CloudProviderOnly(Cloud.AWS)
     @Test(dependsOnMethods = "updateKeyValidationForFileInBucket")
     @TestCase(value = {"EPMCMBIBPC-1174"})
     public void addSeveralKeysToFileMetadata() {

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ObjectMetadataFileTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ObjectMetadataFileTest.java
@@ -191,8 +191,15 @@ public class ObjectMetadataFileTest extends AbstractBfxPipelineTest implements A
     public void removeAllKeysValidation() {
         fileMetadata()
                 .deleteAllKeys()
-                .cancel()
-                .assertNumberOfKeysIs(3)
+                .cancel();
+        if (Cloud.AZURE.name().toLowerCase().equals(C.CLOUD_PROVIDER.toLowerCase())) {
+            fileMetadata()
+                    .assertNumberOfKeysIs(2);
+        } else {
+            fileMetadata()
+                    .assertNumberOfKeysIs(3);
+        }
+        fileMetadata()
                 .deleteAllKeys()
                 .ensureTitleIs("Do you want to delete all metadata?")
                 .ok()

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ObjectMetadataFileTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ObjectMetadataFileTest.java
@@ -159,17 +159,17 @@ public class ObjectMetadataFileTest extends AbstractBfxPipelineTest implements A
     public void addSeveralKeysToFileMetadata() {
         fileMetadata()
                 .addKeyWithValue(key3, value3)
-                .addKeyWithValue(key4, value4)
+                .addKeyWithValue(key5, value5)
                 .assertKeyWithValueIsPresent(key3, value3)
-                .assertKeyWithValueIsPresent(key4, value4)
+                .assertKeyWithValueIsPresent(key5, value5)
                 .addKeyWithValue(key7, value7)
                 .messageShouldAppear(emptyKeyErrorMessage);
         if ("azure".equals(C.CLOUD_PROVIDER)) {
             return;
         }
         fileMetadata()
-                .addKeyWithValue(key5, value5)
-                .assertKeyWithValueIsPresent(key5, value5);
+                .addKeyWithValue(key4, value4)
+                .assertKeyWithValueIsPresent(key4, value4);
     }
 
     @Test(dependsOnMethods = "addSeveralKeysToFileMetadata")

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ObjectMetadataFileTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ObjectMetadataFileTest.java
@@ -165,7 +165,7 @@ public class ObjectMetadataFileTest extends AbstractBfxPipelineTest implements A
                 .assertKeyWithValueIsPresent(key5, value5)
                 .addKeyWithValue(key7, value7)
                 .messageShouldAppear(emptyKeyErrorMessage);
-        if (Cloud.AZURE.name().equals(C.CLOUD_PROVIDER)) {
+        if (Cloud.AZURE.name().toLowerCase().equals(C.CLOUD_PROVIDER.toLowerCase())) {
             return;
         }
         fileMetadata()

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ObjectMetadataFileTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ObjectMetadataFileTest.java
@@ -21,6 +21,7 @@ import com.epam.pipeline.autotests.mixins.Authorization;
 import com.epam.pipeline.autotests.utils.C;
 import com.epam.pipeline.autotests.utils.TestCase;
 import com.epam.pipeline.autotests.utils.Utils;
+import com.epam.pipeline.autotests.utils.listener.Cloud;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -164,7 +165,7 @@ public class ObjectMetadataFileTest extends AbstractBfxPipelineTest implements A
                 .assertKeyWithValueIsPresent(key5, value5)
                 .addKeyWithValue(key7, value7)
                 .messageShouldAppear(emptyKeyErrorMessage);
-        if ("azure".equals(C.CLOUD_PROVIDER)) {
+        if (Cloud.AZURE.name().equals(C.CLOUD_PROVIDER)) {
             return;
         }
         fileMetadata()

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ObjectMetadataFileTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ObjectMetadataFileTest.java
@@ -21,12 +21,8 @@ import com.epam.pipeline.autotests.mixins.Authorization;
 import com.epam.pipeline.autotests.utils.C;
 import com.epam.pipeline.autotests.utils.TestCase;
 import com.epam.pipeline.autotests.utils.Utils;
-import com.epam.pipeline.autotests.utils.listener.Cloud;
-import com.epam.pipeline.autotests.utils.listener.CloudProviderOnly;
-import com.epam.pipeline.autotests.utils.listener.ConditionalTestAnalyzer;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -34,11 +30,15 @@ import java.net.URISyntaxException;
 import java.nio.file.Paths;
 
 import static com.codeborne.selenide.Condition.visible;
-import static com.epam.pipeline.autotests.ao.Primitive.*;
+import static com.epam.pipeline.autotests.ao.Primitive.ADD_KEY;
+import static com.epam.pipeline.autotests.ao.Primitive.CLOSE;
+import static com.epam.pipeline.autotests.ao.Primitive.DELETE_ICON;
+import static com.epam.pipeline.autotests.ao.Primitive.ENLARGE;
+import static com.epam.pipeline.autotests.ao.Primitive.FILE_PREVIEW;
+import static com.epam.pipeline.autotests.ao.Primitive.REMOVE_ALL;
 import static com.epam.pipeline.autotests.utils.Utils.sleep;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-@Listeners(value = ConditionalTestAnalyzer.class)
 public class ObjectMetadataFileTest extends AbstractBfxPipelineTest implements Authorization {
 
     private final String bucket = "file-metadata-test-bucket-" + Utils.randomSuffix();
@@ -154,19 +154,22 @@ public class ObjectMetadataFileTest extends AbstractBfxPipelineTest implements A
                 .assertValueIs(value2);
     }
 
-    @CloudProviderOnly(Cloud.AWS)
     @Test(dependsOnMethods = "updateKeyValidationForFileInBucket")
     @TestCase(value = {"EPMCMBIBPC-1174"})
     public void addSeveralKeysToFileMetadata() {
         fileMetadata()
                 .addKeyWithValue(key3, value3)
                 .addKeyWithValue(key4, value4)
-                .addKeyWithValue(key5, value5)
                 .assertKeyWithValueIsPresent(key3, value3)
                 .assertKeyWithValueIsPresent(key4, value4)
-                .assertKeyWithValueIsPresent(key5, value5)
                 .addKeyWithValue(key7, value7)
                 .messageShouldAppear(emptyKeyErrorMessage);
+        if ("azure".equals(C.CLOUD_PROVIDER)) {
+            return;
+        }
+        fileMetadata()
+                .addKeyWithValue(key5, value5)
+                .assertKeyWithValueIsPresent(key5, value5);
     }
 
     @Test(dependsOnMethods = "addSeveralKeysToFileMetadata")

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ObjectMetadataFileTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ObjectMetadataFileTest.java
@@ -165,7 +165,7 @@ public class ObjectMetadataFileTest extends AbstractBfxPipelineTest implements A
                 .assertKeyWithValueIsPresent(key5, value5)
                 .addKeyWithValue(key7, value7)
                 .messageShouldAppear(emptyKeyErrorMessage);
-        if (Cloud.AZURE.name().toLowerCase().equals(C.CLOUD_PROVIDER.toLowerCase())) {
+        if (Cloud.AZURE.name().equalsIgnoreCase(C.CLOUD_PROVIDER)) {
             return;
         }
         fileMetadata()
@@ -192,7 +192,7 @@ public class ObjectMetadataFileTest extends AbstractBfxPipelineTest implements A
         fileMetadata()
                 .deleteAllKeys()
                 .cancel();
-        if (Cloud.AZURE.name().toLowerCase().equals(C.CLOUD_PROVIDER.toLowerCase())) {
+        if (Cloud.AZURE.name().equalsIgnoreCase(C.CLOUD_PROVIDER)) {
             fileMetadata()
                     .assertNumberOfKeysIs(2);
         } else {

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/RoleModelTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/RoleModelTest.java
@@ -124,6 +124,14 @@ public class RoleModelTest
                     .removeStorage(anotherBucket)
                     .removePipeline(pipelineName);
 
+            navigationMenu()
+                    .settings()
+                    .switchToUserManagement()
+                    .switchToGroups()
+                    .deleteGroupIfPresent(userGroup)
+                    .sleep(1, SECONDS)
+                    .ok();
+
             Utils.removeStorages(this, bucketForDataStoragesTests, presetBucketForDataStoragesTests);
         });
     }
@@ -933,14 +941,6 @@ public class RoleModelTest
                 ToolPermission.inherit(READ, tool, registry, group),
                 ToolPermission.inherit(WRITE, tool, registry, group),
                 ToolPermission.inherit(EXECUTE, tool, registry, group));
-
-        navigationMenu()
-                .settings()
-                .switchToUserManagement()
-                .switchToGroups()
-                .deleteGroupIfPresent(userGroup)
-                .sleep(1, SECONDS)
-                .ok();
     }
 
     private void createGroupPrerequisites() {
@@ -951,6 +951,7 @@ public class RoleModelTest
                         .switchToGroups()
                         .pressCreateGroup()
                         .enterGroupName(userGroup)
+                        .sleep(2, SECONDS)
                         .create()
                         .sleep(3, SECONDS)
                         .ok()
@@ -980,6 +981,7 @@ public class RoleModelTest
                 .searchForUserEntry(userLogin)
                 .edit()
                 .addRoleOrGroup(userGroup)
+                .sleep(2, SECONDS)
                 .ok()
                 .sleep(1, SECONDS)
                 .closeAll();

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/RoleModelTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/RoleModelTest.java
@@ -93,6 +93,8 @@ public class RoleModelTest
                 .createPipeline(Template.SHELL, firstOfTheSeveralPipelines)
                 .createPipeline(Template.SHELL, secondOfTheSeveralPipelines);
 
+        createGroupPrerequisites();
+
         logout();
     }
 
@@ -932,6 +934,28 @@ public class RoleModelTest
                 ToolPermission.inherit(WRITE, tool, registry, group),
                 ToolPermission.inherit(EXECUTE, tool, registry, group));
 
+        navigationMenu()
+                .settings()
+                .switchToUserManagement()
+                .switchToGroups()
+                .deleteGroupIfPresent(userGroup)
+                .sleep(1, SECONDS)
+                .ok();
+    }
+
+    private void createGroupPrerequisites() {
+        loginAsAdminAndPerform(() ->
+                navigationMenu()
+                        .settings()
+                        .switchToUserManagement()
+                        .switchToGroups()
+                        .pressCreateGroup()
+                        .enterGroupName(userGroup)
+                        .create()
+                        .sleep(3, SECONDS)
+                        .ok()
+        );
+        refresh();
         tools()
                 .performWithin(registry, group, tool, tool ->
                         tool.permissions()
@@ -939,10 +963,24 @@ public class RoleModelTest
                                 .closeAll()
                 );
 
+        addUserToGroup(user.login.toUpperCase(), userGroup);
+        addUserToGroup(userWithoutCompletedRuns.login.toUpperCase(), userGroup);
+
         givePermissions(userGroup,
                 ToolPermission.inherit(READ, tool, registry, group),
                 ToolPermission.inherit(WRITE, tool, registry, group),
                 ToolPermission.inherit(EXECUTE, tool, registry, group));
     }
 
+    private void addUserToGroup(final String userLogin, final String userGroup) {
+        navigationMenu()
+                .settings()
+                .switchToUserManagement()
+                .switchToUsers()
+                .searchForUserEntry(userLogin)
+                .edit()
+                .addRoleOrGroup(userGroup)
+                .ok()
+                .closeAll();
+    }
 }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/RoleModelTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/RoleModelTest.java
@@ -981,6 +981,7 @@ public class RoleModelTest
                 .edit()
                 .addRoleOrGroup(userGroup)
                 .ok()
+                .sleep(1, SECONDS)
                 .closeAll();
     }
 }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ToolsScanTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ToolsScanTest.java
@@ -166,7 +166,7 @@ public class ToolsScanTest extends AbstractAutoRemovingPipelineRunningTest imple
                                 .validateReportTableColumns()
                                 .selectComponent("kernel-headers")
                                 .click(versionTab("PACKAGES"))
-                                .validatePackageList(Arrays.asList("pip", "py", "luigi"), true)
+                                .validatePackageList(Arrays.asList("pip", "py"), true)
                                 .validateEcosystem(Arrays.asList("Python.Dist", "System"))
                                 .selectEcosystem("System")
                                 .validatePackageList(Arrays.asList("bash", "bzip2", "gcc"), false)

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/WDLPipelineTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/WDLPipelineTest.java
@@ -18,16 +18,27 @@ package com.epam.pipeline.autotests;
 import com.epam.pipeline.autotests.ao.PipelineGraphTabAO;
 import com.epam.pipeline.autotests.ao.Template;
 import com.epam.pipeline.autotests.mixins.Navigation;
+import com.epam.pipeline.autotests.utils.C;
 import com.epam.pipeline.autotests.utils.TestCase;
 import com.epam.pipeline.autotests.utils.Utils;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
+import static com.codeborne.selenide.Selenide.open;
 import static com.epam.pipeline.autotests.ao.Primitive.FULLSCREEN;
 import static com.epam.pipeline.autotests.ao.Primitive.ZOOM_IN;
 import static com.epam.pipeline.autotests.ao.Primitive.ZOOM_OUT;
 
 public class WDLPipelineTest extends AbstractBfxPipelineTest implements Navigation {
     private final String pipelineName = "wdl-pipeline-test-" + Utils.randomSuffix();
+
+    @AfterClass
+    public void removePipeline() {
+        open(C.ROOT_ADDRESS);
+        navigationMenu()
+                .library()
+                .removePipeline(pipelineName);
+    }
 
     @Test
     @TestCase(value = {"EPMCMBIBPC-351"})

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/WDLTaskEditorTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/WDLTaskEditorTest.java
@@ -37,6 +37,7 @@ import static com.epam.pipeline.autotests.ao.Primitive.*;
 import static com.epam.pipeline.autotests.utils.PipelineSelectors.combobox;
 import static com.epam.pipeline.autotests.utils.PipelineSelectors.menuitem;
 import static com.epam.pipeline.autotests.utils.PipelineSelectors.modalWithTitle;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class WDLTaskEditorTest
         extends AbstractBfxPipelineTest
@@ -196,6 +197,7 @@ public class WDLTaskEditorTest
                 .close()
                 .parent()
                 .saveAndCommitWithMessage("commit message")
+                .sleep(1, SECONDS)
                 .ensure(modalWithTitle("Commit"), disappears);
     }
 

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/RunsMenuAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/RunsMenuAO.java
@@ -34,6 +34,7 @@ import static com.codeborne.selenide.CollectionCondition.*;
 import static com.codeborne.selenide.Condition.*;
 import static com.codeborne.selenide.Selectors.*;
 import static com.codeborne.selenide.Selenide.*;
+import static com.epam.pipeline.autotests.ao.Primitive.STATUS;
 import static com.epam.pipeline.autotests.utils.C.COMPLETION_TIMEOUT;
 import static com.epam.pipeline.autotests.utils.PipelineSelectors.button;
 import static com.epam.pipeline.autotests.utils.PipelineSelectors.elementWithText;
@@ -92,6 +93,11 @@ public class RunsMenuAO implements AccessObject<RunsMenuAO> {
 
     public LogAO showLog(String runId) {
         sleep(1, SECONDS);
+        show(runId);
+        sleep(3, SECONDS);
+        if (new LogAO().get(STATUS).exists()) {
+            return new LogAO();
+        }
         show(runId);
         return new LogAO();
     }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/SettingsPageAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/SettingsPageAO.java
@@ -541,7 +541,7 @@ public class SettingsPageAO extends PopupAO<SettingsPageAO, PipelinesLibraryAO> 
 
             public GroupsTabAO deleteGroupIfPresent(String group) {
                 sleep(1, SECONDS);
-                performIf(context().$(byText(group)).is(visible), t -> deleteGroup(group));
+                performIf(context().$(byText(group)).isDisplayed(), t -> deleteGroup(group));
                 return this;
             }
 

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/SettingsPageAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/SettingsPageAO.java
@@ -539,6 +539,12 @@ public class SettingsPageAO extends PopupAO<SettingsPageAO, PipelinesLibraryAO> 
                 return new CreateGroupPopup(this);
             }
 
+            public GroupsTabAO deleteGroupIfPresent(String group) {
+                sleep(1, SECONDS);
+                performIf(context().$(byText(group)).is(visible), t -> deleteGroup(group));
+                return this;
+            }
+
             public GroupsTabAO deleteGroup(final String groupName) {
                 sleep(1, SECONDS);
                 context().$(byText(groupName))

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/SettingsPageAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/SettingsPageAO.java
@@ -540,14 +540,16 @@ public class SettingsPageAO extends PopupAO<SettingsPageAO, PipelinesLibraryAO> 
             }
 
             public GroupsTabAO deleteGroupIfPresent(String group) {
-                sleep(1, SECONDS);
-                performIf(context().$(byText(group)).isDisplayed(), t -> deleteGroup(group));
+                sleep(2, SECONDS);
+                performIf(context().$$(byText(group)).filterBy(visible).first().exists(), t -> deleteGroup(group));
                 return this;
             }
 
             public GroupsTabAO deleteGroup(final String groupName) {
                 sleep(1, SECONDS);
-                context().$(byText(groupName))
+                context().$$(byText(groupName))
+                        .filterBy(visible)
+                        .first()
                         .closest(".ant-table-row-level-0")
                         .find(byClassName("ant-btn-danger"))
                         .click();


### PR DESCRIPTION
Solves some tasks from #209 

**AWS** stand:

1. Additional check was added for the run log button. In case if run doesn't open log page it tries one more time.

**AZURE** stand:
1. `ObjectMetadataFileTest` : EPMCMBIBPC-1174 (in case of adding a file attributes key containing string with spaces) test was changed in according to Azure cloud provider. 
Resolves #206 
2. Small sleep after saving of wdl changes was added to `WDLTaskEditorTest`.
3. `AutopauseTest` has been adapted to the Azure cloud provider.
4. `WDLPipelineTest` : removePipeline() with AfterClass annotation was added that delete pipeline after work test completion.
5. `RoleModelTest` has been updated. Independent creation of DOMAIN USERS group was added.
6. `ToolsScanTest` : EPMCMBIBPC-1996 test has been updated by removing the luigi package.