### PR TITLE
Pre/Post-commit hooks implementation for pause

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerContainerOperationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerContainerOperationManager.java
@@ -214,6 +214,7 @@ public class DockerContainerOperationManager {
                     .newImageName(run.getDockerImage())
                     .defaultTaskName(run.getTaskName())
                     .preCommitCommand(preferenceManager.getPreference(SystemPreferences.PRE_COMMIT_COMMAND_PATH))
+                    .postCommitCommand(preferenceManager.getPreference(SystemPreferences.POST_COMMIT_COMMAND_PATH))
                     .build()
                     .getCommand();
 

--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerPauseCommand.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerPauseCommand.java
@@ -36,6 +36,7 @@ public class DockerPauseCommand extends AbstractDockerCommand {
     private final String newImageName;
     private final String defaultTaskName;
     private final String preCommitCommand;
+    private final String postCommitCommand;
 
     private final String runPauseScriptUrl;
 
@@ -57,6 +58,7 @@ public class DockerPauseCommand extends AbstractDockerCommand {
         command.add(newImageName);
         command.add(defaultTaskName);
         command.add(preCommitCommand);
+        command.add(postCommitCommand);
         return command;
     }
 }

--- a/scripts/commit-run-scripts/pause_run.sh
+++ b/scripts/commit-run-scripts/pause_run.sh
@@ -40,9 +40,19 @@ download_file() {
 
 commit_file_and_stop_docker() {
     pipe_log_info "[INFO] Start commiting pipeline run" "$TASK_NAME"
+    commit_hook ${CONTAINER_ID} "pre" false true ${PRE_COMMIT_COMMAND}
+
     commit_file ${NEW_IMAGE_NAME}
     check_last_exit_code $? "[ERROR] Error occured while committing temporary container" \
-                            "[INFO] Temporary container was successfully committed with name: $NEW_IMAGE_NAME"
+                            "[INFO] Temporary container was successfully committed with name: ${NEW_IMAGE_NAME}"
+
+    export tmp_container=`docker run --entrypoint "/bin/sleep" -d ${NEW_IMAGE_NAME} 1d`
+
+    commit_hook ${tmp_container} "post" false true ${POST_COMMIT_COMMAND}
+
+    pipe_exec "docker commit ${tmp_container} ${NEW_IMAGE_NAME} > /dev/null" "$TASK_NAME"
+    check_last_exit_code $? "[ERROR] Error occured while committing container" \
+                            "[INFO] Container was successfully committed with name: $NEW_IMAGE_NAME"
 
     pipe_exec "docker logs ${CONTAINER_ID}" "${DEFAULT_TASK_NAME}"
     check_last_exit_code $? "[ERROR] Error occurred while retrieving logs from docker container ${CONTAINER_ID}" \
@@ -78,6 +88,7 @@ TIMEOUT=${7}
 export NEW_IMAGE_NAME=${8}
 export DEFAULT_TASK_NAME=${9}
 export PRE_COMMIT_COMMAND=${10}
+export POST_COMMIT_COMMAND=${11}
 
 export TASK_NAME="PausePipelineRun"
 export CP_PYTHON2_PATH=python


### PR DESCRIPTION
Implementation for issue #165 for pause operation. Expands implementation for previous PR #185.

- Changes for `pause_run.sh` script
    - has a new input parameters `PRE_COMMIT_COMMAND` and `POST_COMMIT_COMMAND`
    - commit logic has been changed:
        1. performs pre-commit operations in the running container
        2. creates a temporary container
        3. performs post-commit operations in the temporary container
        4. commits temporary container
- If a corresponding pre/post script is not found in the docker image - it will not be executed