### PR TITLE
Unify azure storage listing for all operations

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AbstractListingIterator.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AbstractListingIterator.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.datastorage.providers.azure;
+
+import com.epam.pipeline.manager.datastorage.providers.ProviderUtils;
+import com.microsoft.azure.storage.blob.ContainerURL;
+import com.microsoft.azure.storage.blob.ListBlobsOptions;
+import com.microsoft.azure.storage.blob.models.ContainerListBlobFlatSegmentResponse;
+import com.microsoft.azure.storage.blob.models.ContainerListBlobHierarchySegmentResponse;
+import com.microsoft.azure.storage.blob.models.ListBlobsFlatSegmentResponse;
+import com.microsoft.azure.storage.blob.models.ListBlobsHierarchySegmentResponse;
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static com.epam.pipeline.manager.datastorage.providers.azure.AzureStorageHelper.unwrap;
+
+abstract class AbstractListingIterator<T> implements Iterator<T> {
+    protected final ContainerURL container;
+    protected final String path;
+    protected final int pageSize;
+    @Getter
+    protected String nextMarker;
+
+    protected T response = null;
+
+    private AbstractListingIterator(final ContainerURL container, final String path, final String nextMarker,
+                                    final int pageSize) {
+        this.container = container;
+        this.path = path;
+        this.nextMarker = nextMarker;
+        this.pageSize = pageSize;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return response == null || StringUtils.isNotBlank(nextMarker);
+    }
+
+    @Override
+    public T next() {
+        response = loadNextResponse();
+        nextMarker = retrieveNextMarker(response);
+        return response;
+    }
+
+    protected abstract T loadNextResponse();
+
+    protected abstract String retrieveNextMarker(T response);
+
+    public Stream<T> stream() {
+        final Spliterator<T> spliterator = Spliterators.spliteratorUnknownSize(this, 0);
+        return StreamSupport.stream(spliterator, false);
+    }
+
+    public static HierarchyIterator hierarchy(final ContainerURL container, final String path, final String nextMarker,
+                                              final int pageSize) {
+        return new HierarchyIterator(container, path, nextMarker, pageSize);
+    }
+
+    public static HierarchyIterator hierarchy(final ContainerURL container, final String path) {
+        return new HierarchyIterator(container, path, null, AzureStorageHelper.MAX_PAGE_SIZE);
+    }
+
+    public static FlatIterator flat(final ContainerURL container, final String path, final String nextMarker,
+                                    final int pageSize) {
+        return new FlatIterator(container, path, nextMarker, pageSize);
+    }
+
+    public static FlatIterator flat(final ContainerURL container, final String path) {
+        return new FlatIterator(container, path, null, AzureStorageHelper.MAX_PAGE_SIZE);
+    }
+
+    static class HierarchyIterator extends AbstractListingIterator<ContainerListBlobHierarchySegmentResponse> {
+
+        private final ListBlobsOptions options = new ListBlobsOptions().withPrefix(path).withMaxResults(pageSize);
+
+        private HierarchyIterator(final ContainerURL container, final String path, final String nextMarker,
+                                  final int pageSize) {
+            super(container, path, nextMarker, pageSize);
+        }
+
+        @Override
+        protected ContainerListBlobHierarchySegmentResponse loadNextResponse() {
+            return unwrap(container.listBlobsHierarchySegment(nextMarker, ProviderUtils.DELIMITER, options));
+        }
+
+        @Override
+        protected String retrieveNextMarker(final ContainerListBlobHierarchySegmentResponse response) {
+            return Optional.ofNullable(response)
+                    .map(ContainerListBlobHierarchySegmentResponse::body)
+                    .map(ListBlobsHierarchySegmentResponse::nextMarker)
+                    .orElse(null);
+        }
+    }
+
+    static class FlatIterator extends AbstractListingIterator<ContainerListBlobFlatSegmentResponse> {
+
+        private final ListBlobsOptions options = new ListBlobsOptions().withPrefix(path).withMaxResults(pageSize);
+
+        private FlatIterator(final ContainerURL container, final String path, final String nextMarker, final int pageSize) {
+            super(container, path, nextMarker, pageSize);
+        }
+
+        @Override
+        protected ContainerListBlobFlatSegmentResponse loadNextResponse() {
+            return unwrap(container.listBlobsFlatSegment(nextMarker, options));
+        }
+
+        @Override
+        protected String retrieveNextMarker(final ContainerListBlobFlatSegmentResponse response) {
+            return Optional.ofNullable(response)
+                    .map(ContainerListBlobFlatSegmentResponse::body)
+                    .map(ListBlobsFlatSegmentResponse::nextMarker)
+                    .orElse(null);
+        }
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureStorageHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureStorageHelper.java
@@ -585,7 +585,7 @@ public class AzureStorageHelper {
     }
 
     @RequiredArgsConstructor
-    private abstract class ListingIterator<T> implements Iterator<T> {
+    private abstract class AbstractListingIterator<T> implements Iterator<T> {
         protected final AzureBlobStorage dataStorage;
         protected final String path;
 
@@ -594,8 +594,8 @@ public class AzureStorageHelper {
         @Getter
         protected String nextMarker = null;
 
-        public ListingIterator(final AzureBlobStorage dataStorage, final String path, final String nextMarker,
-                               final int pageSize) {
+        AbstractListingIterator(final AzureBlobStorage dataStorage, final String path, final String nextMarker,
+                                final int pageSize) {
             this(dataStorage, path);
             this.nextMarker = nextMarker;
             this.pageSize = pageSize;
@@ -609,13 +609,13 @@ public class AzureStorageHelper {
         @Override
         public T next() {
             response = loadNextResponse();
-            nextMarker = nextMarker(response);
+            nextMarker = retrieveNextMarker(response);
             return response;
         }
 
         protected abstract T loadNextResponse();
 
-        protected abstract String nextMarker(T response);
+        protected abstract String retrieveNextMarker(T response);
 
         public Stream<T> stream() {
             final Spliterator<T> spliterator = Spliterators.spliteratorUnknownSize(this, 0);
@@ -623,14 +623,14 @@ public class AzureStorageHelper {
         }
     }
 
-    private class HierarchyListingIterator extends ListingIterator<ContainerListBlobHierarchySegmentResponse> {
+    private class HierarchyListingIterator extends AbstractListingIterator<ContainerListBlobHierarchySegmentResponse> {
 
-        public HierarchyListingIterator(final AzureBlobStorage dataStorage, final String path, final String nextMarker,
-                                        final int pageSize) {
+        HierarchyListingIterator(final AzureBlobStorage dataStorage, final String path, final String nextMarker,
+                                 final int pageSize) {
             super(dataStorage, path, nextMarker, pageSize);
         }
 
-        public HierarchyListingIterator(final AzureBlobStorage dataStorage, final String path) {
+        HierarchyListingIterator(final AzureBlobStorage dataStorage, final String path) {
             super(dataStorage, path);
         }
 
@@ -642,7 +642,7 @@ public class AzureStorageHelper {
         }
 
         @Override
-        protected String nextMarker(final ContainerListBlobHierarchySegmentResponse response) {
+        protected String retrieveNextMarker(final ContainerListBlobHierarchySegmentResponse response) {
             return Optional.ofNullable(response)
                     .map(ContainerListBlobHierarchySegmentResponse::body)
                     .map(ListBlobsHierarchySegmentResponse::nextMarker)
@@ -650,14 +650,14 @@ public class AzureStorageHelper {
         }
     }
 
-    private class FlatListingIterator extends ListingIterator<ContainerListBlobFlatSegmentResponse> {
+    private class FlatListingIterator extends AbstractListingIterator<ContainerListBlobFlatSegmentResponse> {
 
-        public FlatListingIterator(final AzureBlobStorage dataStorage, final String path, final String nextMarker,
-                                   final int pageSize) {
+        FlatListingIterator(final AzureBlobStorage dataStorage, final String path, final String nextMarker,
+                            final int pageSize) {
             super(dataStorage, path, nextMarker, pageSize);
         }
 
-        public FlatListingIterator(final AzureBlobStorage dataStorage, final String path) {
+        FlatListingIterator(final AzureBlobStorage dataStorage, final String path) {
             super(dataStorage, path);
         }
 
@@ -669,7 +669,7 @@ public class AzureStorageHelper {
         }
 
         @Override
-        protected String nextMarker(final ContainerListBlobFlatSegmentResponse response) {
+        protected String retrieveNextMarker(final ContainerListBlobFlatSegmentResponse response) {
             return Optional.ofNullable(response)
                     .map(ContainerListBlobFlatSegmentResponse::body)
                     .map(ListBlobsFlatSegmentResponse::nextMarker)

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureStorageHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureStorageHelper.java
@@ -471,7 +471,7 @@ public class AzureStorageHelper {
 
     private boolean blobExists(final AzureBlobStorage dataStorage, final String path) {
         return list(AbstractListingIterator.flat(getContainerURL(dataStorage), path, null, 1))
-                .anyMatch(it -> it.getName().equals(path));
+                .anyMatch(it -> it.getPath().equals(path));
     }
 
     private void validatePath(final String path) {
@@ -480,10 +480,11 @@ public class AzureStorageHelper {
     }
 
     private DataStorageFile createDataStorageFile(final BlobItem blob, final String path) {
-        final String fileName = StringUtils.isBlank(path) ? blob.name() : FilenameUtils.getName(blob.name());
+        final String fileName = FilenameUtils.getName(blob.name());
+        final String filePath = computeFilePath(path, fileName, blob);
         final DataStorageFile dataStorageFile = new DataStorageFile();
         dataStorageFile.setName(fileName);
-        dataStorageFile.setPath(computeFilePath(fileName, path));
+        dataStorageFile.setPath(filePath);
         final Map<String, String> labels = new HashMap<>();
         if (blob.properties().accessTier() != null) {
             labels.put("StorageClass", blob.properties().accessTier().toString());
@@ -496,8 +497,8 @@ public class AzureStorageHelper {
         return dataStorageFile;
     }
 
-    private String computeFilePath(final String fileName, final String path) {
-        return StringUtils.isNotBlank(path) ? ProviderUtils.withTrailingDelimiter(path) + fileName : fileName;
+    private String computeFilePath(final String path, final String fileName, final BlobItem blob) {
+        return StringUtils.isNotBlank(path) ? ProviderUtils.withTrailingDelimiter(path) + fileName : blob.name();
     }
 
     private DataStorageFile getDataStorageFile(final AzureBlobStorage storage, final String path) {


### PR DESCRIPTION
Resolves #189.

The pull request unifies storage paginated listing calls. It brings support for moving and deleting folders with more than 5000 file. Moreover, a number of api calls while copying folders was optimized.