### PR TITLE
Improve Azure runs termination

### DIFF
--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -416,7 +416,6 @@ public final class MessageConstants {
     public static final String ERROR_AZURE_STORAGE_KEY_REQUIRED = "error.azure.storage.key.required";
     public static final String ERROR_AZURE_INSTANCE_NOT_FOUND = "error.azure.instance.not.found";
     public static final String ERROR_AZURE_INSTANCE_NOT_RUNNING = "error.azure.instance.not.running";
-    public static final String ERROR_AZURE_INSTANCE_NOT_ALIVE = "error.azure.instance.not.alive";
     public static final String ERROR_DATASTORAGE_AZURE_INVALID_ACCOUNT_KEY =
             "error.datastorage.azure.invalid.account.key";
     public static final String ERROR_DATASTORAGE_AZURE_CREATE_FILE = "error.datastorage.azure.create.file";

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
@@ -451,7 +451,7 @@ public class PipelineRunController extends AbstractRestController {
         return Result.success();
     }
 
-    @GetMapping(value = "/run/{runId}/terminate")
+    @PostMapping(value = "/run/{runId}/terminate")
     @ResponseBody
     @ApiOperation(
             value = "Terminates paused pipeline run.",

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzureInstanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzureInstanceService.java
@@ -176,13 +176,13 @@ public class AzureInstanceService implements CloudInstanceService<AzureRegion> {
                                          final Supplier<VirtualMachine> supplier) {
         try {
             final VirtualMachine vm = supplier.get();
-            instance.setNodeId(vm.vmId());
+            instance.setNodeId(vm.name());
             final NetworkInterface networkInterface = vmService.getVMNetworkInterface(region.getAuthFile(), vm);
-            instance.setNodeName(networkInterface.primaryIPConfiguration().privateIPAddress());
-            instance.setNodeIP(networkInterface.internalFqdn());
+            instance.setNodeName(vm.name());
+            instance.setNodeIP(networkInterface.primaryIPConfiguration().privateIPAddress());
             return instance;
         } catch (AzureException e) {
-            log.error("An error while getting instance description {}", nodeLabel);
+            log.error(String.format("An error while getting instance description %s", nodeLabel), e);
             return null;
         }
     }

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -389,6 +389,5 @@ error.azure.storage.account.required=Storage account must be specified.
 error.azure.storage.key.required=Storage account key must be specified.
 error.azure.instance.not.found=Failed to find Azure instance with id {0}.
 error.azure.instance.not.running=Azure instance {0} is not in active state. Current state: {1}.
-error.azure.instance.not.alive=Azure instance {0} is not in running or paused state. Current state: {1}.
 error.datastorage.azure.invalid.account.key=Azure account key for account name ''{0}'' is invalid.
 error.datastorage.azure.create.file=Could not create a file in azure: {0}.


### PR DESCRIPTION
In addition to #222 resolves issue #188 for backend.

The pull request changes Azure runs termination mechanism introduces in #222. It deletes all run corresponding resources (virtual machine, networking and etc.) rather then deallocating the virtual machine.

Moreover it fixes `AzureInstanceService.describeInstance` method which set wrong node id and node ip parameters.

Also the pull request changes http method from `GET` to `POST` for `/run/{runId}/terminate` endpoint .