### PR TITLE
GCP: pipe cli progress bar

### DIFF
--- a/pipe-cli/requirements.txt
+++ b/pipe-cli/requirements.txt
@@ -16,7 +16,7 @@ PyJWT==1.6.1
 pypac==0.8.1
 beautifulsoup4==4.6.1
 azure-storage-blob==1.5.0
-google-cloud-storage==1.14.0
+google-cloud-storage==1.15.0
 pyasn1-modules==0.2.4
 pyasn1==0.4.5
 setuptools


### PR DESCRIPTION
Resolves issue #145.

Brings support for observable chunked upload / download operations introducing a workaround for the official sdk limitations. The progress bar is adapted to show all the intermediate steps while uploading / downloading a blob.

Moreover, the `google-cloud-storage` dependency is updated from `1.14.0` to `1.15.0`. It is necessary for getting rid of the workaround for blob generation deletion introduced in #57.