### PR TITLE
Issue 233. Check run status while creating service endpoints for run.

### DIFF
--- a/deploy/docker/cp-edge/sync-routes.py
+++ b/deploy/docker/cp-edge/sync-routes.py
@@ -117,6 +117,11 @@ def get_service_list(pod_id, pod_run_id, pod_ip):
         response_data = call_api(get_run_details_method)
         if response_data:
                 run_info = response_data["payload"]
+
+                if not run_info["status"] or run_info["status"] != 'RUNNING':
+                        print('Status for pipeline with id: {}, is not RUNNING. Service urls will not been proxied'.format(pod_run_id))
+                        return {}
+
                 pod_owner = run_info["owner"]
                 docker_image = run_info["dockerImage"]
                 runs_sids = None
@@ -173,7 +178,7 @@ def get_service_list(pod_id, pod_run_id, pod_ip):
                                                 else:
                                                         edge_target = edge_target + "/"
 
-                                                services_list[edge_location] = {"pod_id": pod_id,
+                                                service_list[edge_location] = {"pod_id": pod_id,
                                                                                 "pod_ip": pod_ip,
                                                                                 "pod_owner": pod_owner,
                                                                                 "shared_users_sids": shared_users_sids,


### PR DESCRIPTION
Implement solution as discussed in #233 

Now before actually create proxy endpoints on server, script will check that run has status RUNNING, and if it's not, will skip it.

I also found mistake in this script. 
It lies with way to populating global variable `services_list`. Method `get_service_list` was designed to collect all service endpoints of a run as temporary `map` and return it to whom it calls, after that global variable `services_list` should be updated with this returned value. But actually we updates `services_list` right in method `get_service_list` by mistake and return empty list. So at the end script worked as expected but I fixed this behavior in order to make the logic of the script more straightforward.