### PR TITLE
Issue 267 implement backward compatibility `aws_region` label

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/cluster/NodeInstance.java
+++ b/api/src/main/java/com/epam/pipeline/entity/cluster/NodeInstance.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static com.epam.pipeline.manager.cluster.KubernetesConstants.AWS_REGION_LABEL;
 import static com.epam.pipeline.manager.cluster.KubernetesConstants.CLOUD_PROVIDER_LABEL;
 import static com.epam.pipeline.manager.cluster.KubernetesConstants.CLOUD_REGION_LABEL;
 import static com.epam.pipeline.manager.cluster.KubernetesConstants.RUN_ID_LABEL;
@@ -79,7 +80,13 @@ public class NodeInstance extends AbstractSecuredEntity {
             this.setLabels(labels);
             if (labels != null) {
                 this.setRunId(labels.get(RUN_ID_LABEL));
-                this.setRegion(labels.get(CLOUD_REGION_LABEL));
+
+                if (labels.containsKey(CLOUD_REGION_LABEL)) {
+                    this.setRegion(labels.get(CLOUD_REGION_LABEL));
+                } else if (labels.containsKey(AWS_REGION_LABEL)) {
+                    this.setRegion(labels.get(AWS_REGION_LABEL));
+                }
+
                 String providerLabel = labels.get(CLOUD_PROVIDER_LABEL);
                 if (StringUtils.isNotBlank(providerLabel)) {
                     this.setProvider(CloudProvider.valueOf(providerLabel));

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesConstants.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesConstants.java
@@ -29,6 +29,7 @@ public final class KubernetesConstants {
 
     public static final String RUN_ID_LABEL = "runid";
     public static final String CLOUD_REGION_LABEL = "cloud_region";
+    public static final String AWS_REGION_LABEL = "aws_region";
     public static final String CLOUD_PROVIDER_LABEL = "cloud_provider";
     public static final String POD_WORKER_NODE_LABEL = "cluster_id";
     public static final String PAUSED_NODE_LABEL = "Paused";

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesManager.java
@@ -349,12 +349,18 @@ public class KubernetesManager {
         }
         final Node node = nodes.get(0);
         final Map<String, String> labels = node.getMetadata().getLabels();
-        if (MapUtils.isEmpty(labels) || !labels.containsKey(KubernetesConstants.CLOUD_REGION_LABEL)) {
+        if (MapUtils.isEmpty(labels) || (!labels.containsKey(KubernetesConstants.CLOUD_REGION_LABEL)
+                        && !labels.containsKey(KubernetesConstants.AWS_REGION_LABEL))) {
             throw new IllegalArgumentException(String.format("Node %s is not labeled with Cloud Region",
                     node.getMetadata().getName()));
         }
+
+        final String regionLabel = labels.containsKey(KubernetesConstants.CLOUD_REGION_LABEL)
+                ? getLabel(node, KubernetesConstants.CLOUD_REGION_LABEL)
+                : getLabel(node, KubernetesConstants.AWS_REGION_LABEL);
+
         return new NodeRegionLabels(CloudProvider.valueOf(getLabel(node, KubernetesConstants.CLOUD_PROVIDER_LABEL)),
-                getLabel(node, KubernetesConstants.CLOUD_REGION_LABEL));
+                regionLabel);
     }
 
     private String getLabel(final Node node, final String label) {

--- a/scripts/autoscaling/aws/node_reassign.py
+++ b/scripts/autoscaling/aws/node_reassign.py
@@ -17,7 +17,8 @@ import argparse
 import pykube
 
 RUN_ID_LABEL = 'runid'
-AWS_REGION_LABEL = 'cloud_region'
+AWS_REGION_LABEL = 'aws_region'
+CLOUD_REGION_LABEL = 'cloud_region'
 
 
 def find_and_tag_instance(ec2, old_id, new_id):
@@ -68,13 +69,14 @@ def change_label(api, nodename, new_id, aws_region):
         "metadata": {
             "name": nodename,
             "labels": {
-                RUN_ID_LABEL: new_id
+                RUN_ID_LABEL: new_id,
+                AWS_REGION_LABEL: None
             }
         }
     }
     node = pykube.Node(api, obj)
     node.labels[RUN_ID_LABEL] = new_id
-    node.labels[AWS_REGION_LABEL] = aws_region
+    node.labels[CLOUD_REGION_LABEL] = aws_region
     node.update()
 
 
@@ -84,9 +86,9 @@ def get_aws_region(api, run_id):
         raise RuntimeError('Cannot find node matching RUN ID %s' % run_id)
     node = nodes.response['items'][0]
     labels = node['metadata']['labels']
-    if AWS_REGION_LABEL not in labels:
+    if AWS_REGION_LABEL not in labels and CLOUD_REGION_LABEL not in labels:
         raise RuntimeError('Node %s is not labeled with AWS Region' % node['metadata']['name'])
-    return labels[AWS_REGION_LABEL]
+    return labels[CLOUD_REGION_LABEL] if CLOUD_REGION_LABEL in labels else labels[AWS_REGION_LABEL]
 
 
 def get_kube_api():

--- a/scripts/autoscaling/aws/nodedown.py
+++ b/scripts/autoscaling/aws/nodedown.py
@@ -17,7 +17,9 @@ import argparse
 import pykube
 
 RUN_ID_LABEL = 'runid'
-AWS_REGION_LABEL = 'cloud_region'
+AWS_REGION_LABEL = 'aws_region'
+CLOUD_REGION_LABEL = 'cloud_region'
+
 
 
 def find_instance(ec2, run_id):
@@ -92,9 +94,9 @@ def get_aws_region(api, run_id):
         raise RuntimeError('Cannot find node matching RUN ID %s' % run_id)
     node = nodes.response['items'][0]
     labels = node['metadata']['labels']
-    if AWS_REGION_LABEL not in labels:
+    if AWS_REGION_LABEL not in labels and CLOUD_REGION_LABEL not in labels:
         raise RuntimeError('Node %s is not labeled with AWS Region' % node['metadata']['name'])
-    return labels[AWS_REGION_LABEL]
+    return labels[CLOUD_REGION_LABEL] if CLOUD_REGION_LABEL in labels else labels[AWS_REGION_LABEL]
 
 
 def get_kube_api():

--- a/scripts/autoscaling/aws/terminate_node.py
+++ b/scripts/autoscaling/aws/terminate_node.py
@@ -17,7 +17,8 @@ import pykube
 import argparse
 
 RUN_ID_LABEL = 'runid'
-AWS_REGION_LABEL = 'cloud_region'
+AWS_REGION_LABEL = 'aws_region'
+CLOUD_REGION_LABEL = 'cloud_region'
 KUBE_CONFIG_PATH = '~/.kube/config'
 
 
@@ -66,9 +67,9 @@ def get_aws_region(api, nodename):
     if node is None:
         raise RuntimeError('Cannot find node matching name %s' % nodename)
     labels = node['metadata']['labels']
-    if AWS_REGION_LABEL not in labels:
+    if AWS_REGION_LABEL not in labels and CLOUD_REGION_LABEL not in labels:
         raise RuntimeError('Node %s is not labeled with AWS Region' % node['metadata']['name'])
-    return labels[AWS_REGION_LABEL]
+    return labels[CLOUD_REGION_LABEL] if CLOUD_REGION_LABEL in labels else labels[AWS_REGION_LABEL]
 
 
 def get_kube_api():


### PR DESCRIPTION
This PR adds backward compatibility for pipeline nodes that labeled with label `aws_region` instead of `cloud_region`

Autoscaling scripts will search `cloud_region` label in node labels and if it fails will try to find `aws_region` as it works in 0.14 release.

reassing_node.py also will change node label `aws_region` to `cloud_region` in order to make this nodes compatible with new label naming.