### PR TITLE
UI Launch cluster dialog: 'Enable grid engine'

### DIFF
--- a/client/src/components/pipelines/launch/form/utilities/launch-cluster-tooltips.js
+++ b/client/src/components/pipelines/launch/form/utilities/launch-cluster-tooltips.js
@@ -30,23 +30,64 @@ import {Icon, Row, Tooltip} from 'antd';
  * Tooltip won't be shown if no value is presented (`undefined`).
  */
 
-const CLUSTER_MODES_TOOLTIP = 'Cluster configuration allows you specify number of compute nodes that will process a job.'
-                              'This is useful if a job is too heavy for a single node or it uses scheduling approach to process a series of tasks across nodes.'
-                              '- Single node: no cluster will be provisioned - this is a default run configuration'
-                              '- Cluster: a specified number of compute nodes will be created and interconnected via a shared filesystem (/common/) and SSH'
-                              '  Optionally, GridEngine can be configured for the cluster. See "Enable GridEngine" checkbox below'
-                              '- Autoscaling: allows to startup a small cluster (even a single/master node) and then scale it up/down according to the workload'
-                              '  This mode will always setup GridEngine, as it is used to control the current jobs queue';
-const ENABLE_GRID_ENGINE_TOOLTIP = 'Setting this checkbox will enable the GridEngine for the cluster, providing all the compatible command-line utilities,e.g.:'
-                                   'qsub, qstat, qhost, qconf, etc.'
-                                   'This checkbox is a convenience option for the "CP_CAP_SGE=true" parameter';
-const AUTOSCALED_CLUSTER_UP_TO_TOOLTIP = 'Defines maximum number of compute nodes, that can be created in the cluster (besides the master node and the "fixed" nodes, see "Default child nodes")'
-                                         'GridEngine queue will be checked for the entries in "wait" state and new compute nodes will be spawned to schedule the jobs'
-                                         'Once the autoscaled nodes are not needed - they will terminated';
-const AUTOSCALED_CLUSTER_DEFAULT_NODES_COUNT_TOOLTIP = 'Defines the number of compute nodes, that will be created initially.'
-                                                       'These nodes will not be scaled down, even if no workload is currently running.'
-                                                       'It can be considered a "fixed" part of the cluster.'
-                                                       'If not set - only a master node will be available at a startup time.';
+const CLUSTER_MODES_TOOLTIP = (
+  <div>
+    <Row>
+      Cluster configuration allows you specify number of compute nodes that will process a job.
+      This is useful if a job is too heavy for a single node or it uses scheduling approach to process a series of tasks across nodes.
+    </Row>
+    <Row>
+      <ul type="circle">
+        <li style={{marginLeft: 5}}>
+          - <b>Single node</b>: no cluster will be provisioned - this is a default run configuration
+        </li>
+        <li style={{marginLeft: 5}}>
+          - <b>Cluster</b>: a specified number of compute nodes will be created and interconnected via a shared filesystem (/common/) and SSH.
+          Optionally, GridEngine can be configured for the cluster. See "Enable GridEngine" checkbox below
+        </li>
+        <li style={{marginLeft: 5}}>
+          - <b>Autoscaling</b>: allows to startup a small cluster (even a single/master node) and then scale it up/down according to the workload.
+          This mode will always setup GridEngine, as it is used to control the current jobs queue.
+        </li>
+      </ul>
+    </Row>
+  </div>
+);
+const ENABLE_GRID_ENGINE_TOOLTIP = (
+  <div>
+    <Row>
+      Setting this checkbox will enable the <b>GridEngine</b> for the cluster, providing all the compatible command-line utilities,e.g.: <b>qsub, qstat, qhost, qconf,</b> etc.
+    </Row>
+    <Row>
+      This checkbox is a convenience option for the <b>"CP_CAP_SGE=true"</b> parameter.
+    </Row>
+  </div>
+);
+const AUTOSCALED_CLUSTER_UP_TO_TOOLTIP = (
+  <div>
+    <Row>
+      Defines <b>maximum number of compute nodes</b>, that can be created in the cluster (besides the master node and the "fixed" nodes, see "Default child nodes").
+    </Row>
+    <Row>
+      GridEngine queue will be checked for the entries in "wait" state and new compute nodes will be spawned to schedule the jobs.
+      Once the autoscaled nodes are not needed - they will terminated.
+    </Row>
+  </div>
+);
+const AUTOSCALED_CLUSTER_DEFAULT_NODES_COUNT_TOOLTIP = (
+  <div>
+    <Row>
+      Defines <b>the number of compute nodes</b>, that will be created initially.
+    </Row>
+    <Row>
+      These nodes will not be scaled down, even if no workload is currently running.
+      It can be considered a "fixed" part of the cluster.
+    </Row>
+    <Row>
+      If not set - only a master node will be available at a startup time.
+    </Row>
+  </div>
+);
 
 export const LaunchClusterTooltip = {
   clusterMode: 'cluster mode',

--- a/client/src/components/pipelines/launch/form/utilities/launch-cluster-tooltips.js
+++ b/client/src/components/pipelines/launch/form/utilities/launch-cluster-tooltips.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import {Icon, Row, Tooltip} from 'antd';
+
+/*
+ * Launch cluster tooltips.
+ *
+ * 4 tooltips are presented for 'Launch cluster' dialog:
+ *  - Common tooltip for popup header (`CLUSTER_MODES_TOOLTIP`)
+ *  - Enable grid engine tooltip for 'Cluster' tab (`ENABLE_GRID_ENGINE_TOOLTIP`)
+ *  - Auto-scaled up to & default child nodes tooltips for 'Auto-scaled cluster' tab
+ *    (`AUTOSCALED_CLUSTER_UP_TO_TOOLTIP`, `AUTOSCALED_CLUSTER_DEFAULT_NODES_COUNT_TOOLTIP`)
+ *
+ * You can use both text & markdown (html) for tooltips.
+ * Tooltip won't be shown if no value is presented (`undefined`).
+ */
+
+const CLUSTER_MODES_TOOLTIP = (
+  <div>
+    <Row><h3 style={{color: 'white'}}>Cluster modes</h3></Row>
+    <ul>
+      <li><b>Single node</b>: single node will be launched</li>
+      <li><b>Cluster</b>: a cluster with fixed child nodes will be launched</li>
+      <li><b>Auto-scaled cluster</b>: you can configure default and maximum child nodes count</li>
+    </ul>
+  </div>
+);
+
+const ENABLE_GRID_ENGINE_TOOLTIP = 'Enable grid engine';
+const AUTOSCALED_CLUSTER_UP_TO_TOOLTIP = undefined;
+const AUTOSCALED_CLUSTER_DEFAULT_NODES_COUNT_TOOLTIP = undefined;
+
+export const LaunchClusterTooltip = {
+  clusterMode: 'cluster mode',
+  cluster: {
+    enableGridEngine: 'enable grid engine'
+  },
+  autoScaledCluster: {
+    autoScaledUpTo: 'up to',
+    defaultNodesCount: 'default nodes count'
+  }
+};
+
+const tooltips = {
+  [LaunchClusterTooltip.clusterMode]:
+    CLUSTER_MODES_TOOLTIP,
+  [LaunchClusterTooltip.cluster.enableGridEngine]:
+    ENABLE_GRID_ENGINE_TOOLTIP,
+  [LaunchClusterTooltip.autoScaledCluster.autoScaledUpTo]:
+    AUTOSCALED_CLUSTER_UP_TO_TOOLTIP,
+  [LaunchClusterTooltip.autoScaledCluster.defaultNodesCount]:
+    AUTOSCALED_CLUSTER_DEFAULT_NODES_COUNT_TOOLTIP
+};
+
+export function renderTooltip (tooltip, style) {
+  if (!tooltips[tooltip]) {
+    return null;
+  }
+  return (
+    <Tooltip title={tooltips[tooltip]}>
+      <Icon
+        type="question-circle"
+        style={style} />
+    </Tooltip>
+  );
+}

--- a/client/src/components/pipelines/launch/form/utilities/launch-cluster-tooltips.js
+++ b/client/src/components/pipelines/launch/form/utilities/launch-cluster-tooltips.js
@@ -30,20 +30,23 @@ import {Icon, Row, Tooltip} from 'antd';
  * Tooltip won't be shown if no value is presented (`undefined`).
  */
 
-const CLUSTER_MODES_TOOLTIP = (
-  <div>
-    <Row><h3 style={{color: 'white'}}>Cluster modes</h3></Row>
-    <ul>
-      <li><b>Single node</b>: single node will be launched</li>
-      <li><b>Cluster</b>: a cluster with fixed child nodes will be launched</li>
-      <li><b>Auto-scaled cluster</b>: you can configure default and maximum child nodes count</li>
-    </ul>
-  </div>
-);
-
-const ENABLE_GRID_ENGINE_TOOLTIP = 'Enable grid engine';
-const AUTOSCALED_CLUSTER_UP_TO_TOOLTIP = undefined;
-const AUTOSCALED_CLUSTER_DEFAULT_NODES_COUNT_TOOLTIP = undefined;
+const CLUSTER_MODES_TOOLTIP = 'Cluster configuration allows you specify number of compute nodes that will process a job.'
+                              'This is useful if a job is too heavy for a single node or it uses scheduling approach to process a series of tasks across nodes.'
+                              '- Single node: no cluster will be provisioned - this is a default run configuration'
+                              '- Cluster: a specified number of compute nodes will be created and interconnected via a shared filesystem (/common/) and SSH'
+                              '  Optionally, GridEngine can be configured for the cluster. See "Enable GridEngine" checkbox below'
+                              '- Autoscaling: allows to startup a small cluster (even a single/master node) and then scale it up/down according to the workload'
+                              '  This mode will always setup GridEngine, as it is used to control the current jobs queue';
+const ENABLE_GRID_ENGINE_TOOLTIP = 'Setting this checkbox will enable the GridEngine for the cluster, providing all the compatible command-line utilities,e.g.:'
+                                   'qsub, qstat, qhost, qconf, etc.'
+                                   'This checkbox is a convenience option for the "CP_CAP_SGE=true" parameter';
+const AUTOSCALED_CLUSTER_UP_TO_TOOLTIP = 'Defines maximum number of compute nodes, that can be created in the cluster (besides the master node and the "fixed" nodes, see "Default child nodes")'
+                                         'GridEngine queue will be checked for the entries in "wait" state and new compute nodes will be spawned to schedule the jobs'
+                                         'Once the autoscaled nodes are not needed - they will terminated';
+const AUTOSCALED_CLUSTER_DEFAULT_NODES_COUNT_TOOLTIP = 'Defines the number of compute nodes, that will be created initially.'
+                                                       'These nodes will not be scaled down, even if no workload is currently running.'
+                                                       'It can be considered a "fixed" part of the cluster.'
+                                                       'If not set - only a master node will be available at a startup time.';
 
 export const LaunchClusterTooltip = {
   clusterMode: 'cluster mode',

--- a/client/src/components/tools/forms/EditToolForm.js
+++ b/client/src/components/tools/forms/EditToolForm.js
@@ -45,7 +45,8 @@ import {
   CP_CAP_AUTOSCALE_WORKERS,
   ConfigureClusterDialog,
   getSkippedSystemParametersList,
-  getSystemParameterDisabledState
+  getSystemParameterDisabledState,
+  gridEngineEnabled
 } from '../../pipelines/launch/form/utilities/launch-cluster';
 
 const Panels = {
@@ -102,6 +103,7 @@ export default class EditToolForm extends React.Component {
     nodesCount: 0,
     maxNodesCount: 0,
     autoScaledCluster: false,
+    gridEngineEnabled: false,
     launchCluster: false
   };
 
@@ -170,6 +172,13 @@ export default class EditToolForm extends React.Component {
               name: CP_CAP_AUTOSCALE_WORKERS,
               type: 'int',
               value: +this.state.maxNodesCount
+            });
+          }
+          if (this.state.launchCluster && this.state.gridEngineEnabled) {
+            params.push({
+              name: CP_CAP_SGE,
+              type: 'boolean',
+              value: true
             });
           }
 
@@ -262,6 +271,7 @@ export default class EditToolForm extends React.Component {
             : 0;
         state.nodesCount = props.configuration.node_count;
         state.autoScaledCluster = props.configuration && autoScaledClusterEnabled(props.configuration.parameters);
+        state.gridEngineEnabled = props.configuration && gridEngineEnabled(props.configuration.parameters);
         state.launchCluster = state.nodesCount > 0 || state.autoScaledCluster;
         this.defaultCommand = props.configuration && props.configuration.cmd_template
           ? props.configuration.cmd_template
@@ -473,6 +483,8 @@ export default class EditToolForm extends React.Component {
         : 0;
     const autoScaledCluster = this.props.configuration &&
       autoScaledClusterEnabled(this.props.configuration.parameters);
+    const gridEngineEnabledValue = this.props.configuration &&
+      gridEngineEnabled(this.props.configuration.parameters);
     const launchCluster = nodesCount > 0 || autoScaledCluster;
     return configurationFormFieldChanged('is_spot') ||
       configurationFormFieldChanged('instance_size', 'instanceType') ||
@@ -484,6 +496,7 @@ export default class EditToolForm extends React.Component {
       (this.toolFormSystemParameters && this.toolFormSystemParameters.modified) ||
       !!launchCluster !== !!this.state.launchCluster ||
       !!autoScaledCluster !== !!this.state.autoScaledCluster ||
+      !!gridEngineEnabledValue !== !!this.state.gridEngineEnabled ||
       (this.state.launchCluster && nodesCount !== this.state.nodesCount) ||
       (this.state.launchCluster && this.state.autoScaledCluster && maxNodesCount !== this.state.maxNodesCount) ||
       limitMountsFieldChanged();
@@ -519,8 +532,8 @@ export default class EditToolForm extends React.Component {
   };
 
   onChangeClusterConfiguration = (configuration) => {
-    const {launchCluster, autoScaledCluster, nodesCount, maxNodesCount} = configuration;
-    this.setState({launchCluster, nodesCount, autoScaledCluster, maxNodesCount},
+    const {launchCluster, autoScaledCluster, nodesCount, maxNodesCount, gridEngineEnabled} = configuration;
+    this.setState({launchCluster, nodesCount, autoScaledCluster, maxNodesCount, gridEngineEnabled},
       this.closeConfigureClusterDialog);
   };
 
@@ -778,6 +791,7 @@ export default class EditToolForm extends React.Component {
                 instanceName={this.props.form.getFieldValue('instanceType')}
                 launchCluster={this.state.launchCluster}
                 autoScaledCluster={this.state.autoScaledCluster}
+                gridEngineEnabled={this.state.gridEngineEnabled}
                 nodesCount={this.state.nodesCount}
                 maxNodesCount={+this.state.maxNodesCount || 1}
                 onClose={this.closeConfigureClusterDialog}


### PR DESCRIPTION
Allow to set the Grid Engine capability when a "fixed" cluster is configured - done (fix for #255 )