### PR TITLE
Backend support for Docker in Docker

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/cluster/DockerMount.java
+++ b/api/src/main/java/com/epam/pipeline/entity/cluster/DockerMount.java
@@ -22,7 +22,7 @@ import lombok.Data;
 @Data
 @Builder
 public class DockerMount {
-    final String name;
-    final String hostPath;
-    final String mountPath;
+    private final String name;
+    private final String hostPath;
+    private final String mountPath;
 }

--- a/api/src/main/java/com/epam/pipeline/entity/cluster/DockerMount.java
+++ b/api/src/main/java/com/epam/pipeline/entity/cluster/DockerMount.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.cluster;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class DockerMount {
+    final String name;
+    final String hostPath;
+    final String mountPath;
+}

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesConstants.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesConstants.java
@@ -16,8 +16,12 @@
 
 package com.epam.pipeline.manager.cluster;
 
+import com.epam.pipeline.entity.cluster.DockerMount;
+
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -64,6 +68,21 @@ public final class KubernetesConstants {
     static {
         NODE_OUT_OF_ORDER_REASONS.add("KubeletOutOfDisk");
         NODE_OUT_OF_ORDER_REASONS.add("NodeStatusUnknown");
+    }
+
+    public static final List<DockerMount> DEFAULT_DOCKER_IN_DOCKER_MOUNTS = new ArrayList<>();
+
+    static {
+        DEFAULT_DOCKER_IN_DOCKER_MOUNTS.add(DockerMount.builder()
+                .name("docker-sock")
+                .hostPath("/var/run/docker.sock")
+                .mountPath("/var/run/docker.sock")
+                .build());
+        DEFAULT_DOCKER_IN_DOCKER_MOUNTS.add(DockerMount.builder()
+                .name("docker-bin")
+                .hostPath("/bin/docker")
+                .mountPath("/usr/bin/docker")
+                .build());
     }
 
     public static final DateTimeFormatter KUBE_DATE_FORMATTER = DateTimeFormatter.ISO_DATE_TIME;

--- a/api/src/main/java/com/epam/pipeline/manager/execution/PipelineLauncher.java
+++ b/api/src/main/java/com/epam/pipeline/manager/execution/PipelineLauncher.java
@@ -170,6 +170,9 @@ public class PipelineLauncher {
         systemParamsWithValue.put(SystemParams.CLUSTER_NAME, DEFAULT_CLUSTER_NAME);
         systemParamsWithValue.put(SystemParams.SSH_PASS, run.getSshPassword());
         putIfStringValuePresent(systemParamsWithValue, SystemParams.RUN_CONFIG_NAME, run.getConfigName());
+        if (Boolean.TRUE.equals(preferenceManager.getPreference(SystemPreferences.DOCKER_IN_DOCKER_ENABLED))) {
+            systemParamsWithValue.put(SystemParams.ENABLE_DOCKER_IN_DOCKER, "true");
+        }
         if (enableAutoscaling) {
             systemParamsWithValue.put(SystemParams.AUTOSCALING_ENABLED, "");
         }

--- a/api/src/main/java/com/epam/pipeline/manager/execution/SystemParams.java
+++ b/api/src/main/java/com/epam/pipeline/manager/execution/SystemParams.java
@@ -59,7 +59,8 @@ public enum SystemParams {
     GS_OAUTH_CLIENT_ID("google-client-id", "GS_CLIENT_ID", true),
     GS_OAUTH_CLIENT_SECRET("google-client-secret", "GS_CLIENT_SECRET", true),
     PARENT_ID("parent-id", "parent_id", false),
-    RESUMED_RUN("resumed-run", "RESUMED_RUN", false);
+    RESUMED_RUN("resumed-run", "RESUMED_RUN", false),
+    ENABLE_DOCKER_IN_DOCKER("dind-enabled", "CP_CAP_DIND");
 
     public static final String CLOUD_REGION_PREFIX = "CP_ACCOUNT_REGION_";
     public static final String CLOUD_ACCOUNT_PREFIX = "CP_ACCOUNT_ID_";

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -19,6 +19,7 @@ package com.epam.pipeline.manager.preference;
 import com.epam.pipeline.common.MessageConstants;
 import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.entity.cluster.CloudRegionsConfiguration;
+import com.epam.pipeline.entity.cluster.DockerMount;
 import com.epam.pipeline.entity.cluster.EnvVarsSettings;
 import com.epam.pipeline.entity.cluster.PriceType;
 import com.epam.pipeline.entity.git.GitlabVersion;
@@ -30,6 +31,7 @@ import com.epam.pipeline.entity.utils.ControlEntry;
 import com.epam.pipeline.entity.utils.DefaultSystemParameter;
 import com.epam.pipeline.exception.PipelineException;
 import com.epam.pipeline.exception.git.GitClientException;
+import com.epam.pipeline.manager.cluster.KubernetesConstants;
 import com.epam.pipeline.manager.datastorage.DataStorageManager;
 import com.epam.pipeline.manager.docker.DockerClient;
 import com.epam.pipeline.manager.docker.DockerClientFactory;
@@ -286,6 +288,13 @@ public class SystemPreferences {
     public static final ObjectPreference<EnvVarsSettings> LAUNCH_ENV_PROPERTIES = new ObjectPreference<>(
         "launch.env.properties", null, new TypeReference<EnvVarsSettings>() {}, LAUNCH_GROUP,
         isNullOrValidJson(new TypeReference<EnvVarsSettings>() {}));
+    public static final BooleanPreference DOCKER_IN_DOCKER_ENABLED = new BooleanPreference(
+            "launch.dind.enable", true, LAUNCH_GROUP, pass);
+    public static final ObjectPreference<List<DockerMount>> DOCKER_IN_DOCKER_MOUNTS = new ObjectPreference<>(
+            "launch.dind.mounts", KubernetesConstants.DEFAULT_DOCKER_IN_DOCKER_MOUNTS,
+            new TypeReference<List<DockerMount>>() {},
+            LAUNCH_GROUP, isNullOrValidJson(new TypeReference<List<DockerMount>>() {}));
+
 
     //DTS submission
     public static final StringPreference DTS_LAUNCH_CMD_TEMPLATE = new StringPreference("dts.launch.cmd",


### PR DESCRIPTION
This PR provides backend changes for issue #295.

New system preferences are added into `LAUNCH` group:
- `launch.dind.enable`  - flag to enable Docker in Docker functionality,  default value - `true`
- `launch.dind.mounts` - list of mounts that shall be added to k8s pod for Docker in Docker, default values are -`/var/run/docker.sock -> /var/run/docker.sock`, `/bin/docker -> /usr/bin/docker`