### PR TITLE
Add Elastic backend for node monitoring

### DIFF
--- a/api/profiles/dev/application.properties
+++ b/api/profiles/dev/application.properties
@@ -18,6 +18,9 @@ database.driverClass=org.postgresql.Driver
 database.max.pool.size=10
 database.initial.pool.size=5
 
+#monitoring configuration
+monitoring.backend=
+
 #monitoring Elaticsearch configuration
 monitoring.elasticsearch.url=
 monitoring.elasticsearch.port=80

--- a/api/profiles/release/application.properties
+++ b/api/profiles/release/application.properties
@@ -17,6 +17,9 @@ database.driverClass=org.postgresql.Driver
 database.max.pool.size=5
 database.initial.pool.size=10
 
+#monitoring configuration
+monitoring.backend=
+
 #flyway configuration
 flyway.sql-migration-prefix=v
 flyway.locations=classpath:db/migration

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -439,6 +439,10 @@ public final class MessageConstants {
     public static final String ERROR_GCP_INSTANCE_NOT_RUNNING = "error.gcp.instance.not.running";
     public static final String ERROR_GCP_INSTANCE_NOT_FOUND = "error.gcp.instance.not.found";
 
+    //Cluster usage monitoring
+    public static final String ERROR_CLUSTER_MONITORING_NEGATIVE_INTERVAL =
+            "error.cluster.monitoring.negative.interval";
+
     private MessageConstants() {
         // no-op
     }

--- a/api/src/main/java/com/epam/pipeline/controller/cluster/ClusterController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/cluster/ClusterController.java
@@ -29,7 +29,8 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -39,16 +40,20 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Controller
 @Api(value = "Cluster methods")
+@RequiredArgsConstructor
 public class ClusterController extends AbstractRestController {
 
     private static final String NAME = "name";
+    private static final String FROM = "from";
+    private static final String TO = "to";
+    private static final String DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm:ss";
 
-    @Autowired
-    private ClusterApiService clusterApiService;
+    private final ClusterApiService clusterApiService;
 
     @RequestMapping(value = "/cluster/node/loadAll", method = RequestMethod.GET)
     @ResponseBody
@@ -168,7 +173,12 @@ public class ClusterController extends AbstractRestController {
     @ApiResponses(
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
             })
-    public Result<List<MonitoringStats>> getNodeUsageStatistics(@PathVariable(value = NAME) final String name) {
-        return Result.success(clusterApiService.getStatsForNode(name));
+    public Result<List<MonitoringStats>> getNodeUsageStatistics(
+            @PathVariable(value = NAME) final String name,
+            @DateTimeFormat(pattern = DATE_TIME_FORMAT)
+            @RequestParam(value = FROM, required = false) final LocalDateTime from,
+            @DateTimeFormat(pattern = DATE_TIME_FORMAT)
+            @RequestParam(value = TO, required = false) final LocalDateTime to) {
+        return Result.success(clusterApiService.getStatsForNode(name, from, to));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/AbstractMetricRequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/AbstractMetricRequester.java
@@ -166,7 +166,7 @@ public abstract class AbstractMetricRequester implements MetricRequester, Monito
                 .toArray(String[]::new);
     }
 
-    protected Optional<Double> value(final List<Aggregation> aggregations, final String name) {
+    protected Optional<Double> doubleValue(final List<Aggregation> aggregations, final String name) {
         return aggregations.stream()
                 .filter(it -> name.equals(it.getName()))
                 .findFirst()
@@ -176,7 +176,7 @@ public abstract class AbstractMetricRequester implements MetricRequester, Monito
     }
 
     protected Optional<Long> longValue(final List<Aggregation> aggregations, final String name) {
-        return value(aggregations, name).map(Double::longValue);
+        return doubleValue(aggregations, name).map(Double::longValue);
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/AbstractMetricRequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/AbstractMetricRequester.java
@@ -75,6 +75,18 @@ public abstract class AbstractMetricRequester implements MetricRequester {
         }
     }
 
+    public static MonitoringRequester getStatsRequester(final ELKUsageMetric metric, final RestHighLevelClient client) {
+        switch (metric) {
+            case CPU:
+                return new CPURequester(client);
+            case MEM:
+                return new MemoryRequester(client);
+            default:
+                throw new IllegalArgumentException("Metric type: " + metric.getName() + " isn't supported!");
+
+        }
+    }
+
     public Map<String, Double> performRequest(final Collection<String> resourceIds,
                                               final LocalDateTime from, final LocalDateTime to) {
         return parseResponse(

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/AbstractMetricRequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/AbstractMetricRequester.java
@@ -42,7 +42,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Stream;
+import java.util.stream.IntStream;
 
 public abstract class AbstractMetricRequester implements MetricRequester, MonitoringRequester {
 
@@ -158,9 +158,10 @@ public abstract class AbstractMetricRequester implements MetricRequester, Monito
     }
 
     private static String[] getIndexNames(final LocalDateTime from, final LocalDateTime to) {
-        return Stream.of(from, to)
+        return IntStream.iterate(0, i -> i + 1)
+                .limit(Duration.between(from, to).toDays() + 1)
+                .mapToObj(from::plusDays)
                 .map(d -> d.format(DATE_FORMATTER))
-                .distinct()
                 .map(dateStr -> String.format(INDEX_NAME_PATTERN, dateStr))
                 .toArray(String[]::new);
     }

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/CPURequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/CPURequester.java
@@ -82,11 +82,11 @@ public class CPURequester extends AbstractMetricRequester {
     }
 
     @Override
-    public List<MonitoringStats> requestStats(final Collection<String> resourceIds, final LocalDateTime from,
-                                              final LocalDateTime to, final Duration interval) {
+    public List<MonitoringStats> requestStats(final String nodeName, final LocalDateTime from, final LocalDateTime to,
+                                              final Duration interval) {
         final SearchSourceBuilder builder = new SearchSourceBuilder()
                 .query(QueryBuilders.boolQuery()
-                        .filter(QueryBuilders.termsQuery(path(FIELD_METRICS_TAGS, NODENAME_RAW_FIELD), resourceIds))
+                        .filter(QueryBuilders.termsQuery(path(FIELD_METRICS_TAGS, NODENAME_RAW_FIELD), nodeName))
                         .filter(QueryBuilders.termQuery(path(FIELD_METRICS_TAGS, FIELD_TYPE), NODE))
                         .filter(QueryBuilders.termQuery(path(FIELD_DOCUMENT_TYPE), metric().getName()))
                         .filter(QueryBuilders.rangeQuery(metric().getTimestamp())

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/CPURequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/CPURequester.java
@@ -26,11 +26,11 @@ import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
-import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.metrics.avg.Avg;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Collection;
@@ -83,17 +83,19 @@ public class CPURequester extends AbstractMetricRequester {
 
     @Override
     public List<MonitoringStats> requestStats(final Collection<String> resourceIds, final LocalDateTime from,
-                                              final LocalDateTime to) {
+                                              final LocalDateTime to, final Duration interval) {
         final SearchSourceBuilder builder = new SearchSourceBuilder()
                 .query(QueryBuilders.boolQuery()
                         .filter(QueryBuilders.termsQuery(path(FIELD_METRICS_TAGS, NODENAME_RAW_FIELD), resourceIds))
                         .filter(QueryBuilders.termQuery(path(FIELD_METRICS_TAGS, FIELD_TYPE), NODE))
-                        .filter(QueryBuilders.termQuery(path(FIELD_DOCUMENT_TYPE), metric().getName())))
+                        .filter(QueryBuilders.termQuery(path(FIELD_DOCUMENT_TYPE), metric().getName()))
+                        .filter(QueryBuilders.rangeQuery(metric().getTimestamp())
+                                .from(from.toInstant(ZoneOffset.UTC).toEpochMilli())
+                                .to(to.toInstant(ZoneOffset.UTC).toEpochMilli())))
                 .size(0)
                 .aggregation(AggregationBuilders.dateHistogram(CPU_HISTOGRAM)
                         .field(metric().getTimestamp())
-                        .interval(1L)
-                        .dateHistogramInterval(DateHistogramInterval.minutes(5))
+                        .interval(interval.toMillis())
                         .subAggregation(AggregationBuilders.avg(AVG_AGGREGATION + CPU_UTILIZATION)
                                 .field(field(NODE_UTILIZATION)))
                         .subAggregation(AggregationBuilders.avg(AVG_AGGREGATION + CPU_CAPACITY)

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/CPURequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/CPURequester.java
@@ -34,7 +34,6 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -55,22 +54,22 @@ public class CPURequester extends AbstractMetricRequester {
     @Override
     public SearchRequest buildRequest(final Collection<String> resourceIds, final LocalDateTime from,
                                       final LocalDateTime to, final Map<String, String> additional) {
-        final SearchSourceBuilder builder = new SearchSourceBuilder()
-                .query(QueryBuilders.boolQuery()
-                        .filter(QueryBuilders.termsQuery(path(FIELD_METRICS_TAGS, FIELD_POD_NAME_RAW), resourceIds))
-                        .filter(QueryBuilders.termQuery(path(FIELD_METRICS_TAGS, FIELD_NAMESPACE_NAME), "default"))
-                        .filter(QueryBuilders.termQuery(path(FIELD_METRICS_TAGS, FIELD_TYPE), "pod_container"))
-                        .filter(QueryBuilders.rangeQuery(metric().getTimestamp())
-                                .from(from.toInstant(ZoneOffset.UTC).toEpochMilli())
-                                .to(to.toInstant(ZoneOffset.UTC).toEpochMilli())))
-                .size(0)
-                .aggregation(AggregationBuilders.terms(AGGREGATION_POD_NAME)
-                        .field(path(FIELD_METRICS_TAGS, FIELD_POD_NAME_RAW))
-                        .size(resourceIds.size())
-                        .subAggregation(AggregationBuilders.avg(AVG_AGGREGATION + USAGE_RATE)
-                                .field(field(USAGE_RATE))));
-
-        return new SearchRequest(getIndexNames(from, to)).types(metric().getName()).source(builder);
+        return request(from, to,
+                new SearchSourceBuilder()
+                        .query(QueryBuilders.boolQuery()
+                                .filter(QueryBuilders.termsQuery(path(FIELD_METRICS_TAGS, FIELD_POD_NAME_RAW),
+                                        resourceIds))
+                                .filter(QueryBuilders.termQuery(path(FIELD_METRICS_TAGS, FIELD_NAMESPACE_NAME),
+                                        DEFAULT))
+                                .filter(QueryBuilders.termQuery(path(FIELD_METRICS_TAGS, FIELD_TYPE), POD_CONTAINER))
+                                .filter(QueryBuilders.rangeQuery(metric().getTimestamp())
+                                        .from(from.toInstant(ZoneOffset.UTC).toEpochMilli())
+                                        .to(to.toInstant(ZoneOffset.UTC).toEpochMilli())))
+                        .size(0)
+                        .aggregation(AggregationBuilders.terms(AGGREGATION_POD_NAME)
+                                .field(path(FIELD_METRICS_TAGS, FIELD_POD_NAME_RAW))
+                                .size(resourceIds.size())
+                                .subAggregation(average(AVG_AGGREGATION + USAGE_RATE, USAGE_RATE))));
     }
 
     @Override
@@ -82,32 +81,18 @@ public class CPURequester extends AbstractMetricRequester {
     }
 
     @Override
-    public List<MonitoringStats> requestStats(final String nodeName, final LocalDateTime from, final LocalDateTime to,
+    protected SearchRequest buildStatsRequest(final String nodeName, final LocalDateTime from, final LocalDateTime to,
                                               final Duration interval) {
-        final SearchSourceBuilder builder = new SearchSourceBuilder()
-                .query(QueryBuilders.boolQuery()
-                        .filter(QueryBuilders.termsQuery(path(FIELD_METRICS_TAGS, NODENAME_RAW_FIELD), nodeName))
-                        .filter(QueryBuilders.termQuery(path(FIELD_METRICS_TAGS, FIELD_TYPE), NODE))
-                        .filter(QueryBuilders.termQuery(path(FIELD_DOCUMENT_TYPE), metric().getName()))
-                        .filter(QueryBuilders.rangeQuery(metric().getTimestamp())
-                                .from(from.toInstant(ZoneOffset.UTC).toEpochMilli())
-                                .to(to.toInstant(ZoneOffset.UTC).toEpochMilli())))
-                .size(0)
-                .aggregation(AggregationBuilders.dateHistogram(CPU_HISTOGRAM)
-                        .field(metric().getTimestamp())
-                        .interval(interval.toMillis())
-                        .minDocCount(1L)
-                        .subAggregation(AggregationBuilders.avg(AVG_AGGREGATION + CPU_UTILIZATION)
-                                .field(field(NODE_UTILIZATION)))
-                        .subAggregation(AggregationBuilders.avg(AVG_AGGREGATION + CPU_CAPACITY)
-                                .field(field(NODE_CAPACITY))));
 
-        final SearchRequest request =
-                new SearchRequest(getIndexNames(from, to)).types(metric().getName()).source(builder);
-        return parse(executeRequest(request));
+        return request(from, to,
+                nodeStatsQuery(nodeName, from, to)
+                        .aggregation(dateHistogram(CPU_HISTOGRAM, interval)
+                                .subAggregation(average(AVG_AGGREGATION + CPU_UTILIZATION, NODE_UTILIZATION))
+                                .subAggregation(average(AVG_AGGREGATION + CPU_CAPACITY, NODE_CAPACITY))));
     }
 
-    private List<MonitoringStats> parse(final SearchResponse response) {
+    @Override
+    protected List<MonitoringStats> parseStatsResponse(final SearchResponse response) {
         return Optional.ofNullable(response.getAggregations())
                 .map(Aggregations::asList)
                 .map(List::stream)
@@ -119,29 +104,26 @@ public class CPURequester extends AbstractMetricRequester {
                 .map(MultiBucketsAggregation::getBuckets)
                 .map(List::stream)
                 .orElseGet(Stream::empty)
-                .map(bucket -> {
-                    final Optional<String> intervalStartOrEnd = Optional.ofNullable(bucket.getKeyAsString());
-                    final List<Aggregation> aggregations = Optional.ofNullable(bucket.getAggregations())
-                            .map(Aggregations::asList)
-                            .orElseGet(Collections::emptyList);
-                    final Optional<Double> utilization = value(aggregations, AVG_AGGREGATION + CPU_UTILIZATION);
-                    final Optional<Integer> capacity = value(aggregations, AVG_AGGREGATION + CPU_CAPACITY)
-                            .map(Double::longValue)
-                            .map(Object::toString)
-                            // CPU capacity is a number of cores times 1000. Therefore last three digits can be omitted.
-                            .map(it -> it.substring(0, it.length() - 3))
-                            .map(Integer::valueOf);
-                    final MonitoringStats monitoringStats = new MonitoringStats();
-                    intervalStartOrEnd.ifPresent(monitoringStats::setStartTime);
-                    final MonitoringStats.CPUUsage cpuUsage = new MonitoringStats.CPUUsage();
-                    utilization.ifPresent(cpuUsage::setLoad);
-                    monitoringStats.setCpuUsage(cpuUsage);
-                    final MonitoringStats.ContainerSpec containerSpec = new MonitoringStats.ContainerSpec();
-                    capacity.ifPresent(containerSpec::setNumberOfCores);
-                    monitoringStats.setContainerSpec(containerSpec);
-                    return monitoringStats;
-                })
+                .map(this::toMonitoringStats)
                 .collect(Collectors.toList());
     }
 
+    private MonitoringStats toMonitoringStats(final MultiBucketsAggregation.Bucket bucket) {
+        final MonitoringStats monitoringStats = new MonitoringStats();
+        Optional.ofNullable(bucket.getKeyAsString()).ifPresent(monitoringStats::setStartTime);
+        final List<Aggregation> aggregations = aggregations(bucket);
+        final Optional<Double> utilization = value(aggregations, AVG_AGGREGATION + CPU_UTILIZATION);
+        final Optional<Integer> capacity = longValue(aggregations, AVG_AGGREGATION + CPU_CAPACITY)
+                .map(Object::toString)
+                // CPU capacity is a number of cores times 1000. Therefore last three digits can be omitted.
+                .map(it -> it.substring(0, it.length() - 3))
+                .map(Integer::valueOf);
+        final MonitoringStats.CPUUsage cpuUsage = new MonitoringStats.CPUUsage();
+        utilization.ifPresent(cpuUsage::setLoad);
+        monitoringStats.setCpuUsage(cpuUsage);
+        final MonitoringStats.ContainerSpec containerSpec = new MonitoringStats.ContainerSpec();
+        capacity.ifPresent(containerSpec::setNumberOfCores);
+        monitoringStats.setContainerSpec(containerSpec);
+        return monitoringStats;
+    }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/CPURequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/CPURequester.java
@@ -112,7 +112,7 @@ public class CPURequester extends AbstractMetricRequester {
         final MonitoringStats monitoringStats = new MonitoringStats();
         Optional.ofNullable(bucket.getKeyAsString()).ifPresent(monitoringStats::setStartTime);
         final List<Aggregation> aggregations = aggregations(bucket);
-        final Optional<Double> utilization = value(aggregations, AVG_AGGREGATION + CPU_UTILIZATION);
+        final Optional<Double> utilization = doubleValue(aggregations, AVG_AGGREGATION + CPU_UTILIZATION);
         final Optional<Integer> capacity = longValue(aggregations, AVG_AGGREGATION + CPU_CAPACITY)
                 .map(Object::toString)
                 // CPU capacity is a number of cores times 1000. Therefore last three digits can be omitted.

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/CPURequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/CPURequester.java
@@ -96,6 +96,7 @@ public class CPURequester extends AbstractMetricRequester {
                 .aggregation(AggregationBuilders.dateHistogram(CPU_HISTOGRAM)
                         .field(metric().getTimestamp())
                         .interval(interval.toMillis())
+                        .minDocCount(1L)
                         .subAggregation(AggregationBuilders.avg(AVG_AGGREGATION + CPU_UTILIZATION)
                                 .field(field(NODE_UTILIZATION)))
                         .subAggregation(AggregationBuilders.avg(AVG_AGGREGATION + CPU_CAPACITY)

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/CPURequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/CPURequester.java
@@ -17,10 +17,13 @@
 package com.epam.pipeline.dao.monitoring.metricrequester;
 
 import com.epam.pipeline.entity.cluster.monitoring.ELKUsageMetric;
+import com.epam.pipeline.entity.cluster.monitoring.MonitoringStats;
+import org.apache.commons.collections4.MapUtils;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.metrics.avg.Avg;
@@ -28,11 +31,15 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-public class CPURequester extends AbstractMetricRequester {
+public class CPURequester extends AbstractMetricRequester implements MonitoringRequester {
 
     CPURequester(final RestHighLevelClient client) {
         super(client);
@@ -66,5 +73,59 @@ public class CPURequester extends AbstractMetricRequester {
                 .collect(Collectors.toMap(
                     b -> b.getKey().toString(),
                     b -> ((Avg) b.getAggregations().get(AVG_AGGREGATION + USAGE_RATE)).getValue()));
+    }
+
+    @Override
+    public List<MonitoringStats> requestStats(final Collection<String> resourceIds, final LocalDateTime from,
+                                              final LocalDateTime to) {
+        final SearchSourceBuilder builder = new SearchSourceBuilder()
+                .query(QueryBuilders.boolQuery()
+                        .filter(QueryBuilders.termsQuery(path(FIELD_METRICS_TAGS, NODENAME_RAW_FIELD), resourceIds))
+                        .filter(QueryBuilders.termQuery(path(FIELD_METRICS_TAGS, FIELD_TYPE), NODE))
+                        .filter(QueryBuilders.rangeQuery(ELKUsageMetric.CPU.getTimestamp())
+                                .from(from.toInstant(ZoneOffset.UTC).toEpochMilli())
+                                .to(to.toInstant(ZoneOffset.UTC).toEpochMilli())));
+
+        final SearchRequest request =
+                new SearchRequest(getIndexNames(from, to)).types(ELKUsageMetric.CPU.getName()).source(builder);
+        return parse(executeRequest(request));
+    }
+
+    private List<MonitoringStats> parse(final SearchResponse response) {
+        return Optional.ofNullable(response.getHits())
+                .map(SearchHits::getHits)
+                .map(Arrays::stream)
+                .orElseGet(Stream::empty)
+                .map(hit -> {
+                    final Map<String, Object> source = MapUtils.emptyIfNull(hit.getSource());
+                    final String timestamp = (String) source.get(ELKUsageMetric.CPU.getTimestamp());
+                    final MonitoringStats monitoringStats = new MonitoringStats();
+                    monitoringStats.setStartTime(timestamp);
+                    final Optional<Long> cpuUsageValue = Optional.of(source)
+                            .map(map -> map.get("Metrics"))
+                            .filter(this::isMap)
+                            .map(this::toMap)
+                            .map(map -> map.get("cpu/usage"))
+                            .filter(this::isMap)
+                            .map(this::toMap)
+                            .map(map -> map.get("value"))
+                            .filter(Long.class::isInstance)
+                            .map(it -> (Long) it);
+                    final MonitoringStats.CPUUsage cpuUsage = new MonitoringStats.CPUUsage();
+                    // TODO 15.05.19: Delete usage by the capacity to get load.
+                    cpuUsageValue.ifPresent(cpuUsage::setLoad);
+                    monitoringStats.setCpuUsage(cpuUsage);
+                    return monitoringStats;
+                })
+                .collect(Collectors.toList());
+    }
+
+    private boolean isMap(final Object object) {
+        return object instanceof Map;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> toMap(final Object object) {
+        return (Map<String, Object>) object;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/FSRequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/FSRequester.java
@@ -158,11 +158,11 @@ public class FSRequester extends AbstractMetricRequester {
     }
 
     @Override
-    public List<MonitoringStats> requestStats(final Collection<String> resourceIds, final LocalDateTime from,
-                                              final LocalDateTime to, final Duration interval) {
+    public List<MonitoringStats> requestStats(final String nodeName, final LocalDateTime from, final LocalDateTime to,
+                                              final Duration interval) {
         final SearchSourceBuilder builder = new SearchSourceBuilder()
                 .query(QueryBuilders.boolQuery()
-                        .filter(QueryBuilders.termsQuery(path(FIELD_METRICS_TAGS, NODENAME_RAW_FIELD), resourceIds))
+                        .filter(QueryBuilders.termsQuery(path(FIELD_METRICS_TAGS, NODENAME_RAW_FIELD), nodeName))
                         .filter(QueryBuilders.termQuery(path(FIELD_METRICS_TAGS, FIELD_TYPE), NODE))
                         .filter(QueryBuilders.termQuery(path(FIELD_DOCUMENT_TYPE), metric().getName()))
                         .filter(QueryBuilders.rangeQuery(metric().getTimestamp())

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/FSRequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/FSRequester.java
@@ -174,6 +174,7 @@ public class FSRequester extends AbstractMetricRequester {
                         .subAggregation(AggregationBuilders.dateHistogram(DISKS_HISTOGRAM)
                                 .field(metric().getTimestamp())
                                 .interval(interval.toMillis())
+                                .minDocCount(1L)
                                 .subAggregation(AggregationBuilders.avg(AVG_AGGREGATION + USAGE)
                                         .field(field(USAGE)))
                                 .subAggregation(AggregationBuilders.avg(AVG_AGGREGATION + LIMIT)

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/MemoryRequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/MemoryRequester.java
@@ -82,11 +82,11 @@ public class MemoryRequester extends AbstractMetricRequester {
     }
 
     @Override
-    public List<MonitoringStats> requestStats(final Collection<String> resourceIds, final LocalDateTime from,
-                                              final LocalDateTime to, final Duration interval) {
+    public List<MonitoringStats> requestStats(final String nodeName, final LocalDateTime from, final LocalDateTime to,
+                                              final Duration interval) {
         final SearchSourceBuilder builder = new SearchSourceBuilder()
                 .query(QueryBuilders.boolQuery()
-                        .filter(QueryBuilders.termsQuery(path(FIELD_METRICS_TAGS, NODENAME_RAW_FIELD), resourceIds))
+                        .filter(QueryBuilders.termsQuery(path(FIELD_METRICS_TAGS, NODENAME_RAW_FIELD), nodeName))
                         .filter(QueryBuilders.termQuery(path(FIELD_METRICS_TAGS, FIELD_TYPE), NODE))
                         .filter(QueryBuilders.termQuery(path(FIELD_DOCUMENT_TYPE), metric().getName()))
                         .filter(QueryBuilders.rangeQuery(metric().getTimestamp())

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/MemoryRequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/MemoryRequester.java
@@ -26,11 +26,11 @@ import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
-import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.metrics.avg.Avg;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Collection;
@@ -83,17 +83,19 @@ public class MemoryRequester extends AbstractMetricRequester {
 
     @Override
     public List<MonitoringStats> requestStats(final Collection<String> resourceIds, final LocalDateTime from,
-                                              final LocalDateTime to) {
+                                              final LocalDateTime to, final Duration interval) {
         final SearchSourceBuilder builder = new SearchSourceBuilder()
                 .query(QueryBuilders.boolQuery()
                         .filter(QueryBuilders.termsQuery(path(FIELD_METRICS_TAGS, NODENAME_RAW_FIELD), resourceIds))
                         .filter(QueryBuilders.termQuery(path(FIELD_METRICS_TAGS, FIELD_TYPE), NODE))
-                        .filter(QueryBuilders.termQuery(path(FIELD_DOCUMENT_TYPE), metric().getName())))
+                        .filter(QueryBuilders.termQuery(path(FIELD_DOCUMENT_TYPE), metric().getName()))
+                        .filter(QueryBuilders.rangeQuery(metric().getTimestamp())
+                                .from(from.toInstant(ZoneOffset.UTC).toEpochMilli())
+                                .to(to.toInstant(ZoneOffset.UTC).toEpochMilli())))
                 .size(0)
                 .aggregation(AggregationBuilders.dateHistogram(MEMORY_HISTOGRAM)
                         .field(metric().getTimestamp())
-                        .interval(1L)
-                        .dateHistogramInterval(DateHistogramInterval.minutes(5))
+                        .interval(interval.toMillis())
                         .subAggregation(AggregationBuilders.avg(AVG_AGGREGATION + MEMORY_UTILIZATION)
                                 .field(field(USAGE)))
                         .subAggregation(AggregationBuilders.avg(AVG_AGGREGATION + MEMORY_CAPACITY)

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/MemoryRequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/MemoryRequester.java
@@ -96,6 +96,7 @@ public class MemoryRequester extends AbstractMetricRequester {
                 .aggregation(AggregationBuilders.dateHistogram(MEMORY_HISTOGRAM)
                         .field(metric().getTimestamp())
                         .interval(interval.toMillis())
+                        .minDocCount(1L)
                         .subAggregation(AggregationBuilders.avg(AVG_AGGREGATION + MEMORY_UTILIZATION)
                                 .field(field(USAGE)))
                         .subAggregation(AggregationBuilders.avg(AVG_AGGREGATION + MEMORY_CAPACITY)

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/MemoryRequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/MemoryRequester.java
@@ -17,10 +17,13 @@
 package com.epam.pipeline.dao.monitoring.metricrequester;
 
 import com.epam.pipeline.entity.cluster.monitoring.ELKUsageMetric;
+import com.epam.pipeline.entity.cluster.monitoring.MonitoringStats;
+import org.apache.commons.collections4.MapUtils;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.metrics.avg.Avg;
@@ -28,11 +31,15 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-public class MemoryRequester extends AbstractMetricRequester {
+public class MemoryRequester extends AbstractMetricRequester implements MonitoringRequester {
 
     MemoryRequester(final RestHighLevelClient client) {
         super(client);
@@ -66,5 +73,60 @@ public class MemoryRequester extends AbstractMetricRequester {
                 .collect(Collectors.toMap(
                     b -> b.getKey().toString(),
                     b -> ((Avg) b.getAggregations().get(AVG_AGGREGATION + NODE_UTILIZATION)).getValue()));
+    }
+
+    @Override
+    public List<MonitoringStats> requestStats(final Collection<String> resourceIds, final LocalDateTime from,
+                                              final LocalDateTime to) {
+        final SearchSourceBuilder builder = new SearchSourceBuilder()
+                .query(QueryBuilders.boolQuery()
+                        .filter(QueryBuilders.termsQuery(path(FIELD_METRICS_TAGS, NODENAME_RAW_FIELD),
+                                resourceIds))
+                        .filter(QueryBuilders.termQuery(path(FIELD_METRICS_TAGS, FIELD_TYPE), NODE))
+                        .filter(QueryBuilders.rangeQuery(ELKUsageMetric.MEM.getTimestamp())
+                                .from(from.toInstant(ZoneOffset.UTC).toEpochMilli())
+                                .to(to.toInstant(ZoneOffset.UTC).toEpochMilli())));
+
+        final SearchRequest request =
+                new SearchRequest(getIndexNames(from, to)).types(ELKUsageMetric.MEM.getName()).source(builder);
+        return parse(executeRequest(request));
+    }
+
+    private List<MonitoringStats> parse(final SearchResponse response) {
+        return Optional.ofNullable(response.getHits())
+                .map(SearchHits::getHits)
+                .map(Arrays::stream)
+                .orElseGet(Stream::empty)
+                .map(hit -> {
+                    final Map<String, Object> source = MapUtils.emptyIfNull(hit.getSource());
+                    final String timestamp = (String) source.get(ELKUsageMetric.MEM.getTimestamp());
+                    final MonitoringStats monitoringStats = new MonitoringStats();
+                    monitoringStats.setStartTime(timestamp);
+                    final Optional<Long> memoryUsageValue = Optional.of(source)
+                            .map(map -> map.get("Metrics"))
+                            .filter(this::isMap)
+                            .map(this::toMap)
+                            .map(map -> map.get("memory/usage"))
+                            .filter(this::isMap)
+                            .map(this::toMap)
+                            .map(map -> map.get("value"))
+                            .filter(Long.class::isInstance)
+                            .map(it -> (Long) it);
+                    final MonitoringStats.MemoryUsage memoryUsage = new MonitoringStats.MemoryUsage();
+                    memoryUsageValue.ifPresent(memoryUsage::setUsage);
+                    monitoringStats.setMemoryUsage(memoryUsage);
+                    // TODO 15.05.19: Add capacity.
+                    return monitoringStats;
+                })
+                .collect(Collectors.toList());
+    }
+
+    private boolean isMap(final Object object) {
+        return object instanceof Map;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> toMap(final Object object) {
+        return (Map<String, Object>) object;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/MonitoringRequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/MonitoringRequester.java
@@ -20,7 +20,6 @@ import com.epam.pipeline.entity.cluster.monitoring.MonitoringStats;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -31,14 +30,13 @@ import java.util.List;
 public interface MonitoringRequester {
 
     /**
-     * Collects usage metric stats.
+     * Collects node usage stats.
      *
-     * @param resourceIds Node name to collect stats for.
+     * @param nodeName Node name to collect stats for.
      * @param from Minimal date for collecting stats.
      * @param to Maximal date for collecting stats.
      * @param interval Duration of a single monitoring.
      * @return Monitoring stats for the given period.
      */
-    List<MonitoringStats> requestStats(Collection<String> resourceIds, LocalDateTime from, LocalDateTime to,
-                                       Duration interval);
+    List<MonitoringStats> requestStats(String nodeName, LocalDateTime from, LocalDateTime to, Duration interval);
 }

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/MonitoringRequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/MonitoringRequester.java
@@ -18,6 +18,7 @@ package com.epam.pipeline.dao.monitoring.metricrequester;
 
 import com.epam.pipeline.entity.cluster.monitoring.MonitoringStats;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
@@ -35,7 +36,9 @@ public interface MonitoringRequester {
      * @param resourceIds Node name to collect stats for.
      * @param from Minimal date for collecting stats.
      * @param to Maximal date for collecting stats.
+     * @param interval Duration of a single monitoring.
      * @return Monitoring stats for the given period.
      */
-    List<MonitoringStats> requestStats(Collection<String> resourceIds, LocalDateTime from, LocalDateTime to);
+    List<MonitoringStats> requestStats(Collection<String> resourceIds, LocalDateTime from, LocalDateTime to,
+                                       Duration interval);
 }

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/MonitoringRequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/MonitoringRequester.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.dao.monitoring.metricrequester;
+
+import com.epam.pipeline.entity.cluster.monitoring.MonitoringStats;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Node usage monitoring requester.
+ *
+ * It collects stats for a single usage metric: CPU, RAM and etc.
+ */
+public interface MonitoringRequester {
+
+    /**
+     * Collects usage metric stats.
+     *
+     * @param resourceIds Node name to collect stats for.
+     * @param from Minimal date for collecting stats.
+     * @param to Maximal date for collecting stats.
+     * @return Monitoring stats for the given period.
+     */
+    List<MonitoringStats> requestStats(Collection<String> resourceIds, LocalDateTime from, LocalDateTime to);
+}

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/NetworkRequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/NetworkRequester.java
@@ -84,6 +84,7 @@ public class NetworkRequester extends AbstractMetricRequester {
                 .aggregation(AggregationBuilders.dateHistogram(NETWORK_HISTOGRAM)
                         .field(metric().getTimestamp())
                         .interval(interval.toMillis())
+                        .minDocCount(1L)
                         .subAggregation(AggregationBuilders.avg(AVG_AGGREGATION + RX_RATE)
                                 .field(field(RX_RATE)))
                         .subAggregation(AggregationBuilders.avg(AVG_AGGREGATION + TX_RATE)

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/NetworkRequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/NetworkRequester.java
@@ -18,6 +18,7 @@ package com.epam.pipeline.dao.monitoring.metricrequester;
 
 import com.epam.pipeline.entity.cluster.monitoring.ELKUsageMetric;
 import com.epam.pipeline.entity.cluster.monitoring.MonitoringStats;
+import org.apache.commons.lang.NotImplementedException;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.RestHighLevelClient;
@@ -59,22 +60,20 @@ public class NetworkRequester extends AbstractMetricRequester {
     @Override
     public SearchRequest buildRequest(final Collection<String> resourceIds, final LocalDateTime from,
                                       final LocalDateTime to, final Map<String, String> additional) {
-        // TODO 17.05.19: Method NetworkRequester::buildRequest is not implemented yet.
-        throw new RuntimeException("Method NetworkRequester::buildRequest is not implemented yet.");
+        throw new NotImplementedException("Method NetworkRequester::buildRequest is not implemented yet.");
     }
 
     @Override
     public Map<String, Double> parseResponse(final SearchResponse response) {
-        // TODO 17.05.19: Method NetworkRequester::buildRequest is not implemented yet.
-        throw new RuntimeException("Method NetworkRequester::buildRequest is not implemented yet.");
+        throw new NotImplementedException("Method NetworkRequester::buildRequest is not implemented yet.");
     }
 
     @Override
-    public List<MonitoringStats> requestStats(final Collection<String> resourceIds, final LocalDateTime from,
-                                              final LocalDateTime to, final Duration interval) {
+    public List<MonitoringStats> requestStats(final String nodeName, final LocalDateTime from, final LocalDateTime to,
+                                              final Duration interval) {
         final SearchSourceBuilder builder = new SearchSourceBuilder()
                 .query(QueryBuilders.boolQuery()
-                        .filter(QueryBuilders.termsQuery(path(FIELD_METRICS_TAGS, NODENAME_RAW_FIELD), resourceIds))
+                        .filter(QueryBuilders.termsQuery(path(FIELD_METRICS_TAGS, NODENAME_RAW_FIELD), nodeName))
                         .filter(QueryBuilders.termQuery(path(FIELD_METRICS_TAGS, FIELD_TYPE), NODE))
                         .filter(QueryBuilders.termQuery(path(FIELD_DOCUMENT_TYPE), metric().getName()))
                         .filter(QueryBuilders.rangeQuery(metric().getTimestamp())

--- a/api/src/main/java/com/epam/pipeline/entity/cluster/monitoring/ELKUsageMetric.java
+++ b/api/src/main/java/com/epam/pipeline/entity/cluster/monitoring/ELKUsageMetric.java
@@ -25,7 +25,8 @@ public enum ELKUsageMetric {
 
     CPU("cpu", "CpuMetricsTimestamp"),
     MEM("memory", "MemoryMetricsTimestamp"),
-    FS("filesystem", "FilesystemMetricsTimestamp");
+    FS("filesystem", "FilesystemMetricsTimestamp"),
+    NETWORK("network", "NetworkMetricsTimestamp");
 
     private final String name;
     private final String timestamp;

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/ClusterApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/ClusterApiService.java
@@ -49,7 +49,7 @@ public class ClusterApiService {
                              final InstanceOfferManager instanceOfferManager,
                              final CAdvisorMonitoringManager cAdvisorMonitoringManager,
                              final ESMonitoringManager esMonitoringManager,
-                             @Value("${monitoring.backend?:" + CADVISOR + "}") final String backend) {
+                             @Value("${monitoring.backend:" + CADVISOR + "}") final String backend) {
         this.nodesManager = nodesManager;
         this.instanceOfferManager = instanceOfferManager;
         if (StringUtils.isBlank(backend) || backend.equals(CADVISOR)) {

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/ClusterApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/ClusterApiService.java
@@ -24,20 +24,42 @@ import com.epam.pipeline.entity.cluster.InstanceType;
 import com.epam.pipeline.entity.cluster.NodeInstance;
 import com.epam.pipeline.entity.cluster.AllowedInstanceAndPriceTypes;
 import com.epam.pipeline.entity.cluster.monitoring.MonitoringStats;
+import com.epam.pipeline.manager.cluster.performancemonitoring.CAdvisorMonitoringManager;
+import com.epam.pipeline.manager.cluster.performancemonitoring.ESMonitoringManager;
 import com.epam.pipeline.manager.cluster.performancemonitoring.UsageMonitoringManager;
 import com.epam.pipeline.manager.security.acl.AclMask;
-import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 @Service
-@RequiredArgsConstructor
 public class ClusterApiService {
+
+    private static final String ELASTIC = "elastic";
+    private static final String CADVISOR = "cadvisor";
 
     private final NodesManager nodesManager;
     private final UsageMonitoringManager usageMonitoringManager;
     private final InstanceOfferManager instanceOfferManager;
+
+    public ClusterApiService(final NodesManager nodesManager,
+                             final InstanceOfferManager instanceOfferManager,
+                             final CAdvisorMonitoringManager cAdvisorMonitoringManager,
+                             final ESMonitoringManager esMonitoringManager,
+                             @Value("${monitoring.backend?:" + CADVISOR + "}") final String backend) {
+        this.nodesManager = nodesManager;
+        this.instanceOfferManager = instanceOfferManager;
+        if (StringUtils.isBlank(backend) || backend.equals(CADVISOR)) {
+            this.usageMonitoringManager = cAdvisorMonitoringManager;
+        } else if (backend.equals(ELASTIC)) {
+            this.usageMonitoringManager = esMonitoringManager;
+        } else {
+            throw new IllegalArgumentException(String.format("Required monitoring backend '%s' is not available. " +
+                    "Use either %s or %s.", backend, CADVISOR, ELASTIC));
+        }
+    }
 
     @PostFilter("hasRole('ADMIN') OR @grantPermissionManager.nodePermission(filterObject, 'READ')")
     public List<NodeInstance> getNodes() {

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/ClusterApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/ClusterApiService.java
@@ -23,25 +23,21 @@ import com.epam.pipeline.entity.cluster.FilterPodsRequest;
 import com.epam.pipeline.entity.cluster.InstanceType;
 import com.epam.pipeline.entity.cluster.NodeInstance;
 import com.epam.pipeline.entity.cluster.AllowedInstanceAndPriceTypes;
-import com.epam.pipeline.manager.cluster.performancemonitoring.CAdvisorMonitoringManager;
 import com.epam.pipeline.entity.cluster.monitoring.MonitoringStats;
+import com.epam.pipeline.manager.cluster.performancemonitoring.UsageMonitoringManager;
 import com.epam.pipeline.manager.security.acl.AclMask;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class ClusterApiService {
 
-    @Autowired
-    private NodesManager nodesManager;
-
-    @Autowired
-    private CAdvisorMonitoringManager cAdvisorMonitorManager;
-
-    @Autowired
-    private InstanceOfferManager instanceOfferManager;
+    private final NodesManager nodesManager;
+    private final UsageMonitoringManager usageMonitoringManager;
+    private final InstanceOfferManager instanceOfferManager;
 
     @PostFilter("hasRole('ADMIN') OR @grantPermissionManager.nodePermission(filterObject, 'READ')")
     public List<NodeInstance> getNodes() {
@@ -73,7 +69,7 @@ public class ClusterApiService {
 
     @PreAuthorize("hasRole('ADMIN') OR @grantPermissionManager.nodePermission(#nodeName, 'READ')")
     public List<MonitoringStats> getStatsForNode(String nodeName) {
-        return cAdvisorMonitorManager.getStatsForNode(nodeName);
+        return usageMonitoringManager.getStatsForNode(nodeName);
     }
 
     public List<InstanceType> getAllowedInstanceTypes(final Long regionId, final Boolean spot) {

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/ClusterApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/ClusterApiService.java
@@ -16,6 +16,7 @@
 
 package com.epam.pipeline.manager.cluster;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import com.epam.pipeline.controller.vo.FilterNodesVO;
@@ -90,8 +91,8 @@ public class ClusterApiService {
     }
 
     @PreAuthorize("hasRole('ADMIN') OR @grantPermissionManager.nodePermission(#nodeName, 'READ')")
-    public List<MonitoringStats> getStatsForNode(String nodeName) {
-        return usageMonitoringManager.getStatsForNode(nodeName);
+    public List<MonitoringStats> getStatsForNode(String nodeName, final LocalDateTime from, final LocalDateTime to) {
+        return usageMonitoringManager.getStatsForNode(nodeName, from, to);
     }
 
     public List<InstanceType> getAllowedInstanceTypes(final Long regionId, final Boolean spot) {

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/CAdvisorMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/CAdvisorMonitoringManager.java
@@ -122,7 +122,6 @@ public class CAdvisorMonitoringManager implements UsageMonitoringManager {
                 .orElse(Collections.emptyList());
     }
 
-    @Override
     public long getDiskAvailableForDocker(final String nodeName,
                                           final String podId,
                                           final String dockerImage) {

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/CAdvisorMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/CAdvisorMonitoringManager.java
@@ -56,7 +56,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 @Service
-public class CAdvisorMonitoringManager {
+public class CAdvisorMonitoringManager implements UsageMonitoringManager {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CAdvisorMonitoringManager.class);
 
@@ -115,12 +115,14 @@ public class CAdvisorMonitoringManager {
         this.client = builder.build();
     }
 
-    public List<MonitoringStats> getStatsForNode(String nodeName) {
+    @Override
+    public List<MonitoringStats> getStatsForNode(final String nodeName) {
         return getInternalip(nodeName)
                 .map(this::executeStatsRequest)
                 .orElse(Collections.emptyList());
     }
 
+    @Override
     public long getDiskAvailableForDocker(final String nodeName,
                                           final String podId,
                                           final String dockerImage) {
@@ -140,9 +142,9 @@ public class CAdvisorMonitoringManager {
         return diskStats.getCapacity() - diskStats.getUsableSpace();
     }
 
-    public List<MonitoringStats> getStatsForContainerDisk(final String nodeName,
-                                                          final String podId,
-                                                          final String dockerImage) {
+    private List<MonitoringStats> getStatsForContainerDisk(final String nodeName,
+                                                           final String podId,
+                                                           final String dockerImage) {
         final String containerId = kubernetesManager.getContainerIdFromKubernetesPod(podId, dockerImage);
         return getInternalip(nodeName)
                 .map(ip -> executeContainerRequest(ip, containerId))
@@ -311,7 +313,7 @@ public class CAdvisorMonitoringManager {
         return LocalDateTime.parse(dateTime, FORMATTER).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
     }
 
-    public String getDockerDiskName(final String nodeName, final String podId, final String dockerImage) {
+    private String getDockerDiskName(final String nodeName, final String podId, final String dockerImage) {
         final MonitoringStats monitoringStats = getLastMonitoringStat(
                 getStatsForContainerDisk(nodeName, podId, dockerImage), nodeName);
 

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ESMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ESMonitoringManager.java
@@ -41,7 +41,7 @@ public class ESMonitoringManager implements UsageMonitoringManager {
         final LocalDateTime now = DateUtils.nowUTC();
         final LocalDateTime end = now;
         final LocalDateTime start = end.minusMinutes(timeRange);
-        return Stream.of(ELKUsageMetric.MEM, ELKUsageMetric.CPU)
+        return Stream.of(ELKUsageMetric.CPU, ELKUsageMetric.MEM, ELKUsageMetric.FS, ELKUsageMetric.NETWORK)
                 .map(it -> AbstractMetricRequester.getStatsRequester(it, client))
                 .map(it -> it.requestStats(Collections.singletonList(nodeName), start, end))
                 .flatMap(List::stream)

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ESMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ESMonitoringManager.java
@@ -39,7 +39,6 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.SignStyle;
 import java.time.temporal.ChronoField;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
@@ -93,7 +92,7 @@ public class ESMonitoringManager implements UsageMonitoringManager {
         final Duration interval = interval(start, end);
         return Stream.of(MONITORING_METRICS)
                 .map(it -> AbstractMetricRequester.getStatsRequester(it, client))
-                .map(it -> it.requestStats(Collections.singletonList(nodeName), start, end, interval))
+                .map(it -> it.requestStats(nodeName, start, end, interval))
                 .flatMap(List::stream)
                 .collect(Collectors.groupingBy(MonitoringStats::getStartTime, Collectors.reducing(this::mergeStats)))
                 .values()

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ESMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ESMonitoringManager.java
@@ -22,6 +22,8 @@ import com.epam.pipeline.entity.cluster.monitoring.MonitoringStats;
 import com.epam.pipeline.entity.utils.DateUtils;
 import lombok.RequiredArgsConstructor;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -34,19 +36,21 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+@Service
 @RequiredArgsConstructor
 public class ESMonitoringManager implements UsageMonitoringManager {
 
     private static final ELKUsageMetric[] MONITORING_METRICS = {ELKUsageMetric.CPU, ELKUsageMetric.MEM,
             ELKUsageMetric.FS, ELKUsageMetric.NETWORK};
-    private final RestHighLevelClient client;
     private static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
             .appendPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
             .toFormatter();
 
+    private final RestHighLevelClient client;
+
     @Override
     public List<MonitoringStats> getStatsForNode(final String nodeName) {
-        final Duration interval = Duration.ofMinutes(5);
+        final Duration interval = Duration.ofMinutes(1);
         final Duration monitoringPeriod = Duration.ofHours(1);
         final LocalDateTime end = DateUtils.nowUTC();
         final LocalDateTime start = end.minus(monitoringPeriod);
@@ -97,11 +101,5 @@ public class ESMonitoringManager implements UsageMonitoringManager {
             first.setContainerSpec(original.map(MonitoringStats::getContainerSpec).orElseGet(second::getContainerSpec));
         }
         return first;
-    }
-
-    @Override
-    public long getDiskAvailableForDocker(final String nodeName, final String podId, final String dockerImage) {
-        // TODO 15.05.19: Method ESMonitoringManager::getDiskAvailableForDocker is not implemented yet.
-        throw new RuntimeException("Method ESMonitoringManager::getDiskAvailableForDocker is not implemented yet.");
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ESMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ESMonitoringManager.java
@@ -51,7 +51,7 @@ import java.util.stream.Stream;
 public class ESMonitoringManager implements UsageMonitoringManager {
 
     private static final ELKUsageMetric[] MONITORING_METRICS = {ELKUsageMetric.CPU, ELKUsageMetric.MEM,
-            ELKUsageMetric.FS, ELKUsageMetric.NETWORK};
+        ELKUsageMetric.FS, ELKUsageMetric.NETWORK};
     private static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
             // Example: 2019-05-17T10:24:23.033Z
             .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD).appendLiteral('-')

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ESMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ESMonitoringManager.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster.performancemonitoring;
+
+import com.epam.pipeline.dao.monitoring.metricrequester.AbstractMetricRequester;
+import com.epam.pipeline.entity.cluster.monitoring.ELKUsageMetric;
+import com.epam.pipeline.entity.cluster.monitoring.MonitoringStats;
+import com.epam.pipeline.entity.utils.DateUtils;
+import lombok.RequiredArgsConstructor;
+import org.elasticsearch.client.RestHighLevelClient;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@RequiredArgsConstructor
+public class ESMonitoringManager implements UsageMonitoringManager {
+
+    private final RestHighLevelClient client;
+
+    @Override
+    public List<MonitoringStats> getStatsForNode(final String nodeName) {
+        final long timeRange = 20;
+        final LocalDateTime now = DateUtils.nowUTC();
+        final LocalDateTime end = now;
+        final LocalDateTime start = end.minusMinutes(timeRange);
+        return Stream.of(ELKUsageMetric.MEM, ELKUsageMetric.CPU)
+                .map(it -> AbstractMetricRequester.getStatsRequester(it, client))
+                .map(it -> it.requestStats(Collections.singletonList(nodeName), start, end))
+                .flatMap(List::stream)
+                .sorted(Comparator.comparing(MonitoringStats::getStartTime))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public long getDiskAvailableForDocker(final String nodeName, final String podId, final String dockerImage) {
+        // TODO 15.05.19: Method ESMonitoringManager::getDiskAvailableForDocker is not implemented yet.
+        throw new RuntimeException("Method ESMonitoringManager::getDiskAvailableForDocker is not implemented yet.");
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ESMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ESMonitoringManager.java
@@ -47,12 +47,12 @@ public class ESMonitoringManager implements UsageMonitoringManager {
     @Override
     public List<MonitoringStats> getStatsForNode(final String nodeName) {
         final Duration interval = Duration.ofMinutes(5);
-        final Duration monitoringPeriod = Duration.ofMinutes(20);
+        final Duration monitoringPeriod = Duration.ofHours(1);
         final LocalDateTime end = DateUtils.nowUTC();
         final LocalDateTime start = end.minus(monitoringPeriod);
         return Stream.of(MONITORING_METRICS)
                 .map(it -> AbstractMetricRequester.getStatsRequester(it, client))
-                .map(it -> it.requestStats(Collections.singletonList(nodeName), start, end))
+                .map(it -> it.requestStats(Collections.singletonList(nodeName), start, end, interval))
                 .flatMap(List::stream)
                 .collect(Collectors.groupingBy(MonitoringStats::getStartTime, Collectors.reducing(this::mergeStats)))
                 .values()

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/UsageMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/UsageMonitoringManager.java
@@ -18,6 +18,8 @@ package com.epam.pipeline.manager.cluster.performancemonitoring;
 
 import com.epam.pipeline.entity.cluster.monitoring.MonitoringStats;
 
+import javax.annotation.Nullable;
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -31,6 +33,20 @@ public interface UsageMonitoringManager {
      * @param nodeName Cluster node name.
      * @return List of monitoring stats.
      */
-    List<MonitoringStats> getStatsForNode(String nodeName);
+    default List<MonitoringStats> getStatsForNode(String nodeName) {
+        return getStatsForNode(nodeName, null, null);
+    }
+
+    /**
+     * Retrieves monitoring stats for node.
+     *
+     * @param nodeName Cluster node name.
+     * @param from Minimal date for collecting stats.
+     * @param to Maximal date for collecting stats.
+     * @return List of monitoring stats.
+     */
+    List<MonitoringStats> getStatsForNode(String nodeName,
+                                          @Nullable LocalDateTime from,
+                                          @Nullable LocalDateTime to);
 
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/UsageMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/UsageMonitoringManager.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster.performancemonitoring;
+
+import com.epam.pipeline.entity.cluster.monitoring.MonitoringStats;
+
+import java.util.List;
+
+/**
+ * Node usage monitoring manager.
+ */
+public interface UsageMonitoringManager {
+
+    /**
+     * Retrieves monitoring stats for node.
+     *
+     * @param nodeName Cluster node name.
+     * @return List of monitoring stats.
+     */
+    List<MonitoringStats> getStatsForNode(String nodeName);
+
+    /**
+     * Get available disk space for container.
+     *
+     * @param nodeName Cluster node name.
+     * @param podId Cluster pod name.
+     * @param dockerImage Container docker image.
+     * @return Available disk space in container.
+     */
+    long getDiskAvailableForDocker(String nodeName, String podId, String dockerImage);
+}

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/UsageMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/UsageMonitoringManager.java
@@ -33,13 +33,4 @@ public interface UsageMonitoringManager {
      */
     List<MonitoringStats> getStatsForNode(String nodeName);
 
-    /**
-     * Get available disk space for container.
-     *
-     * @param nodeName Cluster node name.
-     * @param podId Cluster pod name.
-     * @param dockerImage Container docker image.
-     * @return Available disk space in container.
-     */
-    long getDiskAvailableForDocker(String nodeName, String podId, String dockerImage);
 }

--- a/api/src/main/java/com/epam/pipeline/manager/preference/PreferenceValidators.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/PreferenceValidators.java
@@ -140,6 +140,10 @@ public final class PreferenceValidators {
             pref.isEmpty() || Arrays.stream(pref.split(",")).allMatch(s -> s.matches("[^\0 \n]+[^\\/]")
                     || "/".equals(s) || "\\".equals(s));
 
+    public static BiPredicate<String, Map<String, Preference>> isGreaterThan(long x) {
+        return (pref, dependencies) -> StringUtils.isNumeric(pref) && Long.parseLong(pref) > x;
+    }
+
     public static BiPredicate<String, Map<String, Preference>> isGreaterThan(int x) {
         return (pref, dependencies) -> StringUtils.isNumeric(pref) && Integer.parseInt(pref) > x;
     }

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -60,6 +60,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiPredicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -299,6 +300,9 @@ public class SystemPreferences {
             new IntPreference("cluster.docker.extra_multi", 3, CLUSTER_GROUP, isGreaterThan(0));
     public static final IntPreference CLUSTER_MONITORING_ELASTIC_INTERVALS_NUMBER = new IntPreference(
             "cluster.monitoring.elastic.intervals.number", 10, CLUSTER_GROUP, isGreaterThan(0));
+    public static final LongPreference CLUSTER_MONITORING_ELASTIC_MINIMAL_INTERVAL = new LongPreference(
+            "cluster.monitoring.elastic.minimal.interval", TimeUnit.MILLISECONDS.convert(1, TimeUnit.MINUTES),
+            CLUSTER_GROUP, isGreaterThan(0L));
 
     //LAUNCH_GROUP
     public static final StringPreference LAUNCH_CMD_TEMPLATE = new StringPreference("launch.cmd.template",

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -297,6 +297,8 @@ public class SystemPreferences {
             new IntPreference("cluster.instance.hdd_extra_multi", 3, CLUSTER_GROUP, isGreaterThan(0));
     public static final IntPreference CLUSTER_DOCKER_EXTRA_MULTI =
             new IntPreference("cluster.docker.extra_multi", 3, CLUSTER_GROUP, isGreaterThan(0));
+    public static final IntPreference CLUSTER_MONITORING_ELASTIC_INTERVALS_NUMBER = new IntPreference(
+            "cluster.monitoring.elastic.intervals.number", 10, CLUSTER_GROUP, isGreaterThan(0));
 
     //LAUNCH_GROUP
     public static final StringPreference LAUNCH_CMD_TEMPLATE = new StringPreference("launch.cmd.template",

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -409,3 +409,6 @@ error.gcp.impersonate.account=Impersonated account for temporary credentials mus
 error.gcp.instance.not.running=GCP instance ''{0}'' is not in active state. Current state: ''{1}''
 error.gcp.instance.not.found=Instance with label ''{0}'' not found!
 
+#Cluster usage monitoring
+error.cluster.monitoring.negative.interval=Specified monitoring interval should have direct chronological order. \
+  The given start date '{0}' happens after the given end date '{1}'.

--- a/api/src/test/java/com/epam/pipeline/app/TestApplication.java
+++ b/api/src/test/java/com/epam/pipeline/app/TestApplication.java
@@ -20,6 +20,7 @@ import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.dao.monitoring.MonitoringESDao;
 import com.epam.pipeline.manager.cloud.CloudFacade;
 import com.epam.pipeline.manager.cluster.InstanceOfferScheduler;
+import com.epam.pipeline.manager.cluster.performancemonitoring.ESMonitoringManager;
 import com.epam.pipeline.security.jwt.JwtTokenGenerator;
 import com.epam.pipeline.security.jwt.JwtTokenVerifier;
 import org.springframework.boot.SpringApplication;
@@ -72,6 +73,9 @@ public class TestApplication {
 
     @MockBean // TODO: remove and fix what's wrong
     public MonitoringESDao monitoringESDao;
+
+    @MockBean
+    public ESMonitoringManager esMonitoringManager;
 
     @MockBean
     public CloudFacade cloudFacade;


### PR DESCRIPTION
Resolves issue #168.

Previously, node usage monitoring data was received from `CAdvisor` service. The pull request brings support for an additional node usage monitoring backend `ElasticSearch`. It allows to monitor data usage for bigger periods of time.

Additional `monitoring.backend` property was added to `application.properties`. It can be used to specify which one of the supported monitoring backends has to be used. It can be either `cadvisor` or `elastic`. The `cadvisor` is used by default.

Two additional preferences was added.
- `cluster.monitoring.elastic.intervals.number` - Maximum number of intervals to collect usage data for. This is limit number of monitoring stats that server returns on any client request. *Default: 10*.
- `cluster.monitoring.elastic.minimal.interval` - Number of millisecond that the smallest monitoring interval can be. The limitation raises from the `Heapster` monitoring rate which is one minute by default. *Default: 60000*.

Node usage API method `/cluster/node/{name}/usage` was updated with two additional optional parameters `from` and `to` which can be used to specify a time period to collect monitoring stats for. Expected date time format: `yyyy-MM-dd HH:mm:ss`.