### PR TITLE
E2E tests update from 20.05.19

### DIFF
--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/NavigationHomeAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/NavigationHomeAO.java
@@ -27,7 +27,7 @@ public class NavigationHomeAO implements AccessObject<PipelinesLibraryAO> {
     }
 
     public GlobalSearchAO globalSearch() {
-        actions().sendKeys(Keys.CONTROL + "F").perform();
+        actions().sendKeys(Keys.chord(Keys.CONTROL, "F")).perform();
         return new GlobalSearchAO();
     }
 

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/NavigationMenuAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/NavigationMenuAO.java
@@ -20,10 +20,11 @@ import org.openqa.selenium.By;
 import static com.codeborne.selenide.Condition.exist;
 import static com.codeborne.selenide.Condition.not;
 import static com.codeborne.selenide.Condition.visible;
-import static com.codeborne.selenide.Selectors.*;
+import static com.codeborne.selenide.Selectors.byClassName;
+import static com.codeborne.selenide.Selectors.byId;
+import static com.codeborne.selenide.Selectors.byXpath;
 import static com.codeborne.selenide.Selenide.$;
 import static com.epam.pipeline.autotests.utils.Conditions.selectedMenuItem;
-import static com.epam.pipeline.autotests.utils.Utils.click;
 import static com.epam.pipeline.autotests.utils.Utils.sleep;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -31,7 +32,7 @@ public class NavigationMenuAO {
 
     public PipelinesLibraryAO library() {
         final By pipelinesPageSelector = byId("navigation-button-pipelines");
-        click(pipelinesPageSelector);
+        $(pipelinesPageSelector).shouldBe(visible).click();
         $(pipelinesPageSelector).shouldBe(selectedMenuItem);
         $(byXpath("//*[.//*[text()[contains(.,'Library')]] and contains(@id, 'pipelines-library-content')]"))
                 .waitUntil(visible, 5000);
@@ -40,7 +41,7 @@ public class NavigationMenuAO {
 
     public RunsMenuAO runs() {
         final By runsPageSelector = byId("navigation-button-runs");
-        click(runsPageSelector);
+        $(runsPageSelector).shouldBe(visible).click();
         $(runsPageSelector).shouldBe(selectedMenuItem);
         $(byId("active-runs-button")).waitUntil(visible, 5000);
         return new RunsMenuAO();
@@ -48,7 +49,7 @@ public class NavigationMenuAO {
 
     public ToolsPage tools() {
         final By toolsPageSelector = byId("navigation-button-tools");
-        click(toolsPageSelector);
+        $(toolsPageSelector).shouldBe(visible).click();
         $(toolsPageSelector).shouldBe(selectedMenuItem);
         $(byId("current-registry-button")).waitUntil(visible, 5000);
         return new ToolsPage();
@@ -56,7 +57,7 @@ public class NavigationMenuAO {
 
     public ClusterMenuAO clusterNodes() {
         final By clusterPageSelector = byId("navigation-button-cluster");
-        click(clusterPageSelector);
+        $(clusterPageSelector).shouldBe(visible).click();
         $(clusterPageSelector).shouldBe(selectedMenuItem);
         $(byXpath("//*[.//*[text()[contains(.,'Cluster nodes')]] and contains(@id, 'root-content')]"))
                 .waitUntil(visible, 5000);
@@ -64,14 +65,14 @@ public class NavigationMenuAO {
     }
 
     public SettingsPageAO settings() {
-        click(byId("navigation-button-settings"));
+        $(byId("navigation-button-settings")).shouldBe(visible).click();
         sleep(1, SECONDS);
         $(byClassName("ant-modal-content")).waitUntil(visible, 5000);
         return new SettingsPageAO(new PipelinesLibraryAO());
     }
 
     public GlobalSearchAO search() {
-        click(byId("navigation-button-search"));
+        $(byId("navigation-button-search")).shouldBe(visible).click();
         sleep(1, SECONDS);
         $(byClassName("earch__search-container")).waitUntil(visible, 5000);
         return new GlobalSearchAO();

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/PipelinesLibraryAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/PipelinesLibraryAO.java
@@ -149,7 +149,7 @@ public class PipelinesLibraryAO implements AccessObject<PipelinesLibraryAO> {
 
     public PipelinesLibraryAO cd(String folderName) {
         $(byId("pipelines-library-tree-container")).shouldBe(visible)
-                .find(byText(folderName)).shouldBe(visible).click();
+                .find(titleOfTreeItem(treeItem(folderName))).shouldBe(visible).click();
         return this;
     }
 

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/ToolGroup.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/ToolGroup.java
@@ -79,7 +79,7 @@ public class ToolGroup implements AccessObject<ToolGroup> {
         SelenideElement element = get(SEARCH);
         element.click();
         element.clear();
-        element.sendKeys(Keys.CONTROL + "v");
+        element.sendKeys(Keys.chord(Keys.CONTROL, "v"));
         return this;
     }
 

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/mixins/Navigation.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/mixins/Navigation.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.epam.pipeline.autotests.mixins;
 
 import com.epam.pipeline.autotests.ao.ClusterMenuAO;
@@ -23,26 +24,23 @@ import com.epam.pipeline.autotests.ao.RunsMenuAO;
 import com.epam.pipeline.autotests.ao.ToolsPage;
 import org.openqa.selenium.By;
 
+import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selectors.byId;
 import static com.codeborne.selenide.Selenide.$;
 import static com.epam.pipeline.autotests.utils.Conditions.selectedMenuItem;
-import static com.epam.pipeline.autotests.utils.Utils.click;
-import static com.epam.pipeline.autotests.utils.Utils.sleep;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 public interface Navigation {
 
     default NavigationMenuAO navigationMenu() {
         final By pipelinesPageSelector = byId("navigation-button-pipelines");
-        click(pipelinesPageSelector);
+        $(pipelinesPageSelector).shouldBe(visible).click();
         $(pipelinesPageSelector).shouldBe(selectedMenuItem);
         return new NavigationMenuAO();
     }
 
     default NavigationHomeAO home() {
         final By homePageSelector = byId("navigation-button-home");
-        click(homePageSelector);
-        sleep(1, SECONDS);
+        $(homePageSelector).shouldBe(visible).click();
         $(homePageSelector).shouldBe(selectedMenuItem);
         return new NavigationHomeAO();
     }
@@ -53,21 +51,21 @@ public interface Navigation {
 
     default ToolsPage tools() {
         final By toolsPageSelector = byId("navigation-button-tools");
-        click(toolsPageSelector);
+        $(toolsPageSelector).shouldBe(visible).click();
         $(toolsPageSelector).shouldBe(selectedMenuItem);
         return new ToolsPage();
     }
 
     default ClusterMenuAO clusterMenu() {
         final By clusterPageSelector = byId("navigation-button-cluster");
-        click(clusterPageSelector);
+        $(clusterPageSelector).shouldBe(visible).click();
         $(clusterPageSelector).shouldBe(selectedMenuItem);
         return new ClusterMenuAO();
     }
 
     default RunsMenuAO runsMenu() {
         final By runsPageSelector = byId("navigation-button-runs");
-        click(runsPageSelector);
+        $(runsPageSelector).shouldBe(visible).click();
         $(runsPageSelector).shouldBe(selectedMenuItem);
         return new RunsMenuAO();
     }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/utils/Utils.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/utils/Utils.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.epam.pipeline.autotests.utils;
 
 import com.codeborne.selenide.ElementsCollection;
@@ -20,6 +21,12 @@ import com.codeborne.selenide.Selenide;
 import com.codeborne.selenide.SelenideElement;
 import com.epam.pipeline.autotests.RunPipelineTest;
 import com.epam.pipeline.autotests.mixins.Navigation;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.SearchContext;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
+
 import java.awt.AWTException;
 import java.awt.Color;
 import java.awt.Robot;
@@ -39,16 +46,9 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.openqa.selenium.By;
-import org.openqa.selenium.Keys;
-import org.openqa.selenium.SearchContext;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.interactions.Actions;
 
-import static com.codeborne.selenide.Condition.enabled;
 import static com.codeborne.selenide.Condition.exist;
 import static com.codeborne.selenide.Condition.text;
-import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selectors.byClassName;
 import static com.codeborne.selenide.Selectors.byText;
 import static com.codeborne.selenide.Selectors.withText;
@@ -362,10 +362,5 @@ public class Utils {
     public static void restartBrowser(final String address) {
         Selenide.close();
         Selenide.open(address);
-    }
-
-    public static void click(final By selector) {
-        $(selector).shouldBe(visible, enabled);
-        Selenide.executeJavaScript("arguments[0].click();", $(selector));
     }
 }


### PR DESCRIPTION
There are several problems with E2E GUI tests revealed on 20 of May:

1. Native JavaScript clicks were used to navigate through the navigation menu buttons. It turned out that it can lead to unhandled clicks by other page elements, f.e. Cloud Pipeline version tooltip. The tooltip wasn't closed and several tests didn't expect that.

2. The original reason why native JavaScript clicks were used in the first place was the strange behavior of the clicks in `GlobalSearchTest` test. It turned out that the clicks were performed with `Ctrl` key pressed. Such a combination *Ctrl + click* opens the link under the button in a new browser tab rather then clicks on the element.

The pull request removes all the usages of native javascript clicks and press the `Ctrl` button only once while using global search and searching tool by name. Moreover, it fixes the click on the root `Library` element in the library tree.