### PR TITLE
E2E tests update from 21.05.19

### DIFF
--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/DetachedConfigurationsTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/DetachedConfigurationsTest.java
@@ -164,6 +164,7 @@ public class DetachedConfigurationsTest
                     .addOutputParameter(outputParameter, outputParameterValue)
                     .click(SAVE)
             );
+        library().clickRoot();
     }
 
     @BeforeClass
@@ -478,7 +479,9 @@ public class DetachedConfigurationsTest
                     .click(SAVE)
             )
             .configurationWithin(configuration1544, configuration ->
-                configuration.ensure(DISK, value(diskSize))
+                configuration
+                    .expandTabs(execEnvironmentTab, advancedTab)
+                    .ensure(DISK, value(diskSize))
                     .ensure(INSTANCE_TYPE, text(instanceType))
                     .ensure(PRICE_TYPE, text(priceType))
             );


### PR DESCRIPTION
There is a problem with E2E GUI tests revealed on 21 of May:

1. After the changes done in #309 it was seen that detach configuration operations doesn't expect click on the library root. It leads to closed configuration tabs.

The pull request opens configuration tabs where it is necessary.