### PR TITLE
Error of cloning folder with detach configuration

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/FolderManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/FolderManager.java
@@ -374,7 +374,7 @@ public class FolderManager {
         }
         if (!CollectionUtils.isEmpty(folderToClone.getConfigurations())) {
             folderToClone.getConfigurations().forEach(runConfiguration -> {
-                runConfiguration.setParent(clonedFolder);
+                runConfiguration.setParent(new Folder(clonedFolder.getId()));
                 configurationManager.create(runConfigurationMapper.toRunConfigurationVO(runConfiguration));
             });
         }


### PR DESCRIPTION
Implementation for issue #305 : do not return whole folder structure. It can lead to cyclic dependencies with  configurations.