### PR TITLE
Repair nextflow docker

### DIFF
--- a/deploy/docker/cp-tools/base/nextflow/Dockerfile
+++ b/deploy/docker/cp-tools/base/nextflow/Dockerfile
@@ -35,16 +35,17 @@ ENV NXF_HOME="$NXF_HOME_ROOT/$NXF_VER"
 ENV CP_CAP_SGE="true"
 
 # Always use DinD's "container" mode to allow docker-based workflows
-ENV CP_CAP_DIND_CONAINER="true"
+ENV CP_CAP_DIND_CONTAINER="true"
 
 # Redefine default analysis and input location to /common, which will be shared across nodes. These values can be also changed during startup
 ENV ANALYSIS_DIR="/common/analysis"
 ENV INPUT_DIR="/common/input"
 
-# Install nextflow itlself into $NEXTFLOW_HOME
-RUN mkdir -p $NEXTFLOW_HOME && \
+# Install nextflow itlself into $NXF_HOME
+RUN mkdir -p $NXF_HOME && \
     cd $NXF_HOME_ROOT && \
-    curl -fsSL get.nextflow.io | bash
+    curl -fsSL get.nextflow.io | bash && \
+    mv nextflow "$NXF_HOME/nextflow"
 
 ADD default.config /etc/nextflow/default.config
 

--- a/deploy/docker/cp-tools/base/nextflow/default.config
+++ b/deploy/docker/cp-tools/base/nextflow/default.config
@@ -1,1 +1,3 @@
 process.executor = 'sge'
+process.penv = 'local'
+docker.enabled = true

--- a/deploy/docker/cp-tools/base/nextflow/nextflow
+++ b/deploy/docker/cp-tools/base/nextflow/nextflow
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-$NEXTFLOW_HOME/nextflow -c /etc/nextflow/default.config $@
+$NXF_HOME/nextflow -c /etc/nextflow/default.config $@


### PR DESCRIPTION
The pull request repairs nextflow docker in the context of #291 issue.

Add default SGE parallel environment to nextflow configuration and enable docker runs by default. Moreover removes a typo and structure nextflow home directory properly.