### PR TITLE
Disable GE autoscaling parameters for additional workers

### DIFF
--- a/workflows/pipe-common/scripts/autoscale_sge.py
+++ b/workflows/pipe-common/scripts/autoscale_sge.py
@@ -411,7 +411,10 @@ class GridEngineScaleUpHandler:
                            '--parent-id %s ' \
                            '--price-type %s ' \
                            'cluster_role worker ' \
-                           'cluster_role_type additional' \
+                           'cluster_role_type additional ' \
+                           'CP_CAP_SGE false ' \
+                           'CP_CAP_AUTOSCALE false ' \
+                           'CP_CAP_AUTOSCALE_WORKERS 0' \
                            % (self.instance_disk, self.instance_type, self.instance_image, self.parent_run_id,
                               self._pipe_cli_price_type(self.price_type))
         run_id = int(self.executor.execute_to_lines(pipe_run_command)[0])


### PR DESCRIPTION
Resolves issue #354.

Additional workers inherit tool default settings. Therefore, if autoscaling is enabled in tool settings all additional workers are configured as GE masters which lead to an autoscaling live-lock.

The pull request overrides GE autoscaler parameters to support tools with enabled autoscaled clusters.