### PR TITLE
Redirect SGE autoscaler script stdout and stderr

### DIFF
--- a/scripts/pipeline-launch/launch.sh
+++ b/scripts/pipeline-launch/launch.sh
@@ -236,7 +236,7 @@ function cp_cap_init {
 
             if [ "$cluster_role" = "master" ] && check_cp_cap "CP_CAP_AUTOSCALE" && check_cp_cap "CP_CAP_SGE"
             then
-                  $CP_PYTHON2_PATH $COMMON_REPO_DIR/scripts/autoscale_sge.py &
+                  nohup $CP_PYTHON2_PATH $COMMON_REPO_DIR/scripts/autoscale_sge.py 1>/dev/null 2>$LOG_DIR/.nohup.sge.autoscale.log &
             fi
       fi
 }


### PR DESCRIPTION
Resolves #377.

Background processes launched from `launch.sh` directly prevent Azure run from finalization even then `launch.sh` itself has finished. Probably it is caused by the run process stdout and stderr which aren't handled the same way for different cloud provider.