### PR TITLE
GCP: input/output pipeline run parameters doesn't work

### DIFF
--- a/pipe-cli/src/utilities/storage/common.py
+++ b/pipe-cli/src/utilities/storage/common.py
@@ -102,7 +102,7 @@ class StorageOperations:
 
     @classmethod
     def show_progress(cls, quiet, size):
-        return not quiet and size is not None
+        return not quiet and size is not None and size != 0
 
     @classmethod
     def get_local_file_size(cls, path):
@@ -190,6 +190,10 @@ class StorageOperations:
             else:
                 item_relative_path = StorageOperations.get_item_name(item.name, prefix + delimiter)
             yield ('File', item.name, item_relative_path, item.size)
+
+    @classmethod
+    def file_is_empty(cls, size):
+        return not size or size == 0
 
 
 class AbstractTransferManager:

--- a/pipe-cli/src/utilities/storage/gs.py
+++ b/pipe-cli/src/utilities/storage/gs.py
@@ -371,7 +371,10 @@ class GsDownloadManager(GsManager, AbstractTransferManager):
             os.makedirs(folder)
         progress_callback = GsProgressPercentage.callback(source_key, size, quiet)
         bucket = self.client.bucket(source_wrapper.bucket.path)
-        blob = self._chunked_blob(bucket, source_key, progress_callback)
+        if StorageOperations.file_is_empty(size):
+            blob = bucket.blob(source_key)
+        else:
+            blob = self._chunked_blob(bucket, source_key, progress_callback)
         blob.download_to_filename(destination_key)
         if progress_callback is not None:
             progress_callback(size)
@@ -445,7 +448,10 @@ class TransferFromHttpOrFtpToGsManager(GsManager, AbstractTransferManager):
                 return
         progress_callback = GsProgressPercentage.callback(relative_path, size, quiet)
         bucket = self.client.bucket(destination_wrapper.bucket.path)
-        blob = self._chunked_blob(bucket, destination_key, progress_callback)
+        if StorageOperations.file_is_empty(size):
+            blob = bucket.blob(source_key)
+        else:
+            blob = self._chunked_blob(bucket, source_key, progress_callback)
         blob.metadata = StorageOperations.generate_tags(tags, source_key)
         blob.upload_from_file(_SourceUrlIO(urlopen(source_key)))
         if progress_callback is not None:


### PR DESCRIPTION
Fix for issue #384 

The original problem is that gcp cli doesn't work with empty file correctly. This way download operation fails on `.DS_Store` file. 

The solution is to process empty files with original gcp sdk method (not with wrapped) and do not show progress bar on empty files (as implemented for `S3`)