### PR TITLE
Add network configuration parameters to gcp deployment

### DIFF
--- a/deploy/contents/install/app/configure-utils.sh
+++ b/deploy/contents/install/app/configure-utils.sh
@@ -923,7 +923,7 @@ function api_setup_base_preferences {
     ## Set cluster.networks.config preference
     local cloud_config_network_file="$CP_CLOUD_CONFIG_PATH/cluster.networks.config.json"
     if [ -f "$cloud_config_network_file" ]; then
-        local cluster_networks_config_json="$(escape_string "$(envsubst '${CP_CLOUD_REGION_ID} ${CP_PREF_CLUSTER_INSTANCE_IMAGE_GPU} ${CP_PREF_CLUSTER_INSTANCE_IMAGE} ${CP_PREF_CLUSTER_INSTANCE_SECURITY_GROUPS} ${CP_PREF_CLUSTER_PROXIES} ${CP_VM_MONITOR_INSTANCE_TAG_NAME} ${CP_VM_MONITOR_INSTANCE_TAG_VALUE}' < "$cloud_config_network_file")")"
+        local cluster_networks_config_json="$(escape_string "$(envsubst '${CP_CLOUD_REGION_ID} ${CP_PREF_CLUSTER_INSTANCE_IMAGE_GPU} ${CP_PREF_CLUSTER_INSTANCE_IMAGE} ${CP_PREF_CLUSTER_INSTANCE_SECURITY_GROUPS} ${CP_PREF_CLUSTER_PROXIES} ${CP_VM_MONITOR_INSTANCE_TAG_NAME} ${CP_VM_MONITOR_INSTANCE_TAG_VALUE} ${CP_PREF_CLUSTER_INSTANCE_NETWORK} ${CP_PREF_CLUSTER_INSTANCE_SUBNETWORK}' < "$cloud_config_network_file")")"
         
         # cluster.networks.config shall be visible, or otherwise node_up.py will NOT be able to get the information from the API Services
         api_set_preference "cluster.networks.config" "$cluster_networks_config_json" "true"

--- a/deploy/contents/install/app/install-utils.sh
+++ b/deploy/contents/install/app/install-utils.sh
@@ -596,6 +596,13 @@ function parse_options {
         return 1
     fi
 
+    if [ "$CP_CLOUD_PLATFORM" == "$CP_GOOGLE" ]; then
+        if [ -z "$CP_PREF_CLUSTER_INSTANCE_NETWORK" ] || [ -z "$CP_PREF_CLUSTER_INSTANCE_SUBNETWORK" ]; then
+            print_err "Network configuration for GCP cloud is required. Please specify a valid network using \"-env CP_PREF_CLUSTER_INSTANCE_NETWORK=\" and \"-env CP_PREF_CLUSTER_INSTANCE_SUBNETWORK=\""
+            return 1
+        fi
+    fi
+
     set_service_host "CP_API_SRV_EXTERNAL_HOST" "CP_API_SRV_INTERNAL_HOST" && \
     set_service_host "CP_IDP_EXTERNAL_HOST" "CP_IDP_INTERNAL_HOST"  && \
     set_service_host "CP_DOCKER_EXTERNAL_HOST" "CP_DOCKER_INTERNAL_HOST" && \

--- a/deploy/contents/install/cloud-configs/gcp/cluster.networks.config.json
+++ b/deploy/contents/install/cloud-configs/gcp/cluster.networks.config.json
@@ -3,7 +3,9 @@
     {
       "name": "${CP_CLOUD_REGION_ID}",
       "default": true,
-      "networks": {},
+      "networks": {
+        "${CP_PREF_CLUSTER_INSTANCE_NETWORK}" : "${CP_PREF_CLUSTER_INSTANCE_SUBNETWORK}"
+      },
       "proxies": [
         ${CP_PREF_CLUSTER_PROXIES}
       ],


### PR DESCRIPTION
This PR adds required parameters CP_PREF_CLUSTER_INSTANCE_NETWORK and CP_PREF_CLUSTER_INSTANCE_SUBNETWORK to GCP deployment in order to configure a network