### PR TITLE
Spot parameter for instance requests

### DIFF
--- a/client/src/components/main/Root.js
+++ b/client/src/components/main/Root.js
@@ -36,8 +36,8 @@ import cloudProviders from '../../models/cloudRegions/CloudProviders';
 import dataStorageCache from '../../models/dataStorage/DataStorageCache';
 import dataStorageAvailable from '../../models/dataStorage/DataStorageAvailable';
 import dtsList from '../../models/dts/DTSList';
-import instanceTypes from '../../models/utils/InstanceTypes';
-import toolInstanceTypes from '../../models/utils/ToolInstanceTypes';
+import InstanceTypes from '../../models/utils/InstanceTypes';
+import ToolInstanceTypes from '../../models/utils/ToolInstanceTypes';
 import FolderLoadWithMetadata from '../../models/folders/FolderLoadWithMetadata';
 import dockerRegistries from '../../models/tools/DockerRegistriesTree';
 import RunCount from '../../models/pipelines/RunCount';
@@ -61,8 +61,17 @@ const users = new Users();
 const allowedInstanceTypes = new AllowedInstanceTypes();
 const searchEngine = new Search();
 
+const spotInstanceTypes = new InstanceTypes(true);
+const onDemandInstanceTypes = new InstanceTypes(false);
+const spotToolInstanceTypes = new ToolInstanceTypes(true);
+const onDemandToolInstanceTypes = new ToolInstanceTypes(false);
+
 (() => { return awsRegions.fetchIfNeededOrWait(); })();
 (() => { return allowedInstanceTypes.fetchIfNeededOrWait(); })();
+(() => { return spotInstanceTypes.fetchIfNeededOrWait(); })();
+(() => { return onDemandInstanceTypes.fetchIfNeededOrWait(); })();
+(() => { return spotToolInstanceTypes.fetchIfNeededOrWait(); })();
+(() => { return onDemandToolInstanceTypes.fetchIfNeededOrWait(); })();
 
 const Root = () =>
   <Provider
@@ -84,8 +93,10 @@ const Root = () =>
       availableCloudRegions,
       cloudProviders,
       folders,
-      instanceTypes,
-      toolInstanceTypes,
+      spotInstanceTypes,
+      onDemandInstanceTypes,
+      spotToolInstanceTypes,
+      onDemandToolInstanceTypes,
       notifications,
       authenticatedUserInfo,
       metadataCache: FolderLoadWithMetadata.metadataCache,

--- a/client/src/components/main/home/panels/PersonalToolsPanel.js
+++ b/client/src/components/main/home/panels/PersonalToolsPanel.js
@@ -347,7 +347,13 @@ export default class PersonalToolsPanel extends React.Component {
           }
           return result;
         };
-        const allowedInstanceTypesRequest = new AllowedInstanceTypes(tool.id);
+        const allowedInstanceTypesRequest = new AllowedInstanceTypes(
+          tool.id,
+          null,
+          parameterIsNotEmpty(versionSettingValue('is_spot'))
+            ? versionSettingValue('is_spot')
+            : this.props.preferences.useSpot
+        );
         await allowedInstanceTypesRequest.fetch();
         let availableInstanceTypes = [];
         let availablePriceTypes = [];

--- a/client/src/components/pipelines/launch/form/LaunchPipelineForm.js
+++ b/client/src/components/pipelines/launch/form/LaunchPipelineForm.js
@@ -3708,9 +3708,13 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
   };
 
   componentDidMount () {
-    if (this.props.allowedInstanceTypes && this.props.parameters &&
-      this.props.parameters.is_spot !== undefined && this.props.parameters.is_spot !== null) {
-      this.props.allowedInstanceTypes.isSpot = `${this.props.parameters.is_spot}` === 'true';
+    if (this.props.allowedInstanceTypes) {
+      if (this.props.parameters && this.props.parameters.is_spot !== undefined &&
+        this.props.parameters.is_spot !== null) {
+        this.props.allowedInstanceTypes.isSpot = `${this.props.parameters.is_spot}` === 'true';
+      } else {
+        this.props.allowedInstanceTypes.isSpot = `${this.props.defaultPriceTypeIsSpot}` === 'true';
+      }
     }
     this.reset(true);
     this.evaluateEstimatedPrice({});

--- a/client/src/components/pipelines/launch/form/LaunchPipelineForm.js
+++ b/client/src/components/pipelines/launch/form/LaunchPipelineForm.js
@@ -91,6 +91,10 @@ function onValuesChange (props, fields) {
   if (fields && fields.exec && fields.exec.cloudRegionId && props.allowedInstanceTypes) {
     props.allowedInstanceTypes.regionId = +fields.exec.cloudRegionId;
   }
+  if (fields && fields[ADVANCED] && fields[ADVANCED].is_spot !== undefined &&
+    fields[ADVANCED].is_spot !== null && props.allowedInstanceTypes) {
+    props.allowedInstanceTypes.isSpot = `${fields[ADVANCED].is_spot}` === 'true';
+  }
 }
 
 function getFormItemClassName (rootClass, key) {
@@ -3704,6 +3708,10 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
   };
 
   componentDidMount () {
+    if (this.props.allowedInstanceTypes && this.props.parameters &&
+      this.props.parameters.is_spot !== undefined && this.props.parameters.is_spot !== null) {
+      this.props.allowedInstanceTypes.isSpot = `${this.props.parameters.is_spot}` === 'true';
+    }
     this.reset(true);
     this.evaluateEstimatedPrice({});
     this.prepare();

--- a/client/src/components/runs/actions/run.js
+++ b/client/src/components/runs/actions/run.js
@@ -38,7 +38,7 @@ import AWSRegionTag from '../../special/AWSRegionTag';
 import awsRegions from '../../../models/cloudRegions/CloudRegions';
 
 // Mark class with @submitsRun if it may launch pipelines / tools
-export const submitsRun = (...opts) => inject('instanceTypes')(...opts);
+export const submitsRun = (...opts) => inject('spotInstanceTypes', 'onDemandInstanceTypes')(...opts);
 
 export function run (parent, callback) {
   if (!parent) {
@@ -108,10 +108,14 @@ function runFn (payload, confirm, title, warning, stores, callbackFn, allowedIns
         }
         return undefined;
       }).filter(p => p !== undefined);
-    } else if (stores && stores.instanceTypes) {
-      await stores.instanceTypes.fetchIfNeededOrWait();
-      if (stores.instanceTypes.loaded) {
-        availableInstanceTypes = (stores.instanceTypes.value || []).map(i => i);
+    } else if (stores && (stores.spotInstanceTypes || stores.onDemandInstanceTypes)) {
+      let storeName = 'onDemandInstanceTypes';
+      if (payload.isSpot) {
+        storeName = 'spotInstanceTypes';
+      }
+      await stores[storeName].fetchIfNeededOrWait();
+      if (stores[storeName].loaded) {
+        availableInstanceTypes = (stores[storeName].value || []).map(i => i);
       }
     }
     if (payload.pipelineId) {

--- a/client/src/components/tools/forms/EditToolForm.js
+++ b/client/src/components/tools/forms/EditToolForm.js
@@ -56,18 +56,8 @@ const Panels = {
   parameters: 'parameters'
 };
 
-function onValuesChange (props, fields) {
-  if (fields && fields.is_spot !== undefined && fields.is_spot !== null &&
-    props.allowedInstanceTypes) {
-    props.allowedInstanceTypes.isSpot = fields.is_spot;
-  }
-}
-
-@Form.create({onValuesChange: onValuesChange})
-@inject('spotToolInstanceTypes', 'onDemandToolInstanceTypes', 'runDefaultParameters')
-@inject(({allowedInstanceTypes}, props) => ({
-  allowedInstanceTypes: allowedInstanceTypes.getAllowedTypes(props.toolId)
-}))
+@Form.create()
+@inject('allowedInstanceTypes', 'spotToolInstanceTypes', 'onDemandToolInstanceTypes', 'runDefaultParameters')
 @observer
 export default class EditToolForm extends React.Component {
   static propTypes = {
@@ -322,8 +312,7 @@ export default class EditToolForm extends React.Component {
 
   componentDidMount () {
     this.reset();
-    if (this.props.allowedInstanceTypes && this.props.parameters &&
-      this.props.parameters.is_spot !== undefined && this.props.parameters.is_spot !== null) {
+    if (this.props.allowedInstanceTypes) {
       const isSpot = this.getPriceTypeInitialValue();
       this.props.allowedInstanceTypes.isSpot = `${isSpot}` === 'true';
     }
@@ -336,6 +325,12 @@ export default class EditToolForm extends React.Component {
       this.reset(nextProps);
     }
   }
+
+  handleIsSpotChange = (isSpot) => {
+    if (this.props.allowedInstanceTypes && isSpot !== undefined && isSpot !== null) {
+      this.props.allowedInstanceTypes.isSpot = `${isSpot}` === 'true';
+    }
+  };
 
   removeLabel = (label) => {
     const labels = this.state.labels;
@@ -357,8 +352,8 @@ export default class EditToolForm extends React.Component {
   @computed
   get instanceTypes () {
     const isSpot = this.props.form.getFieldValue('is_spot') !== undefined
-      ? this.props.form.getFieldValue('is_spot')
-      : this.getPriceTypeInitialValue();
+      ? `${this.props.form.getFieldValue('is_spot')}` === 'true'
+      : `${this.getPriceTypeInitialValue()}` === 'true';
     let storeName = 'onDemandToolInstanceTypes';
     if (isSpot) {
       storeName = 'spotToolInstanceTypes';
@@ -748,7 +743,7 @@ export default class EditToolForm extends React.Component {
                   {
                     initialValue: this.getPriceTypeInitialValue()
                   })(
-                    <Select disabled={this.state.pending || this.props.readOnly}>
+                    <Select disabled={this.state.pending || this.props.readOnly} onChange={this.handleIsSpotChange}>
                       {
                         this.allowedPriceTypes
                           .map(t => <Select.Option key={`${t.isSpot}`}>{t.name}</Select.Option>)

--- a/client/src/components/tools/forms/EditToolForm.js
+++ b/client/src/components/tools/forms/EditToolForm.js
@@ -315,6 +315,7 @@ export default class EditToolForm extends React.Component {
     if (this.props.allowedInstanceTypes) {
       const isSpot = this.getPriceTypeInitialValue();
       this.props.allowedInstanceTypes.isSpot = `${isSpot}` === 'true';
+      this.props.allowedInstanceTypes.toolId = this.props.toolId;
     }
 
     this.props.onInitialized && this.props.onInitialized(this);

--- a/client/src/models/utils/AllowedInstanceTypes.js
+++ b/client/src/models/utils/AllowedInstanceTypes.js
@@ -18,17 +18,34 @@ import Remote from '../basic/Remote';
 
 export default class AllowedInstanceTypes extends Remote {
 
+  _isSpot;
   _toolId;
   _regionId;
   _initialRegionId;
   _changed = false;
 
-  constructor (toolId, regionId) {
+  constructor (toolId, regionId, isSpot) {
     super();
     this._toolId = toolId;
     this._regionId = regionId;
+    this._isSpot = isSpot;
     this.initialize();
     this.fetchIfNeededOrWait();
+  }
+
+  get isSpot () {
+    return this._isSpot;
+  }
+
+  set isSpot (value) {
+    if (value !== undefined && value !== null && this._isSpot !== value) {
+      this._isSpot = value;
+      this.initialize();
+      this.invalidateCache();
+      this._loaded = false;
+      this.fetchIfNeededOrWait();
+      this._changed = true;
+    }
   }
 
   set toolId (value) {
@@ -87,6 +104,9 @@ export default class AllowedInstanceTypes extends Remote {
     }
     if (this._regionId) {
       params.push(`regionId=${this._regionId}`);
+    }
+    if (this._isSpot !== undefined && this._isSpot !== null) {
+      params.push(`spot=${this._isSpot ? 'true' : 'false'}`);
     }
     if (params.length) {
       this.url = `/cluster/instance/allowed?${params.join('&')}`;

--- a/client/src/models/utils/InstanceTypes.js
+++ b/client/src/models/utils/InstanceTypes.js
@@ -18,11 +18,15 @@ import Remote from '../basic/Remote';
 
 class InstanceTypes extends Remote {
 
-  constructor () {
+  constructor (isSpot) {
     super();
-    this.url = '/cluster/instance/loadAll';
+    if (isSpot !== undefined && isSpot !== null) {
+      this.url = `/cluster/instance/loadAll?spot=${!!isSpot}`;
+    } else {
+      this.url = '/cluster/instance/loadAll';
+    }
   }
 
 }
 
-export default new InstanceTypes();
+export default InstanceTypes;

--- a/client/src/models/utils/ToolInstanceTypes.js
+++ b/client/src/models/utils/ToolInstanceTypes.js
@@ -18,11 +18,15 @@ import Remote from '../basic/Remote';
 
 class ToolInstanceTypes extends Remote {
 
-  constructor () {
+  constructor (isSpot) {
     super();
-    this.url = '/cluster/instance/loadAll?toolInstances=true';
+    if (isSpot !== undefined && isSpot !== null) {
+      this.url = `/cluster/instance/loadAll?toolInstances=true&spot=${!!isSpot}`;
+    } else {
+      this.url = '/cluster/instance/loadAll?toolInstances=true';
+    }
   }
 
 }
 
-export default new ToolInstanceTypes();
+export default ToolInstanceTypes;


### PR DESCRIPTION
Requests `/cluster/instance/loadAll` and `/cluster/instance/allowed` are now submitted with `spot` argument as there could be different responses depend on `spot` parameter.