### PR TITLE
Extract GE autoscaler scale up polling timeout preference

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -478,6 +478,9 @@ public class SystemPreferences {
     public static final IntPreference GE_AUTOSCALING_SCALE_DOWN_TIMEOUT =
             new IntPreference("ge.autoscaling.scale.down.timeout", null,
                     GRID_ENGINE_AUTOSCALING_GROUP, pass);
+    public static final IntPreference GE_AUTOSCALING_SCALE_UP_POLLING_TIMEOUT =
+            new IntPreference("ge.autoscaling.scale.up.polling.timeout", null,
+                    GRID_ENGINE_AUTOSCALING_GROUP, pass);
 
 
     private static final Pattern GIT_VERSION_PATTERN = Pattern.compile("(\\d)\\.(\\d)");

--- a/workflows/pipe-common/test/test_sge_autoscaler_scale_up_handler.py
+++ b/workflows/pipe-common/test/test_sge_autoscaler_scale_up_handler.py
@@ -32,11 +32,13 @@ instance_type = 'instance_type'
 instance_image = 'instance_image'
 price_type = 'price_type'
 instance_cores = 4
+polling_timeout = 600
 scale_up_handler = GridEngineScaleUpHandler(cmd_executor=cmd_executor, pipe=pipe, grid_engine=grid_engine,
                                             host_storage=host_storage, parent_run_id=parent_run_id,
                                             default_hostfile=default_hostfile, instance_disk=instance_disk,
                                             instance_type=instance_type, instance_image=instance_image,
-                                            price_type=price_type, instance_cores=instance_cores, polling_timeout=0)
+                                            price_type=price_type, instance_cores=instance_cores,
+                                            polling_timeout=polling_timeout, polling_delay=0)
 
 
 def setup_function():


### PR DESCRIPTION
Resolves issue #400.

The pull request extracts GE autoscaler polling timeout to a new system preference `ge.autoscaling.scale.up.polling.timeout`. The preference defines how many seconds GE autoscaler should wait for *pod initialization* and *run initialization*. Default value remains the same. It equals `600` seconds or 10 minutes.