### PR TITLE
Issue 362 Implement GCPMonitorService

### DIFF
--- a/vm-monitor/build.gradle
+++ b/vm-monitor/build.gradle
@@ -81,6 +81,9 @@ dependencies {
     implementation group: "com.microsoft.azure", name: "azure-mgmt-resources", version: "1.19.0"
     implementation group: "com.microsoft.azure", name: "azure", version: "1.19.0"
 
+    //GCP
+    implementation group: "com.google.apis", name: "google-api-services-compute", version: "v1-rev214-1.25.0"
+
     //Tests
     implementation group: "org.springframework.boot", name: "spring-boot-starter-test", version: springBootVersion
     testImplementation group: "org.projectlombok", name: "lombok", version: lombokVersion

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/exception/GCPMonitorException.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/exception/GCPMonitorException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.vmmonitor.exception;
+
+public final class GCPMonitorException extends RuntimeException {
+    public GCPMonitorException() {
+        super();
+    }
+
+    public GCPMonitorException(String message) {
+        super(message);
+    }
+
+    public GCPMonitorException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/impl/GCPMonitorService.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/impl/GCPMonitorService.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.vmmonitor.service.impl;
+
+import com.epam.pipeline.entity.region.CloudProvider;
+import com.epam.pipeline.entity.region.GCPRegion;
+import com.epam.pipeline.vmmonitor.exception.GCPMonitorException;
+import com.epam.pipeline.vmmonitor.model.vm.VMTag;
+import com.epam.pipeline.vmmonitor.model.vm.VirtualMachine;
+import com.epam.pipeline.vmmonitor.service.VMMonitorService;
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.compute.Compute;
+import com.google.api.services.compute.ComputeScopes;
+import com.google.api.services.compute.model.Instance;
+import com.google.api.services.compute.model.InstanceList;
+import com.google.api.services.compute.model.NetworkInterface;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.GeneralSecurityException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+public class GCPMonitorService implements VMMonitorService<GCPRegion> {
+    private static final String FILTER_PATTERN = "(status = RUNNING) AND (labels.%s = %s)";
+
+    private final JsonFactory jsonFactory;
+    private final HttpTransport httpTransport;
+    private final VMTag instanceTag;
+
+    public GCPMonitorService(@Value("${monitor.instance.tag}") final String instanceTagString) {
+        try {
+            this.httpTransport = GoogleNetHttpTransport.newTrustedTransport();
+        } catch (GeneralSecurityException | IOException e) {
+            log.error("Can't receive GoogleNetHttpTransport instance!");
+            throw new GCPMonitorException("Can't create monitor instance!");
+        }
+        this.instanceTag = VMTag.fromProperty(instanceTagString);
+        this.jsonFactory = JacksonFactory.getDefaultInstance();
+    }
+
+    @Override
+    public List<VirtualMachine> fetchRunningVms(final GCPRegion region) {
+        verifyProjectInfo(region);
+        final Compute compute = getGCPCompute(region);
+        final InstanceList instances = getGcpVmInstances(region, compute);
+        return createListOfVMsFromGCPInstances(instances);
+    }
+
+    @Override
+    public CloudProvider provider() {
+        return CloudProvider.GCP;
+    }
+
+
+    private void verifyProjectInfo(final GCPRegion region) {
+        Assert.notNull(region.getProject(), "Project ID is not specified for GCP region.");
+        Assert.notNull(region.getRegionCode(), "Zone ID is not specified for GCP region.");
+    }
+
+    Compute getGCPCompute(final GCPRegion region) {
+        try {
+            final GoogleCredential credential = getCredentials(region.getAuthFile());
+            return new Compute.Builder(httpTransport, jsonFactory, credential).build();
+        } catch (IOException e) {
+            log.error(e.getMessage(), e);
+            throw new GCPMonitorException(e.getMessage(), e);
+        }
+    }
+
+    private GoogleCredential getCredentials(final String authFile) throws IOException {
+        if (StringUtils.isBlank(authFile)) {
+            return GoogleCredential.getApplicationDefault();
+        }
+        try (InputStream stream = new FileInputStream(authFile)) {
+            return GoogleCredential.fromStream(stream)
+                                   .createScoped(Collections.singletonList(ComputeScopes.COMPUTE_READONLY));
+        }
+    }
+
+    InstanceList getGcpVmInstances(final GCPRegion region, final Compute compute) {
+        final String filter = String.format(FILTER_PATTERN, instanceTag.getKey(), instanceTag.getValue());
+        try {
+            return Optional.ofNullable(compute.instances()
+                                              .list(region.getProject(), region.getRegionCode())
+                                              .setFilter(filter)
+                                              .execute()).orElse(new InstanceList());
+        } catch (IOException e) {
+            log.error(e.getMessage(), e);
+            throw new GCPMonitorException(e.getMessage(), e);
+        }
+    }
+
+    private List<VirtualMachine> createListOfVMsFromGCPInstances(final InstanceList instances) {
+        return ListUtils.emptyIfNull(instances.getItems())
+                        .stream()
+                        .map(this::toVM)
+                        .collect(Collectors.toList());
+    }
+
+    private VirtualMachine toVM(final Instance instance) {
+        return VirtualMachine.builder()
+                             .instanceName(instance.getName())
+                             .cloudProvider(provider())
+                             .instanceId(instance.getId().toString())
+                             .privateIp(getInternalIP(instance))
+                             .tags(instance.getLabels())
+                             .build();
+    }
+
+    private String getInternalIP(Instance instance) {
+        final List<NetworkInterface> networkInterfaces = instance.getNetworkInterfaces();
+        return CollectionUtils.isNotEmpty(networkInterfaces)
+                ? networkInterfaces.get(0).getNetworkIP()
+                : null;
+    }
+}

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/impl/GCPMonitorService.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/impl/GCPMonitorService.java
@@ -33,7 +33,6 @@ import com.google.api.services.compute.model.Instance;
 import com.google.api.services.compute.model.InstanceList;
 import com.google.api.services.compute.model.NetworkInterface;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
@@ -138,10 +137,10 @@ public class GCPMonitorService implements VMMonitorService<GCPRegion> {
                              .build();
     }
 
-    private String getInternalIP(Instance instance) {
-        final List<NetworkInterface> networkInterfaces = instance.getNetworkInterfaces();
-        return CollectionUtils.isNotEmpty(networkInterfaces)
-                ? networkInterfaces.get(0).getNetworkIP()
-                : null;
+    private String getInternalIP(final Instance instance) {
+        return ListUtils.emptyIfNull(instance.getNetworkInterfaces()).stream()
+                                                                     .findFirst()
+                                                                     .map(NetworkInterface::getNetworkIP)
+                                                                     .orElse(null);
     }
 }

--- a/vm-monitor/src/test/java/com/epam/pipeline/vmmonitor/service/impl/GCPMonitorServiceTest.java
+++ b/vm-monitor/src/test/java/com/epam/pipeline/vmmonitor/service/impl/GCPMonitorServiceTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.vmmonitor.service.impl;
+
+import com.epam.pipeline.entity.region.CloudProvider;
+import com.epam.pipeline.entity.region.GCPRegion;
+import com.epam.pipeline.vmmonitor.model.vm.VirtualMachine;
+import com.epam.pipeline.vmmonitor.service.VMMonitorService;
+import com.google.api.services.compute.Compute;
+import com.google.api.services.compute.model.Instance;
+import com.google.api.services.compute.model.InstanceList;
+import com.google.api.services.compute.model.NetworkInterface;
+
+import java.util.*;
+import java.math.BigInteger;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+@SuppressWarnings("PMD.AvoidUsingHardCodedIP")
+public class GCPMonitorServiceTest {
+    private static final String CREDENTIALS_PATH = ""; // path to the Google credentials
+    private static final String PROJECT_NAME = ""; // Project ID (for example: "resounding-rune-122345")
+    private static final String REGION_CODE = ""; // the name of the zone (for example: "us-central1-a")
+    private static final String TAG = "monitored=true"; // tag for VM instances to be searched
+    private static final String TEST_INSTANCE_NAME1 = "testInstance1";
+    private static final String TEST_INSTANCE_NAME2 = "testInstance2";
+    private static final String TEST_INSTANCE_ID1 = "1";
+    private static final String TEST_INSTANCE_ID2 = "2";
+    private static final String TEST_INSTANCE_INTERNAL_IP1 = "10.128.0.1";
+    private static final String TEST_INSTANCE_INTERNAL_IP2 = "10.128.0.2";
+
+    @Spy
+    private final GCPMonitorService service = new GCPMonitorService(TAG);
+    private final GCPRegion testGcpRegion = new GCPRegion();
+
+    @Before
+    public void initializeTestGcpRegion() {
+        testGcpRegion.setAuthFile(CREDENTIALS_PATH);
+        testGcpRegion.setProject(PROJECT_NAME);
+        testGcpRegion.setRegionCode(REGION_CODE);
+    }
+
+    @Test
+    public void getProvider() {
+        final VMMonitorService service = new GCPMonitorService(TAG);
+        Assertions.assertEquals(CloudProvider.GCP, service.provider());
+    }
+
+    @Test
+    public void emptyProjectName() {
+        final GCPRegion gcpRegion = new GCPRegion();
+        gcpRegion.setAuthFile(CREDENTIALS_PATH);
+        gcpRegion.setRegionCode(REGION_CODE);
+        Assertions.assertThrows(IllegalArgumentException.class,
+            () -> new GCPMonitorService(TAG).fetchRunningVms(gcpRegion));
+    }
+
+    @Test
+    public void emptyZoneId() {
+        final GCPRegion gcpRegion = new GCPRegion();
+        gcpRegion.setAuthFile(CREDENTIALS_PATH);
+        gcpRegion.setProject(PROJECT_NAME);
+        Assertions.assertThrows(IllegalArgumentException.class,
+            () -> new GCPMonitorService(TAG).fetchRunningVms(gcpRegion));
+    }
+
+    @Test
+    public void emptyInstanceList() {
+        final InstanceList list = new InstanceList();
+        list.setItems(Collections.emptyList());
+        final Compute mockedCompute = Mockito.mock(Compute.class);
+        Mockito.doReturn(mockedCompute).when(service).getGCPCompute(Mockito.any());
+        Mockito.doReturn(list).when(service).getGcpVmInstances(Mockito.any(), Mockito.any());
+        Assertions.assertEquals(0, service.fetchRunningVms(testGcpRegion).size());
+    }
+
+    @Test
+    public void notEmptyInstanceList() {
+        final List<VirtualMachine> expectedVMs = Arrays.asList(
+                        VirtualMachine.builder()
+                                      .instanceName(TEST_INSTANCE_NAME1)
+                                      .instanceId(TEST_INSTANCE_ID1)
+                                      .cloudProvider(CloudProvider.GCP)
+                                      .privateIp(TEST_INSTANCE_INTERNAL_IP1)
+                                      .build(),
+                        VirtualMachine.builder()
+                                      .instanceName(TEST_INSTANCE_NAME2)
+                                      .instanceId(TEST_INSTANCE_ID2)
+                                      .cloudProvider(CloudProvider.GCP)
+                                      .privateIp(TEST_INSTANCE_INTERNAL_IP2)
+                                      .build());
+
+        final List<NetworkInterface> networkInterfaces1 =
+            Collections.singletonList(new NetworkInterface().setNetworkIP(TEST_INSTANCE_INTERNAL_IP1));
+        final List<NetworkInterface> networkInterfaces2 =
+            Collections.singletonList(new NetworkInterface().setNetworkIP(TEST_INSTANCE_INTERNAL_IP2));
+        final List<Instance> instances = Arrays.asList(
+                        new Instance().setName(TEST_INSTANCE_NAME1)
+                                      .setId(new BigInteger(TEST_INSTANCE_ID1))
+                                      .setZone(REGION_CODE)
+                                      .setNetworkInterfaces(networkInterfaces1),
+                        new Instance().setName(TEST_INSTANCE_NAME2)
+                                      .setId(new BigInteger(TEST_INSTANCE_ID2))
+                                      .setZone(REGION_CODE)
+                                      .setNetworkInterfaces(networkInterfaces2));
+        final InstanceList receivedGcpInstances = new InstanceList();
+        receivedGcpInstances.setItems(instances);
+
+        final Compute mockedCompute = Mockito.mock(Compute.class);
+        Mockito.doReturn(mockedCompute).when(service).getGCPCompute(Mockito.any());
+        Mockito.doReturn(receivedGcpInstances).when(service).getGcpVmInstances(Mockito.any(), Mockito.any());
+        final List<VirtualMachine> virtualMachines = service.fetchRunningVms(testGcpRegion);
+        final Map<String, VirtualMachine> actualVMs = virtualMachines.stream()
+                 .collect(Collectors.toMap(VirtualMachine::getInstanceName, Function.identity()));
+
+        Assertions.assertEquals(expectedVMs.size(), virtualMachines.size());
+        expectedVMs.forEach(vm -> Assertions.assertTrue(assertVMs(vm, actualVMs.get(vm.getInstanceName()))));
+    }
+
+    private static boolean assertVMs(final VirtualMachine expected, final VirtualMachine actual) {
+        return expected.getInstanceName().equals(actual.getInstanceName())
+                   && expected.getInstanceId().equals(actual.getInstanceId())
+                   && expected.getCloudProvider().equals(actual.getCloudProvider())
+                   && expected.getPrivateIp().equals(actual.getPrivateIp());
+    }
+}


### PR DESCRIPTION
PR solves issue [#362](https://github.com/epam/cloud-pipeline/issues/362)
It allows tracking running VM instances from Google Compute Engine, labeled with a certain tag.

- GCP support for VM Monitor service is implemented.
- Google Compute Service API dependency added to build.gradle
- Custom GCPMonitorException to describe unexpected events during requests via Google API
- Unit tests were specified