### PR TITLE
GCP: Install additional libs on Debian images for gcfuse

### DIFF
--- a/workflows/pipe-common/shell/install_gcsfuse
+++ b/workflows/pipe-common/shell/install_gcsfuse
@@ -48,6 +48,7 @@ EOF
         yum update -y -q
         yum install -y -q gcsfuse
     else
+        apt-get install -y -qq gnupg lsb-release > /dev/null
         export GCSFUSE_REPO=gcsfuse-`lsb_release -c -s`
         echo "deb http://packages.cloud.google.com/apt $GCSFUSE_REPO main" | tee /etc/apt/sources.list.d/gcsfuse.list
         curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -


### PR DESCRIPTION
This PR brings changes on mount_storages scripts for installing new libs.
Right now if launch.sh tries to install gcfuse on Debian images it will fail because of missing libs. This PR solve the problem by installing it first.