### PR TITLE
Use google cloud operation API to get termination state of an instance

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPInstanceStatus.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPInstanceStatus.java
@@ -22,7 +22,7 @@ import java.util.Collection;
 
 public enum GCPInstanceStatus {
 
-    PROVISIONING, STAGING, RUNNING, STOPPING, STOPPED, SUSPENDING, SUSPENDED, TERMINATED;
+    PROVISIONING, STAGING, RUNNING, STOPPING, STOPPED, SUSPENDING, SUSPENDED, TERMINATED, PREEMPTED;
 
     public static Collection<GCPInstanceStatus> getWorkingStatuses() {
         return Arrays.asList(PROVISIONING, STAGING, RUNNING);

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPVMService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPVMService.java
@@ -87,11 +87,10 @@ public class GCPVMService {
         }
     }
 
-    public Optional<InstanceTerminationState> getTerminationState(final GCPRegion region,
-                                                                  final String instanceId) {
+    public Optional<InstanceTerminationState> getTerminationState(final GCPRegion region, final String instanceId) {
         Optional<InstanceTerminationState> result = Optional.empty();
         try {
-            OperationList operationList = gcpClient.buildComputeClient(region)
+            final OperationList operationList = gcpClient.buildComputeClient(region)
                     .zoneOperations()
                     .list(region.getProject(), region.getRegionCode())
                     .setFilter(String.format(COMPUTE_OPERATIONS_FILTER, instanceId)).execute();


### PR DESCRIPTION
This PR brings new usage of google cloud operation API to get termination reason for GCP instances. 