### PR TITLE
Issue 459 Fix NPE in ResourceMonitorManager

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
@@ -199,8 +199,11 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
         final int idleTimeout = preferenceManager.getPreference(SystemPreferences.SYSTEM_MAX_IDLE_TIMEOUT_MINUTES);
 
         final Map<String, PipelineRun> notProlongedRuns = running.entrySet().stream()
-                .filter(e -> DateUtils.nowUTC().isAfter(e.getValue().getProlongedAtTime()
-                        .plus(idleTimeout, ChronoUnit.MINUTES)))
+                .filter(e -> {
+                    LocalDateTime prolongedAtTime = e.getValue().getProlongedAtTime();
+                    return prolongedAtTime == null || DateUtils.nowUTC().isAfter(prolongedAtTime
+                            .plus(idleTimeout, ChronoUnit.MINUTES));
+                })
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         log.debug("Checking cpu stats for pipelines: " + String.join(", ", notProlongedRuns.keySet()));

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.PostConstruct;
@@ -199,11 +200,9 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
         final int idleTimeout = preferenceManager.getPreference(SystemPreferences.SYSTEM_MAX_IDLE_TIMEOUT_MINUTES);
 
         final Map<String, PipelineRun> notProlongedRuns = running.entrySet().stream()
-                .filter(e -> {
-                    LocalDateTime prolongedAtTime = e.getValue().getProlongedAtTime();
-                    return prolongedAtTime == null || DateUtils.nowUTC().isAfter(prolongedAtTime
-                            .plus(idleTimeout, ChronoUnit.MINUTES));
-                })
+                .filter(e -> Optional.ofNullable(e.getValue().getProlongedAtTime())
+                        .map(timestamp -> DateUtils.nowUTC().isAfter(timestamp.plus(idleTimeout, ChronoUnit.MINUTES)))
+                        .orElse(Boolean.FALSE))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         log.debug("Checking cpu stats for pipelines: " + String.join(", ", notProlongedRuns.keySet()));

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -1168,6 +1168,7 @@ public class PipelineRunManager {
         Long runId = pipelineRunDao.createRunId();
         restartedRun.setId(runId);
         restartedRun.setStartDate(DateUtils.now());
+        restartedRun.setProlongedAtTime(DateUtils.nowUTC());
 
         Optional<Pipeline> pipeline = Optional.ofNullable(run.getPipelineId())
                 .map(pipelineId -> pipelineManager.load(pipelineId));


### PR DESCRIPTION
There was a case when `ResourceMonitorManager` can fail with NPE. 
This PR fixes this problem by setting field `prolongedAtTime` to current time for restarted runs (as it currently perform for newly created runs). In `ResourceMonitorManager` class we also assume that runs without  `prolongedAtTime` field isn't prolonged at all.