### PR TITLE
GUI issue #447 fixed cosmetic bug with "Run" button appearance

### DIFF
--- a/client/src/components/pipelines/version/PipelineDetails.js
+++ b/client/src/components/pipelines/version/PipelineDetails.js
@@ -189,7 +189,7 @@ export default class PipelineDetails extends localization.LocalizedReactComponen
         </Menu>
       );
       return (
-        <Button.Group>
+        <Button.Group style={{display: 'inline-flex'}}>
           <Button
             id="launch-pipeline-button"
             size="small"


### PR DESCRIPTION
### There was cosmetic bug with appearance of "Run" button.
Caused by dynamic height of "Run" and "Expand" buttons, depending on screen resolution. As a result, each of buttons was centered in different ways.
![60101907-48c6f400-9765-11e9-87c9-3e004200237e](https://user-images.githubusercontent.com/41908792/60435526-7b179c00-9c12-11e9-856d-ffa4cd26dc54.png)

#### This Pull Request fixes this issue (#447) by adding display rule (```inline-flex```) to parent container (```<Button.Group>```) of "Run" and "Expand" buttons.

Tested in Chrome, Mozilla, Edge.
