### PR TITLE
NTLM Proxy support for Pipeline CLI

### DIFF
--- a/pipe-cli/build_linux.sh
+++ b/pipe-cli/build_linux.sh
@@ -19,22 +19,45 @@ _BUILD_DOCKER_IMAGE="python:2.7-stretch"
 
 cat >$_BUILD_SCRIPT_NAME <<EOL
 
+###
+# Setup Pyinstaller
+###
+
 mkdir -p $PYINSTALLER_PATH
-
 cd $PYINSTALLER_PATH
-
 git clone --single-branch --branch resolve_tmpdir https://github.com/mzueva/pyinstaller.git
 cd pyinstaller/bootloader/
-
 python2 ./waf all
 
-#echo "Runtime tmpdir: $PIPE_CLI_RUNTIME_TMP_DIR"
+###
+# Setup common dependencies
+###
+python2 -m pip install -r ${PIPE_CLI_SOURCES_DIR}/requirements.txt
 
-python2 -m pip install -r ${PIPE_CLI_SOURCES_DIR}/requirements.txt && \
+###
+# Build ntlm proxy
+###
+cd /tmp
+git clone https://github.com/sidoruka/ntlmaps.git && \
+cd ntlmaps && \
+git checkout 5f798a88369eddbe732364b98fbd445aacc809d0
+
+python2 $PYINSTALLER_PATH/pyinstaller/pyinstaller.py \
+        main.py -y \
+        --clean \
+        --distpath /tmp/ntlmaps/dist \
+        -p /tmp/ntlmaps/lib \
+        --add-data ./server.cfg:./ \
+        --name ntlmaps
+
+chmod +x /tmp/ntlmaps/dist/ntlmaps/ntlmaps
+
+###
+# Build pipe
+###
 cd $PIPE_CLI_SOURCES_DIR && \
 python2 $PYINSTALLER_PATH/pyinstaller/pyinstaller.py \
                                 --add-data "$PIPE_CLI_SOURCES_DIR/res/effective_tld_names.dat.txt:tld/res/" \
-                                --onefile \
                                 --hidden-import=UserList \
                                 --hidden-import=UserString \
                                 --hidden-import=commands \
@@ -56,7 +79,9 @@ python2 $PYINSTALLER_PATH/pyinstaller/pyinstaller.py \
                                 --clean \
                                 --runtime-tmpdir $PIPE_CLI_RUNTIME_TMP_DIR \
                                 --distpath $PIPE_CLI_LINUX_DIST_DIR/dist \
-                                ${PIPE_CLI_SOURCES_DIR}/pipe.py
+                                --add-data /tmp/ntlmaps/dist/ntlmaps:ntlmaps \
+                                ${PIPE_CLI_SOURCES_DIR}/pipe.py \
+                                --onefile
 EOL
 
 docker pull $_BUILD_DOCKER_IMAGE &> /dev/null

--- a/pipe-cli/build_windows.sh
+++ b/pipe-cli/build_windows.sh
@@ -13,6 +13,53 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#######################################
+# Step 1: Build NTLM APS with Python 2
+#######################################
+
+CP_PYINSTALL_WIN32_PY2_DOCKER="lifescience/cloud-pipeline:pyinstaller-win32-py2"
+docker pull $CP_PYINSTALL_WIN32_PY2_DOCKER
+if [ $? -ne 0 ]; then
+    echo "Unable to pull $CP_PYINSTALL_WIN32_PY2_DOCKER image, it will be rebuilt"
+    docker build docker/win32 -t $CP_PYINSTALL_WIN32_PY2_DOCKER
+fi
+
+_BUILD_SCRIPT_NAME=/tmp/build_pytinstaller_win32_py2_$(date +%s).sh
+
+cat >$_BUILD_SCRIPT_NAME <<'EOL'
+
+pip install --upgrade setuptools && \
+pip install -r /pipe-cli/requirements.txt
+
+cd /tmp
+git clone https://github.com/sidoruka/ntlmaps.git && \
+cd ntlmaps && \
+git checkout 5f798a88369eddbe732364b98fbd445aacc809d0
+
+pyinstaller main.py -y \
+        --clean \
+        --distpath /tmp/ntlmaps/dist \
+        -p /tmp/ntlmaps/lib \
+        --add-data "./server.cfg;./" \
+        --name ntlmaps
+
+cp -r /tmp/ntlmaps/dist/ntlmaps /pipe-cli/
+EOL
+
+docker run -i --rm \
+           -v $PIPE_CLI_SOURCES_DIR:/pipe-cli \
+           -v $_BUILD_SCRIPT_NAME:$_BUILD_SCRIPT_NAME \
+           $CP_PYINSTALL_WIN32_PY2_DOCKER \
+           bash $_BUILD_SCRIPT_NAME
+
+rm -f $_BUILD_SCRIPT_NAME
+
+
+#######################################
+# Step 2: pipe CLI
+#######################################
+
+
 CP_PYINSTALL_WIN64_DOCKER="lifescience/cloud-pipeline:pyinstaller-win64"
 docker pull $CP_PYINSTALL_WIN64_DOCKER
 if [ $? -ne 0 ]; then
@@ -53,7 +100,8 @@ pyinstaller --add-data "/pipe-cli/res/effective_tld_names.dat.txt;tld/res/" \
             --clean \
             --workpath /tmp \
             --distpath /pipe-cli/dist/win64 \
-            pipe.py && \
+            pipe.py \
+            --add-data "/pipe-cli/ntlmaps;ntlmaps" && \
 cd /pipe-cli/dist/win64 && \
 zip -r -q pipe.zip pipe
 EOL

--- a/pipe-cli/docker/win32/Dockerfile
+++ b/pipe-cli/docker/win32/Dockerfile
@@ -1,0 +1,79 @@
+# MIT License
+
+# Copyright (c) 2016 Chris R
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+FROM ubuntu:14.04
+
+ENV DEBIAN_FRONTEND noninteractive
+
+ARG WINE_VERSION=winehq-devel
+ARG PYTHON_VERSION=2.7.12
+ARG PYINSTALLER_VERSION=3.3
+
+# we need wine for this all to work, so we'll use the PPA
+RUN set -x \
+    && dpkg --add-architecture i386 \
+    && apt-get update -qy \
+    && apt-get install --no-install-recommends -qfy software-properties-common git \
+    && add-apt-repository ppa:wine/wine-builds \
+    && apt-get update -qy \
+    && apt-get install --no-install-recommends -qfy $WINE_VERSION winetricks wget \
+    && apt-get clean
+
+# wine settings
+ENV WINEARCH win32
+ENV WINEDEBUG fixme-all
+ENV WINEPREFIX /wine
+
+# PYPI repository location
+ENV PYPI_URL=https://pypi.python.org/
+# PYPI index location
+ENV PYPI_INDEX_URL=https://pypi.python.org/simple
+
+# install python inside wine
+RUN set -x \
+    && wget -nv https://www.python.org/ftp/python/$PYTHON_VERSION/python-$PYTHON_VERSION.msi \
+    && wine msiexec /qn /a python-$PYTHON_VERSION.msi \
+    && rm python-$PYTHON_VERSION.msi \
+    && wget -nv https://download.microsoft.com/download/7/9/6/796EF2E4-801B-4FC4-AB28-B59FBF6D907B/VCForPython27.msi \
+    && wine msiexec /qn /a VCForPython27.msi \
+    && rm VCForPython27.msi \
+    && sed -i 's/_windows_cert_stores = .*/_windows_cert_stores = ("ROOT",)/' "/wine/drive_c/Python27/Lib/ssl.py" \
+    && echo 'wine '\''C:\Python27\python.exe'\'' "$@"' > /usr/bin/python \
+    && echo 'wine '\''C:\Python27\Scripts\easy_install.exe'\'' "$@"' > /usr/bin/easy_install \
+    && echo 'wine '\''C:\Python27\Scripts\pip.exe'\'' "$@"' > /usr/bin/pip \
+    && echo 'wine '\''C:\Python27\Scripts\pyinstaller.exe'\'' "$@"' > /usr/bin/pyinstaller \
+    && chmod +x /usr/bin/* \
+    && wget https://bootstrap.pypa.io/ez_setup.py -O - | /usr/bin/python \
+    && /usr/bin/easy_install pip \
+    && echo 'assoc .py=PythonScript' | wine cmd \
+    && echo 'ftype PythonScript=c:\Python27\python.exe "%1" %*' | wine cmd \
+    && while pgrep wineserver >/dev/null; do echo "Waiting for wineserver"; sleep 1; done \
+    && rm -rf /tmp/.wine-*
+
+# put the src folder inside wine
+RUN mkdir /src/ && ln -s /src /wine/drive_c/src
+VOLUME /src/
+WORKDIR /wine/drive_c/src/
+RUN mkdir -p /wine/drive_c/tmp
+
+# install pyinstaller
+RUN /usr/bin/pip install pyinstaller==$PYINSTALLER_VERSION

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -81,9 +81,9 @@ def configure(auth_token, api, timezone, proxy, proxy_ntlm, proxy_ntlm_user, pro
     if proxy_ntlm and not proxy_ntlm_user:
         proxy_ntlm_user = click.prompt('Username for the proxy NTLM authentication', type=str)
     if proxy_ntlm and not proxy_ntlm_domain:
-        proxy_ntlm_domain = click.prompt('Domain of the {} user'.format(proxy_ntlm_user), type=str, hide_input=True)
+        proxy_ntlm_domain = click.prompt('Domain of the {} user'.format(proxy_ntlm_user), type=str)
     if proxy_ntlm and not proxy_ntlm_pass:
-        proxy_ntlm_pass = click.prompt('Password of the {} user'.format(proxy_ntlm_user), type=str)
+        proxy_ntlm_pass = click.prompt('Password of the {} user'.format(proxy_ntlm_user), type=str, hide_input=True)
 
     Config.store(auth_token, 
                  api, 

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -78,8 +78,8 @@ def cli():
               prompt='Proxy address',
               help='URL of a proxy for all calls',
               default='')
-@click.option('-nt', '--proxy-ntlm', 
-              help='Use NTLM authentication for the server, specified by the "--proxy"', 
+@click.option('-nt', '--proxy-ntlm',
+              help='Use NTLM authentication for the server, specified by the "--proxy"',
               is_flag=True)
 @click.option('-nu', '--proxy-ntlm-user',
               help='Username for the NTLM authentication against the server, specified by the "--proxy"',
@@ -100,9 +100,9 @@ def configure(auth_token, api, timezone, proxy, proxy_ntlm, proxy_ntlm_user, pro
     if proxy_ntlm and not proxy_ntlm_pass:
         proxy_ntlm_pass = click.prompt('Password of the {} user'.format(proxy_ntlm_user), type=str, hide_input=True)
 
-    Config.store(auth_token, 
-                 api, 
-                 timezone, 
+    Config.store(auth_token,
+                 api,
+                 timezone,
                  proxy,
                  proxy_ntlm,
                  proxy_ntlm_user,

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -63,10 +63,36 @@ def cli():
               prompt='Proxy address',
               help='URL of a proxy for all calls',
               default='')
-def configure(auth_token, api, timezone, proxy):
+@click.option('-nt', '--proxy-ntlm', 
+              help='Use NTLM authentication for the server, specified by the "--proxy"', 
+              is_flag=True)
+@click.option('-nu', '--proxy-ntlm-user',
+              help='Username for the NTLM authentication against the server, specified by the "--proxy"',
+              default=None)
+@click.option('-nd', '--proxy-ntlm-domain',
+              help='Domain name of the user, specified by the "--proxy-ntlm-user"',
+              default=None)
+@click.option('-np', '--proxy-ntlm-pass',
+              help='Password of the user, specified by the "--proxy-ntlm-user"',
+              default=None)
+def configure(auth_token, api, timezone, proxy, proxy_ntlm, proxy_ntlm_user, proxy_ntlm_domain, proxy_ntlm_pass):
     """Configures CLI parameters
     """
-    Config.store(auth_token, api, timezone, proxy)
+    if proxy_ntlm and not proxy_ntlm_user:
+        proxy_ntlm_user = click.prompt('Username for the proxy NTLM authentication', type=str)
+    if proxy_ntlm and not proxy_ntlm_domain:
+        proxy_ntlm_domain = click.prompt('Domain of the {} user'.format(proxy_ntlm_user), type=str, hide_input=True)
+    if proxy_ntlm and not proxy_ntlm_pass:
+        proxy_ntlm_pass = click.prompt('Password of the {} user'.format(proxy_ntlm_user), type=str)
+
+    Config.store(auth_token, 
+                 api, 
+                 timezone, 
+                 proxy,
+                 proxy_ntlm,
+                 proxy_ntlm_user,
+                 proxy_ntlm_domain,
+                 proxy_ntlm_pass)
 
 
 def echo_title(title, line=True):

--- a/pipe-cli/src/config.py
+++ b/pipe-cli/src/config.py
@@ -89,7 +89,7 @@ class Config(object):
                     self.proxy_ntlm_domain = data['proxy_ntlm_domain']
                 if 'proxy_ntlm_pass' in data:
                     try:
-                        self.proxy_ntlm_pass = Config.get_string_from_base64(base64.decode(data['proxy_ntlm_pass']))
+                        self.proxy_ntlm_pass = Config.decode_password(data['proxy_ntlm_pass'])
                     except:
                         self.proxy_ntlm_pass = None
         else:
@@ -144,7 +144,7 @@ class Config(object):
                   'proxy_ntlm': proxy_ntlm, 
                   'proxy_ntlm_user': proxy_ntlm_user,
                   'proxy_ntlm_domain': proxy_ntlm_domain,
-                  'proxy_ntlm_pass': cls.get_string_from_base64(base64.encode(proxy_ntlm_pass))
+                  'proxy_ntlm_pass': cls.encode_password(proxy_ntlm_pass)
                   }
         config_file = cls.config_path()
 
@@ -165,6 +165,16 @@ class Config(object):
         if isinstance(data, bytes):
             return data.decode(sys.getdefaultencoding())
         return data
+
+    @classmethod
+    def encode_password(cls, raw_password):
+        data = base64.b64encode(raw_password.encode(sys.getdefaultencoding()))
+        return cls.get_string_from_base64(data)
+
+    @classmethod
+    def decode_password(cls, encoded_password):
+        decoded = base64.b64decode(encoded_password.encode(sys.getdefaultencoding()))
+        return cls.get_string_from_base64(decoded)
 
     @classmethod
     def instance(cls):

--- a/pipe-cli/src/config.py
+++ b/pipe-cli/src/config.py
@@ -168,11 +168,15 @@ class Config(object):
 
     @classmethod
     def encode_password(cls, raw_password):
+        if not raw_password:
+            return raw_password
         data = base64.b64encode(raw_password.encode(sys.getdefaultencoding()))
         return cls.get_string_from_base64(data)
 
     @classmethod
     def decode_password(cls, encoded_password):
+        if not encoded_password:
+            return encoded_password
         decoded = base64.b64decode(encoded_password.encode(sys.getdefaultencoding()))
         return cls.get_string_from_base64(decoded)
 

--- a/pipe-cli/src/config.py
+++ b/pipe-cli/src/config.py
@@ -24,6 +24,8 @@ from pypac.resolver import ProxyResolver as PacProxyResolver
 
 from .utilities import time_zone_param_type, network_utilities
 
+OWNER_ONLY_PERMISSION = 0o600
+
 
 def is_frozen():
     return getattr(sys, 'frozen', False)
@@ -147,7 +149,12 @@ class Config(object):
                   'proxy_ntlm_pass': cls.encode_password(proxy_ntlm_pass)
                   }
         config_file = cls.config_path()
-
+        # create file
+        with open(config_file, 'w+'):
+            os.utime(config_file, None)
+        # set permissions
+        os.chmod(config_file, OWNER_ONLY_PERMISSION)
+        # save
         with open(config_file, 'w+') as config_file_stream:
             json.dump(config, config_file_stream)
 

--- a/pipe-cli/src/config.py
+++ b/pipe-cli/src/config.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import base64
 import json
 import os
 import pytz
@@ -87,7 +88,7 @@ class Config(object):
                     self.proxy_ntlm_domain = data['proxy_ntlm_domain']
                 if 'proxy_ntlm_pass' in data:
                     try:
-                        self.proxy_ntlm_pass = data['proxy_ntlm_pass']
+                        self.proxy_ntlm_pass = Config.get_string_from_base64(base64.decode(data['proxy_ntlm_pass']))
                     except:
                         self.proxy_ntlm_pass = None
         else:
@@ -139,9 +140,10 @@ class Config(object):
                   'tz': timezone, 
                   'proxy': proxy, 
                   'proxy_ntlm': proxy_ntlm, 
-                  'proxy_ntlm_user': proxy_ntlm_user, 
+                  'proxy_ntlm_user': proxy_ntlm_user,
                   'proxy_ntlm_domain': proxy_ntlm_domain,
-                  'proxy_ntlm_pass': proxy_ntlm_pass }
+                  'proxy_ntlm_pass': cls.get_string_from_base64(base64.encode(proxy_ntlm_pass))
+                  }
         config_file = cls.config_path()
 
         with open(config_file, 'w+') as config_file_stream:
@@ -155,6 +157,12 @@ class Config(object):
             os.makedirs(config_folder)
         config_file = os.path.join(config_folder, 'config.json')
         return config_file
+
+    @classmethod
+    def get_string_from_base64(cls, data):
+        if isinstance(data, bytes):
+            return data.decode(sys.getdefaultencoding())
+        return data
 
     @classmethod
     def instance(cls):

--- a/pipe-cli/src/config.py
+++ b/pipe-cli/src/config.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import click
 from functools import update_wrapper
 import base64
 import click
@@ -140,7 +139,6 @@ class Config(object):
             if not pac_file:
                 return None
             proxy_resolver = PacProxyResolver(pac_file)
-            
             url_to_resolve = target_url
             if not url_to_resolve and self.api:
                 url_to_resolve = self.api

--- a/pipe-cli/src/config.py
+++ b/pipe-cli/src/config.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import base64
+import click
 import json
 import os
 import pytz
@@ -134,7 +135,8 @@ class Config(object):
                                      'Remove the NTLM parameters or change the PAC to the proxy URL')
         if proxy_ntlm and not is_frozen():
             raise ProxyInvalidConfig('NTLM proxy authentication is supported only for prebuilt CLI binaries.')
-
+        if proxy_ntlm_pass:
+            click.secho('Warning: NTLM proxy user password will be stored unencrypted.', fg='yellow')
         config = {'api': api, 
                   'access_key': access_key, 
                   'tz': timezone, 

--- a/pipe-cli/src/utilities/network_utilities.py
+++ b/pipe-cli/src/utilities/network_utilities.py
@@ -1,0 +1,113 @@
+# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import atexit
+from contextlib import closing
+import os
+import signal
+import socket
+import subprocess
+import time
+
+try:
+    from urllib.parse import urlparse  # Python 3
+except ImportError:
+    from urlparse import urlparse  # Python 2
+
+PROXY_NTLM_PID = None
+PROXY_NTLM_PORT = None
+PROXY_NTLM_PORT_DEFAULT = 10101
+
+def kill_ntlm_aps():
+    global PROXY_NTLM_PID
+    if PROXY_NTLM_PID:
+        try:
+            os.kill(PROXY_NTLM_PID, signal.SIGTERM)
+        except:
+            pass
+
+def get_ntlm_aps_local_url():
+    global PROXY_NTLM_PORT
+    if PROXY_NTLM_PORT:
+        return 'http://localhost:' + str(PROXY_NTLM_PORT)
+    else:
+        return None
+
+def wait_for_ntlm_aps(port, attempts=10):
+    ntlm_aps_ready = False
+    while not ntlm_aps_ready and attempts != 0:
+        with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+            sock.settimeout(1)
+            ntlm_aps_ready = sock.connect_ex(('localhost',port)) == 0
+            attempts = attempts - 1
+            time.sleep(1)
+    return ntlm_aps_ready
+    
+
+def start_ntlm_aps(ntlmaps_bin, domain, user, password, downstream_proxy, port=None):
+    global PROXY_NTLM_PID
+    global PROXY_NTLM_PORT
+
+    if PROXY_NTLM_PID:
+        return get_ntlm_aps_local_url()
+
+    if not port:
+        PROXY_NTLM_PORT = find_free_port(PROXY_NTLM_PORT_DEFAULT)
+
+    proxy_url = urlparse(downstream_proxy)
+    proxy_host = proxy_url.hostname
+    proxy_port = proxy_url.port
+
+    if not proxy_host or not proxy_port:
+        raise Exception('Cannot get proxy host or port from {}. Make sure it is sepcified in the format: http://HOST:PORT'.format(downstream_proxy))
+
+    ntlm_aps_cmd = [ ntlmaps_bin,
+                        "--domain", domain,
+                        "--username", user,
+                        "--password", password,
+                        "--port", str(PROXY_NTLM_PORT),
+                        "--downstream-proxy-host", proxy_host,
+                        "--downstream-proxy-port", str(proxy_port) ]
+
+    with open(os.devnull, 'w') as dev_null:
+        ntlm_aps_proc = subprocess.Popen(ntlm_aps_cmd, stdout=dev_null, stderr=dev_null)
+        PROXY_NTLM_PID = ntlm_aps_proc.pid
+        
+    _ = atexit.register(kill_ntlm_aps)
+
+    if not wait_for_ntlm_aps(PROXY_NTLM_PORT):
+        raise Exception('Failed to connect to the NTLM APS instance on port ' + str(PROXY_NTLM_PORT))
+
+    return get_ntlm_aps_local_url()
+    
+
+def try_port(port):
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    result = False
+    try:
+        sock.bind(('0.0.0.0', port))
+        result = True
+    except:
+        result = False
+    sock.close()
+    return result
+
+def find_free_port(start_from=10000, attempts=100):
+    port = start_from
+    while attempts != 0:
+        if try_port(port):
+            return port
+        attempts = attempts - 1
+        port = port + 1
+    raise Exception('Unable to find free port after {} attempts'.format(attempts))

--- a/pipe-cli/src/utilities/network_utilities.py
+++ b/pipe-cli/src/utilities/network_utilities.py
@@ -46,7 +46,7 @@ class NTLMProxy(object):
                         "--domain", domain,
                         "--username", user,
                         "--password", password,
-                        "--port", str(proxy_port),
+                        "--port", str(port),
                         "--downstream-proxy-host", proxy_host,
                         "--downstream-proxy-port", str(proxy_port)]
 


### PR DESCRIPTION
This PR adds NTLM proxy support (#404) to Pipeline CLI for `frozen` (prebuilt installations).

# NTLM Proxy configuration
Several new options are added to `pipe configure` command:
- `-nt --proxy-ntlm` - flag to enable NTLM proxy support
- `-nu --proxy-ntlm-user` - username for NTLM proxy authorization
- `-np --proxy-ntlm-pass` - password for NTLM proxy authorization
- `-nd --proxy-ntlm-domain` - domain for NTLM proxy authorization

If NTLM proxy is enabled pipe cli will run [ntlmaps](https://github.com/sidoruka/ntlmaps) proxy under the hood and use it as `http(s)_proxy` for all pipe requests.  `--proxy` setting will be used as downstream proxy  in this case.

# Limitations
- user password for NTLM proxy authorization is stored base64 - encoded in the config.json file. Permissions for this file are set as RW owner only for linux version
- NTLM proxy is not supported for not `frozen` pipe cli installations (installed form sources using `pip`)