### PR TITLE
Gui issue #418 incorrect behavior of "start idle" checkbox

### DIFF
--- a/client/src/components/pipelines/launch/form/LaunchPipelineForm.js
+++ b/client/src/components/pipelines/launch/form/LaunchPipelineForm.js
@@ -1080,7 +1080,8 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
         fireCloudInputs: {},
         fireCloudOutputs: {},
         fireCloudDefaultInputs: this.props.fireCloudMethod ? this.props.fireCloudMethod.methodInputs : null,
-        fireCloudDefaultOutputs: this.props.fireCloudMethod ? this.props.fireCloudMethod.methodOutputs : null
+        fireCloudDefaultOutputs: this.props.fireCloudMethod ? this.props.fireCloudMethod.methodOutputs : null,
+        startIdle: this.props.parameters.cmd_template.trim() === 'sleep infinity'
       });
     }
     this.setState(state);
@@ -2961,7 +2962,8 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
                 (this.state.pipeline && this.props.detached)
               }
               onChange={(e) => this.setState({startIdle: e.target.checked})}
-              value={this.state.startIdle}>
+              value={this.state.startIdle}
+              checked={this.state.startIdle}>
               Start idle
             </Checkbox>
             {hints.renderHint(this.localizedStringWithSpotDictionaryFn, hints.startIdleHint)}

--- a/client/src/components/pipelines/launch/form/LaunchPipelineForm.js
+++ b/client/src/components/pipelines/launch/form/LaunchPipelineForm.js
@@ -638,9 +638,7 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
     if (keepPipeline) {
       this.setState({
         openedPanels: this.getDefaultOpenedPanels(),
-				startIdle: this.props.parameters.cmd_template 
-					? this.props.parameters.cmd_template === 'sleep infinity' 
-					: false,
+				startIdle: this.props.parameters.cmd_template === 'sleep infinity',
         isDts: this.isDts(),
         execEnvSelectValue,
         dtsId,
@@ -680,9 +678,7 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
     } else {
       this.setState({
         openedPanels: this.getDefaultOpenedPanels(),
-				startIdle: this.props.parameters.cmd_template 
-					? this.props.parameters.cmd_template === 'sleep infinity' 
-					: false,
+				startIdle: this.props.parameters.cmd_template === 'sleep infinity',
         isDts: this.isDts(),
         execEnvSelectValue,
         dtsId,

--- a/client/src/components/pipelines/launch/form/LaunchPipelineForm.js
+++ b/client/src/components/pipelines/launch/form/LaunchPipelineForm.js
@@ -638,7 +638,9 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
     if (keepPipeline) {
       this.setState({
         openedPanels: this.getDefaultOpenedPanels(),
-        startIdle: false,
+				startIdle: this.props.parameters.cmd_template 
+					? this.props.parameters.cmd_template === 'sleep infinity' 
+					: false,
         isDts: this.isDts(),
         execEnvSelectValue,
         dtsId,
@@ -678,7 +680,9 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
     } else {
       this.setState({
         openedPanels: this.getDefaultOpenedPanels(),
-        startIdle: false,
+				startIdle: this.props.parameters.cmd_template 
+					? this.props.parameters.cmd_template === 'sleep infinity' 
+					: false,
         isDts: this.isDts(),
         execEnvSelectValue,
         dtsId,
@@ -1080,8 +1084,7 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
         fireCloudInputs: {},
         fireCloudOutputs: {},
         fireCloudDefaultInputs: this.props.fireCloudMethod ? this.props.fireCloudMethod.methodInputs : null,
-        fireCloudDefaultOutputs: this.props.fireCloudMethod ? this.props.fireCloudMethod.methodOutputs : null,
-        startIdle: this.props.parameters.cmd_template.trim() === 'sleep infinity'
+        fireCloudDefaultOutputs: this.props.fireCloudMethod ? this.props.fireCloudMethod.methodOutputs : null
       });
     }
     this.setState(state);
@@ -2962,7 +2965,6 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
                 (this.state.pipeline && this.props.detached)
               }
               onChange={(e) => this.setState({startIdle: e.target.checked})}
-              value={this.state.startIdle}
               checked={this.state.startIdle}>
               Start idle
             </Checkbox>


### PR DESCRIPTION
### There was case with incorrect behavior of ```"Start idle"``` checkbox and ```Cmd template``` input form field.

When you activate 'Start idle' checkbox - form field have to dissapear and save that presence. 
But when you change tab to another configuration - checkbox is unset and form field appears, even if its value is 'sleep infinity' (this value is condition to dissapearing form field and checkbox activation). And vise versa.

The reason of that behavior is: 
1. ```"Checked"``` condition for checkbox not defined.
2. ```startIdle``` state of component is forced to ```false``` every time component did update, regardless of form input value.

#### This Pull Request fixes this issue (#418) via:
1.  Added checked condition to checkbox value from state.
2. Added proper state condition logic, which depends of ```Cmd template``` value (matches value every time component re-render)
3. Trim cmd value before match with default string, so ``` sleep infinity   ``` with spaces before or after the end of a string will force to update ```startIdle``` to the proper state.