### PR TITLE
Install capabilities scripts for single master run

### DIFF
--- a/scripts/pipeline-launch/launch.sh
+++ b/scripts/pipeline-launch/launch.sh
@@ -886,7 +886,7 @@ then
     mount_nfs_if_required "$parent_id"
     cluster_setup_client "$parent_id" "$SHARED_FOLDER"
     _SETUP_RESULT=$?
-elif [ -z "$cluster_role" ];
+elif [ -z "$cluster_role" ] || [ "$cluster_role" = "master" ];
 then 
       # If this is a common run (not a cluster - still publish scripts for CAPs)
       export cluster_role="master"


### PR DESCRIPTION
Resolves #342.

Cloud Pipeline server sets `cluster_role` parameter for single master detached configuration but omits it for single master pipeline configuration. The change makes `cluster_role` parameter optional for single master runs to remove any possible inconsistencies between launch configurations.