### PR TITLE
Fix of NPE while building cloud-specific environment variables for run

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacadeImpl.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacadeImpl.java
@@ -164,6 +164,13 @@ public class CloudFacadeImpl implements CloudFacade {
                     return envVars;
                 })
                 .flatMap(map -> map.entrySet().stream())
+                .filter(entry -> {
+                    if (entry.getValue() == null) {
+                        log.warn("Cloud environment variable {} is null.", entry.getKey());
+                        return false;
+                    }
+                    return true;
+                })
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e2));
     }
 


### PR DESCRIPTION
This PR consists of filter out null values with warn logs for building cloud-specific environment variables for run (issue #486).