### PR TITLE
GCP: incorrect behavior of the file version deletion

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageHelper.java
@@ -177,7 +177,7 @@ public class GSBucketStorageHelper {
         final String bucketName = dataStorage.getPath();
 
         if (StringUtils.isBlank(version) && totally) {
-            deleteAllVersions(bucketName, path, client);
+            deleteAllFileVersions(bucketName, path, client);
             return;
         }
 
@@ -528,6 +528,18 @@ public class GSBucketStorageHelper {
         dataStorageFile.setDeleteMarker(isDeleted);
         dataStorageFile.setVersion(String.valueOf(blob.getGeneration()));
         return dataStorageFile;
+    }
+
+    private void deleteAllFileVersions(final String bucketName, final String path, final Storage client) {
+        final Page<Blob> blobs = client.list(bucketName,
+                Storage.BlobListOption.versions(true),
+                Storage.BlobListOption.currentDirectory(),
+                Storage.BlobListOption.prefix(path));
+        blobs.iterateAll().forEach(blob -> {
+            if (blob.getName().equals(path)) {
+                deleteBlob(blob, client, true);
+            }
+        });
     }
 
     private void deleteAllVersions(final String bucketName, final String path, final Storage client) {


### PR DESCRIPTION
Provides fix for issue #446 

The original behavior of `DELETE datastorage/{id}/list` is list all versions started with `path` and delete them. This way this method deletes all files from bucket which starts with specified path.
The solution is to check exact paths match before deletion.