### PR TITLE
Repair transferring from http and ftp to google storage

### DIFF
--- a/pipe-cli/src/utilities/storage/gs.py
+++ b/pipe-cli/src/utilities/storage/gs.py
@@ -569,9 +569,9 @@ class TransferFromHttpOrFtpToGsManager(GsManager, AbstractTransferManager):
         progress_callback = GsProgressPercentage.callback(relative_path, size, quiet)
         bucket = self.client.bucket(destination_wrapper.bucket.path)
         if StorageOperations.file_is_empty(size):
-            blob = bucket.blob(source_key)
+            blob = bucket.blob(destination_key)
         else:
-            blob = self._progress_blob(bucket, source_key, progress_callback, size)
+            blob = self._progress_blob(bucket, destination_key, progress_callback, size)
         blob.metadata = StorageOperations.generate_tags(tags, source_key)
         blob.upload_from_file(_SourceUrlIO(urlopen(source_key)))
         if progress_callback is not None:

--- a/pipe-cli/src/utilities/storage/local.py
+++ b/pipe-cli/src/utilities/storage/local.py
@@ -68,5 +68,7 @@ class TransferFromHttpOrFtpToLocal(object):
 
 
 class LocalOperations:
-    def get_transfer_from_http_or_ftp_manager(self, *_, **__):
+
+    @classmethod
+    def get_transfer_from_http_or_ftp_manager(cls, *_, **__):
         return TransferFromHttpOrFtpToLocal()


### PR DESCRIPTION
Resolves issue #472.

The pull request fixes a typo in transferring from http and ftp to google storage manager which ended up in the usage of http url as a cloud storage path.

Moreover pull request repairs the initialization of the transferring from http and ftp to local file system manager.