### PR TITLE
Inherit cloud region from parent run in cromwell

### DIFF
--- a/deploy/docker/cp-tools/base/cromwell/cromwell_submit_task.sh
+++ b/deploy/docker/cp-tools/base/cromwell/cromwell_submit_task.sh
@@ -111,6 +111,7 @@ fi
 CP_WDL_TASK_CMD="pipe run   --cluster_role worker \
                             --cluster_role_type additional \
                             --job_name ${CP_WDL_TASK_JOB_NAME} \
+                            --region-id ${CLOUD_REGION_ID} \
                             --quiet \
                             --yes \
                             --sync \


### PR DESCRIPTION
Resolves third item of #485.

The pull request makes worker runs created as cromwell tasks to inherit parent's run cloud region.