### PR TITLE
Issue 361 Implement indexing of GS Buckets files

### DIFF
--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/datastorage/GSBucketStorage.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/datastorage/GSBucketStorage.java
@@ -26,6 +26,10 @@ public class GSBucketStorage extends AbstractDataStorage {
 
     private Long regionId;
 
+    public GSBucketStorage() {
+        setType(DataStorageType.GS);
+    }
+
     public GSBucketStorage(final Long id, final String name, final String path, final StoragePolicy policy,
                            final String mountPoint) {
         super(id, name, ProviderUtils.normalizeBucketName(path), DataStorageType.GS, policy, mountPoint);

--- a/elasticsearch-agent/build.gradle
+++ b/elasticsearch-agent/build.gradle
@@ -78,9 +78,12 @@ dependencies {
     // AWS
     implementation group: "com.amazonaws", name: "aws-java-sdk-s3", version: awsSdkS3Version
     implementation group: "com.amazonaws", name: "aws-java-sdk-sts", version: awsSdkSTSVersion
-
+    
     // Azure
     compile group: "com.microsoft.azure", name: "azure-storage-blob", version: azureSdkBlobVersion
+
+    //GS Bucket
+    compile group:"com.google.cloud", name:"google-cloud-storage", version:googleStorageSdkVersion
 
     //Tests
     implementation group: "org.springframework.boot", name: "spring-boot-starter-test", version: springBootVersion

--- a/elasticsearch-agent/gradle.properties
+++ b/elasticsearch-agent/gradle.properties
@@ -21,6 +21,8 @@ awsSdkSTSVersion=1.11.211
 
 azureSdkBlobVersion=10.4.0
 
+googleStorageSdkVersion=1.64.0
+
 junitVersion=5.2.0
 mockitoVersion=2.21.0
 hamcrestVersion=1.3

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/app/GSFileSyncConfiguration.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/app/GSFileSyncConfiguration.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.epam.pipeline.elasticsearchagent.app;
+
+import com.epam.pipeline.elasticsearchagent.service.ElasticsearchServiceClient;
+import com.epam.pipeline.elasticsearchagent.service.ObjectStorageFileManager;
+import com.epam.pipeline.elasticsearchagent.service.ObjectStorageIndex;
+import com.epam.pipeline.elasticsearchagent.service.impl.*;
+import com.epam.pipeline.entity.datastorage.DataStorageType;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty(value = "sync.gs-file.disable", matchIfMissing = true, havingValue = "false")
+public class GSFileSyncConfiguration {
+
+    @Value("${sync.index.common.prefix}")
+    private String indexPrefix;
+
+    @Value("${sync.gs-file.index.name}")
+    private String indexName;
+
+    @Value("${sync.gs-file.index.mapping}")
+    private String indexSettingsPath;
+
+    @Value("${sync.gs-file.bulk.insert.size:1000}")
+    private Integer bulkInsertSize;
+
+    @Bean
+    public ObjectStorageFileManager gsFileManager() {
+        return new GsBucketFileManager();
+    }
+
+    @Bean
+    public ObjectStorageIndex gsFileSynchronizer(
+            final CloudPipelineAPIClient apiClient,
+            final ElasticsearchServiceClient esClient,
+            final ElasticIndexService indexService,
+            final @Qualifier("gsFileManager") ObjectStorageFileManager gsFileManager) {
+        return new ObjectStorageIndexImpl(apiClient, esClient, indexService,
+                gsFileManager, indexPrefix + indexName,
+                indexSettingsPath, bulkInsertSize, DataStorageType.GS);
+    }
+
+}

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/AzureBlobManager.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/AzureBlobManager.java
@@ -136,7 +136,8 @@ public class AzureBlobManager implements ObjectStorageFileManager {
         file.setSize(blob.properties().contentLength());
         file.setChanged(ESConstants.FILE_DATE_FORMAT.format(Date.from(blob.properties().lastModified().toInstant())));
         if (blob.properties().accessTier() != null) {
-            file.setLabels(Collections.singletonMap("StorageClass",  blob.properties().accessTier().toString()));
+            file.setLabels(Collections.singletonMap(ESConstants.STORAGE_CLASS_LABEL,
+                    blob.properties().accessTier().toString()));
         }
         file.setTags(blob.metadata());
         return file;

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/GsBucketFileManager.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/GsBucketFileManager.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.epam.pipeline.elasticsearchagent.service.impl;
+
+import com.epam.pipeline.elasticsearchagent.model.PermissionsContainer;
+import com.epam.pipeline.elasticsearchagent.service.ObjectStorageFileManager;
+import com.epam.pipeline.elasticsearchagent.service.impl.converter.storage.StorageFileMapper;
+import com.epam.pipeline.elasticsearchagent.utils.ESConstants;
+import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
+import com.epam.pipeline.entity.datastorage.DataStorageFile;
+import com.epam.pipeline.entity.datastorage.TemporaryCredentials;
+import com.epam.pipeline.entity.search.SearchDocumentType;
+import com.google.api.services.storage.StorageScopes;
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageClass;
+import com.google.cloud.storage.StorageOptions;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.elasticsearch.action.index.IndexRequest;
+
+import java.text.ParseException;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Optional;
+import java.util.TimeZone;
+import java.util.Map;
+import java.util.HashMap;
+
+import static com.epam.pipeline.elasticsearchagent.utils.ESConstants.DOC_MAPPING_TYPE;
+
+@Slf4j
+public class GsBucketFileManager implements ObjectStorageFileManager {
+    private final StorageFileMapper fileMapper = new StorageFileMapper();
+
+    static {
+        TimeZone tz = TimeZone.getTimeZone("UTC");
+        ESConstants.FILE_DATE_FORMAT.setTimeZone(tz);
+    }
+
+    @Override
+    public void listAndIndexFiles(final String indexName,
+                                  final AbstractDataStorage dataStorage,
+                                  final TemporaryCredentials credentials,
+                                  final PermissionsContainer permissionsContainer,
+                                  final IndexRequestContainer requestContainer) {
+        final Iterable<Blob> blobs = getAllBlobsFromStorage(dataStorage, credentials);
+        blobs.forEach(file -> indexFile(requestContainer,
+                                        file,
+                                        dataStorage,
+                                        credentials,
+                                        permissionsContainer,
+                                        indexName));
+    }
+
+    Iterable<Blob> getAllBlobsFromStorage(final AbstractDataStorage dataStorage,
+                                          final TemporaryCredentials credentials) {
+        final Storage googleStorage = getGoogleStorage(credentials);
+        final String bucketName = dataStorage.getName();
+        return googleStorage.list(bucketName).iterateAll();
+    }
+
+    private Storage getGoogleStorage(final TemporaryCredentials credentials) {
+        final GoogleCredentials googleCredentials = createGoogleCredentials(credentials);
+        return StorageOptions
+                .newBuilder()
+                .setCredentials(googleCredentials)
+                .setProjectId(credentials.getAccessKey())
+                .build()
+                .getService();
+    }
+
+    private GoogleCredentials createGoogleCredentials(final TemporaryCredentials credentials) {
+        try {
+            final Date expirationDate = ESConstants.FILE_DATE_FORMAT.parse(credentials.getExpirationTime());
+            final AccessToken token = new AccessToken(credentials.getToken(), expirationDate);
+            return GoogleCredentials
+                    .create(token)
+                    .createScoped(Collections.singletonList(StorageScopes.DEVSTORAGE_READ_ONLY));
+        } catch (ParseException e) {
+            log.error(e.getMessage());
+            throw new DateTimeParseException(e.getMessage(), credentials.getExpirationTime(), e.getErrorOffset());
+        }
+    }
+
+    private void indexFile(final IndexRequestContainer indexContainer,
+                           final Blob file,
+                           final AbstractDataStorage storage,
+                           final TemporaryCredentials credentials,
+                           final PermissionsContainer permissions,
+                           final String indexName) {
+        convertToStorageFile(file)
+                .ifPresent(
+                        item -> indexContainer
+                                .add(createIndexRequest(item,
+                                                        indexName,
+                                                        storage,
+                                                        credentials.getRegion(),
+                                                        permissions)));
+    }
+
+    private Optional<DataStorageFile> convertToStorageFile(final Blob blob) {
+        final String relativePath = blob.getName();
+        if (StringUtils.endsWithIgnoreCase(relativePath, ESConstants.HIDDEN_FILE_NAME)) {
+            return Optional.empty();
+        }
+        final DataStorageFile file = new DataStorageFile();
+        file.setName(relativePath);
+        file.setPath(relativePath);
+        file.setSize(blob.getSize());
+        file.setChanged(ESConstants.FILE_DATE_FORMAT.format(Date.from(Instant.ofEpochMilli(blob.getUpdateTime()))));
+        file.setVersion(null);
+        file.setDeleteMarker(null);
+        final Map<String, String> labels = new HashMap<>(blob.getMetadata());
+        final StorageClass storageClass = blob.getStorageClass();
+        if (storageClass != null) {
+            labels.put(ESConstants.STORAGE_CLASS_LABEL, storageClass.name());
+        }
+        file.setLabels(labels);
+        return Optional.of(file);
+    }
+
+    IndexRequest createIndexRequest(final DataStorageFile item,
+                                    final String indexName,
+                                    final AbstractDataStorage storage,
+                                    final String region,
+                                    final PermissionsContainer permissions) {
+        return new IndexRequest(indexName, DOC_MAPPING_TYPE)
+                .source(fileMapper.fileToDocument(item, storage, region, permissions,
+                                                  SearchDocumentType.GS_FILE));
+    }
+}

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/S3FileManager.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/S3FileManager.java
@@ -147,7 +147,7 @@ public class S3FileManager implements ObjectStorageFileManager {
         file.setDeleteMarker(null);
         Map<String, String> labels = new HashMap<>();
         if (s3ObjectSummary.getStorageClass() != null) {
-            labels.put("StorageClass", s3ObjectSummary.getStorageClass());
+            labels.put(ESConstants.STORAGE_CLASS_LABEL, s3ObjectSummary.getStorageClass());
         }
         file.setLabels(labels);
         return file;

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/utils/ESConstants.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/utils/ESConstants.java
@@ -23,6 +23,7 @@ public final class ESConstants {
 
     public static final String DOC_MAPPING_TYPE = "_doc";
     public static final String HIDDEN_FILE_NAME = ".DS_Store";
+    public static final String STORAGE_CLASS_LABEL = "StorageClass";
     public static final DateFormat FILE_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
 
     private ESConstants() {

--- a/elasticsearch-agent/src/main/resources/application.properties
+++ b/elasticsearch-agent/src/main/resources/application.properties
@@ -56,6 +56,12 @@ sync.s3-file.index.name=s3-file
 sync.s3-file.enable.tags=false
 sync.s3-file.bulk.insert.size=1000
 
+#GS Files Settings
+#sync.gs-file.disable=true
+sync.gs-file.index.name=gs-file
+sync.gs-file.index.mapping=classpath:/templates/storage_file.json
+sync.gs-file.bulk.insert.size=1000
+
 #NFS Files Settings
 #sync.nfs-file.disable=true
 sync.nfs-file.index.mapping=classpath:/templates/storage_file.json

--- a/elasticsearch-agent/src/test/java/com/epam/pipeline/elasticsearchagent/service/impl/GsBucketFileManagerTest.java
+++ b/elasticsearch-agent/src/test/java/com/epam/pipeline/elasticsearchagent/service/impl/GsBucketFileManagerTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.epam.pipeline.elasticsearchagent.service.impl;
+
+import com.epam.pipeline.elasticsearchagent.model.PermissionsContainer;
+import com.epam.pipeline.elasticsearchagent.utils.ESConstants;
+import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
+import com.epam.pipeline.entity.datastorage.DataStorageFile;
+import com.epam.pipeline.entity.datastorage.GSBucketStorage;
+import com.epam.pipeline.entity.datastorage.TemporaryCredentials;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.StorageClass;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GsBucketFileManagerTest {
+    private static final String INDEX_NAME = "testIndex";
+    private static final String TEST_BLOB_NAME_1 = "1";
+    private static final String TEST_BLOB_NAME_2 = "2";
+
+    @Spy
+    private final GsBucketFileManager manager = new GsBucketFileManager();
+    @Mock
+    private IndexRequestContainer requestContainer;
+
+    private final AbstractDataStorage dataStorage = new GSBucketStorage();
+    private final TemporaryCredentials temporaryCredentials = new TemporaryCredentials();
+    private final PermissionsContainer permissionsContainer = new PermissionsContainer();
+
+    @Test
+    public void shouldAddZeroFilesToRequestContainer() {
+        final List<Blob> files = Collections.emptyList();
+        verifyRequestContainerState(files, 0);
+    }
+
+    @Test
+    public void shouldAddTwoFilesToRequestContainer() {
+        final List<Blob> files = Arrays.asList(createBlob(TEST_BLOB_NAME_1), createBlob(TEST_BLOB_NAME_2));
+        verifyRequestContainerState(files, 2);
+    }
+
+    @Test
+    public void shouldNotAddHiddenFilesToRequestContainer() {
+        final List<Blob> files = Arrays.asList(createBlob(TEST_BLOB_NAME_1), createHiddenBlob(TEST_BLOB_NAME_2));
+        verifyRequestContainerState(files, 1);
+    }
+
+    private void verifyRequestContainerState(final List<Blob> files, final int numberOfInvocation) {
+        setUpReturnValues(files);
+        manager.listAndIndexFiles(INDEX_NAME,
+                                  dataStorage,
+                                  temporaryCredentials,
+                                  permissionsContainer,
+                                  requestContainer);
+        verifyNumberOfInsertions(numberOfInvocation);
+        verifyBlobMapping(files, numberOfInvocation);
+    }
+
+    private void setUpReturnValues(final List<Blob> files) {
+        Mockito.doReturn(files)
+               .when(manager)
+               .getAllBlobsFromStorage(dataStorage, temporaryCredentials);
+    }
+
+    private void verifyBlobMapping(final List<Blob> files, final int numberOfInvocation) {
+        final List<DataStorageFile> capturedValues = captureDataStorageFilesIndexing(numberOfInvocation);
+        final Map<String, DataStorageFile> dsFiles =
+                capturedValues.stream()
+                              .collect(Collectors.toMap(DataStorageFile::getName,
+                                                        Function.identity()));
+        files.stream().filter(this::isNotHiddenBlob)
+             .forEach(blob -> assertBlobToFile(blob, dsFiles.get(blob.getName())));
+    }
+
+    private boolean isNotHiddenBlob(final Blob blob) {
+        return !StringUtils.endsWithIgnoreCase(blob.getName(), ESConstants.HIDDEN_FILE_NAME);
+    }
+
+    private List<DataStorageFile> captureDataStorageFilesIndexing(final int numberOfInvocation) {
+        final ArgumentCaptor<DataStorageFile> captor = ArgumentCaptor.forClass(DataStorageFile.class);
+        verify(manager, times(numberOfInvocation))
+                .createIndexRequest(captor.capture(), any(), any(), any(), any());
+        return captor.getAllValues();
+    }
+
+    private void assertBlobToFile(final Blob blob, final DataStorageFile file) {
+        assertEquals(blob.getName(), file.getName());
+        assertEquals(blob.getName(), file.getPath());
+        assertEquals(blob.getSize(), file.getSize());
+        assertThat(file.getLabels(),
+                   hasEntry(ESConstants.STORAGE_CLASS_LABEL, blob.getStorageClass().name()));
+    }
+
+    private void verifyNumberOfInsertions(final int numberOfInvocation) {
+        verify(requestContainer, times(numberOfInvocation)).add(any());
+    }
+
+    private Blob createBlob(final String name) {
+        final Blob result = Mockito.mock(Blob.class);
+        final Long fileSize = 100L;
+        final StorageClass storageClass = StorageClass.REGIONAL;
+        Mockito.doReturn(name).when(result).getName();
+        Mockito.doReturn(fileSize).when(result).getSize();
+        Mockito.doReturn(storageClass).when(result).getStorageClass();
+        return result;
+    }
+
+    private Blob createHiddenBlob(final String name) {
+        return createBlob(name + ESConstants.HIDDEN_FILE_NAME.toLowerCase());
+    }
+}


### PR DESCRIPTION
PR solves issue #361
It allows elasticsearch-agent indexing files from GS Buckets.

- Implementation of ObjectStorageFileManager interface for GS Buckets (GsBucketFileManager) is provided
- GSFileSyncConfiguration class enables GS objects synchronization
- Unit tests were specified
-  Common label for FileManagers is extracted to ESConstants.STORAGE_CLASS_LABEL
