### PR TITLE
GUI: preventing navigation if there are unsaved changes in configuration form

### DIFF
--- a/client/src/components/pipelines/launch/form/LaunchPipelineForm.js
+++ b/client/src/components/pipelines/launch/form/LaunchPipelineForm.js
@@ -17,7 +17,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {inject, observer} from 'mobx-react';
-import {computed, observable} from 'mobx';
+import {action, computed, observable} from 'mobx';
 import {
   Alert,
   Button,
@@ -73,36 +73,22 @@ import {
   getSystemParameterDisabledState,
   gridEngineEnabled
 } from './utilities/launch-cluster';
+import checkModifiedState from './utilities/launch-form-modified-state';
+import {
+  ADVANCED,
+  EXEC_ENVIRONMENT,
+  PARAMETERS,
+  SYSTEM_PARAMETERS
+} from './utilities/launch-form-sections';
 import {names} from '../../../../models/utils/ContextualPreference';
 
 const FormItem = Form.Item;
 const RUN_SELECTED_KEY = 'run selected';
 const RUN_CLUSTER_KEY = 'run cluster';
 
-const EXEC_ENVIRONMENT = 'exec';
-const ADVANCED = 'advanced';
-const PARAMETERS = 'parameters';
-const SYSTEM_PARAMETERS = 'systemParameters';
-
 const CLOUD_PLATFORM_ENVIRONMENT = 'CLOUD_PLATFORM';
 const FIRE_CLOUD_ENVIRONMENT = 'FIRECLOUD';
 const DTS_ENVIRONMENT = 'DTS';
-
-function onValuesChange (props, fields) {
-  if (fields &&
-    fields.exec &&
-    fields.exec.cloudRegionId &&
-    props.allowedInstanceTypes) {
-    props.allowedInstanceTypes.setRegionId(+fields.exec.cloudRegionId);
-  }
-  if (fields &&
-    fields[ADVANCED] &&
-    fields[ADVANCED].is_spot !== undefined &&
-    fields[ADVANCED].is_spot !== null &&
-    props.allowedInstanceTypes) {
-    props.allowedInstanceTypes.setIsSpot(`${fields[ADVANCED].is_spot}` === 'true');
-  }
-}
 
 function getFormItemClassName (rootClass, key) {
   if (key) {
@@ -111,12 +97,17 @@ function getFormItemClassName (rootClass, key) {
   return rootClass;
 }
 
-@Form.create({onValuesChange: onValuesChange})
-@inject('runDefaultParameters', 'googleApi', 'awsRegions', 'dtsList', 'preferences', 'dockerRegistries')
+@inject(
+  'runDefaultParameters',
+  'googleApi',
+  'awsRegions',
+  'dtsList',
+  'preferences',
+  'dockerRegistries'
+)
 @localization.localizedComponent
 @observer
-export default class LaunchPipelineForm extends localization.LocalizedReactComponent {
-
+class LaunchPipelineForm extends localization.LocalizedReactComponent {
   localizedStringWithSpotDictionaryFn = (key) => {
     return this.localizedString(
       key,
@@ -175,7 +166,9 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
       snapshot: PropTypes.string,
       configuration: PropTypes.string,
       configurationSnapshot: PropTypes.string
-    })
+    }),
+    onInitialized: PropTypes.func,
+    onModified: PropTypes.func
   };
 
   static defaultProps = {
@@ -243,8 +236,14 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
     fireCloudOutputs: {},
     fireCloudInputsErrors: {},
     fireCloudOutputsErrors: {},
-    fireCloudDefaultInputs: (this.props.fireCloudMethod && this.props.fireCloudMethod.methodInputs) || [],
-    fireCloudDefaultOutputs: (this.props.fireCloudMethod && this.props.fireCloudMethod.methodOutputs) || [],
+    fireCloudDefaultInputs: (
+      this.props.fireCloudMethod &&
+      this.props.fireCloudMethod.methodInputs
+    ) || [],
+    fireCloudDefaultOutputs: (
+      this.props.fireCloudMethod &&
+      this.props.fireCloudMethod.methodOutputs
+    ) || [],
     autoPause: true
   };
 
@@ -298,6 +297,24 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
   };
 
   prevParameters = {};
+
+  @observable modified = false;
+  @observable cmdTemplateValue;
+
+  @action
+  formFieldsChanged = () => {
+    this.modified = checkModifiedState(
+      this.props,
+      this.state,
+      {
+        defaultCloudRegionId: this.defaultCloudRegionId,
+        execEnvSelectValue: this.getExecEnvSelectValue().execEnvSelectValue,
+        spotInitialValue: this.correctPriceTypeValue(this.getDefaultValue('is_spot')),
+        cmdTemplateValue: this.cmdTemplateValue
+      }
+    );
+    this.props.onModified && this.props.onModified(this.modified);
+  };
 
   @observable
   _fireCloudConfigurations = null;
@@ -363,7 +380,8 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
         obj[param.name] = param.value;
       }
       return obj;
-    } else if (this.selectedFireCloudConfiguration && this.selectedFireCloudConfiguration.payloadObject) {
+    } else if (this.selectedFireCloudConfiguration &&
+      this.selectedFireCloudConfiguration.payloadObject) {
       return this.selectedFireCloudConfiguration.payloadObject.inputs || {};
     }
     return {};
@@ -377,7 +395,8 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
         obj[param.name] = param.value;
       }
       return obj;
-    } else if (this.selectedFireCloudConfiguration && this.selectedFireCloudConfiguration.payloadObject) {
+    } else if (this.selectedFireCloudConfiguration &&
+      this.selectedFireCloudConfiguration.payloadObject) {
       return this.selectedFireCloudConfiguration.payloadObject.outputs || {};
     }
     return {};
@@ -495,7 +514,8 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
 
   @computed
   get currentCloudRegion () {
-    const formValue = this.getSectionFieldValue(EXEC_ENVIRONMENT)('cloudRegionId') || this.getDefaultValue('cloudRegionId') || this.defaultCloudRegionId;
+    const formValue = this.getSectionFieldValue(EXEC_ENVIRONMENT)('cloudRegionId') ||
+      this.getDefaultValue('cloudRegionId') || this.defaultCloudRegionId;
     return this.awsRegions.filter(r => `${r.id}` === `${formValue}`)[0];
   }
 
@@ -517,7 +537,7 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
 
   handleSubmit = (e) => {
     e.preventDefault();
-    this.props.form.validateFields((err, values) => {
+    this.props.form.validateFields(async (err, values) => {
       if (!err && this.validateFireCloudConnections()) {
         let payload;
         if (this.props.editConfigurationMode) {
@@ -526,7 +546,12 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
           payload = this.generateLaunchPayload(values);
         }
         if (this.props.onLaunch) {
-          this.props.onLaunch(payload);
+          const result = await this.props.onLaunch(payload);
+          if (result) {
+            this.reset();
+            this.prepare();
+            this.formFieldsChanged();
+          }
         }
       } else {
         const openedPanels = this.state.openedPanels;
@@ -588,7 +613,13 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
           case RUN_SELECTED_KEY:
             if (this.props.runConfiguration) {
               if (this.props.isDetachedConfiguration) {
-                this.props.runConfiguration(payload, entitiesIds, metadataClass, expansionExpression, folderId);
+                this.props.runConfiguration(
+                  payload,
+                  entitiesIds,
+                  metadataClass,
+                  expansionExpression,
+                  folderId
+                );
               } else {
                 this.props.runConfiguration(payload);
               }
@@ -596,7 +627,13 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
             break;
           case RUN_CLUSTER_KEY:
             if (this.props.isDetachedConfiguration) {
-              this.props.runConfigurationCluster(payload, entitiesIds, metadataClass, expansionExpression, folderId);
+              this.props.runConfigurationCluster(
+                payload,
+                entitiesIds,
+                metadataClass,
+                expansionExpression,
+                folderId
+              );
             } else {
               this.props.runConfigurationCluster(payload);
             }
@@ -638,7 +675,7 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
     if (keepPipeline) {
       this.setState({
         openedPanels: this.getDefaultOpenedPanels(),
-				startIdle: this.props.parameters.cmd_template === 'sleep infinity',
+        startIdle: this.props.parameters.cmd_template === 'sleep infinity',
         isDts: this.isDts(),
         execEnvSelectValue,
         dtsId,
@@ -648,7 +685,8 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
         autoScaledCluster: autoScaledCluster,
         gridEngineEnabled: gridEngineEnabledValue,
         nodesCount: +this.props.parameters.node_count,
-        maxNodesCount: this.props.parameters.parameters && this.props.parameters.parameters[CP_CAP_AUTOSCALE_WORKERS]
+        maxNodesCount: this.props.parameters.parameters &&
+        this.props.parameters.parameters[CP_CAP_AUTOSCALE_WORKERS]
           ? +this.props.parameters.parameters[CP_CAP_AUTOSCALE_WORKERS].value
           : 0,
         bucketBrowserVisible: false,
@@ -674,11 +712,11 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
         fireCloudOutputs: {},
         fireCloudInputsErrors: {},
         fireCloudOutputsErrors: {}
-      });
+      }, this.formFieldsChanged);
     } else {
       this.setState({
         openedPanels: this.getDefaultOpenedPanels(),
-				startIdle: this.props.parameters.cmd_template === 'sleep infinity',
+        startIdle: this.props.parameters.cmd_template === 'sleep infinity',
         isDts: this.isDts(),
         execEnvSelectValue,
         dtsId,
@@ -691,7 +729,8 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
         autoScaledCluster: autoScaledCluster,
         gridEngineEnabled: gridEngineEnabledValue,
         nodesCount: +this.props.parameters.node_count,
-        maxNodesCount: this.props.parameters.parameters && this.props.parameters.parameters[CP_CAP_AUTOSCALE_WORKERS]
+        maxNodesCount: this.props.parameters.parameters &&
+        this.props.parameters.parameters[CP_CAP_AUTOSCALE_WORKERS]
           ? +this.props.parameters.parameters[CP_CAP_AUTOSCALE_WORKERS].value
           : 0,
         bucketBrowserVisible: false,
@@ -723,7 +762,7 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
         fireCloudInputsErrors: {},
         fireCloudOutputsErrors: {},
         autoPause: true
-      });
+      }, this.formFieldsChanged);
     }
   };
 
@@ -738,7 +777,9 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
       parameters: {},
       configuration: values.configuration,
       is_spot: (values[ADVANCED].is_spot || `${this.getDefaultValue('is_spot')}`) === 'true',
-      cloudRegionId: values[EXEC_ENVIRONMENT].cloudRegionId ? +values[EXEC_ENVIRONMENT].cloudRegionId : undefined
+      cloudRegionId: values[EXEC_ENVIRONMENT].cloudRegionId
+        ? +values[EXEC_ENVIRONMENT].cloudRegionId
+        : undefined
     };
     if (this.state.isDts && this.props.detached) {
       payload.instance_size = undefined;
@@ -766,7 +807,9 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
           if (parameter && parameter.name) {
             payload[PARAMETERS][parameter.name] = {
               type: parameter.type,
-              value: (parameter.type || '').toLowerCase() === 'boolean' ? getBooleanValue(parameter.value) : (parameter.value || ''),
+              value: (parameter.type || '').toLowerCase() === 'boolean'
+                ? getBooleanValue(parameter.value)
+                : (parameter.value || ''),
               required: `${parameter.required || false}`.toLowerCase() === 'true',
               enum: parameter.enumeration
             };
@@ -787,7 +830,9 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
           if (parameter && parameter.name) {
             payload[PARAMETERS][parameter.name] = {
               type: parameter.type,
-              value: (parameter.type || '').toLowerCase() === 'boolean' ? getBooleanValue(parameter.value) : (parameter.value || ''),
+              value: (parameter.type || '').toLowerCase() === 'boolean'
+                ? getBooleanValue(parameter.value)
+                : (parameter.value || ''),
               required: `${parameter.required || false}`.toLowerCase() === 'true',
               enum: parameter.enumeration
             };
@@ -826,10 +871,13 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
       this.state.fireCloudMethodName &&
       this.state.fireCloudMethodNamespace &&
       this.state.fireCloudMethodSnapshot) {
-      payload.methodName = `${this.state.fireCloudMethodNamespace}/${this.state.fireCloudMethodName}`;
+      payload.methodName =
+        `${this.state.fireCloudMethodNamespace}/${this.state.fireCloudMethodName}`;
       payload.methodSnapshot = this.state.fireCloudMethodSnapshot;
-      if (this.state.fireCloudMethodConfiguration && this.state.fireCloudMethodConfigurationSnapshot) {
-        payload.methodConfigurationName = `${this.state.fireCloudMethodNamespace}/${this.state.fireCloudMethodConfiguration}`;
+      if (this.state.fireCloudMethodConfiguration &&
+        this.state.fireCloudMethodConfigurationSnapshot) {
+        payload.methodConfigurationName =
+          `${this.state.fireCloudMethodNamespace}/${this.state.fireCloudMethodConfiguration}`;
         payload.methodConfigurationSnapshot = this.state.fireCloudMethodConfigurationSnapshot;
       }
       payload.executionEnvironment = FIRE_CLOUD_ENVIRONMENT;
@@ -856,11 +904,15 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
       pipelineId: this.props.pipeline ? this.props.pipeline.id : undefined,
       version: this.props.version,
       params: {},
-      isSpot: (values[ADVANCED].is_spot || `${this.getDefaultValue('is_spot')}`)=== 'true',
-      cloudRegionId: values[EXEC_ENVIRONMENT].cloudRegionId ? +values[EXEC_ENVIRONMENT].cloudRegionId : undefined,
+      isSpot: (values[ADVANCED].is_spot || `${this.getDefaultValue('is_spot')}`) === 'true',
+      cloudRegionId: values[EXEC_ENVIRONMENT].cloudRegionId
+        ? +values[EXEC_ENVIRONMENT].cloudRegionId
+        : undefined,
       prettyUrl: this.prettyUrlEnabled ? values[ADVANCED].prettyUrl : undefined
     };
-    if ((values[ADVANCED].is_spot || `${this.getDefaultValue('is_spot')}`) !== 'true' && !this.state.autoPause) {
+    if ((values[ADVANCED].is_spot ||
+      `${this.getDefaultValue('is_spot')}`) !== 'true' &&
+      !this.state.autoPause) {
       payload.nonPause = true;
     }
     const getBooleanValue = (value) => {
@@ -879,7 +931,9 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
         if (parameter && parameter.name && parameter.value) {
           payload.params[parameter.name] = {
             type: parameter.type,
-            value: (parameter.type || '').toLowerCase() === 'boolean' ? getBooleanValue(parameter.value) : (parameter.value || ''),
+            value: (parameter.type || '').toLowerCase() === 'boolean'
+              ? getBooleanValue(parameter.value)
+              : (parameter.value || ''),
             required: `${parameter.required || false}`.toLowerCase() === 'true',
             enum: parameter.enumeration
           };
@@ -900,7 +954,9 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
         if (parameter && parameter.name && parameter.value) {
           payload.params[parameter.name] = {
             type: parameter.type,
-            value: (parameter.type || '').toLowerCase() === 'boolean' ? getBooleanValue(parameter.value) : (parameter.value || ''),
+            value: (parameter.type || '').toLowerCase() === 'boolean'
+              ? getBooleanValue(parameter.value)
+              : (parameter.value || ''),
             required: `${parameter.required || false}`.toLowerCase() === 'true',
             enum: parameter.enumeration
           };
@@ -925,7 +981,7 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
       payload.params[CP_CAP_SGE] = {
         type: 'boolean',
         value: true
-      }
+      };
     }
     return payload;
   };
@@ -1055,10 +1111,11 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
     const gridEngineEnabledValue = gridEngineEnabled(this.props.parameters.parameters);
     let state = {
       launchCluster: +this.props.parameters.node_count > 0 || autoScaledCluster,
-      autoScaledClusterEnabled: autoScaledCluster,
+      autoScaledCluster: autoScaledCluster,
       gridEngineEnabled: gridEngineEnabledValue,
       nodesCount: +this.props.parameters.node_count,
-      maxNodesCount: this.props.parameters.parameters && this.props.parameters.parameters[CP_CAP_AUTOSCALE_WORKERS]
+      maxNodesCount: this.props.parameters.parameters &&
+      this.props.parameters.parameters[CP_CAP_AUTOSCALE_WORKERS]
         ? +this.props.parameters.parameters[CP_CAP_AUTOSCALE_WORKERS].value
         : 0,
       pipeline: this.props.pipeline,
@@ -1079,8 +1136,12 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
           ? this.props.fireCloudMethod.configurationSnapshot : null,
         fireCloudInputs: {},
         fireCloudOutputs: {},
-        fireCloudDefaultInputs: this.props.fireCloudMethod ? this.props.fireCloudMethod.methodInputs : null,
-        fireCloudDefaultOutputs: this.props.fireCloudMethod ? this.props.fireCloudMethod.methodOutputs : null
+        fireCloudDefaultInputs: this.props.fireCloudMethod
+          ? this.props.fireCloudMethod.methodInputs
+          : null,
+        fireCloudDefaultOutputs: this.props.fireCloudMethod
+          ? this.props.fireCloudMethod.methodOutputs
+          : null
       });
     }
     this.setState(state);
@@ -1092,7 +1153,8 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
         this.getDefaultValue('instance_disk');
     }
     if (!type) {
-      this.props.allowedInstanceTypes && await this.props.allowedInstanceTypes.fetchIfNeededOrWait();
+      this.props.allowedInstanceTypes &&
+      await this.props.allowedInstanceTypes.fetchIfNeededOrWait();
       type = this.getSectionFieldValue(EXEC_ENVIRONMENT)('type') ||
         this.correctInstanceTypeValue(this.getDefaultValue('instance_size'));
     }
@@ -1209,14 +1271,16 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
             type="info-circle" />
         </Popover>
       );
-      const priceStr = `${(this.state.estimatedPrice.pricePerHour * this.multiplyValueBy).toFixed(2)} $`;
+      const {pricePerHour} = this.state.estimatedPrice;
+      const priceStr = `${(pricePerHour * this.multiplyValueBy).toFixed(2)} $`;
       return (
         <span style={{marginLeft: 5}}>Estimated price per hour: <span className={className}>
           {priceStr} {info}</span>
         </span>
       );
     } else if (this.state.estimatedPrice.pricePerHour > 0) {
-      const priceStr = `${(this.state.estimatedPrice.pricePerHour * this.multiplyValueBy).toFixed(2)} $`;
+      const {pricePerHour} = this.state.estimatedPrice;
+      const priceStr = `${(pricePerHour * this.multiplyValueBy).toFixed(2)} $`;
       return (
         <span style={{marginLeft: 5}}>Estimated price per hour: <span className={className}>
           {priceStr}</span>
@@ -1239,6 +1303,7 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
   cmdTemplateEditorValueChanged = (code) => {
     const advancedValues = this.getSectionValue(ADVANCED);
     advancedValues.cmdTemplate = code;
+    this.cmdTemplateValue = code;
     this.props.form.setFieldsValue({[ADVANCED]: advancedValues});
   };
 
@@ -1273,7 +1338,9 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
           }
           this.parameterIndexIdentifier[parameterIndexIdentifierKey] =
             this.parameterIndexIdentifier[parameterIndexIdentifierKey] + 1;
-          parameters.keys.push(`param_${this.parameterIndexIdentifier[parameterIndexIdentifierKey]}`);
+          parameters.keys.push(
+            `param_${this.parameterIndexIdentifier[parameterIndexIdentifierKey]}`
+          );
           let value;
           let type = 'string';
           let required = false;
@@ -1303,16 +1370,17 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
             value = parameter;
           }
 
-          parameters.params[`param_${this.parameterIndexIdentifier[parameterIndexIdentifierKey]}`] = {
-            name: key,
-            key: `param_${this.parameterIndexIdentifier[parameterIndexIdentifierKey]}`,
-            type: type,
-            enumeration,
-            value: value,
-            required: required,
-            readOnly: readOnly,
-            system: system
-          };
+          parameters
+            .params[`param_${this.parameterIndexIdentifier[parameterIndexIdentifierKey]}`] = {
+              name: key,
+              key: `param_${this.parameterIndexIdentifier[parameterIndexIdentifierKey]}`,
+              type: type,
+              enumeration,
+              value: value,
+              required: required,
+              readOnly: readOnly,
+              system: system
+            };
         }
       }
     }
@@ -1340,17 +1408,17 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
             })(
             this.props.isDetachedConfiguration
               ? <AutoCompleteForParameter
-                readOnly={this.props.readOnly && !this.props.canExecute || readOnly}
+                readOnly={this.props.readOnly || !this.props.canExecute || readOnly}
                 hideAutoComplete={!this.props.currentConfigurationIsDefault}
                 placeholder={'Value'}
                 parameterKey={key}
                 currentMetadataEntity={this.state.currentMetadataEntity.slice()}
                 currentProjectMetadata={this.state.currentProjectMetadata}
                 rootEntityId={this.state.rootEntityId}
-                showWithButton={true}
+                showWithButton
               />
               : <Input
-                disabled={(this.props.readOnly && !this.props.canExecute) || readOnly}
+                disabled={this.props.readOnly || !this.props.canExecute || readOnly}
                 placeholder="Value"
                 className={styles.parameterValue}
               />
@@ -1360,7 +1428,11 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
     );
   };
 
-  renderSelectionParameter = (sectionName, {key, value, required, readOnly, enumeration}, system = false) => {
+  renderSelectionParameter = (
+    sectionName,
+    {key, value, required, readOnly, enumeration},
+    system = false
+  ) => {
     const rules = [];
     if (required || system) {
       rules.push({
@@ -1378,7 +1450,8 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
             {
               rules: rules,
               initialValue: value
-            })(
+            }
+          )(
             <Select
               disabled={(this.props.readOnly && !this.props.canExecute) || readOnly}
               placeholder="Value"
@@ -1404,8 +1477,8 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
           this.getSectionFieldDecorator(sectionName)(`params.${key}.value`,
             {
               initialValue: value
-            })
-          (
+            }
+          )(
             <BooleanParameterInput
               disabled={(this.props.readOnly && !this.props.canExecute) || readOnly}
               className={styles.parameterValue} />
@@ -1452,8 +1525,12 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
     rules.push({
       validator: (rule, value, callback) => {
         if (value && value.length) {
-          const parts = value.split(',').map(f => f.trim()).filter(f => f.toLowerCase().indexOf('nfs://') === 0);
+          const parts = value
+            .split(',')
+            .map(f => f.trim())
+            .filter(f => f.toLowerCase().indexOf('nfs://') === 0);
           if (parts.length) {
+            // eslint-disable-next-line
             callback('NFS mounts are not supported');
           }
         }
@@ -1472,7 +1549,7 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
           })(
             this.props.isDetachedConfiguration
               ? <AutoCompleteForParameter
-                readOnly={this.props.readOnly && !this.props.canExecute || readOnly}
+                readOnly={this.props.readOnly || !this.props.canExecute || readOnly}
                 hideAutoComplete={!this.props.currentConfigurationIsDefault}
                 placeholder={'Path'}
                 parameterKey={key}
@@ -1486,7 +1563,7 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
                 }}
               />
               : <Input
-                disabled={this.props.readOnly && !this.props.canExecute  || readOnly}
+                disabled={this.props.readOnly || !this.props.canExecute || readOnly}
                 style={{width: '100%'}}
                 addonBefore={
                   <div
@@ -1512,7 +1589,7 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
   };
 
   closePipelineBrowser = () => {
-    this.setState({pipelineBrowserVisible: false});
+    this.setState({pipelineBrowserVisible: false}, this.formFieldsChanged);
   };
 
   selectPipelineConfirm = async (pipeline, isFireCloud = false) => {
@@ -1653,6 +1730,7 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
       }
     }
     this.closePipelineBrowser();
+    this.formFieldsChanged();
   };
 
   openMetadataBrowser = () => {
@@ -1667,7 +1745,13 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
   };
 
   selectMetadataConfirm = (entitiesIds, metadataClass, expansionExpression, folderId) => {
-    this.run({key: this.state.currentLaunchKey}, entitiesIds, metadataClass, expansionExpression, folderId);
+    this.run(
+      {key: this.state.currentLaunchKey},
+      entitiesIds,
+      metadataClass,
+      expansionExpression,
+      folderId
+    );
   };
 
   renderPipelineSelection = () => {
@@ -1678,19 +1762,18 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
     if (this.state.pipeline) {
       inputValue = this.state.pipeline.name;
       if (this.state.version && !this.state.pipeline.unknown) {
-        if (!this.state.pipelineConfiguration) {
-          inputValue = `${inputValue} (${this.state.version})`;
-        } else {
-          inputValue = `${inputValue} (${this.state.version} - ${this.state.pipelineConfiguration})`;
+        let versionStr = `(${this.state.version})`;
+        if (this.state.pipelineConfiguration) {
+          versionStr = `(${this.state.version} - ${this.state.pipelineConfiguration})`;
         }
+        inputValue = `${inputValue} ${versionStr}`;
       }
     } else if (this.state.fireCloudMethodName &&
       this.state.fireCloudMethodNamespace &&
       this.state.fireCloudMethodSnapshot) {
+      inputValue = `${this.state.fireCloudMethodNamespace}/${this.state.fireCloudMethodName}`;
       if (this.state.fireCloudMethodConfiguration) {
-        inputValue = `${this.state.fireCloudMethodNamespace}/${this.state.fireCloudMethodName} (${this.state.fireCloudMethodConfiguration})`;
-      } else {
-        inputValue = `${this.state.fireCloudMethodNamespace}/${this.state.fireCloudMethodName}`;
+        inputValue = `${inputValue} (${this.state.fireCloudMethodConfiguration})`;
       }
     }
     const ref = (input) => {
@@ -1799,7 +1882,9 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
       });
       if (this._dtsCoresTotal) {
         const isPlural = this._dtsCoresTotal !== 1;
-        infoString = `${this._dtsCoresTotal} core${isPlural ? 's' : ''} total / ${this._dtsCoresAvailable} available`;
+        const totalStr = `${this._dtsCoresTotal} core${isPlural ? 's' : ''} total`;
+        const availableStr = `${this._dtsCoresAvailable} available`;
+        infoString = `${totalStr} / ${availableStr}`;
       }
     }
     return [
@@ -1828,10 +1913,13 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
         validation[EXEC_ENVIRONMENT].coresNumber.message = 'Minimum value is 1';
       } else if (this._dtsCoresTotal && +value > this._dtsCoresTotal) {
         validation[EXEC_ENVIRONMENT].coresNumber.result = 'error';
-        validation[EXEC_ENVIRONMENT].coresNumber.message = 'The selected number of cores cannot be more than the total amount';
+        validation[EXEC_ENVIRONMENT].coresNumber.message =
+          'The selected number of cores cannot be more than the total amount';
       } else if (this._dtsCoresTotal && +value > this._dtsCoresAvailable) {
         validation[EXEC_ENVIRONMENT].coresNumber.result = 'warning';
-        validation[EXEC_ENVIRONMENT].coresNumber.message = `At the moment - only ${this._dtsCoresAvailable} cores are available. Your job will wait in queue until more cores are freed`;
+        const availableStr = `At the moment - only ${this._dtsCoresAvailable} cores are available`;
+        validation[EXEC_ENVIRONMENT].coresNumber.message =
+          `${availableStr}. Your job will wait in queue until more cores are freed`;
       } else {
         validation[EXEC_ENVIRONMENT].coresNumber.result = 'success';
         validation[EXEC_ENVIRONMENT].coresNumber.message = null;
@@ -1878,7 +1966,8 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
                     }
                   ],
                   initialValue: this.getDefaultValue('coresNumber')
-                })(
+                }
+              )(
                 <Input
                   disabled={this.props.readOnly && !this.props.canExecute} />
               )}
@@ -1946,11 +2035,17 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
       }
     }
     if (error) {
+      // eslint-disable-next-line
       callback('No duplicates are allowed');
     } else if (!isSystemParameter && this.isSystemParameter({name: value})) {
+      // eslint-disable-next-line
       callback('Name is reserved for system parameter');
     } else if (value &&
-      [LIMIT_MOUNTS_PARAMETER, ...getSkippedSystemParametersList()].indexOf(value.toUpperCase()) >= 0) {
+      [
+        LIMIT_MOUNTS_PARAMETER,
+        ...getSkippedSystemParametersList()
+      ].indexOf(value.toUpperCase()) >= 0) {
+      // eslint-disable-next-line
       callback('Name is reserved');
     } else {
       callback();
@@ -1961,6 +2056,7 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
     if (value && +value > 0 && Number.isInteger(+value) && `${value}` === `${+value}`) {
       callback();
     } else {
+      // eslint-disable-next-line
       callback('Please enter positive number');
     }
   };
@@ -2007,7 +2103,7 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
   isSystemParameter = (parameter) => {
     if (this.props.runDefaultParameters.loaded) {
       return (this.props.runDefaultParameters.value || [])
-          .filter(p => p.name === parameter.name).length > 0;
+        .filter(p => p.name === parameter.name).length > 0;
     }
     return false;
   };
@@ -2015,7 +2111,7 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
   getSystemParameter = (parameter) => {
     if (parameter && parameter.name && this.props.runDefaultParameters.loaded) {
       return (this.props.runDefaultParameters.value || [])
-          .filter(p => p.name === parameter.name)[0];
+        .filter(p => p.name === parameter.name)[0];
     }
     return null;
   };
@@ -2041,10 +2137,12 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
       parameters = this.buildDefaultParameters(isSystemParametersSection);
       this.rebuildParameters[sectionName] = false;
     } else {
-      parameters = this.getSectionValue(sectionName) || this.buildDefaultParameters(isSystemParametersSection);
+      parameters = this.getSectionValue(sectionName) ||
+        this.buildDefaultParameters(isSystemParametersSection);
     }
 
-    const keysFormItem = this.props.isDetachedConfiguration && this.props.selectedPipelineParametersIsLoading
+    const keysFormItem = this.props.isDetachedConfiguration &&
+    this.props.selectedPipelineParametersIsLoading
       ? null
       : (
         <FormItem
@@ -2080,9 +2178,12 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
     const addParameterButtonFn = () => {
       if (isSystemParametersSection) {
         const notToShowSystemParametersFn = (section, isSystem) => {
-          const sectionValue = this.getSectionValue(section) || this.buildDefaultParameters(isSystem);
+          const sectionValue = this.getSectionValue(section) ||
+            this.buildDefaultParameters(isSystem);
           return sectionValue && sectionValue.params && sectionValue.keys
-            ? sectionValue.keys.map(key => sectionValue.params[key]).filter(param => !!param).map(p => p.name)
+            ? sectionValue.keys
+              .map(key => sectionValue.params[key])
+              .filter(param => !!param).map(p => p.name)
             : [];
         };
         return (
@@ -2129,7 +2230,9 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
                 disabled={(this.props.readOnly && !this.props.canExecute) ||
                 (!!this.state.pipeline && this.props.detached)}
                 id="add-parameter-button"
-                onClick={() => this.addParameter(sectionName, {type: 'string'}, isSystemParametersSection)}>
+                onClick={
+                  () => this.addParameter(sectionName, {type: 'string'}, isSystemParametersSection)
+                }>
                 Add parameter
               </Button>
               {
@@ -2143,7 +2246,7 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
                         <Icon type="down" />
                       </Button>
                     </Dropdown>
-                ) : undefined
+                  ) : undefined
               }
             </Button.Group>
           </Row>
@@ -2152,7 +2255,8 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
     };
 
     const renderRootEntity = () => {
-      return this.props.currentConfigurationIsDefault && this.state.currentMetadataEntity.length > 0 && (
+      return this.props.currentConfigurationIsDefault &&
+        this.state.currentMetadataEntity.length > 0 && (
         <FormItem
           key="root_entity_type_select"
           className={`${styles.formItemRow} ${styles.rootEntityTypeContainer} root_entity`}>
@@ -2305,16 +2409,25 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
                           message: 'Name can contain only letters, digits and \'_\'.'
                         },
                         {
-                          validator: this.validateParameterName(sectionName, key, isSystemParametersSection)
+                          validator: this.validateParameterName(
+                            sectionName,
+                            key,
+                            isSystemParametersSection
+                          )
                         }],
                       initialValue: name
-                    })(
+                    }
+                  )(
                     <Input
                       disabled={(this.props.readOnly && !this.props.canExecute) ||
                       required || isSystemParametersSection ||
                       (!!this.state.pipeline && this.props.detached)}
                       placeholder="Name"
-                      className={isSystemParametersSection ? styles.systemParameterName : styles.parameterName} />
+                      className={
+                        isSystemParametersSection
+                          ? styles.systemParameterName
+                          : styles.parameterName
+                      } />
                   )}
                 </FormItem>
               </Col>
@@ -2325,7 +2438,11 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
               </Col>
               <Col
                 span={3}
-                className={systemParameterValueIsBlocked ? styles.hiddenItem : styles.removeParameter}>
+                className={
+                  systemParameterValueIsBlocked
+                    ? styles.hiddenItem
+                    : styles.removeParameter
+                }>
                 {
                   !required &&
                   !(this.props.readOnly && !this.props.canExecute) &&
@@ -2337,12 +2454,17 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
                         type="minus-circle-o"
                         onClick={() => this.removeParameter(sectionName, key)}
                       />
-                  )
+                    )
                     : undefined
                 }
                 {
                   isSystemParametersSection && systemParameterHint &&
-                  hints.renderHint(this.localizedStringWithSpotDictionaryFn, systemParameterHint, null, {marginLeft: 15})
+                  hints.renderHint(
+                    this.localizedStringWithSpotDictionaryFn,
+                    systemParameterHint,
+                    null,
+                    {marginLeft: 15}
+                  )
                 }
               </Col>
             </FormItem>
@@ -2359,7 +2481,7 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
       this.renderSeparator('System parameters', 0, 'header', {marginTop: 20, marginBottom: 10}),
       !this.isFireCloudSelected ? keysFormItem : undefined,
       ...currentParameters,
-      !this.isFireCloudSelected ? addParameterButtonFn(): undefined
+      !this.isFireCloudSelected ? addParameterButtonFn() : undefined
     ];
   };
 
@@ -2397,10 +2519,15 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
         hasFeedback>
         {this.getSectionFieldDecorator(EXEC_ENVIRONMENT)('dockerImage',
           {
-            rules: [{required: !this.state.fireCloudMethodName, message: 'Docker image is required'}],
+            rules: [
+              {
+                required: !this.state.fireCloudMethodName,
+                message: 'Docker image is required'
+              }
+            ],
             initialValue: this.getDefaultValue('docker_image')
-          })
-        (
+          }
+        )(
           <DockerImageInput disabled={
             !!this.state.fireCloudMethodName ||
             (this.props.readOnly && !this.props.canExecute) ||
@@ -2412,7 +2539,9 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
 
   @computed
   get disableAutoPauseEnabled () {
-    return !this.state.fireCloudMethodName && !this.props.detached && !this.props.editConfigurationMode;
+    return !this.state.fireCloudMethodName &&
+      !this.props.detached &&
+      !this.props.editConfigurationMode;
   }
 
   @computed
@@ -2420,7 +2549,8 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
     if (this.state.fireCloudMethodName || this.props.detached) {
       return undefined;
     }
-    const dockerImage = this.getSectionFieldValue(EXEC_ENVIRONMENT)('dockerImage') || this.getDefaultValue('docker_image');
+    const dockerImage = this.getSectionFieldValue(EXEC_ENVIRONMENT)('dockerImage') ||
+      this.getDefaultValue('docker_image');
     if (dockerImage && this.props.dockerRegistries.loaded) {
       const [registry, group, toolAndVersion] = dockerImage.toLowerCase().split('/');
       const [imageRegistry] = (this.props.dockerRegistries.value.registries || [])
@@ -2441,6 +2571,8 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
 
   renderPrettyUrlFormItem = () => {
     if (this.prettyUrlEnabled) {
+      const errorMessage =
+        'Please enter a valid url name (only characters, numbers and \'_\' symbols allowed)';
       return (
         <FormItem
           className={getFormItemClassName(styles.formItemRow, 'prettyUrl')}
@@ -2456,11 +2588,12 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
                   rules: [
                     {
                       pattern: /^[a-zA-Z\d_]+$/,
-                      message: 'Please enter a valid url name (only characters, numbers and \'_\' symbols allowed)'
+                      message: errorMessage
                     }
                   ],
                   initialValue: this.getDefaultValue('prettyUrl')
-                })(
+                }
+              )(
                 <Input
                   disabled={(this.props.readOnly && !this.props.canExecute)} />
               )}
@@ -2479,6 +2612,8 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
     if (this.state.isDts && this.props.detached) {
       return undefined;
     }
+    const instanceTypeStr = (t) =>
+      `${t.name} (CPU: ${t.vcpu}, RAM: ${t.memory}${t.gpu ? `, GPU: ${t.gpu}` : ''})`;
     return (
       <FormItem
         className={getFormItemClassName(styles.formItem, 'type')}
@@ -2495,7 +2630,8 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
               }
             ],
             initialValue: this.correctInstanceTypeValue(this.getDefaultValue('instance_size'))
-          })(
+          }
+        )(
           <Select
             disabled={
               !!this.state.fireCloudMethodName ||
@@ -2518,7 +2654,9 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
                 .filter((familyName, index, array) => array.indexOf(familyName) === index)
                 .map(instanceFamily => {
                   return (
-                    <Select.OptGroup key={instanceFamily || 'Other'} label={instanceFamily || 'Other'} >
+                    <Select.OptGroup
+                      key={instanceFamily || 'Other'}
+                      label={instanceFamily || 'Other'} >
                       {
                         this.instanceTypes
                           .filter(t => t.instanceFamily === instanceFamily)
@@ -2526,9 +2664,9 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
                             <Select.Option
                               key={t.sku}
                               value={t.name}
-                              title={`${t.name} (CPU: ${t.vcpu}, RAM: ${t.memory}${t.gpu ? `, GPU: ${t.gpu}` : ''})`}
+                              title={instanceTypeStr(t)}
                             >
-                              {t.name} (CPU: {t.vcpu}, RAM: {t.memory}{t.gpu ? `, GPU: ${t.gpu}`: ''})
+                              {instanceTypeStr(t)}
                             </Select.Option>
                           )
                       }
@@ -2562,7 +2700,8 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
               }
             ],
             initialValue: this.getDefaultValue('cloudRegionId') || this.defaultCloudRegionId
-          })(
+          }
+        )(
           <Select
             disabled={
               !!this.state.fireCloudMethodName ||
@@ -2613,11 +2752,17 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
   closeConfigureClusterDialog = () => {
     this.setState({
       configureClusterDialogVisible: false
-    });
+    }, this.formFieldsChanged);
   };
 
   onChangeClusterConfiguration = (configuration) => {
-    const {launchCluster, autoScaledCluster, nodesCount, maxNodesCount, gridEngineEnabled} = configuration;
+    const {
+      launchCluster,
+      autoScaledCluster,
+      nodesCount,
+      maxNodesCount,
+      gridEngineEnabled
+    } = configuration;
     this.setState({
       launchCluster,
       autoScaledCluster,
@@ -2717,7 +2862,11 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
                 pattern: /^\d+(\.\d+)?$/,
                 message: 'Please enter a valid positive number'
               },
-              {required: !this.state.fireCloudMethodName && !this.state.isDts, message: 'Instance disk is required'},
+              {
+                required: !this.state.fireCloudMethodName &&
+                  !this.state.isDts,
+                message: 'Instance disk is required'
+              },
               {
                 validator: (rule, value, callback) => {
                   if (!!this.state.fireCloudMethodName || this.state.isDts) {
@@ -2726,9 +2875,11 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
                   }
                   if (!isNaN(value)) {
                     if (+value > 15360) {
+                      // eslint-disable-next-line
                       callback('Maximum value is 15360');
                       return;
                     } else if (+value < 15) {
+                      // eslint-disable-next-line
                       callback('Minimum value is 15');
                       return;
                     }
@@ -2738,9 +2889,13 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
               }
             ],
             initialValue: this.getDefaultValue('instance_disk')
-          })(
+          }
+        )(
           <Input
-            disabled={!!this.state.fireCloudMethodName || (this.props.readOnly && !this.props.canExecute)}
+            disabled={
+              !!this.state.fireCloudMethodName ||
+              (this.props.readOnly && !this.props.canExecute)
+            }
             onChange={this.diskSizeChanged} />
         )}
       </FormItem>
@@ -2810,8 +2965,11 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
                       message: 'Price type is required'
                     }
                   ],
-                  initialValue: initialValue !== undefined && initialValue !== null ? `${initialValue}` : undefined
-                })(
+                  initialValue: initialValue !== undefined && initialValue !== null
+                    ? `${initialValue}`
+                    : undefined
+                }
+              )(
                 <Select
                   onSelect={(isSpot) => this.evaluateEstimatedPrice({isSpot})}
                   disabled={
@@ -2854,7 +3012,17 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
         };
         return (
           <Row type="flex" align="middle" style={{marginTop: 10, marginBottom: 10}}>
-            <Col xs={10} sm={5} md={4} lg={3} xl={2} style={{textAlign: 'right', paddingRight: 10, color: '#333'}}>
+            <Col
+              xs={10}
+              sm={5}
+              md={4}
+              lg={3}
+              xl={2}
+              style={{
+                textAlign: 'right',
+                paddingRight: 10,
+                color: '#333'
+              }}>
               Auto pause:
             </Col>
             <Col xs={24} sm={16} md={15} lg={15} xl={10}>
@@ -2899,9 +3067,13 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
                   }
                 ],
                 initialValue: this.getDefaultValue('timeout')
-              })(
+              }
+            )(
               <Input
-                disabled={!!this.state.fireCloudMethodName || (this.props.readOnly && !this.props.canExecute)} />
+                disabled={
+                  !!this.state.fireCloudMethodName ||
+                  (this.props.readOnly && !this.props.canExecute)
+                } />
             )}
           </FormItem>
         </Col>
@@ -2914,7 +3086,8 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
 
   renderLimitMountsFormItem = () => {
     const getDefaultValue = () => {
-      if (this.props.parameters.parameters && this.props.parameters.parameters[LIMIT_MOUNTS_PARAMETER]) {
+      if (this.props.parameters.parameters &&
+        this.props.parameters.parameters[LIMIT_MOUNTS_PARAMETER]) {
         return this.props.parameters.parameters[LIMIT_MOUNTS_PARAMETER].value;
       }
       return null;
@@ -2932,9 +3105,13 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
               {this.getSectionFieldDecorator(ADVANCED)('limitMounts',
                 {
                   initialValue: getDefaultValue()
-                })(
+                }
+              )(
                 <LimitMountsInput
-                  disabled={!!this.state.fireCloudMethodName || (this.props.readOnly && !this.props.canExecute)} />
+                  disabled={
+                    !!this.state.fireCloudMethodName ||
+                    (this.props.readOnly && !this.props.canExecute)
+                  } />
               )}
             </FormItem>
           </div>
@@ -2960,7 +3137,7 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
                 (this.props.readOnly && !this.props.canExecute) ||
                 (this.state.pipeline && this.props.detached)
               }
-              onChange={(e) => this.setState({startIdle: e.target.checked})}
+              onChange={(e) => this.setState({startIdle: e.target.checked}, this.formFieldsChanged)}
               checked={this.state.startIdle}>
               Start idle
             </Checkbox>
@@ -2969,40 +3146,44 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
           {
             !this.state.startIdle
               ? (
-              <Row>
-                <Col span={24}>
-                  <FormItem
-                    className={styles.formItemRow}
-                    required={!this.state.fireCloudMethodName}>
-                    {this.getSectionFieldDecorator(ADVANCED)('cmdTemplate',
-                      {
-                        rules: [{required: !this.state.fireCloudMethodName, message: 'Command template is required'}],
-                        initialValue: this.getDefaultValue('cmd_template')
-                      })(
-                      <Input
-                        disabled={
+                <Row>
+                  <Col span={24}>
+                    <FormItem
+                      className={styles.formItemRow}
+                      required={!this.state.fireCloudMethodName}>
+                      {this.getSectionFieldDecorator(ADVANCED)('cmdTemplate',
+                        {
+                          rules: [{
+                            required: !this.state.fireCloudMethodName,
+                            message: 'Command template is required'
+                          }],
+                          initialValue: this.getDefaultValue('cmd_template')
+                        }
+                      )(
+                        <Input
+                          disabled={
+                            (this.props.readOnly && !this.props.canExecute) ||
+                            (this.state.pipeline && this.props.detached)
+                          }
+                          className={styles.hiddenItem} />
+                      )}
+                      <CodeEditor
+                        ref={(editor) => { this.codeEditor = editor; }}
+                        readOnly={
+                          !!this.state.fireCloudMethodName ||
                           (this.props.readOnly && !this.props.canExecute) ||
                           (this.state.pipeline && this.props.detached)
                         }
-                        className={styles.hiddenItem} />
-                    )}
-                    <CodeEditor
-                      ref={editor => this.codeEditor = editor}
-                      readOnly={
-                        !!this.state.fireCloudMethodName ||
-                        (this.props.readOnly && !this.props.canExecute) ||
-                        (this.state.pipeline && this.props.detached)
-                      }
-                      className={styles.codeEditor}
-                      language="shell"
-                      onChange={this.cmdTemplateEditorValueChanged}
-                      lineWrapping
-                      defaultCode={this.getDefaultValue('cmd_template')}
-                    />
-                  </FormItem>
-                </Col>
-              </Row>
-            ) : undefined
+                        className={styles.codeEditor}
+                        language="shell"
+                        onChange={this.cmdTemplateEditorValueChanged}
+                        lineWrapping
+                        defaultCode={this.getDefaultValue('cmd_template')}
+                      />
+                    </FormItem>
+                  </Col>
+                </Row>
+              ) : undefined
           }
         </Row>
       </FormItem>
@@ -3019,6 +3200,7 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
     };
     if (this.codeEditor) {
       this.codeEditor.reset();
+      this.cmdTemplateValue = undefined;
     }
     this.resetState(keepPipeline);
   }
@@ -3147,11 +3329,15 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
         if (this.state.launchCluster && !this.state.autoScaledCluster) {
           const instanceType = this.getSectionFieldValue(EXEC_ENVIRONMENT)('type') ||
             this.getDefaultValue('instance_size');
-          descriptions.push(`${instanceType} ${ConfigureClusterDialog.getClusterDescription(this).toLowerCase()}`);
+          descriptions.push(
+            `${instanceType} ${ConfigureClusterDialog.getClusterDescription(this).toLowerCase()}`
+          );
         } else if (this.state.launchCluster && this.state.autoScaledCluster) {
           const instanceType = this.getSectionFieldValue(EXEC_ENVIRONMENT)('type') ||
             this.getDefaultValue('instance_size');
-          descriptions.push(`${instanceType} ${ConfigureClusterDialog.getClusterDescription(this).toLowerCase()}`);
+          descriptions.push(
+            `${instanceType} ${ConfigureClusterDialog.getClusterDescription(this).toLowerCase()}`
+          );
         } else {
           descriptions.push(this.getSectionFieldValue(EXEC_ENVIRONMENT)('type') ||
             this.getDefaultValue('instance_size'));
@@ -3163,14 +3349,16 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
         const isSpot = `${this.getSectionFieldValue(ADVANCED)('is_spot') ||
           this.getDefaultValue('is_spot')}` === 'true';
         descriptions.push(getSpotTypeName(isSpot, this.currentCloudRegionProvider));
-        const timeout = this.getSectionFieldValue(ADVANCED)('timeout') || this.getDefaultValue('timeout');
+        const timeout = this.getSectionFieldValue(ADVANCED)('timeout') ||
+          this.getDefaultValue('timeout');
         if (timeout && !isNaN(timeout)) {
           descriptions.push(`Timeout: ${timeout} min`);
         }
         if (this.state.startIdle) {
           descriptions.push('Start idle');
         } else {
-          let command = this.getSectionFieldValue(ADVANCED)('cmdTemplate') || this.getDefaultValue('cmd_template');
+          let command = this.getSectionFieldValue(ADVANCED)('cmdTemplate') ||
+            this.getDefaultValue('cmd_template');
           if (command) {
             if (command.length > 50) {
               command = `${command.substring(0, 50)}...`;
@@ -3204,27 +3392,27 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
         <Col span={24 - 2 * marginInCols}>
           <table style={{width: '100%'}}>
             <tbody>
-            <tr>
-              <td style={{width: '50%'}}>
-                <div
-                  style={{
-                    margin: '0 5px',
-                    verticalAlign: 'middle',
-                    height: 1,
-                    backgroundColor: '#ccc'
-                  }}>{'\u00A0'}</div>
-              </td>
-              <td style={{width: 1, whiteSpace: 'nowrap'}}><b>{text}</b></td>
-              <td style={{width: '50%'}}>
-                <div
-                  style={{
-                    margin: '0 5px',
-                    verticalAlign: 'middle',
-                    height: 1,
-                    backgroundColor: '#ccc'
-                  }}>{'\u00A0'}</div>
-              </td>
-            </tr>
+              <tr>
+                <td style={{width: '50%'}}>
+                  <div
+                    style={{
+                      margin: '0 5px',
+                      verticalAlign: 'middle',
+                      height: 1,
+                      backgroundColor: '#ccc'
+                    }}>{'\u00A0'}</div>
+                </td>
+                <td style={{width: 1, whiteSpace: 'nowrap'}}><b>{text}</b></td>
+                <td style={{width: '50%'}}>
+                  <div
+                    style={{
+                      margin: '0 5px',
+                      verticalAlign: 'middle',
+                      height: 1,
+                      backgroundColor: '#ccc'
+                    }}>{'\u00A0'}</div>
+                </td>
+              </tr>
             </tbody>
           </table>
         </Col>
@@ -3292,7 +3480,7 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
         const onChange = (e) => {
           const values = this.state[stateKey];
           values[conn.name] = e.target.value;
-          this.setState({[stateKey]: values});
+          this.setState({[stateKey]: values}, this.formFieldsChanged);
         };
         let value = defaultConnections[conn.name];
         if (this.state[stateKey][conn.name] !== undefined) {
@@ -3318,7 +3506,7 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
                           {error}
                         </Row>
                       </div>
-                  )
+                    )
                     : conn.name
                 }
                 trigger="hover">
@@ -3389,7 +3577,10 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
     const content = renderer && renderer(options);
     if (content) {
       return (
-        <Row type="flex" className={styles.formItemContainer} style={options ? options.containerStyle : undefined}>
+        <Row
+          type="flex"
+          className={styles.formItemContainer}
+          style={options ? options.containerStyle : undefined}>
           {content}
           <div className={styles.hintContainer}>
             {hint ? hints.renderHint(this.localizedStringWithSpotDictionaryFn, hint) : '\u00A0'}
@@ -3416,36 +3607,42 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
                       size="small"
                       id="remove-pipeline-configuration-button"
                       type="danger"
-                      onClick={() => this.props.onRemoveConfiguration && this.props.onRemoveConfiguration()}
+                      onClick={
+                        () => this.props.onRemoveConfiguration && this.props.onRemoveConfiguration()
+                      }
                       style={{verticalAlign: 'middle'}}>
                     Remove
-                  </Button>
-                ) : undefined
+                    </Button>
+                  ) : undefined
               }
               {
                 !this.props.currentConfigurationIsDefault && !this.props.readOnly
-                ? (
-                  <Button
-                    size="small"
-                    id="set-pipeline-configuration-as-default-button"
-                    onClick={() => this.props.onSetConfigurationAsDefault && this.props.onSetConfigurationAsDefault()}
-                    style={{verticalAlign: 'middle', marginLeft: 10}}>
-                    Set as default
-                  </Button>
-                ) : undefined
+                  ? (
+                    <Button
+                      size="small"
+                      id="set-pipeline-configuration-as-default-button"
+                      onClick={
+                        () => this.props.onSetConfigurationAsDefault &&
+                          this.props.onSetConfigurationAsDefault()
+                      }
+                      style={{verticalAlign: 'middle', marginLeft: 10}}>
+                      Set as default
+                    </Button>
+                  ) : undefined
               }
               {
                 !this.props.readOnly
-                ? (
-                  <Button
-                    size="small"
-                    id="save-pipeline-configuration-button"
-                    type="primary"
-                    htmlType="submit"
-                    style={{verticalAlign: 'middle', marginLeft: 10}}>
-                    Save
-                  </Button>
-                ) : undefined
+                  ? (
+                    <Button
+                      size="small"
+                      id="save-pipeline-configuration-button"
+                      disabled={!this.modified}
+                      type="primary"
+                      htmlType="submit"
+                      style={{verticalAlign: 'middle', marginLeft: 10}}>
+                      Save
+                    </Button>
+                  ) : undefined
               }
             </FormItem>
           </td>
@@ -3469,6 +3666,8 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
     };
     const renderFormTitle = () => {
       if (this.props.editConfigurationMode) {
+        const nameError =
+          'Name can contain only letters, digits, spaces, \'_\', \'-\', \'@\' and \'.\'.';
         return [
           <td key="name" style={{width: 40, whiteSpace: 'nowrap'}}>
             Name:
@@ -3486,12 +3685,13 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
                     },
                     {
                       pattern: /^[\da-zA-Z._\-@ ]+$/,
-                      message: 'Name can contain only letters, digits, spaces, \'_\', \'-\', \'@\' and \'.\'.'
+                      message: nameError
                     }
                   ],
                   initialValue: this.props.currentConfigurationName
-                })(
-                  <Input disabled={this.props.readOnly && !this.props.canExecute} />
+                }
+              )(
+                <Input disabled={this.props.readOnly && !this.props.canExecute} />
               )}
             </FormItem>
           </td>,
@@ -3523,7 +3723,7 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
                 onChange={configurationChange}
                 filterOption={
                   (input, option) =>
-                  option.props.value.toLowerCase().indexOf(input.toLowerCase()) >= 0} >
+                    option.props.value.toLowerCase().indexOf(input.toLowerCase()) >= 0} >
                 {
                   this.props.configurations.map(c => {
                     return (
@@ -3547,7 +3747,9 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
             pipelineVersion = this.props.version;
           }
         } else {
-          const dockerImageParts = (this.props.form.getFieldValue(`${EXEC_ENVIRONMENT}.dockerImage`) || '').split('/');
+          const dockerImageParts = (
+            this.props.form.getFieldValue(`${EXEC_ENVIRONMENT}.dockerImage`) || ''
+          ).split('/');
           if (dockerImageParts.length > 0) {
             pipelineName = dockerImageParts[dockerImageParts.length - 1].split(':')[0];
             pipelineVersion = dockerImageParts[dockerImageParts.length - 1].split(':')[1];
@@ -3562,10 +3764,13 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
               type="play-circle-o"
               style={{color: '#2282bf'}} />
             Launch <b id="launch-form-pipeline-name">{pipelineName}</b> {
-            pipelineVersion && <span id="launch-form-pipeline-version">{pipelineVersion}</span>}.
+              pipelineVersion && <span id="launch-form-pipeline-version">{pipelineVersion}</span>}.
           </td>,
           ...configuration,
-          <td key="estimated price" className={styles.itemHeader} style={{width: 1, whiteSpace: 'nowrap'}}>
+          <td
+            key="estimated price"
+            className={styles.itemHeader}
+            style={{width: 1, whiteSpace: 'nowrap'}}>
             {this.renderEstimatedPriceInfo()}
           </td>
         ];
@@ -3583,7 +3788,7 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
             </tbody>
           </table>
           {
-              this.props.errors && this.props.errors.length > 0
+            this.props.errors && this.props.errors.length > 0
               ? (
                 <Row>
                   <Alert
@@ -3598,10 +3803,12 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
                     } />
                   <br />
                 </Row>)
-                : undefined
-            }
+              : undefined
+          }
           {
-              this.props.pipeline && !roleModel.executeAllowed(this.props.pipeline) && !this.props.detached
+            this.props.pipeline &&
+            !roleModel.executeAllowed(this.props.pipeline) &&
+            !this.props.detached
               ? (
                 <Row>
                   <Alert
@@ -3610,84 +3817,90 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
                   <br />
                 </Row>
               ) : undefined
-            }
-            <Collapse
-              bordered={false}
-              onChange={(tabs) => this.setState({openedPanels: tabs})}
-              activeKey={this.state.openedPanels}>
-              <Collapse.Panel
-                id="launch-pipeline-exec-environment-panel"
-                key={EXEC_ENVIRONMENT}
-                className={styles.section}
-                header={this.getPanelHeader(EXEC_ENVIRONMENT)}>
-                <Row type="flex" justify="space-between">
-                  <div
-                    className={styles.settingsContainer}
-                    style={{padding: 5}}>
-                    <div className={styles.settingsContent}>
-                      {this.renderFormItemRow(this.renderPipelineSelection, hints.pipelineHint)}
-                      {this.renderFormItemRow(this.renderExecutionEnvironmentSelection)}
-                      {this.renderFormItemRow(this.renderDockerImageFormItem, hints.dockerImageHint)}
-                      {this.renderFormItemRow(this.renderInstanceTypeSelection, hints.instanceTypeHint)}
-                      {this.renderFormItemRow(this.renderDiskFormItem, hints.diskHint)}
-                      {
-                        !this.state.fireCloudMethodName && !this.state.isDts &&
-                        <Row type="flex" justify="end" style={{paddingRight: 30, marginBottom: 10}}>
-                          <a
-                            onClick={this.openConfigureClusterDialog}
-                            style={{color: '#777', textDecoration: 'underline'}}>
-                            <Icon type="setting" /> {ConfigureClusterDialog.getConfigureClusterButtonDescription(this)}
-                          </a>
-                        </Row>
-                      }
-                      <ConfigureClusterDialog
-                        instanceName={this.getSectionFieldValue(EXEC_ENVIRONMENT)('type')}
-                        launchCluster={this.state.launchCluster}
-                        autoScaledCluster={this.state.autoScaledCluster}
-                        gridEngineEnabled={this.state.gridEngineEnabled}
-                        nodesCount={this.state.nodesCount}
-                        maxNodesCount={this.state.maxNodesCount || 1}
-                        onClose={this.closeConfigureClusterDialog}
-                        onChange={this.onChangeClusterConfiguration}
-                        visible={this.state.configureClusterDialogVisible}
-                        disabled={this.props.readOnly && !this.props.canExecute} />
-                      {this.renderFormItemRow(this.renderAWSRegionSelection, hints.awsRegionHint)}
-                      {this.renderFormItemRow(this.renderCoresFormItem)}
-                    </div>
+          }
+          <Collapse
+            bordered={false}
+            onChange={(tabs) => this.setState({openedPanels: tabs})}
+            activeKey={this.state.openedPanels}>
+            <Collapse.Panel
+              id="launch-pipeline-exec-environment-panel"
+              key={EXEC_ENVIRONMENT}
+              className={styles.section}
+              header={this.getPanelHeader(EXEC_ENVIRONMENT)}>
+              <Row type="flex" justify="space-between">
+                <div
+                  className={styles.settingsContainer}
+                  style={{padding: 5}}>
+                  <div className={styles.settingsContent}>
+                    {this.renderFormItemRow(this.renderPipelineSelection, hints.pipelineHint)}
+                    {this.renderFormItemRow(this.renderExecutionEnvironmentSelection)}
+                    {this.renderFormItemRow(this.renderDockerImageFormItem, hints.dockerImageHint)}
+                    {
+                      this.renderFormItemRow(
+                        this.renderInstanceTypeSelection,
+                        hints.instanceTypeHint
+                      )
+                    }
+                    {this.renderFormItemRow(this.renderDiskFormItem, hints.diskHint)}
+                    {
+                      !this.state.fireCloudMethodName && !this.state.isDts &&
+                      <Row type="flex" justify="end" style={{paddingRight: 30, marginBottom: 10}}>
+                        <a
+                          onClick={this.openConfigureClusterDialog}
+                          style={{color: '#777', textDecoration: 'underline'}}>
+                          <Icon type="setting" />
+                          {ConfigureClusterDialog.getConfigureClusterButtonDescription(this)}
+                        </a>
+                      </Row>
+                    }
+                    <ConfigureClusterDialog
+                      instanceName={this.getSectionFieldValue(EXEC_ENVIRONMENT)('type')}
+                      launchCluster={this.state.launchCluster}
+                      autoScaledCluster={this.state.autoScaledCluster}
+                      gridEngineEnabled={this.state.gridEngineEnabled}
+                      nodesCount={this.state.nodesCount}
+                      maxNodesCount={this.state.maxNodesCount || 1}
+                      onClose={this.closeConfigureClusterDialog}
+                      onChange={this.onChangeClusterConfiguration}
+                      visible={this.state.configureClusterDialogVisible}
+                      disabled={this.props.readOnly && !this.props.canExecute} />
+                    {this.renderFormItemRow(this.renderAWSRegionSelection, hints.awsRegionHint)}
+                    {this.renderFormItemRow(this.renderCoresFormItem)}
                   </div>
-                  <div
-                    className={styles.settingsContainer}
-                    style={{padding: 5}}>
-                    <div className={styles.settingsContent}>
-                      {
-                        this.renderExecutionEnvironmentSummary()
-                      }
-                    </div>
+                </div>
+                <div
+                  className={styles.settingsContainer}
+                  style={{padding: 5}}>
+                  <div className={styles.settingsContent}>
+                    {
+                      this.renderExecutionEnvironmentSummary()
+                    }
                   </div>
-                </Row>
-              </Collapse.Panel>
-              <Collapse.Panel
-                id="launch-pipeline-advanced-panel"
-                key={ADVANCED}
-                className={styles.section}
-                header={this.getPanelHeader(ADVANCED)}>
-                {this.renderPriceTypeSelection()}
-                {this.renderDisableAutoPauseFormItem()}
-                {this.renderPrettyUrlFormItem()}
-                {this.renderTimeoutFormItem()}
-                {this.renderLimitMountsFormItem()}
-                {this.renderCmdTemplateFormItem()}
-                {this.renderParameters(true, SYSTEM_PARAMETERS)}
-              </Collapse.Panel>
-              <Collapse.Panel
-                id="launch-pipeline-parameters-panel"
-                key={PARAMETERS}
-                className={styles.section}
-                header={this.getPanelHeader(PARAMETERS)}>
-                {this.renderParameters(false, PARAMETERS)}
-                {this.isFireCloudSelected && this.renderFireCloudConfigConnectionsList()}
-              </Collapse.Panel>
-            </Collapse>
+                </div>
+              </Row>
+            </Collapse.Panel>
+            <Collapse.Panel
+              id="launch-pipeline-advanced-panel"
+              key={ADVANCED}
+              className={styles.section}
+              header={this.getPanelHeader(ADVANCED)}>
+              {this.renderPriceTypeSelection()}
+              {this.renderDisableAutoPauseFormItem()}
+              {this.renderPrettyUrlFormItem()}
+              {this.renderTimeoutFormItem()}
+              {this.renderLimitMountsFormItem()}
+              {this.renderCmdTemplateFormItem()}
+              {this.renderParameters(true, SYSTEM_PARAMETERS)}
+            </Collapse.Panel>
+            <Collapse.Panel
+              id="launch-pipeline-parameters-panel"
+              key={PARAMETERS}
+              className={styles.section}
+              header={this.getPanelHeader(PARAMETERS)}>
+              {this.renderParameters(false, PARAMETERS)}
+              {this.isFireCloudSelected && this.renderFireCloudConfigConnectionsList()}
+            </Collapse.Panel>
+          </Collapse>
         </div>
         <BucketBrowser
           multiple
@@ -3712,17 +3925,20 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
           fireCloudMethodConfiguration={this.state.fireCloudMethodConfiguration}
           fireCloudMethodConfigurationSnapshot={this.state.fireCloudMethodConfigurationSnapshot}
         />
-        {this.state.currentProjectId ? <MetadataBrowser
-            multiple={false}
-            readOnly={true}
-            onCancel={this.closeMetadataBrowser}
-            onSelect={this.selectMetadataConfirm}
-            visible={this.state.metadataBrowserVisible}
-            initialFolderId={this.state.currentProjectId}
-            rootEntityId={this.state.rootEntityId}
-            currentMetadataEntity={this.state.currentMetadataEntity.slice()}
-          />
-          : undefined
+        {
+          this.state.currentProjectId
+            ? (
+              <MetadataBrowser
+                multiple={false}
+                readOnly
+                onCancel={this.closeMetadataBrowser}
+                onSelect={this.selectMetadataConfirm}
+                visible={this.state.metadataBrowserVisible}
+                initialFolderId={this.state.currentProjectId}
+                rootEntityId={this.state.rootEntityId}
+                currentMetadataEntity={this.state.currentMetadataEntity.slice()}
+              />
+            ) : undefined
         }
       </Form>
     );
@@ -3738,14 +3954,6 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
   };
 
   componentDidMount () {
-    // if (this.props.allowedInstanceTypes) {
-    //   if (this.props.parameters && this.props.parameters.is_spot !== undefined &&
-    //     this.props.parameters.is_spot !== null) {
-    //     this.props.allowedInstanceTypes.setIsSpot(`${this.props.parameters.is_spot}` === 'true');
-    //   } else {
-    //     this.props.allowedInstanceTypes.setIsSpot(`${this.props.defaultPriceTypeIsSpot}` === 'true');
-    //   }
-    // }
     this.reset(true);
     this.evaluateEstimatedPrice({});
     this.prepare();
@@ -3755,11 +3963,13 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
         this.loadFireCloudConfigurations();
       }
     }
+    this.props.onInitialized && this.props.onInitialized(this);
   }
 
   componentDidUpdate (prevProps, prevState) {
     if (this.state.fireCloudMethodName &&
       this.state.execEnvSelectValue !== FIRE_CLOUD_ENVIRONMENT) {
+      // eslint-disable-next-line
       this.setState({execEnvSelectValue: FIRE_CLOUD_ENVIRONMENT});
     }
     if (prevState.dtsId !== this.state.dtsId && this.state.dtsId) {
@@ -3831,7 +4041,8 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
     }
     if (nextProps.isDetachedConfiguration &&
       !nextProps.selectedPipelineParametersIsLoading &&
-      this.props.selectedPipelineParametersIsLoading !== nextProps.selectedPipelineParametersIsLoading
+      this.props.selectedPipelineParametersIsLoading !==
+      nextProps.selectedPipelineParametersIsLoading
     ) {
       this.rebuildParameters = {
         [PARAMETERS]: true,
@@ -3871,5 +4082,49 @@ export default class LaunchPipelineForm extends localization.LocalizedReactCompo
       });
     }
   }
+}
 
+export default class extends React.Component {
+  launchForm;
+
+  onInitialized = (form) => {
+    this.launchForm = form;
+  };
+
+  onValuesChange = (props, fields) => {
+    if (fields &&
+      fields.exec &&
+      fields.exec.cloudRegionId &&
+      props.allowedInstanceTypes) {
+      props.allowedInstanceTypes.setRegionId(+fields.exec.cloudRegionId);
+    }
+    if (fields &&
+      fields[ADVANCED] &&
+      fields[ADVANCED].is_spot !== undefined &&
+      fields[ADVANCED].is_spot !== null &&
+      props.allowedInstanceTypes) {
+      props.allowedInstanceTypes.setIsSpot(`${fields[ADVANCED].is_spot}` === 'true');
+    }
+  };
+
+  onFieldsChange = (props, fields) => {
+    if (this.launchForm &&
+      this.launchForm.formFieldsChanged &&
+      Object.values(fields).filter(v => !v.dirty).length > 0) {
+      this.launchForm.formFieldsChanged();
+    }
+  };
+
+  launchPipelineForm = Form.create({
+    onValuesChange: this.onValuesChange,
+    onFieldsChange: this.onFieldsChange
+  })(LaunchPipelineForm);
+
+  render () {
+    const LaunchForm = this.launchPipelineForm;
+    const props = this.props;
+    return (
+      <LaunchForm {...props} onInitialized={this.onInitialized} />
+    );
+  }
 }

--- a/client/src/components/pipelines/launch/form/utilities/launch-form-modified-state.js
+++ b/client/src/components/pipelines/launch/form/utilities/launch-form-modified-state.js
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  ADVANCED,
+  EXEC_ENVIRONMENT,
+  PARAMETERS,
+  SYSTEM_PARAMETERS
+} from './launch-form-sections';
+import {
+  autoScaledClusterEnabled,
+  CP_CAP_AUTOSCALE_WORKERS,
+  getSkippedSystemParametersList,
+  gridEngineEnabled
+} from './launch-cluster';
+import {LIMIT_MOUNTS_PARAMETER} from '../LimitMountsInput';
+
+function modified (form, parameters, formName, parametersName, defaultValue) {
+  return `${form.getFieldValue(formName) || defaultValue}` !==
+    `${parameters[parametersName] || defaultValue}`;
+}
+
+function clusterModified (parameters, state) {
+  const autoScaledCluster = autoScaledClusterEnabled(parameters.parameters);
+  const gridEngineEnabledValue = gridEngineEnabled(parameters.parameters);
+  const initial = {
+    autoScaledCluster,
+    gridEngineEnabled: gridEngineEnabledValue,
+    launchCluster: +(parameters.node_count) > 0 || autoScaledCluster,
+    nodesCount: +(parameters.node_count),
+    maxNodesCount: parameters.parameters && parameters.parameters[CP_CAP_AUTOSCALE_WORKERS]
+      ? +(parameters.parameters[CP_CAP_AUTOSCALE_WORKERS].value)
+      : 0
+  };
+  return initial.autoScaledCluster !== state.autoScaledCluster ||
+    initial.gridEngineEnabled !== state.gridEngineEnabled ||
+    initial.launchCluster !== state.launchCluster ||
+    `${initial.nodesCount || 0}` !== `${state.nodesCount || 0}` ||
+    `${initial.maxNodesCount || 0}` !== `${state.maxNodesCount || 0}`;
+}
+
+function pipelineCheck (props, state) {
+  const {
+    pipeline,
+    version,
+    pipelineConfiguration,
+    fireCloudMethod
+  } = props;
+  const initial = {
+    pipeline: pipeline ? +pipeline.id : null,
+    version,
+    pipelineConfiguration,
+    fireCloudMethodName: fireCloudMethod
+      ? fireCloudMethod.name : null,
+    fireCloudMethodNamespace: fireCloudMethod
+      ? fireCloudMethod.namespace : null,
+    fireCloudMethodSnapshot: fireCloudMethod
+      ? fireCloudMethod.snapshot : null,
+    fireCloudMethodConfiguration: fireCloudMethod
+      ? fireCloudMethod.configuration : null,
+    fireCloudMethodConfigurationSnapshot: fireCloudMethod
+      ? fireCloudMethod.configurationSnapshot : null
+  };
+  const current = {
+    pipeline: state.pipeline ? +state.pipeline.id : null,
+    version: state.version,
+    pipelineConfiguration: state.pipelineConfiguration,
+    fireCloudMethodName: state.fireCloudMethodName,
+    fireCloudMethodNamespace: state.fireCloudMethodNamespace,
+    fireCloudMethodSnapshot: state.fireCloudMethodSnapshot,
+    fireCloudMethodConfiguration: state.fireCloudMethodConfiguration,
+    fireCloudMethodConfigurationSnapshot: state.fireCloudMethodConfigurationSnapshot,
+    fireCloudInputsLength: Object.keys(state.fireCloudInputs).length,
+    fireCloudOutputsLength: Object.keys(state.fireCloudOutputs).length
+  };
+  return (
+    initial.pipeline !== current.pipeline ||
+    initial.version !== current.version ||
+    initial.pipelineConfiguration !== current.pipelineConfiguration ||
+    initial.fireCloudMethodName !== current.fireCloudMethodName ||
+    initial.fireCloudMethodNamespace !== current.fireCloudMethodNamespace ||
+    initial.fireCloudMethodSnapshot !== current.fireCloudMethodSnapshot ||
+    initial.fireCloudMethodConfiguration !== current.fireCloudMethodConfiguration ||
+    initial.fireCloudMethodConfigurationSnapshot !== current.fireCloudMethodConfigurationSnapshot ||
+    current.fireCloudInputsLength > 0 ||
+    current.fireCloudInputsLength > 0
+  );
+}
+
+function executionEnvironmentCheck (props, state, {execEnvSelectValue}) {
+  const {
+    fireCloudMethod
+  } = props;
+  const initial = {
+    isDts: !!fireCloudMethod,
+    execEnvSelectValue
+  };
+  return initial.isDts !== state.isDts ||
+    initial.execEnvSelectValue !== state.execEnvSelectValue;
+}
+
+function spotOnDemandCheck (form, {spotInitialValue}) {
+  return `${form.getFieldValue(`${ADVANCED}.is_spot`)}` !== `${spotInitialValue}`;
+}
+
+function autoPauseCheck (form, state) {
+  return `${form.getFieldValue(`${ADVANCED}.is_spot`)}` === 'false' && !state.autoPause;
+}
+
+function limitMountsCheck (form, parameters) {
+  const getDefaultValue = () => {
+    if (parameters.parameters && parameters.parameters[LIMIT_MOUNTS_PARAMETER]) {
+      return parameters.parameters[LIMIT_MOUNTS_PARAMETER].value;
+    }
+    return null;
+  };
+  const initial = getDefaultValue();
+  return form.getFieldValue(`${ADVANCED}.limitMounts`) !== initial;
+}
+function cmdTemplateCheck (state, parameters, {cmdTemplateValue}) {
+  let code = cmdTemplateValue;
+  if (state.startIdle) {
+    code = 'sleep infinity';
+  }
+  if (code === undefined) {
+    return false;
+  }
+  return code !== parameters['cmd_template'];
+}
+
+function parametersCheck (form, parameters, state) {
+  const formParams = form.getFieldValue(PARAMETERS);
+  const formSystemParams = form.getFieldValue(SYSTEM_PARAMETERS);
+  const formValue = {};
+  if (formParams && formParams.keys) {
+    for (let i = 0; i < formParams.keys.length; i++) {
+      const key = formParams.keys[i];
+      if (!formParams.params || !formParams.params.hasOwnProperty(key)) {
+        continue;
+      }
+      const parameter = formParams.params[key];
+      if (parameter && parameter.name && parameter.value) {
+        formValue[parameter.name] = parameter.value;
+      }
+    }
+  }
+  if (formSystemParams && formSystemParams.keys) {
+    for (let i = 0; i < formSystemParams.keys.length; i++) {
+      const key = formSystemParams.keys[i];
+      if (!formSystemParams.params || !formSystemParams.params.hasOwnProperty(key)) {
+        continue;
+      }
+      const parameter = formSystemParams.params[key];
+      if (parameter && parameter.name && parameter.value) {
+        formValue[parameter.name] = parameter.value;
+      }
+    }
+  }
+  const initialValue = Object.keys(parameters.parameters || {})
+    .filter(key => [
+      LIMIT_MOUNTS_PARAMETER,
+      ...getSkippedSystemParametersList({state})
+    ].indexOf(key) === -1)
+    .map(key => ({key, value: parameters.parameters[key].value}))
+    .reduce((r, c) => ({...r, [c.key]: c.value}), {});
+  const check = (source, test) => {
+    const sourceEntries = Object.entries(source);
+    for (let i = 0; i < sourceEntries.length; i++) {
+      const [name, value] = sourceEntries[i];
+      if (!test.hasOwnProperty(name) || `${test[name]}` !== `${value}`) {
+        return true;
+      }
+    }
+    return false;
+  };
+  return Object.keys(formValue).length !== Object.keys(initialValue).length ||
+    check(formValue, initialValue) ||
+    check(initialValue, formValue);
+}
+
+export default function (props, state, options) {
+  const {form, parameters} = props;
+  const {
+    defaultCloudRegionId
+  } = options;
+  // configuration name check
+  return modified(form, props, 'configuration.name', 'currentConfigurationName') ||
+    // pipeline check
+    pipelineCheck(props, state) ||
+    // execution environment check
+    executionEnvironmentCheck(props, state, options) ||
+    // instance type check
+    modified(form, parameters, `${EXEC_ENVIRONMENT}.type`, 'instance_size') ||
+    // docker image check
+    modified(form, parameters, `${EXEC_ENVIRONMENT}.dockerImage`, 'docker_image') ||
+    // disk check
+    modified(form, parameters, `${EXEC_ENVIRONMENT}.disk`, 'instance_disk') ||
+    // cluster state check
+    clusterModified(parameters, state) ||
+    // cloud region check
+    modified(
+      form,
+      parameters,
+      `${EXEC_ENVIRONMENT}.cloudRegionId`,
+      'cloudRegionId',
+      defaultCloudRegionId
+    ) ||
+    // cores number check
+    modified(form, parameters, `${EXEC_ENVIRONMENT}.coresNumber`, 'coresNumber') ||
+    // spot/on-demand check
+    spotOnDemandCheck(form, options) ||
+    // auto-pause check
+    autoPauseCheck(form, state) ||
+    // pretty url check
+    modified(form, parameters, `${ADVANCED}.prettyUrl`, 'prettyUrl') ||
+    // timeout check
+    modified(form, parameters, `${ADVANCED}.timeout`, 'timeout') ||
+    // limit mounts check
+    limitMountsCheck(form, parameters) ||
+    // cmd template check
+    cmdTemplateCheck(state, parameters, options) ||
+    // check general parameters
+    parametersCheck(form, parameters);
+}

--- a/client/src/components/pipelines/launch/form/utilities/launch-form-sections.js
+++ b/client/src/components/pipelines/launch/form/utilities/launch-form-sections.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const EXEC_ENVIRONMENT = 'exec';
+export const ADVANCED = 'advanced';
+export const PARAMETERS = 'parameters';
+export const SYSTEM_PARAMETERS = 'systemParameters';


### PR DESCRIPTION
This PR implements some improvements for `detached` and `pipeline` configuration forms:
- `save` button is disabled if there are no changes;
- **GUI** will warn user on any navigation attempt if there are unsaved changes in configuration.
