### PR TITLE
Use implicit directories capability in gcsfuse

### DIFF
--- a/workflows/pipe-common/scripts/mount_storage.py
+++ b/workflows/pipe-common/scripts/mount_storage.py
@@ -422,7 +422,7 @@ class GCPMounter(StorageMounter):
         if not params:
             return ""
         return 'gcsfuse -o {permissions} --key-file {credentials} --temp-dir {tmp_dir} ' \
-               '--dir-mode {mask} --file-mode {mask} {path} {mount}'.format(**params)
+               '--dir-mode {mask} --file-mode {mask} --implicit-dirs {path} {mount}'.format(**params)
 
     def _get_credentials(self, storage):
         account_region = os.getenv('CP_ACCOUNT_REGION_{}'.format(storage.region_id))


### PR DESCRIPTION
Resolves #445.

The pull request enables implicit directories support in google storage mounts by default. See original issue for more information.

From now on listing and copy operations work fine for implicit directories (e.g. created using GUI). Nevertheless some operations on such directories fail. F.e. `mv` and `rm` operations will end up with the following error message.
```
rm -r /cloud-data/storage/implicit-folder
    rm: cannot remove 'storage/implicit-folder': No such file or directory
```