### PR TITLE
GCP nodeup script changes

### DIFF
--- a/workflows/pipe-common/pipeline/autoscaling/awsprovider.py
+++ b/workflows/pipe-common/pipeline/autoscaling/awsprovider.py
@@ -130,9 +130,6 @@ class AWSInstanceProvider(AbstractInstanceProvider):
             utils.pipe_log('No existing instance found for RunID {}\n-'.format(run_id))
         return ins_id, ins_ip
 
-    def find_nodes_with_run_id(self, run_id):
-        return [self.find_instance(run_id)]
-
     def terminate_instance(self, instance_id):
         if not instance_id or len(instance_id) == 0:
             utils.pipe_log('[ERROR] None or empty string specified when calling terminate_instance, nothing will be done')

--- a/workflows/pipe-common/pipeline/autoscaling/cloudprovider.py
+++ b/workflows/pipe-common/pipeline/autoscaling/cloudprovider.py
@@ -44,4 +44,5 @@ class AbstractInstanceProvider(object):
         pass
 
     def find_nodes_with_run_id(self, run_id):
-        pass
+        instance = self.find_instance(run_id)
+        return [instance] if instance is not None else []

--- a/workflows/pipe-common/pipeline/autoscaling/gcpprovider.py
+++ b/workflows/pipe-common/pipeline/autoscaling/gcpprovider.py
@@ -228,9 +228,6 @@ class GCPInstanceProvider(AbstractInstanceProvider):
 
         self.__wait_for_operation(delete['name'])
 
-    def find_nodes_with_run_id(self, run_id):
-        return [self.find_instance(run_id)]
-
     def terminate_instance_by_ip_or_name(self, internal_ip, node_name):
         items = self.__filter_instances("")
         for instance in items:


### PR DESCRIPTION
this PR fixes bug when nodeup script tries to delete instance without instance id in a catch clause.
It could happen when script fails on a very start and no one real instance was run, in this case method find_instance_by_run_id will return `None` as instance name and it will be passed to `terminate_instance` method  