### PR TITLE
Introduce storage mounts data transfer restrictor

### DIFF
--- a/deploy/contents/install/preferences/launch.env.properties.json
+++ b/deploy/contents/install/preferences/launch.env.properties.json
@@ -2,6 +2,7 @@
     "variables": {
         "CP_CLUSTER_NAME": "CLOUD_PIPELINE",
         "CP_RESTRICTED_PACKAGES": "nvidia-",
-        "CP_RESTRICTING_PACKAGE_MANAGERS": "apt,apt-get,aptitude,yum,pip,pip2,pip3"
+        "CP_RESTRICTING_PACKAGE_MANAGERS": "apt,apt-get,aptitude,yum,pip,pip2,pip3",
+        "CP_ALLOWED_MOUNT_TRANSFER_SIZE": "50"
     }
 }

--- a/scripts/pipeline-launch/launch.sh
+++ b/scripts/pipeline-launch/launch.sh
@@ -417,28 +417,29 @@ function create_sys_dir {
 }
 
 function initialise_restrictors {
-    RESTRICTING_COMMANDS="$1"
-    RESTRICTOR="$2"
-    RESTRICTORS_BIN="$3"
-    IFS=',' read -r -a RESTRICTING_COMMANDS_LIST <<< "$RESTRICTING_COMMANDS"
+    local _RESTRICTING_COMMANDS="$1"
+    local _RESTRICTOR="$2"
+    local _RESTRICTORS_BIN="$3"
+    IFS=',' read -r -a RESTRICTING_COMMANDS_LIST <<< "$_RESTRICTING_COMMANDS"
     for COMMAND in "${RESTRICTING_COMMANDS_LIST[@]}"
     do
         COMMAND_PATH=$(command -v "$COMMAND")
         if [[ "$?" == 0 ]]
         then
-            COMMAND_WRAPPER_PATH="$RESTRICTORS_BIN/$COMMAND"
+            COMMAND_WRAPPER_PATH="$_RESTRICTORS_BIN/$COMMAND"
             COMMAND_PERMISSIONS=$(stat -c %a "$COMMAND_PATH")
             if [[ "$?" == 0 ]]
             then
-                echo "$COMMON_REPO_DIR/shell/$RESTRICTOR \"$COMMAND_PATH\" \"\$@\"" > "$COMMAND_WRAPPER_PATH"
+                echo "$COMMON_REPO_DIR/shell/$_RESTRICTOR \"$COMMAND_PATH\" \"\$@\"" > "$COMMAND_WRAPPER_PATH"
                 chmod "$COMMAND_PERMISSIONS" "$COMMAND_WRAPPER_PATH"
             fi
         fi
     done
 }
 
-function list_fuse_mounts() {
-    echo $(df -T | awk '$2 == "fuse"' | awk '{ print $7 }')
+function list_storage_mounts() {
+    local _MOUNT_ROOT="$1"
+    echo $(df -T | awk '$2 == "fuse"' | awk '{ print $7 }' | grep "^$_MOUNT_ROOT")
 }
 
 ######################################################
@@ -1108,7 +1109,7 @@ initialise_restrictors "$CP_RESTRICTING_PACKAGE_MANAGERS" "package_manager_restr
 
 if [[ "$CP_ALLOWED_MOUNT_TRANSFER_SIZE" ]]
 then
-    MOUNTED_PATHS=$(list_fuse_mounts)
+    MOUNTED_PATHS=$(list_storage_mounts "$DATA_STORAGE_MOUNT_ROOT")
     initialise_restrictors "cp,mv" "transfer_restrictor \"$MOUNTED_PATHS\" \"$DATA_STORAGE_MOUNT_ROOT\"" "$CP_USR_BIN"
 fi
 

--- a/workflows/pipe-common/shell/package_manager_restrictor
+++ b/workflows/pipe-common/shell/package_manager_restrictor
@@ -64,7 +64,7 @@ then
     echo "##   within Cloud Pipeline run container. This may lead to an unusable docker       ##"
     echo "##   image, if committed (i.e. image will not be able to start).                    ##"
     echo "##                                                                                  ##"
-    echo "##   Please refer to the following GitHub issue to for the details:                 ##"
+    echo "##   Please refer to the following GitHub issue for the details:                    ##"
     echo "##   https://github.com/epam/cloud-pipeline/issues/158                              ##"
     echo "##                                                                                  ##"
     echo "######################################################################################"

--- a/workflows/pipe-common/shell/transfer_restrictor
+++ b/workflows/pipe-common/shell/transfer_restrictor
@@ -54,36 +54,85 @@ function has_prefix() {
     return 1
 }
 
+function resolve_sources_and_destination() {
+    _FORWARDING_ARGUMENTS=($1)
+    DESTINATION=""
+    SOURCES=()
+    for INDEX in "${!_FORWARDING_ARGUMENTS[@]}"
+    do
+        # TODO 09.07.19: Filter out all non-source or non-destination positional arguments.
+        ARGUMENT="${_FORWARDING_ARGUMENTS[INDEX]}"
+        if [[ "$ARGUMENT" == "-t" ]]
+        then
+            NEXT_INDEX=$((INDEX + 1))
+            NEXT_ARGUMENT="${_FORWARDING_ARGUMENTS[NEXT_INDEX]}"
+            DESTINATION=$(resolve_symlinks "$NEXT_ARGUMENT")
+        elif [[ "$ARGUMENT" != -* ]]
+        then
+            RESOLVED_ARGUMENT=$(resolve_symlinks "$ARGUMENT")
+            if [[ "$RESOLVED_ARGUMENT" != "$DESTINATION" ]]
+            then
+                SOURCES+=("$RESOLVED_ARGUMENT")
+            fi
+        fi
+    done
+    if (( "${#SOURCES[@]}" ))
+    then
+        if [[ -z "$DESTINATION" ]]
+        then
+            DESTINATION="${SOURCES[${#SOURCES[@]}-1]}"
+            unset "SOURCES[${#SOURCES[@]}-1]"
+        fi
+        echo "${SOURCES[@]} $DESTINATION"
+    fi
+}
+
 function allowed_transfer() {
-    _FORWARDING_ARGUMENTS="$1"
-    _ALLOWED_TRANSFER_SIZE="$2"
-    _MOUNTED_PATHS="$3"
-    if [[ -z "$_ALLOWED_TRANSFER_SIZE" ]] || [[ -z "$_MOUNTED_PATHS" ]]
+    _SOURCES=($1)
+    _DESTINATION="$2"
+    _ALLOWED_TRANSFER_SIZE="$3"
+    _MOUNTED_PATHS="$4"
+    if [[ -z "$_SOURCES" ]] \
+    || [[ -z "$_DESTINATION" ]] \
+    || [[ -z "$_ALLOWED_TRANSFER_SIZE" ]] \
+    || [[ -z "$_MOUNTED_PATHS" ]]
     then
         return 0
     fi
 
-    _FORWARDING_ARGUMENTS=($_FORWARDING_ARGUMENTS)
-    ARGUMENTS_NUMBER="${#_FORWARDING_ARGUMENTS[@]}"
-    SOURCE_ARGUMENT_INDEX=$((ARGUMENTS_NUMBER - 2))
-    DESTINATION_ARGUMENT_INDEX=$((ARGUMENTS_NUMBER - 1))
-    SOURCE="${_FORWARDING_ARGUMENTS[SOURCE_ARGUMENT_INDEX]}"
-    DESTINATION="${_FORWARDING_ARGUMENTS[DESTINATION_ARGUMENT_INDEX]}"
-    if [[ -f "$SOURCE" ]] || [[ -d "$SOURCE" ]]
-    then
-        SOURCE_SIZE=$(get_size "$SOURCE")
-        if (( SOURCE_SIZE > _ALLOWED_TRANSFER_SIZE ))
+    RESTRICTED_TRANSFER_SIZE=""
+    for SOURCE in "${_SOURCES[@]}"
+    do
+        if [[ -f "$SOURCE" ]] || [[ -d "$SOURCE" ]]
         then
-            RESOLVED_SOURCE=$(resolve_symlinks "$SOURCE")
-            RESOLVED_DESTINATION=$(resolve_symlinks "$DESTINATION")
-            if has_prefix "$RESOLVED_SOURCE" "$_MOUNTED_PATHS" \
-                || has_prefix "$RESOLVED_DESTINATION" "$_MOUNTED_PATHS"
+            SOURCE_SIZE=$(get_size "$SOURCE")
+            if (( SOURCE_SIZE > _ALLOWED_TRANSFER_SIZE ))
             then
-                return 1
+                RESTRICTED_TRANSFER_SIZE="$SOURCE_SIZE"
+                if has_prefix "$SOURCE" "$_MOUNTED_PATHS"
+                then
+                    return 1
+                fi
             fi
         fi
+    done
+
+    if [[ "$RESTRICTED_TRANSFER_SIZE" ]]
+    then
+        if has_prefix "$_DESTINATION" "$_MOUNTED_PATHS"
+        then
+            return 1
+        fi
     fi
+
     return 0
+}
+
+function replace_all() {
+    _STRING="$1"
+    _PATTERN="$2"
+    _REPLACEMENT="$3"
+    echo "$_STRING" | sed "s/$_PATTERN/$_REPLACEMENT/"
 }
 
 MOUNTED_PATHS="$1"
@@ -91,24 +140,36 @@ MOUNT_ROOT="$2"
 UNDERLYING_TRANSFER_COMMAND="$3"
 shift 3 # removes first three arguments from the arguments list
 FORWARDING_ARGUMENTS="$@"
-
 ALLOWED_TRANSFER_SIZE="$CP_ALLOWED_MOUNT_TRANSFER_SIZE"
 
-if ! allowed_transfer "$FORWARDING_ARGUMENTS" "$ALLOWED_TRANSFER_SIZE" "$MOUNTED_PATHS"
+SOURCES_AND_DESTINATION=($(resolve_sources_and_destination "$FORWARDING_ARGUMENTS"))
+if (( "${#SOURCES_AND_DESTINATION[@]}" ))
 then
-    UNDERLYING_TRANSFER_COMMAND_NAME=$(basename "$UNDERLYING_TRANSFER_COMMAND")
-    ESCAPED_MOUNT_ROOT=$(escape_slashes "$MOUNT_ROOT/")
-    STORAGE_PREFIX=$(escape_slashes "cp://")
-    SUBSTITUTED_FORWARDING_ARGUMENTS=$(echo "$FORWARDING_ARGUMENTS" | sed "s/$ESCAPED_MOUNT_ROOT/$STORAGE_PREFIX/")
-    cat 1>&2 <<EOF
+    DESTINATION="${SOURCES_AND_DESTINATION[${#SOURCES_AND_DESTINATION[@]}-1]}"
+    SOURCES=("${SOURCES_AND_DESTINATION[@]}")
+    unset "SOURCES[${#SOURCES[@]}-1]"
+
+    if ! allowed_transfer "$SOURCES" "$DESTINATION" "$ALLOWED_TRANSFER_SIZE" "$MOUNTED_PATHS"
+    then
+        UNDERLYING_TRANSFER_COMMAND_NAME=$(basename "$UNDERLYING_TRANSFER_COMMAND")
+        ESCAPED_MOUNT_ROOT=$(escape_slashes "$MOUNT_ROOT/")
+        STORAGE_PREFIX=$(escape_slashes "cp://")
+        SUBSTITUTED_DESTINATION=$(replace_all "$DESTINATION" "^$ESCAPED_MOUNT_ROOT" "$STORAGE_PREFIX")
+        OFFERED_COMMAND_REPLACEMENT=""
+        for SOURCE in "${SOURCES[@]}"
+        do
+            SUBSTITUTED_SOURCE=$(replace_all "$SOURCE" "^$ESCAPED_MOUNT_ROOT" "$STORAGE_PREFIX")
+            OFFERED_COMMAND_REPLACEMENT="$OFFERED_COMMAND_REPLACEMENT
+     pipe storage $UNDERLYING_TRANSFER_COMMAND_NAME $SUBSTITUTED_SOURCE $SUBSTITUTED_DESTINATION"
+        done
+        cat 1>&2 <<EOF
 
                     CLOUD PIPELINE TRANSFER MANAGEMENT WARNING
 
      You are going to transfer data using FUSE-mounted object storage.
      Data transfer exceeds ${ALLOWED_TRANSFER_SIZE} Gb. Such operation may not work properly.
      For such data volumes please use the \`pipe\` command interface:
-
-     pipe storage ${UNDERLYING_TRANSFER_COMMAND_NAME} ${SUBSTITUTED_FORWARDING_ARGUMENTS}
+     ${OFFERED_COMMAND_REPLACEMENT}
 
      Please refer to the following GitHub issue for the details:
      https://github.com/epam/cloud-pipeline/issues/500
@@ -116,6 +177,7 @@ then
      The operation is continued...
 
 EOF
+    fi
 fi
 
 "$UNDERLYING_TRANSFER_COMMAND" $FORWARDING_ARGUMENTS

--- a/workflows/pipe-common/shell/transfer_restrictor
+++ b/workflows/pipe-common/shell/transfer_restrictor
@@ -169,11 +169,6 @@ function allowed_transfer() {
     return 0
 }
 
-function escape_slashes() {
-    _STRING="$1"
-    echo "${_STRING//\//\/}"
-}
-
 function root_mount_path() {
     _PATH="$1"
     _MOUNTED_PATHS=($2)
@@ -191,14 +186,15 @@ function replace_all() {
     _STRING="$1"
     _PATTERN="$2"
     _REPLACEMENT="$3"
-    echo "$_STRING" | sed "s/$_PATTERN/$_REPLACEMENT/"
+    echo "$_STRING" | sed "s~$_PATTERN~$_REPLACEMENT~"
 }
 
 MOUNTED_PATHS="$1"
-MOUNT_ROOT="$2"
+MOUNT_ROOT="$2/"
 UNDERLYING_TRANSFER_COMMAND="$3"
 shift 3 # removes first three arguments from the arguments list
 FORWARDING_ARGUMENTS="$@"
+STORAGE_PREFIX="cp://"
 ALLOWED_TRANSFER_SIZE="$CP_ALLOWED_MOUNT_TRANSFER_SIZE"
 ALLOWED_TRANSFER_SIZE_TIMEOUT="${CP_ALLOWED_MOUNT_TRANSFER_SIZE_TIMEOUT:-5}"
 ALLOWED_TRANSFER_FILES="${CP_ALLOWED_MOUNT_TRANSFER_FILES:-100}"
@@ -214,14 +210,12 @@ then
     if ! allowed_transfer "$SOURCES_STRING" "$DESTINATION" "$MOUNTED_PATHS" "$ALLOWED_TRANSFER_SIZE" "$ALLOWED_TRANSFER_SIZE_TIMEOUT" "$ALLOWED_TRANSFER_FILES"
     then
         UNDERLYING_TRANSFER_COMMAND_NAME=$(basename "$UNDERLYING_TRANSFER_COMMAND")
-        ESCAPED_MOUNT_ROOT=$(escape_slashes "$MOUNT_ROOT/")
-        STORAGE_PREFIX=$(escape_slashes "cp://")
         if root_mount_path "$DESTINATION" "$MOUNTED_PATHS"
         then
             # Workaround for pipe cli issue: https://github.com/epam/cloud-pipeline/issues/510
             DESTINATION=$(with_trailing_delimiter "$DESTINATION")
         fi
-        SUBSTITUTED_DESTINATION=$(replace_all "$DESTINATION" "^$ESCAPED_MOUNT_ROOT" "$STORAGE_PREFIX")
+        SUBSTITUTED_DESTINATION=$(replace_all "$DESTINATION" "^$MOUNT_ROOT" "$STORAGE_PREFIX")
         if [[ -d "$SUBSTITUTED_DESTINATION" ]]
         then
             SUBSTITUTED_DESTINATION=$(with_trailing_delimiter "$SUBSTITUTED_DESTINATION")
@@ -229,7 +223,7 @@ then
         OFFERED_COMMAND_REPLACEMENT=""
         for SOURCE in "${SOURCES[@]}"
         do
-            SUBSTITUTED_SOURCE=$(replace_all "$SOURCE" "^$ESCAPED_MOUNT_ROOT" "$STORAGE_PREFIX")
+            SUBSTITUTED_SOURCE=$(replace_all "$SOURCE" "^$MOUNT_ROOT" "$STORAGE_PREFIX")
             OFFERED_COMMAND_REPLACEMENT="$OFFERED_COMMAND_REPLACEMENT
      pipe storage $UNDERLYING_TRANSFER_COMMAND_NAME -rf $SUBSTITUTED_SOURCE $SUBSTITUTED_DESTINATION"
         done

--- a/workflows/pipe-common/shell/transfer_restrictor
+++ b/workflows/pipe-common/shell/transfer_restrictor
@@ -41,12 +41,12 @@ function resolve_symlinks() {
     echo $(readlink -f "$_FILE_OR_DIRECTORY")
 }
 
-function storage_mounted_path() {
-    _FILE_OR_DIRECTORY="$1"
-    IFS=',' read -r -a _MOUNTED_PATHS <<< "$2"
-    for MOUNTED_PATH in "${_MOUNTED_PATHS[@]}"
+function has_prefix() {
+    _STRING="$1"
+    _PREFIXES=($2)
+    for PREFIX in "${_PREFIXES[@]}"
     do
-        if [[ "$_FILE_OR_DIRECTORY" == "$MOUNTED_PATH"* ]]
+        if [[ "$_STRING" == "$PREFIX"* ]]
         then
             return 0
         fi
@@ -58,7 +58,6 @@ function allowed_transfer() {
     _FORWARDING_ARGUMENTS="$1"
     _ALLOWED_TRANSFER_SIZE="$2"
     _MOUNTED_PATHS="$3"
-
     if [[ -z "$_ALLOWED_TRANSFER_SIZE" ]] || [[ -z "$_MOUNTED_PATHS" ]]
     then
         return 0
@@ -70,7 +69,6 @@ function allowed_transfer() {
     DESTINATION_ARGUMENT_INDEX=$((ARGUMENTS_NUMBER - 1))
     SOURCE="${_FORWARDING_ARGUMENTS[SOURCE_ARGUMENT_INDEX]}"
     DESTINATION="${_FORWARDING_ARGUMENTS[DESTINATION_ARGUMENT_INDEX]}"
-
     if [[ -f "$SOURCE" ]] || [[ -d "$SOURCE" ]]
     then
         SOURCE_SIZE=$(get_size "$SOURCE")
@@ -78,7 +76,8 @@ function allowed_transfer() {
         then
             RESOLVED_SOURCE=$(resolve_symlinks "$SOURCE")
             RESOLVED_DESTINATION=$(resolve_symlinks "$DESTINATION")
-            if storage_mounted_path "$RESOLVED_SOURCE" "$_MOUNTED_PATHS" || storage_mounted_path "$RESOLVED_DESTINATION" "$_MOUNTED_PATHS"
+            if has_prefix "$RESOLVED_SOURCE" "$_MOUNTED_PATHS" \
+                || has_prefix "$RESOLVED_DESTINATION" "$_MOUNTED_PATHS"
             then
                 return 1
             fi
@@ -113,6 +112,8 @@ then
 
      Please refer to the following GitHub issue for the details:
      https://github.com/epam/cloud-pipeline/issues/500
+
+     The operation is continued...
 
 EOF
 fi

--- a/workflows/pipe-common/shell/transfer_restrictor
+++ b/workflows/pipe-common/shell/transfer_restrictor
@@ -29,39 +29,14 @@
 
 set -o pipefail
 
-function escape_slashes() {
-    _STRING="$1"
-    echo "${_STRING//\//\/}"
-}
-
-function get_size() {
-    _FILE_OR_DIRECTORY="$1"
-    _TIMEOUT="$2"
-    TOTAL_SIZE=$(timeout "$_TIMEOUT"s du -sh --block-size=1G "$_FILE_OR_DIRECTORY" | awk '{print $1}')
-    if [[ "$?" != 0 ]]
-    then
-        # Assume that the directory size is pretty big if du command has been timed out.
-        let TOTAL_SIZE="(2**63)-1"
-    fi
-    echo "$TOTAL_SIZE"
-}
-
 function resolve_symlinks() {
     _FILE_OR_DIRECTORY="$1"
     echo $(readlink -f "$_FILE_OR_DIRECTORY")
 }
 
-function has_prefix() {
+function with_trailing_delimiter() {
     _STRING="$1"
-    _PREFIXES=($2)
-    for PREFIX in "${_PREFIXES[@]}"
-    do
-        if [[ "$_STRING" == "$PREFIX"* ]]
-        then
-            return 0
-        fi
-    done
-    return 1
+    echo "${_STRING%/}/"
 }
 
 function resolve_sources_and_destination() {
@@ -72,12 +47,12 @@ function resolve_sources_and_destination() {
     do
         # TODO 09.07.19: Filter out all non-source or non-destination positional arguments.
         ARGUMENT="${_FORWARDING_ARGUMENTS[INDEX]}"
-        if [[ "$ARGUMENT" == "-t" ]]
+        if [[ "$ARGUMENT" == "-t" ]] || [[ "$ARGUMENT" == "--target-directory" ]]
         then
             NEXT_INDEX=$((INDEX + 1))
             NEXT_ARGUMENT="${_FORWARDING_ARGUMENTS[NEXT_INDEX]}"
             DESTINATION=$(resolve_symlinks "$NEXT_ARGUMENT")
-            DESTINATION="${DESTINATION%/}/"
+            DESTINATION=$(with_trailing_delimiter "$DESTINATION")
         elif [[ "$ARGUMENT" != -* ]]
         then
             RESOLVED_ARGUMENT=$(resolve_symlinks "$ARGUMENT")
@@ -97,10 +72,35 @@ function resolve_sources_and_destination() {
         if (( "${#SOURCES[@]}" > 1 ))
         then
             # Add trailing delimiter if there are multiple sources.
-            DESTINATION="${DESTINATION%/}/"
+            DESTINATION=$(with_trailing_delimiter "$DESTINATION")
         fi
         echo "${SOURCES[@]} $DESTINATION"
     fi
+}
+
+function has_prefix() {
+    _STRING="$1"
+    _PREFIXES=($2)
+    for PREFIX in "${_PREFIXES[@]}"
+    do
+        if [[ "$_STRING" == "$PREFIX"* ]]
+        then
+            return 0
+        fi
+    done
+    return 1
+}
+
+function get_size() {
+    _FILE_OR_DIRECTORY="$1"
+    _TIMEOUT="$2"
+    TOTAL_SIZE=$(timeout "$_TIMEOUT"s du -sh --block-size=1G "$_FILE_OR_DIRECTORY" | awk '{print $1}')
+    if [[ "$?" != 0 ]]
+    then
+        # Assume that the directory size is pretty big if du command has been timed out.
+        let TOTAL_SIZE="(2**63)-1"
+    fi
+    echo "$TOTAL_SIZE"
 }
 
 function allowed_transfer() {
@@ -146,6 +146,24 @@ function allowed_transfer() {
     return 0
 }
 
+function escape_slashes() {
+    _STRING="$1"
+    echo "${_STRING//\//\/}"
+}
+
+function root_mount_path() {
+    _PATH="$1"
+    _MOUNTED_PATHS=($2)
+    for MOUNT_PATH in "${_MOUNTED_PATHS[@]}"
+    do
+        if [[ "$_PATH" == "$MOUNT_PATH" ]]
+        then
+            return 0
+        fi
+    done
+    return 1
+}
+
 function replace_all() {
     _STRING="$1"
     _PATTERN="$2"
@@ -167,17 +185,22 @@ then
     DESTINATION="${SOURCES_AND_DESTINATION[${#SOURCES_AND_DESTINATION[@]}-1]}"
     SOURCES=("${SOURCES_AND_DESTINATION[@]}")
     unset "SOURCES[${#SOURCES[@]}-1]"
+    SOURCES_STRING="${SOURCES[@]}"
 
-    if ! allowed_transfer "$SOURCES" "$DESTINATION" "$MOUNTED_PATHS" "$ALLOWED_TRANSFER_SIZE" "$ALLOWED_TRANSFER_SIZE_TIMEOUT"
+    if ! allowed_transfer "$SOURCES_STRING" "$DESTINATION" "$MOUNTED_PATHS" "$ALLOWED_TRANSFER_SIZE" "$ALLOWED_TRANSFER_SIZE_TIMEOUT"
     then
         UNDERLYING_TRANSFER_COMMAND_NAME=$(basename "$UNDERLYING_TRANSFER_COMMAND")
         ESCAPED_MOUNT_ROOT=$(escape_slashes "$MOUNT_ROOT/")
         STORAGE_PREFIX=$(escape_slashes "cp://")
+        if root_mount_path "$DESTINATION" "$MOUNTED_PATHS"
+        then
+            # Workaround for pipe cli issue: https://github.com/epam/cloud-pipeline/issues/510
+            DESTINATION=$(with_trailing_delimiter "$DESTINATION")
+        fi
         SUBSTITUTED_DESTINATION=$(replace_all "$DESTINATION" "^$ESCAPED_MOUNT_ROOT" "$STORAGE_PREFIX")
         if [[ -d "$SUBSTITUTED_DESTINATION" ]]
         then
-            # TODO 10.07.19: Extract trailing slash function.
-            SUBSTITUTED_DESTINATION="${SUBSTITUTED_DESTINATION%/}/"
+            SUBSTITUTED_DESTINATION=$(with_trailing_delimiter "$SUBSTITUTED_DESTINATION")
         fi
         OFFERED_COMMAND_REPLACEMENT=""
         for SOURCE in "${SOURCES[@]}"

--- a/workflows/pipe-common/shell/transfer_restrictor
+++ b/workflows/pipe-common/shell/transfer_restrictor
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The script is a transfer wrapper provided by Cloud Pipeline.
+#
+# It checks transferring size of storage mount related operations. If the transferring file size exceeds the maximum
+# allowed value then the warning message will be shown.
+#
+# It takes the required transfer command (cp, mv) absolute path as a first argument and all its arguments as
+# the following arguments.
+#
+# It uses CP_ALLOWED_MOUNT_TRANSFER_SIZE to get a maximum allowed transfer size.
+#
+# See https://github.com/epam/cloud-pipeline/issues/500 for more information.
+
+function escape_slashes() {
+    _STRING="$1"
+    echo "${_STRING//\//\/}"
+}
+
+function get_size() {
+    _FILE_OR_DIRECTORY="$1"
+    echo $(du -sh --block-size=1G "$_FILE_OR_DIRECTORY" | awk '{print $1}')
+}
+
+function resolve_symlinks() {
+    _FILE_OR_DIRECTORY="$1"
+    echo $(readlink -f "$_FILE_OR_DIRECTORY")
+}
+
+function storage_mounted_path() {
+    _FILE_OR_DIRECTORY="$1"
+    IFS=',' read -r -a _MOUNTED_PATHS <<< "$2"
+    for MOUNTED_PATH in "${_MOUNTED_PATHS[@]}"
+    do
+        if [[ "$_FILE_OR_DIRECTORY" == "$MOUNTED_PATH"* ]]
+        then
+            return 0
+        fi
+    done
+    return 1
+}
+
+function allowed_transfer() {
+    _FORWARDING_ARGUMENTS="$1"
+    _ALLOWED_TRANSFER_SIZE="$2"
+    _MOUNTED_PATHS="$3"
+
+    if [[ -z "$_ALLOWED_TRANSFER_SIZE" ]] || [[ -z "$_MOUNTED_PATHS" ]]
+    then
+        return 0
+    fi
+
+    _FORWARDING_ARGUMENTS=($_FORWARDING_ARGUMENTS)
+    ARGUMENTS_NUMBER="${#_FORWARDING_ARGUMENTS[@]}"
+    SOURCE_ARGUMENT_INDEX=$((ARGUMENTS_NUMBER - 2))
+    DESTINATION_ARGUMENT_INDEX=$((ARGUMENTS_NUMBER - 1))
+    SOURCE="${_FORWARDING_ARGUMENTS[SOURCE_ARGUMENT_INDEX]}"
+    DESTINATION="${_FORWARDING_ARGUMENTS[DESTINATION_ARGUMENT_INDEX]}"
+
+    if [[ -f "$SOURCE" ]] || [[ -d "$SOURCE" ]]
+    then
+        SOURCE_SIZE=$(get_size "$SOURCE")
+        if (( SOURCE_SIZE > _ALLOWED_TRANSFER_SIZE ))
+        then
+            RESOLVED_SOURCE=$(resolve_symlinks "$SOURCE")
+            RESOLVED_DESTINATION=$(resolve_symlinks "$DESTINATION")
+            if storage_mounted_path "$RESOLVED_SOURCE" "$_MOUNTED_PATHS" || storage_mounted_path "$RESOLVED_DESTINATION" "$_MOUNTED_PATHS"
+            then
+                return 1
+            fi
+        fi
+    fi
+    return 0
+}
+
+MOUNTED_PATHS="$1"
+MOUNT_ROOT="$2"
+UNDERLYING_TRANSFER_COMMAND="$3"
+shift 3 # removes first three arguments from the arguments list
+FORWARDING_ARGUMENTS="$@"
+
+ALLOWED_TRANSFER_SIZE="$CP_ALLOWED_MOUNT_TRANSFER_SIZE"
+
+if ! allowed_transfer "$FORWARDING_ARGUMENTS" "$ALLOWED_TRANSFER_SIZE" "$MOUNTED_PATHS"
+then
+    UNDERLYING_TRANSFER_COMMAND_NAME=$(basename "$UNDERLYING_TRANSFER_COMMAND")
+    ESCAPED_MOUNT_ROOT=$(escape_slashes "$MOUNT_ROOT/")
+    STORAGE_PREFIX=$(escape_slashes "cp://")
+    SUBSTITUTED_FORWARDING_ARGUMENTS=$(echo "$FORWARDING_ARGUMENTS" | sed "s/$ESCAPED_MOUNT_ROOT/$STORAGE_PREFIX/")
+    cat 1>&2 <<EOF
+
+                    CLOUD PIPELINE TRANSFER MANAGEMENT WARNING
+
+     You are going to transfer data using FUSE-mounted object storage.
+     Data transfer exceeds ${ALLOWED_TRANSFER_SIZE} Gb. Such operation may not work properly.
+     For such data volumes please use the \`pipe\` command interface:
+
+     pipe storage ${UNDERLYING_TRANSFER_COMMAND_NAME} ${SUBSTITUTED_FORWARDING_ARGUMENTS}
+
+     Please refer to the following GitHub issue for the details:
+     https://github.com/epam/cloud-pipeline/issues/500
+
+EOF
+fi
+
+"$UNDERLYING_TRANSFER_COMMAND" $FORWARDING_ARGUMENTS

--- a/workflows/pipe-common/shell/transfer_restrictor
+++ b/workflows/pipe-common/shell/transfer_restrictor
@@ -22,8 +22,10 @@
 # It takes the required transfer command (cp, mv) absolute path as a first argument and all its arguments as
 # the following arguments.
 #
-# It uses CP_ALLOWED_MOUNT_TRANSFER_SIZE to get a maximum allowed transfer size
-# and CP_ALLOWED_MOUNT_TRANSFER_SIZE_TIMEOUT to get a timeout for transfer size analysis.
+# It uses several environment variables to retrieve configurations:
+#  CP_ALLOWED_MOUNT_TRANSFER_SIZE to get a maximum allowed transfer size,
+#  CP_ALLOWED_MOUNT_TRANSFER_SIZE_TIMEOUT to get a timeout for transfer size analysis,
+#  CP_ALLOWED_MOUNT_TRANSFER_FILES to get a maximum allowed number of transferred files (AZURE only).
 #
 # See https://github.com/epam/cloud-pipeline/issues/500 for more information.
 
@@ -94,11 +96,30 @@ function has_prefix() {
 function get_size() {
     _FILE_OR_DIRECTORY="$1"
     _TIMEOUT="$2"
-    TOTAL_SIZE=$(timeout "$_TIMEOUT"s du -sh --block-size=1G "$_FILE_OR_DIRECTORY" | awk '{print $1}')
-    if [[ "$?" != 0 ]]
+    _MAX_FILES="$3"
+    # Assume that the file or directory size is of infinite if its analysis has reached timeout or failed.
+    let INFINITE_SIZE="(2**63)-1"
+    if [[ "$CLOUD_PROVIDER" == "AZURE" ]]
     then
-        # Assume that the directory size is pretty big if du command has been timed out.
-        let TOTAL_SIZE="(2**63)-1"
+        # Workaround for azure blobfuse issue: https://github.com/Azure/azure-storage-fuse/issues/119
+        FILE_SIZES=($(timeout "$_TIMEOUT"s find "$_FILE_OR_DIRECTORY" -type f | head -n "$_MAX_FILES" | xargs ls -lU | awk '{ print $5 }'))
+        if [[ "$?" != 0 ]] || (( "${#FILE_SIZES[@]}" == "$_MAX_FILES" ))
+        then
+            let TOTAL_SIZE="$INFINITE_SIZE"
+        else
+            let TOTAL_SIZE="0"
+            for FILE_SIZE in "${FILE_SIZES[@]}"
+            do
+                let TOTAL_SIZE="$TOTAL_SIZE + $FILE_SIZE"
+            done
+            let TOTAL_SIZE="$TOTAL_SIZE / (1024 * 1024 * 1024)"
+        fi
+    else
+        TOTAL_SIZE=$(timeout "$_TIMEOUT"s du -sh --block-size=1G "$_FILE_OR_DIRECTORY" | awk '{print $1}')
+        if [[ "$?" != 0 ]]
+        then
+            let TOTAL_SIZE="$INFINITE_SIZE"
+        fi
     fi
     echo "$TOTAL_SIZE"
 }
@@ -109,11 +130,13 @@ function allowed_transfer() {
     _MOUNTED_PATHS="$3"
     _ALLOWED_TRANSFER_SIZE="$4"
     _ALLOWED_TRANSFER_SIZE_TIMEOUT="$5"
+    _ALLOWED_TRANSFER_FILES="$6"
     if [[ -z "$_SOURCES" ]] \
     || [[ -z "$_DESTINATION" ]] \
     || [[ -z "$_MOUNTED_PATHS" ]] \
     || [[ -z "$_ALLOWED_TRANSFER_SIZE" ]] \
-    || [[ -z "$_ALLOWED_TRANSFER_SIZE_TIMEOUT" ]]
+    || [[ -z "$_ALLOWED_TRANSFER_SIZE_TIMEOUT" ]] \
+    || [[ -z "$_ALLOWED_TRANSFER_FILES" ]]
     then
         return 0
     fi
@@ -123,7 +146,7 @@ function allowed_transfer() {
     do
         if [[ -f "$SOURCE" ]] || [[ -d "$SOURCE" ]]
         then
-            SOURCE_SIZE=$(get_size "$SOURCE" "$_ALLOWED_TRANSFER_SIZE_TIMEOUT")
+            SOURCE_SIZE=$(get_size "$SOURCE" "$_ALLOWED_TRANSFER_SIZE_TIMEOUT" "$_ALLOWED_TRANSFER_FILES")
             if (( SOURCE_SIZE > _ALLOWED_TRANSFER_SIZE ))
             then
                 RESTRICTED_TRANSFER_SIZE="$SOURCE_SIZE"
@@ -178,6 +201,7 @@ shift 3 # removes first three arguments from the arguments list
 FORWARDING_ARGUMENTS="$@"
 ALLOWED_TRANSFER_SIZE="$CP_ALLOWED_MOUNT_TRANSFER_SIZE"
 ALLOWED_TRANSFER_SIZE_TIMEOUT="${CP_ALLOWED_MOUNT_TRANSFER_SIZE_TIMEOUT:-5}"
+ALLOWED_TRANSFER_FILES="${CP_ALLOWED_MOUNT_TRANSFER_FILES:-100}"
 
 SOURCES_AND_DESTINATION=($(resolve_sources_and_destination "$FORWARDING_ARGUMENTS"))
 if (( "${#SOURCES_AND_DESTINATION[@]}" ))
@@ -187,7 +211,7 @@ then
     unset "SOURCES[${#SOURCES[@]}-1]"
     SOURCES_STRING="${SOURCES[@]}"
 
-    if ! allowed_transfer "$SOURCES_STRING" "$DESTINATION" "$MOUNTED_PATHS" "$ALLOWED_TRANSFER_SIZE" "$ALLOWED_TRANSFER_SIZE_TIMEOUT"
+    if ! allowed_transfer "$SOURCES_STRING" "$DESTINATION" "$MOUNTED_PATHS" "$ALLOWED_TRANSFER_SIZE" "$ALLOWED_TRANSFER_SIZE_TIMEOUT" "$ALLOWED_TRANSFER_FILES"
     then
         UNDERLYING_TRANSFER_COMMAND_NAME=$(basename "$UNDERLYING_TRANSFER_COMMAND")
         ESCAPED_MOUNT_ROOT=$(escape_slashes "$MOUNT_ROOT/")

--- a/workflows/pipe-common/shell/transfer_restrictor
+++ b/workflows/pipe-common/shell/transfer_restrictor
@@ -22,9 +22,12 @@
 # It takes the required transfer command (cp, mv) absolute path as a first argument and all its arguments as
 # the following arguments.
 #
-# It uses CP_ALLOWED_MOUNT_TRANSFER_SIZE to get a maximum allowed transfer size.
+# It uses CP_ALLOWED_MOUNT_TRANSFER_SIZE to get a maximum allowed transfer size
+# and CP_ALLOWED_MOUNT_TRANSFER_SIZE_TIMEOUT to get a timeout for transfer size analysis.
 #
 # See https://github.com/epam/cloud-pipeline/issues/500 for more information.
+
+set -o pipefail
 
 function escape_slashes() {
     _STRING="$1"
@@ -33,7 +36,14 @@ function escape_slashes() {
 
 function get_size() {
     _FILE_OR_DIRECTORY="$1"
-    echo $(du -sh --block-size=1G "$_FILE_OR_DIRECTORY" | awk '{print $1}')
+    _TIMEOUT="$2"
+    TOTAL_SIZE=$(timeout "$_TIMEOUT"s du -sh --block-size=1G "$_FILE_OR_DIRECTORY" | awk '{print $1}')
+    if [[ "$?" != 0 ]]
+    then
+        # Assume that the directory size is pretty big if du command has been timed out.
+        let TOTAL_SIZE="(2**63)-1"
+    fi
+    echo "$TOTAL_SIZE"
 }
 
 function resolve_symlinks() {
@@ -67,10 +77,11 @@ function resolve_sources_and_destination() {
             NEXT_INDEX=$((INDEX + 1))
             NEXT_ARGUMENT="${_FORWARDING_ARGUMENTS[NEXT_INDEX]}"
             DESTINATION=$(resolve_symlinks "$NEXT_ARGUMENT")
+            DESTINATION="${DESTINATION%/}/"
         elif [[ "$ARGUMENT" != -* ]]
         then
             RESOLVED_ARGUMENT=$(resolve_symlinks "$ARGUMENT")
-            if [[ "$RESOLVED_ARGUMENT" != "$DESTINATION" ]]
+            if [[ "$RESOLVED_ARGUMENT" != "${DESTINATION%/}" ]]
             then
                 SOURCES+=("$RESOLVED_ARGUMENT")
             fi
@@ -83,6 +94,11 @@ function resolve_sources_and_destination() {
             DESTINATION="${SOURCES[${#SOURCES[@]}-1]}"
             unset "SOURCES[${#SOURCES[@]}-1]"
         fi
+        if (( "${#SOURCES[@]}" > 1 ))
+        then
+            # Add trailing delimiter if there are multiple sources.
+            DESTINATION="${DESTINATION%/}/"
+        fi
         echo "${SOURCES[@]} $DESTINATION"
     fi
 }
@@ -90,12 +106,14 @@ function resolve_sources_and_destination() {
 function allowed_transfer() {
     _SOURCES=($1)
     _DESTINATION="$2"
-    _ALLOWED_TRANSFER_SIZE="$3"
-    _MOUNTED_PATHS="$4"
+    _MOUNTED_PATHS="$3"
+    _ALLOWED_TRANSFER_SIZE="$4"
+    _ALLOWED_TRANSFER_SIZE_TIMEOUT="$5"
     if [[ -z "$_SOURCES" ]] \
     || [[ -z "$_DESTINATION" ]] \
+    || [[ -z "$_MOUNTED_PATHS" ]] \
     || [[ -z "$_ALLOWED_TRANSFER_SIZE" ]] \
-    || [[ -z "$_MOUNTED_PATHS" ]]
+    || [[ -z "$_ALLOWED_TRANSFER_SIZE_TIMEOUT" ]]
     then
         return 0
     fi
@@ -105,7 +123,7 @@ function allowed_transfer() {
     do
         if [[ -f "$SOURCE" ]] || [[ -d "$SOURCE" ]]
         then
-            SOURCE_SIZE=$(get_size "$SOURCE")
+            SOURCE_SIZE=$(get_size "$SOURCE" "$_ALLOWED_TRANSFER_SIZE_TIMEOUT")
             if (( SOURCE_SIZE > _ALLOWED_TRANSFER_SIZE ))
             then
                 RESTRICTED_TRANSFER_SIZE="$SOURCE_SIZE"
@@ -141,6 +159,7 @@ UNDERLYING_TRANSFER_COMMAND="$3"
 shift 3 # removes first three arguments from the arguments list
 FORWARDING_ARGUMENTS="$@"
 ALLOWED_TRANSFER_SIZE="$CP_ALLOWED_MOUNT_TRANSFER_SIZE"
+ALLOWED_TRANSFER_SIZE_TIMEOUT="${CP_ALLOWED_MOUNT_TRANSFER_SIZE_TIMEOUT:-5}"
 
 SOURCES_AND_DESTINATION=($(resolve_sources_and_destination "$FORWARDING_ARGUMENTS"))
 if (( "${#SOURCES_AND_DESTINATION[@]}" ))
@@ -149,25 +168,30 @@ then
     SOURCES=("${SOURCES_AND_DESTINATION[@]}")
     unset "SOURCES[${#SOURCES[@]}-1]"
 
-    if ! allowed_transfer "$SOURCES" "$DESTINATION" "$ALLOWED_TRANSFER_SIZE" "$MOUNTED_PATHS"
+    if ! allowed_transfer "$SOURCES" "$DESTINATION" "$MOUNTED_PATHS" "$ALLOWED_TRANSFER_SIZE" "$ALLOWED_TRANSFER_SIZE_TIMEOUT"
     then
         UNDERLYING_TRANSFER_COMMAND_NAME=$(basename "$UNDERLYING_TRANSFER_COMMAND")
         ESCAPED_MOUNT_ROOT=$(escape_slashes "$MOUNT_ROOT/")
         STORAGE_PREFIX=$(escape_slashes "cp://")
         SUBSTITUTED_DESTINATION=$(replace_all "$DESTINATION" "^$ESCAPED_MOUNT_ROOT" "$STORAGE_PREFIX")
+        if [[ -d "$SUBSTITUTED_DESTINATION" ]]
+        then
+            # TODO 10.07.19: Extract trailing slash function.
+            SUBSTITUTED_DESTINATION="${SUBSTITUTED_DESTINATION%/}/"
+        fi
         OFFERED_COMMAND_REPLACEMENT=""
         for SOURCE in "${SOURCES[@]}"
         do
             SUBSTITUTED_SOURCE=$(replace_all "$SOURCE" "^$ESCAPED_MOUNT_ROOT" "$STORAGE_PREFIX")
             OFFERED_COMMAND_REPLACEMENT="$OFFERED_COMMAND_REPLACEMENT
-     pipe storage $UNDERLYING_TRANSFER_COMMAND_NAME $SUBSTITUTED_SOURCE $SUBSTITUTED_DESTINATION"
+     pipe storage $UNDERLYING_TRANSFER_COMMAND_NAME -rf $SUBSTITUTED_SOURCE $SUBSTITUTED_DESTINATION"
         done
         cat 1>&2 <<EOF
 
                     CLOUD PIPELINE TRANSFER MANAGEMENT WARNING
 
-     You are going to transfer data using FUSE-mounted object storage.
-     Data transfer exceeds ${ALLOWED_TRANSFER_SIZE} Gb. Such operation may not work properly.
+     You are going to transfer data using FUSE-mounted object storage. Data transfer
+     exceeds ${ALLOWED_TRANSFER_SIZE} Gb or contains too many files. Such operation may not work properly.
      For such data volumes please use the \`pipe\` command interface:
      ${OFFERED_COMMAND_REPLACEMENT}
 


### PR DESCRIPTION
Resolves issue #500.

Pull request adds storage mounts data transfer restrictor for `cp` and `mv` commands. The restrictor warns user every time `cp` or `mv` command is used to download to storage mount, upload from storage mount or transfer between storage mount large enough data.

There are several environment variables that can be used to configure transfer manager behaviour:
- `CP_ALLOWED_MOUNT_TRANSFER_SIZE` - number of *gigabytes* that is allowed to be transferred without warning. By default is not specified and any amount of data is allowed.
- `CP_ALLOWED_MOUNT_TRANSFER_SIZE_TIMEOUT` - number of *seconds* that the transfer size retrieving operation can take. By default *5 seconds*.
- `CP_ALLOWED_MOUNT_TRANSFER_FILES` - number of files that is allowed to be transferred without warning. *Supported only for Azure cloud provider*. By default *100 files*.

Azure transfer getting size implementation differs from other cloud providers due to an existing issue https://github.com/Azure/azure-storage-fuse/issues/119.