### PR TITLE
Issue #406: added Spring Data JPA implementation to fetch event data from DB

### DIFF
--- a/elasticsearch-agent/build.gradle
+++ b/elasticsearch-agent/build.gradle
@@ -33,10 +33,11 @@ dependencies {
         all*.exclude module : 'spring-boot-starter-logging'
     }
 
-    //SpringBoot
+    // SpringBoot
     implementation group: "org.springframework.boot", name: "spring-boot-starter", version: springBootVersion
     implementation group: "org.springframework.boot", name: "spring-boot-starter-jdbc", version: springBootVersion
     implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: springBootVersion
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa', version: springBootVersion
 
     // Elasticsearch
     implementation group: "org.elasticsearch.client", name: "elasticsearch-rest-client", version: elasticsearchVersion
@@ -46,8 +47,10 @@ dependencies {
     // DB
     // Pool
     implementation group: "com.mchange", name: "c3p0", version: c3p0Version
-    //Postgres
+    // Postgres
     implementation group: "org.postgresql", name: "postgresql", version: postgresqlVersion
+    implementation group: 'com.vladmihalcea', name: 'hibernate-types-52', version: '2.5.0'
+
 
     // Logging
     implementation group: "org.apache.logging.log4j", name: "log4j-slf4j-impl", version: log4jVersion
@@ -82,7 +85,7 @@ dependencies {
     // Azure
     compile group: "com.microsoft.azure", name: "azure-storage-blob", version: azureSdkBlobVersion
 
-    //Tests
+    // Tests
     implementation group: "org.springframework.boot", name: "spring-boot-starter-test", version: springBootVersion
     testImplementation group: "org.projectlombok", name: "lombok", version: lombokVersion
     testImplementation group: "org.elasticsearch.client", name: "transport", version: elasticsearchVersion

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/dao/PipelineEventRepository.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/dao/PipelineEventRepository.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.epam.pipeline.elasticsearchagent.dao;
+
+import com.epam.pipeline.elasticsearchagent.model.PipelineEvent;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+
+public interface PipelineEventRepository extends CrudRepository<PipelineEvent, Long> {
+
+    List<PipelineEvent> findPipelineEventByObjectTypeAndCreatedDateLessThan(final PipelineEvent.ObjectType objectType,
+                                                                            final LocalDateTime before);
+    @Transactional
+    void deletePipelineEventByObjectIdAndObjectTypeAndCreatedDateLessThan(final Long id,
+                                                                          final PipelineEvent.ObjectType objectType,
+                                                                          final LocalDateTime before);
+}

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/model/PipelineEvent.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/model/PipelineEvent.java
@@ -15,25 +15,47 @@
  */
 package com.epam.pipeline.elasticsearchagent.model;
 
+import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
 import java.time.LocalDateTime;
 
 @Data
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@Entity
+@Table(name = "pipeline_event", schema = "pipeline")
+@TypeDef(name = "jsonb", typeClass = JsonBinaryType.class)
 public class PipelineEvent {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+    @Enumerated
+    @Column(name = "operation")
     private EventType eventType;
+    @Column(name = "stamp", columnDefinition = "timestamp with time zone")
     private LocalDateTime createdDate;
+    @Enumerated
     private ObjectType objectType;
     private Long objectId;
+    @Type(type = "jsonb")
+    @Column(columnDefinition = "jsonb")
     private String data;
 
     @RequiredArgsConstructor

--- a/elasticsearch-agent/src/main/resources/application.properties
+++ b/elasticsearch-agent/src/main/resources/application.properties
@@ -15,6 +15,9 @@ database.driverClass=org.postgresql.Driver
 database.max.pool.size=10
 database.initial.pool.size=5
 
+#Hibernate
+spring.jpa.hibernate.ddl-auto=update
+
 #Cloud Pipeline API settings
 cloud.pipeline.host=
 cloud.pipeline.token=

--- a/elasticsearch-agent/src/test/java/com/epam/pipeline/elasticsearchagent/dao/PipelineEventRepositoryTest.java
+++ b/elasticsearch-agent/src/test/java/com/epam/pipeline/elasticsearchagent/dao/PipelineEventRepositoryTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.epam.pipeline.elasticsearchagent.dao;
+
+import com.epam.pipeline.elasticsearchagent.AbstractSpringApplicationTest;
+import com.epam.pipeline.elasticsearchagent.model.EventType;
+import com.epam.pipeline.elasticsearchagent.model.PipelineEvent;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
+public class PipelineEventRepositoryTest extends AbstractSpringApplicationTest {
+
+    @Autowired
+    private PipelineEventRepository pipelineEventRepository;
+
+    private PipelineEvent pipelineEvent;
+
+    @BeforeEach
+    public void init() {
+        pipelineEvent = PipelineEvent.builder()
+                .createdDate(LocalDateTime.now())
+                .eventType(EventType.UPDATE)
+                .objectId(1L)
+                .objectType(PipelineEvent.ObjectType.PIPELINE)
+                .data("{\"tag\": {\"type\": \"string\", \"value\": \"admin\"}}")
+                .build();
+        pipelineEventRepository.save(pipelineEvent);
+    }
+
+    @Test
+    public void findPipelineEventByObjectTypeAndCreatedDateLessThan() {
+        final List<PipelineEvent> result = pipelineEventRepository
+                .findPipelineEventByObjectTypeAndCreatedDateLessThan(
+                        PipelineEvent.ObjectType.PIPELINE,
+                        LocalDateTime.now().plusDays(1)
+                );
+
+        final PipelineEvent pipelineEventFromDb = result.get(0);
+
+        Assert.assertEquals(1, result.size());
+        Assert.assertEquals(pipelineEvent.getCreatedDate(), pipelineEventFromDb.getCreatedDate());
+        Assert.assertEquals(pipelineEvent.getEventType(), pipelineEventFromDb.getEventType());
+        Assert.assertEquals(pipelineEvent.getObjectId(), pipelineEventFromDb.getObjectId());
+        Assert.assertEquals(pipelineEvent.getObjectType(), pipelineEventFromDb.getObjectType());
+        Assert.assertEquals(pipelineEvent.getData(), pipelineEventFromDb.getData());
+    }
+
+    @Test
+    public void deletePipelineEventByObjectIdAndObjectTypeAndCreatedDateLessThan() {
+        pipelineEventRepository.deletePipelineEventByObjectIdAndObjectTypeAndCreatedDateLessThan(
+                1L,
+                PipelineEvent.ObjectType.PIPELINE,
+                LocalDateTime.now().plusDays(1)
+        );
+        final Optional<PipelineEvent> result = pipelineEventRepository.findById(1L);
+        Assert.assertFalse(result.isPresent());
+
+    }
+}

--- a/elasticsearch-agent/src/test/resources/test-application.properties
+++ b/elasticsearch-agent/src/test/resources/test-application.properties
@@ -1,5 +1,5 @@
 #DB
-database.url=jdbc:postgresql://127.0.0.1:5432/pipeline_test
+database.url=jdbc:postgresql://localhost:5432/pipeline_test
 database.username=postgres
 database.password=
 database.driverClass=org.postgresql.Driver


### PR DESCRIPTION
Implementation for issue #406

This PR provides proof of concept for using `Spring Data JPA` with `elasticsearch-agent` service.
`Spring Data JPA` support was added to fetch event data from DB instead of `JDBC`.

The following changes was added to `pipeline_event` table:
-  a new column `id` was added
-  type for columns `operation` and `object_type` was changed from `text` to `integer`