### PR TITLE
Issue #501: Estimate run's disk size according to the input/common parameters

### DIFF
--- a/api/src/main/java/com/epam/pipeline/app/AppConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/AppConfiguration.java
@@ -95,6 +95,11 @@ public class AppConfiguration implements SchedulingConfigurer {
         return new DelegatingSecurityContextExecutor(getThreadPoolTaskExecutor("PauseRun"));
     }
 
+    @Bean
+    public Executor dataStoragePathExecutor() {
+        return getSingleThreadExecutor("PathExecutor");
+    }
+
     private Executor getThreadPoolTaskExecutor(String name) {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(pausePoolSize);

--- a/api/src/main/java/com/epam/pipeline/controller/datastorage/DataStorageController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/datastorage/DataStorageController.java
@@ -25,7 +25,6 @@ import com.epam.pipeline.controller.vo.data.storage.UpdateDataStorageItemVO;
 import com.epam.pipeline.controller.vo.security.EntityWithPermissionVO;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorageItem;
-import com.epam.pipeline.entity.datastorage.TemporaryCredentials;
 import com.epam.pipeline.entity.datastorage.DataStorageAction;
 import com.epam.pipeline.entity.datastorage.DataStorageDownloadFileUrl;
 import com.epam.pipeline.entity.datastorage.DataStorageException;
@@ -34,6 +33,8 @@ import com.epam.pipeline.entity.datastorage.DataStorageItemContent;
 import com.epam.pipeline.entity.datastorage.DataStorageListing;
 import com.epam.pipeline.entity.datastorage.DataStorageStreamingContent;
 import com.epam.pipeline.entity.datastorage.DataStorageWithShareMount;
+import com.epam.pipeline.entity.datastorage.TemporaryCredentials;
+import com.epam.pipeline.entity.datastorage.PathDescription;
 import com.epam.pipeline.entity.datastorage.rules.DataStorageRule;
 import com.epam.pipeline.manager.datastorage.DataStorageApiService;
 import io.swagger.annotations.Api;
@@ -46,7 +47,6 @@ import org.apache.commons.fileupload.FileItemStream;
 import org.apache.commons.fileupload.FileUploadException;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
@@ -643,7 +643,7 @@ public class DataStorageController extends AbstractRestController {
         return Result.success(dataStorageApiService.getStoragePermission(page, pageSize, filterMask));
     }
 
-    @PostMapping(value = "/datastorage/sizes")
+    @PostMapping(value = "/datastorage/path/size")
     @ResponseBody
     @ApiOperation(
             value = "Returns full size specified by path.",
@@ -652,7 +652,7 @@ public class DataStorageController extends AbstractRestController {
     @ApiResponses(
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
             })
-    public Result<List<ImmutablePair<String, Long>>> getDataSizes(@RequestBody final List<String> paths) {
+    public Result<List<PathDescription>> getDataSizes(@RequestBody final List<String> paths) {
         return Result.success(dataStorageApiService.getDataSizes(paths));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/datastorage/DataStorageController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/datastorage/DataStorageController.java
@@ -46,6 +46,7 @@ import org.apache.commons.fileupload.FileItemStream;
 import org.apache.commons.fileupload.FileUploadException;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
@@ -642,4 +643,16 @@ public class DataStorageController extends AbstractRestController {
         return Result.success(dataStorageApiService.getStoragePermission(page, pageSize, filterMask));
     }
 
+    @PostMapping(value = "/datastorage/sizes")
+    @ResponseBody
+    @ApiOperation(
+            value = "Returns full size specified by path.",
+            notes = "Returns full size specified by path.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public Result<List<ImmutablePair<String, Long>>> getDataSizes(@RequestBody final List<String> paths) {
+        return Result.success(dataStorageApiService.getDataSizes(paths));
+    }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageApiService.java
@@ -32,15 +32,16 @@ import com.epam.pipeline.entity.datastorage.DataStorageListing;
 import com.epam.pipeline.entity.datastorage.DataStorageStreamingContent;
 import com.epam.pipeline.entity.datastorage.DataStorageWithShareMount;
 import com.epam.pipeline.entity.datastorage.TemporaryCredentials;
+import com.epam.pipeline.entity.datastorage.PathDescription;
 import com.epam.pipeline.entity.datastorage.rules.DataStorageRule;
 import com.epam.pipeline.entity.security.acl.AclClass;
 import com.epam.pipeline.manager.cloud.TemporaryCredentialsManager;
 import com.epam.pipeline.manager.security.GrantPermissionManager;
 import com.epam.pipeline.manager.security.acl.AclMask;
 import com.epam.pipeline.manager.security.acl.AclMaskList;
+import com.epam.pipeline.security.acl.AclExpressions;
 import com.epam.pipeline.security.acl.AclPermission;
 import org.apache.commons.collections4.ListUtils;
-import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PostAuthorize;
 import org.springframework.security.access.prepost.PostFilter;
@@ -318,7 +319,8 @@ public class DataStorageApiService {
                 .loadAllEntitiesPermissions(AclClass.DATA_STORAGE, page, pageSize, true, mask);
     }
 
-    public List<ImmutablePair<String, Long>> getDataSizes(final List<String> paths) {
+    @PostAuthorize(AclExpressions.STORAGE_PATHS_WRITE)
+    public List<PathDescription> getDataSizes(final List<String> paths) {
         return dataStorageManager.getDataSizes(paths);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageApiService.java
@@ -40,6 +40,7 @@ import com.epam.pipeline.manager.security.acl.AclMask;
 import com.epam.pipeline.manager.security.acl.AclMaskList;
 import com.epam.pipeline.security.acl.AclPermission;
 import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PostAuthorize;
 import org.springframework.security.access.prepost.PostFilter;
@@ -315,5 +316,9 @@ public class DataStorageApiService {
                 .orElse(AclPermission.WRITE.getMask() | AclPermission.READ.getMask());
         return grantPermissionManager
                 .loadAllEntitiesPermissions(AclClass.DATA_STORAGE, page, pageSize, true, mask);
+    }
+
+    public List<ImmutablePair<String, Long>> getDataSizes(final List<String> paths) {
+        return dataStorageManager.getDataSizes(paths);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageProviderManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageProviderManager.java
@@ -27,6 +27,7 @@ import com.epam.pipeline.entity.datastorage.DataStorageItemContent;
 import com.epam.pipeline.entity.datastorage.DataStorageListing;
 import com.epam.pipeline.entity.datastorage.DataStorageStreamingContent;
 import com.epam.pipeline.entity.datastorage.DataStorageType;
+import com.epam.pipeline.entity.datastorage.PathDescription;
 import com.epam.pipeline.manager.datastorage.providers.StorageProvider;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
@@ -170,7 +171,8 @@ public final class StorageProviderManager {
         return getStorageProvider(dataStorage).buildFullStoragePath(dataStorage, name);
     }
 
-    public Long getDataSize(final AbstractDataStorage dataStorage, final String path) {
-        return getStorageProvider(dataStorage).getDataSize(dataStorage, path);
+    public PathDescription getDataSize(final AbstractDataStorage dataStorage, final String path,
+                                       final PathDescription pathDescription) {
+        return getStorageProvider(dataStorage).getDataSize(dataStorage, path, pathDescription);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageProviderManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageProviderManager.java
@@ -169,4 +169,8 @@ public final class StorageProviderManager {
     public String buildFullStoragePath(AbstractDataStorage dataStorage, String name) {
         return getStorageProvider(dataStorage).buildFullStoragePath(dataStorage, name);
     }
+
+    public Long getDataSize(final AbstractDataStorage dataStorage, final String path) {
+        return getStorageProvider(dataStorage).getDataSize(dataStorage, path);
+    }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/ProviderUtils.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/ProviderUtils.java
@@ -16,6 +16,7 @@
 
 package com.epam.pipeline.manager.datastorage.providers;
 
+import com.epam.pipeline.entity.datastorage.PathDescription;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.function.Function;
@@ -48,22 +49,24 @@ public final class ProviderUtils {
         return StringUtils.isNotBlank(path) && path.endsWith(DELIMITER) ? path.substring(0, path.length() - 1) : path;
     }
 
-    public static <T> Long getSizeByPath(final Iterable<T> items, final String requestPath,
-                                         final Function<T, Long> getSize, final Function<T, String> getName) {
+    public static <T> PathDescription getSizeByPath(final Iterable<T> items, final String requestPath,
+                                                    final Function<T, Long> getSize, final Function<T, String> getName,
+                                                    final PathDescription pathDescription) {
         final boolean rootOrFolder = isRootOrFolder(requestPath);
 
-        Long folderSize = 0L;
         for (final T item : items) {
             if (rootOrFolder) {
-                folderSize += getSize.apply(item);
+                pathDescription.increaseSize(getSize.apply(item));
             } else if (getName.apply(item).equals(requestPath)) {
-                return getSize.apply(item);
+                pathDescription.setSize(getSize.apply(item));
+                pathDescription.setCompleted(true);
+                return pathDescription;
             } else if (getName.apply(item).startsWith(requestPath + ProviderUtils.DELIMITER)) {
-                folderSize += getSize.apply(item);
+                pathDescription.increaseSize(getSize.apply(item));
             }
         }
 
-        return folderSize;
+        return pathDescription;
     }
 
     public static boolean isRootOrFolder(final String requestPath) {

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/ProviderUtils.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/ProviderUtils.java
@@ -18,6 +18,8 @@ package com.epam.pipeline.manager.datastorage.providers;
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.function.Function;
+
 public final class ProviderUtils {
 
     public static final String DELIMITER = "/";
@@ -44,5 +46,27 @@ public final class ProviderUtils {
 
     public static String withoutTrailingDelimiter(final String path) {
         return StringUtils.isNotBlank(path) && path.endsWith(DELIMITER) ? path.substring(0, path.length() - 1) : path;
+    }
+
+    public static <T> Long getSizeByPath(final Iterable<T> items, final String requestPath,
+                                         final Function<T, Long> getSize, final Function<T, String> getName) {
+        final boolean rootOrFolder = isRootOrFolder(requestPath);
+
+        Long folderSize = 0L;
+        for (final T item : items) {
+            if (rootOrFolder) {
+                folderSize += getSize.apply(item);
+            } else if (getName.apply(item).equals(requestPath)) {
+                return getSize.apply(item);
+            } else if (getName.apply(item).startsWith(requestPath + ProviderUtils.DELIMITER)) {
+                folderSize += getSize.apply(item);
+            }
+        }
+
+        return folderSize;
+    }
+
+    public static boolean isRootOrFolder(final String requestPath) {
+        return StringUtils.isBlank(requestPath) || requestPath.endsWith(DELIMITER);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/ProviderUtils.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/ProviderUtils.java
@@ -56,12 +56,15 @@ public final class ProviderUtils {
 
         for (final T item : items) {
             if (rootOrFolder) {
+                // if required path is definitely folder lists all files without filtering
                 pathDescription.increaseSize(getSize.apply(item));
             } else if (getName.apply(item).equals(requestPath)) {
+                // a file with exact match has been found => required path is path to file
                 pathDescription.setSize(getSize.apply(item));
                 pathDescription.setCompleted(true);
                 return pathDescription;
             } else if (getName.apply(item).startsWith(requestPath + ProviderUtils.DELIMITER)) {
+                // if required path is folder but '/' at the end was not specified
                 pathDescription.increaseSize(getSize.apply(item));
             }
         }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/StorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/StorageProvider.java
@@ -29,6 +29,7 @@ import com.epam.pipeline.entity.datastorage.DataStorageItemContent;
 import com.epam.pipeline.entity.datastorage.DataStorageListing;
 import com.epam.pipeline.entity.datastorage.DataStorageStreamingContent;
 import com.epam.pipeline.entity.datastorage.DataStorageType;
+import com.epam.pipeline.entity.datastorage.PathDescription;
 import com.epam.pipeline.entity.datastorage.StoragePolicy;
 import com.epam.pipeline.entity.region.VersioningAwareRegion;
 
@@ -106,5 +107,5 @@ public interface StorageProvider<T extends AbstractDataStorage> {
         return storagePolicy;
     }
 
-    Long getDataSize(T dataStorage, String path);
+    PathDescription getDataSize(T dataStorage, String path, PathDescription pathDescription);
 }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/StorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/StorageProvider.java
@@ -105,4 +105,6 @@ public interface StorageProvider<T extends AbstractDataStorage> {
         }
         return storagePolicy;
     }
+
+    Long getDataSize(T dataStorage, String path);
 }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3StorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3StorageProvider.java
@@ -216,6 +216,11 @@ public class S3StorageProvider implements StorageProvider<S3bucketDataStorage> {
         return "--dir-mode 0774 --file-mode 0774 -o rw -o allow_other -f --gid 0";
     }
 
+    @Override
+    public Long getDataSize(final S3bucketDataStorage dataStorage, final String path) {
+        return getS3Helper(dataStorage).getDataSize(dataStorage, path);
+    }
+
     public S3Helper getS3Helper(S3bucketDataStorage dataStorage) {
         AwsRegion region = getAwsRegion(dataStorage);
         return new RegionAwareS3Helper(region, messageHelper);

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3StorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3StorageProvider.java
@@ -29,6 +29,7 @@ import com.epam.pipeline.entity.datastorage.DataStorageItemContent;
 import com.epam.pipeline.entity.datastorage.DataStorageListing;
 import com.epam.pipeline.entity.datastorage.DataStorageStreamingContent;
 import com.epam.pipeline.entity.datastorage.DataStorageType;
+import com.epam.pipeline.entity.datastorage.PathDescription;
 import com.epam.pipeline.entity.datastorage.StoragePolicy;
 import com.epam.pipeline.entity.datastorage.aws.S3bucketDataStorage;
 import com.epam.pipeline.entity.region.AwsRegion;
@@ -217,8 +218,9 @@ public class S3StorageProvider implements StorageProvider<S3bucketDataStorage> {
     }
 
     @Override
-    public Long getDataSize(final S3bucketDataStorage dataStorage, final String path) {
-        return getS3Helper(dataStorage).getDataSize(dataStorage, path);
+    public PathDescription getDataSize(final S3bucketDataStorage dataStorage, final String path,
+                                       final PathDescription pathDescription) {
+        return getS3Helper(dataStorage).getDataSize(dataStorage, path, pathDescription);
     }
 
     public S3Helper getS3Helper(S3bucketDataStorage dataStorage) {

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureBlobStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureBlobStorageProvider.java
@@ -24,6 +24,7 @@ import com.epam.pipeline.entity.datastorage.DataStorageItemContent;
 import com.epam.pipeline.entity.datastorage.DataStorageListing;
 import com.epam.pipeline.entity.datastorage.DataStorageStreamingContent;
 import com.epam.pipeline.entity.datastorage.DataStorageType;
+import com.epam.pipeline.entity.datastorage.PathDescription;
 import com.epam.pipeline.entity.datastorage.azure.AzureBlobStorage;
 import com.epam.pipeline.entity.region.AzureRegion;
 import com.epam.pipeline.entity.region.AzureRegionCredentials;
@@ -188,8 +189,9 @@ public class AzureBlobStorageProvider implements StorageProvider<AzureBlobStorag
     }
 
     @Override
-    public Long getDataSize(final AzureBlobStorage dataStorage, final String path) {
-        return getAzureStorageHelper(dataStorage).getDataSize(dataStorage, path);
+    public PathDescription getDataSize(final AzureBlobStorage dataStorage, final String path,
+                                       final PathDescription pathDescription) {
+        return getAzureStorageHelper(dataStorage).getDataSize(dataStorage, path, pathDescription);
     }
 
     private AzureStorageHelper getAzureStorageHelper(final AzureBlobStorage storage) {

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureBlobStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureBlobStorageProvider.java
@@ -187,6 +187,11 @@ public class AzureBlobStorageProvider implements StorageProvider<AzureBlobStorag
         return null;
     }
 
+    @Override
+    public Long getDataSize(final AzureBlobStorage dataStorage, final String path) {
+        return getAzureStorageHelper(dataStorage).getDataSize(dataStorage, path);
+    }
+
     private AzureStorageHelper getAzureStorageHelper(final AzureBlobStorage storage) {
         final AzureRegion region = cloudRegionManager.getAzureRegion(storage);
         final AzureRegionCredentials credentials = cloudRegionManager.loadCredentials(region);

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureStorageHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureStorageHelper.java
@@ -27,6 +27,7 @@ import com.epam.pipeline.entity.datastorage.DataStorageItemContent;
 import com.epam.pipeline.entity.datastorage.DataStorageItemType;
 import com.epam.pipeline.entity.datastorage.DataStorageListing;
 import com.epam.pipeline.entity.datastorage.DataStorageStreamingContent;
+import com.epam.pipeline.entity.datastorage.PathDescription;
 import com.epam.pipeline.entity.datastorage.azure.AzureBlobStorage;
 import com.epam.pipeline.entity.region.AzurePolicy;
 import com.epam.pipeline.entity.region.AzureRegion;
@@ -339,12 +340,17 @@ public class AzureStorageHelper {
         }
     }
 
-    public Long getDataSize(final AzureBlobStorage dataStorage, final String path) {
+    public PathDescription getDataSize(final AzureBlobStorage dataStorage, final String path,
+                                       final PathDescription pathDescription) {
         final String requestPath = Optional.ofNullable(path).orElse("");
         final List<BlobItem> items = rawList(AbstractListingIterator.flat(getContainerURL(dataStorage), requestPath))
                 .collect(Collectors.toList());
-        return ProviderUtils.getSizeByPath(items, requestPath,
-                item -> item.properties().contentLength(), BlobItem::name);
+
+        ProviderUtils.getSizeByPath(items, requestPath, item -> item.properties().contentLength(),
+                BlobItem::name, pathDescription);
+
+        pathDescription.setCompleted(true);
+        return pathDescription;
     }
 
     private void deleteFolder(final AzureBlobStorage dataStorage, final String path) {

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageHelper.java
@@ -407,6 +407,15 @@ public class GSBucketStorageHelper {
         client.update(bucketInfoBuilder.build());
     }
 
+    public Long getDataSize(final GSBucketStorage dataStorage, final String path) {
+        final String requestPath = Optional.ofNullable(path).orElse("");
+
+        final Storage client = gcpClient.buildStorageClient(region);
+        final Page<Blob> blobs = client.list(dataStorage.getPath(), Storage.BlobListOption.prefix(requestPath));
+
+        return ProviderUtils.getSizeByPath(blobs.iterateAll(), requestPath, BlobInfo::getSize, BlobInfo::getName);
+    }
+
     private List<Cors> buildCors() {
         if (StringUtils.isBlank(region.getCorsRules())) {
             return null;

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageHelper.java
@@ -27,6 +27,7 @@ import com.epam.pipeline.entity.datastorage.DataStorageFolder;
 import com.epam.pipeline.entity.datastorage.DataStorageItemContent;
 import com.epam.pipeline.entity.datastorage.DataStorageListing;
 import com.epam.pipeline.entity.datastorage.DataStorageStreamingContent;
+import com.epam.pipeline.entity.datastorage.PathDescription;
 import com.epam.pipeline.entity.datastorage.StoragePolicy;
 import com.epam.pipeline.entity.datastorage.gcp.GSBucketStorage;
 import com.epam.pipeline.entity.region.GCPRegion;
@@ -407,13 +408,17 @@ public class GSBucketStorageHelper {
         client.update(bucketInfoBuilder.build());
     }
 
-    public Long getDataSize(final GSBucketStorage dataStorage, final String path) {
+    public PathDescription getDataSize(final GSBucketStorage dataStorage, final String path,
+                                       final PathDescription pathDescription) {
         final String requestPath = Optional.ofNullable(path).orElse("");
-
         final Storage client = gcpClient.buildStorageClient(region);
         final Page<Blob> blobs = client.list(dataStorage.getPath(), Storage.BlobListOption.prefix(requestPath));
 
-        return ProviderUtils.getSizeByPath(blobs.iterateAll(), requestPath, BlobInfo::getSize, BlobInfo::getName);
+        ProviderUtils.getSizeByPath(blobs.iterateAll(), requestPath, BlobInfo::getSize, BlobInfo::getName,
+                pathDescription);
+
+        pathDescription.setCompleted(true);
+        return pathDescription;
     }
 
     private List<Cors> buildCors() {

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageProvider.java
@@ -183,6 +183,11 @@ public class GSBucketStorageProvider implements StorageProvider<GSBucketStorage>
         return null;
     }
 
+    @Override
+    public Long getDataSize(final GSBucketStorage dataStorage, final String path) {
+        return getHelper(dataStorage).getDataSize(dataStorage, path);
+    }
+
     private GSBucketStorageHelper getHelper(final GSBucketStorage storage) {
         final GCPRegion gcpRegion = cloudRegionManager.getGCPRegion(storage);
         return new GSBucketStorageHelper(messageHelper, gcpRegion, gcpClient);

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageProvider.java
@@ -25,6 +25,7 @@ import com.epam.pipeline.entity.datastorage.DataStorageItemContent;
 import com.epam.pipeline.entity.datastorage.DataStorageListing;
 import com.epam.pipeline.entity.datastorage.DataStorageStreamingContent;
 import com.epam.pipeline.entity.datastorage.DataStorageType;
+import com.epam.pipeline.entity.datastorage.PathDescription;
 import com.epam.pipeline.entity.datastorage.StoragePolicy;
 import com.epam.pipeline.entity.datastorage.gcp.GSBucketStorage;
 import com.epam.pipeline.entity.region.GCPRegion;
@@ -184,8 +185,9 @@ public class GSBucketStorageProvider implements StorageProvider<GSBucketStorage>
     }
 
     @Override
-    public Long getDataSize(final GSBucketStorage dataStorage, final String path) {
-        return getHelper(dataStorage).getDataSize(dataStorage, path);
+    public PathDescription getDataSize(final GSBucketStorage dataStorage, final String path,
+                                       final PathDescription pathDescription) {
+        return getHelper(dataStorage).getDataSize(dataStorage, path, pathDescription);
     }
 
     private GSBucketStorageHelper getHelper(final GSBucketStorage storage) {

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProvider.java
@@ -524,4 +524,9 @@ public class NFSStorageProvider implements StorageProvider<NFSDataStorage> {
     public String getDefaultMountOptions(NFSDataStorage dataStorage) {
         return shareMountManager.load(dataStorage.getFileShareMountId()).getMountOptions();
     }
+
+    @Override
+    public Long getDataSize(final NFSDataStorage dataStorage, final String path) {
+        throw new UnsupportedOperationException("Getting item size info is not implemented for NFS storages");
+    }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProvider.java
@@ -30,6 +30,7 @@ import com.epam.pipeline.entity.datastorage.DataStorageListing;
 import com.epam.pipeline.entity.datastorage.DataStorageStreamingContent;
 import com.epam.pipeline.entity.datastorage.DataStorageType;
 import com.epam.pipeline.entity.datastorage.FileShareMount;
+import com.epam.pipeline.entity.datastorage.PathDescription;
 import com.epam.pipeline.entity.datastorage.nfs.NFSDataStorage;
 import com.epam.pipeline.entity.region.AbstractCloudRegion;
 import com.epam.pipeline.entity.region.AbstractCloudRegionCredentials;
@@ -526,7 +527,8 @@ public class NFSStorageProvider implements StorageProvider<NFSDataStorage> {
     }
 
     @Override
-    public Long getDataSize(final NFSDataStorage dataStorage, final String path) {
+    public PathDescription getDataSize(final NFSDataStorage dataStorage, final String path,
+                                       final PathDescription pathDescription) {
         throw new UnsupportedOperationException("Getting item size info is not implemented for NFS storages");
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -132,7 +132,7 @@ public class SystemPreferences {
     public static final StringPreference STORAGE_OBJECT_PREFIX = new StringPreference("storage.object.prefix",
             null, DATA_STORAGE_GROUP, pass);
     public static final LongPreference STORAGE_LISTING_TIME_LIMIT =
-            new LongPreference("storage.listing.time.limit",5000L, DATA_STORAGE_GROUP, pass);
+            new LongPreference("storage.listing.time.limit",3000L, DATA_STORAGE_GROUP, pass);
 
     // GIT_GROUP
     public static final StringPreference GIT_HOST = new StringPreference("git.host", null, GIT_GROUP, null);

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -131,6 +131,8 @@ public class SystemPreferences {
             "storage.transfer.pipeline.version", null, DATA_STORAGE_GROUP, pass);
     public static final StringPreference STORAGE_OBJECT_PREFIX = new StringPreference("storage.object.prefix",
             null, DATA_STORAGE_GROUP, pass);
+    public static final LongPreference STORAGE_LISTING_TIME_LIMIT =
+            new LongPreference("storage.listing.time.limit",5000L, DATA_STORAGE_GROUP, pass);
 
     // GIT_GROUP
     public static final StringPreference GIT_HOST = new StringPreference("git.host", null, GIT_GROUP, null);

--- a/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionManager.java
@@ -32,6 +32,7 @@ import com.epam.pipeline.entity.configuration.AbstractRunConfigurationEntry;
 import com.epam.pipeline.entity.configuration.RunConfiguration;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.DataStorageAction;
+import com.epam.pipeline.entity.datastorage.PathDescription;
 import com.epam.pipeline.entity.filter.AclSecuredFilter;
 import com.epam.pipeline.entity.issue.Issue;
 import com.epam.pipeline.entity.issue.IssueComment;
@@ -483,6 +484,12 @@ public class GrantPermissionManager {
             }
         }
         return true;
+    }
+
+    public boolean hasDataStoragePathsPermission(final List<PathDescription> paths, final String permissionName) {
+        return ListUtils.emptyIfNull(paths).stream()
+                .allMatch(path -> permissionsHelper.isAllowed(permissionName,
+                        entityManager.load(AclClass.DATA_STORAGE, path.getDataStorageId())));
     }
 
     public boolean checkStorageShared(Long storageId) {

--- a/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
+++ b/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
@@ -62,6 +62,9 @@ public final class AclExpressions {
             "(hasRole('ADMIN') OR @grantPermissionManager.storagePermission(#id, 'OWNER')) "
             + "AND @grantPermissionManager.checkStorageShared(#id)";
 
+    public static final String STORAGE_PATHS_WRITE = ADMIN_ONLY + OR +
+            "@grantPermissionManager.hasDataStoragePathsPermission(returnObject, 'WRITE')";
+
     public static final String RUN_COMMIT_EXECUTE =
         "hasRole('ADMIN') OR (@grantPermissionManager.runPermission(#runId, 'EXECUTE')"
             + " AND hasPermission(#registryId, 'com.epam.pipeline.entity.pipeline.DockerRegistry', 'WRITE'))";

--- a/core/src/main/java/com/epam/pipeline/entity/datastorage/PathDescription.java
+++ b/core/src/main/java/com/epam/pipeline/entity/datastorage/PathDescription.java
@@ -32,4 +32,9 @@ public class PathDescription {
     private String path;
     private Long size;
     private Long dataStorageId;
+    private Boolean completed;
+
+    public void increaseSize(final Long size) {
+        this.size += size;
+    }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/datastorage/PathDescription.java
+++ b/core/src/main/java/com/epam/pipeline/entity/datastorage/PathDescription.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.datastorage;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PathDescription {
+    private String path;
+    private Long size;
+    private Long dataStorageId;
+}


### PR DESCRIPTION
This PR provides implementation for issue #501 
 
A new API method `datastorage/path/size` was added. This method takes  an array with paths (from input parameters) and returns their sizes in bytes with the following format:
```
[
   {
      "path": "s3://my-bucket/folder/",
      "size": "1984",
      "dataStorageId": "1",
      "completed": "true"
   } 
]
```
Also, preference `storage.listing.time.limit` with default value 3000 ms was added.