### PR TITLE
Issue #538: Some properties in ES Application.properties use environment variables

### DIFF
--- a/elasticsearch-agent/src/main/resources/application.properties
+++ b/elasticsearch-agent/src/main/resources/application.properties
@@ -3,21 +3,21 @@ server.port=8080
 server.servlet.context-path=/elastic-agent
 
 #ElasticSearch Client Configuration
-elasticsearch.client.url=localhost
-elasticsearch.client.port=9200
+elasticsearch.client.url=${ES_CLIENT_URL:localhost}
+elasticsearch.client.port=${ES_CLIENT_PORT:9200}
 elasticsearch.client.scheme=http
 
 #DB
-database.url=
-database.username=pipeline
-database.password=pipeline
+database.url=${PGS_URL}
+database.username=${PGS_USER:pipeline}
+database.password=${PGS_PASS:pipeline}
 database.driverClass=org.postgresql.Driver
 database.max.pool.size=10
 database.initial.pool.size=5
 
 #Cloud Pipeline API settings
-cloud.pipeline.host=
-cloud.pipeline.token=
+cloud.pipeline.host=${API}
+cloud.pipeline.token=${API_TOKEN}
 
 #Common sync settings
 sync.index.common.prefix=cp-


### PR DESCRIPTION
Resolves issue #538

The following values in the application.properties file were changed for use evironment variables:

- elasticsearch.client.url=${ES_CLIENT_URL}
- elasticsearch.client.port=${ES_CLIENT_PORT}
- database.url=${PGS_URL}
- database.username=${PGS_USER}
- database.password=${PGS_PASS}
- cloud.pipeline.host=${API}
- cloud.pipeline.token=${API_TOKEN}