### PR TITLE
Gui tests improvements from 26/07/19

### DIFF
--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/PauseResumeTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/PauseResumeTest.java
@@ -37,6 +37,7 @@ import static com.codeborne.selenide.Condition.matchText;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.open;
+import static com.codeborne.selenide.Selenide.refresh;
 import static com.epam.pipeline.autotests.ao.LogAO.InstanceParameters.getParameterValueLink;
 import static com.epam.pipeline.autotests.ao.LogAO.InstanceParameters.parameterWithName;
 import static com.epam.pipeline.autotests.ao.LogAO.log;
@@ -50,6 +51,7 @@ import static com.epam.pipeline.autotests.ao.Primitive.SSH_LINK;
 import static com.epam.pipeline.autotests.ao.Primitive.START_IDLE;
 import static com.epam.pipeline.autotests.utils.Conditions.textMatches;
 import static com.epam.pipeline.autotests.utils.PipelineSelectors.button;
+import static com.epam.pipeline.autotests.utils.Utils.sleep;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -314,6 +316,8 @@ public class PauseResumeTest extends AbstractSeveralPipelineRunningTest implemen
 
     private void checkNodePage(final Supplier<?> nodePage, final String ipHyperlink) {
         open(ipHyperlink);
+        sleep(5, SECONDS);
+        refresh();
         nodePage.get();
     }
 

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/CommitPopup.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/CommitPopup.java
@@ -88,8 +88,9 @@ public class CommitPopup extends PopupAO<CommitPopup, ConfirmationPopupAO<LogAO>
 
     public CommitPopup setName(final String name) {
         Utils.clearTextField(get(IMAGE_NAME));
-        sleep(1, SECONDS);
-        return addToValue(IMAGE_NAME, name);
+        sleep(3, SECONDS);
+        Utils.sendKeysByChars(get(IMAGE_NAME), name);
+        return this;
     }
 
     @Override

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/utils/Utils.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/utils/Utils.java
@@ -117,7 +117,7 @@ public class Utils {
         action.perform();
     }
 
-    public static void sendKeysWithSlashes(String text) {
+    public static void sendKeysWithSlashes(final String text) {
         //////////////////////////////////////////////////////////////////////////
         // ! WARNING: there is robot to fix forward slashed issue
         // https://sqa.stackexchange.com/questions/25038/selenium-send-keys-on-chromium-confused-by-forward-slashes
@@ -137,6 +137,22 @@ public class Utils {
             actions().sendKeys(s).perform();
         }
         //////////////////////////////////////////////////////////////////////////
+    }
+
+    public static void sendKeysByChars(final SelenideElement field, final String text) {
+        final char[] charArray = text.toCharArray();
+        int charNumber = 0;
+        for (final char character : charArray) {
+            while (true) {
+                field.sendKeys(String.valueOf(character));
+                sleep(10, MILLISECONDS);
+                final String enteredText = field.getAttribute("value");
+                if (enteredText.charAt(charNumber) == character) {
+                    break;
+                }
+            }
+            charNumber++;
+        }
     }
 
     public static String getPipelineRunId(final String pipelineName) {


### PR DESCRIPTION
The following changes were applied to gui tests:

-  the approach to entering tool name in commit popup was changed
-  refresh endpoint page was added to validate `pauseAndResumeEndpointValidation()`
