### PR TITLE
Issue #556 Update spot request status each time

### DIFF
--- a/scripts/autoscaling/aws/nodeup.py
+++ b/scripts/autoscaling/aws/nodeup.py
@@ -743,6 +743,7 @@ def find_spot_instance(ec2, aws_region, bid_price, run_id, ins_img, ins_type, in
     while rep <= num_rep:
         current_request = ec2.describe_spot_instance_requests(SpotInstanceRequestIds=[request_id])['SpotInstanceRequests'][0]
         status = current_request['Status']['Code']
+        last_status = status
         if status == 'fulfilled':
             ins_id = current_request['InstanceId']
             instance = None
@@ -784,7 +785,6 @@ def find_spot_instance(ec2, aws_region, bid_price, run_id, ins_img, ins_type, in
 
             pipe_log('Instance is successfully created for spot request {}. ID: {}, IP: {}\n-'.format(request_id, ins_id, ins_ip))
             break
-        last_status = status
         pipe_log('- Spot request {} is not yet fulfilled. Still waiting...'.format(request_id))
         rep = increment_or_fail(num_rep, rep,
                                 'Exceeded retry count ({}) for spot instance. Spot instance request status code: {}.'


### PR DESCRIPTION
This PR should solve #556 

# Bug
Now AWS `nodeup.sh` script has a bug when `spot request status` is updated only when it isn't `fulfilled`. So in this case the following situation is possible:
1. nodeup script is run for spot instance to be launched
2. we get:
```
       spot_request_status != 'fulfilled'
```
So we update 
```
        last_status = status
```
3. the next retry iteration will bring us status == 'fulfilled' and spot successfully created, but last_status isn't updated 
4. Instead of returning `ip address` and `instance_name` of instance we will fail with exit code 5

 # Solution
Simple reordering of update operation for `last_status` solves this bug