### PR TITLE
Fix the 'pipe' CLI version displaying

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,10 @@ jobs:
       install: true
       language: java
       script:
+        # Previously pipe-cli:build and pipe-cli:buildLinux were executed in a single gradle command
+        # But this caused an invalid version set to the second one. See https://github.com/epam/cloud-pipeline/issues/561
+        # As a workaround - commands were divided into two calls for now
+        # FIXME: this shall be reviewed further to uncover the real causes of such a behavior
         - ./gradlew -PbuildNumber=${TRAVIS_BUILD_NUMBER}.${TRAVIS_COMMIT} -Pprofile=release pipe-cli:build --no-daemon
         - ./gradlew -PbuildNumber=${TRAVIS_BUILD_NUMBER}.${TRAVIS_COMMIT} -Pprofile=release pipe-cli:buildLinux --no-daemon
         - tar -zcf cli-linux.tgz pipe-cli/dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,8 @@ jobs:
       install: true
       language: java
       script:
-        - ./gradlew -PbuildNumber=${TRAVIS_BUILD_NUMBER}.${TRAVIS_COMMIT} -Pprofile=release pipe-cli:build pipe-cli:buildLinux --no-daemon
+        - ./gradlew -PbuildNumber=${TRAVIS_BUILD_NUMBER}.${TRAVIS_COMMIT} -Pprofile=release pipe-cli:build --no-daemon
+        - ./gradlew -PbuildNumber=${TRAVIS_BUILD_NUMBER}.${TRAVIS_COMMIT} -Pprofile=release pipe-cli:buildLinux --no-daemon
         - tar -zcf cli-linux.tgz pipe-cli/dist
       after_success:
         - aws s3 mv cli-linux.tgz s3://cloud-pipeline-oss-builds/temp/${TRAVIS_BUILD_NUMBER}/


### PR DESCRIPTION
Resolves issue #561

Build `CLI Common/Linux` command was changed in **travis.yml** to fix the `pipe` CLI version displaying. Now the version is the same as in GUI. 