### PR TITLE
Swap device support

### DIFF
--- a/deploy/contents/install/cloud-configs/aws/cluster.networks.config.json
+++ b/deploy/contents/install/cloud-configs/aws/cluster.networks.config.json
@@ -23,10 +23,6 @@
                 {
                     "name": "swap_ratio",
                     "path": "0.01"
-                },
-                {
-                    "name": "swap_location",
-                    "path": "/ebs/swap/swapfile"
                 }
             ],
             "security_group_ids": [

--- a/deploy/contents/install/cloud-configs/az/cluster.networks.config.json
+++ b/deploy/contents/install/cloud-configs/az/cluster.networks.config.json
@@ -23,10 +23,6 @@
                 {
                     "name": "swap_ratio",
                     "path": "0.01"
-                },
-                {
-                    "name": "swap_location",
-                    "path": "/mnt/resource/swapfile"
                 }
             ],
             "security_group_ids": [

--- a/deploy/contents/install/cloud-configs/gcp/cluster.networks.config.json
+++ b/deploy/contents/install/cloud-configs/gcp/cluster.networks.config.json
@@ -9,6 +9,12 @@
       "proxies": [
         ${CP_PREF_CLUSTER_PROXIES}
       ],
+      "swap": [
+        {
+          "name": "swap_ratio",
+          "path": "0.01"
+        }
+      ],
       "amis": [
         {
           "instance_mask": "gpu-*",

--- a/scripts/autoscaling/init_multicloud.sh
+++ b/scripts/autoscaling/init_multicloud.sh
@@ -58,67 +58,6 @@ function update_nameserver {
   fi
 }
 
-function setup_swap {
-  local default_swap_file="/ebs/swap/swapfile"
-  local swap_ratio="${1:-0}"
-  local swap_file="${2:-$default_swap_file}"
-  
-  # If swap_ratio/swap_file are not set at all - they will appear with @ in the beginning and the end
-  # Consider that as default values
-  if [[ "$swap_ratio" == "@"*"@" ]]; then
-    swap_ratio=0
-  fi
-  if [[ "$swap_file" == "@"*"@" ]]; then
-    swap_file=$default_swap_file
-  fi
-
-  # If explicitely set to 0 - do not do anything
-  if [ -z "$swap_ratio" ] || [ "$swap_ratio" == "0" ]; then
-    echo "Swap ratio is not set of equals to 0"
-    return 0
-  fi
-
-  # If swap file already exists - fallback, as it may be a paused run
-  if [ -f "$swap_file" ]; then
-    echo "Swap file already exists at ${swap_file}. Refusing to proceed with the swap configuration"
-    return 1
-  fi
-
-  local physical_ram_kb=$(grep MemTotal /proc/meminfo | awk '{print $2}')
-  local swap_size_gb=$(echo "$physical_ram_kb * $swap_ratio / 1024 / 1024" | bc)
-  if [ $? -ne 0 ] || [ "$swap_size_gb" == "0" ]; then
-    echo "Unable to compute swap size. physical_ram_kb: $physical_ram_kb swap_ratio: $swap_ratio swap_size_gb: $swap_size_gb"
-    return 1
-  fi
-
-  mkdir -p $(dirname $swap_file)
-
-  echo "$swap_size_gb Gb swap file will be create at $swap_file"
-  dd if=/dev/zero of=$swap_file bs=1G count=$swap_size_gb
-  if [ $? -ne 0 ]; then
-    echo "Unable to create a swapfile at $swap_file"
-    rm -f "$swap_file"
-    return 1
-  fi
-
-  chmod 600 $swap_file
-  mkswap $swap_file
-  if [ $? -ne 0 ]; then
-    echo "Unable to mkswap at $swap_file"
-    rm -f "$swap_file"
-    return 1
-  fi
-
-  swapon $swap_file
-  if [ $? -ne 0 ]; then
-    echo "Unable to swapon at $swap_file"
-    rm -f "$swap_file"
-    return 1
-  fi
-
-  return 0
-}
-
 # Mount all drives that do not have mount points yet. Each drive will be mounted to /ebsN folder (N is a number of a drive)
 UNMOUNTED_DRIVES=$(lsblk -sdrpn -o NAME,TYPE,MOUNTPOINT | awk '$2 == "disk" && $3 == "" { print $1 }')
 DRIVE_NUM=0
@@ -151,11 +90,6 @@ do
   rm -rf $MOUNT_POINT/lost+found/   
  
 done
-
-# Setup swap configuration
-swap_ratio="@swap_ratio@"
-swap_location="@swap_location@"
-setup_swap "${swap_ratio:-0}" "${swap_location:-/ebs/swap/swapfile}"
 
 # Stop docker if it is running and clean any remaining default directories
 systemctl stop docker

--- a/workflows/pipe-common/pipeline/autoscaling/azureprovider.py
+++ b/workflows/pipe-common/pipeline/autoscaling/azureprovider.py
@@ -56,17 +56,19 @@ class AzureInstanceProvider(AbstractInstanceProvider):
                      num_rep, time_rep, kube_ip, kubeadm_token):
         try:
             ins_key = utils.read_ssh_key(ins_key)
-            user_data_script = utils.get_user_data_script(self.zone, ins_type, ins_img, kube_ip, kubeadm_token)
+            swap_size = utils.get_swap_size(self.zone, ins_type, is_spot, "AZURE")
+            user_data_script = utils.get_user_data_script(self.zone, ins_type, ins_img, kube_ip, kubeadm_token,
+                                                          swap_size)
             instance_name = "az-" + uuid.uuid4().hex[0:16]
 
             if not is_spot:
                 self.__create_public_ip_address(instance_name, run_id)
                 self.__create_nic(instance_name, run_id)
                 return self.__create_vm(instance_name, run_id, ins_type, ins_img, ins_hdd, user_data_script,
-                                        ins_key, "pipeline", kms_encyr_key_id)
+                                        ins_key, "pipeline", swap_size)
             else:
                 return self.__create_low_priority_vm(instance_name, run_id, ins_type, ins_img, ins_hdd,
-                                                     user_data_script, ins_key, "pipeline")
+                                                     user_data_script, ins_key, "pipeline", swap_size)
         except Exception as e:
             self.__delete_all_by_run_id(run_id)
             raise RuntimeError(e)
@@ -277,7 +279,7 @@ class AzureInstanceProvider(AbstractInstanceProvider):
         return disk_type
 
     def __create_vm(self, instance_name, run_id, instance_type, instance_image, disk, user_data_script,
-                  ssh_pub_key, user, kms_encyr_key_id):
+                  ssh_pub_key, user, swap_size):
         nic = self.network_client.network_interfaces.get(
             self.resource_group_name,
             instance_name + '-nic'
@@ -289,9 +291,8 @@ class AzureInstanceProvider(AbstractInstanceProvider):
             image_name
         )
 
-        storage_profile = self.__get_storage_profile(disk, image, instance_type)
-        storage_profile["dataDisks"][0]["name"] = instance_name + "-data"
-
+        storage_profile = self.__get_storage_profile(disk, image, instance_type,
+                                                     instance_name=instance_name, swap_size=swap_size)
         vm_parameters = {
             'location': self.zone,
             'os_profile': self.__get_os_profile(instance_name, ssh_pub_key, user, user_data_script, 'computer_name'),
@@ -315,7 +316,7 @@ class AzureInstanceProvider(AbstractInstanceProvider):
         return instance_name, private_ip
 
     def __create_low_priority_vm(self, scale_set_name, run_id, instance_type, instance_image,
-                                 disk, user_data_script, ssh_pub_key, user):
+                                 disk, user_data_script, ssh_pub_key, user, swap_size):
 
         resource_group, image_name = AzureInstanceProvider.get_res_grp_and_res_name_from_string(instance_image, 'images')
 
@@ -340,7 +341,7 @@ class AzureInstanceProvider(AbstractInstanceProvider):
                     'priority': 'Low',
                     'evictionPolicy': 'delete',
                     'os_profile': self.__get_os_profile(scale_set_name, ssh_pub_key, user, user_data_script, 'computer_name_prefix'),
-                    'storage_profile': self.__get_storage_profile(disk, image, instance_type),
+                    'storage_profile': self.__get_storage_profile(disk, image, instance_type, swap_size=swap_size),
                     "network_profile": {
                         "networkInterfaceConfigurations": [
                             {
@@ -418,7 +419,14 @@ class AzureInstanceProvider(AbstractInstanceProvider):
         }
         return profile
 
-    def __get_storage_profile(self, disk, image, instance_type):
+    def __get_storage_profile(self, disk, image, instance_type, instance_name=None, swap_size=None):
+        disk_type = self.__get_disk_type(instance_type)
+        disk_name = None if instance_name is None else instance_name + "-data"
+        disk_lun = 62
+        data_disks = [self.__get_data_disk(disk, disk_type, disk_lun, disk_name=disk_name)]
+        if swap_size is not None and swap_size > 0:
+            swap_name = None if instance_name is None else instance_name + "-swap"
+            data_disks.append(self.__get_data_disk(swap_size, disk_type, disk_lun + 1, disk_name=swap_name))
         return {
             'image_reference': {
                 'id': image.id
@@ -426,21 +434,25 @@ class AzureInstanceProvider(AbstractInstanceProvider):
             "osDisk": {
                 "caching": "ReadWrite",
                 "managedDisk": {
-                    "storageAccountType": self.__get_disk_type(instance_type)
+                    "storageAccountType": disk_type
                 },
                 "createOption": "FromImage"
             },
-            "dataDisks": [
-                {
-                    "diskSizeGB": disk,
-                    "lun": 63,
-                    "createOption": "Empty",
-                    "managedDisk": {
-                        "storageAccountType": self.__get_disk_type(instance_type)
-                    }
-                }
-            ]
+            "dataDisks": data_disks
         }
+
+    def __get_data_disk(self, size, disk_type, lun, disk_name=None):
+        disk = {
+            "diskSizeGB": size,
+            "lun": lun,
+            "createOption": "Empty",
+            "managedDisk": {
+                "storageAccountType": disk_type
+            }
+        }
+        if disk_name is not None:
+            disk["name"] = disk_name
+        return disk
 
     def __get_instance_name_and_private_ip_from_vmss(self, scale_set_name):
         vm_vmss_id = None


### PR DESCRIPTION
This PR enables support of swap configuration using a separate block device and provides solution for issues #427 and #203.

# Implementation details
1. Swap is configured using `swap` section in `cluster.networks.config` preference. The only supported/required configuration is `swap_ratio` with sets swap/ram ration. For example, with the following configuration for each run an additional swap block device will be configured with `device size = instance_ram_gb * 0.1`:

`"swap": [
    {
     "name": "swap_ratio",
     "path": "0.1"
    }]`

2. Swap device is configured in `init_multicloud.sh` script. Block device is selected by size. Block device is configured only if a disk with matching size exists and it is not the only one disk.


