### PR TITLE
pipe CLI shall allow to update the executable automatically

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import click
 import requests
 import sys
@@ -22,7 +21,7 @@ from src.api.cluster import Cluster
 from src.api.pipeline import Pipeline
 from src.api.pipeline_run import PipelineRun
 from src.api.user import User
-from src.config import Config, ConfigNotFoundError, silent_print_config_info
+from src.config import Config, ConfigNotFoundError, silent_print_config_info, is_frozen
 from src.model.pipeline_run_filter_model import DEFAULT_PAGE_SIZE, DEFAULT_PAGE_INDEX
 from src.model.pipeline_run_model import PriceType
 from src.utilities import date_utilities, time_zone_param_type, state_utilities
@@ -32,6 +31,7 @@ from src.utilities.metadata_operations import MetadataOperations
 from src.utilities.permissions_operations import PermissionsOperations
 from src.utilities.pipeline_run_operations import PipelineRunOperations
 from src.utilities.ssh_operations import run_ssh
+from src.utilities.update_cli_version import UpdateCLIVersionManager
 from src.version import __version__
 
 MAX_INSTANCE_COUNT = 1000
@@ -1092,6 +1092,24 @@ def ssh(ctx, run_id):
     except Exception as runtime_error:
         click.echo('Error: {}'.format(str(runtime_error)), err=True)
         sys.exit(1)
+
+
+@cli.command(name='update')
+@click.argument('path', required=False)
+@Config.validate_access_token
+def update_cli_version(path):
+    """
+    Install latest Cloud Pipeline CLI version.
+    :param path: the API URL path to download Cloud Pipeline CLI source
+    """
+    if is_frozen():
+        try:
+            UpdateCLIVersionManager(path).update()
+        except Exception as e:
+            click.echo("Error: %s" % e.message, err=True)
+    else:
+        click.echo("Updating Cloud Pipeline CLI is not available")
+
 
 # Used to run a PyInstaller "freezed" version
 if getattr(sys, 'frozen', False):

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1104,9 +1104,9 @@ def update_cli_version(path):
     """
     if is_frozen():
         try:
-            UpdateCLIVersionManager(path).update()
+            UpdateCLIVersionManager().update(path)
         except Exception as e:
-            click.echo("Error: %s" % e.message, err=True)
+            click.echo("Error: %s" % e, err=True)
     else:
         click.echo("Updating Cloud Pipeline CLI is not available")
 

--- a/pipe-cli/src/utilities/update_cli_version.py
+++ b/pipe-cli/src/utilities/update_cli_version.py
@@ -23,8 +23,9 @@ import subprocess
 import uuid
 from datetime import datetime
 
-
 from src.config import Config
+
+PERMISSION_DENIED_ERROR = "Permission denied: the user has no permissions to modify '%s'"
 
 
 class UpdateCLIVersionManager(object):
@@ -77,11 +78,6 @@ class CLIVersionUpdater:
             raise RuntimeError("Failed to find Cloud Pipeline CLI download url")
         return api_path.replace(self.CP_RESTAPI_SUFFIX, self.get_download_suffix())
 
-    @staticmethod
-    def check_write_permissions(path):
-        if not os.access(path, os.X_OK | os.W_OK):
-            raise RuntimeError("Access denied: the user has no permissions to modify folder '%s'" % path)
-
 
 class LinuxUpdater(CLIVersionUpdater):
 
@@ -90,7 +86,7 @@ class LinuxUpdater(CLIVersionUpdater):
 
     def update_version(self, path):
         path_to_script = os.path.realpath(sys.argv[0])
-        self.check_write_permissions(path_to_script)
+        self.check_write_permissions(os.path.dirname(path_to_script))
         self.replace_executable(path_to_script, path)
         self.set_x_permission(path_to_script)
 
@@ -105,6 +101,11 @@ class LinuxUpdater(CLIVersionUpdater):
         st = os.stat(path_to_script)
         os.chmod(path_to_script, st.st_mode | stat.S_IEXEC)
 
+    @staticmethod
+    def check_write_permissions(path):
+        if not os.access(path, os.R_OK) or not os.access(path, os.W_OK):
+            raise RuntimeError(PERMISSION_DENIED_ERROR % path)
+
 
 class WindowsUpdater(CLIVersionUpdater):
     WINDOWS_SRC_ZIP = 'pipe.zip'
@@ -118,10 +119,10 @@ class WindowsUpdater(CLIVersionUpdater):
         random_prefix = str(uuid.uuid4()).replace("-", "")
 
         tmp_folder = self.get_tmp_folder()
-        self.check_write_permissions(tmp_folder)
+        self.check_write_permissions(tmp_folder, random_prefix)
 
         path_to_src_dir = os.path.dirname(sys.executable)
-        self.check_write_permissions(path_to_src_dir)
+        self.check_write_permissions(path_to_src_dir, random_prefix)
 
         tmp_src_dir = self.download_new_src(path, random_prefix)
         path_to_bat = os.path.join(tmp_folder, "pipe-update-%s.bat" % random_prefix)
@@ -137,7 +138,7 @@ class WindowsUpdater(CLIVersionUpdater):
             if errorlevel 1 (
                 for /d %%b in ("{src_dir}\\*") do (
                     rd /q /s "%%b" 2>> "{log_file}" || (
-                        echo Failed to delete "%%b" file >> "{log_file}"
+                        echo Failed to delete "%%b" >> "{log_file}"
                         goto fail
                     )
                 )
@@ -203,3 +204,13 @@ class WindowsUpdater(CLIVersionUpdater):
         if not os.path.exists(tmp_folder):
             os.makedirs(tmp_folder)
         return tmp_folder
+
+    @staticmethod
+    def check_write_permissions(path, prefix):
+        try:
+            path_to_tmp_file = os.path.join(path, "tmp-%s" % prefix)
+            with open(path_to_tmp_file, 'a') as tmp_file:
+                tmp_file.write("")
+            os.remove(path_to_tmp_file)
+        except OSError:
+            raise RuntimeError(PERMISSION_DENIED_ERROR % path)

--- a/pipe-cli/src/utilities/update_cli_version.py
+++ b/pipe-cli/src/utilities/update_cli_version.py
@@ -1,0 +1,62 @@
+# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import stat
+import sys
+import requests
+
+from src.config import Config
+
+
+CP_RESTAPI_SUFFIX = 'restapi/'
+CP_CLI_DOWNLOAD_SUFFIX = 'pipe'
+
+
+class UpdateCLIVersionManager(object):
+
+    def __init__(self, path=None):
+        if path:
+            self.path = path
+        else:
+            config = Config.instance()
+            self.path = str(config.api)
+            if not self.path:
+                raise RuntimeError("Failed to find Cloud Pipeline CLI download url")
+        self.path = self.path.replace(CP_RESTAPI_SUFFIX, CP_CLI_DOWNLOAD_SUFFIX)
+
+    def update(self):
+        path_to_script = os.path.realpath(sys.argv[0])
+        requests.urllib3.disable_warnings()
+        self.download_executable(path_to_script)
+        self.set_x_permission(path_to_script)
+
+    def download_executable(self, path_to_script):
+        is_d = self.is_downloadable()
+        if is_d:
+            os.remove(path_to_script)
+            request = requests.get(self.path, verify=False)
+            open(path_to_script, 'wb').write(request.content)
+        else:
+            raise RuntimeError("Provided url '%s' not downloadable or invalid." % self.path)
+
+    def is_downloadable(self):
+        header = requests.head(self.path, verify=False, allow_redirects=True).headers
+        content_type = header.get('content-type')
+        return content_type is None or 'html' not in content_type.lower()
+
+    @staticmethod
+    def set_x_permission(path_to_script):
+        st = os.stat(path_to_script)
+        os.chmod(path_to_script, st.st_mode | stat.S_IEXEC)

--- a/pipe-cli/src/utilities/update_cli_version.py
+++ b/pipe-cli/src/utilities/update_cli_version.py
@@ -79,7 +79,7 @@ class CLIVersionUpdater:
 
     @staticmethod
     def check_write_permissions(path):
-        if not os.access(path, os.X_OK & os.W_OK):
+        if not os.access(path, os.X_OK | os.W_OK):
             raise RuntimeError("Access denied: the user has no permissions to modify folder '%s'" % path)
 
 

--- a/pipe-cli/src/utilities/update_cli_version.py
+++ b/pipe-cli/src/utilities/update_cli_version.py
@@ -125,7 +125,7 @@ class WindowsUpdater(CLIVersionUpdater):
             bat_file.write(')\n')
             bat_file.write(':end\n')
             bat_file.write('(goto) 2>nul & del "%~f0"\n')
-        subprocess.Popen(path_to_bat, shell=True)
+        subprocess.Popen("{}".format(path_to_bat), shell=True)
 
     def download_new_src(self, path, prefix):
         tmp_folder = self.get_tmp_folder()


### PR DESCRIPTION
This PR provides implementation for issue #589 

a new CLI option `update` is introduced with optional argument (API url). Usage examples:
```
pipe update <api url>
```
If API url is not specified the `pipe` will try to find this url in environment variables (`$API`) or configuration JSON.

The behavior of the update operation depends on the OS.

#### For Linux binary:
- deletes current pipe executable file
- downloads the latest version from API

#### For Windows binary:
- download the latest version of pipe CLI to temporary directory
- removes all files under the directory that contains `pipe.exe`
- copies files from tmp directory to src directory described at the previous  point
- removes temporary directory

#### For other OSes (i.e. installed from the sources dist tarball):
- an error message will be shown and no update will happen