### PR TITLE
Issue 623_2 Cloud Pipeline shall allow to "block" the user via group blocking status

### DIFF
--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -254,6 +254,7 @@ public final class MessageConstants {
     public static final String USER_GROUP_IS_REQUIRED = "user.group.is.required";
     public static final String ERROR_MUTABLE_ACL_RETURN = "error.mutable.acl.return";
     public static final String ERROR_NO_GROUP_WAS_FOUND = "error.no.group.was.found";
+    public static final String ERROR_GROUP_STATUS_EXISTS = "group.status.exists";
 
     // Security
     public static final String ERROR_PERMISSION_PARAM_REQUIRED = "permission.param.is.required";

--- a/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
@@ -22,6 +22,7 @@ import com.epam.pipeline.controller.vo.PipelineUserVO;
 import com.epam.pipeline.controller.vo.RouteType;
 import com.epam.pipeline.entity.security.JwtRawToken;
 import com.epam.pipeline.entity.user.CustomControl;
+import com.epam.pipeline.entity.user.GroupStatus;
 import com.epam.pipeline.entity.user.PipelineUser;
 import com.epam.pipeline.manager.security.AuthManager;
 import com.epam.pipeline.manager.user.UserApiService;
@@ -33,6 +34,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -288,5 +290,33 @@ public class UserController extends AbstractRestController {
             })
     public Result<List<String>> findGroups(@RequestParam String prefix) {
         return Result.success(userApiService.findGroups(prefix));
+    }
+
+    @RequestMapping(value = "/group/{groupName}/block", method = {RequestMethod.POST, RequestMethod.PUT})
+    @ResponseBody
+    @ApiOperation(
+            value = "Creates or updates the block status of a group.",
+            notes = "Creates the block status of a group or updates it if it exists. " +
+                    "If the group is blocked, none of its users can't access their accounts.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public Result<GroupStatus> upsertGroupBlockingStatus(@PathVariable final String groupName,
+                                                         @RequestParam final Boolean blockStatus) {
+        return Result.success(userApiService.upsertGroupBlockingStatus(groupName, blockStatus));
+    }
+
+    @DeleteMapping(value = "/group/{groupName}/block")
+    @ResponseBody
+    @ApiOperation(
+            value = "Removes the block status of a group.",
+            notes = "Removes the block status of a group.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public Result<GroupStatus> deleteGroupBlockingStatus(@PathVariable final String groupName) {
+        return Result.success(userApiService.deleteGroupBlockingStatus(groupName));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/user/GroupStatusDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/user/GroupStatusDao.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.dao.user;
+
+import com.epam.pipeline.entity.user.GroupStatus;
+import org.springframework.beans.factory.annotation.Required;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcDaoSupport;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+public class GroupStatusDao extends NamedParameterJdbcDaoSupport {
+
+    private String upsertGroupStatusQuery;
+    private String loadGroupStatusQuery;
+    private String deleteGroupStatusQuery;
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public GroupStatus upsertGroupBlockingStatusQuery(final GroupStatus groupStatus) {
+        getNamedParameterJdbcTemplate().update(upsertGroupStatusQuery,
+                GroupParameters.getParameters(groupStatus));
+        return groupStatus;
+    }
+
+    public List<GroupStatus> loadGroupsBlockingStatus(final List<String> groupNames) {
+        return getNamedParameterJdbcTemplate().query(loadGroupStatusQuery,
+                GroupParameters.getNamesListParameters(groupNames),
+                GroupParameters.getRowMapper());
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void deleteGroupBlockingStatus(final String groupName) {
+        getJdbcTemplate().update(deleteGroupStatusQuery, groupName);
+    }
+
+
+    enum GroupParameters {
+        GROUP_NAME,
+        GROUP_BLOCKED_STATUS,
+        GROUPS;
+
+        private static MapSqlParameterSource getParameters(final GroupStatus groupStatus) {
+            final MapSqlParameterSource params = new MapSqlParameterSource();
+            params.addValue(GROUP_NAME.name(), groupStatus.getGroupName());
+            params.addValue(GROUP_BLOCKED_STATUS.name(), groupStatus.isBlocked());
+            return params;
+        }
+
+        private static RowMapper<GroupStatus> getRowMapper() {
+            return (rs, rowNum) -> new GroupStatus(rs.getString(GROUP_NAME.name()),
+                    rs.getBoolean(GROUP_BLOCKED_STATUS.name()));
+        }
+
+        private static MapSqlParameterSource getNamesListParameters(List<String> groupNames) {
+            final MapSqlParameterSource params = new MapSqlParameterSource();
+            params.addValue(GROUPS.name(), groupNames);
+            return params;
+        }
+    }
+
+    @Required
+    public void setUpsertGroupStatusQuery(final String upsertGroupStatusQuery) {
+        this.upsertGroupStatusQuery = upsertGroupStatusQuery;
+    }
+
+    @Required
+    public void setLoadGroupsBlockedStatusQuery(final String loadGroupStatusQuery) {
+        this.loadGroupStatusQuery = loadGroupStatusQuery;
+    }
+
+    @Required
+    public void setDeleteGroupStatusQuery(final String deleteGroupStatusQuery) {
+        this.deleteGroupStatusQuery = deleteGroupStatusQuery;
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/dao/user/UserDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/user/UserDao.java
@@ -174,7 +174,6 @@ public class UserDao extends NamedParameterJdbcDaoSupport {
         getJdbcTemplate().update(deleteUserRolesQuery, id);
     }
 
-
     @Transactional(propagation = Propagation.MANDATORY)
     public void assignRoleToUsers(Long roleId, List<Long> userIds) {
         processBatchQuery(addRoleToUserQuery, roleId, userIds);

--- a/api/src/main/java/com/epam/pipeline/manager/user/UserApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/UserApiService.java
@@ -18,6 +18,7 @@ package com.epam.pipeline.manager.user;
 
 import com.epam.pipeline.controller.vo.PipelineUserVO;
 import com.epam.pipeline.entity.user.CustomControl;
+import com.epam.pipeline.entity.user.GroupStatus;
 import com.epam.pipeline.entity.user.PipelineUser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -64,6 +65,22 @@ public class UserApiService {
     @PreAuthorize(ADMIN_ONLY)
     public PipelineUser updateUserBlockingStatus(final Long id, final boolean blockStatus) {
         return userManager.updateUserBlockingStatus(id, blockStatus);
+    }
+
+    /**
+     * Updates `blocked` field of a given group or creates a new group status if no such exists
+     * @param groupName name of the group to be updated
+     * @param blockStatus boolean condition of group (true - blocked, false - not blocked)
+     * @return created/updated groupStatus
+     */
+    @PreAuthorize(ADMIN_ONLY)
+    public GroupStatus upsertGroupBlockingStatus(final String groupName, final boolean blockStatus) {
+        return userManager.upsertGroupBlockingStatus(groupName, blockStatus);
+    }
+
+    @PreAuthorize(ADMIN_ONLY)
+    public GroupStatus deleteGroupBlockingStatus(final String groupName) {
+        return userManager.deleteGroupBlockingStatus(groupName);
     }
 
     @PreAuthorize(ADMIN_ONLY)

--- a/api/src/main/java/com/epam/pipeline/manager/user/UserManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/UserManager.java
@@ -34,6 +34,7 @@ import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.manager.security.AuthManager;
 import com.epam.pipeline.security.UserContext;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
@@ -191,7 +192,7 @@ public class UserManager {
     }
 
     public List<GroupStatus> loadGroupBlockingStatus(final List<String> groupNames) {
-        return groupStatusDao.loadGroupsBlockingStatus(groupNames);
+        return ListUtils.emptyIfNull(groupStatusDao.loadGroupsBlockingStatus(groupNames));
     }
 
     @Transactional(propagation = Propagation.REQUIRED)

--- a/api/src/main/java/com/epam/pipeline/security/saml/SAMLUserDetailsServiceImpl.java
+++ b/api/src/main/java/com/epam/pipeline/security/saml/SAMLUserDetailsServiceImpl.java
@@ -18,6 +18,7 @@ package com.epam.pipeline.security.saml;
 
 import com.epam.pipeline.common.MessageConstants;
 import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.entity.user.GroupStatus;
 import com.epam.pipeline.entity.user.PipelineUser;
 import com.epam.pipeline.entity.user.Role;
 import com.epam.pipeline.manager.security.GrantPermissionManager;
@@ -87,9 +88,10 @@ public class SAMLUserDetailsServiceImpl implements SAMLUserDetailsService {
             List<Long> roles = roleManager.getDefaultRolesIds();
             PipelineUser createdUser = userManager.createUser(userName,
                     roles, groups, attributes, null);
+            LOGGER.debug("Created user {} with groups {}", userName, groups);
+            validateGroupsBlockingStatus(groups, userName);
             UserContext userContext = new UserContext(createdUser.getId(), userName);
             userContext.setGroups(createdUser.getGroups());
-            LOGGER.debug("Created user {} with groups {}", userName, groups);
             userContext.setRoles(createdUser.getRoles());
             return userContext;
         } else {
@@ -104,7 +106,17 @@ public class SAMLUserDetailsServiceImpl implements SAMLUserDetailsService {
                 loadedUser = userManager.updateUserSAMLInfo(loadedUser.getId(), userName, roles, groups, attributes);
                 LOGGER.debug("Updated user groups {} ", groups);
             }
+            validateGroupsBlockingStatus(groups, userName);
             return new UserContext(loadedUser);
+        }
+    }
+
+    private void validateGroupsBlockingStatus(final List<String> groups, final String userName) {
+        final boolean isValidGroupList = userManager.loadGroupBlockingStatus(groups).stream()
+                .noneMatch(GroupStatus::isBlocked);
+        if (!isValidGroupList) {
+            LOGGER.debug("User {} is blocked due to one of his groups is blocked!", userName);
+            throw new LockedException("User is blocked!");
         }
     }
 

--- a/api/src/main/resources/dao/group-status-dao.xml
+++ b/api/src/main/resources/dao/group-status-dao.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <bean class="com.epam.pipeline.dao.user.GroupStatusDao" id="groupStatusDao" autowire="byName">
+        <property name="upsertGroupStatusQuery">
+            <value>
+                <![CDATA[
+                    INSERT INTO pipeline.group_status (
+                        group_name,
+                        blocked)
+                    VALUES (
+                        :GROUP_NAME,
+                        :GROUP_BLOCKED_STATUS)
+                    ON CONFLICT (group_name)
+                        DO UPDATE
+                        SET blocked=:GROUP_BLOCKED_STATUS;
+                ]]>
+            </value>
+        </property>
+        <property name="loadGroupsBlockedStatusQuery">
+            <value>
+                <![CDATA[
+                    SELECT
+                        group_name,
+                        blocked as group_blocked_status
+                    FROM  pipeline.group_status
+                    WHERE group_name in (:GROUPS)
+                ]]>
+            </value>
+        </property>
+        <property name="deleteGroupStatusQuery">
+            <value>
+                <![CDATA[
+                    DELETE FROM pipeline.group_status
+                    WHERE group_name = ?
+                ]]>
+            </value>
+        </property>
+    </bean>
+</beans>

--- a/api/src/main/resources/db/migration/v2019.09.10_15.00__Issue623_2_add_group_blocking_support.sql
+++ b/api/src/main/resources/db/migration/v2019.09.10_15.00__Issue623_2_add_group_blocking_support.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS pipeline.group_status (
+    group_name TEXT NOT NULL PRIMARY KEY,
+    blocked BOOLEAN DEFAULT FALSE
+);

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -248,6 +248,7 @@ error.permission.is.not.granted=Permission is not granted for ''{0}'' on ''{1}''
 error.entity.is.locked=''{0}'' with id ''{1}'' is locked from changes.
 error.mutable.acl.return=MutableAcl should be been returned
 error.no.group.was.found=No groups were found for user ''{0}''
+group.status.exists=Group status for ''{0}'' already exists.
 
 # Metadata
 error.metadata.not.found=Error: metadata for id ''{0}'' and class ''{1}'' not found.

--- a/api/src/test/java/com/epam/pipeline/dao/user/GroupStatusDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/user/GroupStatusDaoTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.dao.user;
+
+import com.epam.pipeline.AbstractSpringTest;
+import com.epam.pipeline.entity.user.GroupStatus;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+
+@Transactional
+public class GroupStatusDaoTest extends AbstractSpringTest {
+
+    private static final String TEST_GROUP_1 = "test_group_1";
+
+    @Autowired
+    private GroupStatusDao groupStatusDao;
+
+    @Test
+    public void testGroupStatusCRUD() {
+        final GroupStatus groupStatusArgument = new GroupStatus(TEST_GROUP_1, false);
+        final GroupStatus savedGroupStatus = groupStatusDao.upsertGroupBlockingStatusQuery(groupStatusArgument);
+        Assert.assertEquals(TEST_GROUP_1, savedGroupStatus.getGroupName());
+        Assert.assertFalse(savedGroupStatus.isBlocked());
+
+        final GroupStatus loadedGroupStatus = loadGroupStatus(TEST_GROUP_1);
+        Assert.assertEquals(savedGroupStatus.getGroupName(), loadedGroupStatus.getGroupName());
+        Assert.assertEquals(savedGroupStatus.isBlocked(), loadedGroupStatus.isBlocked());
+
+        final GroupStatus blockedGroupStatus = new GroupStatus(TEST_GROUP_1, true);
+        final GroupStatus updatedGroupStatus = groupStatusDao.upsertGroupBlockingStatusQuery(blockedGroupStatus);
+        Assert.assertEquals(blockedGroupStatus.getGroupName(), updatedGroupStatus.getGroupName());
+        Assert.assertTrue(updatedGroupStatus.isBlocked());
+
+        groupStatusDao.deleteGroupBlockingStatus(TEST_GROUP_1);
+        Assert.assertNull(loadGroupStatus(TEST_GROUP_1));
+    }
+
+    private GroupStatus loadGroupStatus(final String groupName) {
+        return groupStatusDao.loadGroupsBlockingStatus(Collections.singletonList(groupName))
+                             .stream()
+                             .findFirst()
+                             .orElse(null);
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/dao/user/UserDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/user/UserDaoTest.java
@@ -270,6 +270,7 @@ public class UserDaoTest extends AbstractSpringTest {
     private boolean isRolePresent(Role roleToFind, Collection<Role> roles) {
         return roles.stream().anyMatch(r -> r.equals(roleToFind));
     }
+
     private boolean assertUserAttributes(Map<String, String> expectedAttributes, Map<String, String> actualAttributes) {
         return CollectionUtils.isEqualCollection(expectedAttributes.entrySet(), actualAttributes.entrySet());
     }

--- a/api/src/test/java/com/epam/pipeline/manager/user/UserManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/user/UserManagerTest.java
@@ -22,7 +22,9 @@ import com.epam.pipeline.AbstractSpringTest;
 import com.epam.pipeline.dao.notification.MonitoringNotificationDao;
 import com.epam.pipeline.entity.notification.NotificationMessage;
 import com.epam.pipeline.entity.notification.NotificationTemplate;
+import com.epam.pipeline.entity.user.GroupStatus;
 import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.entity.user.Role;
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +34,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 
 public class UserManagerTest extends AbstractSpringTest {
@@ -41,7 +44,8 @@ public class UserManagerTest extends AbstractSpringTest {
     private static final String BODY = "Body";
     private static final Long DEFAULT_STORAGE_ID = null;
     private static final List<Long> DEFAULT_USER_ROLES = Collections.singletonList(2L);
-    private static final List<String> DEFAULT_USER_GROUPS = Collections.emptyList();
+    private static final String TEST_GROUP_NAME_1 = "test_group_1";
+    private static final List<String> DEFAULT_USER_GROUPS = Collections.singletonList(TEST_GROUP_NAME_1);
     private static final Map<String, String> DEFAULT_USER_ATTRIBUTE = Collections.emptyMap();
 
     @Autowired
@@ -52,9 +56,31 @@ public class UserManagerTest extends AbstractSpringTest {
 
     @Test
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void updateUser() {
+    public void createUser() {
         Assert.assertNull(userManager.loadUserByName(TEST_USER));
+        final PipelineUser newUser = createDefaultPipelineUser();
+        Assert.assertEquals(TEST_USER.toUpperCase(), newUser.getUserName());
+        Assert.assertEquals(DEFAULT_USER_GROUPS, newUser.getGroups());
+        Assert.assertEquals(DEFAULT_USER_ATTRIBUTE, newUser.getAttributes());
+        Assert.assertEquals(DEFAULT_USER_ROLES, newUser.getRoles()
+                                                       .stream()
+                                                       .map(Role::getId)
+                                                       .collect(Collectors.toList()));
+        Assert.assertEquals(DEFAULT_STORAGE_ID, newUser.getDefaultStorageId());
+    }
 
+    @Test
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void readUser() {
+        Assert.assertNull(userManager.loadUserByName(TEST_USER));
+        final PipelineUser newUser = createDefaultPipelineUser();
+        final PipelineUser loadedUser = userManager.loadUserById(newUser.getId());
+        compareAllFieldOfUsers(newUser, loadedUser);
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void updateUser() {
         final PipelineUser user = createDefaultPipelineUser();
         Assert.assertFalse(user.isBlocked());
 
@@ -85,6 +111,57 @@ public class UserManagerTest extends AbstractSpringTest {
         Assert.assertFalse(notificationDao.loadAllNotifications().isEmpty());
         userManager.deleteUser(user.getId());
         Assert.assertTrue(notificationDao.loadAllNotifications().isEmpty());
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void createGroupStatus() {
+        Assert.assertNotNull(userManager.upsertGroupBlockingStatus(TEST_GROUP_NAME_1, false));
+        Assert.assertFalse(getGroupStatus(TEST_GROUP_NAME_1).isBlocked());
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void updateGroupStatus() {
+        userManager.upsertGroupBlockingStatus(TEST_GROUP_NAME_1, false);
+        Assert.assertFalse(getGroupStatus(TEST_GROUP_NAME_1).isBlocked());
+        userManager.upsertGroupBlockingStatus(TEST_GROUP_NAME_1, true);
+        Assert.assertTrue(getGroupStatus(TEST_GROUP_NAME_1).isBlocked());
+        userManager.upsertGroupBlockingStatus(TEST_GROUP_NAME_1, false);
+        Assert.assertFalse(getGroupStatus(TEST_GROUP_NAME_1).isBlocked());
+    }
+
+    private GroupStatus getGroupStatus(final String groupName) {
+        return userManager.loadGroupBlockingStatus(Collections.singletonList(groupName))
+                          .stream()
+                          .findFirst()
+                          .orElse(null);
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void deleteGroupStatus() {
+        userManager.upsertGroupBlockingStatus(TEST_GROUP_NAME_1, false);
+        Assert.assertFalse(getGroupStatus(TEST_GROUP_NAME_1).isBlocked());
+        userManager.deleteGroupBlockingStatus(TEST_GROUP_NAME_1);
+        Assert.assertNull(getGroupStatus(TEST_GROUP_NAME_1));
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void loadGroupStatusForNonexistentGroup() {
+        Assert.assertNull(getGroupStatus(TEST_GROUP_NAME_1));
+    }
+
+    private void compareAllFieldOfUsers(PipelineUser firstUser, PipelineUser secondUser) {
+        Assert.assertEquals(firstUser.getUserName(), secondUser.getUserName());
+        Assert.assertEquals(firstUser.getEmail(), secondUser.getEmail());
+        Assert.assertEquals(firstUser.getId(), secondUser.getId());
+        Assert.assertEquals(firstUser.getGroups(), secondUser.getGroups());
+        Assert.assertEquals(firstUser.getAttributes(), secondUser.getAttributes());
+        Assert.assertEquals(firstUser.getAuthorities(), secondUser.getAuthorities());
+        Assert.assertEquals(firstUser.getRoles(), secondUser.getRoles());
+        Assert.assertEquals(firstUser.getDefaultStorageId(), secondUser.getDefaultStorageId());
     }
 
     private PipelineUser createDefaultPipelineUser() {

--- a/core/src/main/java/com/epam/pipeline/entity/user/GroupStatus.java
+++ b/core/src/main/java/com/epam/pipeline/entity/user/GroupStatus.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.user;
+
+import lombok.Data;
+
+@Data
+public class GroupStatus {
+
+    private final String groupName;
+    private final boolean blocked;
+}


### PR DESCRIPTION
PR solves the second part of issue #623
It allows blocking a whole group of users to deny their access to the account.

- Table `group_status` for storing blocked groups is created
- CRUD methods for group status are implemented in UserController and underlying layers    
- Handling of `blocked` group status is provided at SAMLUserDetailsServiceImpl class: user can't be successfully authorized if belongs to any of the blocked groups