### PR TITLE
`pipe`: the `view-runs` command doesn't correctly work with the `-dt` option

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -251,7 +251,7 @@ def view_pipe(pipeline, versions, parameters, storage_rules, permissions):
 @click.argument('run-id', required=False, type=int)
 @click.option('-s', '--status', help='List pipelines with a specific status [ANY/FAILURE/SUCCESS/STOPPED/RUNNING]')
 @click.option('-df', '--date-from', help='List pipeline runs started after date')
-@click.option('-dt', '--date-to', help='List pipeline runs started before date')
+@click.option('-dt', '--date-to', help='List pipeline runs completed before date')
 @click.option('-p', '--pipeline', help='List runs for a specific pipeline type@version')
 @click.option('-pid', '--parent-id', help='List runs for a specific parent pipeline run', type=int)
 @click.option('-f', '--find', help='Search runs with a specific substring in a run parameters')
@@ -286,6 +286,9 @@ def view_all_runs(status, date_from, date_to, pipeline, parent_id, find, top):
     runs_table.field_names = ["RunID", "Parent RunID", "Pipeline", "Version", "Status", "Started"]
     runs_table.align = "r"
     try:
+        if date_to and not status:
+            click.echo("The run status shall be specified for viewing completed before specified date runs")
+            sys.exit(1)
         statuses = []
         if status is not None:
             if status.upper() != 'ANY':


### PR DESCRIPTION
Fix for issue #616 
The main problem was that the default status is `RUNNING` which is impossible for completed runs. 
The following changes was added:
- help message was fixed
- error message was added for case when `-dt` option is specified but `-s` not