### PR TITLE
Issue 666 Implementation of tags for PipelineRun

### DIFF
--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
@@ -28,6 +28,7 @@ import com.epam.pipeline.controller.vo.PipelineRunFilterVO;
 import com.epam.pipeline.controller.vo.PipelineRunServiceUrlVO;
 import com.epam.pipeline.controller.vo.RunCommitVO;
 import com.epam.pipeline.controller.vo.RunStatusVO;
+import com.epam.pipeline.controller.vo.TagsVO;
 import com.epam.pipeline.controller.vo.configuration.RunConfigurationWithEntitiesVO;
 import com.epam.pipeline.entity.cluster.PipelineRunPrice;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
@@ -459,5 +460,17 @@ public class PipelineRunController extends AbstractRestController {
     @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
     public Result<PipelineRun>  terminateRun(@PathVariable(value = RUN_ID) Long runId) {
         return Result.success(runApiService.terminateRun(runId));
+    }
+
+    @PostMapping(value = "/run/{runId}/tag")
+    @ResponseBody
+    @ApiOperation(
+            value = "Updates tags for pipeline run.",
+            notes = "Updates tags for pipeline run. To remove all the tags pass empty map or null inside VO.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<PipelineRun>  updateRunTags(@PathVariable(value = RUN_ID) final Long runId,
+                                              @RequestBody final TagsVO tagsVO) {
+        return Result.success(runApiService.updateTags(runId, tagsVO));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/vo/TagsVO.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/TagsVO.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.controller.vo;
+
+import lombok.Data;
+
+import java.util.Map;
+
+@Data
+public class TagsVO {
+    private final Map<String, String> tags;
+}

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
@@ -115,6 +115,7 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
 
     private String updateRunQuery;
     private String loadRunByPrettyUrlQuery;
+    private String updateTagsQuery;
     // We put Propagation.REQUIRED here because this method can be called from non-transaction context
     // (see PipelineRunManager, it performs internal call for launchPipeline)
 
@@ -349,6 +350,16 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     @Transactional(propagation = Propagation.MANDATORY)
     public void updateServiceUrl(PipelineRun run) {
         getNamedParameterJdbcTemplate().update(updateServiceUrlQuery, PipelineRunParameters
+                .getParameters(run, getConnection()));
+    }
+
+    /**
+     * Updates tags the provided run in a database
+     * @param run run with updated tags
+     **/
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void updateTags(final PipelineRun run) {
+        getNamedParameterJdbcTemplate().update(updateTagsQuery, PipelineRunParameters
                 .getParameters(run, getConnection()));
     }
 
@@ -646,7 +657,8 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
         NODE_REAL_DISK,
         QUEUED,
         NODEUP_TASK,
-        ACCESS_TYPE;
+        ACCESS_TYPE,
+        TAGS;
 
         public static final RunAccessType DEFAULT_ACCESS_TYPE = RunAccessType.ENDPOINT;
 
@@ -688,6 +700,7 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
             params.addValue(PRICE_PER_HOUR.name(), run.getPricePerHour());
             params.addValue(STATE_REASON.name(), run.getStateReasonMessage());
             params.addValue(NON_PAUSE.name(), run.isNonPause());
+            params.addValue(TAGS.name(), JsonMapper.convertDataToJsonStringForQuery(run.getTags()));
             addInstanceFields(run, params);
             return params;
         }
@@ -846,6 +859,7 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
                 if (loadEnvVars) {
                     run.setEnvVars(getEnvVarsRowMapper().mapRow(rs, rowNum));
                 }
+                run.setTags(getTagsRowMapper().mapRow(rs, rowNum));
                 return run;
             };
         }
@@ -891,6 +905,10 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
                     new TypeReference<Map<String, String>>() {});
         }
 
+        static RowMapper<Map<String, String>> getTagsRowMapper() {
+            return (rs, rowNum) -> JsonMapper.parseData(rs.getString(TAGS.name()),
+                    new TypeReference<Map<String, String>>() {});
+        }
     }
     private static Array mapListToSqlArray(List<Long> list, Connection connection) {
         Long[] emptyArray = new Long[0];
@@ -1073,5 +1091,10 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setLoadRunSidsQueryForList(final String loadRunSidsQueryForList) {
         this.loadRunSidsQueryForList = loadRunSidsQueryForList;
+    }
+
+    @Required
+    public void setUpdateTagsQuery(final String updateTagsQuery) {
+        this.updateTagsQuery = updateTagsQuery;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -22,6 +22,7 @@ import com.epam.pipeline.controller.PagedResult;
 import com.epam.pipeline.controller.vo.PagingRunFilterVO;
 import com.epam.pipeline.controller.vo.PipelineRunFilterVO;
 import com.epam.pipeline.controller.vo.PipelineRunServiceUrlVO;
+import com.epam.pipeline.controller.vo.TagsVO;
 import com.epam.pipeline.dao.pipeline.PipelineRunDao;
 import com.epam.pipeline.entity.AbstractSecuredEntity;
 import com.epam.pipeline.entity.cluster.InstancePrice;
@@ -842,14 +843,16 @@ public class PipelineRunManager {
 
     /**
      * Updates run's tags
-     * @param run {@link PipelineRun} for pipeline run which tagsshould be updated
+     * @param runId is ID of pipeline run which tags should be updated
+     * @param newTags object, containing a map with tags to set for a pipeline
      * @return
      */
     @Transactional(propagation = Propagation.REQUIRED)
-    public PipelineRun updateTags(final PipelineRun run) {
-        final PipelineRun loadedRun = pipelineRunDao.loadPipelineRun(run.getId());
-        Assert.notNull(loadedRun,
-                messageHelper.getMessage(MessageConstants.ERROR_PIPELINE_NOT_FOUND, run.getId()));
+    public PipelineRun updateTags(final Long runId, final TagsVO newTags) {
+        final PipelineRun run = pipelineRunDao.loadPipelineRun(runId);
+        Assert.notNull(run,
+                messageHelper.getMessage(MessageConstants.ERROR_PIPELINE_NOT_FOUND, runId));
+        run.setTags(newTags.getTags());
         pipelineRunDao.updateTags(run);
         return run;
     }

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -841,6 +841,20 @@ public class PipelineRunManager {
     }
 
     /**
+     * Updates run's tags
+     * @param run {@link PipelineRun} for pipeline run which tagsshould be updated
+     * @return
+     */
+    @Transactional(propagation = Propagation.REQUIRED)
+    public PipelineRun updateTags(final PipelineRun run) {
+        final PipelineRun loadedRun = pipelineRunDao.loadPipelineRun(run.getId());
+        Assert.notNull(loadedRun,
+                messageHelper.getMessage(MessageConstants.ERROR_PIPELINE_NOT_FOUND, run.getId()));
+        pipelineRunDao.updateTags(run);
+        return run;
+    }
+
+    /**
      * Updates run state reason message which was retrieved from instance {@StateReason}
      * @param run {@link PipelineRun} for pipeline run which state reason message should be updated
      * @param stateReasonMessage message that should be updated

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/RunApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/RunApiService.java
@@ -24,6 +24,7 @@ import com.epam.pipeline.controller.vo.PagingRunFilterExpressionVO;
 import com.epam.pipeline.controller.vo.PagingRunFilterVO;
 import com.epam.pipeline.controller.vo.PipelineRunFilterVO;
 import com.epam.pipeline.controller.vo.PipelineRunServiceUrlVO;
+import com.epam.pipeline.controller.vo.TagsVO;
 import com.epam.pipeline.controller.vo.configuration.RunConfigurationWithEntitiesVO;
 import com.epam.pipeline.dao.filter.FilterRunParameters;
 import com.epam.pipeline.entity.cluster.PipelineRunPrice;
@@ -159,6 +160,12 @@ public class RunApiService {
     @AclMask
     public PipelineRun updatePrettyUrl(Long runId, String url) {
         return runManager.updatePrettyUrl(runId, url);
+    }
+
+    @PreAuthorize(RUN_ID_EXECUTE)
+    @AclMask
+    public PipelineRun updateTags(final Long runId, final TagsVO tagsVO) {
+        return runManager.updateTags(runId, tagsVO);
     }
 
     @AclFilter

--- a/api/src/main/resources/dao/pipeline-run-dao.xml
+++ b/api/src/main/resources/dao/pipeline-run-dao.xml
@@ -65,7 +65,8 @@
                         state_reason,
                         non_pause,
                         node_real_disk,
-                        node_cloud_provider)
+                        node_cloud_provider,
+                        tags)
                     VALUES (
                         :RUN_ID,
                         :PIPELINE_ID,
@@ -108,7 +109,8 @@
                         :STATE_REASON,
                         :NON_PAUSE,
                         :NODE_REAL_DISK,
-                        :NODE_CLOUD_PROVIDER)
+                        :NODE_CLOUD_PROVIDER,
+                        to_jsonb(:TAGS::jsonb))
                 ]]>
             </value>
         </property>
@@ -158,6 +160,7 @@
                         r.non_pause,
                         r.node_real_disk,
                         r.node_cloud_provider,
+                        r.tags,
                         tasks.task_name IS NOT NULL as initialization_finished,
                         init_node_tasks.task_name IS NULL as queued,
                         pipelines.pipeline_name
@@ -168,13 +171,13 @@
                         (SELECT DISTINCT
                            run_id,
                            task_name
-                         FROM pipeline_run_log
+                         FROM pipeline.pipeline_run_log
                          WHERE status = ? AND task_name = ?) tasks ON tasks.run_id = r.run_id
                     LEFT JOIN
                         (SELECT DISTINCT
                            run_id,
                            task_name
-                         FROM pipeline_run_log
+                         FROM pipeline.pipeline_run_log
                          WHERE run_id = ? AND task_name = ?) init_node_tasks ON init_node_tasks.run_id = r.run_id
                     WHERE
                         r.run_id = ?
@@ -242,7 +245,8 @@
                         state_reason,
                         non_pause,
                         node_real_disk,
-                        node_cloud_provider
+                        node_cloud_provider,
+                        tags
                     FROM
                         pipeline.pipeline_run
                     WHERE
@@ -297,7 +301,8 @@
                         state_reason,
                         non_pause,
                         node_real_disk,
-                        node_cloud_provider
+                        node_cloud_provider,
+                        tags
                     FROM
                         pipeline.pipeline_run
                     WHERE
@@ -352,7 +357,8 @@
                         state_reason,
                         non_pause,
                         node_real_disk,
-                        node_cloud_provider
+                        node_cloud_provider,
+                        tags
                     FROM
                         pipeline.pipeline_run
                     WHERE
@@ -445,7 +451,8 @@
                         price_per_hour = :PRICE_PER_HOUR,
                         state_reason = :STATE_REASON,
                         non_pause = :NON_PAUSE,
-                        node_real_disk =:NODE_REAL_DISK
+                        node_real_disk =:NODE_REAL_DISK,
+                        tags = to_jsonb(:TAGS::jsonb)
                     WHERE
                         run_id = :RUN_ID
                 ]]>
@@ -550,6 +557,7 @@
                       r.non_pause,
                       r.node_real_disk,
                       r.node_cloud_provider,
+                      r.tags,
                       TRUE as initialization_finished,
                       FALSE as queued,
                       p.pipeline_name
@@ -607,6 +615,7 @@
                       r.non_pause,
                       r.node_real_disk,
                       r.node_cloud_provider,
+                      r.tags,
                       TRUE as initialization_finished,
                       FALSE as queued,
                       p.pipeline_name
@@ -663,7 +672,8 @@
                       r.state_reason,
                       r.non_pause,
                       r.node_real_disk,
-                      r.node_cloud_provider
+                      r.node_cloud_provider,
+                      r.tags
                     FROM
                         pipeline.pipeline_run r
                     WHERE
@@ -711,7 +721,8 @@
                       active_run.state_reason,
                       active_run.non_pause,
                       active_run.node_real_disk,
-                      active_run.node_cloud_provider
+                      active_run.node_cloud_provider,
+                      active_run.tags
                     FROM active_run
                     INNER JOIN
                         (SELECT DISTINCT run_id
@@ -772,7 +783,8 @@
                       r.state_reason,
                       r.non_pause,
                       r.node_real_disk,
-                      r.node_cloud_provider
+                      r.node_cloud_provider,
+                      r.tags
                     FROM
                         pipeline.pipeline_run r
                     WHERE
@@ -819,7 +831,8 @@
                       active_run.state_reason,
                       active_run.non_pause,
                       active_run.node_real_disk,
-                      active_run.node_cloud_provider
+                      active_run.node_cloud_provider,
+                      active_run.tags
                     FROM active_run
                     INNER JOIN
                         (SELECT DISTINCT run_id
@@ -877,7 +890,8 @@
                         r.state_reason,
                         r.non_pause,
                         r.node_real_disk,
-                        r.node_cloud_provider
+                        r.node_cloud_provider,
+                        r.tags
                     FROM
                         pipeline.pipeline_run r
                     WHERE
@@ -930,7 +944,8 @@
                         r.state_reason,
                         r.non_pause,
                         r.node_real_disk,
-                        r.node_cloud_provider
+                        r.node_cloud_provider,
+                        r.tags
                     FROM
                         pipeline.pipeline_run r
                     WHERE
@@ -984,6 +999,7 @@
                         r.non_pause,
                         r.node_real_disk,
                         r.node_cloud_provider,
+                        r.tags,
                         tasks.task_name IS NOT NULL as initialization_finished,
                         init_node_tasks.task_name IS NULL as queued,
                         pipelines.pipeline_name
@@ -994,13 +1010,13 @@
                         (SELECT DISTINCT
                            run_id,
                            task_name
-                         FROM pipeline_run_log
+                         FROM pipeline.pipeline_run_log
                          WHERE status = :TASK_STATUS AND task_name = :TASK_NAME) tasks ON tasks.run_id = r.run_id
                     LEFT JOIN
                         (SELECT DISTINCT
                            run_id,
                            task_name
-                         FROM pipeline_run_log
+                         FROM pipeline.pipeline_run_log
                          WHERE task_name = :NODEUP_TASK) init_node_tasks ON init_node_tasks.run_id = r.run_id
                     @WHERE@
                     ORDER BY r.run_id DESC
@@ -1072,6 +1088,7 @@
                         runs.non_pause,
                         runs.node_real_disk,
                         runs.node_cloud_provider,
+                        runs.tags,
                         tasks.task_name IS NOT NULL as initialization_finished,
                         init_node_tasks.task_name IS NULL as queued,
                         pipelines.pipeline_name
@@ -1082,13 +1099,13 @@
                         (SELECT DISTINCT
                            run_id,
                            task_name
-                         FROM pipeline_run_log
+                         FROM pipeline.pipeline_run_log
                          WHERE status = :TASK_STATUS AND task_name = :TASK_NAME) tasks ON tasks.run_id = runs.run_id
                     LEFT JOIN
                         (SELECT DISTINCT
                            run_id,
                            task_name
-                         FROM pipeline_run_log
+                         FROM pipeline.pipeline_run_log
                          WHERE task_name = :NODEUP_TASK) init_node_tasks ON init_node_tasks.run_id = runs.run_id
                     WHERE runs.run_id IN (:list)
                 ]]>
@@ -1140,9 +1157,10 @@
                             p.state_reason,
                             p.non_pause,
                             p.node_real_disk,
-                            p.node_cloud_provider
+                            p.node_cloud_provider,
+                            p.tags
                         FROM (SELECT *
-                            FROM pipeline_run r
+                            FROM pipeline.pipeline_run r
                             WHERE parent_id ISNULL @WHERE@
                             ORDER BY run_id DESC
                             LIMIT :LIMIT OFFSET :OFFSET) as p
@@ -1189,7 +1207,8 @@
                             c.state_reason,
                             c.non_pause,
                             c.node_real_disk,
-                            c.node_cloud_provider
+                            c.node_cloud_provider,
+                            c.tags
                         FROM
                             pipeline.pipeline_run c
                         INNER JOIN runs ON runs.run_id = c.parent_id
@@ -1237,6 +1256,7 @@
                         runs.non_pause,
                         runs.node_real_disk,
                         runs.node_cloud_provider,
+                        runs.tags,
                         tasks.task_name IS NOT NULL as initialization_finished,
                         init_node_tasks.task_name IS NULL as queued,
                         pipelines.pipeline_name
@@ -1331,6 +1351,16 @@
                         pipeline.pipeline_run r
                     WHERE
                         r.run_id = ?
+                ]]>
+            </value>
+        </property>
+        <property name="updateTagsQuery">
+            <value>
+                <![CDATA[
+                    UPDATE pipeline.pipeline_run SET
+                        tags = to_jsonb(:TAGS::jsonb)
+                    WHERE
+                        run_id = :RUN_ID
                 ]]>
             </value>
         </property>

--- a/api/src/main/resources/db/migration/v2019.09.17_15.00__Issue_624-add_tags_pipeline_run.sql
+++ b/api/src/main/resources/db/migration/v2019.09.17_15.00__Issue_624-add_tags_pipeline_run.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pipeline.pipeline_run ADD tags jsonb;

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
@@ -178,6 +178,8 @@ public class PipelineRunDaoTest extends AbstractSpringTest {
         updateTagsAndVerifySaveIsCorrect(run, tags);
         tags.remove(TAG_KEY_2);
         updateTagsAndVerifySaveIsCorrect(run, tags);
+        run.setTags(null);
+        loadTagsAndCompareWithExpected(run, Collections.emptyMap());
     }
 
     private void updateTagsAndVerifySaveIsCorrect(final PipelineRun run, final Map<String, String> tags) {
@@ -186,7 +188,7 @@ public class PipelineRunDaoTest extends AbstractSpringTest {
         loadTagsAndCompareWithExpected(run, tags);
     }
 
-    private void loadTagsAndCompareWithExpected(PipelineRun run, Map<String, String> tags) {
+    private void loadTagsAndCompareWithExpected(final PipelineRun run, final Map<String, String> tags) {
         final Map<String, String> loadedTags = pipelineRunDao.loadPipelineRun(run.getId()).getTags();
         assertThat(loadedTags, CoreMatchers.is(tags));
     }

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
@@ -36,6 +36,7 @@ import com.epam.pipeline.manager.ObjectCreatorUtils;
 import com.epam.pipeline.manager.execution.EnvVarsBuilder;
 import com.epam.pipeline.manager.execution.EnvVarsBuilderTest;
 import com.epam.pipeline.manager.execution.SystemParams;
+import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,6 +52,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -60,6 +62,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThat;
 
 @Transactional
 public class PipelineRunDaoTest extends AbstractSpringTest {
@@ -93,6 +96,11 @@ public class PipelineRunDaoTest extends AbstractSpringTest {
     private static final BigDecimal PRICE_PER_HOUR = new BigDecimal("0.08");
     private static final String TEST_REPO = "///";
     private static final String TEST_REPO_SSH = "git@test";
+
+    private static final String TAG_KEY_1 = "key1";
+    private static final String TAG_KEY_2 = "key2";
+    private static final String TAG_VALUE_1 = "value1";
+    private static final String TAG_VALUE_2 = "value2";
 
     @Autowired
     private PipelineRunDao pipelineRunDao;
@@ -155,6 +163,32 @@ public class PipelineRunDaoTest extends AbstractSpringTest {
 
         PipelineRun loadedRun = pipelineRunDao.loadPipelineRun(run.getId());
         assertEquals(run.getCommitStatus(), loadedRun.getCommitStatus());
+    }
+
+    @Test
+    public void updateTags() {
+        final PipelineRun run = createTestPipelineRun();
+        final Map<String, String> tags = new HashMap<>();
+        loadTagsAndCompareWithExpected(run, tags);
+        tags.put(TAG_KEY_1, TAG_VALUE_1);
+        updateTagsAndVerifySaveIsCorrect(run, tags);
+        tags.put(TAG_KEY_2, TAG_VALUE_2);
+        updateTagsAndVerifySaveIsCorrect(run, tags);
+        tags.remove(TAG_KEY_1);
+        updateTagsAndVerifySaveIsCorrect(run, tags);
+        tags.remove(TAG_KEY_2);
+        updateTagsAndVerifySaveIsCorrect(run, tags);
+    }
+
+    private void updateTagsAndVerifySaveIsCorrect(final PipelineRun run, final Map<String, String> tags) {
+        run.setTags(tags);
+        pipelineRunDao.updateTags(run);
+        loadTagsAndCompareWithExpected(run, tags);
+    }
+
+    private void loadTagsAndCompareWithExpected(PipelineRun run, Map<String, String> tags) {
+        final Map<String, String> loadedTags = pipelineRunDao.loadPipelineRun(run.getId()).getTags();
+        assertThat(loadedTags, CoreMatchers.is(tags));
     }
 
     @Test

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunManagerTest.java
@@ -53,6 +53,7 @@ import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.manager.region.CloudRegionManager;
 import io.reactivex.subjects.BehaviorSubject;
 import org.apache.commons.collections.CollectionUtils;
+import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -480,6 +481,28 @@ public class PipelineRunManagerTest extends AbstractManagerTest {
         final PipelineRun pipelineRun = launchPipeline(configurationWithParentId, new Pipeline(), INSTANCE_TYPE, null);
 
         assertThat(pipelineRun.getInstance().getCloudRegionId(), is(NON_DEFAULT_REGION_ID));
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    @WithMockUser
+    public void shouldThrowExceptionOnInexistentRunTagUpdate() {
+        final PipelineRun emptyRun = new PipelineRun();
+        pipelineRunManager.updateTags(emptyRun);
+    }
+
+    @Test
+    @WithMockUser
+    public void testUpdateRunTags() {
+        final PipelineRun pipelineRun = launchPipeline(configuration, INSTANCE_TYPE, PARENT_RUN_ID);
+        final PipelineRun loadedPipelineRun1 = pipelineRunManager.loadPipelineRun(pipelineRun.getId());
+        final Map<String, String> tags = loadedPipelineRun1.getTags();
+        assertThat(Collections.emptyMap(), CoreMatchers.is(tags));
+
+        tags.put("newKey", "newValue");
+        pipelineRun.setTags(tags);
+        pipelineRunManager.updateTags(pipelineRun);
+        final PipelineRun loadedPipelineRun2 = pipelineRunManager.loadPipelineRun(pipelineRun.getId());
+        assertThat(tags, CoreMatchers.is(loadedPipelineRun2.getTags()));
     }
 
     private void checkResolvedValue(List<PipelineRunParameter> actualParameters, String paramValue,

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
@@ -110,6 +110,7 @@ public class PipelineRun extends AbstractSecuredEntity {
     @JsonIgnore
     private AbstractSecuredEntity parent;
     private AclClass aclClass = AclClass.PIPELINE;
+    private Map<String, String> tags;
 
 
     public PipelineRun() {


### PR DESCRIPTION
PR solves issue #666 
It brings handling of tags for PipelineRun entity.

- Add column `tags` (jsonb) to `pipeline_run` table
- Add tags field (Map<String, String>) for PipelineRun
- Add functionality for proceeding tags to PipelineRunDao and PipelineRunManager