### PR TITLE
Issue 624 Highlight "Idle" and "Pressured" jobs in the Cloud Pipeline API/GUI/CLI

### DIFF
--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
@@ -358,9 +358,20 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
      * @param run run with updated tags
      **/
     @Transactional(propagation = Propagation.MANDATORY)
-    public void updateTags(final PipelineRun run) {
+    public void updateRunTags(final PipelineRun run) {
         getNamedParameterJdbcTemplate().update(updateTagsQuery, PipelineRunParameters
                 .getParameters(run, getConnection()));
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void updateRunsTags(final Collection<PipelineRun> runs) {
+        if (CollectionUtils.isEmpty(runs)) {
+            return;
+        }
+        final MapSqlParameterSource[] params = runs.stream()
+                .map(run -> PipelineRunParameters.getParameters(run, getConnection()))
+                .toArray(MapSqlParameterSource[]::new);
+        getNamedParameterJdbcTemplate().batchUpdate(updateTagsQuery, params);
     }
 
     public int countFilteredPipelineRuns(PipelineRunFilterVO filter, PipelineRunFilterVO.ProjectFilter projectFilter) {

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
@@ -168,7 +168,7 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
     private List<PipelineRun> getRunsToUpdatePressuredTags(final Map<String, PipelineRun> running,
                               final List<Pair<PipelineRun, Map<ELKUsageMetric, Double>>> runsToNotify) {
         final Set<Long> listOfRunsIdToNotify = runsToNotify
-                .parallelStream()
+                .stream()
                 .map(p -> p.getLeft().getId())
                 .collect(Collectors.toSet());
         final Predicate<PipelineRun> isToBeNotified = r -> listOfRunsIdToNotify.contains(r.getId());

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Set;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -121,13 +122,11 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
 
     public void monitorResourceUsage() {
         List<PipelineRun> runs = pipelineRunManager.loadRunningPipelineRuns();
-
-        final List<PipelineRun> runsToUpdateTags = processIdleRuns(runs);
-        runsToUpdateTags.addAll(processOverloadedRuns(runs));
-        pipelineRunManager.updateRunsTags(runsToUpdateTags);
+        processIdleRuns(runs);
+        processOverloadedRuns(runs);
     }
 
-    private List<PipelineRun> processOverloadedRuns(final List<PipelineRun> runs) {
+    private void processOverloadedRuns(final List<PipelineRun> runs) {
         final Map<String, PipelineRun> running = runs.stream()
                 .filter(r -> {
                     final boolean hasNodeName = Objects.nonNull(r.getInstance())
@@ -163,46 +162,24 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
 
         final List<PipelineRun> runsToUpdateTags = getRunsToUpdatePressuredTags(running, runsToNotify);
         notificationManager.notifyHighResourceConsumingRuns(runsToNotify, NotificationType.HIGH_CONSUMED_RESOURCES);
-        return runsToUpdateTags;
+        pipelineRunManager.updateRunsTags(runsToUpdateTags);
     }
 
     private List<PipelineRun> getRunsToUpdatePressuredTags(final Map<String, PipelineRun> running,
                               final List<Pair<PipelineRun, Map<ELKUsageMetric, Double>>> runsToNotify) {
-        final List<PipelineRun> listOfRunsToNotify = runsToNotify
+        final Set<Long> listOfRunsIdToNotify = runsToNotify
                 .parallelStream()
-                .map(Pair::getLeft)
-                .collect(Collectors.toList());
-        final Predicate<PipelineRun> runToBeNotified = listOfRunsToNotify::contains;
-        final Stream<PipelineRun> runsToAddTag = listOfRunsToNotify
-                .parallelStream()
-                .filter(this::hasNoPressuredTag)
-                .map(this::addPressuredTagToRun);
-        final Stream<PipelineRun> runsToRemoveTag = running.values()
-                .parallelStream()
-                .filter(runToBeNotified.negate())
-                .filter(this::hasPressuredTag)
-                .map(this::removePressuredTagFromRun);
+                .map(p -> p.getLeft().getId())
+                .collect(Collectors.toSet());
+        final Stream<PipelineRun> runsStream = running.values().parallelStream();
+        final Predicate<PipelineRun> isToBeNotified = r -> listOfRunsIdToNotify.contains(r.getId());
+        final Stream<PipelineRun> runsToAddTag = runsStream
+                .filter(isToBeNotified)
+                .map(r -> r.inverseTagForRun(UTILIZATION_LEVEL_HIGH, TRUE_VALUE_STRING));
+        final Stream<PipelineRun> runsToRemoveTag = runsStream
+                .filter(isToBeNotified.negate())
+                .map(r -> r.inverseTagForRun(UTILIZATION_LEVEL_HIGH, TRUE_VALUE_STRING));
         return Stream.concat(runsToAddTag, runsToRemoveTag).collect(Collectors.toList());
-    }
-
-    private boolean hasPressuredTag(final PipelineRun run) {
-        final String tagToBeRemoved = run.getTags().get(UTILIZATION_LEVEL_HIGH);
-        return tagToBeRemoved != null
-                && tagToBeRemoved.equals(TRUE_VALUE_STRING);
-    }
-
-    private boolean hasNoPressuredTag(final PipelineRun run) {
-        return !hasPressuredTag(run);
-    }
-
-    private PipelineRun removePressuredTagFromRun(final PipelineRun run) {
-        run.getTags().remove(UTILIZATION_LEVEL_HIGH);
-        return run;
-    }
-
-    private PipelineRun addPressuredTagToRun(final PipelineRun run) {
-        run.getTags().put(UTILIZATION_LEVEL_HIGH, TRUE_VALUE_STRING);
-        return run;
     }
 
     private Pair<PipelineRun, Map<ELKUsageMetric, Double>> matchRunAndMetrics(
@@ -239,7 +216,7 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
         return result;
     }
 
-    private List<PipelineRun> processIdleRuns(final List<PipelineRun> runs) {
+    private void processIdleRuns(final List<PipelineRun> runs) {
         final Map<String, PipelineRun> running = runs.stream()
                 .collect(Collectors.toMap(PipelineRun::getPodId, r -> r));
 
@@ -267,18 +244,14 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
         final IdleRunAction action = IdleRunAction.valueOf(preferenceManager
                 .getPreference(SystemPreferences.SYSTEM_IDLE_ACTION));
 
-        final List<PipelineRun> runsToUpdateTags = new ArrayList<>(running.size());
-        final List<PipelineRun> runsToUpdate = processRuns(notProlongedRuns, cpuMetrics,
-                idleCpuLevel, actionTimeout, action, runsToUpdateTags);
-        pipelineRunManager.updatePipelineRunsLastNotification(runsToUpdate);
-        return runsToUpdateTags;
+        processRuns(notProlongedRuns, cpuMetrics, idleCpuLevel, actionTimeout, action);
     }
 
-    private List<PipelineRun> processRuns(Map<String, PipelineRun> running, Map<String, Double> cpuMetrics,
-                                          double idleCpuLevel, int actionTimeout, IdleRunAction action,
-                                          List<PipelineRun> runsToUpdateTags) {
+    private void processRuns(Map<String, PipelineRun> running, Map<String, Double> cpuMetrics,
+                                          double idleCpuLevel, int actionTimeout, IdleRunAction action) {
         List<PipelineRun> runsToUpdate = new ArrayList<>(running.size());
         List<Pair<PipelineRun, Double>> runsToNotify = new ArrayList<>(running.size());
+        final List<PipelineRun> runsToUpdateTags = new ArrayList<>(running.size());
         for (Map.Entry<String, PipelineRun> entry : running.entrySet()) {
             PipelineRun run = entry.getValue();
             if (run.isNonPause() || isClusterRun(run)) {
@@ -291,14 +264,12 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
                 double cpuUsageRate = metric / MILLIS / type.getVCPU();
                 if (Precision.compareTo(cpuUsageRate, idleCpuLevel, ONE_THOUSANDTH) < 0) {
                     processIdleRun(run, actionTimeout, action, runsToNotify, runsToUpdate, cpuUsageRate);
-                    if (run.getTags().put(UTILIZATION_LEVEL_LOW, TRUE_VALUE_STRING) == null) {
+                    if (run.addTag(UTILIZATION_LEVEL_LOW, TRUE_VALUE_STRING)) {
                         runsToUpdateTags.add(run);
                     }
                 } else if (run.getLastIdleNotificationTime() != null) { // No action is longer needed, clear timeout
                     run.setLastIdleNotificationTime(null);
-                    final String tagToBeRemoved = run.getTags().remove(UTILIZATION_LEVEL_LOW);
-                    if (tagToBeRemoved != null
-                            && tagToBeRemoved.equals(TRUE_VALUE_STRING)) {
+                    if (run.removeTag(UTILIZATION_LEVEL_LOW, TRUE_VALUE_STRING)) {
                         runsToUpdateTags.add(run);
                     }
                     runsToUpdate.add(run);
@@ -306,7 +277,8 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
             }
         }
         notificationManager.notifyIdleRuns(runsToNotify, NotificationType.IDLE_RUN);
-        return runsToUpdate;
+        pipelineRunManager.updatePipelineRunsLastNotification(runsToUpdate);
+        pipelineRunManager.updateRunsTags(runsToUpdateTags);
     }
 
     private void processIdleRun(PipelineRun run, int actionTimeout, IdleRunAction action,

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.PostConstruct;
@@ -72,6 +73,9 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
     private static final int MILLIS = 1000;
     private static final double PERCENT = 100.0;
     private static final double ONE_THOUSANDTH = 0.001;
+    private static final String UTILIZATION_LEVEL_LOW = "IDLED";
+    private static final String UTILIZATION_LEVEL_HIGH = "PRESSURED";
+    private static final String TRUE_VALUE_STRING = "true";
 
     private final PipelineRunManager pipelineRunManager;
     private final NotificationManager notificationManager;
@@ -118,11 +122,12 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
     public void monitorResourceUsage() {
         List<PipelineRun> runs = pipelineRunManager.loadRunningPipelineRuns();
 
-        processIdleRuns(runs);
-        processOverloadedRuns(runs);
+        final List<PipelineRun> runsToUpdateTags = processIdleRuns(runs);
+        runsToUpdateTags.addAll(processOverloadedRuns(runs));
+        pipelineRunManager.updateRunsTags(runsToUpdateTags);
     }
 
-    private void processOverloadedRuns(final List<PipelineRun> runs) {
+    private List<PipelineRun> processOverloadedRuns(final List<PipelineRun> runs) {
         final Map<String, PipelineRun> running = runs.stream()
                 .filter(r -> {
                     final boolean hasNodeName = Objects.nonNull(r.getInstance())
@@ -156,7 +161,48 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
                 .filter(pod -> isPodUnderPressure(pod.getValue(), thresholds))
                 .collect(Collectors.toList());
 
+        final List<PipelineRun> runsToUpdateTags = getRunsToUpdatePressuredTags(running, runsToNotify);
         notificationManager.notifyHighResourceConsumingRuns(runsToNotify, NotificationType.HIGH_CONSUMED_RESOURCES);
+        return runsToUpdateTags;
+    }
+
+    private List<PipelineRun> getRunsToUpdatePressuredTags(final Map<String, PipelineRun> running,
+                              final List<Pair<PipelineRun, Map<ELKUsageMetric, Double>>> runsToNotify) {
+        final List<PipelineRun> listOfRunsToNotify = runsToNotify
+                .parallelStream()
+                .map(Pair::getLeft)
+                .collect(Collectors.toList());
+        final Predicate<PipelineRun> runToBeNotified = listOfRunsToNotify::contains;
+        final Stream<PipelineRun> runsToAddTag = listOfRunsToNotify
+                .parallelStream()
+                .filter(this::hasNoPressuredTag)
+                .map(this::addPressuredTagToRun);
+        final Stream<PipelineRun> runsToRemoveTag = running.values()
+                .parallelStream()
+                .filter(runToBeNotified.negate())
+                .filter(this::hasPressuredTag)
+                .map(this::removePressuredTagFromRun);
+        return Stream.concat(runsToAddTag, runsToRemoveTag).collect(Collectors.toList());
+    }
+
+    private boolean hasPressuredTag(final PipelineRun run) {
+        final String tagToBeRemoved = run.getTags().get(UTILIZATION_LEVEL_HIGH);
+        return tagToBeRemoved != null
+                && tagToBeRemoved.equals(TRUE_VALUE_STRING);
+    }
+
+    private boolean hasNoPressuredTag(final PipelineRun run) {
+        return run.getTags().get(UTILIZATION_LEVEL_HIGH) == null;
+    }
+
+    private PipelineRun removePressuredTagFromRun(final PipelineRun run) {
+        run.getTags().remove(UTILIZATION_LEVEL_HIGH);
+        return run;
+    }
+
+    private PipelineRun addPressuredTagToRun(final PipelineRun run) {
+        run.getTags().put(UTILIZATION_LEVEL_HIGH, TRUE_VALUE_STRING);
+        return run;
     }
 
     private Pair<PipelineRun, Map<ELKUsageMetric, Double>> matchRunAndMetrics(
@@ -193,7 +239,7 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
         return result;
     }
 
-    private void processIdleRuns(final List<PipelineRun> runs) {
+    private List<PipelineRun> processIdleRuns(final List<PipelineRun> runs) {
         final Map<String, PipelineRun> running = runs.stream()
                 .collect(Collectors.toMap(PipelineRun::getPodId, r -> r));
 
@@ -221,16 +267,18 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
         final IdleRunAction action = IdleRunAction.valueOf(preferenceManager
                 .getPreference(SystemPreferences.SYSTEM_IDLE_ACTION));
 
+        final List<PipelineRun> runsToUpdateTags = new ArrayList<>(running.size());
         final List<PipelineRun> runsToUpdate = processRuns(notProlongedRuns, cpuMetrics,
-                idleCpuLevel, actionTimeout, action);
+                idleCpuLevel, actionTimeout, action, runsToUpdateTags);
         pipelineRunManager.updatePipelineRunsLastNotification(runsToUpdate);
+        return runsToUpdateTags;
     }
 
     private List<PipelineRun> processRuns(Map<String, PipelineRun> running, Map<String, Double> cpuMetrics,
-                                          double idleCpuLevel, int actionTimeout, IdleRunAction action) {
+                                          double idleCpuLevel, int actionTimeout, IdleRunAction action,
+                                          List<PipelineRun> runsToUpdateTags) {
         List<PipelineRun> runsToUpdate = new ArrayList<>(running.size());
         List<Pair<PipelineRun, Double>> runsToNotify = new ArrayList<>(running.size());
-
         for (Map.Entry<String, PipelineRun> entry : running.entrySet()) {
             PipelineRun run = entry.getValue();
             if (run.isNonPause() || isClusterRun(run)) {
@@ -243,13 +291,20 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
                 double cpuUsageRate = metric / MILLIS / type.getVCPU();
                 if (Precision.compareTo(cpuUsageRate, idleCpuLevel, ONE_THOUSANDTH) < 0) {
                     processIdleRun(run, actionTimeout, action, runsToNotify, runsToUpdate, cpuUsageRate);
+                    if (run.getTags().put(UTILIZATION_LEVEL_LOW, TRUE_VALUE_STRING) == null) {
+                        runsToUpdateTags.add(run);
+                    }
                 } else if (run.getLastIdleNotificationTime() != null) { // No action is longer needed, clear timeout
                     run.setLastIdleNotificationTime(null);
+                    final String tagToBeRemoved = run.getTags().remove(UTILIZATION_LEVEL_LOW);
+                    if (tagToBeRemoved != null
+                            && tagToBeRemoved.equals(TRUE_VALUE_STRING)) {
+                        runsToUpdateTags.add(run);
+                    }
                     runsToUpdate.add(run);
                 }
             }
         }
-
         notificationManager.notifyIdleRuns(runsToNotify, NotificationType.IDLE_RUN);
         return runsToUpdate;
     }

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
@@ -167,11 +167,11 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
 
     private List<PipelineRun> getRunsToUpdatePressuredTags(final Map<String, PipelineRun> running,
                               final List<Pair<PipelineRun, Map<ELKUsageMetric, Double>>> runsToNotify) {
-        final Set<Long> listOfRunsIdToNotify = runsToNotify
+        final Set<Long> runsIdToNotify = runsToNotify
                 .stream()
                 .map(p -> p.getLeft().getId())
                 .collect(Collectors.toSet());
-        final Predicate<PipelineRun> isToBeNotified = r -> listOfRunsIdToNotify.contains(r.getId());
+        final Predicate<PipelineRun> isToBeNotified = r -> runsIdToNotify.contains(r.getId());
         final Stream<PipelineRun> runsToAddTag = running.values()
                 .stream()
                 .filter(isToBeNotified)

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
@@ -26,7 +26,6 @@ import java.util.Set;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.PostConstruct;
@@ -171,15 +170,14 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
                 .stream()
                 .map(p -> p.getLeft().getId())
                 .collect(Collectors.toSet());
-        final Predicate<PipelineRun> isToBeNotified = r -> runsIdToNotify.contains(r.getId());
         final Stream<PipelineRun> runsToAddTag = running.values()
                 .stream()
-                .filter(isToBeNotified)
+                .filter(r -> runsIdToNotify.contains(r.getId()))
                 .filter(r -> !r.hasTag(UTILIZATION_LEVEL_HIGH))
                 .peek(r -> r.addTag(UTILIZATION_LEVEL_HIGH, TRUE_VALUE_STRING));
         final Stream<PipelineRun> runsToRemoveTag =  running.values()
                 .stream()
-                .filter(isToBeNotified.negate())
+                .filter(r -> !runsIdToNotify.contains(r.getId()))
                 .filter(r -> r.hasTag(UTILIZATION_LEVEL_HIGH))
                 .peek(r -> r.removeTag(UTILIZATION_LEVEL_HIGH));
         return Stream.concat(runsToAddTag, runsToRemoveTag).collect(Collectors.toList());

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -853,8 +853,13 @@ public class PipelineRunManager {
         Assert.notNull(run,
                 messageHelper.getMessage(MessageConstants.ERROR_PIPELINE_NOT_FOUND, runId));
         run.setTags(newTags.getTags());
-        pipelineRunDao.updateTags(run);
+        pipelineRunDao.updateRunTags(run);
         return run;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void updateRunsTags(final Collection<PipelineRun> runs) {
+        pipelineRunDao.updateRunsTags(runs);
     }
 
     /**

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
@@ -166,10 +166,10 @@ public class PipelineRunDaoTest extends AbstractSpringTest {
     }
 
     @Test
-    public void updateTags() {
+    public void testUpdateRunTags() {
         final PipelineRun run = createTestPipelineRun();
         final Map<String, String> tags = new HashMap<>();
-        loadTagsAndCompareWithExpected(run, tags);
+        loadTagsAndCompareWithExpected(run.getId(), tags);
         tags.put(TAG_KEY_1, TAG_VALUE_1);
         updateTagsAndVerifySaveIsCorrect(run, tags);
         tags.put(TAG_KEY_2, TAG_VALUE_2);
@@ -179,17 +179,31 @@ public class PipelineRunDaoTest extends AbstractSpringTest {
         tags.remove(TAG_KEY_2);
         updateTagsAndVerifySaveIsCorrect(run, tags);
         run.setTags(null);
-        loadTagsAndCompareWithExpected(run, Collections.emptyMap());
+        loadTagsAndCompareWithExpected(run.getId(), Collections.emptyMap());
+    }
+
+    @Test
+    public void updateTagsForRuns() {
+        final PipelineRun run1 = createTestPipelineRun();
+        final Map<String, String> tags1 = Collections.singletonMap(TAG_KEY_1, TAG_VALUE_1);
+        run1.setTags(tags1);
+        final PipelineRun run2 = createTestPipelineRun();
+        final Map<String, String> tags2 = Collections.singletonMap(TAG_KEY_2, TAG_VALUE_2);
+        run2.setTags(tags2);
+
+        pipelineRunDao.updateRunsTags(Arrays.asList(run1, run2));
+        loadTagsAndCompareWithExpected(run1.getId(), tags1);
+        loadTagsAndCompareWithExpected(run2.getId(), tags2);
     }
 
     private void updateTagsAndVerifySaveIsCorrect(final PipelineRun run, final Map<String, String> tags) {
         run.setTags(tags);
-        pipelineRunDao.updateTags(run);
-        loadTagsAndCompareWithExpected(run, tags);
+        pipelineRunDao.updateRunTags(run);
+        loadTagsAndCompareWithExpected(run.getId(), tags);
     }
 
-    private void loadTagsAndCompareWithExpected(final PipelineRun run, final Map<String, String> tags) {
-        final Map<String, String> loadedTags = pipelineRunDao.loadPipelineRun(run.getId()).getTags();
+    private void loadTagsAndCompareWithExpected(final Long runId, final Map<String, String> tags) {
+        final Map<String, String> loadedTags = pipelineRunDao.loadPipelineRun(runId).getTags();
         assertThat(loadedTags, CoreMatchers.is(tags));
     }
 

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManagerTest.java
@@ -36,6 +36,7 @@ import com.epam.pipeline.security.jwt.JwtAuthenticationToken;
 import io.reactivex.Observable;
 import io.reactivex.subjects.BehaviorSubject;
 import org.apache.commons.lang3.tuple.Pair;
+import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -61,6 +62,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
@@ -87,6 +89,9 @@ public class ResourceMonitoringManagerTest {
     private static final int HALF_AN_HOUR = 30;
     private static final String HIGH_CONSUMING_POD_ID = "high-consuming";
     private static final double PERCENTS = 100.0;
+    private static final String UTILIZATION_LEVEL_LOW = "IDLED";
+    private static final String UTILIZATION_LEVEL_HIGH = "PRESSURED";
+    private static final String TRUE_VALUE_STRING = "true";
 
     private ResourceMonitoringManager resourceMonitoringManager;
 
@@ -168,6 +173,7 @@ public class ResourceMonitoringManagerTest {
 
         RunInstance spotInstance = new RunInstance(testType.getName(), 0, 0, null,
                 null, null, "spotNode", true, null, null);
+        final Map <String, String> stubTagMap = new HashMap<>();
         okayRun = new PipelineRun();
         okayRun.setInstance(spotInstance);
         okayRun.setPodId("okay-pod");
@@ -176,6 +182,7 @@ public class ResourceMonitoringManagerTest {
                                           .toEpochMilli()));
         okayRun.setProlongedAtTime(DateUtils.nowUTC().minus(TEST_MAX_IDLE_MONITORING_TIMEOUT + 1,
                 ChronoUnit.MINUTES));
+        okayRun.setTags(stubTagMap);
 
         idleSpotRun = new PipelineRun();
         idleSpotRun.setInstance(new RunInstance(testType.getName(), 0, 0, null,
@@ -186,7 +193,7 @@ public class ResourceMonitoringManagerTest {
                                               .toEpochMilli()));
         idleSpotRun.setProlongedAtTime(DateUtils.nowUTC().minus(TEST_MAX_IDLE_MONITORING_TIMEOUT + 1,
                 ChronoUnit.MINUTES));
-
+        idleSpotRun.setTags(stubTagMap);
 
         idleOnDemandRun = new PipelineRun();
         idleOnDemandRun.setInstance(
@@ -197,6 +204,7 @@ public class ResourceMonitoringManagerTest {
                                                                   ChronoUnit.MINUTES).toEpochMilli()));
         idleOnDemandRun.setProlongedAtTime(DateUtils.nowUTC().minus(TEST_MAX_IDLE_MONITORING_TIMEOUT + 1,
                 ChronoUnit.MINUTES));
+        idleOnDemandRun.setTags(stubTagMap);
 
         idleRunToProlong = new PipelineRun();
         idleRunToProlong.setInstance(
@@ -207,6 +215,7 @@ public class ResourceMonitoringManagerTest {
                 ChronoUnit.MINUTES).toEpochMilli()));
         idleRunToProlong.setProlongedAtTime(DateUtils.nowUTC().minus(TEST_MAX_IDLE_MONITORING_TIMEOUT + 1,
                 ChronoUnit.MINUTES));
+        idleRunToProlong.setTags(stubTagMap);
 
         highConsumingRun = new PipelineRun();
         highConsumingRun.setInstance(new RunInstance(testType.getName(), 0, 0, null,
@@ -216,6 +225,7 @@ public class ResourceMonitoringManagerTest {
         highConsumingRun.setStartDate(new Date(Instant.now().toEpochMilli()));
         highConsumingRun.setProlongedAtTime(DateUtils.nowUTC()
                 .plus(TEST_MAX_IDLE_MONITORING_TIMEOUT, ChronoUnit.MINUTES));
+        highConsumingRun.setTags(stubTagMap);
 
         mockStats = new HashMap<>();
         mockStats.put(okayRun.getPodId(), TEST_OK_RUN_CPU_LOAD); // in milicores, equals 80% of core load, per 2 cores,
@@ -478,7 +488,7 @@ public class ResourceMonitoringManagerTest {
         mockStats.put(idleSpotRun.getPodId(), NON_IDLE_CPU_LOAD); // mock not idle anymore
 
         Thread.sleep(10);
-
+        idleSpotRun.setTags(new HashMap<>());
         resourceMonitoringManager.monitorResourceUsage();
 
         verify(pipelineRunManager).updatePipelineRunsLastNotification(runsToUpdateCaptor.capture());
@@ -536,6 +546,31 @@ public class ResourceMonitoringManagerTest {
         List<Pair<PipelineRun, Map<ELKUsageMetric, Double>>> value = runsToNotifyResConsumingCaptor.getValue();
         Assert.assertEquals(1, value.size());
         Assert.assertEquals(HIGH_CONSUMING_POD_ID, value.get(0).getKey().getPodId());
+    }
+
+    @Test
+    public void testIdledRunTagging() {
+        final Map<String, String> idledTagMap = Collections.singletonMap(UTILIZATION_LEVEL_LOW, TRUE_VALUE_STRING);
+        okayRun.setTags(new HashMap<>(idledTagMap));
+        okayRun.setLastIdleNotificationTime(DateUtils.nowUTC().minusSeconds(HALF_AN_HOUR));
+        when(pipelineRunManager.loadRunningPipelineRuns()).thenReturn(Arrays.asList(idleOnDemandRun, okayRun));
+
+        resourceMonitoringManager.monitorResourceUsage();
+        assertThat(idleOnDemandRun.getTags(), CoreMatchers.is(idledTagMap));
+        assertThat(okayRun.getTags(), CoreMatchers.is(Collections.emptyMap()));
+        Assert.assertNull(okayRun.getLastIdleNotificationTime());
+    }
+
+    @Test
+    public void testPressuredRunTagging() {
+        final Map<String, String> pressuredTagMap = Collections.singletonMap(UTILIZATION_LEVEL_HIGH, TRUE_VALUE_STRING);
+        okayRun.setTags(new HashMap<>(pressuredTagMap));
+        okayRun.setLastIdleNotificationTime(DateUtils.nowUTC().minusSeconds(HALF_AN_HOUR));
+        when(pipelineRunManager.loadRunningPipelineRuns()).thenReturn(Arrays.asList(highConsumingRun, okayRun));
+
+        resourceMonitoringManager.monitorResourceUsage();
+        assertThat(highConsumingRun.getTags(), CoreMatchers.is(pressuredTagMap));
+        assertThat(okayRun.getTags(), CoreMatchers.is(Collections.emptyMap()));
     }
 
     private HashMap<String, Double> getMockedHighConsumingStats() {

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManagerTest.java
@@ -573,6 +573,19 @@ public class ResourceMonitoringManagerTest {
         assertThat(okayRun.getTags(), CoreMatchers.is(Collections.emptyMap()));
     }
 
+    @Test
+    public void testIdledPressuredTagsRemains() {
+        final Map<String, String> idledTagMap = Collections.singletonMap(UTILIZATION_LEVEL_LOW, TRUE_VALUE_STRING);
+        final Map<String, String> pressuredTagMap = Collections.singletonMap(UTILIZATION_LEVEL_HIGH, TRUE_VALUE_STRING);
+        highConsumingRun.setTags(new HashMap<>(pressuredTagMap));
+        idleOnDemandRun.setTags(new HashMap<>(idledTagMap));
+        when(pipelineRunManager.loadRunningPipelineRuns()).thenReturn(Arrays.asList(idleOnDemandRun, highConsumingRun));
+
+        resourceMonitoringManager.monitorResourceUsage();
+        assertThat(highConsumingRun.getTags(), CoreMatchers.is(pressuredTagMap));
+        assertThat(idleOnDemandRun.getTags(), CoreMatchers.is(idledTagMap));
+    }
+
     private HashMap<String, Double> getMockedHighConsumingStats() {
         HashMap<String, Double> stats = new HashMap<>();
         stats.put(highConsumingRun.getInstance().getNodeName(), TEST_HIGH_CONSUMING_RUN_LOAD / PERCENTS + DELTA);

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
@@ -173,4 +173,49 @@ public class PipelineRun extends AbstractSecuredEntity {
     public String getTaskName() {
         return StringUtils.isEmpty(pipelineName) ? podId : pipelineName;
     }
+
+    /**
+     * Check if given key represented in tag map
+     * @param key key to be checked
+     * @return true - if tag map contains the given key, false - otherwise
+     */
+    public boolean hasTag(final String key) {
+        return tags.containsKey(key);
+    }
+
+    /**
+     * Add tag to the given run
+     * @param key key to be inserted
+     * @param value value to be checked
+     * @return true - if new tag is added, false - otherwise
+     */
+    public boolean addTag(final String key, final String value) {
+        return tags.putIfAbsent(key, value) == null;
+    }
+
+    /**
+     * Remove tag from the given run
+     * @param key key to be removed
+     * @param value value to be removed
+     * @return true - if the given tag is removed, false - otherwise
+     */
+
+    public boolean removeTag(final String key, final String value) {
+        return tags.remove(key, value);
+    }
+
+    /**
+     * If tag isn't set for run, add new one, or remove it otherwise.
+     * @param key tag key to be proceeded
+     * @param value tag value to be proceeded
+     * @return run with updated tags
+     */
+    public PipelineRun inverseTagForRun(final String key, final String value) {
+        if (hasTag(key)) {
+            addTag(key, value);
+        } else {
+            removeTag(key, value);
+        }
+        return this;
+    }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
@@ -196,26 +196,9 @@ public class PipelineRun extends AbstractSecuredEntity {
     /**
      * Remove tag from the given run
      * @param key key to be removed
-     * @param value value to be removed
      * @return true - if the given tag is removed, false - otherwise
      */
-
-    public boolean removeTag(final String key, final String value) {
-        return tags.remove(key, value);
-    }
-
-    /**
-     * If tag isn't set for run, add new one, or remove it otherwise.
-     * @param key tag key to be proceeded
-     * @param value tag value to be proceeded
-     * @return run with updated tags
-     */
-    public PipelineRun inverseTagForRun(final String key, final String value) {
-        if (hasTag(key)) {
-            removeTag(key, value);
-        } else {
-            addTag(key, value);
-        }
-        return this;
+    public boolean removeTag(final String key) {
+        return tags.remove(key) != null;
     }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
@@ -212,9 +212,9 @@ public class PipelineRun extends AbstractSecuredEntity {
      */
     public PipelineRun inverseTagForRun(final String key, final String value) {
         if (hasTag(key)) {
-            addTag(key, value);
-        } else {
             removeTag(key, value);
+        } else {
+            addTag(key, value);
         }
         return this;
     }

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
@@ -187,18 +187,16 @@ public class PipelineRun extends AbstractSecuredEntity {
      * Add tag to the given run
      * @param key key to be inserted
      * @param value value to be checked
-     * @return true - if new tag is added, false - otherwise
      */
-    public boolean addTag(final String key, final String value) {
-        return tags.putIfAbsent(key, value) == null;
+    public void addTag(final String key, final String value) {
+        tags.putIfAbsent(key, value);
     }
 
     /**
      * Remove tag from the given run
      * @param key key to be removed
-     * @return true - if the given tag is removed, false - otherwise
      */
-    public boolean removeTag(final String key) {
-        return tags.remove(key) != null;
+    public void removeTag(final String key) {
+        tags.remove(key);
     }
 }


### PR DESCRIPTION
PR solves the issue #624.

It brings tagging of PipelineRuns with low- or high-resource consumption.
ResourceMonitorManager add "IDLED" or "PRESSURED" tag for a run entities, when it's CPU/Memory/Disk consumption is lower/higher than a certain level, defined by the admin, and removes such tags, when resource consumption going back to normal level.
- Added changes to inner ResourceMonitorManager logic;
- Added method `updateRunsTags` to PipelineRunManager to use batch updating of runs tags;
- Tests for new functionality were provided as well.

