### PR TITLE
FSBrowser shall (optionally) follow symlinks when packing directory into tar.gz

### DIFF
--- a/fs-browser/fsbrowser/app.py
+++ b/fs-browser/fsbrowser/app.py
@@ -149,6 +149,10 @@ def delete(path):
         return jsonify(error(e.__str__()))
 
 
+def str_to_bool(input_value):
+    return input_value.lower() in ("true", "t")
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--host", default="127.0.0.1")
@@ -158,7 +162,7 @@ def main():
     parser.add_argument("--process_count", default=2)
     parser.add_argument("--run_id", required=False)
     parser.add_argument("--log_dir", required=False)
-    parser.add_argument("--follow_symlinks", default=True)
+    parser.add_argument("--follow_symlinks", default="True", type=str_to_bool)
 
     args = parser.parse_args()
     app.config['fsbrowser'] = FsBrowserManager(args.working_directory, args.process_count,

--- a/fs-browser/fsbrowser/app.py
+++ b/fs-browser/fsbrowser/app.py
@@ -158,10 +158,12 @@ def main():
     parser.add_argument("--process_count", default=2)
     parser.add_argument("--run_id", required=False)
     parser.add_argument("--log_dir", required=False)
+    parser.add_argument("--follow_symlinks", default=True)
 
     args = parser.parse_args()
     app.config['fsbrowser'] = FsBrowserManager(args.working_directory, args.process_count,
-                                               BrowserLogger(args.run_id, args.log_dir), args.transfer_storage)
+                                               BrowserLogger(args.run_id, args.log_dir), args.transfer_storage,
+                                               args.follow_symlinks)
 
     app.run(host=args.host, port=args.port)
 

--- a/fs-browser/fsbrowser/src/fs_browser_manager.py
+++ b/fs-browser/fsbrowser/src/fs_browser_manager.py
@@ -25,12 +25,13 @@ from fsbrowser.src.transfer_task import TransferTask, TaskStatus
 
 class FsBrowserManager(object):
 
-    def __init__(self, working_directory, process_count, logger, storage):
+    def __init__(self, working_directory, process_count, logger, storage, follow_symlinks):
         self.tasks = {}
         self.pool = ThreadPool(processes=process_count)
         self.working_directory = working_directory
         self.logger = logger
         self.storage_name, self.storage_path = self._parse_transfer_storage_path(storage)
+        self.follow_symlinks = follow_symlinks
 
     def list(self, path):
         items = []
@@ -50,7 +51,7 @@ class FsBrowserManager(object):
         task_id = str(uuid.uuid4().hex)
         task = TransferTask(task_id, self.storage_name, self.storage_path, self.logger)
         self.tasks.update({task_id: task})
-        self.pool.apply_async(task.download, [path, self.working_directory])
+        self.pool.apply_async(task.download, [path, self.working_directory, self.follow_symlinks])
         return task_id
 
     def init_upload(self, path):


### PR DESCRIPTION
Fix for issue #672 

A new `fs-browser` command line option `--follow_symlinks` was introduced. If this option is specified and true the download operation will follow symlinks. Otherwise, the download operation will skip symlinks. The default behavior is to follow symlinks.
