### PR TITLE
Issue 645 Rename GitLab's repository if the name of the Pipeline is changed.

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/git/GitProjectRequest.java
+++ b/api/src/main/java/com/epam/pipeline/entity/git/GitProjectRequest.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class GitProjectRequest {
     private String name;
+    private String path;
     private String description;
     private String visibility;
 }

--- a/api/src/main/java/com/epam/pipeline/manager/git/GitLabApi.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/GitLabApi.java
@@ -37,6 +37,7 @@ import retrofit2.http.DELETE;
 import retrofit2.http.GET;
 import retrofit2.http.Header;
 import retrofit2.http.POST;
+import retrofit2.http.PUT;
 import retrofit2.http.Path;
 import retrofit2.http.Query;
 
@@ -228,4 +229,12 @@ public interface GitLabApi {
     Call<GitRepositoryEntry> addProjectHook(@Path(PROJECT) String project,
                                             @Body GitHookRequest hookRequest);
 
+    /**
+     * Update a project info.
+     *
+     * @param project The ID or URL-encoded path of the project
+     */
+    @PUT("api/v3/projects/{project}")
+    Call<GitProject> updateProject(@Path(PROJECT) String project,
+                                   @Body GitProjectRequest projectInfo);
 }

--- a/api/src/main/java/com/epam/pipeline/manager/git/GitManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/GitManager.java
@@ -853,4 +853,12 @@ public class GitManager {
             throw new IllegalArgumentException(e.getMessage(), e);
         }
     }
+
+    public GitProject updateRepositoryName(final String projectIdOrName, final String newName) {
+        try {
+            return getDefaultGitlabClient().updateProjectName(projectIdOrName, newName);
+        } catch (GitClientException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
+    }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/git/GitlabClient.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/GitlabClient.java
@@ -68,6 +68,8 @@ import java.util.Optional;
 import java.util.TimeZone;
 import java.util.stream.Stream;
 
+import static com.epam.pipeline.utils.GitUtils.convertPipeNameToProject;
+
 @Wither
 @AllArgsConstructor
 @NoArgsConstructor
@@ -209,13 +211,6 @@ public class GitlabClient {
         return createGitProject(template, description, convertPipeNameToProject(name), indexingEnabled, hookUrl);
     }
 
-    private String convertPipeNameToProject(String name) {
-        // This regexp differ from one from GitUtils, actually there is no sing why we should replace all '.'
-        // and etc from name, and cant user the same pattern from GitUtils here, but since it legacy method
-        // we decided to leave it as is
-        return name.trim().toLowerCase().replaceAll("[^\\w\\s]", "").replaceAll("\\s+", "-");
-    }
-
     public boolean projectExists(String name) throws GitClientException {
         try {
             String projectId = makeProjectId(namespace, convertPipeNameToProject(name));
@@ -329,6 +324,15 @@ public class GitlabClient {
     public GitRepositoryEntry createProjectHook(String hookUrl) throws GitClientException {
         String projectId = makeProjectId(namespace, projectName);
         return addProjectHook(projectId, hookUrl);
+    }
+
+    public GitProject updateProjectName(final String currentName, final String newName) throws GitClientException{
+        final String normalizedNewName = convertPipeNameToProject(newName);
+        return execute(gitLabApi.updateProject(makeProjectId(namespace, convertPipeNameToProject(currentName)),
+                                               GitProjectRequest.builder()
+                                                   .name(normalizedNewName)
+                                                   .path(normalizedNewName)
+                                                   .build()));
     }
 
     private <R> R execute(Call<R> call) throws GitClientException {

--- a/api/src/main/java/com/epam/pipeline/manager/git/GitlabClient.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/GitlabClient.java
@@ -35,6 +35,7 @@ import com.epam.pipeline.entity.git.UpdateGitFileRequest;
 import com.epam.pipeline.entity.template.Template;
 import com.epam.pipeline.exception.git.GitClientException;
 import com.epam.pipeline.exception.git.UnexpectedResponseStatusException;
+import com.epam.pipeline.utils.GitUtils;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Wither;
@@ -67,8 +68,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.TimeZone;
 import java.util.stream.Stream;
-
-import static com.epam.pipeline.utils.GitUtils.convertPipeNameToProject;
 
 @Wither
 @AllArgsConstructor
@@ -208,12 +207,14 @@ public class GitlabClient {
 
     public GitProject createTemplateRepository(Template template, String name, String description,
                                                boolean indexingEnabled, String hookUrl) throws GitClientException {
-        return createGitProject(template, description, convertPipeNameToProject(name), indexingEnabled, hookUrl);
+        return createGitProject(template, description,
+                                GitUtils.convertPipeNameToProject(name),
+                                indexingEnabled, hookUrl);
     }
 
     public boolean projectExists(String name) throws GitClientException {
         try {
-            String projectId = makeProjectId(namespace, convertPipeNameToProject(name));
+            String projectId = makeProjectId(namespace, GitUtils.convertPipeNameToProject(name));
             Response<GitProject> response = gitLabApi.getProject(projectId).execute();
             return response.isSuccessful();
         } catch (IOException e) {
@@ -226,7 +227,7 @@ public class GitlabClient {
     }
 
     public GitProject getProject(String name) throws GitClientException {
-        String project = convertPipeNameToProject(name);
+        String project = GitUtils.convertPipeNameToProject(name);
         return execute(gitLabApi.getProject(project));
     }
 
@@ -326,9 +327,9 @@ public class GitlabClient {
         return addProjectHook(projectId, hookUrl);
     }
 
-    public GitProject updateProjectName(final String currentName, final String newName) throws GitClientException{
-        final String normalizedNewName = convertPipeNameToProject(newName);
-        return execute(gitLabApi.updateProject(makeProjectId(namespace, convertPipeNameToProject(currentName)),
+    public GitProject updateProjectName(final String currentName, final String newName) throws GitClientException {
+        final String normalizedNewName = GitUtils.convertPipeNameToProject(newName);
+        return execute(gitLabApi.updateProject(makeProjectId(namespace, GitUtils.convertPipeNameToProject(currentName)),
                                                GitProjectRequest.builder()
                                                    .name(normalizedNewName)
                                                    .path(normalizedNewName)

--- a/api/src/main/java/com/epam/pipeline/utils/GitUtils.java
+++ b/api/src/main/java/com/epam/pipeline/utils/GitUtils.java
@@ -23,7 +23,12 @@ public final class GitUtils {
 
     //regex for alphanumeric characters, underscore, dots and dash, allowing dash only in the middle
     private static final Pattern NAME_PATTERN = Pattern.compile("^[a-zA-Z0-9_.]+([-.][a-zA-Z0-9_]+)*$");
-    private static final String PROJECT_NAME_IN_URL_PATTERN = "(?<=/)[\\w]+(?=\\.git$)";
+
+    // This regexps differ from NAME_PATTERN, actually there is no sign why we should replace all '.' and etc
+    // from name, and can't use the same pattern here, but since it's legacy we decided to leave it as is.
+    // In case of any changes these patterns must match each other in terms of allowed symbols for name.
+    private static final String PROJECT_NAME_IN_URL_PATTERN = "(?<=/)\\w+(?=\\.git$)";
+    private static final String CHARS_TO_BE_REMOVED_FROM_NAME = "[^\\w\\s]";
 
     private GitUtils() {}
 
@@ -41,8 +46,6 @@ public final class GitUtils {
     }
 
     public static String convertPipeNameToProject(final String name) {
-        // This regexp differ from NAME_PATTERN, actually there is no sign why we should replace all '.' and etc
-        // from name, and cant use the same pattern here, but since it's legacy method we decided to leave it as is
-        return name.trim().toLowerCase().replaceAll("[^\\w\\s]", "").replaceAll("\\s+", "-");
+        return name.trim().toLowerCase().replaceAll(CHARS_TO_BE_REMOVED_FROM_NAME, "").replaceAll("\\s+", "-");
     }
 }

--- a/api/src/main/java/com/epam/pipeline/utils/GitUtils.java
+++ b/api/src/main/java/com/epam/pipeline/utils/GitUtils.java
@@ -23,6 +23,7 @@ public final class GitUtils {
 
     //regex for alphanumeric characters, underscore, dots and dash, allowing dash only in the middle
     private static final Pattern NAME_PATTERN = Pattern.compile("^[a-zA-Z0-9_.]+([-.][a-zA-Z0-9_]+)*$");
+    private static final String PROJECT_NAME_IN_URL_PATTERN = "(?<=/)[\\w]+(?=\\.git$)";
 
     private GitUtils() {}
 
@@ -33,5 +34,15 @@ public final class GitUtils {
     public static boolean checkGitNaming(String name) {
         Matcher m = NAME_PATTERN.matcher(name);
         return m.matches();
+    }
+
+    public static String replaceGitProjectNameInUrl(final String url, final String newName) {
+        return url.replaceFirst(PROJECT_NAME_IN_URL_PATTERN, newName);
+    }
+
+    public static String convertPipeNameToProject(final String name) {
+        // This regexp differ from NAME_PATTERN, actually there is no sign why we should replace all '.' and etc
+        // from name, and cant use the same pattern here, but since it's legacy method we decided to leave it as is
+        return name.trim().toLowerCase().replaceAll("[^\\w\\s]", "").replaceAll("\\s+", "-");
     }
 }

--- a/api/src/main/resources/dao/pipeline-dao.xml
+++ b/api/src/main/resources/dao/pipeline-dao.xml
@@ -58,7 +58,9 @@
                         description = :DESCRIPTION,
                         folder_id = :FOLDER_ID,
                         owner = :OWNER,
-                        repository_token = :REPOSITORY_TOKEN
+                        repository_token = :REPOSITORY_TOKEN,
+                        repository = :REPOSITORY,
+                        repository_ssh = :REPOSITORY_SSH
                     WHERE
                         pipeline_id = :PIPELINE_ID
                 ]]>


### PR DESCRIPTION
PR solves the issue #645 
It performs pipeline repository (GitLab project) rename if pipeline name is changed.

- Method to rename GitLab repository is added to `GitManager` and `GitClient` classes.
- Pipeline fields `repository` and `repositorySsh` are updating with the renaming of a repository.
- If the process of repository renaming fails, all DB changes are reverted.
- Tests are added and common methods are extracted to util class.

![image](https://user-images.githubusercontent.com/20845227/65761466-7ede9000-e127-11e9-800d-9ff3e876e8fe.png)
![image](https://user-images.githubusercontent.com/20845227/65761487-8a31bb80-e127-11e9-8aea-1081fc01ec65.png)
