### PR TITLE
Issue #696: Expose "/info" (or similar) API endpoint

### DIFF
--- a/api/src/main/java/com/epam/pipeline/controller/app/ApplicationInfoController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/app/ApplicationInfoController.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.controller.app;
+
+import com.epam.pipeline.controller.AbstractRestController;
+import com.epam.pipeline.controller.Result;
+import com.epam.pipeline.entity.app.ApplicationInfo;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+@Api(value = "Application info methods")
+@RequestMapping(value = "/app")
+public class ApplicationInfoController extends AbstractRestController {
+
+    @GetMapping(value = "/info")
+    @ResponseBody
+    @ApiOperation(
+            value = "Returns an application version info",
+            notes = "Returns an application version info",
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)}
+    )
+    public Result<ApplicationInfo> getInfo() {
+        return Result.success(new ApplicationInfo());
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/entity/app/ApplicationInfo.java
+++ b/api/src/main/java/com/epam/pipeline/entity/app/ApplicationInfo.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.app;
+
+import lombok.Data;
+
+@Data
+public class ApplicationInfo {
+
+    private final String version;
+
+    public ApplicationInfo() {
+        this.version = getClass().getPackage().getImplementationVersion();
+    }
+}


### PR DESCRIPTION
Implements issue #696 
Provides a new API method `/app/info` which returns version info:
```
{
    "version": <version>
}
```