### PR TITLE
"pipe" shall consider current API version

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -17,6 +17,7 @@ import requests
 import sys
 from prettytable import prettytable
 
+from src.api.app_info import ApplicationInfo
 from src.api.cluster import Cluster
 from src.api.pipeline import Pipeline
 from src.api.pipeline_run import PipelineRun
@@ -38,9 +39,19 @@ MAX_INSTANCE_COUNT = 1000
 MAX_CORES_COUNT = 10000
 
 
+def silent_print_api_version():
+    try:
+        api_info = ApplicationInfo().info()
+    except ConfigNotFoundError:
+        return
+    if 'version' in api_info and api_info['version']:
+        click.echo('Cloud Pipeline API, version {}'.format(api_info['version']))
+
+
 def print_version(ctx, param, value):
     if value is False:
         return
+    silent_print_api_version()
     click.echo('Cloud Pipeline CLI, version {}'.format(__version__))
     silent_print_config_info()
     ctx.exit()

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -42,10 +42,10 @@ MAX_CORES_COUNT = 10000
 def silent_print_api_version():
     try:
         api_info = ApplicationInfo().info()
+        if 'version' in api_info and api_info['version']:
+            click.echo('Cloud Pipeline API, version {}'.format(api_info['version']))
     except ConfigNotFoundError:
         return
-    if 'version' in api_info and api_info['version']:
-        click.echo('Cloud Pipeline API, version {}'.format(api_info['version']))
 
 
 def print_version(ctx, param, value):

--- a/pipe-cli/src/api/app_info.py
+++ b/pipe-cli/src/api/app_info.py
@@ -1,0 +1,31 @@
+# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from src.api.base import API
+
+
+class ApplicationInfo(API):
+
+    def __init__(self):
+        super(ApplicationInfo, self).__init__()
+
+    @classmethod
+    def info(cls):
+        api = cls.instance()
+        response_data = api.call('app/info', None)
+        if 'payload' in response_data:
+            return response_data['payload']
+        if 'message' in response_data:
+            raise RuntimeError(response_data['message'])
+        else:
+            raise RuntimeError("Failed to load application info.")

--- a/pipe-cli/src/utilities/update_cli_version.py
+++ b/pipe-cli/src/utilities/update_cli_version.py
@@ -16,6 +16,8 @@ import os
 import stat
 import sys
 from abc import ABCMeta
+
+import click
 import requests
 import platform
 import zipfile
@@ -24,6 +26,7 @@ import uuid
 from datetime import datetime
 
 from src.config import Config
+from src.utilities.version_utils import need_to_update_version
 
 PERMISSION_DENIED_ERROR = "Permission denied: the user has no permissions to modify '%s'"
 
@@ -34,6 +37,10 @@ class UpdateCLIVersionManager(object):
         pass
 
     def update(self, path=None):
+        if not need_to_update_version():
+            click.echo("The Cloud Pipeline CLI version is up-to-date")
+            return
+
         updater = self.get_updater()
 
         if not path:

--- a/pipe-cli/src/utilities/version_utils.py
+++ b/pipe-cli/src/utilities/version_utils.py
@@ -1,0 +1,53 @@
+# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from src.api.app_info import ApplicationInfo
+from src.version import __version__
+
+VERSION_DELIMITER = "."
+
+
+def need_to_update_version():
+    api_info = ApplicationInfo().info()
+    if 'version' not in api_info or not api_info['version']:
+        raise RuntimeError("Failed to load Cloud Pipeline API version")
+    api_version = parse_version(api_info['version'])
+    cli_version = parse_version(__version__)
+
+    if None in api_version:
+        raise RuntimeError("Cloud Pipeline API version has invalid format. "
+                           "Expected format is <major>.<minor>.<patch>.<build>.<...>")
+
+    for api, cli in zip(api_version, cli_version):
+        if not cli:
+            return True
+        if int(api) > int(cli):
+            return True
+        if int(api) < int(cli):
+            return False
+    return False
+
+
+def parse_version(version):
+    parts = version.split(VERSION_DELIMITER)
+    major = parse_version_part(parts, 0)
+    minor = parse_version_part(parts, 1)
+    patch = parse_version_part(parts, 2)
+    build = parse_version_part(parts, 3)
+    return [major, minor, patch, build]
+
+
+def parse_version_part(parts, index):
+    if len(parts) > index:
+        return parts[index]
+    return None


### PR DESCRIPTION
Implementation for issue #697 
Provides the following changes:
- for `--version` operation: additional info message with current Cloud Pipeline API version was added 
- for `update` operation: do not update Cloud Pipeline CLI if it is already up-to-date 