### PR TITLE
Fix elastic monitoring backend datetime issues

### DIFF
--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/AbstractMetricRequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/AbstractMetricRequester.java
@@ -21,6 +21,7 @@ import com.epam.pipeline.entity.cluster.monitoring.MonitoringStats;
 import com.epam.pipeline.exception.PipelineException;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.aggregations.Aggregation;
@@ -49,6 +50,12 @@ public abstract class AbstractMetricRequester implements MetricRequester, Monito
     private static final DateTimeFormatter DATE_FORMATTER =DateTimeFormatter.ofPattern("yyyy.MM.dd");
 
     private static final String INDEX_NAME_PATTERN = "heapster-%s";
+
+    private static final IndicesOptions INDICES_OPTIONS = IndicesOptions.fromOptions(true,
+            SearchRequest.DEFAULT_INDICES_OPTIONS.allowNoIndices(),
+            SearchRequest.DEFAULT_INDICES_OPTIONS.expandWildcardsOpen(),
+            SearchRequest.DEFAULT_INDICES_OPTIONS.expandWildcardsClosed(),
+            SearchRequest.DEFAULT_INDICES_OPTIONS);
 
     protected static final String FIELD_METRICS = "Metrics";
     protected static final String FIELD_METRICS_TAGS = "MetricsTags";
@@ -154,7 +161,10 @@ public abstract class AbstractMetricRequester implements MetricRequester, Monito
 
     protected SearchRequest request(final LocalDateTime from, final LocalDateTime to,
                                     final SearchSourceBuilder builder) {
-        return new SearchRequest(getIndexNames(from, to)).types(metric().getName()).source(builder);
+        return new SearchRequest(getIndexNames(from, to))
+                .types(metric().getName())
+                .source(builder)
+                .indicesOptions(INDICES_OPTIONS);
     }
 
     private static String[] getIndexNames(final LocalDateTime from, final LocalDateTime to) {

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/NodesManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/NodesManager.java
@@ -183,12 +183,8 @@ public class NodesManager {
                 return Optional.of(nodeInstance);
             }
         } catch (KubernetesClientException e) {
-            return missingNodeInstance(name, request);
+            log.warn("Node wasn't found in cluster.", e);
         }
-        return missingNodeInstance(name, request);
-    }
-
-    private Optional<NodeInstance> missingNodeInstance(final String name, final FilterPodsRequest request) {
         final List<String> podStatuses = Optional.ofNullable(request)
                 .map(FilterPodsRequest::getPodStatuses)
                 .orElseGet(Collections::emptyList);

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/NodesManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/NodesManager.java
@@ -37,6 +37,7 @@ import io.fabric8.kubernetes.api.model.Node;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.MapUtils;
@@ -181,7 +182,13 @@ public class NodesManager {
                 );
                 return Optional.of(nodeInstance);
             }
+        } catch (KubernetesClientException e) {
+            return missingNodeInstance(name, request);
         }
+        return missingNodeInstance(name, request);
+    }
+
+    private Optional<NodeInstance> missingNodeInstance(final String name, final FilterPodsRequest request) {
         final List<String> podStatuses = Optional.ofNullable(request)
                 .map(FilterPodsRequest::getPodStatuses)
                 .orElseGet(Collections::emptyList);

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/CAdvisorMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/CAdvisorMonitoringManager.java
@@ -42,10 +42,6 @@ import java.io.IOException;
 import java.net.Proxy;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
-import java.time.format.SignStyle;
-import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -63,17 +59,6 @@ public class CAdvisorMonitoringManager implements UsageMonitoringManager {
 
     private static final String CORE_MASK_DELIMETER = "-";
     private static final int KILO = 1000;
-
-
-    private static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
-            .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD).appendLiteral('-')
-            .appendValue(ChronoField.MONTH_OF_YEAR, 2).appendLiteral('-')
-            .appendValue(ChronoField.DAY_OF_MONTH, 2).appendLiteral("T")
-            .appendValue(ChronoField.HOUR_OF_DAY).appendLiteral(":")
-            .appendValue(ChronoField.MINUTE_OF_HOUR).appendLiteral(":")
-            .appendValue(ChronoField.SECOND_OF_MINUTE).appendLiteral(".")
-            .appendValue(ChronoField.NANO_OF_SECOND).appendLiteral("Z")
-            .toFormatter();
 
     private int cAdvisorPort;
 
@@ -142,7 +127,7 @@ public class CAdvisorMonitoringManager implements UsageMonitoringManager {
     }
 
     private static LocalDateTime dateTime(final String dateTime) {
-        return LocalDateTime.parse(dateTime, FORMATTER);
+        return LocalDateTime.parse(dateTime, MonitoringConstants.FORMATTER);
     }
 
     public long getDiskAvailableForDocker(final String nodeName,

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ESMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ESMonitoringManager.java
@@ -58,15 +58,8 @@ public class ESMonitoringManager implements UsageMonitoringManager {
     @Override
     public List<MonitoringStats> getStatsForNode(final String nodeName, final LocalDateTime from,
                                                  final LocalDateTime to) {
-        final LocalDateTime start;
-        final LocalDateTime end;
-        if (from == null || to == null) {
-            start = creationDate(nodeName);
-            end = DateUtils.nowUTC();
-        } else {
-            start = from;
-            end = to;
-        }
+        final LocalDateTime start = Optional.ofNullable(from).orElseGet(() -> creationDate(nodeName));
+        final LocalDateTime end = Optional.ofNullable(to).orElseGet(DateUtils::nowUTC);
         return getStats(nodeName, start, end);
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/MonitoringConstants.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/MonitoringConstants.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster.performancemonitoring;
+
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.SignStyle;
+import java.time.temporal.ChronoField;
+
+public class MonitoringConstants {
+
+    public static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
+            .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD).appendLiteral('-')
+            .appendValue(ChronoField.MONTH_OF_YEAR, 2).appendLiteral('-')
+            .appendValue(ChronoField.DAY_OF_MONTH, 2).appendLiteral("T")
+            .appendValue(ChronoField.HOUR_OF_DAY).appendLiteral(":")
+            .appendValue(ChronoField.MINUTE_OF_HOUR).appendLiteral(":")
+            .appendValue(ChronoField.SECOND_OF_MINUTE).appendLiteral(".")
+            .appendValue(ChronoField.NANO_OF_SECOND).appendLiteral("Z")
+            .toFormatter();
+
+    private MonitoringConstants() {
+        //no op
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/MonitoringConstants.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/MonitoringConstants.java
@@ -27,9 +27,9 @@ public class MonitoringConstants {
             .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD).appendLiteral('-')
             .appendValue(ChronoField.MONTH_OF_YEAR, 2).appendLiteral('-')
             .appendValue(ChronoField.DAY_OF_MONTH, 2).appendLiteral("T")
-            .appendValue(ChronoField.HOUR_OF_DAY).appendLiteral(":")
-            .appendValue(ChronoField.MINUTE_OF_HOUR).appendLiteral(":")
-            .appendValue(ChronoField.SECOND_OF_MINUTE).appendLiteral(".")
+            .appendValue(ChronoField.HOUR_OF_DAY, 2).appendLiteral(":")
+            .appendValue(ChronoField.MINUTE_OF_HOUR, 2).appendLiteral(":")
+            .appendValue(ChronoField.SECOND_OF_MINUTE, 2).appendLiteral(".")
             .appendValue(ChronoField.NANO_OF_SECOND).appendLiteral("Z")
             .toFormatter();
 

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/MonitoringConstants.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/MonitoringConstants.java
@@ -21,7 +21,7 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.SignStyle;
 import java.time.temporal.ChronoField;
 
-public class MonitoringConstants {
+public final class MonitoringConstants {
 
     public static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
             .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD).appendLiteral('-')

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -411,4 +411,4 @@ error.gcp.instance.not.found=Instance with label ''{0}'' not found!
 
 #Cluster usage monitoring
 error.cluster.monitoring.negative.interval=Specified monitoring interval should have direct chronological order. \
-  The given start date '{0}' happens after the given end date '{1}'.
+  The given start date ''{0}'' happens after the given end date ''{1}''.


### PR DESCRIPTION
Relates to issue #168 and fixes changes merged in #306.

Pull request brings several fixes:
- Use node instance `creationTimestamp` rather then `createdDate` as a default usage monitoring period start.
- Configure elastic to not fail on unavailable indices.
- Trim monitoring stats to suit requested period.
- Unify `cadvisor` and `elastic` monitoring backends date time formatting.
