### PR TITLE
Issue 720 remove unnecessary getUser call

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/git/GitlabClient.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/GitlabClient.java
@@ -161,15 +161,14 @@ public class GitlabClient {
         final String cloneToken;
         final String userName;
         final String email;
-        GitlabUser gitlabUser = getUser(user);
         if (issueToken && !externalHost) {
-            final GitlabUser user = findUser(gitlabUser.getUsername())
+            final GitlabUser gitlabUser = findUser(this.user)
                     .orElseGet(() -> GitlabUser.builder().username(adminName).id(adminId).build());
-            userName = user.getUsername();
-            cloneToken = createImpersonationToken(projectName, user.getId(), duration);
-            email = user.getEmail();
+            userName = gitlabUser.getUsername();
+            cloneToken = createImpersonationToken(projectName, gitlabUser.getId(), duration);
+            email = gitlabUser.getEmail();
         } else {
-            userName = externalHost ? gitlabUser.getUsername().replaceAll("@.*$", "") : adminName;
+            userName = externalHost ? this.user.replaceAll("@.*$", "") : adminName;
             cloneToken = adminToken;
             email = null;
         }


### PR DESCRIPTION
This PR related to #720. It deletes unnecessary `getUser` call form `buildCloneCredentials` method