### PR TITLE
Refactor KillerThread in PodMonitor.

### DIFF
--- a/api/profiles/dev/application.properties
+++ b/api/profiles/dev/application.properties
@@ -63,6 +63,9 @@ docker.registry.login.script=
 pause.run.script.url=
 pause.pool.size=3
 
+#scheduled tasks
+scheduled.pool.size=5
+
 #luigi
 kube.namespace=default
 luigi.graph.script=

--- a/api/src/main/java/com/epam/pipeline/app/AppConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/AppConfiguration.java
@@ -46,7 +46,9 @@ import java.util.concurrent.Executors;
 public class AppConfiguration implements SchedulingConfigurer {
 
     private static final int MAX_LOG_PAYLOAD_LENGTH = 1000;
-    private static final int SCHEDULED_TASKS_POOL_SIZE = 3;
+
+    @Value("${scheduled.pool.size:5}")
+    private int scheduledPoolSize;
 
     @Value("${pause.pool.size:10}")
     private int pausePoolSize;
@@ -68,7 +70,7 @@ public class AppConfiguration implements SchedulingConfigurer {
     public TaskScheduler taskScheduler() {
         ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
         scheduler.setRemoveOnCancelPolicy(true);
-        scheduler.setPoolSize(SCHEDULED_TASKS_POOL_SIZE); // For PodMonior, AutoscaleManager and ToolScanScheduler
+        scheduler.setPoolSize(scheduledPoolSize); // For AbstractSchedulingManager's subclasses' tasks
         return scheduler;
     }
 

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -145,7 +145,7 @@ public final class MessageConstants {
     public static final String DEBUG_MONITOR_CHECK_RUNNING = "debug.monitor.check.running";
     public static final String DEBUG_MONITOR_CHECK_FINISHED = "debug.monitor.check.finished";
     public static final String INFO_MONITOR_KILL_TASK = "info.monitor.kill.task";
-    public static final String ERROR_KILLER_THREAD_FAILED = "error.killer.thread.failed";
+    public static final String ERROR_POD_RELEASE_TASK = "error.pod.release.task";
     public static final String ERROR_RESTART_STATE_REASONS_NOT_FOUND = "error.instance.restart.state.reasons.not.found";
 
     // ResourceMonitoringManager messages

--- a/api/src/main/java/com/epam/pipeline/manager/preference/PreferenceValidators.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/PreferenceValidators.java
@@ -156,6 +156,10 @@ public final class PreferenceValidators {
         return (pref, dependencies) -> StringUtils.isNumeric(pref) && Integer.parseInt(pref) >= x;
     }
 
+    public static BiPredicate<String, Map<String, Preference>> isLessThan(int x) {
+        return (pref, dependencies) -> NumberUtils.isNumber(pref) && Integer.parseInt(pref) < x;
+    }
+
     /**
      * A no-op validator, that is always true
      */

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -68,6 +68,7 @@ import java.util.stream.Collectors;
 
 import static com.epam.pipeline.manager.preference.PreferenceValidators.isGreaterThan;
 import static com.epam.pipeline.manager.preference.PreferenceValidators.isGreaterThanOrEquals;
+import static com.epam.pipeline.manager.preference.PreferenceValidators.isLessThan;
 import static com.epam.pipeline.manager.preference.PreferenceValidators.isNullOrValidJson;
 import static com.epam.pipeline.manager.preference.PreferenceValidators.pass;
 
@@ -344,6 +345,14 @@ public class SystemPreferences {
         "launch.task.status.update.rate", 30000, LAUNCH_GROUP, isGreaterThan(5000));
     public static final StringPreference LAUNCH_DOCKER_IMAGE = new StringPreference("launch.docker.image", null,
                                                                                     LAUNCH_GROUP, null);
+    /**
+     * Sets unused pods release rate, on which application will kill Kubernetes pods, which were used by finished
+     * pipeline runs, milliseconds. This rate should be less, than
+     * @see #LAUNCH_TASK_STATUS_UPDATE_RATE
+     * to kill unused pods as soon as possible
+     */
+    public static final IntPreference RELEASE_UNUSED_NODES_RATE = new IntPreference(
+        "launch.pods.release.rate", 3000, LAUNCH_GROUP, isLessThan(LAUNCH_TASK_STATUS_UPDATE_RATE.getDefaultValue()));
 
     // UI_GROUP
     public static final StringPreference UI_PROJECT_INDICATOR = new StringPreference("ui.project.indicator",

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -146,7 +146,7 @@ error.registry.action.not.allowed=Action {0} is not allowed for user {1} in regi
 debug.monitor.check.running=Checking running tasks status
 debug.monitor.check.finished=Finished pod monitor cycle
 info.monitor.kill.task=Killing pods for {0}
-error.killer.thread.failed=Killer thread failed with an exception: {0}
+error.pod.release.task=An exception is caught during pod release task: {0}
 error.instance.restart.state.reasons.not.found=Instance state reasons for run restart are not specified.
 
 info.run.idle.notify=Pipeline Run {0} is idle: CPU usage: {1}, notification will be sent


### PR DESCRIPTION
Previously we used KillerThread to release pods, received after `PodMonitor.updateStatus` execution. The problem is that if this thread is terminated unexpectedly, we are not releasing unused pods anymore.

PR solves this issue, the approach of release is changed to execution as a scheduled task with a short rate. 