### PR TITLE
Issue 733 ES synchronization improvements

### DIFF
--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineController.java
@@ -429,8 +429,8 @@ public class PipelineController extends AbstractRestController {
     @ResponseBody
     @ApiOperation(
         value = "Truncate first bytes of a file content",
-        notes = "Gets first bytes of content of the file, specified by path in the repository and pipeline version ID. " +
-                "The file content is returned Base64 encoded",
+        notes = "Gets first bytes of content of the file, specified by path in the repository and pipeline "
+                + "version ID. The file content is returned Base64 encoded",
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiResponses(
         value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
@@ -440,7 +440,8 @@ public class PipelineController extends AbstractRestController {
         @RequestParam(value = VERSION) final String version,
         @RequestParam String path,
         @RequestParam Integer byteLimit) throws GitClientException {
-        return new ResponseEntity<>(pipelineApiService.getTruncatedPipelineFileContent(id, version, path, byteLimit), HttpStatus.OK);
+        return new ResponseEntity<>(pipelineApiService.getTruncatedPipelineFileContent(id, version, path, byteLimit),
+                                    HttpStatus.OK);
     }
 
     @RequestMapping(value = "/pipeline/{id}/file", method= RequestMethod.POST)

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineController.java
@@ -425,6 +425,24 @@ public class PipelineController extends AbstractRestController {
         return new ResponseEntity<>(pipelineApiService.getPipelineFileContents(id, version, path), HttpStatus.OK);
     }
 
+    @GetMapping(value = "/pipeline/{id}/file/truncate")
+    @ResponseBody
+    @ApiOperation(
+        value = "Truncate first bytes of a file content",
+        notes = "Gets first bytes of content of the file, specified by path in the repository and pipeline version ID. " +
+                "The file content is returned Base64 encoded",
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+        value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+        })
+    public ResponseEntity<byte[]> getTruncatedPipelineFile(
+        @PathVariable(value = ID) Long id,
+        @RequestParam(value = VERSION) final String version,
+        @RequestParam String path,
+        @RequestParam Integer byteLimit) throws GitClientException {
+        return new ResponseEntity<>(pipelineApiService.getTruncatedPipelineFileContent(id, version, path, byteLimit), HttpStatus.OK);
+    }
+
     @RequestMapping(value = "/pipeline/{id}/file", method= RequestMethod.POST)
     @ResponseBody
     @ApiOperation(

--- a/api/src/main/java/com/epam/pipeline/manager/git/GitLabApi.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/GitLabApi.java
@@ -31,6 +31,7 @@ import com.epam.pipeline.entity.git.GitTokenRequest;
 import com.epam.pipeline.entity.git.GitlabUser;
 import com.epam.pipeline.entity.git.GitlabVersion;
 import com.epam.pipeline.entity.git.UpdateGitFileRequest;
+import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.DELETE;
@@ -40,6 +41,7 @@ import retrofit2.http.POST;
 import retrofit2.http.PUT;
 import retrofit2.http.Path;
 import retrofit2.http.Query;
+import retrofit2.http.Streaming;
 
 import java.util.List;
 
@@ -120,6 +122,20 @@ public interface GitLabApi {
     Call<GitFile> getFiles(@Path(PROJECT) String idOrName,
                            @Path(FILE_PATH) String filePath,
                            @Query(REF) String reference);
+
+    /**
+     * Allows you to receive raw content of a file.
+     * This endpoint can be accessed without authentication if the repository is publicly accessible.
+     *
+     * @param idOrName  The ID or URL-encoded path of the project
+     * @param filePath  Url encoded full path to new file. Ex. lib%2Fclass%2Erb
+     * @param reference The name of branch, tag or commit
+     */
+    @Streaming
+    @GET("api/v3/projects/{project}/repository/files/{file_path}/raw")
+    Call<ResponseBody> getFilesRawContent(@Path(PROJECT) String idOrName,
+                                          @Path(value = FILE_PATH, encoded = true) String filePath,
+                                          @Query(REF) String reference);
 
     /**
      * Allows you to receive information about file in repository like name, size, content.

--- a/api/src/main/java/com/epam/pipeline/manager/git/GitManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/GitManager.java
@@ -664,6 +664,11 @@ public class GitManager {
                 .getFileContents(path, getRevisionName(version));
     }
 
+    public byte[] getTruncatedPipelineFileContent(Pipeline pipeline, String version, String path, int byteLimit)
+        throws GitClientException {
+        return this.getGitlabClientForPipeline(pipeline)
+            .getTruncatedFileContents(path, getRevisionName(version), byteLimit);
+    }
 
     /**
      * Returns docs file list of specified pipeline version

--- a/api/src/main/java/com/epam/pipeline/manager/git/GitManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/GitManager.java
@@ -664,8 +664,8 @@ public class GitManager {
                 .getFileContents(path, getRevisionName(version));
     }
 
-    public byte[] getTruncatedPipelineFileContent(Pipeline pipeline, String version, String path, int byteLimit)
-        throws GitClientException {
+    public byte[] getTruncatedPipelineFileContent(final Pipeline pipeline, final String version,
+                                                  final String path, int byteLimit) throws GitClientException {
         return this.getGitlabClientForPipeline(pipeline)
             .getTruncatedFileContents(path, getRevisionName(version), byteLimit);
     }

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineApiService.java
@@ -203,8 +203,8 @@ public class PipelineApiService {
     }
 
     @PreAuthorize(PIPELINE_ID_READ)
-    public byte[] getTruncatedPipelineFileContent(Long id, String version, String path, Integer byteLimit)
-        throws GitClientException {
+    public byte[] getTruncatedPipelineFileContent(final Long id, final String version, final String path,
+                                                  final Integer byteLimit) throws GitClientException {
         return gitManager.getTruncatedPipelineFileContent(pipelineManager.load(id), version, path, byteLimit);
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineApiService.java
@@ -202,6 +202,12 @@ public class PipelineApiService {
         return gitManager.getPipelineFileContents(pipelineManager.load(id), version, path);
     }
 
+    @PreAuthorize(PIPELINE_ID_READ)
+    public byte[] getTruncatedPipelineFileContent(Long id, String version, String path, Integer byteLimit)
+        throws GitClientException {
+        return gitManager.getTruncatedPipelineFileContent(pipelineManager.load(id), version, path, byteLimit);
+    }
+
     @PreAuthorize(PIPELINE_ID_WRITE)
     public GitCommitEntry modifyFile(Long id, PipelineSourceItemVO sourceItemVO) throws GitClientException {
         return gitManager.modifyFile(pipelineManager.load(id, true), sourceItemVO);

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
@@ -127,6 +127,10 @@ public interface CloudPipelineAPI {
     @GET("pipeline/{id}/file")
     Call<byte[]> loadFileContent(@Path(ID) Long pipelineId, @Query(VERSION) String version, @Query(PATH) String path);
 
+    @GET("pipeline/{id}/file/truncate")
+    Call<byte[]> loadTruncatedFileContent(@Path(ID) Long pipelineId, @Query(VERSION) String version,
+                                          @Query(PATH) String path, @Query(PATH) Integer byteLimit);
+
     @GET("datastorage/loadAll")
     Call<Result<List<AbstractDataStorage>>> loadAllDataStorages();
 

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
@@ -128,8 +128,8 @@ public interface CloudPipelineAPI {
     Call<byte[]> loadFileContent(@Path(ID) Long pipelineId, @Query(VERSION) String version, @Query(PATH) String path);
 
     @GET("pipeline/{id}/file/truncate")
-    Call<byte[]> loadTruncatedFileContent(@Path(ID) Long pipelineId, @Query(VERSION) String version,
-                                          @Query(PATH) String path, @Query(PATH) Integer byteLimit);
+    Call<Result<byte[]>> loadTruncatedFileContent(@Path(ID) Long pipelineId, @Query(VERSION) String version,
+                                                  @Query(PATH) String path, @Query(PATH) Integer byteLimit);
 
     @GET("datastorage/loadAll")
     Call<Result<List<AbstractDataStorage>>> loadAllDataStorages();

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/app/AzureBlobStorageSyncConfiguration.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/app/AzureBlobStorageSyncConfiguration.java
@@ -78,12 +78,14 @@ public class AzureBlobStorageSyncConfiguration {
             final PipelineEventDao eventDao,
             final ElasticIndexService indexService,
             final BulkRequestSender requestSender,
-            final @Value("${sync.az-blob-storage.index.mapping}") String azStorageMapping) {
+            final @Value("${sync.az-blob-storage.index.mapping}") String azStorageMapping,
+            final @Value("${sync.load.common.entity.chunk.size:1000}") int chunkSize) {
         return new EntitySynchronizer(eventDao,
                 PipelineEvent.ObjectType.AZ,
                 azStorageMapping,
                 azEventConverter,
                 indexService,
-                requestSender);
+                requestSender,
+                chunkSize);
     }
 }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/app/CommonSyncConfiguration.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/app/CommonSyncConfiguration.java
@@ -53,6 +53,8 @@ public class CommonSyncConfiguration {
     private static final String FALSE = "false";
     @Value("${sync.index.common.prefix}")
     private String commonIndexPrefix;
+    @Value("${sync.load.common.entity.chunk.size:1000}")
+    private int syncChunkSize;
 
     @Bean
     public BulkRequestSender bulkRequestSender(
@@ -80,7 +82,8 @@ public class CommonSyncConfiguration {
                 runMapping,
                 new EventToRequestConverterImpl<>(commonIndexPrefix, indexName, loader, mapper),
                 indexService,
-                requestSender);
+                requestSender,
+                syncChunkSize);
     }
 
     @Bean
@@ -99,7 +102,8 @@ public class CommonSyncConfiguration {
                 toolMapping,
                 new EventToRequestConverterImpl<>(commonIndexPrefix, indexName, loader, mapper),
                 indexService,
-                requestSender);
+                requestSender,
+                syncChunkSize);
     }
 
     @Bean
@@ -117,7 +121,8 @@ public class CommonSyncConfiguration {
                 folderMapping,
                 new EventToRequestConverterImpl<>(commonIndexPrefix, indexName, loader, mapper),
                 indexService,
-                requestSender);
+                requestSender,
+                syncChunkSize);
     }
 
     @Bean
@@ -135,7 +140,8 @@ public class CommonSyncConfiguration {
                 mapping,
                 new EventToRequestConverterImpl<>(commonIndexPrefix, indexName, loader, mapper),
                 indexService,
-                requestSender);
+                requestSender,
+                syncChunkSize);
     }
 
     @Bean
@@ -153,7 +159,8 @@ public class CommonSyncConfiguration {
                 mapping,
                 new EventToRequestConverterImpl<>(commonIndexPrefix, indexName, loader, mapper),
                 indexService,
-                requestSender);
+                requestSender,
+                syncChunkSize);
     }
 
     @Bean
@@ -171,7 +178,8 @@ public class CommonSyncConfiguration {
                 mapping,
                 new EventToRequestConverterImpl<>(commonIndexPrefix, indexName, loader, mapper),
                 indexService,
-                requestSender);
+                requestSender,
+                syncChunkSize);
     }
 
     @Bean
@@ -189,7 +197,8 @@ public class CommonSyncConfiguration {
                 mapping,
                 new EventToRequestConverterImpl<>(commonIndexPrefix, indexName, loader, mapper),
                 indexService,
-                requestSender);
+                requestSender,
+                syncChunkSize);
     }
 
     @Bean
@@ -213,6 +222,7 @@ public class CommonSyncConfiguration {
                 new RunConfigurationEventConverter(commonIndexPrefix, indexName,
                         loader, documentBuilder, elasticsearchClient, indexService),
                 indexService,
-                requestSender);
+                requestSender,
+                syncChunkSize);
     }
 }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/app/GSStorageSyncConfiguration.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/app/GSStorageSyncConfiguration.java
@@ -62,12 +62,14 @@ public class GSStorageSyncConfiguration {
             final PipelineEventDao eventDao,
             final ElasticIndexService indexService,
             final BulkRequestSender requestSender,
-            final @Value("${sync.gs-storage.index.mapping}") String gsStorageMapping) {
+            final @Value("${sync.gs-storage.index.mapping}") String gsStorageMapping,
+            final @Value("${sync.load.common.entity.chunk.size:1000}") int chunkSize) {
         return new EntitySynchronizer(eventDao,
                 PipelineEvent.ObjectType.GS,
                 gsStorageMapping,
                 gsEventConverter,
                 indexService,
-                requestSender);
+                requestSender,
+                chunkSize);
     }
 }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/app/NFSStorageSyncConfiguration.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/app/NFSStorageSyncConfiguration.java
@@ -76,12 +76,14 @@ public class NFSStorageSyncConfiguration {
             final PipelineEventDao eventDao,
             final ElasticIndexService indexService,
             final BulkRequestSender requestSender,
-            final @Value("${sync.nfs-storage.index.mapping}") String nfsStorageMapping) {
+            final @Value("${sync.nfs-storage.index.mapping}") String nfsStorageMapping,
+            final @Value("${sync.load.common.entity.chunk.size:1000}") int chunkSize) {
         return new EntitySynchronizer(eventDao,
                 PipelineEvent.ObjectType.NFS,
                 nfsStorageMapping,
                 nfsEventConverter,
                 indexService,
-                requestSender);
+                requestSender,
+                chunkSize);
     }
 }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/app/S3StorageSyncConfiguration.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/app/S3StorageSyncConfiguration.java
@@ -77,12 +77,14 @@ public class S3StorageSyncConfiguration {
             final PipelineEventDao eventDao,
             final ElasticIndexService indexService,
             final BulkRequestSender requestSender,
-            final @Value("${sync.s3-storage.index.mapping}") String s3StorageMapping) {
+            final @Value("${sync.s3-storage.index.mapping}") String s3StorageMapping,
+            final @Value("${sync.load.common.entity.chunk.size:1000}") int chunkSize) {
         return new EntitySynchronizer(eventDao,
                 PipelineEvent.ObjectType.S3,
                 s3StorageMapping,
                 s3EventConverter,
                 indexService,
-                requestSender);
+                requestSender,
+                chunkSize);
     }
 }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/BulkRequestSender.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/BulkRequestSender.java
@@ -79,7 +79,7 @@ public class BulkRequestSender {
 
     }
 
-
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public void indexDocuments(final String indexName,
                                final List<PipelineEvent.ObjectType> objectTypes,
                                final List<DocWriteRequest> documentRequests,
@@ -109,7 +109,6 @@ public class BulkRequestSender {
             return;
         }
         Arrays.stream(response.getItems())
-            .filter(item -> !item.isFailed())
             .collect(Collectors.groupingBy(idConverter::getId))
             .forEach((id, items) -> responsePostProcessor.postProcessResponse(items, objectTypes, id, syncStart));
     }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/BulkRequestSender.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/BulkRequestSender.java
@@ -87,9 +87,13 @@ public class BulkRequestSender {
                                final int bulkSize) {
         final int partitionSize = Integer.min(MAX_PARTITION_SIZE,
                                               Integer.max(MIN_PARTITION_SIZE, bulkSize / 10));
-        ListUtils.partition(documentRequests, partitionSize)
-                .forEach(chunk -> indexChunk(indexName, chunk, objectTypes, syncStart));
-
+        ListUtils.partition(documentRequests, partitionSize).forEach(chunk -> {
+            try {
+                indexChunk(indexName, chunk, objectTypes, syncStart);
+            } catch (Exception e) {
+                log.error("Partial error during {} index sync: {}.", indexName, e.getMessage());
+            }
+        });
     }
 
     private void indexChunk(final String indexName,

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/CloudPipelineAPIClient.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/CloudPipelineAPIClient.java
@@ -152,8 +152,9 @@ public class CloudPipelineAPIClient {
         return QueryUtils.executeFileContent(cloudPipelineAPI.loadFileContent(id, version, path));
     }
 
-    public String getTruncatedPipelineFile(final Long id, final String version, final String path, final int byteLimit) {
-        return QueryUtils.executeFileContent(cloudPipelineAPI.loadTruncatedFileContent(id, version, path, byteLimit));
+    public byte[] getTruncatedPipelineFile(final Long id, final String version, final String path,
+                                           final int byteLimit) {
+        return QueryUtils.execute(cloudPipelineAPI.loadTruncatedFileContent(id, version, path, byteLimit));
     }
 
     public List<GitRepositoryEntry> loadRepositoryContents(final Long id, final String version, final String path) {

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/CloudPipelineAPIClient.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/CloudPipelineAPIClient.java
@@ -152,6 +152,10 @@ public class CloudPipelineAPIClient {
         return QueryUtils.executeFileContent(cloudPipelineAPI.loadFileContent(id, version, path));
     }
 
+    public String getTruncatedPipelineFile(final Long id, final String version, final String path, final int byteLimit) {
+        return QueryUtils.executeFileContent(cloudPipelineAPI.loadTruncatedFileContent(id, version, path, byteLimit));
+    }
+
     public List<GitRepositoryEntry> loadRepositoryContents(final Long id, final String version, final String path) {
         return QueryUtils.execute(cloudPipelineAPI.loadRepositoryContent(id, version, path));
     }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/EntitySynchronizer.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/EntitySynchronizer.java
@@ -53,6 +53,7 @@ public class EntitySynchronizer implements ElasticsearchSynchronizer {
                 log.debug("{} entities for synchronization were not found.", objectType);
                 return;
             }
+
             log.debug("Merged {} events for {}", mergeEvents.size(), objectType);
 
             final String indexName = converter.buildIndexName();

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/GsBucketFileManager.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/GsBucketFileManager.java
@@ -109,12 +109,8 @@ public class GsBucketFileManager implements ObjectStorageFileManager {
                            final String indexName) {
         convertToStorageFile(file)
                 .ifPresent(
-                        item -> indexContainer
-                                .add(createIndexRequest(item,
-                                                        indexName,
-                                                        storage,
-                                                        credentials.getRegion(),
-                                                        permissions)));
+                    item -> indexContainer
+                            .add(createIndexRequest(item, indexName, storage, credentials.getRegion(), permissions)));
     }
 
     private Optional<DataStorageFile> convertToStorageFile(final Blob blob) {

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/PipelineCodeHandler.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/PipelineCodeHandler.java
@@ -32,6 +32,7 @@ import com.epam.pipeline.entity.security.acl.AclClass;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.elasticsearch.action.DocWriteRequest;
@@ -247,10 +248,10 @@ public class PipelineCodeHandler {
                                             final String repoEntryPath,
                                             final PermissionsContainer permissionsContainer) {
         log.debug("Indexing entry {}", repoEntryPath);
-        final String fileContent =
+        final byte[] fileContent =
                 cloudPipelineAPIClient.getTruncatedPipelineFile(pipeline.getId(), revisionName, repoEntryPath,
                                                                 codeLimitBytes);
-        if (StringUtils.isBlank(fileContent)) {
+        if (ArrayUtils.isEmpty(fileContent)) {
             log.debug("Missing file content for path {} revision {}", repoEntryPath, revisionName);
             return null;
         }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/pipeline/PipelineCodeMapper.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/pipeline/PipelineCodeMapper.java
@@ -70,6 +70,6 @@ public class PipelineCodeMapper {
     private String buildFileContent(final String fullContent) {
         return fullContent.length() < maxDocChars
                ? fullContent
-               : null;
+               : fullContent.substring(0, maxDocChars);
     }
 }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/pipeline/PipelineCodeMapper.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/pipeline/PipelineCodeMapper.java
@@ -20,7 +20,6 @@ import com.epam.pipeline.entity.pipeline.Pipeline;
 import com.epam.pipeline.entity.search.SearchDocumentType;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -29,9 +28,6 @@ import static com.epam.pipeline.elasticsearchagent.service.ElasticsearchSynchron
 
 @Component
 public class PipelineCodeMapper {
-
-    @Value("${sync.pipeline-code.max.chars:10000}")
-    private int maxDocChars;
 
     public XContentBuilder pipelineCodeToDocument(final Pipeline pipeline,
                                                   final String pipelineVersion,
@@ -46,7 +42,7 @@ public class PipelineCodeMapper {
                     .field("pipelineName", pipeline.getName())
                     .field("pipelineVersion", pipelineVersion)
                     .field("path", path)
-                    .field("content", buildFileContent(fileContent));
+                    .field("content", fileContent);
 
             jsonBuilder.array("allowed_users", permissions.getAllowedUsers().toArray());
             jsonBuilder.array("denied_users", permissions.getDeniedUsers().toArray());
@@ -58,18 +54,5 @@ public class PipelineCodeMapper {
         } catch (IOException e) {
             throw new IllegalArgumentException("An error occurred while creating document: ", e);
         }
-    }
-
-    /**
-     * Create a String object containing code, that will add to full-text search.
-     * Note, that we set the max chars limit for the document to control ElasticSearch memory consumption.
-     *
-     * @param fullContent content of the file we want to index
-     * @return content or <code>null</code> if content is too big
-     */
-    private String buildFileContent(final String fullContent) {
-        return fullContent.length() < maxDocChars
-               ? fullContent
-               : fullContent.substring(0, maxDocChars);
     }
 }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/run/PipelineRunMapper.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/run/PipelineRunMapper.java
@@ -46,8 +46,11 @@ public class PipelineRunMapper implements EntityMapper<PipelineRunWithLog> {
 
     private final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(DATE_PATTERN);
 
-    @Value("${sync.run.log.lines.size:1000}")
-    private int maxLogLines;
+    private final int maxLogLines;
+
+    public PipelineRunMapper(@Value("${sync.run.log.lines.size:1000}") final int maxLogLines) {
+        this.maxLogLines = maxLogLines;
+    }
 
     @Override
     public XContentBuilder map(final EntityContainer<PipelineRunWithLog> container) {

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/run/PipelineRunMapper.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/run/PipelineRunMapper.java
@@ -29,11 +29,13 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -43,6 +45,9 @@ import static com.epam.pipeline.elasticsearchagent.service.ElasticsearchSynchron
 public class PipelineRunMapper implements EntityMapper<PipelineRunWithLog> {
 
     private final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(DATE_PATTERN);
+
+    @Value("${sync.run.log.lines.size:1000}")
+    private int maxLogLines;
 
     @Override
     public XContentBuilder map(final EntityContainer<PipelineRunWithLog> container) {
@@ -148,6 +153,8 @@ public class PipelineRunMapper implements EntityMapper<PipelineRunWithLog> {
             return;
         }
         jsonBuilder.array("logs", runLogs.stream()
+                .sorted(Comparator.comparing(RunLog::getDate).reversed())
+                .limit(maxLogLines)
                 .map(log -> {
                     final String logText = log.getLogText();
                     final String taskName = Optional.ofNullable(log.getTask())

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/utils/EventProcessorUtils.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/utils/EventProcessorUtils.java
@@ -20,6 +20,7 @@ import com.epam.pipeline.elasticsearchagent.model.PipelineEvent;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -56,7 +57,7 @@ public final class EventProcessorUtils {
             return deleteEvent;
         }
         return events.stream().filter(event -> event.getEventType() != EventType.DELETE)
-                .findFirst();
+            .max(Comparator.comparing(PipelineEvent::getCreatedDate));
     }
 
 }

--- a/elasticsearch-agent/src/main/resources/application.properties
+++ b/elasticsearch-agent/src/main/resources/application.properties
@@ -35,12 +35,14 @@ sync.pipeline-code.index.name=pipeline-code
 sync.pipeline-code.index.paths=config.json;docs/;src/
 sync.pipeline-code.bulk.insert.size=1000
 sync.pipeline-code.default-branch=refs/heads/master
+sync.pipeline-code.max.chars=10000;
 
 #Pipeline Run Settings
 #sync.run.disable=true
 sync.run.index.mapping=classpath:/templates/pipeline_run.json
 sync.run.index.name=pipeline-run
 sync.run.bulk.insert.size=100
+sync.run.log.lines.size=1000
 
 #Azure blob storage Settings
 sync.az-blob-storage.index.name=az-storage

--- a/elasticsearch-agent/src/main/resources/application.properties
+++ b/elasticsearch-agent/src/main/resources/application.properties
@@ -35,7 +35,7 @@ sync.pipeline-code.index.name=pipeline-code
 sync.pipeline-code.index.paths=config.json;docs/;src/
 sync.pipeline-code.bulk.insert.size=1000
 sync.pipeline-code.default-branch=refs/heads/master
-sync.pipeline-code.max.chars=10000
+sync.pipeline-code.max.bytes=10240
 
 #Pipeline Run Settings
 #sync.run.disable=true

--- a/elasticsearch-agent/src/main/resources/application.properties
+++ b/elasticsearch-agent/src/main/resources/application.properties
@@ -35,7 +35,7 @@ sync.pipeline-code.index.name=pipeline-code
 sync.pipeline-code.index.paths=config.json;docs/;src/
 sync.pipeline-code.bulk.insert.size=1000
 sync.pipeline-code.default-branch=refs/heads/master
-sync.pipeline-code.max.chars=10000;
+sync.pipeline-code.max.chars=10000
 
 #Pipeline Run Settings
 #sync.run.disable=true

--- a/elasticsearch-agent/src/main/resources/application.properties
+++ b/elasticsearch-agent/src/main/resources/application.properties
@@ -24,6 +24,7 @@ sync.index.common.prefix=cp-
 sync.last.synchronization.file=lastSynchronizationTime.txt
 sync.submit.threads=1
 sync.scheduler.delay=30000
+sync.load.common.entity.chunk.size=1000
 
 #Pipeline Settings
 #sync.pipeline.disable=true

--- a/elasticsearch-agent/src/main/resources/dao/pipeline-event-dao.xml
+++ b/elasticsearch-agent/src/main/resources/dao/pipeline-event-dao.xml
@@ -30,6 +30,7 @@
                         pipeline.pipeline_event
                     WHERE
                         object_type = :OBJECT_TYPE AND stamp < :STAMP
+                    LIMIT :LIMIT;
                 ]]>
             </value>
         </property>

--- a/elasticsearch-agent/src/test/java/com/epam/pipeline/elasticsearchagent/TestConstants.java
+++ b/elasticsearch-agent/src/test/java/com/epam/pipeline/elasticsearchagent/TestConstants.java
@@ -35,6 +35,7 @@ public final class TestConstants {
     public static final String ADMIN_GROUP = "ROLE_ADMIN";
     public static final String TEST_KEY = "key";
     public static final String TEST_VALUE = "value";
+    public static final byte[] TEST_VALUE_BYTE = TEST_VALUE.getBytes();
     public static final String ALLOW_USER = "allow_user_name";
     public static final String ALLOW_GROUP = "allow_group_name";
     public static final String DENY_USER = "deny_user_name";

--- a/elasticsearch-agent/src/test/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/pipeline/PipelineCodeMapperTest.java
+++ b/elasticsearch-agent/src/test/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/pipeline/PipelineCodeMapperTest.java
@@ -27,6 +27,7 @@ import static com.epam.pipeline.elasticsearchagent.TestConstants.PERMISSIONS_CON
 import static com.epam.pipeline.elasticsearchagent.TestConstants.TEST_NAME;
 import static com.epam.pipeline.elasticsearchagent.TestConstants.TEST_PATH;
 import static com.epam.pipeline.elasticsearchagent.TestConstants.TEST_VALUE;
+import static com.epam.pipeline.elasticsearchagent.TestConstants.TEST_VALUE_BYTE;
 import static com.epam.pipeline.elasticsearchagent.TestConstants.TEST_VERSION;
 
 @SuppressWarnings({"PMD.TooManyStaticImports"})
@@ -40,8 +41,8 @@ class PipelineCodeMapperTest {
         pipeline.setId(1L);
         pipeline.setName(TEST_NAME);
 
-        XContentBuilder contentBuilder = mapper.pipelineCodeToDocument(pipeline, TEST_VERSION, TEST_PATH, TEST_VALUE,
-                PERMISSIONS_CONTAINER);
+        XContentBuilder contentBuilder = mapper.pipelineCodeToDocument(pipeline, TEST_VERSION, TEST_PATH,
+                TEST_VALUE_BYTE, PERMISSIONS_CONTAINER);
 
         verifyPipelineCode(pipeline, TEST_VERSION, TEST_PATH, TEST_VALUE, contentBuilder);
         verifyPermissions(PERMISSIONS_CONTAINER, contentBuilder);

--- a/elasticsearch-agent/src/test/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/run/RunMapperTest.java
+++ b/elasticsearch-agent/src/test/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/run/RunMapperTest.java
@@ -49,10 +49,11 @@ class RunMapperTest {
 
     private static final int NODE_DISK = 40;
     private static final BigDecimal PRICE = new BigDecimal("1.2");
+    private static final int MAX_LOG_LINES = 100;
 
     @Test
     void shouldMapRun() throws IOException {
-        PipelineRunMapper mapper = new PipelineRunMapper();
+        PipelineRunMapper mapper = new PipelineRunMapper(MAX_LOG_LINES);
 
         PipelineRunWithLog pipelineRunWithLog = new PipelineRunWithLog();
 


### PR DESCRIPTION
This PR solves issue #733.

It changes the way of events' synchronization to improve stability by having better control over memory consumption.

- Limit the number of events to be loaded from DB for synchronization at a time.
- Split merged events processing to chunks, so the potential failure of a document uploading won't fail the whole synchronization cycle.
- Limit max length for PipelineRun's logs will be indexed: only recent records if the log is too long.
- Limit max length for Gitlab (Pipeline) files will be indexed: if the file is too long, its content is not being indexed.
- Introduce new values in application.properties for configuration.


