### PR TITLE
Issue 728 IDLE/Pressure tags shall not be applied to the paused runs 

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
@@ -73,9 +73,9 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
     private static final int MILLIS = 1000;
     private static final double PERCENT = 100.0;
     private static final double ONE_THOUSANDTH = 0.001;
-    private static final String UTILIZATION_LEVEL_LOW = "IDLE";
-    private static final String UTILIZATION_LEVEL_HIGH = "PRESSURE";
-    private static final String TRUE_VALUE_STRING = "true";
+    public static final String UTILIZATION_LEVEL_LOW = "IDLE";
+    public static final String UTILIZATION_LEVEL_HIGH = "PRESSURE";
+    public static final String TRUE_VALUE_STRING = "true";
 
     private final PipelineRunManager pipelineRunManager;
     private final NotificationManager notificationManager;

--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerContainerOperationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerContainerOperationManager.java
@@ -18,7 +18,6 @@ package com.epam.pipeline.manager.docker;
 
 import com.epam.pipeline.common.MessageConstants;
 import com.epam.pipeline.common.MessageHelper;
-import com.epam.pipeline.controller.vo.PipelineRunServiceUrlVO;
 import com.epam.pipeline.entity.cloud.CloudInstanceOperationResult;
 import com.epam.pipeline.entity.configuration.PipelineConfiguration;
 import com.epam.pipeline.entity.pipeline.CommitStatus;
@@ -236,8 +235,9 @@ public class DockerContainerOperationManager {
                     TaskStatus.PAUSED.name());
 
             run.setPodIP(null);
-            runManager.updatePodIP(run);
-            runManager.updateServiceUrl(run.getId(), new PipelineRunServiceUrlVO());
+            run.setServiceUrl(null);
+            removeUtilizationLevelTags(run);
+            runManager.updateRunInfo(run);
 
             Process sshConnection = submitCommandViaSSH(instance.getNodeIP(), pauseRunCommand);
 
@@ -259,9 +259,8 @@ public class DockerContainerOperationManager {
             kubernetesManager.deletePod(run.getPodId());
             cloudFacade.stopInstance(instance.getCloudRegionId(), instance.getNodeId());
             kubernetesManager.deleteNode(instance.getNodeName());
-            removeUtilizationLevelTags(run);
             run.setStatus(TaskStatus.PAUSED);
-            runManager.updateRunInfo(run);
+            runManager.updatePipelineStatus(run);
         } catch (Exception e) {
             LOGGER.error(e.getMessage(), e);
             addRunLog(run, e.getMessage(), PAUSE_RUN_TASK);

--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerContainerOperationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerContainerOperationManager.java
@@ -261,7 +261,7 @@ public class DockerContainerOperationManager {
             kubernetesManager.deleteNode(instance.getNodeName());
             removeUtilizationLevelTags(run);
             run.setStatus(TaskStatus.PAUSED);
-            runManager.updatePipelineStatus(run);
+            runManager.updateRunInfo(run);
         } catch (Exception e) {
             LOGGER.error(e.getMessage(), e);
             addRunLog(run, e.getMessage(), PAUSE_RUN_TASK);

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -842,6 +842,21 @@ public class PipelineRunManager {
     }
 
     /**
+     * Update whole pipeline info (use instead of calling few specific update methods if need).
+     * @param run {@link PipelineRun} which will be updated
+     * @return updated pipeline run
+     */
+    @Transactional(propagation = Propagation.REQUIRED)
+    public PipelineRun updateRunInfo(final PipelineRun run) {
+        final Long runId = run.getId();
+        final PipelineRun loadedRun = pipelineRunDao.loadPipelineRun(runId);
+        Assert.notNull(loadedRun,
+                       messageHelper.getMessage(MessageConstants.ERROR_PIPELINE_NOT_FOUND, runId));
+        pipelineRunDao.updateRun(run);
+        return run;
+    }
+
+    /**
      * Updates run's tags
      * @param runId is ID of pipeline run which tags should be updated
      * @param newTags object, containing a map with tags to set for a pipeline

--- a/api/src/test/java/com/epam/pipeline/manager/docker/DockerContainerOperationManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/docker/DockerContainerOperationManagerTest.java
@@ -38,7 +38,7 @@ public class DockerContainerOperationManagerTest extends AbstractManagerTest {
     private static final String INSUFFICIENT_INSTANCE_CAPACITY = "InsufficientInstanceCapacity";
     private static final String NODE_NAME = "node-1";
     private static final String NODE_ID = "node-id";
-    private static final String STUB_STRING = "";
+    private static final String TEST_TAG = "tag";
     private static final long REGION_ID = 1L;
 
     @InjectMocks
@@ -93,14 +93,14 @@ public class DockerContainerOperationManagerTest extends AbstractManagerTest {
     @Test
     public void pauseRun() throws IOException {
         final PipelineRun idledRun =
-            createRunWithTags(ResourceMonitoringManager.UTILIZATION_LEVEL_LOW, STUB_STRING);
+            createRunWithTags(ResourceMonitoringManager.UTILIZATION_LEVEL_LOW, TEST_TAG);
         final PipelineRun pressuredRun =
-            createRunWithTags(ResourceMonitoringManager.UTILIZATION_LEVEL_HIGH, STUB_STRING);
+            createRunWithTags(ResourceMonitoringManager.UTILIZATION_LEVEL_HIGH, TEST_TAG);
 
         Mockito.when(kubernetesManager.getContainerIdFromKubernetesPod(Mockito.anyString(), Mockito.anyString()))
-            .thenReturn(STUB_STRING);
+            .thenReturn(TEST_TAG);
         Mockito.when(nodesManager.terminateNode(NODE_NAME)).thenReturn(new NodeInstance());
-        Mockito.when(authManager.issueTokenForCurrentUser().getToken()).thenReturn(STUB_STRING);
+        Mockito.when(authManager.issueTokenForCurrentUser().getToken()).thenReturn(TEST_TAG);
         Process sshConnection = Mockito.mock(Process.class);
         Mockito.doReturn(sshConnection).when(operationManager)
             .submitCommandViaSSH(Mockito.anyString(), Mockito.anyString());
@@ -109,8 +109,8 @@ public class DockerContainerOperationManagerTest extends AbstractManagerTest {
         operationManager.pauseRun(idledRun);
         operationManager.pauseRun(pressuredRun);
 
-        assertRunStateAfterPause(idledRun, STUB_STRING);
-        assertRunStateAfterPause(pressuredRun, STUB_STRING);
+        assertRunStateAfterPause(idledRun, TEST_TAG);
+        assertRunStateAfterPause(pressuredRun, TEST_TAG);
     }
 
     private void assertRunStateAfterPause(final PipelineRun run, final String ... expectedTags) {

--- a/api/src/test/java/com/epam/pipeline/manager/docker/DockerContainerOperationManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/docker/DockerContainerOperationManagerTest.java
@@ -1,25 +1,34 @@
 package com.epam.pipeline.manager.docker;
 
 import com.epam.pipeline.entity.cloud.CloudInstanceOperationResult;
+import com.epam.pipeline.entity.cluster.NodeInstance;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.epam.pipeline.entity.region.AwsRegion;
 import com.epam.pipeline.manager.AbstractManagerTest;
 import com.epam.pipeline.manager.cloud.CloudFacade;
+import com.epam.pipeline.manager.cluster.KubernetesManager;
+import com.epam.pipeline.manager.cluster.NodesManager;
+import com.epam.pipeline.manager.cluster.performancemonitoring.ResourceMonitoringManager;
 import com.epam.pipeline.manager.pipeline.PipelineRunManager;
 import com.epam.pipeline.manager.pipeline.RunLogManager;
 import com.epam.pipeline.manager.region.CloudRegionManager;
+import com.epam.pipeline.manager.security.AuthManager;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.io.IOException;
 import java.util.Collections;
+import java.util.Map;
 
 import static com.epam.pipeline.entity.cloud.CloudInstanceOperationResult.Status;
 
@@ -29,9 +38,11 @@ public class DockerContainerOperationManagerTest extends AbstractManagerTest {
     private static final String INSUFFICIENT_INSTANCE_CAPACITY = "InsufficientInstanceCapacity";
     private static final String NODE_NAME = "node-1";
     private static final String NODE_ID = "node-id";
+    private static final String STUB_STRING = "";
     private static final long REGION_ID = 1L;
 
     @InjectMocks
+    @Spy
     @Autowired
     private DockerContainerOperationManager operationManager;
 
@@ -46,6 +57,15 @@ public class DockerContainerOperationManagerTest extends AbstractManagerTest {
 
     @Mock
     private RunLogManager logManager;
+
+    @Mock
+    private KubernetesManager kubernetesManager;
+
+    @Mock
+    private NodesManager nodesManager;
+
+    @Mock (answer = Answers.RETURNS_DEEP_STUBS)
+    private AuthManager authManager;
 
     @Before
     public void setUp() {
@@ -68,6 +88,46 @@ public class DockerContainerOperationManagerTest extends AbstractManagerTest {
         operationManager.resumeRun(run, Collections.emptyList());
 
         Assert.assertEquals(run.getStatus(), TaskStatus.PAUSED);
+    }
+
+    @Test
+    public void pauseRun() throws IOException {
+        final PipelineRun idledRun =
+            createRunWithTags(ResourceMonitoringManager.UTILIZATION_LEVEL_LOW, STUB_STRING);
+        final PipelineRun pressuredRun =
+            createRunWithTags(ResourceMonitoringManager.UTILIZATION_LEVEL_HIGH, STUB_STRING);
+
+        Mockito.when(kubernetesManager.getContainerIdFromKubernetesPod(Mockito.anyString(), Mockito.anyString()))
+            .thenReturn(STUB_STRING);
+        Mockito.when(nodesManager.terminateNode(NODE_NAME)).thenReturn(new NodeInstance());
+        Mockito.when(authManager.issueTokenForCurrentUser().getToken()).thenReturn(STUB_STRING);
+        Process sshConnection = Mockito.mock(Process.class);
+        Mockito.doReturn(sshConnection).when(operationManager)
+            .submitCommandViaSSH(Mockito.anyString(), Mockito.anyString());
+        Mockito.when(sshConnection.exitValue()).thenReturn(0);
+
+        operationManager.pauseRun(idledRun);
+        operationManager.pauseRun(pressuredRun);
+
+        assertRunStateAfterPause(idledRun, STUB_STRING);
+        assertRunStateAfterPause(pressuredRun, STUB_STRING);
+    }
+
+    private void assertRunStateAfterPause(final PipelineRun run, final String ... expectedTags) {
+        final Map<String, String> updatedTags = run.getTags();
+        Assert.assertEquals(expectedTags.length, updatedTags.size());
+        for (String expectedTag : expectedTags) {
+            Assert.assertTrue(updatedTags.containsKey(expectedTag));
+        }
+        Assert.assertEquals(TaskStatus.PAUSED, run.getStatus());
+    }
+
+    private PipelineRun createRunWithTags(final String ... tags) {
+        final PipelineRun result = createRun();
+        for (String tag : tags) {
+            result.addTag(tag, ResourceMonitoringManager.TRUE_VALUE_STRING);
+        }
+        return result;
     }
 
     private PipelineRun createRun() {

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
@@ -36,6 +36,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -115,6 +116,7 @@ public class PipelineRun extends AbstractSecuredEntity {
 
     public PipelineRun() {
         this.terminating = false;
+        this.tags = new HashMap<>();
     }
 
     public PipelineRun(Long id, String name) {


### PR DESCRIPTION
This PR solves issue #728

IDLE and PRESSURE tags are dropped when a job is being paused.

- Drop utilization tags when a run state is changing to PAUSED.
- Unit tests to prove tags are being removed.