### PR TITLE
(issue #624) Fix bug when IDLE tag wasn't set after a long time

### DIFF
--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -151,6 +151,14 @@ public final class MessageConstants {
     // ResourceMonitoringManager messages
     public static final String INFO_RUN_IDLE_NOTIFY = "info.run.idle.notify";
     public static final String INFO_RUN_IDLE_ACTION = "info.run.idle.action";
+    public static final String DEBUG_CPU_RUN_METRICS_RECEIVED = "debug.cpu.run.metrics.received";
+    public static final String DEBUG_RUN_METRICS_REQUEST = "debug.run.metrics.request";
+    public static final String DEBUG_RUN_IDLE_SKIP_CHECK = "debug.run.idle.skip.check";
+    public static final String DEBUG_RUN_IDLED = "debug.run.idled";
+    public static final String DEBUG_RUN_NOT_IDLED = "debug.run.not.idled";
+    public static final String DEBUG_RUN_HAS_NOT_NODE_NAME = "debug.run.has.not.node.name";
+    public static final String DEBUG_MEMORY_METRICS = "debug.memory.metrics.received";
+
 
     // Kubernetes messages
     public static final String ERROR_NODE_NOT_FOUND = "error.node.not.found";

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -154,7 +154,6 @@ public final class MessageConstants {
     public static final String DEBUG_CPU_RUN_METRICS_RECEIVED = "debug.cpu.run.metrics.received";
     public static final String DEBUG_RUN_METRICS_REQUEST = "debug.run.metrics.request";
     public static final String DEBUG_RUN_IDLE_SKIP_CHECK = "debug.run.idle.skip.check";
-    public static final String DEBUG_RUN_IDLED = "debug.run.idled";
     public static final String DEBUG_RUN_NOT_IDLED = "debug.run.not.idled";
     public static final String DEBUG_RUN_HAS_NOT_NODE_NAME = "debug.run.has.not.node.name";
     public static final String DEBUG_MEMORY_METRICS = "debug.memory.metrics.received";

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/CPURequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/CPURequester.java
@@ -26,8 +26,6 @@ import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
-import org.elasticsearch.search.aggregations.bucket.terms.Terms;
-import org.elasticsearch.search.aggregations.metrics.avg.Avg;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 
 import java.time.Duration;
@@ -74,11 +72,7 @@ public class CPURequester extends AbstractMetricRequester {
 
     @Override
     public Map<String, Double> parseResponse(final SearchResponse response) {
-        return ((Terms)response.getAggregations().get(AGGREGATION_POD_NAME)).getBuckets().stream()
-                .filter(b -> Double.isFinite(((Avg) b.getAggregations().get(AVG_AGGREGATION + USAGE_RATE)).getValue()))
-                .collect(Collectors.toMap(
-                    b -> b.getKey().toString(),
-                    b -> ((Avg) b.getAggregations().get(AVG_AGGREGATION + USAGE_RATE)).getValue()));
+        return collectAggregation(response, AGGREGATION_POD_NAME, AVG_AGGREGATION + USAGE_RATE);
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/CPURequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/CPURequester.java
@@ -75,6 +75,7 @@ public class CPURequester extends AbstractMetricRequester {
     @Override
     public Map<String, Double> parseResponse(final SearchResponse response) {
         return ((Terms)response.getAggregations().get(AGGREGATION_POD_NAME)).getBuckets().stream()
+                .filter(b -> Double.isFinite(((Avg) b.getAggregations().get(AVG_AGGREGATION + USAGE_RATE)).getValue()))
                 .collect(Collectors.toMap(
                     b -> b.getKey().toString(),
                     b -> ((Avg) b.getAggregations().get(AVG_AGGREGATION + USAGE_RATE)).getValue()));

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/MemoryRequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/MemoryRequester.java
@@ -73,7 +73,8 @@ public class MemoryRequester extends AbstractMetricRequester {
     @Override
     public Map<String, Double> parseResponse(final SearchResponse response) {
         return ((Terms) response.getAggregations().get(AGGREGATION_NODE_NAME)).getBuckets().stream()
-                .filter(b -> Double.isFinite(((Avg) b.getAggregations().get(AVG_AGGREGATION + USAGE_RATE)).getValue()))
+                .filter(b -> Double.isFinite(((Avg) b.getAggregations()
+                        .get(AVG_AGGREGATION + NODE_UTILIZATION)).getValue()))
                 .collect(Collectors.toMap(
                     b -> b.getKey().toString(),
                     b -> ((Avg) b.getAggregations().get(AVG_AGGREGATION + NODE_UTILIZATION)).getValue()));

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/MemoryRequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/MemoryRequester.java
@@ -73,6 +73,7 @@ public class MemoryRequester extends AbstractMetricRequester {
     @Override
     public Map<String, Double> parseResponse(final SearchResponse response) {
         return ((Terms) response.getAggregations().get(AGGREGATION_NODE_NAME)).getBuckets().stream()
+                .filter(b -> Double.isFinite(((Avg) b.getAggregations().get(AVG_AGGREGATION + USAGE_RATE)).getValue()))
                 .collect(Collectors.toMap(
                     b -> b.getKey().toString(),
                     b -> ((Avg) b.getAggregations().get(AVG_AGGREGATION + NODE_UTILIZATION)).getValue()));

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/MemoryRequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/MemoryRequester.java
@@ -26,8 +26,6 @@ import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
-import org.elasticsearch.search.aggregations.bucket.terms.Terms;
-import org.elasticsearch.search.aggregations.metrics.avg.Avg;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 
 import java.time.Duration;
@@ -72,12 +70,7 @@ public class MemoryRequester extends AbstractMetricRequester {
 
     @Override
     public Map<String, Double> parseResponse(final SearchResponse response) {
-        return ((Terms) response.getAggregations().get(AGGREGATION_NODE_NAME)).getBuckets().stream()
-                .filter(b -> Double.isFinite(((Avg) b.getAggregations()
-                        .get(AVG_AGGREGATION + NODE_UTILIZATION)).getValue()))
-                .collect(Collectors.toMap(
-                    b -> b.getKey().toString(),
-                    b -> ((Avg) b.getAggregations().get(AVG_AGGREGATION + NODE_UTILIZATION)).getValue()));
+        return collectAggregation(response, AGGREGATION_NODE_NAME, AVG_AGGREGATION + NODE_UTILIZATION);
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/PodFSRequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/PodFSRequester.java
@@ -39,7 +39,6 @@ import java.util.stream.Stream;
 
 public class PodFSRequester extends FSRequester {
 
-    public static final String FILE_SYSTEM_METRICS_TIMESTAMP = "FilesystemMetricsTimestamp";
     public static final String FILESYSTEM = "filesystem";
 
     PodFSRequester(final RestHighLevelClient client) {

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
@@ -140,7 +140,7 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
         final int timeRange = preferenceManager.getPreference(SystemPreferences.SYSTEM_MONITORING_METRIC_TIME_RANGE);
         final Map<ELKUsageMetric, Double> thresholds = getThresholds();
         log.debug(messageHelper.getMessage(MessageConstants.DEBUG_RUN_METRICS_REQUEST,
-                "MEMORY, DISK ",running.size(), String.join(", ", running.keySet())));
+                "MEMORY, DISK ", running.size(), String.join(", ", running.keySet())));
 
         final LocalDateTime previousMinute = previousMinuteTime();
         final Map<ELKUsageMetric, Map<String, Double>> metrics = Stream.of(ELKUsageMetric.MEM, ELKUsageMetric.FS)
@@ -273,7 +273,6 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
                         InstanceType.builder().vCPU(1).build());
                 double cpuUsageRate = metric / MILLIS / type.getVCPU();
                 if (Precision.compareTo(cpuUsageRate, idleCpuLevel, ONE_THOUSANDTH) < 0) {
-                    log.debug(messageHelper.getMessage(MessageConstants.DEBUG_RUN_IDLED, run.getPodId(), cpuUsageRate));
                     processIdleRun(run, actionTimeout, action, runsToNotify,
                                    runsToUpdateNotificationTime, cpuUsageRate, runsToUpdateTags);
                 } else if (run.getLastIdleNotificationTime() != null) { // No action is longer needed, clear timeout

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
@@ -142,11 +142,11 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
         log.debug(messageHelper.getMessage(MessageConstants.DEBUG_RUN_METRICS_REQUEST,
                 "MEMORY, DISK ", running.size(), String.join(", ", running.keySet())));
 
-        final LocalDateTime previousMinute = previousMinuteTime();
+        final LocalDateTime now = DateUtils.nowUTC();
         final Map<ELKUsageMetric, Map<String, Double>> metrics = Stream.of(ELKUsageMetric.MEM, ELKUsageMetric.FS)
                 .collect(Collectors.toMap(metric -> metric, metric ->
                         monitoringDao.loadMetrics(metric, running.keySet(),
-                                previousMinute.minusMinutes(timeRange), previousMinute)));
+                                now.minusMinutes(timeRange + ONE), now)));
 
         log.debug(messageHelper.getMessage(MessageConstants.DEBUG_MEMORY_METRICS, metrics.entrySet().stream()
                 .map(e -> e.getKey().getName() + ": { " + e.getValue().entrySet().stream()
@@ -164,10 +164,6 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
         final List<PipelineRun> runsToUpdateTags = getRunsToUpdatePressuredTags(running, runsToNotify);
         notificationManager.notifyHighResourceConsumingRuns(runsToNotify, NotificationType.HIGH_CONSUMED_RESOURCES);
         pipelineRunManager.updateRunsTags(runsToUpdateTags);
-    }
-
-    private LocalDateTime previousMinuteTime() {
-        return DateUtils.nowUTC().minusMinutes(ONE);
     }
 
     private List<PipelineRun> getRunsToUpdatePressuredTags(final Map<String, PipelineRun> running,
@@ -238,9 +234,9 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
         log.debug(messageHelper.getMessage(MessageConstants.DEBUG_RUN_METRICS_REQUEST,
                 "CPU", notProlongedRuns.size(), String.join(", ", notProlongedRuns.keySet())));
 
-        final LocalDateTime previousMinute = previousMinuteTime();
+        final LocalDateTime now = DateUtils.nowUTC();
         final Map<String, Double> cpuMetrics = monitoringDao.loadMetrics(ELKUsageMetric.CPU,
-                notProlongedRuns.keySet(), previousMinute.minusMinutes(idleTimeout), previousMinute);
+                notProlongedRuns.keySet(), now.minusMinutes(idleTimeout + ONE), now);
         log.debug(messageHelper.getMessage(MessageConstants.DEBUG_CPU_RUN_METRICS_RECEIVED,
                 cpuMetrics.entrySet().stream().map(e -> e.getKey() + ":" + e.getValue())
                         .collect(Collectors.joining(", ")))

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
@@ -132,14 +132,15 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
                     final boolean hasNodeName = Objects.nonNull(r.getInstance())
                             && Objects.nonNull(r.getInstance().getNodeName());
                     if (!hasNodeName) {
-                        log.debug("Pipeline with id: " + r.getId() + " has not node name.");
+                        log.debug(messageHelper.getMessage(MessageConstants.DEBUG_RUN_HAS_NOT_NODE_NAME, r.getId()));
                     }
                     return hasNodeName;
                 })
                 .collect(Collectors.toMap(r -> r.getInstance().getNodeName(), r -> r));
         final int timeRange = preferenceManager.getPreference(SystemPreferences.SYSTEM_MONITORING_METRIC_TIME_RANGE);
         final Map<ELKUsageMetric, Double> thresholds = getThresholds();
-        log.debug("Checking memory and disk stats for pipelines: " + String.join(", ", running.keySet()));
+        log.debug(messageHelper.getMessage(MessageConstants.DEBUG_RUN_METRICS_REQUEST,
+                "MEMORY, DISK ",running.size(), String.join(", ", running.keySet())));
 
         final LocalDateTime previousMinute = previousMinuteTime();
         final Map<ELKUsageMetric, Map<String, Double>> metrics = Stream.of(ELKUsageMetric.MEM, ELKUsageMetric.FS)
@@ -147,12 +148,12 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
                         monitoringDao.loadMetrics(metric, running.keySet(),
                                 previousMinute.minusMinutes(timeRange), previousMinute)));
 
-        log.debug("memory and disk metrics received: " + metrics.entrySet().stream()
+        log.debug(messageHelper.getMessage(MessageConstants.DEBUG_MEMORY_METRICS, metrics.entrySet().stream()
                 .map(e -> e.getKey().getName() + ": { " + e.getValue().entrySet().stream()
                         .map(metric -> metric.getKey() + ":" + metric.getValue())
                         .collect(Collectors.joining(", ")) + " }"
                 )
-                .collect(Collectors.joining("; ")));
+                .collect(Collectors.joining("; "))));
 
         final List<Pair<PipelineRun, Map<ELKUsageMetric, Double>>> runsToNotify = running.entrySet()
                 .stream()
@@ -234,14 +235,16 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
                         .orElse(Boolean.FALSE))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
-        log.debug("Checking cpu stats for pipelines: " + String.join(", ", notProlongedRuns.keySet()));
+        log.debug(messageHelper.getMessage(MessageConstants.DEBUG_RUN_METRICS_REQUEST,
+                "CPU", notProlongedRuns.size(), String.join(", ", notProlongedRuns.keySet())));
 
         final LocalDateTime previousMinute = previousMinuteTime();
         final Map<String, Double> cpuMetrics = monitoringDao.loadMetrics(ELKUsageMetric.CPU,
                 notProlongedRuns.keySet(), previousMinute.minusMinutes(idleTimeout), previousMinute);
-
-        log.debug("CPU Metrics received: " + cpuMetrics.entrySet().stream().map(e -> e.getKey() + ":" + e.getValue())
-            .collect(Collectors.joining(", ")));
+        log.debug(messageHelper.getMessage(MessageConstants.DEBUG_CPU_RUN_METRICS_RECEIVED,
+                cpuMetrics.entrySet().stream().map(e -> e.getKey() + ":" + e.getValue())
+                        .collect(Collectors.joining(", ")))
+        );
 
         final double idleCpuLevel = preferenceManager.getPreference(
                 SystemPreferences.SYSTEM_IDLE_CPU_THRESHOLD_PERCENT) / PERCENT;
@@ -261,6 +264,7 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
         for (Map.Entry<String, PipelineRun> entry : running.entrySet()) {
             PipelineRun run = entry.getValue();
             if (run.isNonPause() || isClusterRun(run)) {
+                log.debug(messageHelper.getMessage(MessageConstants.DEBUG_RUN_IDLE_SKIP_CHECK, run.getPodId()));
                 continue;
             }
             Double metric = cpuMetrics.get(entry.getKey());
@@ -269,9 +273,12 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
                         InstanceType.builder().vCPU(1).build());
                 double cpuUsageRate = metric / MILLIS / type.getVCPU();
                 if (Precision.compareTo(cpuUsageRate, idleCpuLevel, ONE_THOUSANDTH) < 0) {
+                    log.debug(messageHelper.getMessage(MessageConstants.DEBUG_RUN_IDLED, run.getPodId(), cpuUsageRate));
                     processIdleRun(run, actionTimeout, action, runsToNotify,
                                    runsToUpdateNotificationTime, cpuUsageRate, runsToUpdateTags);
                 } else if (run.getLastIdleNotificationTime() != null) { // No action is longer needed, clear timeout
+                    log.debug(messageHelper.getMessage(MessageConstants.DEBUG_RUN_NOT_IDLED,
+                            run.getPodId(), cpuUsageRate));
                     processFormerIdleRun(run, runsToUpdateNotificationTime, runsToUpdateTags);
                 }
             }

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -154,7 +154,6 @@ info.run.idle.action=Pipeline Run {0} is idle: CPU usage: {1}, notification was 
 debug.cpu.run.metrics.received=CPU metrics ''{0}''
 debug.run.metrics.request=Checking {0} stats for {1} pipelines ''{2}''
 debug.run.idle.skip.check=Run {0} marked as nonPause or is cluster run! Skip.
-debug.run.idled=Run {0} has CPU usage rate: {1} considered as idled.
 debug.run.not.idled=Run {0} has CPU usage rate: {1} considered as not idled, tag will be cleared.
 debug.run.has.not.node.name=Pipeline with id: {0} has not node name.
 debug.memory.metrics.received=Memory and disk metrics received ''{0}''

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -151,6 +151,13 @@ error.instance.restart.state.reasons.not.found=Instance state reasons for run re
 
 info.run.idle.notify=Pipeline Run {0} is idle: CPU usage: {1}, notification will be sent
 info.run.idle.action=Pipeline Run {0} is idle: CPU usage: {1}, notification was already be sent. Action: {2}
+debug.cpu.run.metrics.received=CPU metrics ''{0}''
+debug.run.metrics.request=Checking {0} stats for {1} pipelines ''{2}''
+debug.run.idle.skip.check=Run {0} marked as nonPause or is cluster run! Skip.
+debug.run.idled=Run {0} has CPU usage rate: {1} considered as idled.
+debug.run.not.idled=Run {0} has CPU usage rate: {1} considered as not idled, tag will be cleared.
+debug.run.has.not.node.name=Pipeline with id: {0} has not node name.
+debug.memory.metrics.received=Memory and disk metrics received ''{0}''
 
 # Kubernetes
 


### PR DESCRIPTION
This PR related to #624 
It fixes bug when check nodes for CPU usage can be skipped when `system.max.idle.timeout.minutes` set to 1, it this case some of the data can be unalienable at the moment in elastic search. This PR move a window for monitoring request. 