### PR TITLE
Issue 733 Bulk request size limitation

### DIFF
--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/app/CommonSyncConfiguration.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/app/CommonSyncConfiguration.java
@@ -55,6 +55,8 @@ public class CommonSyncConfiguration {
     private String commonIndexPrefix;
     @Value("${sync.load.common.entity.chunk.size:1000}")
     private int syncChunkSize;
+    @Value("${elastic.request.limit.size.mb:100}")
+    private int maxRequestSizeMb;
 
     @Bean
     public BulkRequestSender bulkRequestSender(
@@ -76,7 +78,7 @@ public class CommonSyncConfiguration {
             final @Value("${sync.run.index.mapping}") String runMapping,
             final @Value("${sync.run.bulk.insert.size:100}") int bulkSize) {
         final BulkRequestSender requestSender = new BulkRequestSender(
-                elasticsearchClient, responsePostProcessor, new ResponseIdConverter() {}, bulkSize);
+                elasticsearchClient, responsePostProcessor, new ResponseIdConverter() {}, bulkSize, maxRequestSizeMb);
         return new EntitySynchronizer(eventDao,
                 PipelineEvent.ObjectType.RUN,
                 runMapping,

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/BulkRequestSender.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/BulkRequestSender.java
@@ -20,14 +20,16 @@ import com.epam.pipeline.elasticsearchagent.service.BulkResponsePostProcessor;
 import com.epam.pipeline.elasticsearchagent.service.ElasticsearchServiceClient;
 import com.epam.pipeline.elasticsearchagent.service.ResponseIdConverter;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.collections4.ListUtils;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.index.IndexRequest;
 import org.springframework.util.ObjectUtils;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -41,11 +43,12 @@ public class BulkRequestSender {
     private static final int DEFAULT_BULK_SIZE = 1000;
     private static final int MAX_PARTITION_SIZE = 200;
     private static final int MIN_PARTITION_SIZE = 10;
+    private static final int DEFAULT_MAX_REQUEST_SIZE_MB = 100;
     private final ElasticsearchServiceClient elasticsearchClient;
     private final BulkResponsePostProcessor responsePostProcessor;
-
     private ResponseIdConverter idConverter = new ResponseIdConverter() {};
     private int currentBulkSize = DEFAULT_BULK_SIZE;
+    private int requestLimitMb = DEFAULT_MAX_REQUEST_SIZE_MB;
 
     public BulkRequestSender(final ElasticsearchServiceClient elasticsearchClient,
                              final BulkResponsePostProcessor responsePostProcessor,
@@ -87,13 +90,33 @@ public class BulkRequestSender {
                                final int bulkSize) {
         final int partitionSize = Integer.min(MAX_PARTITION_SIZE,
                                               Integer.max(MIN_PARTITION_SIZE, bulkSize / 10));
-        ListUtils.partition(documentRequests, partitionSize).forEach(chunk -> {
-            try {
-                indexChunk(indexName, chunk, objectTypes, syncStart);
-            } catch (Exception e) {
-                log.error("Partial error during {} index sync: {}.", indexName, e.getMessage());
-            }
-        });
+        final RequestChunk requestChunk = new RequestChunk(partitionSize);
+        documentRequests.stream()
+            .filter(this::fitsDocSizeLimit)
+            .forEach(request -> tryToProceedRequestsInChunk(indexName, objectTypes, syncStart, requestChunk, request));
+        if (!requestChunk.isEmpty()) {
+            tryToIndexChunk(indexName, objectTypes, syncStart, requestChunk);
+        }
+    }
+
+    private void tryToProceedRequestsInChunk(final String indexName, final List<PipelineEvent.ObjectType> objectTypes,
+                                             final LocalDateTime syncStart, final RequestChunk chunk,
+                                             final DocWriteRequest request) {
+        if (chunk.isFull()
+                || (chunk.getSizeMB() + RequestChunk.getRequestSizeMb(request)) > requestLimitMb) {
+            tryToIndexChunk(indexName, objectTypes, syncStart, chunk);
+            chunk.clear();
+        }
+        chunk.add(request);
+    }
+
+    private void tryToIndexChunk(final String indexName, final List<PipelineEvent.ObjectType> objectTypes,
+                                 final LocalDateTime syncStart, final RequestChunk chunk) {
+        try {
+            indexChunk(indexName, chunk.getRequests(), objectTypes, syncStart);
+        } catch (Exception e) {
+            log.error("Partial error during {} index sync: {}.", indexName, e.getMessage());
+        }
     }
 
     private void indexChunk(final String indexName,
@@ -111,5 +134,59 @@ public class BulkRequestSender {
         Arrays.stream(response.getItems())
             .collect(Collectors.groupingBy(idConverter::getId))
             .forEach((id, items) -> responsePostProcessor.postProcessResponse(items, objectTypes, id, syncStart));
+    }
+
+    private boolean fitsDocSizeLimit(final DocWriteRequest request) {
+        if (RequestChunk.getRequestSizeMb(request) < requestLimitMb) {
+            return true;
+        } else {
+            log.warn("Can't index {} due to the doc oversize!", request.id());
+            return false;
+        }
+    }
+
+    @Getter
+    private static class RequestChunk {
+
+        private double sizeMB;
+        private final int maxElementsInChunk;
+        private final List<DocWriteRequest> requests;
+
+        public RequestChunk(final int maxElementsInChunk) {
+            this.requests = new ArrayList<>();
+            this.maxElementsInChunk = maxElementsInChunk;
+        }
+
+        public void add(final DocWriteRequest request) {
+            requests.add(request);
+            sizeMB += getRequestSizeMb(request);
+        }
+
+        public void clear() {
+            requests.clear();
+            sizeMB = 0;
+        }
+
+        public boolean isFull() {
+            return requests.size() == maxElementsInChunk;
+        }
+
+        public boolean isEmpty() {
+            return requests.isEmpty();
+        }
+
+        /**
+         * Tries to cast request to {@link IndexRequest} and calculate its content size.
+         *
+         * @param request request to be evaluated
+         * @return estimated size of a request in MB or 0 if unable to evaluate
+         */
+        public static double getRequestSizeMb(final DocWriteRequest request) {
+            try {
+                return ((IndexRequest) request).source().length() / (2 << 20);
+            } catch (ClassCastException e) {
+                return 0;
+            }
+        }
     }
 }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/BulkRequestSender.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/BulkRequestSender.java
@@ -20,22 +20,15 @@ import com.epam.pipeline.elasticsearchagent.service.BulkResponsePostProcessor;
 import com.epam.pipeline.elasticsearchagent.service.ElasticsearchServiceClient;
 import com.epam.pipeline.elasticsearchagent.service.ResponseIdConverter;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.action.DocWriteRequest;
-import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.common.bytes.BytesReference;
-import org.springframework.util.ObjectUtils;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
+import java.util.Objects;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -45,18 +38,27 @@ public class BulkRequestSender {
     private static final int DEFAULT_BULK_SIZE = 1000;
     private static final int MAX_PARTITION_SIZE = 200;
     private static final int MIN_PARTITION_SIZE = 10;
-    private static final int DEFAULT_MAX_REQUEST_SIZE_MB = 100;
     private final ElasticsearchServiceClient elasticsearchClient;
     private final BulkResponsePostProcessor responsePostProcessor;
     private ResponseIdConverter idConverter = new ResponseIdConverter() {};
     private int currentBulkSize = DEFAULT_BULK_SIZE;
-    private int requestLimitMb = DEFAULT_MAX_REQUEST_SIZE_MB;
+    private long requestLimitMb = MemLimitIndexRequestContainer.DEFAULT_MAX_REQUEST_SIZE_MB;
 
     public BulkRequestSender(final ElasticsearchServiceClient elasticsearchClient,
                              final BulkResponsePostProcessor responsePostProcessor,
                              final ResponseIdConverter idConverter) {
         this(elasticsearchClient, responsePostProcessor);
         this.idConverter = idConverter;
+    }
+
+    public BulkRequestSender(final ElasticsearchServiceClient elasticsearchClient,
+                             final BulkResponsePostProcessor responsePostProcessor,
+                             final ResponseIdConverter idConverter,
+                             final Integer bulkSize,
+                             final Integer requestLimitMb) {
+        this(elasticsearchClient, responsePostProcessor, idConverter);
+        this.currentBulkSize = bulkSize;
+        this.requestLimitMb = requestLimitMb;
     }
 
     public void indexDocuments(final String indexName,
@@ -92,104 +94,22 @@ public class BulkRequestSender {
                                final int bulkSize) {
         final int partitionSize = Integer.min(MAX_PARTITION_SIZE,
                                               Integer.max(MIN_PARTITION_SIZE, bulkSize / 10));
-        final RequestChunk requestChunk = new RequestChunk(partitionSize);
-        documentRequests
-            .forEach(request -> tryToProceedRequestsInChunk(indexName, objectTypes, syncStart, requestChunk, request));
-        if (!requestChunk.isEmpty()) {
-            tryToIndexChunk(indexName, objectTypes, syncStart, requestChunk);
+        try (IndexRequestContainer requestContainer =
+                 new MemLimitIndexRequestContainer(requests -> elasticsearchClient.sendRequests(indexName, requests),
+                                                   partitionSize, requestLimitMb)) {
+            requestContainer.enablePostProcessing(responsePostProcessor, idConverter, objectTypes, syncStart);
+            documentRequests.stream()
+                .map(this::tryToCastToIndexRequest)
+                .filter(Objects::nonNull)
+                .forEach(requestContainer::add);
         }
     }
 
-    private void tryToProceedRequestsInChunk(final String indexName, final List<PipelineEvent.ObjectType> objectTypes,
-                                             final LocalDateTime syncStart, final RequestChunk chunk,
-                                             final DocWriteRequest request) {
-        if (exceedsDocSizeLimit(request)) {
-            log.warn("Can't index {} doc with id:{} due to its oversize!", objectTypes, request.id());
-            return;
-        }
-        if (chunk.isFull()
-                || (chunk.getSizeMB() + RequestChunk.getRequestSizeMb(request)) > requestLimitMb) {
-            tryToIndexChunk(indexName, objectTypes, syncStart, chunk);
-            chunk.clear();
-        }
-        chunk.add(request);
-    }
-
-    private void tryToIndexChunk(final String indexName, final List<PipelineEvent.ObjectType> objectTypes,
-                                 final LocalDateTime syncStart, final RequestChunk chunk) {
+    private IndexRequest tryToCastToIndexRequest(final DocWriteRequest request) {
         try {
-            indexChunk(indexName, chunk.getRequests(), objectTypes, syncStart);
-        } catch (Exception e) {
-            log.error("Partial error during {} index sync: {}.", indexName, e.getMessage());
-        }
-    }
-
-    private void indexChunk(final String indexName,
-                            final List<DocWriteRequest> documentRequests,
-                            final List<PipelineEvent.ObjectType> objectTypes,
-                            final LocalDateTime syncStart) {
-        log.debug("Inserting {} documents for {}", documentRequests.size(), objectTypes);
-        final BulkResponse response = elasticsearchClient
-                .sendRequests(indexName, documentRequests);
-
-        if (ObjectUtils.isEmpty(response)) {
-            log.error("Elasticsearch documents for {} were not created.", objectTypes);
-            return;
-        }
-        Arrays.stream(response.getItems())
-            .collect(Collectors.groupingBy(idConverter::getId))
-            .forEach((id, items) -> responsePostProcessor.postProcessResponse(items, objectTypes, id, syncStart));
-    }
-
-    private boolean exceedsDocSizeLimit(final DocWriteRequest request) {
-        return RequestChunk.getRequestSizeMb(request) > requestLimitMb;
-    }
-
-    @Getter
-    private static class RequestChunk {
-
-        private double sizeMB;
-        private final int maxElementsInChunk;
-        private final List<DocWriteRequest> requests;
-
-        public RequestChunk(final int maxElementsInChunk) {
-            this.requests = new ArrayList<>();
-            this.maxElementsInChunk = maxElementsInChunk;
-        }
-
-        public void add(final DocWriteRequest request) {
-            requests.add(request);
-            sizeMB += getRequestSizeMb(request);
-        }
-
-        public void clear() {
-            requests.clear();
-            sizeMB = 0;
-        }
-
-        public boolean isFull() {
-            return requests.size() == maxElementsInChunk;
-        }
-
-        public boolean isEmpty() {
-            return requests.isEmpty();
-        }
-
-        /**
-         * Tries to cast request to {@link IndexRequest} and calculate its content size.
-         *
-         * @param request request to be evaluated
-         * @return estimated size of a request in MB or 0 if unable to evaluate
-         */
-        public static double getRequestSizeMb(final DocWriteRequest request) {
-            try {
-                return Optional.ofNullable(((IndexRequest) request).source())
-                           .map(BytesReference::length)
-                           .map(Integer::doubleValue)
-                           .orElse(0.0) / (2 << 20);
-            } catch (ClassCastException e) {
-                return 0;
-            }
+            return (IndexRequest) request;
+        } catch (ClassCastException e) {
+            return null;
         }
     }
 }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/MemLimitIndexRequestContainer.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/MemLimitIndexRequestContainer.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.epam.pipeline.elasticsearchagent.service.impl;
+
+import com.epam.pipeline.elasticsearchagent.service.BulkRequestCreator;
+import lombok.extern.slf4j.Slf4j;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.common.bytes.BytesReference;
+
+import java.util.Optional;
+
+@Slf4j
+public class MemLimitIndexRequestContainer extends IndexRequestContainer {
+
+    public static final long DEFAULT_MAX_REQUEST_SIZE_MB = 100;
+    private static int MB_TO_BYTES = 2 << 20;
+    private long byteSizeLimit = DEFAULT_MAX_REQUEST_SIZE_MB * MB_TO_BYTES;
+    private long currentSizeBytes = 0L;
+
+    public MemLimitIndexRequestContainer(final BulkRequestCreator bulkRequestCreator,
+                                         final int bulkSize) {
+        super(bulkRequestCreator, bulkSize);
+    }
+
+    public MemLimitIndexRequestContainer(final BulkRequestCreator bulkRequestCreator, final int bulkSize,
+                                         final long byteSizeLimit) {
+        this(bulkRequestCreator, bulkSize);
+        if (byteSizeLimit <= 0) {
+            throw new IllegalArgumentException("Byte limit should be a positive value!");
+        }
+        this.byteSizeLimit = byteSizeLimit * MB_TO_BYTES;
+    }
+
+    @Override
+    public void add(final IndexRequest request) {
+        if ((currentSizeBytes + getRequestSize(request)) > byteSizeLimit) {
+            flush();
+        }
+        super.add(request);
+    }
+
+    @Override
+    protected void flush() {
+        log.debug("Inserting {} documents for {}", requests.size(), objectTypes);
+        super.flush();
+        currentSizeBytes = 0L;
+    }
+
+    private long getRequestSize(final IndexRequest request) {
+        return Optional.ofNullable(request.source())
+            .map(BytesReference::length)
+            .orElse(0);
+    }
+}

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/PipelineSynchronizer.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/PipelineSynchronizer.java
@@ -83,6 +83,7 @@ public class PipelineSynchronizer implements ElasticsearchSynchronizer {
             final @Value("${sync.pipeline-code.index.name}") String pipelineCodeIndexName,
             final @Value("${sync.pipeline-code.index.paths}") String pipelineFileIndexPaths,
             final @Value("${sync.pipeline-code.bulk.insert.size}") Integer bulkInsertSize,
+            final @Value("${elastic.request.limit.size.mb}") Integer requestLimitMb,
             final CloudPipelineAPIClient cloudPipelineAPIClient,
             final ElasticsearchServiceClient elasticsearchServiceClient,
             final ElasticIndexService indexService,
@@ -106,7 +107,7 @@ public class PipelineSynchronizer implements ElasticsearchSynchronizer {
         PipelineIdConverter idConverter = new PipelineIdConverter(indexPrefix + pipelineIndexName,
                 indexPrefix + pipelineCodeIndexName);
         this.requestSender = new BulkRequestSender(
-                elasticsearchClient, bulkResponsePostProcessor, idConverter, bulkInsertSize);
+                elasticsearchClient, bulkResponsePostProcessor, idConverter, bulkInsertSize, requestLimitMb);
     }
 
     @Override

--- a/elasticsearch-agent/src/main/resources/application.properties
+++ b/elasticsearch-agent/src/main/resources/application.properties
@@ -6,6 +6,7 @@ server.servlet.context-path=/elastic-agent
 elasticsearch.client.url=localhost
 elasticsearch.client.port=9200
 elasticsearch.client.scheme=http
+elastic.request.limit.size.mb=100
 
 #DB
 database.url=


### PR DESCRIPTION
This PR partially solves issue #733 .
Request chunk splitting additionally covered by chunk memory size limitation besides elements count limitation. Elasticsearch can't index request with size over the value of its `http.max_content_length` property, so we are tracking bulk request size.

- introduce `elastic.request.limit.size.mb` in application.properties;
- monitor documents' size during chunk creation (execute bulk request if the next request added will cause limitation oversize; skip the files exceeding the limit).