### PR TITLE
Issue #759: Allow to configure run visibility policy

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/pipeline/PipelineApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/pipeline/PipelineApiService.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.manager.pipeline;
+package com.epam.pipeline.acl.pipeline;
 
 import com.epam.pipeline.controller.vo.CheckRepositoryVO;
 import com.epam.pipeline.controller.vo.GenerateFileVO;
@@ -37,6 +37,11 @@ import com.epam.pipeline.entity.pipeline.Revision;
 import com.epam.pipeline.exception.git.GitClientException;
 import com.epam.pipeline.manager.cluster.InstanceOfferManager;
 import com.epam.pipeline.manager.git.GitManager;
+import com.epam.pipeline.manager.pipeline.DocumentGenerationPropertyManager;
+import com.epam.pipeline.manager.pipeline.PipelineFileGenerationManager;
+import com.epam.pipeline.manager.pipeline.PipelineManager;
+import com.epam.pipeline.manager.pipeline.PipelineRunManager;
+import com.epam.pipeline.manager.pipeline.PipelineVersionManager;
 import com.epam.pipeline.manager.security.GrantPermissionManager;
 import com.epam.pipeline.manager.security.acl.AclMask;
 import com.epam.pipeline.manager.security.acl.AclMaskList;

--- a/api/src/main/java/com/epam/pipeline/app/AclSecurityConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/AclSecurityConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.cache.ehcache.EhCacheFactoryBean;
 import org.springframework.cache.ehcache.EhCacheManagerFactoryBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.PermissionEvaluator;
 import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
@@ -51,6 +52,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import javax.sql.DataSource;
 
 @Configuration
+@ComponentScan(basePackages = {"com.epam.pipeline.acl"})
 public class AclSecurityConfiguration extends GlobalMethodSecurityConfiguration {
 
     @Autowired

--- a/api/src/main/java/com/epam/pipeline/app/AppConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/AppConfiguration.java
@@ -40,6 +40,7 @@ import java.util.concurrent.Executors;
 @EnableAsync
 @ComponentScan(basePackages = {"com.epam.pipeline.dao",
         "com.epam.pipeline.manager",
+        "com.epam.pipeline.acl",
         "com.epam.pipeline.security",
         "com.epam.pipeline.aspect",
         "com.epam.pipeline.event"})

--- a/api/src/main/java/com/epam/pipeline/app/AppConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/AppConfiguration.java
@@ -40,7 +40,6 @@ import java.util.concurrent.Executors;
 @EnableAsync
 @ComponentScan(basePackages = {"com.epam.pipeline.dao",
         "com.epam.pipeline.manager",
-        "com.epam.pipeline.acl",
         "com.epam.pipeline.security",
         "com.epam.pipeline.aspect",
         "com.epam.pipeline.event"})

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineController.java
@@ -38,7 +38,7 @@ import com.epam.pipeline.entity.pipeline.Pipeline;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.Revision;
 import com.epam.pipeline.exception.git.GitClientException;
-import com.epam.pipeline.manager.pipeline.PipelineApiService;
+import com.epam.pipeline.acl.pipeline.PipelineApiService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
@@ -39,7 +39,7 @@ import com.epam.pipeline.entity.pipeline.run.PipelineStart;
 import com.epam.pipeline.entity.pipeline.run.parameter.RunSid;
 import com.epam.pipeline.entity.utils.DefaultSystemParameter;
 import com.epam.pipeline.manager.filter.WrongFilterException;
-import com.epam.pipeline.manager.pipeline.RunApiService;
+import com.epam.pipeline.acl.run.RunApiService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineServiceController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineServiceController.java
@@ -21,7 +21,7 @@ import com.epam.pipeline.controller.PagedResult;
 import com.epam.pipeline.controller.Result;
 import com.epam.pipeline.controller.vo.PagingRunFilterVO;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
-import com.epam.pipeline.manager.pipeline.RunApiService;
+import com.epam.pipeline.acl.run.RunApiService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSInstanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSInstanceService.java
@@ -65,6 +65,9 @@ public class AWSInstanceService implements CloudInstanceService<AwsRegion> {
     private final String nodeTerminateScript;
     private final CmdExecutor cmdExecutor = new CmdExecutor();
 
+    // TODO: 25-10-2019 @Lazy annotation added to resolve issue with circular dependency.
+    // It would be great fix this issue by actually removing this dependency:
+    // CloudFacade  -> AWSInstanceService -> InstanceOfferManager -> CloudFacade
     public AWSInstanceService(final EC2Helper ec2Helper,
                               final PreferenceManager preferenceManager,
                               final @Lazy InstanceOfferManager instanceOfferManager,

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSInstanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSInstanceService.java
@@ -37,6 +37,7 @@ import com.epam.pipeline.manager.preference.SystemPreferences;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -66,7 +67,7 @@ public class AWSInstanceService implements CloudInstanceService<AwsRegion> {
 
     public AWSInstanceService(final EC2Helper ec2Helper,
                               final PreferenceManager preferenceManager,
-                              final InstanceOfferManager instanceOfferManager,
+                              final @Lazy InstanceOfferManager instanceOfferManager,
                               final CommonCloudInstanceService instanceService,
                               final ClusterCommandService commandService,
                               @Value("${cluster.nodeup.script}") final String nodeUpScript,

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -65,7 +65,7 @@ import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.manager.region.CloudRegionManager;
 import com.epam.pipeline.manager.security.AuthManager;
-import com.epam.pipeline.manager.security.RunPermissionManager;
+import com.epam.pipeline.manager.security.run.RunPermissionManager;
 import com.epam.pipeline.utils.PasswordGenerator;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -65,7 +65,7 @@ import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.manager.region.CloudRegionManager;
 import com.epam.pipeline.manager.security.AuthManager;
-import com.epam.pipeline.manager.security.GrantPermissionManager;
+import com.epam.pipeline.manager.security.RunPermissionManager;
 import com.epam.pipeline.utils.PasswordGenerator;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
@@ -144,7 +144,7 @@ public class PipelineRunManager {
     private ToolManager toolManager;
 
     @Autowired
-    private GrantPermissionManager permissionManager;
+    private RunPermissionManager permissionManager;
 
     @Autowired
     private PipelineConfigurationManager configurationManager;

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/runner/RunConfigurationProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/runner/RunConfigurationProvider.java
@@ -31,7 +31,7 @@ import com.epam.pipeline.manager.cluster.InstanceOfferManager;
 import com.epam.pipeline.manager.pipeline.PipelineConfigurationManager;
 import com.epam.pipeline.manager.pipeline.PipelineManager;
 import com.epam.pipeline.manager.pipeline.ToolManager;
-import com.epam.pipeline.manager.security.PermissionsHelper;
+import com.epam.pipeline.manager.security.CheckPermissionHelper;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.BooleanUtils;
 import org.springframework.stereotype.Service;
@@ -48,7 +48,7 @@ public class RunConfigurationProvider implements ConfigurationProvider<RunConfig
         CloudPlatformPreferences> {
     private final PipelineManager pipelineManager;
     private final ToolManager toolManager;
-    private final PermissionsHelper permissionsHelper;
+    private final CheckPermissionHelper permissionsHelper;
     private final PipelineConfigurationManager pipelineConfigurationManager;
     private final InstanceOfferManager instanceOfferManager;
     private final MessageHelper messageHelper;

--- a/api/src/main/java/com/epam/pipeline/manager/preference/PreferenceValidators.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/PreferenceValidators.java
@@ -30,6 +30,7 @@ import com.epam.pipeline.security.ExternalServiceEndpoint;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang.math.NumberUtils;
+import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.util.AntPathMatcher;
@@ -158,6 +159,10 @@ public final class PreferenceValidators {
 
     public static BiPredicate<String, Map<String, Preference>> isLessThan(int x) {
         return (pref, dependencies) -> NumberUtils.isNumber(pref) && Integer.parseInt(pref) < x;
+    }
+
+    public static BiPredicate<String, Map<String, Preference>> isValidEnum(final Class<? extends Enum> enumClass) {
+        return (pref, dependencies) -> EnumUtils.isValidEnum(enumClass, pref);
     }
 
     /**

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -45,6 +45,7 @@ import com.epam.pipeline.manager.preference.AbstractSystemPreference.IntPreferen
 import com.epam.pipeline.manager.preference.AbstractSystemPreference.LongPreference;
 import com.epam.pipeline.manager.preference.AbstractSystemPreference.ObjectPreference;
 import com.epam.pipeline.manager.preference.AbstractSystemPreference.StringPreference;
+import com.epam.pipeline.manager.security.run.RunVisibilityPolicy;
 import com.epam.pipeline.security.ExternalServiceEndpoint;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -318,7 +319,9 @@ public class SystemPreferences {
     public static final ObjectPreference<List<DockerMount>> DOCKER_IN_DOCKER_MOUNTS = new ObjectPreference<>(
             "launch.dind.mounts", null, new TypeReference<List<DockerMount>>() {},
             LAUNCH_GROUP, isNullOrValidJson(new TypeReference<List<DockerMount>>() {}));
-
+    public static final ObjectPreference<RunVisibilityPolicy> RUN_VISIBILITY_POLICY = new ObjectPreference<>(
+            "launch.run.visibility", RunVisibilityPolicy.INHERIT, new TypeReference<RunVisibilityPolicy>() {},
+            LAUNCH_GROUP,  isNullOrValidJson(new TypeReference<RunVisibilityPolicy>() {}));
 
     //DTS submission
     public static final StringPreference DTS_LAUNCH_CMD_TEMPLATE = new StringPreference("dts.launch.cmd",

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -319,9 +319,9 @@ public class SystemPreferences {
     public static final ObjectPreference<List<DockerMount>> DOCKER_IN_DOCKER_MOUNTS = new ObjectPreference<>(
             "launch.dind.mounts", null, new TypeReference<List<DockerMount>>() {},
             LAUNCH_GROUP, isNullOrValidJson(new TypeReference<List<DockerMount>>() {}));
-    public static final ObjectPreference<RunVisibilityPolicy> RUN_VISIBILITY_POLICY = new ObjectPreference<>(
-            "launch.run.visibility", RunVisibilityPolicy.INHERIT, new TypeReference<RunVisibilityPolicy>() {},
-            LAUNCH_GROUP,  isNullOrValidJson(new TypeReference<RunVisibilityPolicy>() {}));
+    public static final StringPreference RUN_VISIBILITY_POLICY = new StringPreference(
+            "launch.run.visibility", RunVisibilityPolicy.INHERIT.name(), LAUNCH_GROUP,
+            PreferenceValidators.isValidEnum(RunVisibilityPolicy.class));
 
     //DTS submission
     public static final StringPreference DTS_LAUNCH_CMD_TEMPLATE = new StringPreference("dts.launch.cmd",

--- a/api/src/main/java/com/epam/pipeline/manager/security/AuthManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/AuthManager.java
@@ -53,6 +53,10 @@ public class AuthManager {
     @Value("${flyway.placeholders.default.admin.id:1}")
     private Long defaultAdminId;
 
+    public Authentication getAuthentication() {
+        return SecurityContextHolder.getContext().getAuthentication();
+    }
+
     /**
      * @return user name of currently logged in user
      */
@@ -158,7 +162,7 @@ public class AuthManager {
     }
 
     private Object getPrincipal() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Authentication authentication = getAuthentication();
         if (authentication == null || authentication.getPrincipal() == null) {
             return UNAUTHORIZED_USER;
         }

--- a/api/src/main/java/com/epam/pipeline/manager/security/CheckPermissionHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/CheckPermissionHelper.java
@@ -38,7 +38,7 @@ import java.util.List;
 // and provide integration tests for ACL permissions
 @Service
 @RequiredArgsConstructor
-public class PermissionsHelper {
+public class CheckPermissionHelper {
     private final PermissionEvaluator permissionEvaluator;
     private final AuthManager authManager;
     private final SidRetrievalStrategy sidRetrievalStrategy;

--- a/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionHandler.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionHandler.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.security;
+
+import com.epam.pipeline.security.acl.JdbcMutableAclServiceImpl;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * {@code GrantPermissionHandler} shall handle all operations permission assignment:
+ * grant, remove permissions, etc.
+ * TODO: Now all this logic is implemented in {@link GrantPermissionManager}, shall be moved to this class.
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class GrantPermissionHandler {
+
+    private final JdbcMutableAclServiceImpl aclService;
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void deleteGrantedAuthority(String name) {
+        Long sidId = aclService.getSidId(name, false);
+        if (sidId == null) {
+            log.debug("Granted authority with name {} was not found in ACL", name);
+            return;
+        }
+        aclService.deleteSidById(sidId);
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionManager.java
@@ -168,7 +168,7 @@ public class GrantPermissionManager {
 
     @Autowired private ConfigurationProviderManager configurationProviderManager;
 
-    @Autowired private PermissionsHelper permissionsHelper;
+    @Autowired private CheckPermissionHelper permissionsHelper;
 
     @Autowired private AbstractEntityPermissionMapper entityPermissionMapper;
 

--- a/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionManager.java
@@ -118,6 +118,13 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 
+/**
+ * {@code GrantPermissionManager} provides methods for ACL permissions handling
+ */
+//TODO: 24-10-2019
+// This class shall be split into smaller parts,
+// - all operations regarding permission granting shall be moved to GrantPermissionHandler.class;
+// - entity specific permission checks shall be extracted into separate classes, like RunPermissionManager.class
 @Service
 @SuppressWarnings("PMD.AvoidCatchingGenericException")
 public class GrantPermissionManager {
@@ -326,16 +333,6 @@ public class GrantPermissionManager {
         acl.insertAce(Math.max(entryIndex, 0), newPermission, userRoleSid, true);
         aclService.updateAcl(acl);
 
-    }
-
-    @Transactional(propagation = Propagation.REQUIRED)
-    public void deleteGrantedAuthority(String name) {
-        Long sidId = aclService.getSidId(name, false);
-        if (sidId == null) {
-            LOGGER.debug("Granted authority with name {} was not found in ACL", name);
-            return;
-        }
-        aclService.deleteSidById(sidId);
     }
 
     public Integer getPermissionsMask(AbstractSecuredEntity entity, boolean merge,

--- a/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionManager.java
@@ -62,6 +62,7 @@ import com.epam.pipeline.manager.pipeline.FolderManager;
 import com.epam.pipeline.manager.pipeline.ToolGroupManager;
 import com.epam.pipeline.manager.pipeline.ToolManager;
 import com.epam.pipeline.manager.pipeline.runner.ConfigurationProviderManager;
+import com.epam.pipeline.manager.security.run.RunPermissionManager;
 import com.epam.pipeline.manager.user.UserManager;
 import com.epam.pipeline.mapper.AbstractEntityPermissionMapper;
 import com.epam.pipeline.mapper.PipelineWithPermissionsMapper;

--- a/api/src/main/java/com/epam/pipeline/manager/security/PermissionsHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/PermissionsHelper.java
@@ -59,12 +59,7 @@ public class PermissionsHelper {
         return isOwner(entity.getOwner());
     }
 
-    public boolean isAdmin() {
-        final GrantedAuthoritySid admin = new GrantedAuthoritySid(DefaultRoles.ROLE_ADMIN.getName());
-        return getSids().stream().anyMatch(sid -> sid.equals(admin));
-    }
-
-    private boolean isOwner(final String owner) {
+    public boolean isOwner(final String owner) {
         if (StringUtils.isBlank(owner)) {
             return false;
         }
@@ -73,6 +68,11 @@ public class PermissionsHelper {
             return false;
         }
         return owner.equalsIgnoreCase(currentUser);
+    }
+
+    public boolean isAdmin() {
+        final GrantedAuthoritySid admin = new GrantedAuthoritySid(DefaultRoles.ROLE_ADMIN.getName());
+        return getSids().stream().anyMatch(sid -> sid.equals(admin));
     }
 
     private List<Sid> getSids() {

--- a/api/src/main/java/com/epam/pipeline/manager/security/PermissionsHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/PermissionsHelper.java
@@ -25,7 +25,6 @@ import org.springframework.security.acls.domain.GrantedAuthoritySid;
 import org.springframework.security.acls.model.Sid;
 import org.springframework.security.acls.model.SidRetrievalStrategy;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -42,8 +41,7 @@ public class PermissionsHelper {
             return true;
         }
         return permissionEvaluator
-                .hasPermission(SecurityContextHolder.getContext().getAuthentication(), entity,
-                        permissionName);
+                .hasPermission(authManager.getAuthentication(), entity, permissionName);
     }
 
     public boolean isOwner(final AbstractSecuredEntity entity) {

--- a/api/src/main/java/com/epam/pipeline/manager/security/PermissionsHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/PermissionsHelper.java
@@ -29,6 +29,13 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+/**
+ * {@code PermissionsHelper} provides methods for ACL permissions check.
+ */
+// TODO: 24-10-2019
+// All common code (not entity specific) methods shall be moved to this class from GrantPermissionManager.class
+// For now some of methods are duplicated, this shall be removed as soon we'll refactor GrantPermissionManager.class
+// and provide integration tests for ACL permissions
 @Service
 @RequiredArgsConstructor
 public class PermissionsHelper {
@@ -44,22 +51,17 @@ public class PermissionsHelper {
                 .hasPermission(authManager.getAuthentication(), entity, permissionName);
     }
 
-    public boolean isOwner(final AbstractSecuredEntity entity) {
-        return isOwner(entity.getOwner());
-    }
-
     public boolean isOwnerOrAdmin(final String owner) {
         return isOwner(owner) || isAdmin();
+    }
+
+    public boolean isOwner(final AbstractSecuredEntity entity) {
+        return isOwner(entity.getOwner());
     }
 
     public boolean isAdmin() {
         final GrantedAuthoritySid admin = new GrantedAuthoritySid(DefaultRoles.ROLE_ADMIN.getName());
         return getSids().stream().anyMatch(sid -> sid.equals(admin));
-    }
-
-    private List<Sid> getSids() {
-        final Authentication authentication = authManager.getAuthentication();
-        return sidRetrievalStrategy.getSids(authentication);
     }
 
     private boolean isOwner(final String owner) {
@@ -71,5 +73,10 @@ public class PermissionsHelper {
             return false;
         }
         return owner.equalsIgnoreCase(currentUser);
+    }
+
+    private List<Sid> getSids() {
+        final Authentication authentication = authManager.getAuthentication();
+        return sidRetrievalStrategy.getSids(authentication);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/security/PermissionsHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/PermissionsHelper.java
@@ -17,19 +17,27 @@
 package com.epam.pipeline.manager.security;
 
 import com.epam.pipeline.entity.AbstractSecuredEntity;
+import com.epam.pipeline.entity.user.DefaultRoles;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.security.access.PermissionEvaluator;
+import org.springframework.security.acls.domain.GrantedAuthoritySid;
+import org.springframework.security.acls.model.Sid;
+import org.springframework.security.acls.model.SidRetrievalStrategy;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class PermissionsHelper {
     private final PermissionEvaluator permissionEvaluator;
     private final AuthManager authManager;
+    private final SidRetrievalStrategy sidRetrievalStrategy;
 
-    public boolean isAllowed(String permissionName, AbstractSecuredEntity entity) {
+    public boolean isAllowed(final String permissionName, final AbstractSecuredEntity entity) {
         if (isOwner(entity)) {
             return true;
         }
@@ -38,8 +46,32 @@ public class PermissionsHelper {
                         permissionName);
     }
 
-    public boolean isOwner(AbstractSecuredEntity entity) {
-        String owner = entity.getOwner();
-        return StringUtils.isNotBlank(owner) && owner.equalsIgnoreCase(authManager.getAuthorizedUser());
+    public boolean isOwner(final AbstractSecuredEntity entity) {
+        return isOwner(entity.getOwner());
+    }
+
+    public boolean isOwnerOrAdmin(final String owner) {
+        return isOwner(owner) || isAdmin();
+    }
+
+    public boolean isAdmin() {
+        final GrantedAuthoritySid admin = new GrantedAuthoritySid(DefaultRoles.ROLE_ADMIN.getName());
+        return getSids().stream().anyMatch(sid -> sid.equals(admin));
+    }
+
+    private List<Sid> getSids() {
+        final Authentication authentication = authManager.getAuthentication();
+        return sidRetrievalStrategy.getSids(authentication);
+    }
+
+    private boolean isOwner(final String owner) {
+        if (StringUtils.isBlank(owner)) {
+            return false;
+        }
+        final String currentUser = authManager.getAuthorizedUser();
+        if (currentUser == null || currentUser.equals(AuthManager.UNAUTHORIZED_USER)) {
+            return false;
+        }
+        return owner.equalsIgnoreCase(currentUser);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/security/RunPermissionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/RunPermissionManager.java
@@ -1,0 +1,145 @@
+package com.epam.pipeline.manager.security;
+
+import com.epam.pipeline.entity.BaseEntity;
+import com.epam.pipeline.entity.filter.AclSecuredFilter;
+import com.epam.pipeline.entity.pipeline.DockerRegistry;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.pipeline.TaskStatus;
+import com.epam.pipeline.entity.pipeline.Tool;
+import com.epam.pipeline.entity.pipeline.ToolGroup;
+import com.epam.pipeline.entity.pipeline.run.parameter.RunAccessType;
+import com.epam.pipeline.entity.pipeline.run.parameter.RunSid;
+import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.entity.user.Role;
+import com.epam.pipeline.manager.docker.DockerRegistryManager;
+import com.epam.pipeline.acl.pipeline.PipelineApiService;
+import com.epam.pipeline.manager.pipeline.PipelineRunManager;
+import com.epam.pipeline.manager.pipeline.ToolGroupManager;
+import com.epam.pipeline.manager.pipeline.ToolManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.ListUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toList;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RunPermissionManager {
+
+    private final PipelineRunManager runManager;
+    private final PipelineApiService pipelineApiService;
+    private final PermissionsHelper permissionsHelper;
+    private final AuthManager authManager;
+    private final DockerRegistryManager registryManager;
+    private final ToolGroupManager toolGroupManager;
+    private final ToolManager toolManager;
+
+    /**
+     * Run permissions: owner and admin have full access to PipelineRun
+     * @param run
+     * @param permissionName
+     * @return
+     */
+    public boolean runPermission(final PipelineRun run, final String permissionName) {
+        //add assert run not null
+        if (permissionsHelper.isOwnerOrAdmin(run.getOwner()) || isRunSshAllowed(run)) {
+            return true;
+        }
+        return Optional.ofNullable(runManager.loadRunParent(run))
+                .map(parent -> permissionsHelper.isAllowed(permissionName, parent))
+                .orElse(false);
+    }
+
+    public boolean runPermission(final Long runId, final String permissionName) {
+        return runPermission(runManager.loadPipelineRun(runId), permissionName);
+    }
+
+    public boolean runStatusPermission(Long runId, TaskStatus taskStatus, String permissionName) {
+        final PipelineRun pipelineRun = runManager.loadPipelineRun(runId);
+        if (taskStatus.isFinal()) {
+            return permissionsHelper.isOwnerOrAdmin(pipelineRun.getOwner());
+        }
+        return runPermission(pipelineRun, permissionName);
+    }
+
+    public boolean isRunSshAllowed(Long runId) {
+        return isRunSshAllowed(runManager.loadPipelineRun(runId));
+    }
+
+    public boolean isRunSshAllowed(PipelineRun pipelineRun) {
+        if (permissionsHelper.isOwnerOrAdmin(pipelineRun.getOwner())) {
+            return true;
+        }
+        final List<RunSid> sshSharedSids = ListUtils.emptyIfNull(pipelineRun.getRunSids())
+                .stream()
+                .filter(sid -> RunAccessType.SSH.equals(sid.getAccessType()))
+                .collect(toList());
+        if (CollectionUtils.isEmpty(sshSharedSids)) {
+            return false;
+        }
+        return Optional.ofNullable(authManager.getCurrentUser())
+                .map(currentUser -> isSharedWithPrincipal(sshSharedSids, currentUser) ||
+                        isSharedWithGroup(sshSharedSids, currentUser))
+                .orElse(false);
+    }
+
+    /**
+     * Method will check permission for a {@link Tool} if it is registered, or for {@link ToolGroup}
+     * if this is a new {@link Tool}. If both {@link Tool} and {@link ToolGroup} do not exist,
+     * permission for {@link DockerRegistry} will be checked. Image is expected in format 'group/image'.
+     * @param registryId
+     * @param image
+     * @param permission
+     * @return
+     */
+    public boolean commitPermission(Long registryId, String image, String permission) {
+        DockerRegistry registry = registryManager.load(registryId);
+        try {
+            String trimmedImage = image.startsWith(registry.getPath()) ?
+                    image.substring(registry.getPath().length() + 1) : image;
+            ToolGroup toolGroup = toolGroupManager.loadToolGroupByImage(registry.getPath(), trimmedImage);
+            Optional<Tool> tool = toolManager.loadToolInGroup(trimmedImage, toolGroup.getId());
+            return tool.map(t -> permissionsHelper.isAllowed(permission, t))
+                    .orElseGet(() -> permissionsHelper.isAllowed(permission, toolGroup));
+        } catch (IllegalArgumentException e) {
+            //case when tool group doesn't exist
+            log.trace(e.getMessage(), e);
+            return permissionsHelper.isAllowed(permission, registry);
+        }
+    }
+
+    public void extendFilter(final AclSecuredFilter filter) {
+        if (permissionsHelper.isAdmin()) {
+            return;
+        }
+        filter.setOwnershipFilter(authManager.getAuthorizedUser().toLowerCase());
+        final List<Long> allowedPipelinesList =
+                pipelineApiService.loadAllPipelinesWithoutVersion()
+                        .stream()
+                        .map(BaseEntity::getId)
+                        .collect(toList());
+        filter.setAllowedPipelines(allowedPipelinesList);
+    }
+
+    private boolean isSharedWithPrincipal(final List<RunSid> sshSharedSids, final PipelineUser currentUser) {
+        return sshSharedSids.stream().anyMatch(sid -> Boolean.TRUE.equals(sid.getIsPrincipal()) &&
+                sid.getName().equalsIgnoreCase(currentUser.getUserName()));
+    }
+
+    private boolean isSharedWithGroup(final List<RunSid> sshSharedSids, final PipelineUser currentUser) {
+        final Set<String> userClaims = new HashSet<>();
+        userClaims.addAll(ListUtils.emptyIfNull(currentUser.getRoles()).stream().map(Role::getName)
+                .collect(toList()));
+        userClaims.addAll(ListUtils.emptyIfNull(currentUser.getGroups()));
+        return sshSharedSids.stream().anyMatch(sid -> Boolean.FALSE.equals(sid.getIsPrincipal()) &&
+                userClaims.contains(sid.getName()));
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/security/acl/AclAspect.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/acl/AclAspect.java
@@ -27,7 +27,7 @@ import com.epam.pipeline.entity.filter.AclSecuredFilter;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.manager.security.AuthManager;
 import com.epam.pipeline.manager.security.GrantPermissionManager;
-import com.epam.pipeline.manager.security.RunPermissionManager;
+import com.epam.pipeline.manager.security.run.RunPermissionManager;
 import com.epam.pipeline.security.acl.AclPermission;
 import com.epam.pipeline.security.acl.JdbcMutableAclServiceImpl;
 import lombok.RequiredArgsConstructor;

--- a/api/src/main/java/com/epam/pipeline/manager/security/acl/AclAspect.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/acl/AclAspect.java
@@ -27,8 +27,10 @@ import com.epam.pipeline.entity.filter.AclSecuredFilter;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.manager.security.AuthManager;
 import com.epam.pipeline.manager.security.GrantPermissionManager;
+import com.epam.pipeline.manager.security.RunPermissionManager;
 import com.epam.pipeline.security.acl.AclPermission;
 import com.epam.pipeline.security.acl.JdbcMutableAclServiceImpl;
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.ListUtils;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.AfterReturning;
@@ -36,22 +38,23 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.acls.domain.ObjectIdentityImpl;
 import org.springframework.security.acls.model.MutableAcl;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-@Aspect @Component
+@Aspect
+@Component
+@RequiredArgsConstructor
 public class AclAspect {
 
     private static final String RETURN_OBJECT = "entity";
     private static final Logger LOGGER = LoggerFactory.getLogger(AclAspect.class);
 
-    @Autowired private JdbcMutableAclServiceImpl aclService;
-
-    @Autowired private GrantPermissionManager permissionManager;
+    private final JdbcMutableAclServiceImpl aclService;
+    private final GrantPermissionManager permissionManager;
+    private final RunPermissionManager runPermissionManager;
 
 
     @AfterReturning(pointcut = "@within(com.epam.pipeline.manager.security.acl.AclSync) && "
@@ -142,7 +145,7 @@ public class AclAspect {
 
     @Before("@annotation(com.epam.pipeline.manager.security.acl.AclFilter) && args(filter,..)")
     public void extendFilter(JoinPoint joinPoint, AclSecuredFilter filter) {
-        permissionManager.extendFilter(filter);
+        runPermissionManager.extendFilter(filter);
     }
 
     private void createEntity(final AbstractSecuredEntity entity) {

--- a/api/src/main/java/com/epam/pipeline/manager/security/run/RunPermissionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/run/RunPermissionManager.java
@@ -36,7 +36,7 @@ import com.epam.pipeline.manager.pipeline.ToolGroupManager;
 import com.epam.pipeline.manager.pipeline.ToolManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.manager.security.AuthManager;
-import com.epam.pipeline.manager.security.PermissionsHelper;
+import com.epam.pipeline.manager.security.CheckPermissionHelper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.ListUtils;
@@ -61,7 +61,7 @@ public class RunPermissionManager {
 
     private final PipelineRunManager runManager;
     private final PipelineApiService pipelineApiService;
-    private final PermissionsHelper permissionsHelper;
+    private final CheckPermissionHelper permissionsHelper;
     private final AuthManager authManager;
     private final DockerRegistryManager registryManager;
     private final ToolGroupManager toolGroupManager;

--- a/api/src/main/java/com/epam/pipeline/manager/security/run/RunPermissionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/run/RunPermissionManager.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.epam.pipeline.manager.security.run;
 
 import com.epam.pipeline.entity.BaseEntity;

--- a/api/src/main/java/com/epam/pipeline/manager/security/run/RunVisibilityPolicy.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/run/RunVisibilityPolicy.java
@@ -16,14 +16,17 @@
 
 package com.epam.pipeline.manager.security.run;
 
+/**
+ * Describe how permissions for {@code PipelineRun} shall be checked.
+ */
 public enum RunVisibilityPolicy {
-    /** PipelineRun permissions shall be inherited
-     * from parent Pipeline, it it is present
+    /**
+     * PipelineRun permissions shall be inherited from parent Pipeline, if it is present.
+     * Currently used as a default policy.
      */
     INHERIT,
     /**
-     * Permissions on PipelineRun shall be
-     *
+     * Permissions on PipelineRun shall be granted only to owner and admin users.
      */
     OWNER;
 }

--- a/api/src/main/java/com/epam/pipeline/manager/security/run/RunVisibilityPolicy.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/run/RunVisibilityPolicy.java
@@ -1,0 +1,5 @@
+package com.epam.pipeline.manager.security.run;
+
+public enum RunVisibilityPolicy {
+    INHERIT, OWNER;
+}

--- a/api/src/main/java/com/epam/pipeline/manager/security/run/RunVisibilityPolicy.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/run/RunVisibilityPolicy.java
@@ -1,5 +1,29 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.epam.pipeline.manager.security.run;
 
 public enum RunVisibilityPolicy {
-    INHERIT, OWNER;
+    /** PipelineRun permissions shall be inherited
+     * from parent Pipeline, it it is present
+     */
+    INHERIT,
+    /**
+     * Permissions on PipelineRun shall be
+     *
+     */
+    OWNER;
 }

--- a/api/src/main/java/com/epam/pipeline/manager/user/RoleManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/RoleManager.java
@@ -25,7 +25,7 @@ import com.epam.pipeline.entity.user.ExtendedRole;
 import com.epam.pipeline.entity.user.PipelineUser;
 import com.epam.pipeline.entity.user.Role;
 import com.epam.pipeline.manager.datastorage.DataStorageValidator;
-import com.epam.pipeline.manager.security.GrantPermissionManager;
+import com.epam.pipeline.manager.security.GrantPermissionHandler;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
@@ -46,7 +46,7 @@ import java.util.stream.Collectors;
 public class RoleManager {
 
     @Autowired
-    private GrantPermissionManager permissionManager;
+    private GrantPermissionHandler permissionHandler;
 
     @Autowired
     private MessageHelper messageHelper;
@@ -93,7 +93,7 @@ public class RoleManager {
     public Role deleteRole(Long id) {
         Role role = loadRole(id);
         Assert.isTrue(!role.isPredefined(), "Predefined system roles cannot be deleted");
-        permissionManager.deleteGrantedAuthority(role.getName());
+        permissionHandler.deleteGrantedAuthority(role.getName());
         roleDao.deleteRoleReferences(id);
         roleDao.deleteRole(id);
         return role;

--- a/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
+++ b/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
@@ -39,16 +39,19 @@ public final class AclExpressions {
             "hasRole('ADMIN') OR hasPermission(#pipeline.id, 'com.epam.pipeline.entity.pipeline.Pipeline', 'WRITE')";
 
     public static final String RUN_ID_READ =
-            "hasRole('ADMIN') OR @grantPermissionManager.runPermission(#runId, 'READ')";
+            "hasRole('ADMIN') OR @runPermissionManager.runPermission(#runId, 'READ')";
 
     public static final String RUN_ID_EXECUTE =
-            "hasRole('ADMIN') OR @grantPermissionManager.runPermission(#runId, 'EXECUTE')";
+            "hasRole('ADMIN') OR @runPermissionManager.runPermission(#runId, 'EXECUTE')";
 
     public static final String RUN_ID_WRITE =
-            "hasRole('ADMIN') OR @grantPermissionManager.runPermission(#runId, 'WRITE')";
+            "hasRole('ADMIN') OR @runPermissionManager.runPermission(#runId, 'WRITE')";
 
     public static final String RUN_ID_OWNER =
-            "hasRole('ADMIN') OR @grantPermissionManager.runPermission(#runId, 'OWNER')";
+            "hasRole('ADMIN') OR @runPermissionManager.runPermission(#runId, 'OWNER')";
+
+    public static final String RUN_ID_SSH =
+            "hasRole('ADMIN') OR @runPermissionManager.runPermission(#runId, 'WRITE')";
 
     public static final String STORAGE_ID_READ =
             "(hasRole('ADMIN') OR @grantPermissionManager.storagePermission(#id, 'READ')) "
@@ -66,7 +69,7 @@ public final class AclExpressions {
             "@grantPermissionManager.hasDataStoragePathsPermission(returnObject, 'READ')";
 
     public static final String RUN_COMMIT_EXECUTE =
-        "hasRole('ADMIN') OR (@grantPermissionManager.runPermission(#runId, 'EXECUTE')"
+        "hasRole('ADMIN') OR (@runPermissionManager.runPermission(#runId, 'EXECUTE')"
             + " AND hasPermission(#registryId, 'com.epam.pipeline.entity.pipeline.DockerRegistry', 'WRITE'))";
 
     public static final String METADATA_OWNER =

--- a/api/src/test/java/com/epam/pipeline/acl/run/PipelineAclFactory.java
+++ b/api/src/test/java/com/epam/pipeline/acl/run/PipelineAclFactory.java
@@ -70,7 +70,7 @@ public class PipelineAclFactory {
         // we need to grant permissions before changing the owner,
         // because it may cause AccessDeniedException for non-owner, non-admin user
         Optional.ofNullable(user)
-                .ifPresent(u -> grantPermission(pipeline, user, permissionMask));
+                .ifPresent(userName -> grantPermission(pipeline, userName, permissionMask));
         if (!owner.equals(authManager.getAuthorizedUser())) {
             doReturn(new UserContext(null, owner))
                     .when(mockUserManager)

--- a/api/src/test/java/com/epam/pipeline/acl/run/PipelineAclFactory.java
+++ b/api/src/test/java/com/epam/pipeline/acl/run/PipelineAclFactory.java
@@ -1,0 +1,100 @@
+package com.epam.pipeline.acl.run;
+
+import com.epam.pipeline.controller.vo.PermissionGrantVO;
+import com.epam.pipeline.entity.AbstractSecuredEntity;
+import com.epam.pipeline.entity.pipeline.Pipeline;
+import com.epam.pipeline.entity.security.acl.AclClass;
+import com.epam.pipeline.manager.EntityManager;
+import com.epam.pipeline.manager.pipeline.PipelineManager;
+import com.epam.pipeline.manager.security.AuthManager;
+import com.epam.pipeline.manager.security.GrantPermissionManager;
+import com.epam.pipeline.manager.user.UserManager;
+import com.epam.pipeline.security.UserContext;
+import com.epam.pipeline.security.acl.JdbcMutableAclServiceImpl;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+
+@RequiredArgsConstructor
+public class PipelineAclFactory {
+    public static final Long TEST_PIPELINE_ID = 10L;
+
+    private final AuthManager authManager;
+    private final GrantPermissionManager grantPermissionManager;
+    private final JdbcMutableAclServiceImpl aclService;
+
+    private final UserManager mockUserManager;
+    private final PipelineManager mockPipelineManager;
+    private final EntityManager mockEntityManager;
+
+    public Pipeline initPipelineForCurrentUser() {
+        return initPipelineForOwner(authManager.getAuthorizedUser());
+    }
+
+    public Pipeline initPipelineForOwner(final String owner) {
+        return initPipelineForOwnerWithPermissions(owner, null, 0);
+    }
+
+    public Pipeline initPipelineForOwnerWithPermissions(final String owner,
+                                                         final String user,
+                                                         final int permissionMask) {
+        final Pipeline pipeline = new Pipeline();
+        pipeline.setId(TEST_PIPELINE_ID);
+        pipeline.setOwner(owner);
+        doReturn(pipeline)
+                .when(mockPipelineManager)
+                .load(eq(TEST_PIPELINE_ID));
+        doReturn(pipeline)
+                .when(mockPipelineManager)
+                .load(eq(TEST_PIPELINE_ID), anyBoolean());
+        aclService.getOrCreateObjectIdentity(pipeline);
+        // we need to grant permissions before changing the owner,
+        // because it may cause AccessDeniedException for non-owner, non-admin user
+        Optional.ofNullable(user)
+                .ifPresent(u -> grantPermission(pipeline, user, permissionMask));
+        if (!owner.equals(authManager.getAuthorizedUser())) {
+            doReturn(new UserContext(null, owner))
+                    .when(mockUserManager)
+                    .loadUserContext(eq(owner));
+            doReturn(pipeline)
+                    .when(mockEntityManager)
+                    .load(eq(AclClass.PIPELINE), eq(TEST_PIPELINE_ID));
+            grantPermissionManager.changeOwner(TEST_PIPELINE_ID, AclClass.PIPELINE, owner);
+        }
+        return pipeline;
+    }
+
+    private void grantPermission(final AbstractSecuredEntity entity,
+                                 final String userName,
+                                 final int mask) {
+        final PermissionGrantVO permissionGrant = new PermissionGrantVO();
+        permissionGrant.setAclClass(entity.getAclClass());
+        permissionGrant.setId(entity.getId());
+        permissionGrant.setPrincipal(true);
+        permissionGrant.setUserName(userName);
+        permissionGrant.setMask(mask);
+        doReturn(entity)
+                .when(mockEntityManager)
+                .load(eq(entity.getAclClass()), eq(entity.getId()));
+        grantPermissionManager.setPermissions(permissionGrant);
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/acl/run/RunAclFactory.java
+++ b/api/src/test/java/com/epam/pipeline/acl/run/RunAclFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.acl.run;
+
+import com.epam.pipeline.entity.pipeline.Pipeline;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.manager.pipeline.PipelineRunManager;
+import com.epam.pipeline.manager.security.AuthManager;
+import lombok.RequiredArgsConstructor;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+
+@RequiredArgsConstructor
+public class RunAclFactory {
+
+    public static final Long TEST_RUN_ID = 1L;
+
+    private final AuthManager authManager;
+    private final PipelineRunManager mockRunManager;
+
+    public PipelineRun initToolPipelineRunForCurrentUser() {
+        return initToolPipelineRunForOwner(authManager.getAuthorizedUser());
+    }
+
+    public PipelineRun initToolPipelineRunForOwner(final String owner) {
+        final PipelineRun pipelineRun = new PipelineRun();
+        pipelineRun.setId(TEST_RUN_ID);
+        pipelineRun.setOwner(owner);
+        doReturn(pipelineRun).when(mockRunManager).loadPipelineRun(eq(TEST_RUN_ID));
+        return pipelineRun;
+    }
+
+    public PipelineRun initPipelineRunForCurrentUser(final Pipeline parent) {
+        return initPipelineRunForOwner(parent, authManager.getAuthorizedUser());
+    }
+
+    public PipelineRun initPipelineRunForOwner(final Pipeline parent, final String owner) {
+        final PipelineRun pipelineRun = new PipelineRun();
+        pipelineRun.setId(TEST_RUN_ID);
+        pipelineRun.setOwner(owner);
+        pipelineRun.setPipelineId(parent.getId());
+        doReturn(pipelineRun).when(mockRunManager).loadPipelineRun(eq(TEST_RUN_ID));
+        doReturn(parent).when(mockRunManager).loadRunParent(eq(pipelineRun));
+        return pipelineRun;
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/acl/run/RunApiServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/acl/run/RunApiServiceTest.java
@@ -197,6 +197,7 @@ public class RunApiServiceTest {
                 .when(mockRunManager)
                 .searchPipelineRuns(eq(filter), eq(false));
         final PagedResult<List<PipelineRun>> result = runApiService.searchPipelineRuns(filter, false);
+
         assertThat(filter.getOwnershipFilter(), equalToIgnoringCase(TEST_USER1));
         assertThat(filter.getAllowedPipelines(), contains(TEST_PIPELINE_ID));
         assertThat(result.getTotalCount(), equalTo(1));

--- a/api/src/test/java/com/epam/pipeline/acl/run/RunApiServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/acl/run/RunApiServiceTest.java
@@ -1,0 +1,174 @@
+package com.epam.pipeline.acl.run;
+
+import com.epam.pipeline.app.AclTestConfiguration;
+import com.epam.pipeline.controller.vo.PermissionGrantVO;
+import com.epam.pipeline.entity.AbstractSecuredEntity;
+import com.epam.pipeline.entity.pipeline.Pipeline;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.manager.EntityManager;
+import com.epam.pipeline.manager.pipeline.PipelineManager;
+import com.epam.pipeline.manager.pipeline.PipelineRunManager;
+import com.epam.pipeline.manager.security.GrantPermissionManager;
+import com.epam.pipeline.manager.user.UserManager;
+import com.epam.pipeline.security.UserContext;
+import com.epam.pipeline.security.acl.AclPermission;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = AclTestConfiguration.class)
+@TestPropertySource(value = {"classpath:test-application.properties"})
+@Transactional
+public class RunApiServiceTest {
+
+    private static final Long TEST_RUN_ID = 1L;
+    private static final String TEST_OWNER = "OWNER";
+    private static final String TEST_USER1 = "USER_1";
+    private static final String TEST_ADMIN_NAME = "ADMIN";
+    private static final String TEST_ADMIN_ROLE = "ADMIN";
+    private static final Long TEST_PIPELINE_ID = 10L;
+
+    @Autowired
+    private RunApiService runApiService;
+
+    @Autowired
+    private GrantPermissionManager grantPermissionManager;
+
+    @Autowired
+    private PipelineRunManager mockRunManager;
+
+    @Autowired
+    private PipelineManager mockPipelineManager;
+
+    @Autowired
+    private EntityManager mockEntityManager;
+
+    @Autowired
+    private UserManager mockUserManager;
+
+    @Test
+    @WithMockUser(username = TEST_OWNER)
+    public void loadToolRunShouldBeAllowedForOwner() {
+        initTestToolPipelineRun();
+        PipelineRun loaded = runApiService.loadPipelineRun(TEST_RUN_ID);
+        Assert.assertEquals(TEST_RUN_ID, loaded.getId());
+    }
+
+    @Test(expected = AccessDeniedException.class)
+    @WithMockUser(username = TEST_USER1)
+    public void loadToolRunShouldBeDeniedForNonOwner() {
+        initTestToolPipelineRun();
+        runApiService.loadPipelineRun(TEST_RUN_ID);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_ADMIN_NAME, roles = {TEST_ADMIN_ROLE})
+    public void loadToolRunShouldBeAllowedForAdmin() {
+        initTestToolPipelineRun();
+        PipelineRun loaded = runApiService.loadPipelineRun(TEST_RUN_ID);
+        Assert.assertEquals(TEST_RUN_ID, loaded.getId());
+    }
+
+    @Test
+    @WithMockUser(username = TEST_OWNER)
+    public void loadPipelineRunShouldBeAllowedForOwner() {
+        initTestPipelineRun();
+        PipelineRun loaded = runApiService.loadPipelineRun(TEST_RUN_ID);
+        Assert.assertEquals(TEST_RUN_ID, loaded.getId());
+    }
+
+    @Test(expected = AccessDeniedException.class)
+    @WithMockUser(username = TEST_USER1)
+    public void loadPipelineRunShouldBeDeniedForNonOwner() {
+        initTestPipelineRun();
+        runApiService.loadPipelineRun(TEST_RUN_ID);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_USER1)
+    public void loadPipelineRunShouldBeAllowedWhenUserIsOwnerOfPipeline() {
+        final Pipeline pipeline = initTestPipeline();
+        pipeline.setOwner(TEST_USER1);
+        initTestPipelineRun(pipeline);
+        final PipelineRun loaded = runApiService.loadPipelineRun(TEST_RUN_ID);
+        Assert.assertEquals(TEST_RUN_ID, loaded.getId());
+    }
+
+    @Test
+    @WithMockUser(username = TEST_USER1)
+    public void loadPipelineRunShouldBeAllowedWhenUserHasReadPermissionOnPipeline() {
+        final Pipeline pipeline = initTestPipeline();
+        initTestPipelineRun(pipeline);
+        grantPermissionOnPipeline(pipeline, TEST_USER1, TEST_OWNER, AclPermission.READ.getMask());
+        final PipelineRun loaded = runApiService.loadPipelineRun(TEST_RUN_ID);
+        Assert.assertEquals(TEST_RUN_ID, loaded.getId());
+    }
+
+    @Test
+    @WithMockUser(username = TEST_ADMIN_NAME, roles = {TEST_ADMIN_ROLE})
+    public void loadPipelineRunShouldBeAllowedForAdmin() {
+        initTestToolPipelineRun();
+        final PipelineRun loaded = runApiService.loadPipelineRun(TEST_RUN_ID);
+        Assert.assertEquals(TEST_RUN_ID, loaded.getId());
+    }
+
+    private PipelineRun initTestToolPipelineRun() {
+        final PipelineRun pipelineRun = new PipelineRun();
+        pipelineRun.setId(TEST_RUN_ID);
+        pipelineRun.setOwner(TEST_OWNER);
+        doReturn(pipelineRun).when(mockRunManager).loadPipelineRun(eq(TEST_RUN_ID));
+        return pipelineRun;
+    }
+
+    private PipelineRun initTestPipelineRun() {
+        return initTestPipelineRun(null);
+    }
+
+    private PipelineRun initTestPipelineRun(final Pipeline parent) {
+        final PipelineRun pipelineRun = new PipelineRun();
+        pipelineRun.setId(TEST_RUN_ID);
+        pipelineRun.setOwner(TEST_OWNER);
+        pipelineRun.setPipelineId(TEST_PIPELINE_ID);
+        doReturn(pipelineRun).when(mockRunManager).loadPipelineRun(eq(TEST_RUN_ID));
+        doReturn(parent).when(mockRunManager).loadRunParent(eq(pipelineRun));
+        return pipelineRun;
+    }
+
+    private Pipeline initTestPipeline() {
+        final Pipeline pipeline = new Pipeline();
+        pipeline.setId(TEST_PIPELINE_ID);
+        pipeline.setOwner(TEST_OWNER);
+        doReturn(pipeline).when(mockPipelineManager).load(eq(TEST_PIPELINE_ID));
+        doReturn(pipeline).when(mockPipelineManager).load(eq(TEST_PIPELINE_ID), anyBoolean());
+        return pipeline;
+    }
+
+    private void grantPermissionOnPipeline(final AbstractSecuredEntity entity,
+                                           final String userName,
+                                           final String owner,
+                                           final int mask) {
+        final PermissionGrantVO permissionGrant = new PermissionGrantVO();
+        permissionGrant.setAclClass(entity.getAclClass());
+        permissionGrant.setId(entity.getId());
+        permissionGrant.setPrincipal(true);
+        permissionGrant.setUserName(userName);
+        permissionGrant.setMask(mask);
+        doReturn(entity).when(mockEntityManager).load(eq(entity.getAclClass()), eq(entity.getId()));
+        grantPermissionManager.setPermissions(permissionGrant);
+
+        doReturn(new UserContext(null, owner)).when(mockUserManager).loadUserContext(eq(owner));
+        grantPermissionManager.changeOwner(entity.getId(), entity.getAclClass(), owner);
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/app/AclTestConfiguration.java
+++ b/api/src/test/java/com/epam/pipeline/app/AclTestConfiguration.java
@@ -6,6 +6,7 @@ import com.epam.pipeline.manager.EntityManager;
 import com.epam.pipeline.manager.cluster.InstanceOfferManager;
 import com.epam.pipeline.manager.cluster.NodesManager;
 import com.epam.pipeline.manager.configuration.RunConfigurationManager;
+import com.epam.pipeline.manager.contextual.ContextualPreferenceManager;
 import com.epam.pipeline.manager.docker.DockerRegistryManager;
 import com.epam.pipeline.manager.event.EntityEventServiceManager;
 import com.epam.pipeline.manager.filter.FilterManager;
@@ -128,6 +129,9 @@ public class AclTestConfiguration {
 
     @MockBean
     protected CloudRegionDao cloudRegionDao;
+
+    @MockBean
+    protected ContextualPreferenceManager contextualPreferenceManager;
 
     @Bean
     public PermissionFactory permissionFactory() {

--- a/api/src/test/java/com/epam/pipeline/app/AclTestConfiguration.java
+++ b/api/src/test/java/com/epam/pipeline/app/AclTestConfiguration.java
@@ -43,6 +43,12 @@ import org.springframework.transaction.PlatformTransactionManager;
 
 import javax.sql.DataSource;
 
+/**
+ * Provides basic configuration for writing tests for ACL security layers (ApiService classes).
+ * This configuration configures all ACL related beans and DB access and provides mock beans for
+ * all dependent classes. For now you can check whether bean is mock or not by checking list of mocks
+ * defined in this class.
+ */
 @SpringBootConfiguration
 @Import({AclSecurityConfiguration.class, DBConfiguration.class, MappersConfiguration.class})
 @ComponentScan(basePackages = {"com.epam.pipeline.manager.security"})

--- a/api/src/test/java/com/epam/pipeline/app/AclTestConfiguration.java
+++ b/api/src/test/java/com/epam/pipeline/app/AclTestConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.security.acls.domain.PermissionFactory;
@@ -47,6 +48,7 @@ import javax.sql.DataSource;
 @ComponentScan(basePackages = {"com.epam.pipeline.manager.security", "com.epam.pipeline.acl"})
 @TestPropertySource(value={"classpath:test-application.properties"})
 @EnableGlobalMethodSecurity(securedEnabled = true, prePostEnabled = true)
+@EnableAspectJAutoProxy
 public class AclTestConfiguration {
 
     @MockBean

--- a/api/src/test/java/com/epam/pipeline/app/AclTestConfiguration.java
+++ b/api/src/test/java/com/epam/pipeline/app/AclTestConfiguration.java
@@ -1,0 +1,142 @@
+package com.epam.pipeline.app;
+
+import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.dao.region.CloudRegionDao;
+import com.epam.pipeline.manager.EntityManager;
+import com.epam.pipeline.manager.cluster.InstanceOfferManager;
+import com.epam.pipeline.manager.cluster.NodesManager;
+import com.epam.pipeline.manager.configuration.RunConfigurationManager;
+import com.epam.pipeline.manager.docker.DockerRegistryManager;
+import com.epam.pipeline.manager.event.EntityEventServiceManager;
+import com.epam.pipeline.manager.filter.FilterManager;
+import com.epam.pipeline.manager.git.GitManager;
+import com.epam.pipeline.manager.issue.IssueManager;
+import com.epam.pipeline.manager.metadata.MetadataEntityManager;
+import com.epam.pipeline.manager.pipeline.DocumentGenerationPropertyManager;
+import com.epam.pipeline.manager.pipeline.FolderManager;
+import com.epam.pipeline.manager.pipeline.PipelineFileGenerationManager;
+import com.epam.pipeline.manager.pipeline.PipelineManager;
+import com.epam.pipeline.manager.pipeline.PipelineRunManager;
+import com.epam.pipeline.manager.pipeline.PipelineVersionManager;
+import com.epam.pipeline.manager.pipeline.RunLogManager;
+import com.epam.pipeline.manager.pipeline.ToolApiService;
+import com.epam.pipeline.manager.pipeline.ToolGroupManager;
+import com.epam.pipeline.manager.pipeline.ToolManager;
+import com.epam.pipeline.manager.pipeline.runner.ConfigurationProviderManager;
+import com.epam.pipeline.manager.pipeline.runner.ConfigurationRunner;
+import com.epam.pipeline.manager.user.UserManager;
+import com.epam.pipeline.manager.utils.UtilsManager;
+import com.epam.pipeline.security.acl.AclPermissionFactory;
+import com.epam.pipeline.security.jwt.JwtTokenGenerator;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.security.acls.domain.PermissionFactory;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import javax.sql.DataSource;
+
+@SpringBootConfiguration
+@Import({AclSecurityConfiguration.class, DBConfiguration.class, MappersConfiguration.class})
+@ComponentScan(basePackages = {"com.epam.pipeline.manager.security", "com.epam.pipeline.acl"})
+@TestPropertySource(value={"classpath:test-application.properties"})
+@EnableGlobalMethodSecurity(securedEnabled = true, prePostEnabled = true)
+public class AclTestConfiguration {
+
+    @MockBean
+    protected MessageHelper messageHelper;
+
+    @MockBean
+    protected PipelineRunManager pipelineRunManager;
+
+    @MockBean
+    protected PipelineManager pipelineManager;
+
+    @MockBean
+    protected PipelineVersionManager pipelineVersionManager;
+
+    @MockBean
+    protected InstanceOfferManager instanceOfferManager;
+
+    @MockBean
+    protected GitManager gitManager;
+
+    @MockBean
+    protected PipelineFileGenerationManager fileGenerationManager;
+
+    @MockBean
+    protected DocumentGenerationPropertyManager documentGenerationPropertyManager;
+
+    @MockBean
+    protected ToolManager toolManager;
+
+    @MockBean
+    protected ToolGroupManager toolGroupManager;
+
+    @MockBean
+    protected DockerRegistryManager dockerRegistryManager;
+
+    @MockBean
+    protected EntityManager entityManager;
+
+    @MockBean
+    protected JwtTokenGenerator jwtTokenGenerator;
+
+    @MockBean
+    protected NodesManager nodesManager;
+
+    @MockBean
+    protected UserManager userManager;
+
+    @MockBean
+    protected MetadataEntityManager metadataEntityManager;
+
+    @MockBean
+    protected IssueManager issueManager;
+
+    @MockBean
+    protected FolderManager folderManager;
+
+    @MockBean
+    protected ConfigurationProviderManager configurationProviderManager;
+
+    @MockBean
+    protected RunConfigurationManager runConfigurationManager;
+
+    @MockBean
+    protected EntityEventServiceManager entityEventServiceManager;
+
+    @MockBean
+    protected ToolApiService toolApiService;
+
+    @MockBean
+    protected FilterManager filterManager;
+
+    @MockBean
+    protected RunLogManager runLogManager;
+
+    @MockBean
+    protected UtilsManager utilsManager;
+
+    @MockBean
+    protected ConfigurationRunner configurationRunner;
+
+    @MockBean
+    protected CloudRegionDao cloudRegionDao;
+
+    @Bean
+    public PermissionFactory permissionFactory() {
+        return new AclPermissionFactory();
+    }
+
+    //TODO: replace with auto configuration?
+    @Bean
+    public PlatformTransactionManager platformTransactionManager(final DataSource dataSource) {
+        return new DataSourceTransactionManager(dataSource);
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/app/AclTestConfiguration.java
+++ b/api/src/test/java/com/epam/pipeline/app/AclTestConfiguration.java
@@ -45,7 +45,7 @@ import javax.sql.DataSource;
 
 @SpringBootConfiguration
 @Import({AclSecurityConfiguration.class, DBConfiguration.class, MappersConfiguration.class})
-@ComponentScan(basePackages = {"com.epam.pipeline.manager.security", "com.epam.pipeline.acl"})
+@ComponentScan(basePackages = {"com.epam.pipeline.manager.security"})
 @TestPropertySource(value={"classpath:test-application.properties"})
 @EnableGlobalMethodSecurity(securedEnabled = true, prePostEnabled = true)
 @EnableAspectJAutoProxy

--- a/api/src/test/java/com/epam/pipeline/app/TestApplication.java
+++ b/api/src/test/java/com/epam/pipeline/app/TestApplication.java
@@ -59,7 +59,11 @@ import java.util.concurrent.Executor;
         ManagementWebSecurityAutoConfiguration.class,
         SecurityFilterAutoConfiguration.class})
 @ComponentScan(
-        basePackages = {"com.epam.pipeline.dao", "com.epam.pipeline.manager",  "com.epam.pipeline.security"},
+        basePackages = {
+                "com.epam.pipeline.dao",
+                "com.epam.pipeline.manager",
+                "com.epam.pipeline.security",
+                "com.epam.pipeline.acl"},
         excludeFilters = {
         @ComponentScan.Filter(type = FilterType.REGEX, pattern="com.epam.pipeline.manager.security.acl.*"),
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = InstanceOfferScheduler.class)})

--- a/api/src/test/java/com/epam/pipeline/app/TestApplicationWithAclSecurity.java
+++ b/api/src/test/java/com/epam/pipeline/app/TestApplicationWithAclSecurity.java
@@ -48,7 +48,9 @@ import org.springframework.test.context.TestPropertySource;
     ManagementWebSecurityAutoConfiguration.class,
     SecurityFilterAutoConfiguration.class})
 @ComponentScan(
-    basePackages = {"com.epam.pipeline.dao", "com.epam.pipeline.manager",  "com.epam.pipeline.security"},
+    basePackages = {
+            "com.epam.pipeline.dao", "com.epam.pipeline.manager",
+            "com.epam.pipeline.acl", "com.epam.pipeline.security"},
     excludeFilters = {
         @ComponentScan.Filter(type = FilterType.REGEX, pattern="com.epam.pipeline.manager.security.Test*"),
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = InstanceOfferScheduler.class)

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/runner/RunConfigurationProviderTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/runner/RunConfigurationProviderTest.java
@@ -33,7 +33,7 @@ import com.epam.pipeline.manager.cluster.InstanceOfferManager;
 import com.epam.pipeline.manager.pipeline.PipelineConfigurationManager;
 import com.epam.pipeline.manager.pipeline.PipelineManager;
 import com.epam.pipeline.manager.pipeline.ToolManager;
-import com.epam.pipeline.manager.security.PermissionsHelper;
+import com.epam.pipeline.manager.security.CheckPermissionHelper;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -51,7 +51,7 @@ public class RunConfigurationProviderTest {
 
     private final PipelineManager pipelineManager = mock(PipelineManager.class);
     private final ToolManager toolManager = mock(ToolManager.class);
-    private final PermissionsHelper permissionsHelper = mock(PermissionsHelper.class);
+    private final CheckPermissionHelper permissionsHelper = mock(CheckPermissionHelper.class);
     private final PipelineConfigurationManager pipelineConfigurationManager = mock(PipelineConfigurationManager.class);
     private final InstanceOfferManager instanceOfferManager = mock(InstanceOfferManager.class);
     private final MessageHelper messageHelper = mock(MessageHelper.class);


### PR DESCRIPTION
Provides implementation for #759

## Implementation
New SystemPreference `launch.run.visibility` was added with two supported values: `OWNER` and `INHERIT` (default). 
- When `launch.run.visibility` is `INHERIT` non-admin users will see their own runs and run of pipelines they have access to.
- When `launch.run.visibility` is `OWNER` non-admin users will see only their own runs

Admin users will have access to all runs in both cases. 
Value of SystemPreference `launch.run.visibility` maybe overridden for a specific user or group (Cloud Pipeline managed role) using contextual preferences (`PUT /contextual/preferences`). The most specific preference (User -> Role -> System) will be applied during permission check.

**_Note!_** Run permissions are still not inherited from tools.