### PR TITLE
pipe-cli: not-handled error while trying to execute commands with invalid config

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -46,6 +46,8 @@ def silent_print_api_version():
             click.echo('Cloud Pipeline API, version {}'.format(api_info['version']))
     except ConfigNotFoundError:
         return
+    except Exception as e:
+        click.echo("Error: {}".format(str(e)), err=True)
 
 
 def print_version(ctx, param, value):


### PR DESCRIPTION
Provides fix for issue #750 
