### PR TITLE
Issue #757 PKI certificates expiration monitoring

### DIFF
--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/model/cert/PkiCertificate.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/model/cert/PkiCertificate.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.vmmonitor.model.cert;
+
+import lombok.Data;
+
+import java.nio.file.Path;
+import java.security.cert.X509Certificate;
+
+@Data
+public class PkiCertificate {
+
+    private final X509Certificate x509Certificate;
+    private final Path pathToCertFile;
+
+}

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/model/cert/PkiCertificate.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/model/cert/PkiCertificate.java
@@ -16,12 +16,12 @@
 
 package com.epam.pipeline.vmmonitor.model.cert;
 
-import lombok.Data;
+import lombok.Value;
 
 import java.nio.file.Path;
 import java.security.cert.X509Certificate;
 
-@Data
+@Value
 public class PkiCertificate {
 
     private final X509Certificate x509Certificate;

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/CertificateMonitor.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/CertificateMonitor.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.vmmonitor.service;
+
+import com.epam.pipeline.vmmonitor.model.cert.PkiCertificate;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.BufferedInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+@Service
+@Slf4j
+public class CertificateMonitor {
+
+    private static final String DELIMITER = ",";
+    private final List<String> directoriesToScan;
+    private final List<String> certificateMasks;
+    private final int daysToNotify;
+    private final VMNotificationService notificationService;
+
+    @Autowired
+    public CertificateMonitor(final VMNotificationService notificationService,
+                              @Value("${monitor.cert.scan.folders}") final String directoriesToScan,
+                              @Value("${monitor.cert.file.masks:pem}") final String certificateMasks,
+                              @Value("${monitor.cert.expiration.notification.days:5}") final int daysToNotify) {
+        this.notificationService = notificationService;
+        this.directoriesToScan = Arrays.asList(directoriesToScan.split(DELIMITER));
+        this.certificateMasks = Arrays.asList(certificateMasks.split(DELIMITER));
+        this.daysToNotify = daysToNotify;
+    }
+
+    public void checkCertificates() {
+        directoriesToScan.forEach(this::scanDirForCertificates);
+    }
+
+    private void scanDirForCertificates(final String dirPath) {
+        try (Stream<Path> paths = Files.walk(Paths.get(dirPath))) {
+            paths
+                .filter(this::isCertFile)
+                .forEach(this::checkExpiration);
+        } catch (IOException e) {
+            log.error("Error during {} scanning: {}!", dirPath, e.getMessage());
+        }
+    }
+
+    private void checkExpiration(final Path filePath) {
+        generateX509Certificate(filePath)
+            .filter(this::isExpiring)
+            .map(x509cert -> new PkiCertificate(x509cert, filePath))
+            .ifPresent(notificationService::notifyExpiringCertificate);
+    }
+
+    private Optional<X509Certificate> generateX509Certificate(final Path pathToFile) {
+        try (FileInputStream fis = new FileInputStream(pathToFile.toString());
+             BufferedInputStream bis = new BufferedInputStream(fis)) {
+            final CertificateFactory factory = CertificateFactory.getInstance("X.509");
+            return Optional.of((X509Certificate) factory.generateCertificate(bis));
+        } catch (CertificateException | IOException e) {
+            log.error("Error generating certificate from {}: {}", pathToFile, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private boolean isCertFile(final Path pathToFile) {
+        return Files.isRegularFile(pathToFile)
+               && certificateMasks.stream().anyMatch(pathToFile::endsWith);
+    }
+
+    private boolean isExpiring(final X509Certificate certificate) {
+        final LocalDateTime expirationDate = LocalDateTime
+            .ofInstant(certificate.getNotAfter().toInstant(), ZoneId.systemDefault());
+        return LocalDateTime.now().plusDays(daysToNotify).isAfter(expirationDate);
+    }
+
+}

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/CertificateMonitor.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/CertificateMonitor.java
@@ -18,6 +18,7 @@ package com.epam.pipeline.vmmonitor.service;
 
 import com.epam.pipeline.vmmonitor.model.cert.PkiCertificate;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -64,6 +65,9 @@ public class CertificateMonitor {
     }
 
     private void scanDirForCertificates(final String dirPath) {
+        if (StringUtils.isBlank(dirPath)) {
+            return;
+        }
         try (Stream<Path> paths = Files.walk(Paths.get(dirPath))) {
             paths
                 .filter(this::isCertFile)
@@ -93,7 +97,7 @@ public class CertificateMonitor {
 
     private boolean isCertFile(final Path pathToFile) {
         return Files.isRegularFile(pathToFile)
-               && certificateMasks.stream().anyMatch(pathToFile::endsWith);
+               && certificateMasks.stream().anyMatch(mask -> pathToFile.toString().endsWith(mask));
     }
 
     private boolean isExpiring(final X509Certificate certificate) {

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/VMNotificationService.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/VMNotificationService.java
@@ -17,6 +17,7 @@
 package com.epam.pipeline.vmmonitor.service;
 
 import com.epam.pipeline.entity.cluster.NodeInstance;
+import com.epam.pipeline.vmmonitor.model.cert.PkiCertificate;
 import com.epam.pipeline.vmmonitor.model.vm.VirtualMachine;
 
 import java.util.List;
@@ -28,4 +29,5 @@ public interface VMNotificationService {
 
     void notifyMissingNode(VirtualMachine vm);
     void notifyMissingLabels(VirtualMachine vm, NodeInstance node, List<String> labels);
+    void notifyExpiringCertificate(PkiCertificate certificate);
 }

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/impl/VMNotificationServiceImpl.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/impl/VMNotificationServiceImpl.java
@@ -17,12 +17,14 @@
 package com.epam.pipeline.vmmonitor.service.impl;
 
 import com.epam.pipeline.entity.cluster.NodeInstance;
+import com.epam.pipeline.vmmonitor.model.cert.PkiCertificate;
 import com.epam.pipeline.vmmonitor.model.vm.VirtualMachine;
 import com.epam.pipeline.vmmonitor.service.NotificationSender;
 import com.epam.pipeline.vmmonitor.service.VMNotificationService;
 import com.epam.pipeline.vo.notification.NotificationMessageVO;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
@@ -33,6 +35,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -46,8 +50,10 @@ public class VMNotificationServiceImpl implements VMNotificationService {
     private final NotificationSender notificationSender;
     private final String missingNodeSubject;
     private final String missingLabelsSubject;
+    private final String certificateExpirationSubject;
     private final String missingNodeTemplatePath;
     private final String missingLabelsTemplatePath;
+    private final String certificateExpirationTemplatePath;
     private final String toUser;
     private final List<String> copyUsers;
 
@@ -57,6 +63,8 @@ public class VMNotificationServiceImpl implements VMNotificationService {
             @Value("${notification.missing-node.template}") final String missingNodeTemplatePath,
             @Value("${notification.missing-labels.subject}") final String missingLabelsSubject,
             @Value("${notification.missing-labels.template}") final String missingLabelsTemplatePath,
+            @Value("${notification.missing-labels.subject}") final String certificateExpirationSubject,
+            @Value("${notification.missing-labels.template}") final String certificateExpirationTemplatePath,
             @Value("${notification.to-user}") final String toUser,
             @Value("${notification.copy-users}") final String copyUsers) {
         this.notificationSender = notificationSender;
@@ -64,6 +72,8 @@ public class VMNotificationServiceImpl implements VMNotificationService {
         this.missingLabelsSubject = missingLabelsSubject;
         this.missingNodeTemplatePath = missingNodeTemplatePath;
         this.missingLabelsTemplatePath = missingLabelsTemplatePath;
+        this.certificateExpirationSubject = certificateExpirationSubject;
+        this.certificateExpirationTemplatePath = certificateExpirationTemplatePath;
         this.toUser = toUser;
         this.copyUsers = Arrays.asList(copyUsers.split(","));
     }
@@ -89,6 +99,14 @@ public class VMNotificationServiceImpl implements VMNotificationService {
         sendMessage(parameters, missingLabelsSubject, missingLabelsTemplatePath);
     }
 
+    @Override
+    public void notifyExpiringCertificate(final PkiCertificate certificate) {
+        final Map<String, Object> parameters = new HashMap<>();
+        addCertParameters(certificate, parameters);
+        log.debug("Sending {} certificate expiration notification", certificate.getX509Certificate().getSubjectDN());
+        sendMessage(parameters, certificateExpirationSubject, certificateExpirationTemplatePath);
+    }
+
     private void addNodeParameters(final NodeInstance node, final Map<String, Object> parameters) {
         parameters.put("nodeName", node.getName());
     }
@@ -98,6 +116,21 @@ public class VMNotificationServiceImpl implements VMNotificationService {
         parameters.put("privateIp", vm.getPrivateIp());
         parameters.put("provider", vm.getCloudProvider().name());
         parameters.put("instanceName", vm.getInstanceName());
+    }
+
+    private void addCertParameters(final PkiCertificate certificate, final Map<String, Object> parameters) {
+        final X509Certificate x509Cert = certificate.getX509Certificate();
+        try {
+            parameters.put("san", x509Cert.getSubjectAlternativeNames());
+        } catch (CertificateParsingException e) {
+            log.warn("Can't obtain SAN info from certificate!", e);
+            parameters.put("san", StringUtils.EMPTY);
+        }
+        parameters.put("serialNumber", x509Cert.getSerialNumber());
+        parameters.put("dn", x509Cert.getSubjectDN());
+        parameters.put("issuer", x509Cert.getIssuerDN());
+        parameters.put("notAfter", x509Cert.getNotAfter());
+        parameters.put("filePath", certificate.getPathToCertFile());
     }
 
     private void sendMessage(final Map<String, Object> parameters, final String subject, final String template) {

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/impl/VMNotificationServiceImpl.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/impl/VMNotificationServiceImpl.java
@@ -101,8 +101,7 @@ public class VMNotificationServiceImpl implements VMNotificationService {
 
     @Override
     public void notifyExpiringCertificate(final PkiCertificate certificate) {
-        final Map<String, Object> parameters = new HashMap<>();
-        addCertParameters(certificate, parameters);
+        final Map<String, Object> parameters = createCertParameters(certificate);
         log.debug("Sending {} certificate expiration notification", certificate.getX509Certificate().getSubjectDN());
         sendMessage(parameters, certificateExpirationSubject, certificateExpirationTemplatePath);
     }
@@ -118,7 +117,8 @@ public class VMNotificationServiceImpl implements VMNotificationService {
         parameters.put("instanceName", vm.getInstanceName());
     }
 
-    private void addCertParameters(final PkiCertificate certificate, final Map<String, Object> parameters) {
+    private Map<String, Object> createCertParameters(final PkiCertificate certificate) {
+        final Map<String, Object> parameters = new HashMap<>();
         final X509Certificate x509Cert = certificate.getX509Certificate();
         try {
             parameters.put("san", x509Cert.getSubjectAlternativeNames());
@@ -131,6 +131,7 @@ public class VMNotificationServiceImpl implements VMNotificationService {
         parameters.put("issuer", x509Cert.getIssuerDN());
         parameters.put("notAfter", x509Cert.getNotAfter());
         parameters.put("filePath", certificate.getPathToCertFile());
+        return parameters;
     }
 
     private void sendMessage(final Map<String, Object> parameters, final String subject, final String template) {

--- a/vm-monitor/src/main/resources/application.properties
+++ b/vm-monitor/src/main/resources/application.properties
@@ -3,11 +3,17 @@ cloud.pipeline.host=
 cloud.pipeline.token=
 cloud.pipeline.api.version=0.15
 
-#Moniroting settings in ms
+#VM-monitoring settings
 monitor.schedule.cron=0 */2 * ? * *
 monitor.instance.tag=monitored=true
 monitor.required.labels=runid
 monitor.runid.label=Name
+
+#Certificate-monitoring settings
+monitor.cert.schedule.cron=0 0 0 ? * *
+monitor.cert.file.masks=pem
+monitor.cert.expiration.notification.days=5
+monitor.cert.scan.folders=${CP_SHARE_SRV_CERT_DIR},${CP_EDGE_CERT_DIR},${CP_DOCKER_CERT_DIR},${CP_IDP_CERT_DIR},${CP_GITLAB_CERT_DIR},${CP_API_SRV_CERT_DIR},${CP_COMMON_CERT_DIR}
 
 #Notification settings
 notification.missing-node.subject=[CloudPipeline] VM $templateParameters["instanceName"] is not registered in cluster
@@ -15,6 +21,9 @@ notification.missing-node.template=classpath:/templates/MISSING-NODE.html
 
 notification.missing-labels.subject=[CloudPipeline] VM $templateParameters["nodeName"] is missing required labels
 notification.missing-labels.template=classpath:/templates/MISSING-LABELS.html
+
+notification.cert-expiration.subject=[CloudPipeline] Certificate expires soon
+notification.cert-expiration.template=classpath:/templates/CERTIFICATE-EXPIRATION.html
 
 notification.to-user=TEST
 notification.copy-users=TEST,TEST

--- a/vm-monitor/src/main/resources/templates/CERTIFICATE-EXPIRATION.html
+++ b/vm-monitor/src/main/resources/templates/CERTIFICATE-EXPIRATION.html
@@ -1,0 +1,45 @@
+<!--
+  ~ Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <style>
+        table,
+        td {
+            border: 1px solid black;
+            border-collapse: collapse;
+            padding: 5px;
+        }
+    </style>
+</head>
+
+<body>
+<p>Dear user,</p>
+<p>*** This is a system generated email, do not reply to this email ***</p>
+<p>Looks like certificate $templateParameters["serialNumber"] for $templateParameters["dn"] expires soon!</p>
+<p> Expiring on: $templateParameters["notAfter"]</p>
+<p> Issued by: $templateParameters["issuer"]</p>
+<p> Stored at: $templateParameters["filePath"]</p>
+<p> SAN: [$templateParameters["san"]]</p>
+<p>This won't be managed automatically by Cloud Pipeline Platform, please verify validity period and renew it manually.</p>
+<p>Best regards,</p>
+<p>Cloud Pipeline Platform</p>
+</body>
+
+</html>

--- a/vm-monitor/src/test/java/com/epam/pipeline/vmmonitor/service/CertificateMonitorTest.java
+++ b/vm-monitor/src/test/java/com/epam/pipeline/vmmonitor/service/CertificateMonitorTest.java
@@ -104,7 +104,7 @@ public class CertificateMonitorTest {
                                                   X509Factory.END_CERT);
             os.write(certText.getBytes());
         } catch (Exception e) {
-            throw new RuntimeException("Error during certificate saving!");
+            System.out.println("Error during certificate saving: " + e.getMessage());
         }
     }
 }

--- a/vm-monitor/src/test/java/com/epam/pipeline/vmmonitor/service/CertificateMonitorTest.java
+++ b/vm-monitor/src/test/java/com/epam/pipeline/vmmonitor/service/CertificateMonitorTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.vmmonitor.service;
+
+import com.epam.pipeline.vmmonitor.service.impl.VMNotificationServiceImpl;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import sun.misc.BASE64Encoder;
+import sun.security.provider.X509Factory;
+import sun.security.tools.keytool.CertAndKeyGen;
+import sun.security.x509.X500Name;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+public class CertificateMonitorTest {
+
+    private static final String TEST_DIR = "src/test/resources/testScanningFolder/";
+    private static final String TEST_CERT_MASK = "pem";
+    private static final String KEY_TYPE = "RSA";
+    private static final String SIG_ALG = "SHA1WithRSA";
+    private static final String CN_TEST = "CN=TEST";
+    private static final int KEY_SIZE = 1024;
+    private static final int DAYS_TO_NOTIFY = 5;
+
+    private final VMNotificationServiceImpl notificationService;
+    private final CertificateMonitor certificateMonitor;
+    private final CertAndKeyGen keyGen;
+
+    public CertificateMonitorTest() throws Exception {
+        notificationService = Mockito.mock(VMNotificationServiceImpl.class);
+        certificateMonitor = new CertificateMonitor(notificationService, TEST_DIR, TEST_CERT_MASK, DAYS_TO_NOTIFY);
+        keyGen = new CertAndKeyGen(KEY_TYPE, SIG_ALG);
+        keyGen.generate(KEY_SIZE);
+    }
+
+    @BeforeEach
+    public void createTestCertDir() throws IOException {
+        Files.createDirectory(Paths.get(TEST_DIR));
+    }
+
+    @AfterEach
+    public void removeTestCertDir() throws IOException {
+        FileUtils.deleteDirectory(new File(TEST_DIR));
+    }
+
+    @Test
+    public void testCheckCertificates() {
+        final List<Integer> certDurations = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9);
+        final int expiringCertificatesCount = (int) certDurations.stream()
+            .filter(dur -> dur <= DAYS_TO_NOTIFY)
+            .count();
+
+        certDurations.stream()
+            .map(this::generateCert)
+            .filter(Objects::nonNull)
+            .forEach(this::saveCertToTestDir);
+
+        certificateMonitor.checkCertificates();
+        Mockito.verify(notificationService, Mockito.times(expiringCertificatesCount))
+            .notifyExpiringCertificate(Mockito.any());
+    }
+
+    private X509Certificate generateCert(final int validityDays) {
+        try {
+            return keyGen.getSelfCertificate(new X500Name(CN_TEST), TimeUnit.DAYS.toSeconds(validityDays));
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private void saveCertToTestDir(final X509Certificate certificate) {
+        final String certName = certificate.getSerialNumber() + ".pem";
+        final BASE64Encoder encoder = new BASE64Encoder();
+        try (FileOutputStream os = new FileOutputStream(TEST_DIR + certName)) {
+            final String certText = String.format("%s\n%s\n%s",
+                                                  X509Factory.BEGIN_CERT,
+                                                  encoder.encode(certificate.getEncoded()),
+                                                  X509Factory.END_CERT);
+            os.write(certText.getBytes());
+        } catch (Exception e) {
+            throw new RuntimeException("Error during certificate saving!");
+        }
+    }
+}


### PR DESCRIPTION
This PR solves the second part of issue #757.

CertificateMonitor service is introduced: it traverses specified directories, searches for certificate files and verifies their expiration date. If a certificate expires less than in a certain amount of days the notification is sent to the user.

- Implement certificates monitoring functionality.
- Modify `application.properties` to let the user configure: 
    1.  _days_ before expiration to notify 
    2.  certificates' file _extensions_
    3.  _directories_ to be scanned.
