### PR TITLE
(issue #771) Change behaviour of pause run script

### DIFF
--- a/scripts/commit-run-scripts/common_commit_initialization.sh
+++ b/scripts/commit-run-scripts/common_commit_initialization.sh
@@ -26,15 +26,15 @@ check_last_exit_code() {
    msg_if_fail=$2
    msg_if_success=$3
 
-   if [[ "$#" -eq 4 ]]; then
-       cmd_on_failure=$4
+   if [[ "$#" -ge 4 ]]; then
+       cmd_on_failure=${@:4}
    fi
 
    if [[ "$exit_code" -ne 0 ]]; then
         pipe_log_fail "$msg_if_fail" "$TASK_NAME"
 
         if [[ ${cmd_on_failure} ]]; then
-           eval ${cmd_on_failure}
+           eval "${cmd_on_failure}"
         fi
         exit 1
     else

--- a/scripts/commit-run-scripts/pause_run.sh
+++ b/scripts/commit-run-scripts/pause_run.sh
@@ -44,7 +44,8 @@ commit_file_and_stop_docker() {
 
     commit_file ${NEW_IMAGE_NAME}
     check_last_exit_code $? "[ERROR] Error occured while committing temporary container" \
-                            "[INFO] Temporary container was successfully committed with name: ${NEW_IMAGE_NAME}"
+                            "[INFO] Temporary container was successfully committed with name: ${NEW_IMAGE_NAME}" \
+                            "exit 126"
 
     export tmp_container=`docker run --entrypoint "/bin/sleep" -d ${NEW_IMAGE_NAME} 1d`
 
@@ -52,11 +53,13 @@ commit_file_and_stop_docker() {
 
     pipe_exec "docker commit ${tmp_container} ${NEW_IMAGE_NAME} > /dev/null" "$TASK_NAME"
     check_last_exit_code $? "[ERROR] Error occured while committing container" \
-                            "[INFO] Container was successfully committed with name: $NEW_IMAGE_NAME"
+                            "[INFO] Container was successfully committed with name: $NEW_IMAGE_NAME" \
+                            "exit 126"
 
     pipe_exec "docker logs ${CONTAINER_ID}" "${DEFAULT_TASK_NAME}"
     check_last_exit_code $? "[ERROR] Error occurred while retrieving logs from docker container ${CONTAINER_ID}" \
-                            "[INFO] Docker container logs were successfully retrieved."
+                            "[INFO] Docker container logs were successfully retrieved." \
+                            "exit 126"
 
     stop_service kubelet
     kubeadm reset


### PR DESCRIPTION
This PR related to #771 
Now if something goes wrong during pause (commiting tmp container, cleanup etc) we will return exit code 126, that will handled by api server as returning to `Running` state 