### PR TITLE
(issue #768) Сheck that azure blob storage already exist 

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureStorageHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureStorageHelper.java
@@ -131,6 +131,13 @@ public class AzureStorageHelper {
     }
 
     public String createBlobStorage(final AzureBlobStorage storage) {
+        if(checkStorage(storage)) {
+            throw new DataStorageException(
+                    messageHelper.getMessage(MessageConstants.ERROR_DATASTORAGE_ALREADY_EXIST,
+                            storage.getName(),
+                            storage.getPath())
+            );
+        }
         unwrap(getContainerURL(storage).create());
         return storage.getPath();
     }


### PR DESCRIPTION
issue #768
Before try to create azure blob storage we will check if this storage already exists on a cloud and if so - will fail with error