### PR TITLE
Issue #783 : Allow to specify pod cpu requests

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/execution/PipelineExecutor.java
+++ b/api/src/main/java/com/epam/pipeline/manager/execution/PipelineExecutor.java
@@ -31,6 +31,8 @@ import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.SecurityContext;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
@@ -42,6 +44,7 @@ import okhttp3.OkHttpClient;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -65,7 +68,9 @@ public class PipelineExecutor {
     private static final String NGINX_ENDPOINT = "nginx";
     private static final long KUBE_TERMINATION_PERIOD = 30L;
     private static final String TRUE = "true";
-    public static final String USE_HOST_NETWORK = "CP_USE_HOST_NETWORK";
+    private static final String USE_HOST_NETWORK = "CP_USE_HOST_NETWORK";
+    private static final String DEFAULT_CPU_REQUEST = "1";
+    private static final String CPU_REQUEST_NAME = "cpu";
 
     private final PreferenceManager preferenceManager;
     private final String kubeNamespace;
@@ -110,7 +115,8 @@ public class PipelineExecutor {
 
             OkHttpClient httpClient = HttpClientUtils.createHttpClient(client.getConfiguration());
             ObjectMeta metadata = getObjectMeta(run, labels);
-            PodSpec spec = getPodSpec(run, envVars, secretName, nodeSelector, run.getDockerImage(), command, pullImage);
+            PodSpec spec = getPodSpec(run, envVars, secretName, nodeSelector, run.getDockerImage(), command,
+                    pullImage, StringUtils.isBlank(getChildLabel(clusterId, run)));
             Pod pod = new Pod("v1", "Pod", metadata, spec, null);
             Pod created = new PodOperationsImpl(httpClient, client.getConfiguration(), kubeNamespace).create(pod);
             LOGGER.debug("Created POD: {}", created.toString());
@@ -118,16 +124,20 @@ public class PipelineExecutor {
     }
 
     private void addWorkerLabel(final String clusterId, final Map<String, String> labels, final PipelineRun run) {
-        final String clusterLabel = StringUtils.defaultIfBlank(clusterId,
-                Optional.ofNullable(run.getParentRunId()).map(String::valueOf).orElse(StringUtils.EMPTY));
+        final String clusterLabel = getChildLabel(clusterId, run);
         if (StringUtils.isNotBlank(clusterLabel)) {
             labels.put(KubernetesConstants.POD_WORKER_NODE_LABEL, clusterLabel);
         }
     }
 
+    private String getChildLabel(final String clusterId, final PipelineRun run) {
+        return StringUtils.defaultIfBlank(clusterId,
+                Optional.ofNullable(run.getParentRunId()).map(String::valueOf).orElse(StringUtils.EMPTY));
+    }
+
     private PodSpec getPodSpec(PipelineRun run, List<EnvVar> envVars, String secretName,
                                Map<String, String> nodeSelector, String dockerImage,
-                               String command, boolean pullImage) {
+                               String command, boolean pullImage, boolean isParentPod) {
         PodSpec spec = new PodSpec();
         spec.setRestartPolicy("Never");
         spec.setTerminationGracePeriodSeconds(KUBE_TERMINATION_PERIOD);
@@ -150,7 +160,7 @@ public class PipelineExecutor {
         }
 
         spec.setContainers(Collections.singletonList(getContainer(
-                envVars, dockerImage, command, pullImage, isDockerInDockerEnabled)));
+                envVars, dockerImage, command, pullImage, isDockerInDockerEnabled, isParentPod)));
         return spec;
     }
 
@@ -159,7 +169,8 @@ public class PipelineExecutor {
                                    String dockerImage,
                                    String command,
                                    boolean pullImage,
-                                   boolean isDockerInDockerEnabled) {
+                                   boolean isDockerInDockerEnabled,
+                                   boolean isParentPod) {
         Container container = new Container();
         container.setName("pipeline");
         SecurityContext securityContext = new SecurityContext();
@@ -174,7 +185,28 @@ public class PipelineExecutor {
         container.setTerminationMessagePath("/dev/termination-log");
         container.setImagePullPolicy(pullImage ? "Always" : "Never");
         container.setVolumeMounts(getMounts(isDockerInDockerEnabled));
+        if (isParentPod) {
+            setCpuRequestIfRequired(envVars, container);
+        }
         return container;
+    }
+
+    private void setCpuRequestIfRequired(List<EnvVar> envVars, Container container) {
+        ListUtils.emptyIfNull(envVars).stream()
+                .filter(var -> SystemParams.CONTAINER_CPU_RESOURCE.getEnvName().equals(var.getName()))
+                .findFirst()
+                .map(var -> {
+                    if (NumberUtils.isDigits(var.getValue())) {
+                        var.getValue();
+                    }
+                    return DEFAULT_CPU_REQUEST;
+                })
+                .filter(cpuRequest -> Integer.parseInt(cpuRequest) > 0)
+                .ifPresent(cpuRequest -> {
+                    ResourceRequirements resources = new ResourceRequirements();
+                    resources.setRequests(Collections.singletonMap(CPU_REQUEST_NAME, new Quantity(cpuRequest)));
+                    container.setResources(resources);
+                });
     }
 
     private List<Volume> getVolumes(final boolean isDockerInDockerEnabled) {

--- a/api/src/main/java/com/epam/pipeline/manager/execution/PipelineLauncher.java
+++ b/api/src/main/java/com/epam/pipeline/manager/execution/PipelineLauncher.java
@@ -187,6 +187,8 @@ public class PipelineLauncher {
             collectSids(systemParamsWithValue, SystemParams.ALLOWED_GROUPS,
                     run.getRunSids(), principalFilter.negate());
         }
+        systemParamsWithValue.put(SystemParams.CONTAINER_CPU_RESOURCE, String.valueOf(
+                preferenceManager.getPreference(SystemPreferences.LAUNCH_CONTAINER_CPU_RESOURCE)));
         String securedEnvVars = Arrays
                 .stream(SystemParams.values())
                 .filter(SystemParams::isSecure)

--- a/api/src/main/java/com/epam/pipeline/manager/execution/SystemParams.java
+++ b/api/src/main/java/com/epam/pipeline/manager/execution/SystemParams.java
@@ -63,7 +63,8 @@ public enum SystemParams {
     FSBROWSER_ENABLED("cp-fsbrowser-enabled", "CP_FSBROWSER_ENABLED", false, true),
     FSBROWSER_PORT("cp-fsbrowser-port", "CP_FSBROWSER_PORT", false, true),
     FSBROWSER_WD("cp-fsbrowser-wd", "CP_FSBROWSER_WD", false, true),
-    FSBROWSER_STORAGE("cp-fsbrowser-storage", "CP_FSBROWSER_STORAGE", false, true);
+    FSBROWSER_STORAGE("cp-fsbrowser-storage", "CP_FSBROWSER_STORAGE", false, true),
+    CONTAINER_CPU_RESOURCE("container-cpu-resource", "CP_CONTAINER_CPU_RESOURCE", false, true);
 
     public static final String CLOUD_REGION_PREFIX = "CP_ACCOUNT_REGION_";
     public static final String CLOUD_ACCOUNT_PREFIX = "CP_ACCOUNT_ID_";

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -322,6 +322,8 @@ public class SystemPreferences {
     public static final StringPreference RUN_VISIBILITY_POLICY = new StringPreference(
             "launch.run.visibility", RunVisibilityPolicy.INHERIT.name(), LAUNCH_GROUP,
             PreferenceValidators.isValidEnum(RunVisibilityPolicy.class));
+    public static final IntPreference LAUNCH_CONTAINER_CPU_RESOURCE = new IntPreference(
+            "launch.container.cpu.resource", 0, LAUNCH_GROUP, isGreaterThan(-1));
 
     //DTS submission
     public static final StringPreference DTS_LAUNCH_CMD_TEMPLATE = new StringPreference("dts.launch.cmd",


### PR DESCRIPTION
Related to #783 
This PR introduces two options to specify cpu requests for pods:
1. PipelineRun parameter `CP_CONTAINER_CPU_RESOURCE`
2. SystemPreference `launch.container.cpu.resource`