### PR TITLE
(issue #767) change way to validate storage policy

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/region/AzureRegionHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/region/AzureRegionHelper.java
@@ -129,7 +129,8 @@ public class AzureRegionHelper implements CloudRegionHelper<AzureRegion, AzureRe
     }
 
     void validateStoragePolicy(final AzurePolicy policy) {
-        if (Objects.isNull(policy)) {
+        if (Objects.isNull(policy) ||
+                (Objects.isNull(policy.getIpMax()) && Objects.isNull(policy.getIpMin()))) {
             return;
         }
 

--- a/api/src/test/java/com/epam/pipeline/manager/region/AzureRegionHelperTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/region/AzureRegionHelperTest.java
@@ -62,10 +62,8 @@ public class AzureRegionHelperTest {
     }
 
     @Test
-    public void shouldThrowIfAzurePolicyIsEmpty() {
+    public void shouldPassIfPolicyExistsButEmpty() {
         final AzureRegionHelper azureRegionHelper = new AzureRegionHelper(messageHelper);
-
-        final AzurePolicy policy = new AzurePolicy();
-        assertThrows(IllegalArgumentException.class, () -> azureRegionHelper.validateStoragePolicy(policy));
+        azureRegionHelper.validateStoragePolicy(new AzurePolicy());
     }
 }

--- a/api/src/test/java/com/epam/pipeline/manager/region/AzureRegionHelperTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/region/AzureRegionHelperTest.java
@@ -23,6 +23,7 @@ import com.epam.pipeline.entity.region.AzureRegionCredentials;
 import org.junit.Test;
 
 import static com.epam.pipeline.util.CustomAssertions.assertThrows;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 
 @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
@@ -64,6 +65,10 @@ public class AzureRegionHelperTest {
     @Test
     public void shouldPassIfPolicyExistsButEmpty() {
         final AzureRegionHelper azureRegionHelper = new AzureRegionHelper(messageHelper);
-        azureRegionHelper.validateStoragePolicy(new AzurePolicy());
+        final AzurePolicy emptyPolicy = new AzurePolicy();
+        //check that policy is empty but validateStoragePolicy does not throw
+        assertNull(emptyPolicy.getIpMax());
+        assertNull(emptyPolicy.getIpMin());
+        azureRegionHelper.validateStoragePolicy(emptyPolicy);
     }
 }


### PR DESCRIPTION
now empty json is valid case