### PR TITLE
Issue #790 : Fix pipe cp for Windows folders

### DIFF
--- a/pipe-cli/src/model/data_storage_wrapper.py
+++ b/pipe-cli/src/model/data_storage_wrapper.py
@@ -75,6 +75,7 @@ class DataStorageWrapper(object):
     def __init__(self, path):
         self.path = path
         self.items = []
+        self.path_separator = StorageOperations.PATH_SEPARATOR
 
     @classmethod
     def get_wrapper(cls, uri, symlinks=None):
@@ -205,8 +206,8 @@ class DataStorageWrapper(object):
 
     def path_with_trailing_separator(self):
         return self.path \
-            if self.path.endswith(StorageOperations.PATH_SEPARATOR) \
-            else self.path + StorageOperations.PATH_SEPARATOR
+            if self.path.endswith(self.path_separator) \
+            else self.path + self.path_separator
 
 
 class CloudDataStorageWrapper(DataStorageWrapper):
@@ -386,6 +387,7 @@ class LocalFileSystemWrapper(DataStorageWrapper):
         if self.path.startswith("~"):
             self.path = os.path.join(os.path.expanduser('~'), self.path.strip("~/"))
         self.symlinks = symlinks
+        self.path_separator = os.sep
 
     def exists(self):
         return os.path.exists(self.path)


### PR DESCRIPTION
This PR provides solution for issue #790. It fixes path separator handling for local filesystem making it OS-sensitive.