### PR TITLE
Issue 792 Add restore s3 folder option

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -56,7 +56,6 @@ test {
             println "Results: ${result.resultType} (${result.testCount} total, ${result.successfulTestCount} success, ${result.failedTestCount} failure, ${result.skippedTestCount} skipped)"
         }
     }
-    useJUnitPlatform()
 }
 
 sourceCompatibility = 1.8
@@ -202,12 +201,6 @@ dependencies {
 
     //Tests
     compile group: "org.springframework.boot", name: "spring-boot-starter-test", version: project.ext.versionSpringBoot
-    // JUnit Jupiter
-    testImplementation('org.junit.jupiter:junit-jupiter:5.4.0')
-
-// JUnit Vintage
-    testCompileOnly('junit:junit:4.12')
-    testRuntimeOnly('org.junit.vintage:junit-vintage-engine:5.4.0')
 }
 
 // >>>>> processes profiles

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -56,6 +56,7 @@ test {
             println "Results: ${result.resultType} (${result.testCount} total, ${result.successfulTestCount} success, ${result.failedTestCount} failure, ${result.skippedTestCount} skipped)"
         }
     }
+    useJUnitPlatform()
 }
 
 sourceCompatibility = 1.8
@@ -201,6 +202,12 @@ dependencies {
 
     //Tests
     compile group: "org.springframework.boot", name: "spring-boot-starter-test", version: project.ext.versionSpringBoot
+    // JUnit Jupiter
+    testImplementation('org.junit.jupiter:junit-jupiter:5.4.0')
+
+// JUnit Vintage
+    testCompileOnly('junit:junit:4.12')
+    testRuntimeOnly('org.junit.vintage:junit-vintage-engine:5.4.0')
 }
 
 // >>>>> processes profiles

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -67,6 +67,7 @@ public final class MessageConstants {
     public static final String ERROR_TEMPLATE_FOLDER_NAME_IS_EMPTY = "error.template.folder.name.empty";
     public static final String ERROR_FOLDER_INVALID_TEMPLATE = "error.folder.template.invalid";
     public static final String ERROR_FOLDER_INVALID_ID = "error.invalid.folder.id";
+    public static final String ERROR_FOLDER_INVALID_PATH = "error.invalid.folder.path";
 
     //Tools errors
     public static final String ERROR_TOOL_NOT_FOUND = "error.tool.not.found";
@@ -184,7 +185,6 @@ public final class MessageConstants {
     public static final String ERROR_DATASTORAGE_ILLEGAL_DURATION_COMBINATION =
             "error.datastorage.rule.illegal.duration.combination";
     public static final String ERROR_INVALID_CREDENTIALS_REQUEST = "error.datastorage.invalid.request";
-    public static final String ERROR_DATASTORAGE_FORBIDDEN_VERSION_WITH_FOLDER_RESTORE = "error.datastorage.forbidden.version.recursion";
     public static final String ERROR_DATASTORAGE_VERSIONING_REQUIRED = "error.datastorage.versioning.required";
     public static final String ERROR_DATASTORAGE_CREATE_FAILED = "error.datastorage.create.failed";
     public static final String ERROR_DATASTORAGE_DELETE_FAILED = "error.datastorage.delete.failed";

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -184,6 +184,7 @@ public final class MessageConstants {
     public static final String ERROR_DATASTORAGE_ILLEGAL_DURATION_COMBINATION =
             "error.datastorage.rule.illegal.duration.combination";
     public static final String ERROR_INVALID_CREDENTIALS_REQUEST = "error.datastorage.invalid.request";
+    public static final String ERROR_DATASTORAGE_FORBIDDEN_VERSION_WITH_RECURSION = "error.datastorage.forbidden.version.recursion";
     public static final String ERROR_DATASTORAGE_VERSIONING_REQUIRED = "error.datastorage.versioning.required";
     public static final String ERROR_DATASTORAGE_CREATE_FAILED = "error.datastorage.create.failed";
     public static final String ERROR_DATASTORAGE_DELETE_FAILED = "error.datastorage.delete.failed";

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -184,7 +184,7 @@ public final class MessageConstants {
     public static final String ERROR_DATASTORAGE_ILLEGAL_DURATION_COMBINATION =
             "error.datastorage.rule.illegal.duration.combination";
     public static final String ERROR_INVALID_CREDENTIALS_REQUEST = "error.datastorage.invalid.request";
-    public static final String ERROR_DATASTORAGE_FORBIDDEN_VERSION_WITH_RECURSION = "error.datastorage.forbidden.version.recursion";
+    public static final String ERROR_DATASTORAGE_FORBIDDEN_VERSION_WITH_FOLDER_RESTORE = "error.datastorage.forbidden.version.recursion";
     public static final String ERROR_DATASTORAGE_VERSIONING_REQUIRED = "error.datastorage.versioning.required";
     public static final String ERROR_DATASTORAGE_CREATE_FAILED = "error.datastorage.create.failed";
     public static final String ERROR_DATASTORAGE_DELETE_FAILED = "error.datastorage.delete.failed";

--- a/api/src/main/java/com/epam/pipeline/controller/datastorage/DataStorageController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/datastorage/DataStorageController.java
@@ -428,9 +428,25 @@ public class DataStorageController extends AbstractRestController {
     public Result restoreFileVersion(
             @PathVariable(value = ID) final Long id,
             @RequestParam(value = PATH) final String path,
-            @RequestParam(value = VERSION, required = false) final String version,
-            @RequestBody(required = false) RestoreFolderVO restoreFolderVO) {
-        dataStorageApiService.restoreFileVersion(id, path, version, restoreFolderVO);
+            @RequestParam(value = VERSION, required = false) final String version) {
+        dataStorageApiService.restoreFileVersion(id, path, version);
+        return Result.success();
+    }
+
+    @RequestMapping(value = "/datastorage/{id}/list/restore/folder", method = RequestMethod.POST)
+    @ResponseBody
+    @ApiOperation(
+            value = "Restores folder version.",
+            notes = "Restores folder version",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public Result restoreFolder(
+            @PathVariable(value = ID) final Long id,
+            @RequestParam(value = PATH) final String path,
+            @RequestBody final RestoreFolderVO restoreFolderVO) {
+        dataStorageApiService.restoreFolderVersion(id, path, restoreFolderVO);
         return Result.success();
     }
 

--- a/api/src/main/java/com/epam/pipeline/controller/datastorage/DataStorageController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/datastorage/DataStorageController.java
@@ -444,7 +444,7 @@ public class DataStorageController extends AbstractRestController {
             })
     public Result restoreFolder(
             @PathVariable(value = ID) final Long id,
-            @RequestParam(value = PATH) final String path,
+            @RequestParam(value = PATH, required = false) final String path,
             @RequestBody final RestoreFolderVO restoreFolderVO) {
         dataStorageApiService.restoreFolder(id, path, restoreFolderVO);
         return Result.success();

--- a/api/src/main/java/com/epam/pipeline/controller/datastorage/DataStorageController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/datastorage/DataStorageController.java
@@ -21,6 +21,7 @@ import com.epam.pipeline.controller.Result;
 import com.epam.pipeline.controller.vo.DataStorageVO;
 import com.epam.pipeline.controller.vo.GenerateDownloadUrlVO;
 import com.epam.pipeline.controller.vo.UploadFileMetadata;
+import com.epam.pipeline.controller.vo.data.storage.RestoreFolderVO;
 import com.epam.pipeline.controller.vo.data.storage.UpdateDataStorageItemVO;
 import com.epam.pipeline.controller.vo.security.EntityWithPermissionVO;
 import com.epam.pipeline.entity.SecuredEntityWithAction;
@@ -427,8 +428,9 @@ public class DataStorageController extends AbstractRestController {
     public Result restoreFileVersion(
             @PathVariable(value = ID) final Long id,
             @RequestParam(value = PATH) final String path,
-            @RequestParam(value = VERSION, required = false) final String version) {
-        dataStorageApiService.restoreFileVersion(id, path, version);
+            @RequestParam(value = VERSION, required = false) final String version,
+            @RequestBody(required = false) RestoreFolderVO restoreFolderVO) {
+        dataStorageApiService.restoreFileVersion(id, path, version, restoreFolderVO);
         return Result.success();
     }
 

--- a/api/src/main/java/com/epam/pipeline/controller/datastorage/DataStorageController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/datastorage/DataStorageController.java
@@ -446,7 +446,7 @@ public class DataStorageController extends AbstractRestController {
             @PathVariable(value = ID) final Long id,
             @RequestParam(value = PATH) final String path,
             @RequestBody final RestoreFolderVO restoreFolderVO) {
-        dataStorageApiService.restoreFolderVersion(id, path, restoreFolderVO);
+        dataStorageApiService.restoreFolder(id, path, restoreFolderVO);
         return Result.success();
     }
 

--- a/api/src/main/java/com/epam/pipeline/controller/datastorage/DataStorageController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/datastorage/DataStorageController.java
@@ -433,11 +433,11 @@ public class DataStorageController extends AbstractRestController {
         return Result.success();
     }
 
-    @RequestMapping(value = "/datastorage/{id}/list/restore/folder", method = RequestMethod.POST)
+    @PostMapping(value = "/datastorage/{id}/list/restore/folder")
     @ResponseBody
     @ApiOperation(
-            value = "Restores folder version.",
-            notes = "Restores folder version",
+            value = "Restores folder.",
+            notes = "Restores folder.",
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiResponses(
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)

--- a/api/src/main/java/com/epam/pipeline/controller/vo/data/storage/RestoreFolderVO.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/data/storage/RestoreFolderVO.java
@@ -9,9 +9,6 @@ import java.util.List;
 @Setter
 public class RestoreFolderVO {
     private boolean recursively;
-    private List<String> contentFilter;
-
-
-
-
+    private List<String> includeList;
+    private List<String> excludeList;
 }

--- a/api/src/main/java/com/epam/pipeline/controller/vo/data/storage/RestoreFolderVO.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/data/storage/RestoreFolderVO.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.epam.pipeline.controller.vo.data.storage;
 
 import lombok.Getter;

--- a/api/src/main/java/com/epam/pipeline/controller/vo/data/storage/RestoreFolderVO.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/data/storage/RestoreFolderVO.java
@@ -1,0 +1,17 @@
+package com.epam.pipeline.controller.vo.data.storage;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class RestoreFolderVO {
+    private boolean recursively;
+    private List<String> contentFilter;
+
+
+
+
+}

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageApiService.java
@@ -200,9 +200,15 @@ public class DataStorageApiService {
     }
 
     @PreAuthorize(STORAGE_ID_OWNER)
-    public void restoreFileVersion(Long id, String path, String version, RestoreFolderVO restoreFolderVO)
+    public void restoreFileVersion(Long id, String path, String version)
             throws DataStorageException {
-        dataStorageManager.restoreVersion(id, path, version, restoreFolderVO);
+        dataStorageManager.restoreFileVersion(id, path, version);
+    }
+
+    @PreAuthorize(STORAGE_ID_OWNER)
+    public void restoreFolderVersion(Long id, String path, RestoreFolderVO restoreFolderVO)
+            throws DataStorageException {
+        dataStorageManager.restoreFolderVersion(id, path, restoreFolderVO);
     }
 
     @PreAuthorize("hasRole('ADMIN') OR "

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageApiService.java
@@ -206,7 +206,7 @@ public class DataStorageApiService {
     }
 
     @PreAuthorize(STORAGE_ID_OWNER)
-    public void restoreFolder(Long id, String path, RestoreFolderVO restoreFolderVO)
+    public void restoreFolder(final Long id, final String path, final RestoreFolderVO restoreFolderVO)
             throws DataStorageException {
         dataStorageManager.restoreFolder(id, path, restoreFolderVO);
     }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageApiService.java
@@ -19,6 +19,7 @@ package com.epam.pipeline.manager.datastorage;
 import com.epam.pipeline.common.MessageConstants;
 import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.controller.vo.DataStorageVO;
+import com.epam.pipeline.controller.vo.data.storage.RestoreFolderVO;
 import com.epam.pipeline.controller.vo.data.storage.UpdateDataStorageItemVO;
 import com.epam.pipeline.controller.vo.security.EntityWithPermissionVO;
 import com.epam.pipeline.entity.SecuredEntityWithAction;
@@ -199,9 +200,9 @@ public class DataStorageApiService {
     }
 
     @PreAuthorize(STORAGE_ID_OWNER)
-    public void restoreFileVersion(Long id, String path, String version)
+    public void restoreFileVersion(Long id, String path, String version, RestoreFolderVO restoreFolderVO)
             throws DataStorageException {
-        dataStorageManager.restoreVersion(id, path, version);
+        dataStorageManager.restoreVersion(id, path, version, restoreFolderVO);
     }
 
     @PreAuthorize("hasRole('ADMIN') OR "

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageApiService.java
@@ -206,9 +206,9 @@ public class DataStorageApiService {
     }
 
     @PreAuthorize(STORAGE_ID_OWNER)
-    public void restoreFolderVersion(Long id, String path, RestoreFolderVO restoreFolderVO)
+    public void restoreFolder(Long id, String path, RestoreFolderVO restoreFolderVO)
             throws DataStorageException {
-        dataStorageManager.restoreFolderVersion(id, path, restoreFolderVO);
+        dataStorageManager.restoreFolder(id, path, restoreFolderVO);
     }
 
     @PreAuthorize("hasRole('ADMIN') OR "

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
@@ -83,7 +83,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -366,12 +365,12 @@ public class DataStorageManager implements SecuredEntityManager {
             throw new DataStorageException(messageHelper.getMessage(
                     MessageConstants.ERROR_DATASTORAGE_VERSIONING_REQUIRED, dataStorage.getName()));
         }
-        if (restoreFolderVO != null){
-            if (restoreFolderVO.isRecursively() && version != null) {
+        if (restoreFolderVO != null) {
+            if (version != null) {
                 throw new DataStorageException(messageHelper.getMessage(
-                        MessageConstants.ERROR_DATASTORAGE_FORBIDDEN_VERSION_WITH_RECURSION));
+                        MessageConstants.ERROR_DATASTORAGE_FORBIDDEN_VERSION_WITH_FOLDER_RESTORE, version));
             }
-            storageProviderManager.restoreFolderVersion(dataStorage, path, version, restoreFolderVO);
+            storageProviderManager.restoreFolderVersion(dataStorage, path, restoreFolderVO);
         } else {
             Assert.notNull(version, "Version is required to restore file version");
             storageProviderManager.restoreFileVersion(dataStorage, path, version);

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
@@ -369,14 +369,14 @@ public class DataStorageManager implements SecuredEntityManager {
         storageProviderManager.restoreFileVersion(dataStorage, path, version);
     }
 
-    public void restoreFolderVersion(Long id, String path, RestoreFolderVO restoreFolderVO) throws DataStorageException{
+    public void restoreFolder(Long id, String path, RestoreFolderVO restoreFolderVO) throws DataStorageException{
         Assert.notNull(path, "Path is required to restore folder");
         AbstractDataStorage dataStorage = load(id);
         if (!dataStorage.isVersioningEnabled()) {
             throw new DataStorageException(messageHelper.getMessage(
                     MessageConstants.ERROR_DATASTORAGE_VERSIONING_REQUIRED, dataStorage.getName()));
         }
-        storageProviderManager.restoreFolderVersion(dataStorage, path, restoreFolderVO);
+        storageProviderManager.restoreFolder(dataStorage, path, restoreFolderVO);
     }
 
     public DataStorageDownloadFileUrl generateDataStorageItemUrl(final Long dataStorageId,

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
@@ -371,7 +371,6 @@ public class DataStorageManager implements SecuredEntityManager {
 
     public void restoreFolder(final Long id, final String path, final RestoreFolderVO restoreFolderVO)
             throws DataStorageException{
-        Assert.notNull(path, "Path is required to restore folder");
         AbstractDataStorage dataStorage = load(id);
         if (!dataStorage.isVersioningEnabled()) {
             throw new DataStorageException(messageHelper.getMessage(

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
@@ -358,23 +358,25 @@ public class DataStorageManager implements SecuredEntityManager {
         return storageProviderManager.getItems(dataStorage, path, showVersion, pageSize, marker);
     }
 
-    public void restoreVersion(Long id, String path, String version, RestoreFolderVO restoreFolderVO) throws DataStorageException {
+    public void restoreFileVersion(Long id, String path, String version) throws DataStorageException {
         Assert.notNull(path, "Path is required to restore file version");
+        Assert.notNull(version, "Version is required to restore file version");
         AbstractDataStorage dataStorage = load(id);
         if (!dataStorage.isVersioningEnabled()) {
             throw new DataStorageException(messageHelper.getMessage(
                     MessageConstants.ERROR_DATASTORAGE_VERSIONING_REQUIRED, dataStorage.getName()));
         }
-        if (restoreFolderVO != null) {
-            if (version != null) {
-                throw new DataStorageException(messageHelper.getMessage(
-                        MessageConstants.ERROR_DATASTORAGE_FORBIDDEN_VERSION_WITH_FOLDER_RESTORE, version));
-            }
-            storageProviderManager.restoreFolderVersion(dataStorage, path, restoreFolderVO);
-        } else {
-            Assert.notNull(version, "Version is required to restore file version");
-            storageProviderManager.restoreFileVersion(dataStorage, path, version);
+        storageProviderManager.restoreFileVersion(dataStorage, path, version);
+    }
+
+    public void restoreFolderVersion(Long id, String path, RestoreFolderVO restoreFolderVO) throws DataStorageException{
+        Assert.notNull(path, "Path is required to restore folder");
+        AbstractDataStorage dataStorage = load(id);
+        if (!dataStorage.isVersioningEnabled()) {
+            throw new DataStorageException(messageHelper.getMessage(
+                    MessageConstants.ERROR_DATASTORAGE_VERSIONING_REQUIRED, dataStorage.getName()));
         }
+        storageProviderManager.restoreFolderVersion(dataStorage, path, restoreFolderVO);
     }
 
     public DataStorageDownloadFileUrl generateDataStorageItemUrl(final Long dataStorageId,

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
@@ -369,7 +369,8 @@ public class DataStorageManager implements SecuredEntityManager {
         storageProviderManager.restoreFileVersion(dataStorage, path, version);
     }
 
-    public void restoreFolder(Long id, String path, RestoreFolderVO restoreFolderVO) throws DataStorageException{
+    public void restoreFolder(final Long id, final String path, final RestoreFolderVO restoreFolderVO)
+            throws DataStorageException{
         Assert.notNull(path, "Path is required to restore folder");
         AbstractDataStorage dataStorage = load(id);
         if (!dataStorage.isVersioningEnabled()) {

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageProviderManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageProviderManager.java
@@ -96,9 +96,9 @@ public final class StorageProviderManager {
         getStorageProvider(dataStorage).restoreFileVersion(dataStorage, path, version);
     }
 
-    public void restoreFolderVersion(AbstractDataStorage dataStorage, String path, RestoreFolderVO restoreFolderVO)
+    public void restoreFolder(AbstractDataStorage dataStorage, String path, RestoreFolderVO restoreFolderVO)
             throws DataStorageException {
-        getStorageProvider(dataStorage).restoreFolderVersion(dataStorage, path, restoreFolderVO);
+        getStorageProvider(dataStorage).restoreFolder(dataStorage, path, restoreFolderVO);
     }
 
     public DataStorageListing getItems(AbstractDataStorage dataStorage, String path,

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageProviderManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageProviderManager.java
@@ -18,6 +18,7 @@ package com.epam.pipeline.manager.datastorage;
 
 import com.epam.pipeline.common.MessageConstants;
 import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.controller.vo.data.storage.RestoreFolderVO;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.ActionStatus;
 import com.epam.pipeline.entity.datastorage.DataStorageDownloadFileUrl;
@@ -93,6 +94,10 @@ public final class StorageProviderManager {
     public void restoreFileVersion(AbstractDataStorage dataStorage, String path, String version)
             throws DataStorageException {
         getStorageProvider(dataStorage).restoreFileVersion(dataStorage, path, version);
+    }
+    public void restoreFolderVersion(AbstractDataStorage dataStorage, String path, String version,
+                                     RestoreFolderVO restoreFolderVO) throws DataStorageException {
+        getStorageProvider(dataStorage).restoreFolderVersion(dataStorage, path, version, restoreFolderVO);
     }
 
     public DataStorageListing getItems(AbstractDataStorage dataStorage, String path,

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageProviderManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageProviderManager.java
@@ -96,8 +96,8 @@ public final class StorageProviderManager {
         getStorageProvider(dataStorage).restoreFileVersion(dataStorage, path, version);
     }
 
-    public void restoreFolder(AbstractDataStorage dataStorage, String path, RestoreFolderVO restoreFolderVO)
-            throws DataStorageException {
+    public void restoreFolder(final AbstractDataStorage dataStorage, final String path,
+                              final RestoreFolderVO restoreFolderVO) throws DataStorageException {
         getStorageProvider(dataStorage).restoreFolder(dataStorage, path, restoreFolderVO);
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageProviderManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageProviderManager.java
@@ -95,9 +95,9 @@ public final class StorageProviderManager {
             throws DataStorageException {
         getStorageProvider(dataStorage).restoreFileVersion(dataStorage, path, version);
     }
-    public void restoreFolderVersion(AbstractDataStorage dataStorage, String path, String version,
-                                     RestoreFolderVO restoreFolderVO) throws DataStorageException {
-        getStorageProvider(dataStorage).restoreFolderVersion(dataStorage, path, version, restoreFolderVO);
+    public void restoreFolderVersion(AbstractDataStorage dataStorage, String path, RestoreFolderVO restoreFolderVO)
+            throws DataStorageException {
+        getStorageProvider(dataStorage).restoreFolderVersion(dataStorage, path, restoreFolderVO);
     }
 
     public DataStorageListing getItems(AbstractDataStorage dataStorage, String path,

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageProviderManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageProviderManager.java
@@ -95,6 +95,7 @@ public final class StorageProviderManager {
             throws DataStorageException {
         getStorageProvider(dataStorage).restoreFileVersion(dataStorage, path, version);
     }
+
     public void restoreFolderVersion(AbstractDataStorage dataStorage, String path, RestoreFolderVO restoreFolderVO)
             throws DataStorageException {
         getStorageProvider(dataStorage).restoreFolderVersion(dataStorage, path, restoreFolderVO);

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/StorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/StorageProvider.java
@@ -49,8 +49,8 @@ public interface StorageProvider<T extends AbstractDataStorage> {
     void restoreFileVersion(T dataStorage, String path, String version)
             throws DataStorageException;
 
-    void restoreFolderVersion(T dataStorage, String path, String version,
-                              RestoreFolderVO restoreFolderVO) throws DataStorageException;
+    void restoreFolderVersion(T dataStorage, String path, RestoreFolderVO restoreFolderVO)
+            throws DataStorageException;
 
     DataStorageListing getItems(T dataStorage, String path,
             Boolean showVersion, Integer pageSize, String marker);

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/StorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/StorageProvider.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.util.Map;
 import java.util.Set;
 
+import com.epam.pipeline.controller.vo.data.storage.RestoreFolderVO;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.ActionStatus;
 import com.epam.pipeline.entity.datastorage.DataStorageDownloadFileUrl;
@@ -47,6 +48,9 @@ public interface StorageProvider<T extends AbstractDataStorage> {
 
     void restoreFileVersion(T dataStorage, String path, String version)
             throws DataStorageException;
+
+    void restoreFolderVersion(T dataStorage, String path, String version,
+                              RestoreFolderVO restoreFolderVO) throws DataStorageException;
 
     DataStorageListing getItems(T dataStorage, String path,
             Boolean showVersion, Integer pageSize, String marker);

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/StorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/StorageProvider.java
@@ -49,7 +49,7 @@ public interface StorageProvider<T extends AbstractDataStorage> {
     void restoreFileVersion(T dataStorage, String path, String version)
             throws DataStorageException;
 
-    void restoreFolderVersion(T dataStorage, String path, RestoreFolderVO restoreFolderVO)
+    void restoreFolder(T dataStorage, String path, RestoreFolderVO restoreFolderVO)
             throws DataStorageException;
 
     DataStorageListing getItems(T dataStorage, String path,

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3Helper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3Helper.java
@@ -108,7 +108,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TimeZone;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
@@ -345,14 +344,10 @@ public class S3Helper {
         final AntPathMatcher matcher = new AntPathMatcher();
         return item.getType() == DataStorageItemType.File &&
                 ((DataStorageFile) item).getDeleteMarker() &&
-                isFileFromRestoreList(restoreFolderVO.getIncludeList(),
-                        includePattern -> matcher.match(includePattern, item.getName())) &&
-                !isFileFromRestoreList(restoreFolderVO.getExcludeList(),
-                        excludePattern -> matcher.match(excludePattern, item.getName()));
-    }
-
-    private boolean isFileFromRestoreList(final List<String> includeOrExcludeList, final Predicate<String> pattern) {
-        return Optional.ofNullable(includeOrExcludeList).map(list -> list.stream().anyMatch(pattern)).orElse(true);
+                Optional.ofNullable(restoreFolderVO.getIncludeList()).map(includeList -> includeList.stream()
+                        .anyMatch(pattern -> matcher.match(pattern, item.getName()))).orElse(true) &&
+                Optional.ofNullable(restoreFolderVO.getExcludeList()).map(excludeList -> excludeList.stream()
+                        .noneMatch(pattern -> matcher.match(pattern, item.getName()))).orElse(true);
     }
 
     private void moveS3Object(final AmazonS3 client, final String bucket, final MoveObjectRequest moveRequest) {

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3Helper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3Helper.java
@@ -340,6 +340,7 @@ public class S3Helper {
         final AntPathMatcher matcher = new AntPathMatcher();
         return item.getType() == DataStorageItemType.File &&
                 ((DataStorageFile) item).getDeleteMarker() &&
+                ((DataStorageFile) item).getVersion() != null &&
                 Optional.ofNullable(restoreFolderVO.getIncludeList()).map(includeList -> includeList.stream()
                         .anyMatch(pattern -> matcher.match(pattern, item.getName()))).orElse(true) &&
                 Optional.ofNullable(restoreFolderVO.getExcludeList()).map(excludeList -> excludeList.stream()

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3Helper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3Helper.java
@@ -64,6 +64,7 @@ import com.amazonaws.waiters.Waiter;
 import com.amazonaws.waiters.WaiterParameters;
 import com.epam.pipeline.common.MessageConstants;
 import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.controller.vo.data.storage.RestoreFolderVO;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorageItem;
 import com.epam.pipeline.entity.datastorage.ActionStatus;
@@ -90,6 +91,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -298,6 +300,21 @@ public class S3Helper {
                     "file size exceeds the limit of %s bytes", path, version, COPYING_FILE_SIZE_LIMIT));
         }
         moveS3Object(client, bucket, new MoveObjectRequest(path, version, path));
+    }
+
+    public void restoreFolderVersion(String bucket, String path, String version, RestoreFolderVO restoreFolderVO) {
+        AmazonS3 client = getDefaultS3Client();
+//        if (fileSizeExceedsLimit(client, bucket, path, version)) {
+//            throw new DataStorageException(String.format("Restoring file '%s' version '%s' was aborted because " +
+//                    "file size exceeds the limit of %s bytes", path, version, COPYING_FILE_SIZE_LIMIT));
+//        }
+        List<AbstractDataStorageItem> dataStorageItems = getItems(bucket, path, false, null, null)
+                .getResults();
+        if (restoreFolderVO.isRecursively()) {
+
+        } else {
+            dataStorageItems.forEach(item -> moveS3Object(client, bucket, new MoveObjectRequest(path, version, item.getPath())));
+        }
     }
 
     private void moveS3Object(final AmazonS3 client, final String bucket, final MoveObjectRequest moveRequest) {

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3Helper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3Helper.java
@@ -306,14 +306,16 @@ public class S3Helper {
         AmazonS3 client = getDefaultS3Client();
         getDeletedItems(bucket, path, true, null, null, restoreFolderVO)
                 .forEach(item -> {
-                    Comparator<DataStorageFile> changedComparator = Comparator
-                            .comparing(DataStorageFile::getChanged, Comparator.reverseOrder());
-                    DataStorageFile file = (DataStorageFile) item;
-                    String lastVersion = file.getVersions().values().stream()
-                            .map(abstractDataStorageItem -> (DataStorageFile) abstractDataStorageItem)
-                            .sorted(changedComparator).skip(1).iterator().next()
-                            .getVersion();
-                    moveS3Object(client, bucket, new MoveObjectRequest(item.getPath(), lastVersion, item.getPath()));
+                    moveS3Object(client, bucket,
+                            new MoveObjectRequest(item.getPath(),
+                                    ((DataStorageFile) item).getVersions().values().stream()
+                                            .map(abstractDataStorageItem -> (DataStorageFile) abstractDataStorageItem)
+                                            .sorted(Comparator.comparing(DataStorageFile::getChanged, Comparator.reverseOrder()))
+                                            .skip(1).iterator().next()
+                                            .getVersion()
+                                    , item.getPath()
+                            )
+                    );
                 });
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3Helper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3Helper.java
@@ -321,7 +321,7 @@ public class S3Helper {
         listVersions(client, bucket, ProviderUtils.withTrailingDelimiter(path), null, null).getResults()
                 .forEach(item -> {
                     recursiveRestoreFolderCall(item, client, bucket, restoreFolderVO, deleter);
-                    if (isFileWithDeleteMarkerAndShouldBeRestore(item, restoreFolderVO)) {
+                    if (ProviderUtils.isFileWithDeleteMarkerAndShouldBeRestore(item, restoreFolderVO)) {
                         deleter.deleteKey(item.getPath(), ((DataStorageFile) item).getVersion());
                     }
                 });
@@ -333,18 +333,6 @@ public class S3Helper {
         if (item.getType() == DataStorageItemType.Folder && restoreFolderVO.isRecursively()) {
             cleanDeleteMarkers(client, bucket, item.getPath(), restoreFolderVO, deleter);
         }
-    }
-
-    private boolean isFileWithDeleteMarkerAndShouldBeRestore(final AbstractDataStorageItem item,
-                                                             final RestoreFolderVO restoreFolderVO) {
-        final AntPathMatcher matcher = new AntPathMatcher();
-        return item.getType() == DataStorageItemType.File &&
-                ((DataStorageFile) item).getDeleteMarker() &&
-                ((DataStorageFile) item).getVersion() != null &&
-                Optional.ofNullable(restoreFolderVO.getIncludeList()).map(includeList -> includeList.stream()
-                        .anyMatch(pattern -> matcher.match(pattern, item.getName()))).orElse(true) &&
-                Optional.ofNullable(restoreFolderVO.getExcludeList()).map(excludeList -> excludeList.stream()
-                        .noneMatch(pattern -> matcher.match(pattern, item.getName()))).orElse(true);
     }
 
     private void moveS3Object(final AmazonS3 client, final String bucket, final MoveObjectRequest moveRequest) {

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3Helper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3Helper.java
@@ -308,11 +308,10 @@ public class S3Helper {
         String requestPath = Optional.ofNullable(path).orElse("");
         if (!StringUtils.isNullOrEmpty(requestPath)) {
             Assert.isTrue(checkItemType(client, bucket, requestPath, true) == DataStorageItemType.Folder,
-                    messageHelper.getMessage(MessageConstants.ERROR_FOLDER_INVALID_PATH, path));
-            ProviderUtils.withTrailingDelimiter(requestPath);
+                    messageHelper.getMessage(MessageConstants.ERROR_FOLDER_INVALID_PATH, requestPath));
         }
         try (S3ObjectDeleter deleter = new S3ObjectDeleter(client, bucket)) {
-            restoreFolderFiles(client, bucket, path, restoreFolderVO, deleter);
+            restoreFolderFiles(client, bucket, requestPath, restoreFolderVO, deleter);
         } catch (SdkClientException e) {
             throw new DataStorageException(e.getMessage(), e.getCause());
         }
@@ -320,7 +319,7 @@ public class S3Helper {
 
     private void restoreFolderFiles(AmazonS3 client, String bucket, String path, RestoreFolderVO restoreFolderVO,
                                     S3ObjectDeleter deleter) {
-        getDeletedFiles(client, bucket, path, restoreFolderVO, deleter)
+        getDeletedFiles(client, bucket, ProviderUtils.withTrailingDelimiter(path), restoreFolderVO, deleter)
                 .forEach(item -> deleter.deleteKey(item.getPath(), ((DataStorageFile) item).getVersion()));
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3StorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3StorageProvider.java
@@ -118,7 +118,7 @@ public class S3StorageProvider implements StorageProvider<S3bucketDataStorage> {
     @Override
     public void restoreFolderVersion(S3bucketDataStorage dataStorage, String path, RestoreFolderVO restoreFolderVO)
             throws DataStorageException {
-        getS3Helper(dataStorage).restoreFolderVersion(dataStorage.getPath(), path, restoreFolderVO);
+        getS3Helper(dataStorage).restoreFolder(dataStorage.getPath(), path, restoreFolderVO);
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3StorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3StorageProvider.java
@@ -19,6 +19,7 @@ package com.epam.pipeline.manager.datastorage.providers.aws.s3;
 import com.amazonaws.services.s3.model.CORSRule;
 import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.config.JsonMapper;
+import com.epam.pipeline.controller.vo.data.storage.RestoreFolderVO;
 import com.epam.pipeline.entity.cluster.CloudRegionsConfiguration;
 import com.epam.pipeline.entity.datastorage.ActionStatus;
 import com.epam.pipeline.entity.datastorage.DataStorageDownloadFileUrl;
@@ -112,6 +113,12 @@ public class S3StorageProvider implements StorageProvider<S3bucketDataStorage> {
     @Override
     public void restoreFileVersion(S3bucketDataStorage dataStorage, String path, String version) {
         getS3Helper(dataStorage).restoreFileVersion(dataStorage.getPath(), path, version);
+    }
+
+    @Override
+    public void restoreFolderVersion(S3bucketDataStorage dataStorage, String path, String version,
+                                     RestoreFolderVO restoreFolderVO) throws DataStorageException {
+        getS3Helper(dataStorage).restoreFolderVersion(dataStorage.getPath(), path, version, restoreFolderVO);
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3StorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3StorageProvider.java
@@ -116,8 +116,8 @@ public class S3StorageProvider implements StorageProvider<S3bucketDataStorage> {
     }
 
     @Override
-    public void restoreFolder(S3bucketDataStorage dataStorage, String path, RestoreFolderVO restoreFolderVO)
-            throws DataStorageException {
+    public void restoreFolder(final S3bucketDataStorage dataStorage, final String path,
+                              final RestoreFolderVO restoreFolderVO) throws DataStorageException {
         getS3Helper(dataStorage).restoreFolder(dataStorage.getPath(), path, restoreFolderVO);
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3StorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3StorageProvider.java
@@ -116,9 +116,9 @@ public class S3StorageProvider implements StorageProvider<S3bucketDataStorage> {
     }
 
     @Override
-    public void restoreFolderVersion(S3bucketDataStorage dataStorage, String path, String version,
-                                     RestoreFolderVO restoreFolderVO) throws DataStorageException {
-        getS3Helper(dataStorage).restoreFolderVersion(dataStorage.getPath(), path, version, restoreFolderVO);
+    public void restoreFolderVersion(S3bucketDataStorage dataStorage, String path, RestoreFolderVO restoreFolderVO)
+            throws DataStorageException {
+        getS3Helper(dataStorage).restoreFolderVersion(dataStorage.getPath(), path, restoreFolderVO);
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3StorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3StorageProvider.java
@@ -116,7 +116,7 @@ public class S3StorageProvider implements StorageProvider<S3bucketDataStorage> {
     }
 
     @Override
-    public void restoreFolderVersion(S3bucketDataStorage dataStorage, String path, RestoreFolderVO restoreFolderVO)
+    public void restoreFolder(S3bucketDataStorage dataStorage, String path, RestoreFolderVO restoreFolderVO)
             throws DataStorageException {
         getS3Helper(dataStorage).restoreFolder(dataStorage.getPath(), path, restoreFolderVO);
     }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureBlobStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureBlobStorageProvider.java
@@ -84,7 +84,7 @@ public class AzureBlobStorageProvider implements StorageProvider<AzureBlobStorag
 
     @Override
     public void restoreFolder(final AzureBlobStorage dataStorage, final String path,
-                              RestoreFolderVO restoreFolderVO) {
+                              final RestoreFolderVO restoreFolderVO) {
         throw new UnsupportedOperationException();
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureBlobStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureBlobStorageProvider.java
@@ -83,8 +83,8 @@ public class AzureBlobStorageProvider implements StorageProvider<AzureBlobStorag
     }
 
     @Override
-    public void restoreFolderVersion(final AzureBlobStorage dataStorage, final String path,
-                                     RestoreFolderVO restoreFolderVO) {
+    public void restoreFolder(final AzureBlobStorage dataStorage, final String path,
+                              RestoreFolderVO restoreFolderVO) {
         throw new UnsupportedOperationException();
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureBlobStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureBlobStorageProvider.java
@@ -17,6 +17,7 @@
 package com.epam.pipeline.manager.datastorage.providers.azure;
 
 import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.controller.vo.data.storage.RestoreFolderVO;
 import com.epam.pipeline.entity.datastorage.ActionStatus;
 import com.epam.pipeline.entity.datastorage.DataStorageDownloadFileUrl;
 import com.epam.pipeline.entity.datastorage.DataStorageFile;
@@ -78,6 +79,12 @@ public class AzureBlobStorageProvider implements StorageProvider<AzureBlobStorag
 
     @Override
     public void restoreFileVersion(final AzureBlobStorage dataStorage, final String path, final String version) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void restoreFolderVersion(final AzureBlobStorage dataStorage, final String path, final String version,
+                                     RestoreFolderVO restoreFolderVO) {
         throw new UnsupportedOperationException();
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureBlobStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureBlobStorageProvider.java
@@ -83,7 +83,7 @@ public class AzureBlobStorageProvider implements StorageProvider<AzureBlobStorag
     }
 
     @Override
-    public void restoreFolderVersion(final AzureBlobStorage dataStorage, final String path, final String version,
+    public void restoreFolderVersion(final AzureBlobStorage dataStorage, final String path,
                                      RestoreFolderVO restoreFolderVO) {
         throw new UnsupportedOperationException();
     }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageProvider.java
@@ -88,7 +88,7 @@ public class GSBucketStorageProvider implements StorageProvider<GSBucketStorage>
 
     @Override
     public void restoreFolder(final GSBucketStorage dataStorage, final String path,
-                              RestoreFolderVO restoreFolderVO) throws DataStorageException {
+                              final RestoreFolderVO restoreFolderVO) throws DataStorageException {
         throw new UnsupportedOperationException();
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageProvider.java
@@ -17,6 +17,7 @@
 package com.epam.pipeline.manager.datastorage.providers.gcp;
 
 import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.controller.vo.data.storage.RestoreFolderVO;
 import com.epam.pipeline.entity.datastorage.ActionStatus;
 import com.epam.pipeline.entity.datastorage.DataStorageDownloadFileUrl;
 import com.epam.pipeline.entity.datastorage.DataStorageException;
@@ -83,6 +84,13 @@ public class GSBucketStorageProvider implements StorageProvider<GSBucketStorage>
     public void restoreFileVersion(final GSBucketStorage dataStorage, final String path, final String version)
             throws DataStorageException {
         getHelper(dataStorage).restoreFileVersion(dataStorage, path, version);
+    }
+
+    @Override
+    public void restoreFolderVersion(final GSBucketStorage dataStorage, final String path, final String version,
+                                     RestoreFolderVO restoreFolderVO)
+            throws DataStorageException {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageProvider.java
@@ -87,8 +87,8 @@ public class GSBucketStorageProvider implements StorageProvider<GSBucketStorage>
     }
 
     @Override
-    public void restoreFolderVersion(final GSBucketStorage dataStorage, final String path,
-                                     RestoreFolderVO restoreFolderVO) throws DataStorageException {
+    public void restoreFolder(final GSBucketStorage dataStorage, final String path,
+                              RestoreFolderVO restoreFolderVO) throws DataStorageException {
         throw new UnsupportedOperationException();
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageProvider.java
@@ -87,9 +87,8 @@ public class GSBucketStorageProvider implements StorageProvider<GSBucketStorage>
     }
 
     @Override
-    public void restoreFolderVersion(final GSBucketStorage dataStorage, final String path, final String version,
-                                     RestoreFolderVO restoreFolderVO)
-            throws DataStorageException {
+    public void restoreFolderVersion(final GSBucketStorage dataStorage, final String path,
+                                     RestoreFolderVO restoreFolderVO) throws DataStorageException {
         throw new UnsupportedOperationException();
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProvider.java
@@ -268,7 +268,7 @@ public class NFSStorageProvider implements StorageProvider<NFSDataStorage> {
     }
 
     @Override
-    public void restoreFolderVersion(NFSDataStorage dataStorage, String path, RestoreFolderVO restoreFolderVO)
+    public void restoreFolder(NFSDataStorage dataStorage, String path, RestoreFolderVO restoreFolderVO)
             throws DataStorageException {
         throw new UnsupportedOperationException();
     }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProvider.java
@@ -18,6 +18,7 @@ package com.epam.pipeline.manager.datastorage.providers.nfs;
 
 import com.epam.pipeline.common.MessageConstants;
 import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.controller.vo.data.storage.RestoreFolderVO;
 import com.epam.pipeline.dao.datastorage.DataStorageDao;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorageItem;
@@ -263,6 +264,13 @@ public class NFSStorageProvider implements StorageProvider<NFSDataStorage> {
     @Override
     public void restoreFileVersion(NFSDataStorage dataStorage, String path, String version)
         throws DataStorageException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void restoreFolderVersion(NFSDataStorage dataStorage, String path, String version,
+                                     RestoreFolderVO restoreFolderVO)
+            throws DataStorageException {
         throw new UnsupportedOperationException();
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProvider.java
@@ -268,8 +268,7 @@ public class NFSStorageProvider implements StorageProvider<NFSDataStorage> {
     }
 
     @Override
-    public void restoreFolderVersion(NFSDataStorage dataStorage, String path, String version,
-                                     RestoreFolderVO restoreFolderVO)
+    public void restoreFolderVersion(NFSDataStorage dataStorage, String path, RestoreFolderVO restoreFolderVO)
             throws DataStorageException {
         throw new UnsupportedOperationException();
     }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProvider.java
@@ -268,8 +268,8 @@ public class NFSStorageProvider implements StorageProvider<NFSDataStorage> {
     }
 
     @Override
-    public void restoreFolder(NFSDataStorage dataStorage, String path, RestoreFolderVO restoreFolderVO)
-            throws DataStorageException {
+    public void restoreFolder(final NFSDataStorage dataStorage, final String path,
+                              final RestoreFolderVO restoreFolderVO) throws DataStorageException {
         throw new UnsupportedOperationException();
     }
 

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -183,7 +183,7 @@ error.datastorage.rule.illegal.duration.combination=Long term duration must be g
   Provided STS value is ''{0}'', LTS value is ''{1}''.
 error.datastorage.invalid.request=At least one permission (READ or WRITE) must be requested.
 error.datastorage.versioning.required=Versioning is not enabled for storage: ''{0}''.
-error.datastorage.forbidden.version.recursion=Error: version cannot be applied with recursion: ''{0}'', simultaneously.
+error.datastorage.forbidden.version.recursion=Error: typed version: ''{0}'', can be applied only for file restoration.
 error.datastorage.create.failed=Failed to create a new storage: ''{0}''.
 error.datastorage.delete.failed=Failed to delete a storage: ''{0}''.
 error.datastorage.type.not.specified=Data Storage type is not specified for data storage ''{0}''.

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -183,6 +183,7 @@ error.datastorage.rule.illegal.duration.combination=Long term duration must be g
   Provided STS value is ''{0}'', LTS value is ''{1}''.
 error.datastorage.invalid.request=At least one permission (READ or WRITE) must be requested.
 error.datastorage.versioning.required=Versioning is not enabled for storage: ''{0}''.
+error.datastorage.forbidden.version.recursion=Error: version cannot be applied with recursion: ''{0}'', simultaneously.
 error.datastorage.create.failed=Failed to create a new storage: ''{0}''.
 error.datastorage.delete.failed=Failed to delete a storage: ''{0}''.
 error.datastorage.type.not.specified=Data Storage type is not specified for data storage ''{0}''.

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -74,6 +74,7 @@ error.template.folder.name.empty=Name is required to create a folder from templa
 error.folder.template.invalid=Failed to read folder template: ''{0}''.
 error.invalid.folder.name=Folder name ''{0}'' contains invalid characters.
 error.invalid.folder.id=Folder ids should be the same for all entities from the list.
+error.invalid.folder.path=Specified path ''{0}'' should be pointed at folder.
 
 # Pipeline runs
 error.wrong.run.status.update=Error: pipeline run stats cannot be updated to ''{0}''
@@ -183,7 +184,6 @@ error.datastorage.rule.illegal.duration.combination=Long term duration must be g
   Provided STS value is ''{0}'', LTS value is ''{1}''.
 error.datastorage.invalid.request=At least one permission (READ or WRITE) must be requested.
 error.datastorage.versioning.required=Versioning is not enabled for storage: ''{0}''.
-error.datastorage.forbidden.version.recursion=Error: typed version: ''{0}'', can be applied only for file restoration.
 error.datastorage.create.failed=Failed to create a new storage: ''{0}''.
 error.datastorage.delete.failed=Failed to delete a storage: ''{0}''.
 error.datastorage.type.not.specified=Data Storage type is not specified for data storage ''{0}''.

--- a/api/src/test/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3HelperTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3HelperTest.java
@@ -60,6 +60,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings({"unused", "PMD.TooManyStaticImports"})
 public class S3HelperTest {
 
     private static final String BUCKET = "bucket";
@@ -234,13 +235,6 @@ public class S3HelperTest {
                 Arguments.of(true, null, Collections.singletonList("*.jpg"), Collections.emptyMap())
         );
     }
-
-
-
-    public void testRestoreFolderShouldRestoreProperFiles() {
-
-    }
-
 
     @Test
     public void testMoveFolderShouldThrowIfAtLeastOneOfItsFilesSizeExceedTheLimit() {


### PR DESCRIPTION
This PR related to issue #792 

Now we can use POST /datastorage/{id}/list/restore to restore batches by specifying corresponded bucket id and folder path.
It is possible to restore batches recursively by setting recursion flag, and also use filters to set excluded and included files to restore.

Description:
The idea is to introduce new object-view RestoreFolderVO with simple content:
    -boolean recursively;
    -List<String> includeList;
    -List<String> excludeList;
by setting a **recursively** flag, we can indicate whether we want to restore files only in the current folder or in subfolders too. In its turn **includeList** and **excludeList** contains patterns used to specify recovery files and exclusions for recovery.
Details:
Not specifying RestoreFolderVO in **POST /datastorage/{id}/list/restore** method means that we want to use this method to  **File** restore.