### PR TITLE
Issue #808 : Content Disposition for S3 signed URLs

### DIFF
--- a/api/src/main/java/com/epam/pipeline/controller/datastorage/DataStorageController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/datastorage/DataStorageController.java
@@ -26,6 +26,7 @@ import com.epam.pipeline.controller.vo.security.EntityWithPermissionVO;
 import com.epam.pipeline.entity.SecuredEntityWithAction;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorageItem;
+import com.epam.pipeline.entity.datastorage.ContentDisposition;
 import com.epam.pipeline.entity.datastorage.DataStorageAction;
 import com.epam.pipeline.entity.datastorage.DataStorageDownloadFileUrl;
 import com.epam.pipeline.entity.datastorage.DataStorageException;
@@ -333,6 +334,26 @@ public class DataStorageController extends AbstractRestController {
         }
     }
 
+    @RequestMapping(value = "/datastorage/{id}/downloadRedirect", method = RequestMethod.GET)
+    @ApiOperation(
+            value = "Generates item's download url and redirect to it.",
+            notes = "Generates item's download url and redirect to it",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public String generateItemUrlAndRedirect(
+            @PathVariable(value = ID) final Long id,
+            @RequestParam(value = PATH) final String path,
+            @RequestParam(value = VERSION, required = false) final String version,
+            @RequestParam(required = false) final ContentDisposition contentDisposition) {
+        final DataStorageDownloadFileUrl url = StringUtils.hasText(version) ?
+                dataStorageApiService.generateDataStorageItemUrlOwner(id, path, version, contentDisposition) :
+                dataStorageApiService.generateDataStorageItemUrl(id, path, version, contentDisposition);
+        return String.format("redirect:%s", url.getUrl());
+    }
+
+
     @RequestMapping(value = "/datastorage/{id}/generateUrl", method = RequestMethod.GET)
     @ResponseBody
     @ApiOperation(
@@ -345,11 +366,14 @@ public class DataStorageController extends AbstractRestController {
     public Result<DataStorageDownloadFileUrl> generateDataStorageItemUrl(
             @PathVariable(value = ID) final Long id,
             @RequestParam(value = PATH) final String path,
-            @RequestParam(value = VERSION, required = false) final String version) {
+            @RequestParam(value = VERSION, required = false) final String version,
+            @RequestParam(required = false) final ContentDisposition contentDisposition) {
         if (StringUtils.hasText(version)) {
-            return Result.success(dataStorageApiService.generateDataStorageItemUrlOwner(id, path, version));
+            return Result.success(dataStorageApiService.generateDataStorageItemUrlOwner(id, path, version,
+                    contentDisposition));
         } else {
-            return Result.success(dataStorageApiService.generateDataStorageItemUrl(id, path, version));
+            return Result.success(dataStorageApiService.generateDataStorageItemUrl(id, path, version,
+                    contentDisposition));
         }
     }
 

--- a/api/src/main/java/com/epam/pipeline/entity/datastorage/ContentDisposition.java
+++ b/api/src/main/java/com/epam/pipeline/entity/datastorage/ContentDisposition.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.epam.pipeline.entity.datastorage;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.function.Function;
+
+@RequiredArgsConstructor
+public enum ContentDisposition {
+    INLINE(filename -> "inline"),
+    ATTACHMENT(filename -> String.format("attachment; filename=%s", filename));
+
+    private final Function<String, String> headerValueFunction;
+
+    public String getHeader(final String filename) {
+        return headerValueFunction.apply(filename);
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageApiService.java
@@ -24,6 +24,7 @@ import com.epam.pipeline.controller.vo.security.EntityWithPermissionVO;
 import com.epam.pipeline.entity.SecuredEntityWithAction;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorageItem;
+import com.epam.pipeline.entity.datastorage.ContentDisposition;
 import com.epam.pipeline.entity.datastorage.DataStorageAction;
 import com.epam.pipeline.entity.datastorage.DataStorageDownloadFileUrl;
 import com.epam.pipeline.entity.datastorage.DataStorageException;
@@ -172,14 +173,15 @@ public class DataStorageApiService {
 
     @PreAuthorize(STORAGE_ID_READ)
     public DataStorageDownloadFileUrl generateDataStorageItemUrl(final Long id, final String path,
-            String version) {
-        return dataStorageManager.generateDataStorageItemUrl(id, path, version);
+            String version, ContentDisposition contentDisposition) {
+        return dataStorageManager.generateDataStorageItemUrl(id, path, version, contentDisposition);
     }
 
     @PreAuthorize(STORAGE_ID_OWNER)
-    public DataStorageDownloadFileUrl generateDataStorageItemUrlOwner(Long id, String path,
-            String version) {
-        return dataStorageManager.generateDataStorageItemUrl(id, path, version);
+    public DataStorageDownloadFileUrl generateDataStorageItemUrlOwner(
+            Long id, String path,
+            String version, ContentDisposition contentDisposition) {
+        return dataStorageManager.generateDataStorageItemUrl(id, path, version, contentDisposition);
     }
 
     @PreAuthorize(STORAGE_ID_READ)

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
@@ -27,6 +27,7 @@ import com.epam.pipeline.entity.SecuredEntityWithAction;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorageFactory;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorageItem;
+import com.epam.pipeline.entity.datastorage.ContentDisposition;
 import com.epam.pipeline.entity.datastorage.DataStorageDownloadFileUrl;
 import com.epam.pipeline.entity.datastorage.DataStorageException;
 import com.epam.pipeline.entity.datastorage.DataStorageFile;
@@ -369,13 +370,13 @@ public class DataStorageManager implements SecuredEntityManager {
     }
 
     public DataStorageDownloadFileUrl generateDataStorageItemUrl(final Long dataStorageId,
-            final String path, String version) {
+            final String path, String version, ContentDisposition contentDisposition) {
         AbstractDataStorage dataStorage = load(dataStorageId);
         if (StringUtils.isNotBlank(version)) {
             Assert.isTrue(dataStorage.isVersioningEnabled(), messageHelper.getMessage(
                     MessageConstants.ERROR_DATASTORAGE_VERSIONING_REQUIRED, dataStorage.getName()));
         }
-        return storageProviderManager.generateDownloadURL(dataStorage, path, version);
+        return storageProviderManager.generateDownloadURL(dataStorage, path, version, contentDisposition);
     }
 
     public List<DataStorageDownloadFileUrl> generateDataStorageItemUrl(final Long dataStorageId,
@@ -385,7 +386,7 @@ public class DataStorageManager implements SecuredEntityManager {
         if (paths == null) {
             return urls;
         }
-        paths.forEach(path -> urls.add(storageProviderManager.generateDownloadURL(dataStorage, path, null)));
+        paths.forEach(path -> urls.add(storageProviderManager.generateDownloadURL(dataStorage, path, null, null)));
         return urls;
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageProviderManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageProviderManager.java
@@ -20,6 +20,7 @@ import com.epam.pipeline.common.MessageConstants;
 import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.ActionStatus;
+import com.epam.pipeline.entity.datastorage.ContentDisposition;
 import com.epam.pipeline.entity.datastorage.DataStorageDownloadFileUrl;
 import com.epam.pipeline.entity.datastorage.DataStorageException;
 import com.epam.pipeline.entity.datastorage.DataStorageFile;
@@ -101,8 +102,9 @@ public final class StorageProviderManager {
     }
 
     public DataStorageDownloadFileUrl generateDownloadURL(AbstractDataStorage dataStorage,
-            String path, String version) {
-        return getStorageProvider(dataStorage).generateDownloadURL(dataStorage, path, version);
+                                                          String path, String version,
+                                                          ContentDisposition contentDisposition) {
+        return getStorageProvider(dataStorage).generateDownloadURL(dataStorage, path, version, contentDisposition);
     }
 
     public DataStorageDownloadFileUrl generateDataStorageItemUploadUrl(AbstractDataStorage dataStorage,

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/StorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/StorageProvider.java
@@ -22,6 +22,7 @@ import java.util.Set;
 
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.ActionStatus;
+import com.epam.pipeline.entity.datastorage.ContentDisposition;
 import com.epam.pipeline.entity.datastorage.DataStorageDownloadFileUrl;
 import com.epam.pipeline.entity.datastorage.DataStorageException;
 import com.epam.pipeline.entity.datastorage.DataStorageFile;
@@ -51,7 +52,8 @@ public interface StorageProvider<T extends AbstractDataStorage> {
     DataStorageListing getItems(T dataStorage, String path,
             Boolean showVersion, Integer pageSize, String marker);
 
-    DataStorageDownloadFileUrl generateDownloadURL(T dataStorage, String path, String version);
+    DataStorageDownloadFileUrl generateDownloadURL(T dataStorage, String path, String version,
+                                                   ContentDisposition contentDisposition);
 
     DataStorageDownloadFileUrl generateDataStorageItemUploadUrl(T dataStorage, String path);
 

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3Helper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3Helper.java
@@ -42,6 +42,7 @@ import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.ObjectTagging;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.ResponseHeaderOverrides;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.services.s3.model.S3VersionSummary;
@@ -67,6 +68,7 @@ import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorageItem;
 import com.epam.pipeline.entity.datastorage.ActionStatus;
+import com.epam.pipeline.entity.datastorage.ContentDisposition;
 import com.epam.pipeline.entity.datastorage.DataStorageDownloadFileUrl;
 import com.epam.pipeline.entity.datastorage.DataStorageException;
 import com.epam.pipeline.entity.datastorage.DataStorageFile;
@@ -84,6 +86,7 @@ import com.epam.pipeline.utils.FileContentUtils;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.Assert;
@@ -333,12 +336,16 @@ public class S3Helper {
     }
 
     public DataStorageDownloadFileUrl generateDownloadURL(String bucket, String path,
-            String version) {
+                                                          String version, ContentDisposition contentDisposition) {
         AmazonS3 client = getDefaultS3Client();
         Date expires = new Date((new Date()).getTime() + URL_EXPIRATION);
         GeneratePresignedUrlRequest request = new GeneratePresignedUrlRequest(bucket, path);
         request.setVersionId(version);
         request.setExpiration(expires);
+        if (contentDisposition != null) {
+            request.setResponseHeaders(new ResponseHeaderOverrides()
+                    .withContentDisposition(contentDisposition.getHeader(FilenameUtils.getName(path))));
+        }
         return generatePresignedUrl(client, expires, request);
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3StorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3StorageProvider.java
@@ -21,6 +21,7 @@ import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.config.JsonMapper;
 import com.epam.pipeline.entity.cluster.CloudRegionsConfiguration;
 import com.epam.pipeline.entity.datastorage.ActionStatus;
+import com.epam.pipeline.entity.datastorage.ContentDisposition;
 import com.epam.pipeline.entity.datastorage.DataStorageDownloadFileUrl;
 import com.epam.pipeline.entity.datastorage.DataStorageException;
 import com.epam.pipeline.entity.datastorage.DataStorageFile;
@@ -132,8 +133,9 @@ public class S3StorageProvider implements StorageProvider<S3bucketDataStorage> {
     }
 
     @Override public DataStorageDownloadFileUrl generateDownloadURL(S3bucketDataStorage dataStorage,
-            String path, String version) {
-        return getS3Helper(dataStorage).generateDownloadURL(dataStorage.getPath(), path, version);
+                                                                    String path, String version,
+                                                                    ContentDisposition contentDisposition) {
+        return getS3Helper(dataStorage).generateDownloadURL(dataStorage.getPath(), path, version, contentDisposition);
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureBlobStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureBlobStorageProvider.java
@@ -18,6 +18,7 @@ package com.epam.pipeline.manager.datastorage.providers.azure;
 
 import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.entity.datastorage.ActionStatus;
+import com.epam.pipeline.entity.datastorage.ContentDisposition;
 import com.epam.pipeline.entity.datastorage.DataStorageDownloadFileUrl;
 import com.epam.pipeline.entity.datastorage.DataStorageFile;
 import com.epam.pipeline.entity.datastorage.DataStorageFolder;
@@ -90,7 +91,7 @@ public class AzureBlobStorageProvider implements StorageProvider<AzureBlobStorag
     @Override
     public DataStorageDownloadFileUrl generateDownloadURL(final AzureBlobStorage dataStorage,
                                                           final String path,
-                                                          final String version) {
+                                                          final String version, ContentDisposition contentDisposition) {
         final BlobSASPermission permission = new BlobSASPermission()
             .withRead(true)
             .withAdd(false)

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageProvider.java
@@ -18,6 +18,7 @@ package com.epam.pipeline.manager.datastorage.providers.gcp;
 
 import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.entity.datastorage.ActionStatus;
+import com.epam.pipeline.entity.datastorage.ContentDisposition;
 import com.epam.pipeline.entity.datastorage.DataStorageDownloadFileUrl;
 import com.epam.pipeline.entity.datastorage.DataStorageException;
 import com.epam.pipeline.entity.datastorage.DataStorageFile;
@@ -93,7 +94,7 @@ public class GSBucketStorageProvider implements StorageProvider<GSBucketStorage>
 
     @Override
     public DataStorageDownloadFileUrl generateDownloadURL(final GSBucketStorage dataStorage, final String path,
-                                                          final String version) {
+                                                          final String version, ContentDisposition contentDisposition) {
         return getHelper(dataStorage).generateDownloadUrl(dataStorage, path, version);
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProvider.java
@@ -22,6 +22,7 @@ import com.epam.pipeline.dao.datastorage.DataStorageDao;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorageItem;
 import com.epam.pipeline.entity.datastorage.ActionStatus;
+import com.epam.pipeline.entity.datastorage.ContentDisposition;
 import com.epam.pipeline.entity.datastorage.DataStorageDownloadFileUrl;
 import com.epam.pipeline.entity.datastorage.DataStorageException;
 import com.epam.pipeline.entity.datastorage.DataStorageFile;
@@ -318,7 +319,7 @@ public class NFSStorageProvider implements StorageProvider<NFSDataStorage> {
 
     @Override
     public DataStorageDownloadFileUrl generateDownloadURL(NFSDataStorage dataStorage, String path,
-                                                          String version) {
+                                                          String version, ContentDisposition contentDisposition) {
 
         String baseApiHostExternal = preferenceManager.getPreference(SystemPreferences.BASE_API_HOST_EXTERNAL);
         String baseApiHost = StringUtils.isNotBlank(baseApiHostExternal) ? baseApiHostExternal :


### PR DESCRIPTION
This PR provides server implementation for #808 

# Implementation

1. Method `GET /datastorage/{id}/generateUrl` now accepts optional parameter `contentDisposition` with two supported values: `INLINE`, `ATTACHMENT`
2. New method `GET /datastorage/{id}/downloadRedirect` is added, it works in the same way as `generateUrl` but as a result it redirects client to generated URL.