### PR TITLE
(issue #819) check that run contains CP_CAP_AUTOSCALE 

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
@@ -345,7 +345,7 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
     }
 
     private void performStop(PipelineRun run, double cpuUsageRate) {
-        if (run.isNonPause() || isClusterRun(run)) {
+        if (run.isNonPause() || run.isClusterRun()) {
             log.debug(messageHelper.getMessage(MessageConstants.DEBUG_RUN_IDLE_SKIP_CHECK, run.getPodId()));
             return;
         }
@@ -355,7 +355,7 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
     }
 
     private void performPause(PipelineRun run, double cpuUsageRate) {
-        if (run.isNonPause() || isClusterRun(run)) {
+        if (run.isNonPause() || run.isClusterRun()) {
             log.debug(messageHelper.getMessage(MessageConstants.DEBUG_RUN_IDLE_SKIP_CHECK, run.getPodId()));
             return;
         }
@@ -363,9 +363,5 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
         pipelineRunManager.pauseRun(run.getId(), true);
         notificationManager.notifyIdleRuns(Collections.singletonList(new ImmutablePair<>(run, cpuUsageRate)),
             NotificationType.IDLE_RUN_PAUSED);
-    }
-
-    private boolean isClusterRun(final PipelineRun run) {
-        return run.getNodeCount() != null && run.getNodeCount() != 0 || run.getParentRunId() != null;
     }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
@@ -52,6 +52,7 @@ public class PipelineRun extends AbstractSecuredEntity {
     public static final String PARAM_DELIMITER = "|";
     public static final String DEFAULT_PIPELINE_NAME = "pipeline";
     private static final Pattern PARAMS_REGEXP = Pattern.compile("([a-zA-Z0-9_]*=[a-zA-Z0-9_]*)");
+    public static final String GE_AUTOSCALING = "CP_CAP_AUTOSCALE";
 
     private Long pipelineId;
     private Date startDate;
@@ -125,6 +126,21 @@ public class PipelineRun extends AbstractSecuredEntity {
 
     public Boolean isTerminating() {
         return terminating;
+    }
+
+    public boolean isClusterRun() {
+                //master node of autoscale cluster
+        return this.hasBooleanParameter(GE_AUTOSCALING)
+                // master node
+                || this.getNodeCount() != null && this.getNodeCount() != 0
+                // worker node
+                || this.getParentRunId() != null;
+    }
+
+    private boolean hasBooleanParameter(String parameterName) {
+        return this.pipelineRunParameters.stream().anyMatch(p ->
+                p.getName().equals(parameterName) && p.getValue() != null
+                        && p.getValue().equalsIgnoreCase("true"));
     }
 
     public void convertParamsToString(Map<String, PipeConfValueVO> parameters) {

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.springframework.util.StringUtils;
 
@@ -138,9 +139,9 @@ public class PipelineRun extends AbstractSecuredEntity {
     }
 
     private boolean hasBooleanParameter(String parameterName) {
-        return this.pipelineRunParameters.stream().anyMatch(p ->
-                p.getName().equals(parameterName) && p.getValue() != null
-                        && p.getValue().equalsIgnoreCase("true"));
+        return CollectionUtils.emptyIfNull(this.pipelineRunParameters).stream()
+                .anyMatch(p -> p.getName().equals(parameterName) && p.getValue() != null
+                               && p.getValue().equalsIgnoreCase("true"));
     }
 
     public void convertParamsToString(Map<String, PipeConfValueVO> parameters) {


### PR DESCRIPTION
This PR relates to #819
Bug can be solved by adding check that run has `CP_CAP_AUTOSCALE` parameter to method `isClusterRun`. It means that run is a master for some autoscale cluster. 
I also did some refactoring to move method `isClusterRun` to `PipelineRun` class to be able to use it in other location for the future.