### PR TITLE
gui_issue-#794_incorrect behaviour while generating .docx, downloading .txt and double downloads was fixed

### DIFF
--- a/client/src/components/pipelines/version/documents/PipelineDocuments.js
+++ b/client/src/components/pipelines/version/documents/PipelineDocuments.js
@@ -258,7 +258,7 @@ export default class PipelineDocuments extends Component {
       let res;
       await pipelineFile.fetch();
       res = pipelineFile.response;
-      if (res.type.includes('application/json') && res instanceof Blob) {
+      if (res.type?.includes('application/json') && res instanceof Blob) {
         this.checkForBlobErrors(res)
           .then(error => error
             ? message.error('Error downloading file', 5)
@@ -301,7 +301,7 @@ export default class PipelineDocuments extends Component {
         }
       });
       res = pipelineGenerateFile.response;
-      if (res.type.includes('application/json') && res instanceof Blob) {
+      if (res.type?.includes('application/json') && res instanceof Blob) {
         this.checkForBlobErrors(res)
           .then(error => error
             ? message.error('Error generating document', 5)


### PR DESCRIPTION
### There was case with incorrect behavior of ```Generate``` or ```Download``` buttons  in ```"Documents" pipeline tab```.
- When you click ```Generate``` or ```Download``` button, docx/txt file will created and downloaded on PC. But if there is any errors occurred while file generation - this errors append  docx/txt document as content.
- When you click ```Generate``` or ```Download``` button - 2 files will simultaneously downloads (except .md files) because table row which contain buttons has its own onClick handler, as well as the buttons. When you click on button, it triggers button onclick handler, after that - event start propagate to row and triggers row onclick handler. And two files downloaded because of that.
This is due to the fact that in case of an error in the process of generating the document, we get an binary Blob object with the error text inside that object from which the docx/txt file is generated later

### This Pull Request partially ```(see issue comments)``` fixes this issues (#795)(#794)(#793) due to these issues are interconnected:

#### Improved error handling by:
- Added check if response data is Blob and has type field of 'application/json' when you click on ```Generate``` or ```Download``` button
- If so, we validate Blob object for errors in status field and if there is no errors, document proceed to generate docx/txt
- If Blob contains ```status = error``` - file prevented to be generated and downloaded. User will see warning popover instead.
- Otherwise, if response is not a blob or don't have field 'application/json' - validation are skipped and file generated

#### Double clicks are fixed by:
- Added ```event.stopPropagation()``` to ```downloadPipelineFile()``` method to prevent propagation of clicks from download button to table row, which have its own onClick handler, that triggers ```downloadPipelineFile()``` second time.
- Added check (is target type not a button) to table row onClick handler as well to prevent possible bugs, due to the fact, that each button in table row has it's own onClick handler.
- Applied small linter styling fixes to ```<PipelineDocuments>``` component.