### PR TITLE
gui_issue-#834_Inconvenient label wrap in Cluster nodes dashboard

### DIFF
--- a/client/src/components/cluster/Cluster.css
+++ b/client/src/components/cluster/Cluster.css
@@ -49,6 +49,7 @@
   margin-left: 1px;
   padding: 1px 3px;
   font-size: xx-small;
+  white-space: nowrap;
 }
 
 .node-label[data-run="true"] {
@@ -82,4 +83,3 @@
 .filter-actions-buttons-container {
   margin: 5px 10px;
 }
-

--- a/client/src/components/cluster/Cluster.css
+++ b/client/src/components/cluster/Cluster.css
@@ -9,6 +9,7 @@
 }
 
 .node-main-info {
+  word-break: break-all;
   font-size: 20px;
   font-weight: 600;
   margin-right: 10px;


### PR DESCRIPTION
### There was case with inconvenient behavior of ```labels``` on the ```"Cluster nodes"``` dashboard.
if the label does not fit into the width of available space, it breaks off and transferred to the next line, looking like these parts of label are two different labels.

### This Pull Request improve this behavior (issue #834) by:

* Added "white-space: nowrap" to label styles, to prevent them wrapping.