### PR TITLE
Issue #625 Allow create, update, delete schedules in batch mode.

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/run/RunScheduleApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/run/RunScheduleApiService.java
@@ -28,6 +28,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -37,20 +38,22 @@ public class RunScheduleApiService {
 
     @PreAuthorize(RUN_ID_EXECUTE)
     @AclMask
-    public RunSchedule createRunSchedule(final Long runId, final PipelineRunScheduleVO runScheduleVO) {
-        return runScheduleManager.createRunSchedule(runId, runScheduleVO);
+    public List<RunSchedule> createRunSchedules(final Long runId, final List<PipelineRunScheduleVO> runScheduleVOs) {
+        return runScheduleManager.createRunSchedules(runId, runScheduleVOs);
     }
 
     @PreAuthorize(RUN_ID_EXECUTE)
     @AclMask
-    public RunSchedule updateRunSchedule(final Long runId, final PipelineRunScheduleVO schedule) {
-        return runScheduleManager.updateRunSchedule(runId, schedule);
+    public List<RunSchedule> updateRunSchedules(final Long runId, final List<PipelineRunScheduleVO> schedules) {
+        return runScheduleManager.updateRunSchedules(runId, schedules);
     }
 
     @PreAuthorize(RUN_ID_EXECUTE)
     @AclMask
-    public RunSchedule deleteRunSchedule(final Long runId, final Long scheduleId) {
-        return runScheduleManager.deleteRunSchedule(runId, scheduleId);
+    public List<RunSchedule> deleteRunSchedule(final Long runId, final List<PipelineRunScheduleVO> schedules) {
+        final List<Long> scheduleIds =
+            schedules.stream().map(PipelineRunScheduleVO::getScheduleId).collect(Collectors.toList());
+        return runScheduleManager.deleteRunSchedules(runId, scheduleIds);
     }
 
     @PreAuthorize(RUN_ID_EXECUTE)

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -146,6 +146,7 @@ public final class MessageConstants {
     public static final String CRON_EXPRESSION_IS_NOT_PROVIDED = "cron.expression.is.not.provided";
     public static final String CRON_EXPRESSION_IS_NOT_VALID = "cron.expression.is.not.valid";
     public static final String CRON_EXPRESSION_ALREADY_EXISTS = "cron.expression.already.exists";
+    public static final String CRON_EXPRESSION_IDENTICAL = "cron.expression.identical";
     public static final String SCHEDULE_ACTION_IS_NOT_PROVIDED = "schedule.action.is.not.provided";
     public static final String ERROR_RUN_SCHEDULE_NOT_FOUND = "error.run.schedule.not.found";
     public static final String ERROR_TIME_ZONE_IS_NOT_PROVIDED = "error.time.zone.is.not.provided";

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunScheduleController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunScheduleController.java
@@ -45,11 +45,12 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PipelineRunScheduleController extends AbstractRestController {
 
-    private final RunScheduleApiService runScheduleApiService;
-
+    private static final String RUN_ID_PATH = "/{runId}";
     private static final String RUN_ID = "runId";
 
-    @PostMapping(value = "/{runId}")
+    private final RunScheduleApiService runScheduleApiService;
+
+    @PostMapping(value = RUN_ID_PATH)
     @ResponseBody
     @ApiOperation(
         value = "Creates pipeline run schedules.",
@@ -61,7 +62,7 @@ public class PipelineRunScheduleController extends AbstractRestController {
         return Result.success(runScheduleApiService.createRunSchedules(runId, schedules));
     }
 
-    @PutMapping(value = "/{runId}")
+    @PutMapping(value = RUN_ID_PATH)
     @ResponseBody
     @ApiOperation(
         value = "Updates pipeline run schedules.",
@@ -73,7 +74,7 @@ public class PipelineRunScheduleController extends AbstractRestController {
         return Result.success(runScheduleApiService.updateRunSchedules(runId, schedules));
     }
 
-    @GetMapping(value = "/{runId}")
+    @GetMapping(value = RUN_ID_PATH)
     @ResponseBody
     @ApiOperation(
         value = "Loads all schedules for a given pipeline run.",
@@ -84,7 +85,7 @@ public class PipelineRunScheduleController extends AbstractRestController {
         return Result.success(runScheduleApiService.loadAllRunSchedulesByRunId(runId));
     }
 
-    @DeleteMapping(value = "/{runId}")
+    @DeleteMapping(value = RUN_ID_PATH)
     @ResponseBody
     @ApiOperation(
         value = "Deletes given pipeline run schedules.",
@@ -96,7 +97,7 @@ public class PipelineRunScheduleController extends AbstractRestController {
         return Result.success(runScheduleApiService.deleteRunSchedule(runId, schedules));
     }
 
-    @DeleteMapping(value = "/{runId}/all")
+    @DeleteMapping(value = RUN_ID_PATH + "/all")
     @ResponseBody
     @ApiOperation(
         value = "Deletes all pipeline run's schedules.",

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunScheduleController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunScheduleController.java
@@ -52,25 +52,25 @@ public class PipelineRunScheduleController extends AbstractRestController {
     @PostMapping(value = "/{runId}")
     @ResponseBody
     @ApiOperation(
-        value = "Creates pipeline run schedule.",
-        notes = "Creates pipeline run schedule.",
+        value = "Creates pipeline run schedules.",
+        notes = "Creates pipeline run schedules.",
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
-    public Result<RunSchedule> createRunSchedule(@PathVariable(value = RUN_ID) final Long runId,
-                                                 @RequestBody final PipelineRunScheduleVO schedule) {
-        return Result.success(runScheduleApiService.createRunSchedule(runId, schedule));
+    public Result<List<RunSchedule>> createRunSchedule(@PathVariable(value = RUN_ID) final Long runId,
+                                                       @RequestBody final List<PipelineRunScheduleVO> schedules) {
+        return Result.success(runScheduleApiService.createRunSchedules(runId, schedules));
     }
 
     @PutMapping(value = "/{runId}")
     @ResponseBody
     @ApiOperation(
-        value = "Updates pipeline run schedule.",
-        notes = "Updates pipeline run schedule.",
+        value = "Updates pipeline run schedules.",
+        notes = "Updates pipeline run schedules.",
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
-    public Result<RunSchedule> updateRunSchedule(@PathVariable(value = RUN_ID) final Long runId,
-                                                 @RequestBody final PipelineRunScheduleVO schedule) {
-        return Result.success(runScheduleApiService.updateRunSchedule(runId, schedule));
+    public Result<List<RunSchedule>> updateRunSchedule(@PathVariable(value = RUN_ID) final Long runId,
+                                                       @RequestBody final List<PipelineRunScheduleVO> schedules) {
+        return Result.success(runScheduleApiService.updateRunSchedules(runId, schedules));
     }
 
     @GetMapping(value = "/{runId}")
@@ -87,13 +87,13 @@ public class PipelineRunScheduleController extends AbstractRestController {
     @DeleteMapping(value = "/{runId}")
     @ResponseBody
     @ApiOperation(
-        value = "Deletes given pipeline run schedule.",
-        notes = "Deletes given pipeline run schedule.",
+        value = "Deletes given pipeline run schedules.",
+        notes = "Deletes given pipeline run schedules.",
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
-    public Result<RunSchedule> deleteRunSchedule(@PathVariable(value = RUN_ID) final Long runId,
-                                                 @RequestBody final PipelineRunScheduleVO schedule) {
-        return Result.success(runScheduleApiService.deleteRunSchedule(runId, schedule.getScheduleId()));
+    public Result<List<RunSchedule>> deleteRunSchedule(@PathVariable(value = RUN_ID) final Long runId,
+                                                       @RequestBody final List<PipelineRunScheduleVO> schedules) {
+        return Result.success(runScheduleApiService.deleteRunSchedule(runId, schedules));
     }
 
     @DeleteMapping(value = "/{runId}/all")

--- a/api/src/main/resources/dao/pipeline-run-schedule-dao.xml
+++ b/api/src/main/resources/dao/pipeline-run-schedule-dao.xml
@@ -38,7 +38,8 @@
         <property name="deleteRunScheduleQuery">
             <value>
                 <![CDATA[
-                    DELETE FROM pipeline.run_schedule WHERE id = ?
+                    DELETE FROM pipeline.run_schedule
+                    WHERE id = :ID
                 ]]>
             </value>
         </property>

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -110,7 +110,8 @@ info.instance.started=Instance ''{0}'' successfully started.
 #Run schedule
 cron.expression.is.not.provided=Cron expression for pipeline run id ''{0}'' is not provided.
 cron.expression.is.not.valid=Cron expression for pipeline run id ''{0}'' is not valid.
-cron.expression.already.exists=Cron expression for pipeline run id ''{0}'' already exists.
+cron.expression.already.exists=Cron expression ''{0}'' for pipeline run id ''{1}'' exists already.
+cron.expression.identical=Check passed cron expressions, some of them are identical!
 schedule.action.is.not.provided=Schedule action for pipeline run id ''{0}'' is not provided.
 error.run.schedule.not.found=Run schedule with requested id: ''{0}'' was not found.
 error.time.zone.is.not.provided=Time zone for pipeline run id ''{0}'' is not provided.


### PR DESCRIPTION
Previously, we were able to add, update and delete schedules one-by-one only, this PR brings a batch operations support to reduce the amount of requests to services. Changes were made in PipelineRunScheduleController and underlaying services.