### PR TITLE
Enable multithreading for Pipe FUSE

### DIFF
--- a/pipe-cli/mount/pipe-fuse.py
+++ b/pipe-cli/mount/pipe-fuse.py
@@ -31,6 +31,7 @@ from pipefuse.api import CloudPipelineClient
 from pipefuse.webdav import CPWebDavClient
 from pipefuse.s3 import S3Client
 from pipefuse.pipefs import PipeFS
+from pipefuse.fslock import get_lock
 from fuse import FUSE
 
 _allowed_logging_level_names = logging._levelNames
@@ -67,7 +68,7 @@ def start(mountpoint, webdav, bucket, buffer_size, chunk_size, cache_ttl, cache_
     else:
         logging.info('Caching is disabled.')
     if buffer_size > 0:
-        client = BufferedFileSystemClient(client, capacity=buffer_size)
+        client = BufferedFileSystemClient(client, capacity=buffer_size, lock=get_lock(threading))
     else:
         logging.info('Buffering is disabled.')
     fs = PipeFS(client=client, mode=int(default_mode, 8))

--- a/pipe-cli/mount/pipe-fuse.py
+++ b/pipe-cli/mount/pipe-fuse.py
@@ -41,7 +41,7 @@ _default_logging_level = logging.ERROR
 
 
 def start(mountpoint, webdav, bucket, buffer_size, chunk_size, cache_ttl, cache_size, default_mode, mount_options=None,
-          threads=False):
+          threads=False, monitoring_delay=600):
     if mount_options is None:
         mount_options = {}
     try:
@@ -71,9 +71,8 @@ def start(mountpoint, webdav, bucket, buffer_size, chunk_size, cache_ttl, cache_
         client = BufferedFileSystemClient(client, capacity=buffer_size)
     else:
         logging.info('Buffering is disabled.')
-    fs = PipeFS(client=client, lock=get_lock(threads), mode=int(default_mode, 8))
-    FUSE(fs, mountpoint, nothreads=not threads, foreground=True, ro=client.is_read_only(), direct_io=True,
-         **mount_options)
+    fs = PipeFS(client=client, lock=get_lock(threads, monitoring_delay=monitoring_delay), mode=int(default_mode, 8))
+    FUSE(fs, mountpoint, nothreads=not threads, foreground=True, ro=client.is_read_only(), **mount_options)
 
 
 def parse_mount_options(options_string):
@@ -110,6 +109,8 @@ if __name__ == '__main__':
     parser.add_argument("-l", "--logging-level", type=str, required=False, default=_default_logging_level,
                         help="Logging level.")
     parser.add_argument("-th", "--threads", action='store_true', help="Enables multithreading.")
+    parser.add_argument("-d", "--monitoring-delay", type=int, required=False, default=600,
+                        help="Delay between path lock monitoring cycles.")
     args = parser.parse_args()
 
     if not args.webdav and not args.bucket:
@@ -124,7 +125,8 @@ if __name__ == '__main__':
     try:
         start(args.mountpoint, webdav=args.webdav, bucket=args.bucket, buffer_size=args.buffer_size,
               chunk_size=args.chunk_size, cache_ttl=args.cache_ttl, cache_size=args.cache_size, default_mode=args.mode,
-              mount_options=parse_mount_options(args.options), threads=args.threads)
+              mount_options=parse_mount_options(args.options), threads=args.threads,
+              monitoring_delay=args.monitoring_delay)
     except BaseException as e:
         logging.error('Unhandled error: %s' % e.message)
         sys.exit(1)

--- a/pipe-cli/mount/pipe-fuse.py
+++ b/pipe-cli/mount/pipe-fuse.py
@@ -41,7 +41,7 @@ _default_logging_level = logging.ERROR
 
 
 def start(mountpoint, webdav, bucket, buffer_size, chunk_size, cache_ttl, cache_size, default_mode, mount_options=None,
-          threading=False):
+          threads=False):
     if mount_options is None:
         mount_options = {}
     try:
@@ -68,11 +68,12 @@ def start(mountpoint, webdav, bucket, buffer_size, chunk_size, cache_ttl, cache_
     else:
         logging.info('Caching is disabled.')
     if buffer_size > 0:
-        client = BufferedFileSystemClient(client, capacity=buffer_size, lock=get_lock(threading))
+        client = BufferedFileSystemClient(client, capacity=buffer_size)
     else:
         logging.info('Buffering is disabled.')
-    fs = PipeFS(client=client, mode=int(default_mode, 8))
-    FUSE(fs, mountpoint, nothreads=not threading, foreground=True, ro=client.is_read_only(), **mount_options)
+    fs = PipeFS(client=client, lock=get_lock(threads), mode=int(default_mode, 8))
+    FUSE(fs, mountpoint, nothreads=not threads, foreground=True, ro=client.is_read_only(), direct_io=True,
+         **mount_options)
 
 
 def parse_mount_options(options_string):
@@ -108,7 +109,7 @@ if __name__ == '__main__':
                         help="String with mount options supported by FUSE")
     parser.add_argument("-l", "--logging-level", type=str, required=False, default=_default_logging_level,
                         help="Logging level.")
-    parser.add_argument("-th", "--threading", action='store_true', help="Enables multithreading.")
+    parser.add_argument("-th", "--threads", action='store_true', help="Enables multithreading.")
     args = parser.parse_args()
 
     if not args.webdav and not args.bucket:
@@ -123,7 +124,7 @@ if __name__ == '__main__':
     try:
         start(args.mountpoint, webdav=args.webdav, bucket=args.bucket, buffer_size=args.buffer_size,
               chunk_size=args.chunk_size, cache_ttl=args.cache_ttl, cache_size=args.cache_size, default_mode=args.mode,
-              mount_options=parse_mount_options(args.options), threading=args.threading)
+              mount_options=parse_mount_options(args.options), threads=args.threads)
     except BaseException as e:
         logging.error('Unhandled error: %s' % e.message)
         sys.exit(1)

--- a/pipe-cli/mount/pipe-fuse.py
+++ b/pipe-cli/mount/pipe-fuse.py
@@ -39,7 +39,8 @@ _allowed_logging_levels_string = ', '.join(_allowed_logging_levels)
 _default_logging_level = logging.ERROR
 
 
-def start(mountpoint, webdav, bucket, buffer_size, chunk_size, cache_ttl, cache_size, default_mode, mount_options=None):
+def start(mountpoint, webdav, bucket, buffer_size, chunk_size, cache_ttl, cache_size, default_mode, mount_options=None,
+          threading=False):
     if mount_options is None:
         mount_options = {}
     try:
@@ -70,7 +71,7 @@ def start(mountpoint, webdav, bucket, buffer_size, chunk_size, cache_ttl, cache_
     else:
         logging.info('Buffering is disabled.')
     fs = PipeFS(client=client, mode=int(default_mode, 8))
-    FUSE(fs, mountpoint, nothreads=True, foreground=True, ro=client.is_read_only(), **mount_options)
+    FUSE(fs, mountpoint, nothreads=not threading, foreground=True, ro=client.is_read_only(), **mount_options)
 
 
 def parse_mount_options(options_string):
@@ -106,6 +107,7 @@ if __name__ == '__main__':
                         help="String with mount options supported by FUSE")
     parser.add_argument("-l", "--logging-level", type=str, required=False, default=_default_logging_level,
                         help="Logging level.")
+    parser.add_argument("-th", "--threading", action='store_true', help="Enables multithreading.")
     args = parser.parse_args()
 
     if not args.webdav and not args.bucket:
@@ -120,7 +122,7 @@ if __name__ == '__main__':
     try:
         start(args.mountpoint, webdav=args.webdav, bucket=args.bucket, buffer_size=args.buffer_size,
               chunk_size=args.chunk_size, cache_ttl=args.cache_ttl, cache_size=args.cache_size, default_mode=args.mode,
-              mount_options=parse_mount_options(args.options))
+              mount_options=parse_mount_options(args.options), threading=args.threading)
     except BaseException as e:
         logging.error('Unhandled error: %s' % e.message)
         sys.exit(1)

--- a/pipe-cli/mount/pipefuse/buff.py
+++ b/pipe-cli/mount/pipefuse/buff.py
@@ -105,7 +105,7 @@ class BufferedFileSystemClient(FileSystemClient):
 
     _READ_AHEAD_SIZE = 20 * MB
 
-    def __init__(self, inner, capacity, lock):
+    def __init__(self, inner, capacity):
         """
         Buffering file system client decorator.
 
@@ -116,7 +116,6 @@ class BufferedFileSystemClient(FileSystemClient):
         """
         self._inner = inner
         self._capacity = capacity
-        self._lock = lock
         self._write_file_buffs = {}
         self._read_file_buffs = {}
 
@@ -140,67 +139,37 @@ class BufferedFileSystemClient(FileSystemClient):
         return self._inner.ls(path, depth)
 
     def upload(self, buf, path):
-        logging.error("upload")
-        try:
-            self._lock.lock(path)
-            self._inner.upload(buf, path)
-        finally:
-            self._lock.unlock(path)
+        self._inner.upload(buf, path)
 
     def delete(self, path):
-        logging.error("delete")
-        try:
-            self._lock.lock(path)
-            self._inner.delete(path)
-        finally:
-            self._lock.unlock(path)
+        self._inner.delete(path)
 
     def mv(self, old_path, path):
-        logging.error("mv")
-        try:
-            self._lock.lock(path)
-            self._inner.mv(old_path, path)
-        finally:
-            self._lock.unlock(path)
+        self._inner.mv(old_path, path)
 
     def mkdir(self, path):
-        logging.error("mkdir")
-        try:
-            self._lock.lock(path)
-            self._inner.mkdir(path)
-        finally:
-            self._lock.unlock(path)
+        self._inner.mkdir(path)
 
     def rmdir(self, path):
-        logging.error("rmdir")
-        try:
-            self._lock.lock(path)
-            self._inner.rmdir(path)
-        finally:
-            self._lock.unlock(path)
+        self._inner.rmdir(path)
 
     def download_range(self, fh, buf, path, offset=0, length=0):
-        logging.error("download_range")
-        try:
-            self._lock.lock(path)
-            buf_key = fh, path
-            file_buf = self._read_file_buffs.get(buf_key)
-            if not file_buf:
-                file_size = self.attrs(path).size
-                if not file_size:
-                    return
-                file_buf = self._new_read_buf(fh, path, file_size, offset)
-                self._read_file_buffs[buf_key] = file_buf
+        buf_key = fh, path
+        file_buf = self._read_file_buffs.get(buf_key)
+        if not file_buf:
+            file_size = self.attrs(path).size
+            if not file_size:
+                return
+            file_buf = self._new_read_buf(fh, path, file_size, offset)
+            self._read_file_buffs[buf_key] = file_buf
+        if not file_buf.suits(offset, length):
+            if file_buf.offset < file_buf.capacity:
+                file_buf.append(self._read_ahead(fh, path, file_buf.offset))
+                file_buf.shrink()
             if not file_buf.suits(offset, length):
-                if file_buf.offset < file_buf.capacity:
-                    file_buf.append(self._read_ahead(fh, path, file_buf.offset))
-                    file_buf.shrink()
-                if not file_buf.suits(offset, length):
-                    file_buf = self._new_read_buf(fh, path, file_buf.capacity, offset)
-                    self._read_file_buffs[buf_key] = file_buf
-            buf.write(file_buf.view(offset, length))
-        finally:
-            self._lock.unlock(path)
+                file_buf = self._new_read_buf(fh, path, file_buf.capacity, offset)
+                self._read_file_buffs[buf_key] = file_buf
+        buf.write(file_buf.view(offset, length))
 
     def _new_read_buf(self, fh, path, file_size, offset):
         file_buf = _ReadBuffer(offset, file_size)
@@ -213,28 +182,23 @@ class BufferedFileSystemClient(FileSystemClient):
             return read_ahead_buf.getvalue()
 
     def upload_range(self, fh, buf, path, offset=0):
-        logging.error("upload_range")
-        try:
-            self._lock.lock(path)
-            logging.debug('Uploading range %d-%d for %d:%s' % (offset, offset + len(buf), fh, path))
-            file_buf = self._write_file_buffs.get(path)
-            if not file_buf:
-                file_buf = self._new_write_buf(self._capacity, offset)
-                self._write_file_buffs[path] = file_buf
-            if file_buf.suits(offset):
-                file_buf.append(buf)
-            else:
-                logging.info('Uploading buffer is not sequential for %s. Buffer will be cleared.' % path)
-                old_file_buf = self._flush_write_buf(fh, path)
-                file_buf = self._new_write_buf(self._capacity, offset, buf, old_file_buf)
-                self._write_file_buffs[path] = file_buf
-            if file_buf.is_full():
-                logging.info('Uploading buffer is full for %s. Buffer will be cleared.' % path)
-                self._flush_write_buf(fh, path)
-                file_buf = self._new_write_buf(self._capacity, file_buf.offset, buf=None, old_write_buf=file_buf)
-                self._write_file_buffs[path] = file_buf
-        finally:
-            self._lock.unlock(path)
+        logging.debug('Uploading range %d-%d for %d:%s' % (offset, offset + len(buf), fh, path))
+        file_buf = self._write_file_buffs.get(path)
+        if not file_buf:
+            file_buf = self._new_write_buf(self._capacity, offset)
+            self._write_file_buffs[path] = file_buf
+        if file_buf.suits(offset):
+            file_buf.append(buf)
+        else:
+            logging.info('Uploading buffer is not sequential for %s. Buffer will be cleared.' % path)
+            old_file_buf = self._flush_write_buf(fh, path)
+            file_buf = self._new_write_buf(self._capacity, offset, buf, old_file_buf)
+            self._write_file_buffs[path] = file_buf
+        if file_buf.is_full():
+            logging.info('Uploading buffer is full for %s. Buffer will be cleared.' % path)
+            self._flush_write_buf(fh, path)
+            file_buf = self._new_write_buf(self._capacity, file_buf.offset, buf=None, old_write_buf=file_buf)
+            self._write_file_buffs[path] = file_buf
 
     def _new_write_buf(self, capacity, offset, buf=None, old_write_buf=None):
         write_buf = _WriteBuffer(offset, capacity, inherited_size=old_write_buf.inherited_size if old_write_buf else 0)
@@ -251,15 +215,10 @@ class BufferedFileSystemClient(FileSystemClient):
         return write_buf
 
     def flush(self, fh, path):
-        logging.error("flush")
-        try:
-            self._lock.lock(path)
-            logging.info('Flushing buffers for %d:%s' % (fh, path))
-            self._flush_read_buf(fh, path)
-            self._flush_write_buf(fh, path)
-            self._inner.flush(fh, path)
-        finally:
-            self._lock.unlock(path)
+        logging.info('Flushing buffers for %d:%s' % (fh, path))
+        self._flush_read_buf(fh, path)
+        self._flush_write_buf(fh, path)
+        self._inner.flush(fh, path)
 
     def _flush_read_buf(self, fh, path):
         return self._read_file_buffs.pop((fh, path), None)

--- a/pipe-cli/mount/pipefuse/fslock.py
+++ b/pipe-cli/mount/pipefuse/fslock.py
@@ -1,0 +1,81 @@
+# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from abc import ABCMeta, abstractmethod
+from threading import RLock
+
+
+def get_lock(threading):
+    return PathLock() if threading else DummyLock()
+
+
+class FileSystemLock:
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def lock(self, path):
+        pass
+
+    @abstractmethod
+    def unlock(self, path):
+        pass
+
+
+class DummyLock(FileSystemLock):
+
+    def lock(self, path):
+        pass
+
+    def unlock(self, path):
+        pass
+
+
+class PathLock(FileSystemLock):
+
+    def __init__(self):
+        self.mutex = RLock()
+        self.__locks = {}
+
+    def lock(self, path):
+        logging.error('Locking path %s' % path)
+        try:
+            self.mutex.acquire()
+            if path not in self.__locks:
+                self.__locks[path] = RLock()
+                logging.error('Created new lock for %s' % path)
+        finally:
+            self.mutex.release()
+
+        try:
+            self.__locks[path].acquire()
+            logging.error('Acquired lock for %s' % path)
+        except:
+            self.__locks[path].release()
+            raise
+        logging.error('Finished locking for %s' % path)
+
+    def unlock(self, path):
+        logging.error('Unlocking path %s' % path)
+        try:
+            self.mutex.acquire()
+            if path not in self.__locks:
+                logging.error('Cannot release non-existing lock.')
+            else:
+                self.__locks[path].release()
+                logging.error('Released lock for %s' % path)
+        finally:
+            self.mutex.release()
+            logging.error('Finished unlocking for %s' % path)
+

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -965,9 +965,9 @@ def storage_delete_object_tags(path, tags, version):
 @click.option('-o', '--options', required=False, help='Specify mount options')
 @click.option('-l', '--log-file', required=False, help='Specify log file for mount operation')
 @click.option('-q', '--quiet', help='Quiet mode', is_flag=True)
-@click.option('-t', '--threading', help='Enables multithreading', is_flag=True)
+@click.option('-t', '--threads', help='Enables multithreading', is_flag=True)
 @Config.validate_access_token
-def mount_storage(mountpoint, file, bucket, options, log_file, quiet, threading):
+def mount_storage(mountpoint, file, bucket, options, log_file, quiet, threads):
     """ Mounts either all available file systems or a single bucket into a local folder.
         Either -f\\--file flag or -b\\--bucket argument should be specified.
         Command is supported for Linux distributions and MacOS and requires
@@ -978,7 +978,7 @@ def mount_storage(mountpoint, file, bucket, options, log_file, quiet, threading)
         - options - any mount options supported by underlying FUSE implementation.
     """
     DataStorageOperations.mount_storage(mountpoint, file=file, log_file=log_file,
-                                        bucket=bucket, options=options, quiet=quiet, threading=threading)
+                                        bucket=bucket, options=options, quiet=quiet, threading=threads)
 
 
 @storage.command('umount')

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -965,8 +965,9 @@ def storage_delete_object_tags(path, tags, version):
 @click.option('-o', '--options', required=False, help='Specify mount options')
 @click.option('-l', '--log-file', required=False, help='Specify log file for mount operation')
 @click.option('-q', '--quiet', help='Quiet mode', is_flag=True)
+@click.option('-t', '--threading', help='Enables multithreading', is_flag=True)
 @Config.validate_access_token
-def mount_storage(mountpoint, file, bucket, options, log_file, quiet):
+def mount_storage(mountpoint, file, bucket, options, log_file, quiet, threading):
     """ Mounts either all available file systems or a single bucket into a local folder.
         Either -f\\--file flag or -b\\--bucket argument should be specified.
         Command is supported for Linux distributions and MacOS and requires
@@ -977,7 +978,7 @@ def mount_storage(mountpoint, file, bucket, options, log_file, quiet):
         - options - any mount options supported by underlying FUSE implementation.
     """
     DataStorageOperations.mount_storage(mountpoint, file=file, log_file=log_file,
-                                        bucket=bucket, options=options, quiet=quiet)
+                                        bucket=bucket, options=options, quiet=quiet, threading=threading)
 
 
 @storage.command('umount')
@@ -1139,3 +1140,6 @@ def update_cli_version(path):
 # Used to run a PyInstaller "freezed" version
 if getattr(sys, 'frozen', False):
     cli(sys.argv[1:])
+
+if __name__ == '__main__':
+    mount_storage()

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1140,6 +1140,3 @@ def update_cli_version(path):
 # Used to run a PyInstaller "freezed" version
 if getattr(sys, 'frozen', False):
     cli(sys.argv[1:])
-
-if __name__ == '__main__':
-    mount_storage()

--- a/pipe-cli/src/utilities/datastorage_operations.py
+++ b/pipe-cli/src/utilities/datastorage_operations.py
@@ -450,14 +450,16 @@ class DataStorageOperations(object):
                 yield ('File', os.path.join(source_path, path), path, size)
 
     @classmethod
-    def mount_storage(cls, mountpoint, file=False, bucket=None, log_file=None, options=None, quiet=False):
+    def mount_storage(cls, mountpoint, file=False, bucket=None, log_file=None, options=None, quiet=False,
+                      threading=False):
         try:
             if not file and not bucket:
                 click.echo('Either file system mode should be enabled (-f/--file) '
                            'or bucket name should be specified (-b/--bucket BUCKET).', err=True)
                 sys.exit(1)
             cls.check_platform("mount")
-            Mount().mount_storages(mountpoint, file, bucket, options, quiet=quiet, log_file=log_file)
+            Mount().mount_storages(mountpoint, file, bucket, options, quiet=quiet, log_file=log_file,
+                                   threading=threading)
         except ALL_ERRORS as error:
             click.echo('Error: %s' % str(error), err=True)
             sys.exit(1)

--- a/pipe-cli/src/utilities/storage/mount.py
+++ b/pipe-cli/src/utilities/storage/mount.py
@@ -52,7 +52,7 @@ class FrozenMount(AbstractMount):
         return self._get_mount_cmd(config, mountpoint, options, additional_args)
 
     def _append_threading(self, args, threading):
-        return args + ' --threading' if threading else args
+        return args + ' --threads' if threading else args
 
     def _get_mount_cmd(self, config, mountpoint, options, additional_arguments):
         mount_bin = self.get_mount_executable(config)
@@ -108,7 +108,7 @@ class SourceMount(AbstractMount):
 
     def _append_threading(self, args, threading):
         if threading:
-            args.append('--threading')
+            args.append('--threads')
         return args
 
     def _get_mount_cmd(self, config, mountpoint, options, additional_arguments):


### PR DESCRIPTION
This PR provides implementation for issue #822 .
A new flag `-t/--threads` was added to `pipe storage mount` command.  When this flag is specified Pipe FUSE will start with enabled multithreading feature.