### PR TITLE
gui_issue-#747_Inconvenient pipeline info layout in Library dashboard

### DIFF
--- a/client/src/components/cluster/Cluster.css
+++ b/client/src/components/cluster/Cluster.css
@@ -30,6 +30,13 @@
 .cluster-node-row-addresses,
 .cluster-node-row-created {
   cursor: pointer;
+  min-width: 100px;
+}
+
+thead[class*="ant-table-thead"] .cluster-node-row-created,
+thead[class*="ant-table-thead"] .cluster-node-row-addresses,
+thead[class*="ant-table-thead"] .cluster-node-row-pipeline {
+  word-break: break-word;
 }
 
 @keyframes logo-spin {

--- a/client/src/components/pipelines/browser/Browser.css
+++ b/client/src/components/pipelines/browser/Browser.css
@@ -21,8 +21,13 @@ th.metadata-column-value {
 
 .tree-item-name {
   cursor: pointer;
-  width: 100px;
+  min-width: 150px;
+  word-break: break-word !important;
+}
+
+.tree-item-version {
   white-space: nowrap;
+  min-width: max-content;
 }
 
 .metadata-folder-item-name {
@@ -62,7 +67,7 @@ th.metadata-column-value {
 
 .tree-item-actions {
   cursor: pointer;
-  width: 200px;
+  min-width: min-content;
 }
 
 .folder-tree-item-actions {
@@ -564,4 +569,10 @@ tr.table-row-selected {
   background-color: #fff;
   border-color: #108ee9;
   text-decoration: none;
+}
+
+@media screen and (max-width: 1280px) {
+  .tree-item-name {
+    min-width: 100px;
+  }
 }

--- a/client/src/components/pipelines/browser/Browser.css
+++ b/client/src/components/pipelines/browser/Browser.css
@@ -22,7 +22,11 @@ th.metadata-column-value {
 .tree-item-name {
   cursor: pointer;
   min-width: 150px;
-  word-break: break-word !important;
+  max-width: 200px;
+}
+
+tbody[class*="ant-table-tbody"] .tree-item-name {
+  word-break: break-word;
 }
 
 .tree-item-version {

--- a/client/src/components/pipelines/browser/Pipeline.js
+++ b/client/src/components/pipelines/browser/Pipeline.js
@@ -116,7 +116,7 @@ export default class Pipeline extends localization.LocalizedReactComponent {
       dataIndex: 'name',
       key: 'name',
       title: 'Name',
-      className: `${styles.treeItemName} ${styles.treeItemNoWrap}`,
+      className: `${styles.treeItemName} ${styles.treeItemVersion}`,
       render: this.renderTreeItemText,
       onCellClick: (item) => this.navigate(item)
     },
@@ -130,7 +130,7 @@ export default class Pipeline extends localization.LocalizedReactComponent {
     {
       dataIndex: 'createdDate',
       key: 'createdDate',
-      className: `${styles.treeItemName} ${styles.treeItemNoWrap}`,
+      className: `${styles.treeItemName}`,
       render: (text, item) => {
         return this.renderTreeItemText(
           <span>


### PR DESCRIPTION
### There was case (#747) with inconvenient behavior of table layout in ```"Library dashboard"``` and ```"Cluster dashboard"```.
-  ```"Library dashboard":``` When you open```Issues``` and ```Attributes``` panels, table cells are reduced to minimum values. For some cells this width can reach several characters length, depending on the screen resolution.
- ```"Cluster dashboard":``` on some cells width can reach several characters length, depending on the screen resolution.

### This Pull Request fixes this issue (#747) by:

- Changed width and word-break rules of cells for better space allocation in ```cluster.css``` and ```browser.css```.
- Added ```media query``` rule in ```browser.css``` (less than 1280px) for cell widths to support low-resolution screens.