### PR TITLE
Support AWS additional disks attaching

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
@@ -29,6 +29,7 @@ import com.epam.pipeline.controller.vo.configuration.RunConfigurationWithEntitie
 import com.epam.pipeline.dao.filter.FilterRunParameters;
 import com.epam.pipeline.entity.cluster.PipelineRunPrice;
 import com.epam.pipeline.entity.pipeline.CommitStatus;
+import com.epam.pipeline.entity.pipeline.DiskAttachRequest;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.PipelineTask;
 import com.epam.pipeline.entity.pipeline.RunInstance;
@@ -266,5 +267,11 @@ public class RunApiService {
     @AclMask
     public PipelineRun terminateRun(final Long runId) {
         return runManager.terminateRun(runId);
+    }
+
+    @PreAuthorize(RUN_ID_OWNER)
+    @AclMask
+    public PipelineRun attachDisk(final Long runId, final DiskAttachRequest request) {
+        return runManager.attachDisk(runId, request);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -141,6 +141,8 @@ public final class MessageConstants {
     public static final String ERROR_RUN_TERMINATION_WRONG_STATUS = "error.run.termination.wrong.status";
     public static final String WARN_RESUME_RUN_FAILED = "warn.resume.run.failed";
     public static final String INFO_INSTANCE_STARTED = "info.instance.started";
+    public static final String ERROR_RUN_DISK_SIZE_NOT_FOUND = "error.run.disk.size.not.found";
+    public static final String ERROR_RUN_DISK_DEVICE_NOT_FOUND = "error.run.disk.device.not.found";
 
     //Run schedule
     public static final String CRON_EXPRESSION_IS_NOT_PROVIDED = "cron.expression.is.not.provided";

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -143,7 +143,6 @@ public final class MessageConstants {
     public static final String INFO_INSTANCE_STARTED = "info.instance.started";
     public static final String ERROR_RUN_DISK_ATTACHING_WRONG_STATUS = "error.run.attaching.wrong.status";
     public static final String ERROR_RUN_DISK_SIZE_NOT_FOUND = "error.run.disk.size.not.found";
-    public static final String ERROR_RUN_DISK_DEVICE_NOT_FOUND = "error.run.disk.device.not.found";
 
     //Run schedule
     public static final String CRON_EXPRESSION_IS_NOT_PROVIDED = "cron.expression.is.not.provided";

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -141,6 +141,7 @@ public final class MessageConstants {
     public static final String ERROR_RUN_TERMINATION_WRONG_STATUS = "error.run.termination.wrong.status";
     public static final String WARN_RESUME_RUN_FAILED = "warn.resume.run.failed";
     public static final String INFO_INSTANCE_STARTED = "info.instance.started";
+    public static final String ERROR_RUN_DISK_ATTACHING_WRONG_STATUS = "error.run.attaching.wrong.status";
     public static final String ERROR_RUN_DISK_SIZE_NOT_FOUND = "error.run.disk.size.not.found";
     public static final String ERROR_RUN_DISK_DEVICE_NOT_FOUND = "error.run.disk.device.not.found";
 

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
@@ -31,6 +31,7 @@ import com.epam.pipeline.controller.vo.RunStatusVO;
 import com.epam.pipeline.controller.vo.TagsVO;
 import com.epam.pipeline.controller.vo.configuration.RunConfigurationWithEntitiesVO;
 import com.epam.pipeline.entity.cluster.PipelineRunPrice;
+import com.epam.pipeline.entity.pipeline.DiskAttachRequest;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.PipelineTask;
 import com.epam.pipeline.entity.pipeline.RunInstance;
@@ -485,5 +486,18 @@ public class PipelineRunController extends AbstractRestController {
     public Result<PipelineRun>  updateRunTags(@PathVariable(value = RUN_ID) final Long runId,
                                               @RequestBody final TagsVO tagsVO) {
         return Result.success(runApiService.updateTags(runId, tagsVO));
+    }
+
+    @PostMapping(value = "/run/{runId}/disk/attach")
+    @ResponseBody
+    @ApiOperation(
+            value = "Creates and attaches new disk to pipeline run.",
+            notes = "Creates and attaches new disk to pipeline run cloud instance by the given request. " +
+                    "Disk size should be specified in GB and disk device name is required.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<PipelineRun> attachDisk(@PathVariable(value = RUN_ID) final Long runId,
+                                          @RequestBody final DiskAttachRequest request) {
+        return Result.success(runApiService.attachDisk(runId, request));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
@@ -493,7 +493,7 @@ public class PipelineRunController extends AbstractRestController {
     @ApiOperation(
             value = "Creates and attaches new disk to pipeline run.",
             notes = "Creates and attaches new disk to pipeline run cloud instance by the given request. " +
-                    "Disk size should be specified in GB and disk device name is required.",
+                    "Disk size should be specified in GB and disk device name (f.e. /dev/sdc) is required.",
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
     public Result<PipelineRun> attachDisk(@PathVariable(value = RUN_ID) final Long runId,

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
@@ -493,7 +493,7 @@ public class PipelineRunController extends AbstractRestController {
     @ApiOperation(
             value = "Creates and attaches new disk to pipeline run.",
             notes = "Creates and attaches new disk to pipeline run cloud instance by the given request. " +
-                    "Disk size should be specified in GB and disk device name (f.e. /dev/sdc) is required.",
+                    "Disk size should be specified in GB.",
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
     public Result<PipelineRun> attachDisk(@PathVariable(value = RUN_ID) final Long runId,

--- a/api/src/main/java/com/epam/pipeline/entity/pipeline/DiskAttachRequest.java
+++ b/api/src/main/java/com/epam/pipeline/entity/pipeline/DiskAttachRequest.java
@@ -1,0 +1,9 @@
+package com.epam.pipeline.entity.pipeline;
+
+import lombok.Value;
+
+@Value
+public class DiskAttachRequest {
+    private final Long size;
+    private final String device;
+}

--- a/api/src/main/java/com/epam/pipeline/entity/pipeline/DiskAttachRequest.java
+++ b/api/src/main/java/com/epam/pipeline/entity/pipeline/DiskAttachRequest.java
@@ -5,5 +5,4 @@ import lombok.Value;
 @Value
 public class DiskAttachRequest {
     private final Long size;
-    private final String device;
 }

--- a/api/src/main/java/com/epam/pipeline/exception/cloud/aws/AwsEc2Exception.java
+++ b/api/src/main/java/com/epam/pipeline/exception/cloud/aws/AwsEc2Exception.java
@@ -21,4 +21,8 @@ public class AwsEc2Exception extends RuntimeException {
     public AwsEc2Exception(final String message) {
         super(message);
     }
+
+    public AwsEc2Exception(final String message, final Throwable throwable) {
+        super(message, throwable);
+    }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacade.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacade.java
@@ -20,6 +20,7 @@ import com.epam.pipeline.entity.cloud.InstanceTerminationState;
 import com.epam.pipeline.entity.cloud.CloudInstanceOperationResult;
 import com.epam.pipeline.entity.cluster.InstanceOffer;
 import com.epam.pipeline.entity.cluster.InstanceType;
+import com.epam.pipeline.entity.pipeline.DiskAttachRequest;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.region.AbstractCloudRegion;
 
@@ -74,4 +75,9 @@ public interface CloudFacade {
     Optional<InstanceTerminationState> getInstanceTerminationState(Long regionId, String instanceId);
 
     List<InstanceType> getAllInstanceTypes(Long regionId, boolean spot);
+
+    /**
+     * Creates and attaches new disk by the given request to an instance associated with run.
+     */
+    void attachDisk(Long regionId, Long runId, DiskAttachRequest request);
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacadeImpl.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacadeImpl.java
@@ -23,6 +23,7 @@ import com.epam.pipeline.entity.cloud.CloudInstanceOperationResult;
 import com.epam.pipeline.entity.cluster.InstanceOffer;
 import com.epam.pipeline.entity.cluster.InstanceType;
 import com.epam.pipeline.entity.cluster.NodeRegionLabels;
+import com.epam.pipeline.entity.pipeline.DiskAttachRequest;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.region.AbstractCloudRegion;
@@ -209,6 +210,12 @@ public class CloudFacadeImpl implements CloudFacade {
     public double getSpotPrice(final Long regionId, final String instanceType) {
         final AbstractCloudRegion region = regionManager.loadOrDefault(regionId);
         return getInstancePriceService(region).getSpotPrice(instanceType, region);
+    }
+
+    @Override
+    public void attachDisk(final Long regionId, final Long runId, final DiskAttachRequest request) {
+        final AbstractCloudRegion region = regionManager.loadOrDefault(regionId);
+        getInstanceService(region).attachDisk(region, runId, request);
     }
 
     private AbstractCloudRegion getRegionByRunId(final Long runId) {

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/CloudInstanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/CloudInstanceService.java
@@ -18,6 +18,7 @@ package com.epam.pipeline.manager.cloud;
 
 import com.epam.pipeline.entity.cloud.InstanceTerminationState;
 import com.epam.pipeline.entity.cloud.CloudInstanceOperationResult;
+import com.epam.pipeline.entity.pipeline.DiskAttachRequest;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.region.AbstractCloudRegion;
 import com.epam.pipeline.manager.cluster.AutoscalerServiceImpl;
@@ -169,4 +170,12 @@ public interface CloudInstanceService<T extends AbstractCloudRegion>
      *  mainly for terminated states
      */
     Optional<InstanceTerminationState> getInstanceTerminationState(T region, String instanceId);
+
+    /**
+     * Creates and attaches new disk by the given request to cloud instance.
+     * @param region
+     * @param runId
+     * @param request
+     */
+    void attachDisk(T region, Long runId, DiskAttachRequest request);
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSInstanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSInstanceService.java
@@ -222,8 +222,7 @@ public class AWSInstanceService implements CloudInstanceService<AwsRegion> {
 
     @Override
     public void attachDisk(final AwsRegion region, final Long runId, final DiskAttachRequest request) {
-        ec2Helper.createAndAttachVolume(String.valueOf(runId), request.getDevice(), request.getSize(),
-                region.getRegionCode());
+        ec2Helper.createAndAttachVolume(String.valueOf(runId), request.getSize(), region.getRegionCode());
     }
 
     private String buildNodeUpCommand(final AwsRegion region,

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSInstanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSInstanceService.java
@@ -21,6 +21,7 @@ import com.amazonaws.auth.BasicSessionCredentials;
 import com.amazonaws.services.ec2.model.Instance;
 import com.epam.pipeline.entity.cloud.InstanceTerminationState;
 import com.epam.pipeline.entity.cloud.CloudInstanceOperationResult;
+import com.epam.pipeline.entity.pipeline.DiskAttachRequest;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.region.AwsRegion;
 import com.epam.pipeline.entity.region.CloudProvider;
@@ -217,6 +218,12 @@ public class AWSInstanceService implements CloudInstanceService<AwsRegion> {
                         .stateCode(state.getCode())
                         .stateMessage(state.getMessage())
                         .build());
+    }
+
+    @Override
+    public void attachDisk(final AwsRegion region, final Long runId, final DiskAttachRequest request) {
+        ec2Helper.createAndAttachVolume(String.valueOf(runId), request.getDevice(), request.getSize(),
+                region.getRegionCode());
     }
 
     private String buildNodeUpCommand(final AwsRegion region,

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/aws/EC2Helper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/aws/EC2Helper.java
@@ -320,14 +320,15 @@ public class EC2Helper {
                                  final Volume volume, final String device) {
         try {
             attachVolume(client, instance.getInstanceId(), volume.getVolumeId(), device);
-        } catch (Exception e) {
+        } catch (AmazonEC2Exception e) {
             deleteVolume(client, volume.getVolumeId());
             throw new AwsEc2Exception(String.format("Volume with id '%s' wasn't attached to instance with id '%s'" +
                     " due to error and it was deleted.", volume.getVolumeId(), instance.getInstanceId()), e);
         }
     }
 
-    private void attachVolume(final AmazonEC2 client, final String instanceId, final String volumeId, final String device) {
+    private void attachVolume(final AmazonEC2 client, final String instanceId, final String volumeId,
+                              final String device) {
         client.attachVolume(new AttachVolumeRequest()
                 .withInstanceId(instanceId)
                 .withVolumeId(volumeId)
@@ -336,7 +337,8 @@ public class EC2Helper {
         waiter.run(new WaiterParameters<>(new DescribeVolumesRequest().withVolumeIds(volumeId)));
     }
 
-    private void enableVolumeDeletionOnInstanceTermination(final AmazonEC2 client, final String instanceId, final String device) {
+    private void enableVolumeDeletionOnInstanceTermination(final AmazonEC2 client, final String instanceId,
+                                                           final String device) {
         client.modifyInstanceAttribute(new ModifyInstanceAttributeRequest()
                 .withInstanceId(instanceId)
                 .withBlockDeviceMappings(new InstanceBlockDeviceMappingSpecification()

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzureInstanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzureInstanceService.java
@@ -19,6 +19,7 @@ package com.epam.pipeline.manager.cloud.azure;
 import com.epam.pipeline.entity.cloud.InstanceTerminationState;
 import com.epam.pipeline.entity.cloud.CloudInstanceOperationResult;
 import com.epam.pipeline.entity.cloud.azure.AzureVirtualMachineStats;
+import com.epam.pipeline.entity.pipeline.DiskAttachRequest;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.region.AzureRegion;
 import com.epam.pipeline.entity.region.AzureRegionCredentials;
@@ -205,6 +206,11 @@ public class AzureInstanceService implements CloudInstanceService<AzureRegion> {
                 .stateCode(status.code())
                 .stateMessage(status.message())
                 .build());
+    }
+
+    @Override
+    public void attachDisk(final AzureRegion region, final Long runId, final DiskAttachRequest request) {
+        throw new UnsupportedOperationException("Disk attaching doesn't work with Azure provider yet.");
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPInstanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPInstanceService.java
@@ -18,6 +18,7 @@ package com.epam.pipeline.manager.cloud.gcp;
 
 import com.epam.pipeline.entity.cloud.InstanceTerminationState;
 import com.epam.pipeline.entity.cloud.CloudInstanceOperationResult;
+import com.epam.pipeline.entity.pipeline.DiskAttachRequest;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.region.CloudProvider;
 import com.epam.pipeline.entity.region.GCPRegion;
@@ -201,6 +202,11 @@ public class GCPInstanceService implements CloudInstanceService<GCPRegion> {
     public Optional<InstanceTerminationState> getInstanceTerminationState(final GCPRegion region,
                                                                           final String instanceId) {
         return vmService.getTerminationState(region, instanceId);
+    }
+
+    @Override
+    public void attachDisk(final GCPRegion region, final Long runId, final DiskAttachRequest request) {
+        throw new UnsupportedOperationException("Disk attaching doesn't work with GCP provider yet.");
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/NodesManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/NodesManager.java
@@ -25,6 +25,7 @@ import com.epam.pipeline.entity.cluster.MasterNode;
 import com.epam.pipeline.entity.cluster.NodeInstance;
 import com.epam.pipeline.entity.cluster.NodeInstanceAddress;
 import com.epam.pipeline.entity.cluster.PodInstance;
+import com.epam.pipeline.entity.pipeline.DiskAttachRequest;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
@@ -303,6 +304,17 @@ public class NodesManager {
                                final AbstractCloudRegion region) {
         cloudFacade.terminateNode(region, nodeInstanceAddress.getAddress(), nodeInstance.getName());
         kubernetesManager.waitNodeDown(nodeInstance.getName(), NODE_DOWN_ATTEMPTS);
+    }
+
+    /**
+     * Creates and attaches new disk to the run cloud instance.
+     */
+    public void attachDisk(final PipelineRun run, final DiskAttachRequest request) {
+        final Optional<RunInstance> instance = Optional.ofNullable(run.getInstance());
+        final AbstractCloudRegion region = instance.map(RunInstance::getCloudRegionId)
+                .map(regionManager::load)
+                .orElseGet(regionManager::loadDefaultRegion);
+        cloudFacade.attachDisk(region.getId(), run.getId(), request);
     }
 
     private boolean isNodeProtected(NodeInstance nodeInstance) {

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -977,8 +977,6 @@ public class PipelineRunManager {
                 messageHelper.getMessage(MessageConstants.ERROR_RUN_DISK_SIZE_NOT_FOUND));
         Assert.isTrue(request.getSize() > 0,
                 messageHelper.getMessage(MessageConstants.ERROR_INSTANCE_DISK_IS_INVALID, request.getSize()));
-        Assert.isTrue(!StringUtils.isEmpty(request.getDevice()),
-                messageHelper.getMessage(MessageConstants.ERROR_RUN_DISK_DEVICE_NOT_FOUND));
         nodesManager.attachDisk(pipelineRun, request);
         return pipelineRun;
     }

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -33,6 +33,7 @@ import com.epam.pipeline.entity.configuration.PipelineConfiguration;
 import com.epam.pipeline.entity.contextual.ContextualPreferenceExternalResource;
 import com.epam.pipeline.entity.contextual.ContextualPreferenceLevel;
 import com.epam.pipeline.entity.pipeline.CommitStatus;
+import com.epam.pipeline.entity.pipeline.DiskAttachRequest;
 import com.epam.pipeline.entity.pipeline.DockerRegistry;
 import com.epam.pipeline.entity.pipeline.Folder;
 import com.epam.pipeline.entity.pipeline.Pipeline;
@@ -954,6 +955,28 @@ public class PipelineRunManager {
         pipelineRun.setEndDate(DateUtils.now());
         updatePipelineStatus(pipelineRun);
         nodesManager.terminateRun(pipelineRun);
+        return pipelineRun;
+    }
+
+    /**
+     * Creates and attaches new disk by the given request to the run.
+     *
+     * @param runId {@link PipelineRun} id for pipeline run.
+     * @param request Attaching disk request.
+     * @return Updated pipeline run.
+     */
+    @Transactional(propagation = Propagation.REQUIRED)
+    public PipelineRun attachDisk(final Long runId, final DiskAttachRequest request) {
+        final PipelineRun pipelineRun = pipelineRunDao.loadPipelineRun(runId);
+        Assert.notNull(pipelineRun,
+                messageHelper.getMessage(MessageConstants.ERROR_RUN_PIPELINES_NOT_FOUND, runId));
+        Assert.notNull(request.getSize(),
+                messageHelper.getMessage(MessageConstants.ERROR_RUN_DISK_SIZE_NOT_FOUND));
+        Assert.isTrue(request.getSize() > 0,
+                messageHelper.getMessage(MessageConstants.ERROR_INSTANCE_DISK_IS_INVALID, request.getSize()));
+        Assert.isTrue(!StringUtils.isEmpty(request.getDevice()),
+                messageHelper.getMessage(MessageConstants.ERROR_RUN_DISK_DEVICE_NOT_FOUND));
+        nodesManager.attachDisk(pipelineRun, request);
         return pipelineRun;
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -970,6 +970,9 @@ public class PipelineRunManager {
         final PipelineRun pipelineRun = pipelineRunDao.loadPipelineRun(runId);
         Assert.notNull(pipelineRun,
                 messageHelper.getMessage(MessageConstants.ERROR_RUN_PIPELINES_NOT_FOUND, runId));
+        Assert.state(pipelineRun.getStatus() == TaskStatus.RUNNING || pipelineRun.getStatus().isPause(),
+                messageHelper.getMessage(MessageConstants.ERROR_RUN_DISK_ATTACHING_WRONG_STATUS, runId,
+                        pipelineRun.getStatus()));
         Assert.notNull(request.getSize(),
                 messageHelper.getMessage(MessageConstants.ERROR_RUN_DISK_SIZE_NOT_FOUND));
         Assert.isTrue(request.getSize() > 0,

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -268,6 +268,10 @@ public class SystemPreferences {
                                                                                            false, CLUSTER_GROUP, pass);
     public static final IntPreference CLUSTER_INSTANCE_HDD = new IntPreference("cluster.instance.hdd", 10,
                                                                                CLUSTER_GROUP, isGreaterThan(0));
+    public static final StringPreference CLUSTER_INSTANCE_DEVICE_PREFIX = new StringPreference("cluster.instance.device.prefix",
+            "/dev/sd", CLUSTER_GROUP, PreferenceValidators.isNotBlank);
+    public static final StringPreference CLUSTER_INSTANCE_DEVICE_SUFFIXES = new StringPreference("cluster.instance.device.suffixes",
+            "defghijklmnopqrstuvwxyz", CLUSTER_GROUP, PreferenceValidators.isNotBlank);
     public static final ObjectPreference<CloudRegionsConfiguration> CLUSTER_NETWORKS_CONFIG =
         new ObjectPreference<>("cluster.networks.config", null, new TypeReference<CloudRegionsConfiguration>() {},
                                CLUSTER_GROUP, isNullOrValidJson(new TypeReference<CloudRegionsConfiguration>() {}));

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -268,10 +268,11 @@ public class SystemPreferences {
                                                                                            false, CLUSTER_GROUP, pass);
     public static final IntPreference CLUSTER_INSTANCE_HDD = new IntPreference("cluster.instance.hdd", 10,
                                                                                CLUSTER_GROUP, isGreaterThan(0));
-    public static final StringPreference CLUSTER_INSTANCE_DEVICE_PREFIX = new StringPreference("cluster.instance.device.prefix",
-            "/dev/sd", CLUSTER_GROUP, PreferenceValidators.isNotBlank);
-    public static final StringPreference CLUSTER_INSTANCE_DEVICE_SUFFIXES = new StringPreference("cluster.instance.device.suffixes",
-            "defghijklmnopqrstuvwxyz", CLUSTER_GROUP, PreferenceValidators.isNotBlank);
+    public static final StringPreference CLUSTER_INSTANCE_DEVICE_PREFIX = new StringPreference(
+            "cluster.instance.device.prefix", "/dev/sd", CLUSTER_GROUP, PreferenceValidators.isNotBlank);
+    public static final StringPreference CLUSTER_INSTANCE_DEVICE_SUFFIXES = new StringPreference(
+            "cluster.instance.device.suffixes", "defghijklmnopqrstuvwxyz", CLUSTER_GROUP,
+            PreferenceValidators.isNotBlank);
     public static final ObjectPreference<CloudRegionsConfiguration> CLUSTER_NETWORKS_CONFIG =
         new ObjectPreference<>("cluster.networks.config", null, new TypeReference<CloudRegionsConfiguration>() {},
                                CLUSTER_GROUP, isNullOrValidJson(new TypeReference<CloudRegionsConfiguration>() {}));

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -106,6 +106,7 @@ error.cmd.template.not.resolved=No cmd template was resolved for the run.
 error.run.termination.wrong.status=Only paused runs can be terminated. Given run ''{0}'' has ''{1}'' status.
 warn.resume.run.failed=Could not resume run. Operation failed with message ''{0}''
 info.instance.started=Instance ''{0}'' successfully started.
+error.run.attaching.wrong.status=Disks can be attached to running or paused runs. Given run ''{0}'' has ''{1}'' status.
 error.run.disk.size.not.found=Pipeline run disk size should be specified.
 error.run.disk.device.not.found=Pipeline run disk device should be specified.
 

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -106,6 +106,8 @@ error.cmd.template.not.resolved=No cmd template was resolved for the run.
 error.run.termination.wrong.status=Only paused runs can be terminated. Given run ''{0}'' has ''{1}'' status.
 warn.resume.run.failed=Could not resume run. Operation failed with message ''{0}''
 info.instance.started=Instance ''{0}'' successfully started.
+error.run.disk.size.not.found=Pipeline run disk size should be specified.
+error.run.disk.device.not.found=Pipeline run disk device should be specified.
 
 #Run schedule
 cron.expression.is.not.provided=Cron expression for pipeline run id ''{0}'' is not provided.

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -108,7 +108,6 @@ warn.resume.run.failed=Could not resume run. Operation failed with message ''{0}
 info.instance.started=Instance ''{0}'' successfully started.
 error.run.attaching.wrong.status=Disks can be attached to running or paused runs. Given run ''{0}'' has ''{1}'' status.
 error.run.disk.size.not.found=Pipeline run disk size should be specified.
-error.run.disk.device.not.found=Pipeline run disk device should be specified.
 
 #Run schedule
 cron.expression.is.not.provided=Cron expression for pipeline run id ''{0}'' is not provided.

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunManagerUnitTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunManagerUnitTest.java
@@ -109,7 +109,7 @@ public class PipelineRunManagerUnitTest {
     @Test
     public void testAttachDiskWithInvalidSize() {
         assertAttachFails(diskAttachRequest(null));
-        assertAttachFails(diskAttachRequest(-10L));
+        assertAttachFails(diskAttachRequest(-SIZE));
     }
 
     @Test

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunManagerUnitTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunManagerUnitTest.java
@@ -34,7 +34,6 @@ import org.mockito.MockitoAnnotations;
 import java.util.function.Predicate;
 
 import static com.epam.pipeline.util.CustomAssertions.assertThrows;
-import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
@@ -46,7 +45,6 @@ public class PipelineRunManagerUnitTest {
     private static final long NOT_EXISTING_RUN_ID = -1L;
     private static final String NODE_NAME = "node_name";
     private static final Long SIZE = 10L;
-    private static final String DEVICE = "/dev/sdc";
 
     @Mock
     private NodesManager nodesManager;
@@ -110,13 +108,8 @@ public class PipelineRunManagerUnitTest {
 
     @Test
     public void testAttachDiskWithInvalidSize() {
-        assertAttachFails(diskAttachRequestWithSize(null));
-        assertAttachFails(diskAttachRequestWithSize(-10L));
-    }
-
-    @Test
-    public void testAttachDiskWithInvalidDevice() {
-        assertAttachFails(diskAttachRequestWithDevice(null));
+        assertAttachFails(diskAttachRequest(null));
+        assertAttachFails(diskAttachRequest(-10L));
     }
 
     @Test
@@ -163,19 +156,11 @@ public class PipelineRunManagerUnitTest {
     }
 
     private DiskAttachRequest diskAttachRequest() {
-        return diskAttachRequest(SIZE, DEVICE);
+        return diskAttachRequest(SIZE);
     }
 
-    private DiskAttachRequest diskAttachRequestWithSize(final Long size) {
-        return diskAttachRequest(size, DEVICE);
-    }
-
-    private DiskAttachRequest diskAttachRequestWithDevice(final String device) {
-        return diskAttachRequest(SIZE, device);
-    }
-
-    private DiskAttachRequest diskAttachRequest(final Long size, final String device) {
-        return new DiskAttachRequest(size, device);
+    private DiskAttachRequest diskAttachRequest(final Long size) {
+        return new DiskAttachRequest(size);
     }
 
     private <T> BaseMatcher<T> matches(final Predicate<T> test) {


### PR DESCRIPTION
Relates to #837.

The pull request brings new API method that can be used to create and attach additional disks to running or paused runs. *Currently only AWS provider is supported.*

Method `POST /run/{run_id}/disk/attach` accepts requests for additional disks creation with the following body where size should be specified in **GB**
```json
{
    "size": 50
}
```

Device name for an attaching disk is resolved automatically depending on already attached disks. Two system preferences are used to resolve allowed device names:
- `cluster.instance.device.prefix` defines prefix for all device names. Defaults to `/dev/sd`.
- `cluster.instance.device.suffixes` defines a list of characters that can be used as suffixes for device names. Defaults to `defghijklmnopqrstuvwxyz`.

In other words new device name will be resolved from the following pattern `{prefix}{suffix}` where prefix is `cluster.instance.device.prefix` and suffix is one of the characters from `cluster.instance.device.suffixes`, f.e. `/dev/sdd` or `/dev/sdm`.

See more about [device name limitations](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html).
