### PR TITLE
Issue #625 save proper timezone ID.

### DIFF
--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunScheduleDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunScheduleDao.java
@@ -116,7 +116,7 @@ public class PipelineRunScheduleDao  extends NamedParameterJdbcDaoSupport {
             params.addValue(RUN_ID.name(), schedule.getRunId());
             params.addValue(CRON_EXPRESSION.name(), schedule.getCronExpression());
             params.addValue(CREATED_DATE.name(), schedule.getCreatedDate());
-            params.addValue(TIME_ZONE.name(), schedule.getTimeZone().getDisplayName());
+            params.addValue(TIME_ZONE.name(), schedule.getTimeZone().getID());
             return params;
         }
 


### PR DESCRIPTION
Fix for issue #625: previously short description was saved instead of proper timezone ID, so API service wasn't able to parse it back into TimeZone object and used to return default GMT timezone always.