### PR TITLE
FSBrowser doesn't clean the temp files, when download is canceled

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/execution/PipelineLauncher.java
+++ b/api/src/main/java/com/epam/pipeline/manager/execution/PipelineLauncher.java
@@ -256,6 +256,9 @@ public class PipelineLauncher {
                 SystemParams.FSBROWSER_WD,
                 preferenceManager.getSystemPreference(SystemPreferences.STORAGE_FSBROWSER_WD).getValue());
         putIfStringValuePresent(systemParamsWithValue,
+                SystemParams.FSBROWSER_TMP,
+                preferenceManager.getSystemPreference(SystemPreferences.STORAGE_FSBROWSER_TMP).getValue());
+        putIfStringValuePresent(systemParamsWithValue,
                 SystemParams.FSBROWSER_STORAGE,
                 preferenceManager.getSystemPreference(SystemPreferences.STORAGE_FSBROWSER_TRANSFER).getValue());
         return systemParamsWithValue;

--- a/api/src/main/java/com/epam/pipeline/manager/execution/SystemParams.java
+++ b/api/src/main/java/com/epam/pipeline/manager/execution/SystemParams.java
@@ -63,6 +63,7 @@ public enum SystemParams {
     FSBROWSER_ENABLED("cp-fsbrowser-enabled", "CP_FSBROWSER_ENABLED", false, true),
     FSBROWSER_PORT("cp-fsbrowser-port", "CP_FSBROWSER_PORT", false, true),
     FSBROWSER_WD("cp-fsbrowser-wd", "CP_FSBROWSER_WD", false, true),
+    FSBROWSER_TMP("cp-fsbrowser-tmp", "CP_FSBROWSER_TMP", false, true),
     FSBROWSER_STORAGE("cp-fsbrowser-storage", "CP_FSBROWSER_STORAGE", false, true),
     CONTAINER_CPU_RESOURCE("container-cpu-resource", "CP_CONTAINER_CPU_RESOURCE", false, true);
 

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -147,6 +147,8 @@ public class SystemPreferences {
             new IntPreference("storage.fsbrowser.port", 8091, DATA_STORAGE_GROUP, isGreaterThan(1000));
     public static final StringPreference STORAGE_FSBROWSER_WD =
             new StringPreference("storage.fsbrowser.wd", "/", DATA_STORAGE_GROUP, pass);
+    public static final StringPreference STORAGE_FSBROWSER_TMP =
+            new StringPreference("storage.fsbrowser.tmp", "/tmp", DATA_STORAGE_GROUP, pass);
     public static final StringPreference STORAGE_FSBROWSER_TRANSFER =
             new StringPreference("storage.fsbrowser.transfer", null, DATA_STORAGE_GROUP, pass);
 

--- a/deploy/contents/install/app/configure-utils.sh
+++ b/deploy/contents/install/app/configure-utils.sh
@@ -1163,6 +1163,7 @@ EOF
         api_set_preference "storage.fsbrowser.enabled" "${CP_PREF_STORAGE_FSBROWSER_ENABLED:-"true"}" "true"
         api_set_preference "storage.fsbrowser.port" "${CP_PREF_STORAGE_FSBROWSER_PORT:-8091}" "true"
         api_set_preference "storage.fsbrowser.wd" "${CP_PREF_STORAGE_FSBROWSER_WD:-"/"}" "true"
+        api_set_preference "storage.fsbrowser.tmp" "${CP_PREF_STORAGE_FSBROWSER_TMP:-"/tmp"}" "true"
         api_set_preference "storage.fsbrowser.transfer" "${CP_PREF_STORAGE_FSBROWSER_TRANSFER:-$CP_PREF_STORAGE_SYSTEM_STORAGE_NAME/fsbrowser}" "true"
     fi
     return $call_api_register_system_storage_result

--- a/fs-browser/fsbrowser/app.py
+++ b/fs-browser/fsbrowser/app.py
@@ -163,11 +163,12 @@ def main():
     parser.add_argument("--run_id", required=False)
     parser.add_argument("--log_dir", required=False)
     parser.add_argument("--follow_symlinks", default="True", type=str_to_bool)
+    parser.add_argument("--tmp_directory", default="/tmp")
 
     args = parser.parse_args()
     app.config['fsbrowser'] = FsBrowserManager(args.working_directory, args.process_count,
                                                BrowserLogger(args.run_id, args.log_dir), args.transfer_storage,
-                                               args.follow_symlinks)
+                                               args.follow_symlinks, args.tmp_directory)
 
     app.run(host=args.host, port=args.port)
 

--- a/fs-browser/fsbrowser/src/transfer_task.py
+++ b/fs-browser/fsbrowser/src/transfer_task.py
@@ -20,7 +20,7 @@ import subprocess
 from fsbrowser.src.cloud_pipeline_api_provider import CloudPipelineApiProvider
 from fsbrowser.src.logger import BrowserLogger
 
-TAF_GZ_EXTENSION = '.tar.gz'
+TAR_GZ_EXTENSION = '.tar.gz'
 DELIMITER = '/'
 TAR_GZ_PERMISSIONS = 0774  # -rwxrwxr--
 
@@ -46,9 +46,10 @@ class TransferTask(object):
         self.process = None
         self.message = None
         self.result = None
-        self.path = None
+        self.upload_path = None
         self.logger = logger
         self.storage_path = storage_path
+        self.tmp_tar_ball = None
 
     def success(self, result=None):
         self.status = TaskStatus.SUCCESS
@@ -76,16 +77,19 @@ class TransferTask(object):
             self.logger.log("Stopping process with PID %s" % str(self.process.pid))
             self.process.kill()
             self.logger.log("Process %s has been stopped" % str(self.process.pid))
-        if self.path:
-            full_path = os.path.join(working_directory, self.path)
+        if self.upload_path:
+            full_path = os.path.join(working_directory, self.upload_path)
             full_directory_path = os.path.dirname(full_path)
             for file_name in os.listdir(full_directory_path):
                 tmp_path = os.path.join(full_directory_path, file_name)
                 if os.path.isfile(tmp_path) and str(self.task_id) in file_name:
                     os.remove(tmp_path)
                     self.logger.log('File %s has been removed' % tmp_path)
+        if self.tmp_tar_ball:
+            os.remove(self.tmp_tar_ball)
+            self.logger.log('File %s has been removed' % self.tmp_tar_ball)
 
-    def download(self, source_path, working_directory, follow_symlinks):
+    def download(self, source_path, working_directory, tmp, follow_symlinks):
         try:
             if self.status != TaskStatus.PENDING:
                 self.logger.log("Failed to start download task: expected task state 'pending' but actual %s"
@@ -96,14 +100,15 @@ class TransferTask(object):
             full_source_path = os.path.join(working_directory, source_path)
             compressed = not os.path.isfile(full_source_path)
             if compressed:
-                self.logger.log("Starting to compress folder for download")
+                self.logger.log("Starting to compress folder for download to temporary folder %s" % tmp)
                 if follow_symlinks and self.check_cyclic_symlinks(full_source_path):
                     raise RuntimeError("Failed to download folder: a cyclic symlinks found in folder '%s'"
                                        % full_source_path)
-                compressed_name = full_source_path + TAF_GZ_EXTENSION
+                compressed_name = os.path.join(tmp, self.task_id) + TAR_GZ_EXTENSION
+                self.tmp_tar_ball = compressed_name
                 self.compress_directory(compressed_name, full_source_path, follow_symlinks)
                 full_source_path = compressed_name
-                source_path = source_path + TAF_GZ_EXTENSION
+                source_path = source_path + TAR_GZ_EXTENSION
             source_file_name = os.path.basename(source_path)
             full_destination_path = os.path.join(self.storage_name, self.storage_path, self.task_id, source_file_name)
             if self.status == TaskStatus.CANCELED:
@@ -130,8 +135,9 @@ class TransferTask(object):
                                 % self.status)
                 return
             self.running()
-            full_source_path = 'cp://%s' % os.path.join(self.storage_name, self.storage_path, self.task_id, self.path)
-            full_destination_path = os.path.join(working_directory, self.path)
+            full_source_path = 'cp://%s' % os.path.join(self.storage_name, self.storage_path, self.task_id,
+                                                        self.upload_path)
+            full_destination_path = os.path.join(working_directory, self.upload_path)
             tmp_destination_path = os.path.join(os.path.dirname(full_destination_path), self.task_id)
             self.pipe_storage_cp(full_source_path, tmp_destination_path)
             os.rename(tmp_destination_path, full_destination_path)

--- a/workflows/pipe-common/shell/fsbrowser_setup
+++ b/workflows/pipe-common/shell/fsbrowser_setup
@@ -26,6 +26,7 @@ fi
 
 CP_FSBROWSER_PORT="${CP_FSBROWSER_PORT:-8091}"
 CP_FSBROWSER_WD="${CP_FSBROWSER_WD:-/}"
+CP_FSBROWSER_TMP="${CP_FSBROWSER_TMP:-/tmp}"
 if [ -z "$CP_FSBROWSER_STORAGE" ]; then
     CP_FSBROWSER_STORAGE="$(curl -k \
                                     -s \
@@ -52,4 +53,5 @@ echo "- Storage: $CP_FSBROWSER_STORAGE"
 nohup fsbrowser --host 0.0.0.0 \
                 --port "${CP_FSBROWSER_PORT}" \
                 --working_directory "${CP_FSBROWSER_WD}" \
+                --tmp_directory "${CP_FSBROWSER_TMP}" \
                 --transfer_storage "${CP_FSBROWSER_STORAGE}" > /var/log/fsbrowser.log 2>&1 &


### PR DESCRIPTION
This PR provides fix for issue #818 

This PR contains the following changes:
- added new `fsbrowser` option `--tmp_directory` to specify temporary directory for downloading folders
- added new preference `storage.fsbrowser.tmp`
- added corresponding environment  variables
- `cancel` method fixed: remove tarball from temporary folder if exists