### PR TITLE
Cannot open any directory via FSBrowser in case when the "FSBrowser work directory" is set to the non-default value

### DIFF
--- a/fs-browser/README.md
+++ b/fs-browser/README.md
@@ -38,7 +38,7 @@ Response example:
 {    
     "payload": [{
         "name": "file_name.txt",
-        "path": "/root/data/file_name.txt",
+        "path": "data/file_name.txt",
         "type": "File" (or "Folder"),
         "size": 1 (size in bytes, avilable for Files only)
     }],

--- a/fs-browser/fsbrowser/src/fs_browser_manager.py
+++ b/fs-browser/fsbrowser/src/fs_browser_manager.py
@@ -37,14 +37,14 @@ class FsBrowserManager(object):
         items = []
         full_path = os.path.join(self.working_directory, path)
         if os.path.isfile(full_path):
-            items.append(File(path, full_path).to_json())
+            items.append(File(os.path.basename(path), path, full_path).to_json())
         else:
             for item_name in os.listdir(full_path):
                 full_item_path = os.path.join(full_path, item_name)
                 if os.path.isfile(full_item_path):
-                    items.append(File(item_name, full_item_path).to_json())
+                    items.append(File(item_name, os.path.join(path, item_name), full_item_path).to_json())
                 else:
-                    items.append(Folder(item_name, full_item_path).to_json())
+                    items.append(Folder(item_name, os.path.join(path, item_name)).to_json())
         return items
 
     def run_download(self, path):

--- a/fs-browser/fsbrowser/src/model/file.py
+++ b/fs-browser/fsbrowser/src/model/file.py
@@ -20,9 +20,10 @@ FILE_TYPE = "File"
 
 class File(FsItem):
 
-    def __init__(self, name, path):
+    def __init__(self, name, path, full_path):
         self.name = name
         self.path = path
+        self.full_path = full_path
         self.size = self._get_size()
 
     def is_file(self):
@@ -37,4 +38,4 @@ class File(FsItem):
         }
 
     def _get_size(self):
-        return os.path.getsize(self.path)
+        return os.path.getsize(self.full_path)


### PR DESCRIPTION
This PR provides fix for issue #853 

`view` method should return path that relative from the working directory