### PR TITLE
Issue #761 Create API method to pull run activity stats.

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
@@ -55,8 +55,10 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.epam.pipeline.security.acl.AclExpressions.ADMIN_ONLY;
 import static com.epam.pipeline.security.acl.AclExpressions.RUN_ID_EXECUTE;
 import static com.epam.pipeline.security.acl.AclExpressions.RUN_ID_OWNER;
 import static com.epam.pipeline.security.acl.AclExpressions.RUN_ID_READ;
@@ -171,6 +173,12 @@ public class RunApiService {
     @AclMask
     public PipelineRun updateTags(final Long runId, final TagsVO tagsVO) {
         return runManager.updateTags(runId, tagsVO);
+    }
+
+    @PreAuthorize(ADMIN_ONLY)
+    @AclMask
+    public List<PipelineRun> loadRunsActivityStats(final LocalDateTime start, final LocalDateTime end) {
+        return runManager.loadRunsActivityStats(start, end);
     }
 
     @AclFilter

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
@@ -65,6 +65,7 @@ import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Controller
@@ -499,5 +500,18 @@ public class PipelineRunController extends AbstractRestController {
     public Result<PipelineRun> attachDisk(@PathVariable(value = RUN_ID) final Long runId,
                                           @RequestBody final DiskAttachRequest request) {
         return Result.success(runApiService.attachDisk(runId, request));
+    }
+
+    @GetMapping(value = "/run/activity")
+    @ResponseBody
+    @ApiOperation(
+        value = "Load runs with its activity statuses.",
+        notes = "Load runs with its activity statuses. " +
+                "Only runs that possibly could cause spending for described period will be returned.",
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<List<PipelineRun>> loadRunsActivityStats(@RequestBody final LocalDateTime start,
+                                                           @RequestBody final LocalDateTime end) {
+        return Result.success(runApiService.loadRunsActivityStats(start, end));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
@@ -510,8 +510,8 @@ public class PipelineRunController extends AbstractRestController {
                 "Only runs that possibly could cause spending for described period will be returned.",
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
-    public Result<List<PipelineRun>> loadRunsActivityStats(@RequestBody final LocalDateTime start,
-                                                           @RequestBody final LocalDateTime end) {
+    public Result<List<PipelineRun>> loadRunsActivityStats(@RequestParam(value = "from") final LocalDateTime start,
+                                                           @RequestParam(value = "to") final LocalDateTime end) {
         return Result.success(runApiService.loadRunsActivityStats(start, end));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
@@ -168,6 +168,11 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
         final MapSqlParameterSource params = new MapSqlParameterSource();
         params.addValue("PERIOD_START", start);
         params.addValue("PERIOD_END", end);
+        final List<Long> targetLastStatuses = Arrays.asList(TaskStatus.RUNNING.getId(),
+                                                            TaskStatus.PAUSING.getId(),
+                                                            TaskStatus.PAUSED.getId(),
+                                                            TaskStatus.RESUMING.getId());
+        params.addValue("TARGET_LAST_STATUSES", targetLastStatuses);
         return getNamedParameterJdbcTemplate().query(loadAllRunsPossiblyActiveInPeriodQuery,
                                                      params,
                                                      PipelineRunParameters.getRowMapper());

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
@@ -50,6 +50,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -116,6 +117,8 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     private String updateRunQuery;
     private String loadRunByPrettyUrlQuery;
     private String updateTagsQuery;
+    private String loadAllRunsPossiblyActiveInPeriodQuery;
+
     // We put Propagation.REQUIRED here because this method can be called from non-transaction context
     // (see PipelineRunManager, it performs internal call for launchPipeline)
 
@@ -137,6 +140,7 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
 
         createRunSids(run.getId(), run.getRunSids());
     }
+
     @Transactional(propagation = Propagation.REQUIRED)
     public PipelineRun loadPipelineRun(Long id) {
         MapSqlParameterSource params = new MapSqlParameterSource();
@@ -157,6 +161,16 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
         } else {
             return null;
         }
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public List<PipelineRun> loadPipelineRunsActiveInPeriod(final LocalDateTime start, final LocalDateTime end) {
+        final MapSqlParameterSource params = new MapSqlParameterSource();
+        params.addValue("PERIOD_START", start);
+        params.addValue("PERIOD_END", end);
+        return getNamedParameterJdbcTemplate().query(loadAllRunsPossiblyActiveInPeriodQuery,
+                                                     params,
+                                                     PipelineRunParameters.getRowMapper());
     }
 
     public String loadSshPassword(Long id) {
@@ -1112,5 +1126,10 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setUpdateTagsQuery(final String updateTagsQuery) {
         this.updateTagsQuery = updateTagsQuery;
+    }
+
+    @Required
+    public void setLoadAllRunsPossiblyActiveInPeriodQuery(final String loadAllRunsPossiblyActiveInPeriodQuery) {
+        this.loadAllRunsPossiblyActiveInPeriodQuery = loadAllRunsPossiblyActiveInPeriodQuery;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -891,7 +891,6 @@ public class PipelineRunManager {
 
         return runs.stream()
             .peek(run -> run.setRunStatuses(runStatuses.get(run.getId())))
-            .filter(run -> CollectionUtils.isNotEmpty(run.getRunStatuses()))
             .collect(Collectors.toList());
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -25,6 +25,7 @@ import com.epam.pipeline.controller.vo.PipelineRunServiceUrlVO;
 import com.epam.pipeline.controller.vo.TagsVO;
 import com.epam.pipeline.dao.pipeline.PipelineRunDao;
 import com.epam.pipeline.entity.AbstractSecuredEntity;
+import com.epam.pipeline.entity.BaseEntity;
 import com.epam.pipeline.entity.cluster.InstancePrice;
 import com.epam.pipeline.entity.cluster.PriceType;
 import com.epam.pipeline.entity.configuration.ExecutionEnvironment;
@@ -82,10 +83,12 @@ import org.springframework.util.StringUtils;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -869,6 +872,58 @@ public class PipelineRunManager {
         return run;
     }
 
+    /**
+     * Returns list of runs, that possibly produced spending during the given period
+     *
+     * @param start beginning of evaluating period
+     * @param end ending of evaluating period
+     * @return run with statuses adjusted
+     */
+    @Transactional(propagation = Propagation.REQUIRED)
+    public List<PipelineRun> loadRunsActivityStats(final LocalDateTime start, final LocalDateTime end) {
+        final List<PipelineRun> runs = pipelineRunDao.loadPipelineRunsActiveInPeriod(start, end);
+        final List<Long> runIds = runs.stream()
+            .map(BaseEntity::getId)
+            .collect(Collectors.toList());
+
+        final Map<Long, List<RunStatus>> runStatuses = runStatusManager.loadRunStatus(runIds).entrySet().stream()
+            .collect(Collectors.toMap(Map.Entry::getKey, e -> adjustStatuses(e.getValue(), start, end)));
+
+        return runs.stream()
+            .peek(run -> run.setRunStatuses(runStatuses.get(run.getId())))
+            .filter(run -> CollectionUtils.isNotEmpty(run.getRunStatuses()))
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Adjust statuses to the given period: all the statuses after the end of the period are removed,
+     * activity periods completed before start of the period are removed as well.
+     * If run was in {@link TaskStatus#RUNNING} state during {@code start} moment, its {@link RunStatus#timestamp}
+     * will be adjusted to {@code start} time point.
+     *
+     * @param runStatuses statuses to be adjusted
+     * @param start beginning of period
+     * @param end ending of period
+     * @return list of adjusted statuses in natural date order
+     */
+    List<RunStatus> adjustStatuses(final List<RunStatus> runStatuses,
+                                   final LocalDateTime start,
+                                   final LocalDateTime end) {
+        runStatuses.removeIf(runStatus -> runStatus.getTimestamp().isAfter(end));
+        runStatuses.sort(Comparator.comparing(RunStatus::getTimestamp));
+        for (int i = runStatuses.size() - 1; i >= 0; i--) {
+            final RunStatus runStatus = runStatuses.get(i);
+            if (runStatus.getTimestamp().isBefore(start)) {
+                if (runStatus.getStatus() == TaskStatus.RUNNING) {
+                    runStatus.setTimestamp(start);
+                    runStatuses.set(i, runStatus);
+                }
+                return runStatuses.subList(i, runStatuses.size());
+            }
+        }
+        return runStatuses;
+    }
+
     @Transactional(propagation = Propagation.REQUIRED)
     public void updateRunsTags(final Collection<PipelineRun> runs) {
         pipelineRunDao.updateRunsTags(runs);
@@ -1171,7 +1226,7 @@ public class PipelineRunManager {
             return parameter;
         }
     }
-    
+
     PipelineRunFilterVO.ProjectFilter resolveProjectFiltering(PipelineRunFilterVO filter) {
         if (CollectionUtils.isEmpty(filter.getProjectIds())) {
             return null;

--- a/api/src/main/resources/dao/pipeline-run-dao.xml
+++ b/api/src/main/resources/dao/pipeline-run-dao.xml
@@ -1407,15 +1407,10 @@
                         tags
                     FROM
                         pipeline.pipeline_run r
-                    INNER JOIN (SELECT run_status_change.run_id as run_id, run_status_change.status as status
-                                        FROM pipeline.run_status_change
-                                     INNER JOIN (SELECT run_id, MAX(date) as date
-                                                        FROM pipeline.run_status_change
-                                                            WHERE date < :PERIOD_END
-                                                                GROUP BY run_id
-                                                 ) as last_status_date
-                                            ON run_status_change.run_id = last_status_date.run_id
-                                                 AND run_status_change.date = last_status_date.date
+                    INNER JOIN (SELECT DISTINCT ON (run_id) run_id, status
+									FROM pipeline.run_status_change
+										WHERE date < :PERIOD_END
+											ORDER BY run_id, date DESC
                                  ) as last_statuses
                     ON r.run_id = last_statuses.run_id
                     WHERE last_statuses.status IN (:TARGET_LAST_STATUSES)

--- a/api/src/main/resources/dao/pipeline-run-dao.xml
+++ b/api/src/main/resources/dao/pipeline-run-dao.xml
@@ -1362,13 +1362,13 @@
             <value>
                 <![CDATA[
                     SELECT
-                        run_id,
+                        r.run_id as run_id,
                         pipeline_id,
                         version,
                         start_date,
                         end_date,
                         parameters,
-                        status,
+                        r.status as status,
                         terminating,
                         pod_id,
                         node_type,
@@ -1407,10 +1407,19 @@
                         tags
                     FROM
                         pipeline.pipeline_run r
-                    WHERE
-                        r.status = 2
-                        OR
-                        r.end_date BETWEEN :PERIOD_START AND :PERIOD_END
+                    INNER JOIN (SELECT run_status_change.run_id as run_id, run_status_change.status as status
+                                        FROM pipeline.run_status_change
+                                     INNER JOIN (SELECT run_id, MAX(date) as date
+                                                        FROM pipeline.run_status_change
+                                                            WHERE date < :PERIOD_END
+                                                                GROUP BY run_id
+                                                 ) as last_status_date
+                                            ON run_status_change.run_id = last_status_date.run_id
+                                                 AND run_status_change.date = last_status_date.date
+                                 ) as last_statuses
+                    ON r.run_id = last_statuses.run_id
+                    WHERE last_statuses.status IN (:TARGET_LAST_STATUSES)
+                            OR r.end_date BETWEEN :PERIOD_START AND :PERIOD_END
                 ]]>
             </value>
         </property>

--- a/api/src/main/resources/dao/pipeline-run-dao.xml
+++ b/api/src/main/resources/dao/pipeline-run-dao.xml
@@ -1358,6 +1358,62 @@
                 ]]>
             </value>
         </property>
+        <property name="loadAllRunsPossiblyActiveInPeriodQuery">
+            <value>
+                <![CDATA[
+                    SELECT
+                        run_id,
+                        pipeline_id,
+                        version,
+                        start_date,
+                        end_date,
+                        parameters,
+                        status,
+                        terminating,
+                        pod_id,
+                        node_type,
+                        node_disk,
+                        node_ip,
+                        node_name,
+                        node_id,
+                        node_image,
+                        node_cloud_region,
+                        docker_image,
+                        cmd_template,
+                        actual_cmd,
+                        timeout,
+                        owner,
+                        service_url,
+                        pod_ip,
+                        commit_status,
+                        last_change_commit_time,
+                        config_name,
+                        node_count,
+                        parent_id,
+                        entities_ids,
+                        is_spot,
+                        configuration_id,
+                        pod_status,
+                        prolonged_at_time,
+                        last_notification_time,
+                        last_idle_notification_time,
+                        exec_preferences,
+                        pretty_url,
+                        price_per_hour,
+                        state_reason,
+                        non_pause,
+                        node_real_disk,
+                        node_cloud_provider,
+                        tags
+                    FROM
+                        pipeline.pipeline_run r
+                    WHERE
+                        r.status = 2
+                        OR
+                        r.end_date BETWEEN :PERIOD_START AND :PERIOD_END
+                ]]>
+            </value>
+        </property>
         <property name="updateTagsQuery">
             <value>
                 <![CDATA[

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
@@ -118,7 +118,7 @@ public class PipelineRunDaoTest extends AbstractSpringTest {
     private PipelineRunDao pipelineRunDao;
 
     @Autowired
-    RunStatusDao runStatusDao;
+    private RunStatusDao runStatusDao;
 
     @Autowired
     private FilterDao filterDao;

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunManagerTest.java
@@ -524,13 +524,13 @@ public class PipelineRunManagerTest extends AbstractManagerTest {
         final LocalDateTime beforeSyncStart = SYNC_PERIOD_START.minusHours(HOURS_12);
         final LocalDateTime afterSyncStart = SYNC_PERIOD_START.plusHours(HOURS_12);
 
-        final PipelineRun run1 = launchPipelineRun(beforeSyncStart, beforeSyncStart);
+        final PipelineRun run1 = launchPipelineRun(beforeSyncStart.minusHours(12), beforeSyncStart);
         final PipelineRun run2 = launchPipelineRun(beforeSyncStart, afterSyncStart);
-        final PipelineRun run3 = launchPipelineRun(afterSyncStart, afterSyncStart);
+        final PipelineRun run3 = launchPipelineRun(afterSyncStart, afterSyncStart.plusHours(HOURS_12));
         final PipelineRun run4 = launchPipelineRun(afterSyncStart, null);
-        final PipelineRun run5 = launchPipelineRun(beforeSyncStart, null);
-        saveStatusForRun(run5.getId(), TaskStatus.PAUSED, beforeSyncStart);
-        saveStatusForRun(run5.getId(), TaskStatus.RUNNING, beforeSyncStart);
+        final PipelineRun run5 = launchPipelineRun(beforeSyncStart.minusHours(HOURS_24), null);
+        saveStatusForRun(run5.getId(), TaskStatus.PAUSED, beforeSyncStart.minusHours(HOURS_18));
+        saveStatusForRun(run5.getId(), TaskStatus.RUNNING, beforeSyncStart.minusHours(HOURS_12));
 
         final Map<Long, PipelineRun> stats =
             pipelineRunManager.loadRunsActivityStats(SYNC_PERIOD_START, SYNC_PERIOD_END).stream()
@@ -575,9 +575,9 @@ public class PipelineRunManagerTest extends AbstractManagerTest {
         pipelineRun.setStartDate(TestUtils.convertLocalDateTimeToDate(startDate));
         saveStatusForRun(pipelineRun.getId(), TaskStatus.RUNNING, startDate);
         if (stopDate != null) {
-            pipelineRun.setStatus(TaskStatus.PAUSED);
+            pipelineRun.setStatus(TaskStatus.STOPPED);
             pipelineRun.setEndDate(TestUtils.convertLocalDateTimeToDate(stopDate));
-            saveStatusForRun(pipelineRun.getId(), TaskStatus.PAUSED, stopDate);
+            saveStatusForRun(pipelineRun.getId(), TaskStatus.STOPPED, stopDate);
         } else {
             pipelineRun.setEndDate(null);
         }

--- a/api/src/test/java/com/epam/pipeline/util/TestUtils.java
+++ b/api/src/test/java/com/epam/pipeline/util/TestUtils.java
@@ -34,6 +34,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.mockito.Mockito;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -151,5 +153,13 @@ public final class TestUtils {
         run.setEntitiesIds(Collections.singletonList(entitiesId));
         run.setConfigurationId(configurationId);
         return run;
+    }
+
+    public static Date convertLocalDateTimeToDate(final LocalDateTime dt) {
+        if (dt == null) {
+            return null;
+        } else {
+            return Date.from(dt.atZone(ZoneId.systemDefault()).toInstant());
+        }
     }
 }


### PR DESCRIPTION
This PR related to issue #761. 
To build spending reports we need to pull pipeline run's activity statistic, which is described by run's statuses changes.
For this puprpose new method `loadRunsActivityStats` is introduced in `PipelineRunController`: it returns runs, that caused spending for requested period.
- necessary methods are implemented in `PipelineRunController` and underlaying services
- tests for new functionality are provided
- to reduce amount of transfered data runs' statuses are filtered, so we keep in response only ones, that intersects with requested period