### PR TITLE
Ability to export user list

### DIFF
--- a/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
@@ -18,6 +18,7 @@ package com.epam.pipeline.controller.user;
 
 import com.epam.pipeline.controller.AbstractRestController;
 import com.epam.pipeline.controller.Result;
+import com.epam.pipeline.controller.vo.PipelineUserExportVO;
 import com.epam.pipeline.controller.vo.PipelineUserVO;
 import com.epam.pipeline.controller.vo.RouteType;
 import com.epam.pipeline.entity.security.JwtRawToken;
@@ -45,6 +46,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import java.util.List;
 
 @Controller
@@ -264,6 +266,19 @@ public class UserController extends AbstractRestController {
             })
     public Result<Boolean> checkUserByGroup(@RequestParam String userName, @RequestParam String group) {
         return Result.success(userApiService.checkUserByGroup(userName, group));
+    }
+
+    @RequestMapping(value = "/user/export", method = RequestMethod.POST)
+    @ResponseBody
+    @ApiOperation(
+            value = "Exports users.",
+            notes = "Exports users with specified information",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public void exportUsers(@RequestBody PipelineUserExportVO attr, HttpServletResponse response) throws IOException {
+        writeFileToResponse(response, userApiService.exportUsers(attr), "users.csv");
     }
 
     @RequestMapping(value = "/group", method = RequestMethod.GET)

--- a/api/src/main/java/com/epam/pipeline/controller/vo/PipelineUserExportVO.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/PipelineUserExportVO.java
@@ -29,4 +29,5 @@ public class PipelineUserExportVO {
     private boolean includeMetadata;
     private boolean includeRegistrationDate;
     private boolean includeFirstLoginDate;
+    private boolean includeHeader;
 }

--- a/api/src/main/java/com/epam/pipeline/controller/vo/PipelineUserExportVO.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/PipelineUserExportVO.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.controller.vo;
+
+import lombok.Data;
+
+
+@Data
+public class PipelineUserExportVO {
+    private boolean includeId;
+    private boolean includeUserName;
+    private boolean includeRoles;
+    private boolean includeGroups;
+    private boolean includeMetadata;
+    private boolean includeRegistrationDate;
+    private boolean includeFirstLoginDate;
+}

--- a/api/src/main/java/com/epam/pipeline/controller/vo/PipelineUserExportVO.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/PipelineUserExportVO.java
@@ -23,6 +23,7 @@ import lombok.Data;
 public class PipelineUserExportVO {
     private boolean includeId;
     private boolean includeUserName;
+    private boolean includeEmail;
     private boolean includeRoles;
     private boolean includeGroups;
     private boolean includeMetadata;

--- a/api/src/main/java/com/epam/pipeline/dao/user/UserDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/user/UserDao.java
@@ -20,6 +20,7 @@ import com.epam.pipeline.config.JsonMapper;
 import com.epam.pipeline.dao.DaoHelper;
 import com.epam.pipeline.entity.user.DefaultRoles;
 import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.entity.user.PipelineUserWithStoragePath;
 import com.epam.pipeline.entity.user.Role;
 import com.epam.pipeline.entity.utils.DateUtils;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -53,6 +54,7 @@ public class UserDao extends NamedParameterJdbcDaoSupport {
     private String createUserQuery;
     private String updateUserQuery;
     private String loadAllUsersQuery;
+    private String loadAllUsersWithDefaultDataStoragePathQuery;
     private String loadUserByNameQuery;
     private String loadUsersByNamesQuery;
     private String loadUserByIdQuery;
@@ -98,6 +100,11 @@ public class UserDao extends NamedParameterJdbcDaoSupport {
 
     public Collection<PipelineUser> loadAllUsers() {
         return getJdbcTemplate().query(loadAllUsersQuery, UserParameters.getUserExtractor());
+    }
+
+    public Collection<PipelineUserWithStoragePath> loadAllUsersWithDataStoragePath() {
+        return getJdbcTemplate().query(loadAllUsersWithDefaultDataStoragePathQuery,
+                UserParameters.getUserWithDataStorageExtractor());
     }
 
     public PipelineUser loadUserByName(String name) {
@@ -234,6 +241,7 @@ public class UserDao extends NamedParameterJdbcDaoSupport {
         ATTRIBUTES,
         PREFIX,
         USER_DEFAULT_STORAGE_ID,
+        USER_DEFAULT_STORAGE_PATH,
         USER_BLOCKED,
         REGISTRATION_DATE,
         FIRST_LOGIN_DATE;
@@ -278,6 +286,30 @@ public class UserDao extends NamedParameterJdbcDaoSupport {
                         Role role = new Role();
                         RoleParameters.parseRole(rs, role, false);
                         user.getRoles().add(role);
+                    }
+                }
+                return users.values();
+            };
+        }
+
+        static ResultSetExtractor<Collection<PipelineUserWithStoragePath>> getUserWithDataStorageExtractor() {
+            return (ResultSet rs) -> {
+                Map<Long, PipelineUserWithStoragePath> users = new HashMap<>();
+                while (rs.next()) {
+                    Long userId = rs.getLong(USER_ID.name());
+                    PipelineUserWithStoragePath user = users.get(userId);
+                    if (user == null) {
+                        user = PipelineUserWithStoragePath.builder()
+                                .pipelineUser(parseUser(rs, userId))
+                                .defaultStoragePath(rs.getString(USER_DEFAULT_STORAGE_PATH.name()))
+                                .build();
+                        users.put(userId, user);
+                    }
+                    rs.getLong(RoleParameters.ROLE_ID.name());
+                    if (!rs.wasNull()) {
+                        Role role = new Role();
+                        RoleParameters.parseRole(rs, role, false);
+                        user.getPipelineUser().getRoles().add(role);
                     }
                 }
                 return users.values();
@@ -423,5 +455,10 @@ public class UserDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setLoadUsersByStorageIdQuery(final String loadUsersByStorageIdQuery) {
         this.loadUsersByStorageIdQuery = loadUsersByStorageIdQuery;
+    }
+
+    @Required
+    public void setLoadAllUsersWithDefaultDataStoragePathQuery(final String loadAllUsersWithDefaultDataStoragePathQuery) {
+        this.loadAllUsersWithDefaultDataStoragePathQuery = loadAllUsersWithDefaultDataStoragePathQuery;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/user/UserApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/UserApiService.java
@@ -16,6 +16,7 @@
 
 package com.epam.pipeline.manager.user;
 
+import com.epam.pipeline.controller.vo.PipelineUserExportVO;
 import com.epam.pipeline.controller.vo.PipelineUserVO;
 import com.epam.pipeline.entity.user.CustomControl;
 import com.epam.pipeline.entity.user.GroupStatus;
@@ -156,5 +157,9 @@ public class UserApiService {
      */
     public List<PipelineUser> findUsers(String prefix) {
         return userManager.findUsers(prefix);
+    }
+
+    public byte[] exportUsers(final PipelineUserExportVO attr) {
+        return userManager.exportUsers(attr);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/user/UserManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/UserManager.java
@@ -25,9 +25,10 @@ import com.epam.pipeline.dao.user.RoleDao;
 import com.epam.pipeline.dao.user.UserDao;
 import com.epam.pipeline.entity.user.CustomControl;
 import com.epam.pipeline.entity.user.DefaultRoles;
-import com.epam.pipeline.entity.user.PipelineUser;
-import com.epam.pipeline.entity.user.Role;
 import com.epam.pipeline.entity.user.GroupStatus;
+import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.entity.user.PipelineUserWithStoragePath;
+import com.epam.pipeline.entity.user.Role;
 import com.epam.pipeline.entity.utils.ControlEntry;
 import com.epam.pipeline.manager.datastorage.DataStorageValidator;
 import com.epam.pipeline.manager.preference.PreferenceManager;
@@ -148,6 +149,10 @@ public class UserManager {
 
     public Collection<PipelineUser> loadAllUsers() {
         return userDao.loadAllUsers();
+    }
+
+    public Collection<PipelineUserWithStoragePath> loadAllUsersWithDataStoragePath() {
+        return userDao.loadAllUsersWithDataStoragePath();
     }
 
     @Transactional(propagation = Propagation.REQUIRED)
@@ -353,14 +358,14 @@ public class UserManager {
         }
 
         try {
-            final ColumnPositionMappingStrategy<PipelineUser> strategy = new ColumnPositionMappingStrategy<>();
-            strategy.setType(PipelineUser.class);
+            final ColumnPositionMappingStrategy<PipelineUserWithStoragePath> strategy = new ColumnPositionMappingStrategy<>();
+            strategy.setType(PipelineUserWithStoragePath.class);
             strategy.setColumnMapping(csvHeader);
 
-            new StatefulBeanToCsvBuilder<PipelineUser>(writer)
+            new StatefulBeanToCsvBuilder<PipelineUserWithStoragePath>(writer)
                     .withMappingStrategy(strategy)
                     .withEscapechar(CSVWriter.NO_ESCAPE_CHARACTER)
-                    .build().write(new ArrayList<>(loadAllUsers()));
+                    .build().write(new ArrayList<>(loadAllUsersWithDataStoragePath()));
             return writer.toString().getBytes();
         } catch (CsvDataTypeMismatchException | CsvRequiredFieldEmptyException e) {
             throw new IllegalStateException(e);
@@ -397,30 +402,31 @@ public class UserManager {
     private String[] getColumnMapping(final PipelineUserExportVO attr) {
         final List<String> result = new ArrayList<>();
         if (attr.isIncludeId()) {
-            result.add(PipelineUser.PipelineUserFields.ID.getValue());
+            result.add(PipelineUserWithStoragePath.PipelineUserFields.ID.getValue());
         }
         if (attr.isIncludeUserName()) {
-            result.add(PipelineUser.PipelineUserFields.USER_NAME.getValue());
+            result.add(PipelineUserWithStoragePath.PipelineUserFields.USER_NAME.getValue());
         }
         if (attr.isIncludeEmail()) {
-            result.add(PipelineUser.PipelineUserFields.EMAIL.getValue());
+            result.add(PipelineUserWithStoragePath.PipelineUserFields.EMAIL.getValue());
         }
         if (attr.isIncludeRoles()) {
-            result.add(PipelineUser.PipelineUserFields.ROLES.getValue());
+            result.add(PipelineUserWithStoragePath.PipelineUserFields.ROLES.getValue());
         }
         if (attr.isIncludeGroups()) {
-            result.add(PipelineUser.PipelineUserFields.GROUPS.getValue());
+            result.add(PipelineUserWithStoragePath.PipelineUserFields.GROUPS.getValue());
         }
         if (attr.isIncludeMetadata()) {
-            result.add(PipelineUser.PipelineUserFields.ATTRIBUTES.getValue());
-            result.add(PipelineUser.PipelineUserFields.BLOCKED.getValue());
-            result.add(PipelineUser.PipelineUserFields.DEFAULT_STORAGE_ID.getValue());
+            result.add(PipelineUserWithStoragePath.PipelineUserFields.ATTRIBUTES.getValue());
+            result.add(PipelineUserWithStoragePath.PipelineUserFields.BLOCKED.getValue());
+            result.add(PipelineUserWithStoragePath.PipelineUserFields.DEFAULT_STORAGE_ID.getValue());
+            result.add(PipelineUserWithStoragePath.PipelineUserFields.DEFAULT_STORAGE_PATH.getValue());
         }
         if (attr.isIncludeRegistrationDate()) {
-            result.add(PipelineUser.PipelineUserFields.REGISTRATION_DATE.getValue());
+            result.add(PipelineUserWithStoragePath.PipelineUserFields.REGISTRATION_DATE.getValue());
         }
         if (attr.isIncludeFirstLoginDate()) {
-            result.add(PipelineUser.PipelineUserFields.FIRST_LOGIN_DATE.getValue());
+            result.add(PipelineUserWithStoragePath.PipelineUserFields.FIRST_LOGIN_DATE.getValue());
         }
         return result.toArray(new String[0]);
     }

--- a/api/src/main/java/com/epam/pipeline/manager/user/UserManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/UserManager.java
@@ -395,32 +395,31 @@ public class UserManager {
     private String[] getColumnMapping(final PipelineUserExportVO attr) {
         final List<String> result = new ArrayList<>();
         if (attr.isIncludeId()) {
-            result.add("id");
+            result.add(PipelineUser.PipelineUserFields.ID.getValue());
         }
         if (attr.isIncludeUserName()) {
-            result.add("userName");
+            result.add(PipelineUser.PipelineUserFields.USER_NAME.getValue());
         }
         if (attr.isIncludeEmail()) {
-            result.add("email");
+            result.add(PipelineUser.PipelineUserFields.EMAIL.getValue());
         }
         if (attr.isIncludeRoles()) {
-            result.add("roles");
+            result.add(PipelineUser.PipelineUserFields.ROLES.getValue());
         }
         if (attr.isIncludeGroups()) {
-            result.add("groups");
+            result.add(PipelineUser.PipelineUserFields.GROUPS.getValue());
         }
         if (attr.isIncludeMetadata()) {
-            result.add("admin");
-            result.add("attributes");
-            result.add("blocked");
-            result.add("defaultStorageId");
+            result.add(PipelineUser.PipelineUserFields.ATTRIBUTES.getValue());
+            result.add(PipelineUser.PipelineUserFields.BLOCKED.getValue());
+            result.add(PipelineUser.PipelineUserFields.DEFAULT_STORAGE_ID.getValue());
 
         }
         if (attr.isIncludeRegistrationDate()) {
-            result.add("registrationDate");
+            result.add(PipelineUser.PipelineUserFields.REGISTRATION_DATE.getValue());
         }
         if (attr.isIncludeFirstLoginDate()) {
-            result.add("firstLoginDate");
+            result.add(PipelineUser.PipelineUserFields.FIRST_LOGIN_DATE.getValue());
         }
         return result.toArray(new String[0]);
     }

--- a/api/src/main/java/com/epam/pipeline/manager/user/UserManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/UserManager.java
@@ -345,15 +345,17 @@ public class UserManager {
 
     public byte[] exportUsers(final PipelineUserExportVO attr) {
         final StringWriter writer = new StringWriter();
-        final String[] csvColumn = getColumnMapping(attr);
+        final String[] csvHeader = getColumnMapping(attr);
 
-        writer.append(String.join(CSV_DELIMITER, csvColumn));
-        writer.append(NEW_LINE);
+        if (attr.isIncludeHeader()) {
+            writer.append(String.join(CSV_DELIMITER, csvHeader));
+            writer.append(NEW_LINE);
+        }
 
         try {
             final ColumnPositionMappingStrategy<PipelineUser> strategy = new ColumnPositionMappingStrategy<>();
             strategy.setType(PipelineUser.class);
-            strategy.setColumnMapping(csvColumn);
+            strategy.setColumnMapping(csvHeader);
 
             new StatefulBeanToCsvBuilder<PipelineUser>(writer)
                     .withMappingStrategy(strategy)
@@ -413,7 +415,6 @@ public class UserManager {
             result.add(PipelineUser.PipelineUserFields.ATTRIBUTES.getValue());
             result.add(PipelineUser.PipelineUserFields.BLOCKED.getValue());
             result.add(PipelineUser.PipelineUserFields.DEFAULT_STORAGE_ID.getValue());
-
         }
         if (attr.isIncludeRegistrationDate()) {
             result.add(PipelineUser.PipelineUserFields.REGISTRATION_DATE.getValue());

--- a/api/src/main/java/com/epam/pipeline/manager/user/UserManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/UserManager.java
@@ -357,7 +357,7 @@ public class UserManager {
 
             new StatefulBeanToCsvBuilder<PipelineUser>(writer)
                     .withMappingStrategy(strategy)
-                    .withQuotechar(CSVWriter.NO_QUOTE_CHARACTER)
+                    .withEscapechar(CSVWriter.NO_ESCAPE_CHARACTER)
                     .build().write(new ArrayList<>(loadAllUsers()));
             return writer.toString().getBytes();
         } catch (CsvDataTypeMismatchException | CsvRequiredFieldEmptyException e) {
@@ -399,6 +399,9 @@ public class UserManager {
         }
         if (attr.isIncludeUserName()) {
             result.add("userName");
+        }
+        if (attr.isIncludeEmail()) {
+            result.add("email");
         }
         if (attr.isIncludeRoles()) {
             result.add("roles");

--- a/api/src/main/resources/dao/user-dao.xml
+++ b/api/src/main/resources/dao/user-dao.xml
@@ -80,6 +80,31 @@
                 ]]>
             </value>
         </property>
+        <property name="loadAllUsersWithDefaultDataStoragePathQuery">
+            <value>
+                <![CDATA[
+                     SELECT
+                      u.id as user_id,
+                      u.name as user_name,
+                      u.groups as user_groups,
+                      u.attributes as attributes,
+                      u.default_storage_id as user_default_storage_id,
+                      u.blocked as user_blocked,
+                      u.registration_date,
+                      u.first_login_date,
+                      r.id as role_id,
+                      r.name as role_name,
+                      r.predefined as role_predefined,
+                      r.user_default as role_user_default,
+                      r.default_storage_id as role_default_storage_id,
+                      ds.path as user_default_storage_path
+                    FROM pipeline.user u
+                      LEFT JOIN pipeline.user_roles ur ON u.id = ur.user_id
+                      LEFT JOIN pipeline.role r ON ur.role_id = r.id
+                      LEFT JOIN pipeline.datastorage ds ON ds.datastorage_id = u.default_storage_id
+                ]]>
+            </value>
+        </property>
         <property name="findUsersByPrefixQuery">
             <value>
                 <![CDATA[

--- a/api/src/test/java/com/epam/pipeline/manager/user/UserManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/user/UserManagerTest.java
@@ -19,14 +19,21 @@
 package com.epam.pipeline.manager.user;
 
 import com.epam.pipeline.AbstractSpringTest;
+import com.epam.pipeline.controller.vo.DataStorageVO;
 import com.epam.pipeline.controller.vo.PipelineUserExportVO;
+import com.epam.pipeline.controller.vo.region.AWSRegionDTO;
 import com.epam.pipeline.dao.notification.MonitoringNotificationDao;
+import com.epam.pipeline.entity.SecuredEntityWithAction;
+import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
+import com.epam.pipeline.entity.datastorage.StorageServiceType;
 import com.epam.pipeline.entity.notification.NotificationMessage;
 import com.epam.pipeline.entity.notification.NotificationTemplate;
 import com.epam.pipeline.entity.user.GroupStatus;
 import com.epam.pipeline.entity.user.PipelineUser;
 import com.epam.pipeline.entity.user.Role;
 import com.epam.pipeline.entity.utils.DateUtils;
+import com.epam.pipeline.manager.datastorage.DataStorageManager;
+import com.epam.pipeline.manager.region.CloudRegionManager;
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,25 +46,32 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static com.epam.pipeline.entity.user.PipelineUserWithStoragePath.PipelineUserFields.*;
+
 
 public class UserManagerTest extends AbstractSpringTest {
 
     private static final String TEST_USER = "TestUser";
     private static final String SUBJECT = "Subject";
     private static final String BODY = "Body";
-    private static final Long DEFAULT_STORAGE_ID = null;
     private static final List<Long> DEFAULT_USER_ROLES = Collections.singletonList(2L);
     private static final String TEST_GROUP_NAME_1 = "test_group_1";
     private static final List<String> DEFAULT_USER_GROUPS = Collections.singletonList(TEST_GROUP_NAME_1);
     private static final Map<String, String> DEFAULT_USER_ATTRIBUTE = Collections.emptyMap();
     private static final String ROLE_USER = "ROLE_USER";
-    private static final String ID = "id";
-    private static final String USER_NAME = "userName";
-    private static final String ROLES = "roles";
     private static final String CSV_SEPARATOR = ",";
+    private static final String USER_DEFAULT_DS = "user-default-ds";
+    private static final String REGION_CODE = "eu-central-1";
+    private static final String REGION_NAME = "aws_region";
 
     @Autowired
     private UserManager userManager;
+
+    @Autowired
+    private DataStorageManager dataStorageManager;
+
+    @Autowired
+    private CloudRegionManager cloudRegionManager;
 
     @Autowired
     private MonitoringNotificationDao notificationDao;
@@ -74,7 +88,7 @@ public class UserManagerTest extends AbstractSpringTest {
                                                        .stream()
                                                        .map(Role::getId)
                                                        .collect(Collectors.toList()));
-        Assert.assertEquals(DEFAULT_STORAGE_ID, newUser.getDefaultStorageId());
+        Assert.assertNull(newUser.getDefaultStorageId());
         Assert.assertNotNull(newUser.getRegistrationDate());
         Assert.assertNull(newUser.getFirstLoginDate());
     }
@@ -100,20 +114,42 @@ public class UserManagerTest extends AbstractSpringTest {
         Assert.assertEquals(2, exported.length);
         Assert.assertTrue(
                 Arrays.stream(exported).anyMatch(
-                        s -> ("\"" + newUser.getId() + "\"" + CSV_SEPARATOR + "\"" + newUser.getUserName() + "\"").equals(s)
+                    s -> ("\"" + newUser.getId() + "\"" + CSV_SEPARATOR + "\"" + newUser.getUserName() + "\"").equals(s)
                 )
         );
 
         attr.setIncludeHeader(true);
         exported = new String(userManager.exportUsers(attr)).split("\n");
         Assert.assertEquals(3, exported.length);
-        Assert.assertEquals(ID + CSV_SEPARATOR + USER_NAME, exported[0]);
+        Assert.assertEquals(ID.getValue() + CSV_SEPARATOR + USER_NAME.getValue(), exported[0]);
 
         attr.setIncludeRoles(true);
         exported = new String(userManager.exportUsers(attr)).split("\n");
         Assert.assertEquals(3, exported.length);
-        Assert.assertEquals(ID + CSV_SEPARATOR + USER_NAME + CSV_SEPARATOR + ROLES, exported[0]);
+        Assert.assertEquals(
+                ID.getValue() + CSV_SEPARATOR + USER_NAME.getValue() + CSV_SEPARATOR + ROLES.getValue(),
+                exported[0]
+        );
         Assert.assertTrue(Arrays.stream(exported).anyMatch(s -> s.contains(ROLE_USER)));
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void exportUsersWithDataStorage() {
+        final PipelineUser userWithDS = createPipelineUserWithDataStorage();
+        PipelineUserExportVO attr = new PipelineUserExportVO();
+        attr.setIncludeMetadata(true);
+        attr.setIncludeHeader(true);
+        attr.setIncludeId(true);
+        final String[] exported = new String(userManager.exportUsers(attr)).split("\n");
+        Assert.assertEquals(3, exported.length);
+        Assert.assertEquals(
+                ID.getValue() + CSV_SEPARATOR + ATTRIBUTES.getValue() + CSV_SEPARATOR + BLOCKED.getValue() +
+                        CSV_SEPARATOR + DEFAULT_STORAGE_ID.getValue() + CSV_SEPARATOR + DEFAULT_STORAGE_PATH.getValue(),
+                exported[0]);
+        Assert.assertTrue(Arrays.stream(exported).anyMatch(
+            s -> s.contains("\"" + userWithDS.getDefaultStorageId() + "\"" + "," + "\"" + USER_DEFAULT_DS + "\""))
+        );
     }
 
     @Test
@@ -226,6 +262,24 @@ public class UserManagerTest extends AbstractSpringTest {
                                       DEFAULT_USER_ROLES,
                                       DEFAULT_USER_GROUPS,
                                       DEFAULT_USER_ATTRIBUTE,
-                                      DEFAULT_STORAGE_ID);
+                                      null);
+    }
+
+    private PipelineUser createPipelineUserWithDataStorage() {
+        DataStorageVO dataStorageVO = new DataStorageVO();
+        dataStorageVO.setServiceType(StorageServiceType.OBJECT_STORAGE);
+        AWSRegionDTO regionDTO = new AWSRegionDTO();
+        regionDTO.setRegionCode(REGION_CODE);
+        regionDTO.setName(REGION_NAME);
+        dataStorageVO.setRegionId(cloudRegionManager.create(regionDTO).getId());
+        dataStorageVO.setPath(USER_DEFAULT_DS);
+        dataStorageVO.setName(USER_DEFAULT_DS);
+        SecuredEntityWithAction<AbstractDataStorage> ds =
+                dataStorageManager.create(dataStorageVO, false, false, false);
+        return userManager.createUser(TEST_USER,
+                DEFAULT_USER_ROLES,
+                DEFAULT_USER_GROUPS,
+                DEFAULT_USER_ATTRIBUTE,
+                ds.getEntity().getId());
     }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/user/PipelineUser.java
+++ b/core/src/main/java/com/epam/pipeline/entity/user/PipelineUser.java
@@ -148,4 +148,25 @@ public class PipelineUser implements StorageContainer {
         }
 
     }
+
+    @Getter
+    public enum PipelineUserFields {
+
+        ID("id"),
+        USER_NAME("userName"),
+        EMAIL("email"),
+        ROLES("roles"),
+        GROUPS("groups"),
+        BLOCKED("blocked"),
+        REGISTRATION_DATE("registrationDate"),
+        FIRST_LOGIN_DATE("firstLoginDate"),
+        ATTRIBUTES("attributes"),
+        DEFAULT_STORAGE_ID("defaultStorageId");
+
+        private final String value;
+
+        PipelineUserFields(final String value) {
+            this.value = value;
+        }
+    }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/user/PipelineUser.java
+++ b/core/src/main/java/com/epam/pipeline/entity/user/PipelineUser.java
@@ -149,24 +149,4 @@ public class PipelineUser implements StorageContainer {
 
     }
 
-    @Getter
-    public enum PipelineUserFields {
-
-        ID("id"),
-        USER_NAME("userName"),
-        EMAIL("email"),
-        ROLES("roles"),
-        GROUPS("groups"),
-        BLOCKED("blocked"),
-        REGISTRATION_DATE("registrationDate"),
-        FIRST_LOGIN_DATE("firstLoginDate"),
-        ATTRIBUTES("attributes"),
-        DEFAULT_STORAGE_ID("defaultStorageId");
-
-        private final String value;
-
-        PipelineUserFields(final String value) {
-            this.value = value;
-        }
-    }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/user/PipelineUserWithStoragePath.java
+++ b/core/src/main/java/com/epam/pipeline/entity/user/PipelineUserWithStoragePath.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.user;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Delegate;
+
+@Getter
+@Setter
+@Builder
+public class PipelineUserWithStoragePath {
+
+    @Delegate
+    private PipelineUser pipelineUser;
+    private String defaultStoragePath;
+
+    @Getter
+    public enum PipelineUserFields {
+
+        ID("id"),
+        USER_NAME("userName"),
+        EMAIL("email"),
+        ROLES("roles"),
+        GROUPS("groups"),
+        BLOCKED("blocked"),
+        REGISTRATION_DATE("registrationDate"),
+        FIRST_LOGIN_DATE("firstLoginDate"),
+        ATTRIBUTES("attributes"),
+        DEFAULT_STORAGE_ID("defaultStorageId"),
+        DEFAULT_STORAGE_PATH("defaultStoragePath");
+
+        private final String value;
+
+        PipelineUserFields(final String value) {
+            this.value = value;
+        }
+    }
+}

--- a/core/src/main/java/com/epam/pipeline/entity/user/Role.java
+++ b/core/src/main/java/com/epam/pipeline/entity/user/Role.java
@@ -55,4 +55,9 @@ public class Role implements StorageContainer {
     public Long getDefaultStorageId() {
         return defaultStorageId;
     }
+
+    @Override
+    public String toString() {
+        return name;
+    }
 }


### PR DESCRIPTION
This PR is related to #852 
It adds opportunity to export user list as csv file.
User can choose information that he want to export:

- id
- userName
- email
- roles
- groups
- metadata
  - attributes 
  - blocked
  - default_storage_id
  - default_storage_path
- registration date
- first login date

Also user can include or not include csv header.