### PR TITLE
FSBrowser: Hide upload button on errors

### DIFF
--- a/fs-browser/fs-browser-client/src/components/browser/index.js
+++ b/fs-browser/fs-browser-client/src/components/browser/index.js
@@ -211,6 +211,7 @@ class Browser extends React.Component {
 
   render() {
     const {directory, path, taskManager} = this.props;
+    const hasError = !!(directory.error || (!directory.pending && !directory.loaded));
     return (
       <>
         <Route
@@ -218,11 +219,12 @@ class Browser extends React.Component {
           render={props => (
             <Header
               {...props}
-              hasError={!!(directory.error || (!directory.pending && !directory.loaded))}
+              hasError={hasError}
             />
           )}
         />
         <Upload
+          showUploadArea={!hasError}
           className={styles.uploadContainer}
           path={path || ''}
         >

--- a/fs-browser/fs-browser-client/src/components/browser/index.js
+++ b/fs-browser/fs-browser-client/src/components/browser/index.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import {inject, observer} from 'mobx-react';
+import {Route} from 'react-router-dom';
 import classNames from 'classnames';
+import Header from '../header';
 import Icon from '../shared/icon';
 import displaySize from '../../utilities/display-size';
 import {parse} from '../../utilities/query-parameters';
@@ -208,21 +210,32 @@ class Browser extends React.Component {
   };
 
   render() {
-    const {path, taskManager} = this.props;
+    const {directory, path, taskManager} = this.props;
     return (
-      <Upload
-        className={styles.uploadContainer}
-        path={path || ''}
-      >
-        <div
-          className={styles.container}
+      <>
+        <Route
+          path="/"
+          render={props => (
+            <Header
+              {...props}
+              hasError={!!(directory.error || (!directory.pending && !directory.loaded))}
+            />
+          )}
+        />
+        <Upload
+          className={styles.uploadContainer}
+          path={path || ''}
         >
-          {this.renderDirectory()}
-          <TaskQueue
-            activeTasksCount={(taskManager.items || []).length}
-          />
-        </div>
-      </Upload>
+          <div
+            className={styles.container}
+          >
+            {this.renderDirectory()}
+            <TaskQueue
+              activeTasksCount={(taskManager.items || []).length}
+            />
+          </div>
+        </Upload>
+      </>
     );
   }
 }

--- a/fs-browser/fs-browser-client/src/components/fs-browser.js
+++ b/fs-browser/fs-browser-client/src/components/fs-browser.js
@@ -7,7 +7,6 @@ import {
 } from 'react-router-dom';
 import {taskManager} from '../models';
 import Browser from './browser';
-import Header from './header';
 import AlertsContainer, {messages} from './shared/alerts';
 
 const history = createHashHistory({});
@@ -32,7 +31,6 @@ export default function () {
           }}
         >
           <AlertsContainer />
-          <Route path="/" component={Header} />
           <Route path="/" component={Browser} />
         </div>
       </Router>

--- a/fs-browser/fs-browser-client/src/components/header/index.js
+++ b/fs-browser/fs-browser-client/src/components/header/index.js
@@ -4,7 +4,7 @@ import PathInput from './path-input';
 import Upload from '../upload';
 import styles from './header.css';
 
-function header({disabled, history}) {
+function header({disabled, history, hasError = false}) {
   const {location} = history;
   const {path} = parse(location.search);
   const onNavigate = (p) => {
@@ -21,7 +21,7 @@ function header({disabled, history}) {
       <Upload
         path={path || ''}
         showUploadArea={false}
-        showButton
+        showButton={!hasError}
         uploadAreaClassName={styles.uploadArea}
       >
         <PathInput


### PR DESCRIPTION
Fix for the #877 

The `Upload` button won't be available If a directory load failed.