### PR TITLE
Issue 761 Billing report agent: storage cost

### DIFF
--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
@@ -47,6 +47,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.util.Assert;
@@ -510,8 +511,11 @@ public class PipelineRunController extends AbstractRestController {
                 "Only runs that possibly could cause spending for described period will be returned.",
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
-    public Result<List<PipelineRun>> loadRunsActivityStats(@RequestParam(value = "from") final LocalDateTime start,
-                                                           @RequestParam(value = "to") final LocalDateTime end) {
+    public Result<List<PipelineRun>> loadRunsActivityStats(
+        @RequestParam(value = "from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        final LocalDateTime start,
+        @RequestParam(value = "to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        final LocalDateTime end) {
         return Result.success(runApiService.loadRunsActivityStats(start, end));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -886,6 +886,10 @@ public class PipelineRunManager {
             .map(BaseEntity::getId)
             .collect(Collectors.toList());
 
+        if (CollectionUtils.isEmpty(runIds)) {
+            return Collections.emptyList();
+        }
+
         final Map<Long, List<RunStatus>> runStatuses = runStatusManager.loadRunStatus(runIds).entrySet().stream()
             .collect(Collectors.toMap(Map.Entry::getKey, e -> adjustStatuses(e.getValue(), start, end)));
 

--- a/api/src/test/java/com/epam/pipeline/util/TestUtils.java
+++ b/api/src/test/java/com/epam/pipeline/util/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/com/epam/pipeline/util/TestUtils.java
+++ b/api/src/test/java/com/epam/pipeline/util/TestUtils.java
@@ -55,10 +55,6 @@ public final class TestUtils {
     public static final String LATEST_TAG = "latest";
     public static final long DOCKER_SIZE = 123456L;
 
-    private TestUtils() {
-        // No-op
-    }
-
     /**
      * Helper method for mocking DockerClient functionality
      * @param dockerClientMock a {@link DockerClient} mock object

--- a/billing-report-agent/build.gradle
+++ b/billing-report-agent/build.gradle
@@ -56,6 +56,9 @@ dependencies {
     implementation group: "org.apache.commons", name: "commons-lang3", version: apacheCommonsLangVersion
     implementation group: "org.apache.commons", name: "commons-collections4", version: apacheCommonsCollectionsVersion
 
+    // AWS
+    compile group: 'com.amazonaws', name: 'aws-java-sdk-pricing', version: awsSdkVersion
+
     //Lombok
     implementation group: "org.projectlombok", name: "lombok", version: lombokVersion
 

--- a/billing-report-agent/gradle.properties
+++ b/billing-report-agent/gradle.properties
@@ -13,6 +13,8 @@ apacheCommonsIOVersion=2.6
 apacheCommonsLangVersion=3.8.1
 apacheCommonsCollectionsVersion=4.2
 
+awsSdkVersion=1.11.699
+
 junitVersion=5.2.0
 mockitoVersion=2.21.0
 hamcrestVersion=1.3

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/app/CommonSyncConfiguration.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/app/CommonSyncConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/app/CommonSyncConfiguration.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/app/CommonSyncConfiguration.java
@@ -16,6 +16,7 @@
 
 package com.epam.pipeline.billingreportagent.app;
 
+import com.epam.pipeline.billingreportagent.model.StorageType;
 import com.epam.pipeline.billingreportagent.service.ElasticsearchServiceClient;
 import com.epam.pipeline.billingreportagent.service.ElasticsearchSynchronizer;
 import com.epam.pipeline.billingreportagent.service.impl.BulkRequestSender;
@@ -86,7 +87,28 @@ public class CommonSyncConfiguration {
                                        elasticsearchClient,
                                        loader,
                                        indexService,
-                                       new AwsStorageToBillingRequestConverter(mapper, elasticsearchClient),
+                                       new AwsStorageToBillingRequestConverter(mapper, elasticsearchClient, "AmazonS3",
+                                                                               StorageType.OBJECT_STORAGE),
                                        DataStorageType.S3);
+    }
+
+    @Bean
+    @ConditionalOnProperty(value = "sync.nfs.storage.disable", matchIfMissing = true, havingValue = FALSE)
+    public StorageSynchronizer efsSynchronizer(final @Value("${sync.run.index.mapping}") String runMapping,
+                                              final @Value("${sync.storage.index.name}") String indexName,
+                                              final StorageLoader loader,
+                                              final ElasticIndexService indexService,
+                                              final ElasticsearchServiceClient elasticsearchClient) {
+        final StorageBillingMapper mapper = new StorageBillingMapper(SearchDocumentType.NFS_STORAGE);
+        return new StorageSynchronizer(runMapping,
+                                       commonIndexPrefix,
+                                       indexName,
+                                       bulkSize,
+                                       elasticsearchClient,
+                                       loader,
+                                       indexService,
+                                       new AwsStorageToBillingRequestConverter(mapper, elasticsearchClient, "AmazonEFS",
+                                                                               StorageType.FILE_STORAGE),
+                                       DataStorageType.NFS);
     }
 }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/ResourceType.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/ResourceType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/StorageType.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/StorageType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/StorageType.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/StorageType.java
@@ -16,7 +16,7 @@
 
 package com.epam.pipeline.billingreportagent.model;
 
-public enum ResourceType {
-    COMPUTE,
-    STORAGE
+public enum StorageType {
+    OBJECT_STORAGE,
+    FILE_STORAGE
 }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/AbstractBillingInfo.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/AbstractBillingInfo.java
@@ -14,25 +14,22 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.billingreportagent.model;
+package com.epam.pipeline.billingreportagent.model.billing;
 
-import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.billingreportagent.model.ResourceType;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 @Data
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class PipelineRunBillingInfo {
+public abstract class AbstractBillingInfo<T> {
 
     private LocalDate date;
-    private PipelineRun pipelineRun;
+    private T entity;
     private Long cost;
-    private Long usageMinutes;
     private ResourceType resourceType;
 }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/AbstractBillingInfo.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/AbstractBillingInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/AbstractBillingInfo.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/AbstractBillingInfo.java
@@ -30,6 +30,10 @@ public abstract class AbstractBillingInfo<T> {
 
     private LocalDate date;
     private T entity;
+
+    /**
+     * Cost in hundredths of cents
+     */
     private Long cost;
     private ResourceType resourceType;
 }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/PipelineRunBillingInfo.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/PipelineRunBillingInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/PipelineRunBillingInfo.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/PipelineRunBillingInfo.java
@@ -28,12 +28,12 @@ import java.time.LocalDate;
 @EqualsAndHashCode(callSuper = true)
 public class PipelineRunBillingInfo extends AbstractBillingInfo<PipelineRun> {
 
+    private Long usageMinutes;
+
     @Builder
     public PipelineRunBillingInfo(final LocalDate date, final PipelineRun run,
                                   final Long cost, final Long usageMinutes) {
         super(date, run, cost, ResourceType.COMPUTE);
         this.usageMinutes = usageMinutes;
     }
-
-    private Long usageMinutes;
 }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/PipelineRunBillingInfo.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/PipelineRunBillingInfo.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.billingreportagent.model.billing;
+
+import com.epam.pipeline.billingreportagent.model.ResourceType;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.time.LocalDate;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class PipelineRunBillingInfo extends AbstractBillingInfo<PipelineRun> {
+
+    @Builder
+    public PipelineRunBillingInfo(final LocalDate date, final PipelineRun run,
+                                  final Long cost, final Long usageMinutes) {
+        super(date, run, cost, ResourceType.COMPUTE);
+        this.usageMinutes = usageMinutes;
+    }
+
+    private Long usageMinutes;
+}

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/StorageBillingInfo.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/StorageBillingInfo.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.billingreportagent.model.billing;
+
+import com.epam.pipeline.billingreportagent.model.ResourceType;
+import com.epam.pipeline.billingreportagent.model.StorageType;
+import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.time.LocalDate;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class StorageBillingInfo extends AbstractBillingInfo<AbstractDataStorage> {
+
+    @Builder
+    public StorageBillingInfo(final LocalDate date, final AbstractDataStorage storage, final Long cost,
+                              final Long usageBytes, final StorageType storageType, final String regionName) {
+        super(date, storage, cost, ResourceType.STORAGE);
+        this.usageBytes = usageBytes;
+        this.storageType = storageType;
+        this.regionName = regionName;
+    }
+
+    private Long usageBytes;
+    private StorageType storageType;
+    private String regionName;
+}

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/StorageBillingInfo.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/StorageBillingInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/StorageBillingInfo.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/StorageBillingInfo.java
@@ -29,6 +29,10 @@ import java.time.LocalDate;
 @EqualsAndHashCode(callSuper = true)
 public class StorageBillingInfo extends AbstractBillingInfo<AbstractDataStorage> {
 
+    private Long usageBytes;
+    private StorageType storageType;
+    private String regionName;
+
     @Builder
     public StorageBillingInfo(final LocalDate date, final AbstractDataStorage storage, final Long cost,
                               final Long usageBytes, final StorageType storageType, final String regionName) {
@@ -37,8 +41,4 @@ public class StorageBillingInfo extends AbstractBillingInfo<AbstractDataStorage>
         this.storageType = storageType;
         this.regionName = regionName;
     }
-
-    private Long usageBytes;
-    private StorageType storageType;
-    private String regionName;
 }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/StoragePricing.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/StoragePricing.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.billingreportagent.model.billing;
+
+import lombok.Getter;
+import lombok.Value;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class StoragePricing {
+
+    private final List<StoragePricingEntity> prices = new ArrayList<>();
+
+    public void addPrice(final StoragePricingEntity entity) {
+        prices.add(entity);
+    }
+
+    @Value
+    public static class StoragePricingEntity {
+
+        private Long beginRangeBytes;
+        private Long endRangeBytes;
+        private BigDecimal priceCentsPerGb;
+    }
+}

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/ElasticsearchAgentService.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/ElasticsearchAgentService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/ElasticsearchAgentService.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/ElasticsearchAgentService.java
@@ -21,8 +21,6 @@ import org.apache.commons.io.input.ReversedLinesFileReader;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.io.File;
@@ -70,7 +68,6 @@ public class ElasticsearchAgentService {
      * documents inside Elasticsearch
      */
     @Scheduled(cron = "${sync.billing.schedule}")
-    @Transactional(propagation = Propagation.REQUIRED)
     public void startElasticsearchAgent() {
         log.debug("Start synchronising billing data...");
 

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/EntityToBillingRequestConverter.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/EntityToBillingRequestConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/EntityToBillingRequestConverter.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/EntityToBillingRequestConverter.java
@@ -23,6 +23,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public interface EntityToBillingRequestConverter<T> {
 
@@ -34,6 +35,16 @@ public interface EntityToBillingRequestConverter<T> {
                                                   String indexName,
                                                   LocalDateTime previousSync,
                                                   LocalDateTime syncStart);
+
+    default List<DocWriteRequest> convertEntitiesToRequests(List<EntityContainer<T>> entityContainers,
+                                                            String indexName,
+                                                            LocalDateTime previousSync,
+                                                            LocalDateTime syncStart) {
+        return entityContainers.stream()
+            .map(entityContainer -> convertEntityToRequests(entityContainer, indexName, previousSync, syncStart))
+            .flatMap(List::stream)
+            .collect(Collectors.toList());
+    }
 
     default String parseDateToString(final LocalDate date) {
         if (date == null) {

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/CloudPipelineAPIClient.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/CloudPipelineAPIClient.java
@@ -18,6 +18,7 @@ package com.epam.pipeline.billingreportagent.service.impl;
 
 import com.epam.pipeline.client.pipeline.CloudPipelineAPI;
 import com.epam.pipeline.client.pipeline.CloudPipelineApiBuilder;
+import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 
 import com.epam.pipeline.entity.user.PipelineUser;
@@ -47,4 +48,9 @@ public class CloudPipelineAPIClient {
     public List<PipelineRun> loadAllPipelineRunsActiveInPeriod(final LocalDateTime from, final LocalDateTime to) {
         return QueryUtils.execute(cloudPipelineAPI.loadRunsActivityStats(from, to));
     }
+
+    public List<AbstractDataStorage> loadAllDataStorages() {
+        return QueryUtils.execute(cloudPipelineAPI.loadAllDataStorages());
+    }
+
 }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/CloudPipelineAPIClient.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/CloudPipelineAPIClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/CloudPipelineAPIClient.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/CloudPipelineAPIClient.java
@@ -45,7 +45,7 @@ public class CloudPipelineAPIClient {
         return QueryUtils.execute(cloudPipelineAPI.loadAllUsers());
     }
 
-    public List<PipelineRun> loadAllPipelineRunsActiveInPeriod(final LocalDateTime from, final LocalDateTime to) {
+    public List<PipelineRun> loadAllPipelineRunsActiveInPeriod(final String from, final String to) {
         return QueryUtils.execute(cloudPipelineAPI.loadRunsActivityStats(from, to));
     }
 

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/AwsStorageServicePricing.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/AwsStorageServicePricing.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.billingreportagent.service.impl.converter;
+
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.pricing.AWSPricing;
+import com.amazonaws.services.pricing.AWSPricingClientBuilder;
+import com.amazonaws.services.pricing.model.Filter;
+import com.amazonaws.services.pricing.model.GetProductsRequest;
+import com.amazonaws.services.pricing.model.GetProductsResult;
+import com.epam.pipeline.billingreportagent.model.billing.StoragePricing;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+public class AwsStorageServicePricing {
+
+    private static final int CENTS_IN_DOLLAR = 100;
+
+    private final Map<Regions, StoragePricing> storagePriceListGb = new HashMap<>();
+
+    /**
+     * Storage service name (either "AmazonS3" or "AmazonEFS")
+     */
+    private final String awsStorageServiceName;
+
+    /**
+     * The highest price all over available regions
+     */
+    private BigDecimal defaultPriceGb;
+
+    public AwsStorageServicePricing(final String awsStorageServiceName) {
+        this.awsStorageServiceName = awsStorageServiceName;
+        updatePrices();
+    }
+
+    public AwsStorageServicePricing(final String awsStorageServiceName,
+                                    final Map<Regions, StoragePricing> initialPriceList) {
+        this.awsStorageServiceName = awsStorageServiceName;
+        this.storagePriceListGb.putAll(initialPriceList);
+        this.defaultPriceGb = calculateDefaultPriceGb();
+    }
+
+    public void updatePrices() {
+        loadFullPriceList(awsStorageServiceName).forEach(price -> {
+            try {
+                final JsonNode regionInfo = new ObjectMapper().readTree(price);
+                final String regionName = regionInfo.path("product").path("attributes").path("location").asText();
+                getRegionFromFullLocation(regionName).ifPresent(region -> fillPricingInfoForRegion(region, regionInfo));
+            } catch (IOException e) {
+                log.error("Can't instantiate AWS storage price list!");
+            }
+        });
+        defaultPriceGb = calculateDefaultPriceGb();
+    }
+
+    public BigDecimal getDefaultPriceGb() {
+        return defaultPriceGb;
+    }
+
+    public StoragePricing getRegionPricing(final Regions region) {
+        return storagePriceListGb.get(region);
+    }
+
+    private void fillPricingInfoForRegion(final Regions region, final JsonNode regionInfo) {
+        final StoragePricing pricing = new StoragePricing();
+        regionInfo.findParents("pricePerUnit").stream()
+            .map(this::extractPricingFromJson)
+            .forEach(pricing::addPrice);
+        storagePriceListGb.put(region, pricing);
+    }
+
+    private BigDecimal calculateDefaultPriceGb() {
+        return storagePriceListGb.values()
+            .stream()
+            .flatMap(pricing -> pricing.getPrices().stream())
+            .map(StoragePricing.StoragePricingEntity::getPriceCentsPerGb)
+            .filter(price -> !BigDecimal.ZERO.equals(price))
+            .max(Comparator.naturalOrder())
+            .orElseThrow(() -> new IllegalStateException("No AWS storage prices loaded!"));
+    }
+
+    private List<String> loadFullPriceList(final String awsStorageServiceName) {
+        final List<String> allPrices = new ArrayList<>();
+        final Filter filter = new Filter();
+        filter.setType("TERM_MATCH");
+        filter.setField("productFamily");
+        filter.setValue("Storage");
+        filter.setField("storageClass");
+        filter.setValue("General Purpose");
+
+        String nextToken = StringUtils.EMPTY;
+        do {
+            final GetProductsRequest request = new GetProductsRequest()
+                .withServiceCode(awsStorageServiceName)
+                .withFilters(filter)
+                .withNextToken(nextToken)
+                .withFormatVersion("aws_v1");
+
+            final AWSPricing awsPricingService = AWSPricingClientBuilder
+                .standard()
+                .withRegion(Regions.US_EAST_1)
+                .build();
+
+            final GetProductsResult result = awsPricingService.getProducts(request);
+            allPrices.addAll(result.getPriceList());
+            nextToken = result.getNextToken();
+        } while (nextToken != null);
+        return allPrices;
+    }
+
+    private Optional<Regions> getRegionFromFullLocation(final String location) {
+        for (Regions region : Regions.values()) {
+            if (region.getDescription().equals(location)) {
+                return Optional.of(region);
+            }
+        }
+        log.warn("Can't parse location: " + location);
+        return Optional.empty();
+    }
+
+    private StoragePricing.StoragePricingEntity extractPricingFromJson(final JsonNode priceDimension) {
+        final BigDecimal priceGb =
+            new BigDecimal(priceDimension.path("pricePerUnit").path("USD").asDouble(), new MathContext(
+                AwsStorageToBillingRequestConverter.PRECISION))
+                .multiply(BigDecimal.valueOf(CENTS_IN_DOLLAR));
+        final long beginRange =
+            priceDimension.path("beginRange").asLong() * AwsStorageToBillingRequestConverter.BYTES_TO_GB;
+        final long endRange = priceDimension.path("endRange").asLong();
+        return new StoragePricing.StoragePricingEntity(beginRange,
+                                                       endRange == 0
+                                                       ? Long.MAX_VALUE
+                                                       : endRange * AwsStorageToBillingRequestConverter.BYTES_TO_GB,
+                                                       priceGb);
+    }
+}

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/AwsStorageToBillingRequestConverter.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/AwsStorageToBillingRequestConverter.java
@@ -55,7 +55,6 @@ public class AwsStorageToBillingRequestConverter implements EntityToBillingReque
     private static final String SIZE_FIELD = "size";
     private static final String REGION_FIELD = "storage_region";
     private static final String ES_FILE_INDEX_PATTERN = "cp-%s-file-%d";
-    private static final String INDEX_PATTERN = "%s-daily-%s";
     private static final RoundingMode ROUNDING_MODE = RoundingMode.CEILING;
 
     private final EntityMapper<StorageBillingInfo> mapper;
@@ -85,13 +84,13 @@ public class AwsStorageToBillingRequestConverter implements EntityToBillingReque
 
     @Override
     public List<DocWriteRequest> convertEntityToRequests(final EntityContainer<AbstractDataStorage> storageContainer,
-                                                         final String indexName,
+                                                         final String indexPrefix,
                                                          final LocalDateTime previousSync,
                                                          final LocalDateTime syncStart) {
         final Long storageId = storageContainer.getEntity().getId();
         final DataStorageType storageType = storageContainer.getEntity().getType();
         final LocalDate reportDate = syncStart.toLocalDate().minusDays(1);
-        final String fullIndex = String.format(INDEX_PATTERN, indexName, parseDateToString(reportDate));
+        final String fullIndex = indexPrefix + parseDateToString(reportDate);
         return requestSumAggregationForStorage(storageId, storageType)
             .map(searchResponse -> buildRequestFromAggregation(storageContainer, syncStart, searchResponse, fullIndex))
             .orElse(Collections.emptyList());

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/AwsStorageToBillingRequestConverter.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/AwsStorageToBillingRequestConverter.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.billingreportagent.service.impl.converter;
+
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.pricing.AWSPricing;
+import com.amazonaws.services.pricing.AWSPricingClientBuilder;
+import com.amazonaws.services.pricing.model.Filter;
+import com.amazonaws.services.pricing.model.GetProductsRequest;
+import com.amazonaws.services.pricing.model.GetProductsResult;
+import com.epam.pipeline.billingreportagent.model.EntityContainer;
+import com.epam.pipeline.billingreportagent.model.StorageType;
+import com.epam.pipeline.billingreportagent.model.billing.StorageBillingInfo;
+import com.epam.pipeline.billingreportagent.service.ElasticsearchServiceClient;
+import com.epam.pipeline.billingreportagent.service.EntityMapper;
+import com.epam.pipeline.billingreportagent.service.EntityToBillingRequestConverter;
+import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
+import com.epam.pipeline.entity.user.PipelineUser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.metrics.sum.ParsedSum;
+import org.elasticsearch.search.aggregations.metrics.sum.SumAggregationBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@SuppressWarnings("checkstyle:MagicNumber")
+public class AwsStorageToBillingRequestConverter implements EntityToBillingRequestConverter<AbstractDataStorage> {
+
+    private static final String STORAGE_SIZE_AGG_NAME = "sizeSumSearch";
+    private static final String SIZE_FIELD = "size";
+    private static final String REGION_FIELD = "storage_region";
+    private static final int BYTES_TO_GB = 1 << 30;
+    private static final int CENTS_IN_DOLLAR = 100;
+    private static final int PRECISION = 5;
+
+    private final EntityMapper<StorageBillingInfo> mapper;
+    private final ElasticsearchServiceClient elasticsearchService;
+    private final Map<Regions, BigDecimal> s3PriceListGb = new HashMap<>();
+    private BigDecimal defaultS3PriceGb;
+
+    public AwsStorageToBillingRequestConverter(final EntityMapper<StorageBillingInfo> mapper,
+                                               final ElasticsearchServiceClient elasticsearchService) {
+        this.mapper = mapper;
+        this.elasticsearchService = elasticsearchService;
+        initPrices();
+    }
+
+    @Override
+    public List<DocWriteRequest> convertEntityToRequests(final EntityContainer<AbstractDataStorage> storageContainer,
+                                                         final String indexName,
+                                                         final LocalDateTime previousSync,
+                                                         final LocalDateTime syncStart) {
+        final SearchRequest searchRequest = new SearchRequest();
+        final Long storageId = storageContainer.getEntity().getId();
+        searchRequest.indices(String.format("*-cp-s3-file-%d", storageId));
+
+        final SumAggregationBuilder sizeSumAgg = AggregationBuilders.sum(STORAGE_SIZE_AGG_NAME)
+            .field(SIZE_FIELD);
+
+        final SearchSourceBuilder sizeSumSearch = new SearchSourceBuilder().aggregation(sizeSumAgg);
+        searchRequest.source(sizeSumSearch);
+
+        final SearchResponse search = elasticsearchService.search(searchRequest);
+
+        final ParsedSum sumAggResult = search.getAggregations().get(STORAGE_SIZE_AGG_NAME);
+        final long storageSize = new Double(sumAggResult.getValue()).longValue();
+
+        if (storageSize == 0
+            || search.getHits().getTotalHits() == 0) {
+            return Collections.emptyList();
+        }
+
+        final LocalDate localDate = syncStart.toLocalDate().minusDays(1);
+        final String fullIndex = String.format("%s-daily-%d-%s",
+                                               indexName,
+                                               storageId,
+                                               parseDateToString(localDate));
+        final String regionLocation = (String) search.getHits().getAt(0).getSourceAsMap().get(REGION_FIELD);
+        final StorageBillingInfo storageBilling = createBilling(storageContainer,
+                                                                storageSize,
+                                                                regionLocation,
+                                                                syncStart.toLocalDate().minusDays(1));
+        return Collections.singletonList(getDocWriteRequest(fullIndex,
+                                                            storageContainer.getOwner(),
+                                                            storageBilling));
+    }
+
+    private DocWriteRequest getDocWriteRequest(final String fullIndex,
+                                               final PipelineUser owner,
+                                               final StorageBillingInfo billing) {
+        final EntityContainer<StorageBillingInfo> entity = EntityContainer.<StorageBillingInfo>builder()
+            .owner(owner)
+            .entity(billing)
+            .build();
+        return new IndexRequest(fullIndex, INDEX_TYPE).source(mapper.map(entity));
+    }
+
+    private StorageBillingInfo createBilling(final EntityContainer<AbstractDataStorage> storageContainer,
+                                             final Long byteSize,
+                                             final String regionLocation,
+                                             final LocalDate billingDate) {
+        final StorageBillingInfo.StorageBillingInfoBuilder billing =
+            StorageBillingInfo.builder()
+                .storage(storageContainer.getEntity())
+                .usageBytes(byteSize)
+                .date(billingDate)
+                .storageType(StorageType.FILE_STORAGE);
+
+        try {
+            final Regions region = Regions.fromName(regionLocation);
+            billing
+                .regionName(region.getName())
+                .cost(calculateDailyCost(byteSize, s3PriceListGb.get(region), billingDate));
+        } catch (IllegalArgumentException e) {
+            billing.cost(calculateDailyCost(byteSize, defaultS3PriceGb, billingDate));
+        }
+
+        return billing.build();
+    }
+
+    /**
+     * Calculate daily spending on files storing in hundredths of a cent
+     * @param sizeBytes storage size
+     * @param monthlyPriceGb price Gb/month in cents
+     * @param date billing date
+     * @return daily cost
+     */
+    private Long calculateDailyCost(final Long sizeBytes, final BigDecimal monthlyPriceGb, final LocalDate date) {
+        final BigDecimal sizeGb = BigDecimal.valueOf(sizeBytes)
+            .divide(BigDecimal.valueOf(BYTES_TO_GB), PRECISION, RoundingMode.CEILING);
+
+        final int daysInMonth = YearMonth.of(date.getYear(), date.getMonthValue()).lengthOfMonth();
+
+        final Long hundredthsOfCentPrice = sizeGb.multiply(monthlyPriceGb)
+            .divide(BigDecimal.valueOf(daysInMonth), RoundingMode.CEILING)
+            .scaleByPowerOfTen(2)
+            .longValue();
+        return hundredthsOfCentPrice == 0
+               ? 1
+               : hundredthsOfCentPrice;
+    }
+
+
+    private void initPrices() {
+        final Filter filter = new Filter();
+        filter.setType("TERM_MATCH");
+        filter.setField("productFamily");
+        filter.setValue("Storage");
+        filter.setField("storageClass");
+        filter.setValue("General Purpose");
+
+        final GetProductsRequest request = new GetProductsRequest()
+            .withServiceCode("AmazonS3")
+            .withFilters(filter)
+            .withFormatVersion("aws_v1");
+
+        final AWSPricing awsPricingService = AWSPricingClientBuilder
+            .standard()
+            .withRegion(Regions.US_EAST_1)
+            .build();
+
+        // TODO use pagination to guaranteed receive all regions
+        final GetProductsResult result = awsPricingService.getProducts(request);
+
+        result.getPriceList().forEach(price -> {
+            try {
+                final JsonNode priceJson = new ObjectMapper().readTree(price);
+                final String regionName = priceJson.path("product").path("attributes").path("location").asText();
+
+                getRegionFromFullLocation(regionName)
+                    .ifPresent(region -> priceJson.findValues("pricePerUnit").stream()
+                        .map(unitPrice ->
+                                 new BigDecimal(unitPrice.path("USD").asDouble(), new MathContext(PRECISION)))
+                        .max(Comparator.naturalOrder())
+                        .map(priceInDollars -> priceInDollars.multiply(BigDecimal.valueOf(CENTS_IN_DOLLAR)))
+                        .ifPresent(maxPrice -> s3PriceListGb.put(region, maxPrice)));
+            } catch (IOException e) {
+                log.error("Can't instantiate AWS storage price list!");
+            }
+        });
+        defaultS3PriceGb = s3PriceListGb.values()
+            .stream()
+            .max(Comparator.naturalOrder())
+            .orElseThrow(() -> new RuntimeException("No AWS storage prices loaded!"));
+    }
+
+    private Optional<Regions> getRegionFromFullLocation(final String location) {
+        for (Regions region : Regions.values()) {
+            if (region.getDescription().equals(location)) {
+                return Optional.of(region);
+            }
+        }
+        log.warn("Can't parse location: " + location);
+        return Optional.empty();
+    }
+}

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverter.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverter.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverter.java
@@ -79,7 +79,7 @@ public class RunToBillingRequestConverter implements EntityToBillingRequestConve
                                                         syncStart);
 
         return createBillingsForPeriod(runContainer.getEntity(), pricePerHour, statuses).stream()
-            .filter(billing -> billing.getCost().equals(0L))
+            .filter(billing -> !billing.getCost().equals(0L))
             .collect(Collectors.toMap(PipelineRunBillingInfo::getDate,
                                       Function.identity(),
                                       this::mergeBillings))

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/loader/PipelineRunLoader.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/loader/PipelineRunLoader.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.billingreportagent.service.impl.converter.run;
+package com.epam.pipeline.billingreportagent.service.impl.loader;
 
 import com.epam.pipeline.billingreportagent.model.EntityContainer;
 import com.epam.pipeline.billingreportagent.service.EntityLoader;

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/loader/PipelineRunLoader.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/loader/PipelineRunLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/loader/PipelineRunLoader.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/loader/PipelineRunLoader.java
@@ -24,7 +24,9 @@ import com.epam.pipeline.entity.user.PipelineUser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -38,7 +40,7 @@ public class PipelineRunLoader implements EntityLoader<PipelineRun> {
 
     @Override
     public List<EntityContainer<PipelineRun>> loadAllEntities() {
-        return loadAllEntitiesActiveInPeriod(LocalDateTime.MIN, LocalDateTime.MAX);
+        return loadAllEntitiesActiveInPeriod(LocalDate.ofEpochDay(0).atStartOfDay(), LocalDateTime.now());
     }
 
     @Override
@@ -46,7 +48,8 @@ public class PipelineRunLoader implements EntityLoader<PipelineRun> {
                                                                             final LocalDateTime to) {
         final Map<String, PipelineUser> users =
             apiClient.loadAllUsers().stream().collect(Collectors.toMap(PipelineUser::getUserName, Function.identity()));
-        return apiClient.loadAllPipelineRunsActiveInPeriod(from, to)
+        return apiClient.loadAllPipelineRunsActiveInPeriod(DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(from),
+                                                           DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(to))
             .stream()
             .map(run -> EntityContainer.<PipelineRun>builder().entity(run).owner(users.get(run.getOwner())).build())
             .collect(Collectors.toList());

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/loader/StorageLoader.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/loader/StorageLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/loader/StorageLoader.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/loader/StorageLoader.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.epam.pipeline.billingreportagent.service.impl.loader;
+
+import com.epam.pipeline.billingreportagent.model.EntityContainer;
+import com.epam.pipeline.billingreportagent.service.EntityLoader;
+import com.epam.pipeline.billingreportagent.service.impl.CloudPipelineAPIClient;
+import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
+import com.epam.pipeline.entity.user.PipelineUser;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+public class StorageLoader implements EntityLoader<AbstractDataStorage> {
+
+    private final CloudPipelineAPIClient apiClient;
+
+    public StorageLoader(final CloudPipelineAPIClient apiClient) {
+        this.apiClient = apiClient;
+    }
+
+    @Override
+    public List<EntityContainer<AbstractDataStorage>> loadAllEntities() {
+        final Map<String, PipelineUser> users =
+            apiClient.loadAllUsers().stream().collect(Collectors.toMap(PipelineUser::getUserName, Function.identity()));
+        return apiClient.loadAllDataStorages()
+            .stream()
+            .map(storage -> EntityContainer.<AbstractDataStorage>builder()
+                .entity(storage)
+                .owner(users.get(storage.getOwner()))
+                .build())
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<EntityContainer<AbstractDataStorage>> loadAllEntitiesActiveInPeriod(final LocalDateTime from,
+                                                                                    final LocalDateTime to) {
+        return loadAllEntities();
+    }
+}

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapper.java
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.billingreportagent.service.impl.converter.run;
+package com.epam.pipeline.billingreportagent.service.impl.mapper;
 
 import static com.epam.pipeline.billingreportagent.service.ElasticsearchSynchronizer.DOC_TYPE_FIELD;
 
 import com.epam.pipeline.billingreportagent.model.EntityContainer;
-import com.epam.pipeline.billingreportagent.model.PipelineRunBillingInfo;
+import com.epam.pipeline.billingreportagent.model.billing.PipelineRunBillingInfo;
 import com.epam.pipeline.billingreportagent.service.EntityMapper;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.RunInstance;
@@ -33,13 +33,13 @@ import java.io.IOException;
 
 @Component
 @NoArgsConstructor
-public class BillingMapper implements EntityMapper<PipelineRunBillingInfo> {
+public class RunBillingMapper implements EntityMapper<PipelineRunBillingInfo> {
 
     @Override
     public XContentBuilder map(final EntityContainer<PipelineRunBillingInfo> container) {
         try (XContentBuilder jsonBuilder = XContentFactory.jsonBuilder()) {
             final PipelineRunBillingInfo billingInfo = container.getEntity();
-            final PipelineRun run = billingInfo.getPipelineRun();
+            final PipelineRun run = billingInfo.getEntity();
             jsonBuilder
                 .startObject()
                 .field(DOC_TYPE_FIELD, SearchDocumentType.PIPELINE_RUN.name())
@@ -53,7 +53,7 @@ public class BillingMapper implements EntityMapper<PipelineRunBillingInfo> {
                 .field("usage", billingInfo.getUsageMinutes())
                 .field("run_price", run.getPricePerHour().unscaledValue().longValue())
                 .field("cloudRegionId", run.getInstance().getCloudRegionId())
-                .field("billingCenter", "TBD");
+                .field("billing_center", "TBD");
             buildUserContent(container.getOwner(), jsonBuilder);
             jsonBuilder.endObject();
             return jsonBuilder;

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapper.java
@@ -53,7 +53,8 @@ public class RunBillingMapper implements EntityMapper<PipelineRunBillingInfo> {
                 .field("usage", billingInfo.getUsageMinutes())
                 .field("run_price", run.getPricePerHour().unscaledValue().longValue())
                 .field("cloudRegionId", run.getInstance().getCloudRegionId())
-                .field("billing_center", "TBD");
+                .field("billing_center", "TBD")
+                .field("created_date", billingInfo.getDate());
             buildUserContent(container.getOwner(), jsonBuilder);
             jsonBuilder.endObject();
             return jsonBuilder;

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapper.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.billingreportagent.service.impl.mapper;
+
+import static com.epam.pipeline.billingreportagent.service.ElasticsearchSynchronizer.DOC_TYPE_FIELD;
+
+import com.epam.pipeline.billingreportagent.model.EntityContainer;
+import com.epam.pipeline.billingreportagent.model.billing.StorageBillingInfo;
+import com.epam.pipeline.billingreportagent.service.EntityMapper;
+import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
+import com.epam.pipeline.entity.search.SearchDocumentType;
+import lombok.RequiredArgsConstructor;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class StorageBillingMapper implements EntityMapper<StorageBillingInfo> {
+
+    private final SearchDocumentType documentType;
+
+    @Override
+    public XContentBuilder map(final EntityContainer<StorageBillingInfo> container) {
+        try (XContentBuilder jsonBuilder = XContentFactory.jsonBuilder()) {
+            final StorageBillingInfo billingInfo = container.getEntity();
+            final AbstractDataStorage storage = billingInfo.getEntity();
+            jsonBuilder
+                .startObject()
+                .field(DOC_TYPE_FIELD, documentType.name())
+                .field("id", storage.getId())
+                .field("resource_type", billingInfo.getResourceType())
+                .field("region", billingInfo.getRegionName())
+                .field("provider", storage.getType())
+                .field("storage_type", billingInfo.getStorageType())
+                .field("billing_center", "TBD")
+                .field("usage", billingInfo.getUsageBytes())
+                .field("cost", billingInfo.getCost())
+                .field("created_date", billingInfo.getDate());
+            buildUserContent(container.getOwner(), jsonBuilder);
+            jsonBuilder.endObject();
+            return jsonBuilder;
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Failed to create elasticsearch document for data storage: ", e);
+        }
+    }
+}
+

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/synchronizer/PipelineRunSynchronizer.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/synchronizer/PipelineRunSynchronizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/synchronizer/StorageSynchronizer.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/synchronizer/StorageSynchronizer.java
@@ -42,7 +42,6 @@ public class StorageSynchronizer implements ElasticsearchSynchronizer {
 
     private final  String storageIndexMappingFile;
     private final String indexPrefix;
-    private final String storageIndexName;
     private final EntityLoader<AbstractDataStorage> loader;
     private final EntityToBillingRequestConverter<AbstractDataStorage> storageToBillingRequestConverter;
     private final ElasticIndexService indexService;
@@ -59,8 +58,7 @@ public class StorageSynchronizer implements ElasticsearchSynchronizer {
                                final EntityToBillingRequestConverter<AbstractDataStorage> storageToBillingReqConverter,
                                final DataStorageType storageType) {
         this.storageIndexMappingFile = storageIndexMappingFile;
-        this.indexPrefix = indexPrefix;
-        this.storageIndexName = storageIndexName;
+        this.indexPrefix = indexPrefix + storageIndexName;
         this.loader = loader;
         this.storageToBillingRequestConverter = storageToBillingReqConverter;
         this.indexService = indexService;
@@ -97,8 +95,7 @@ public class StorageSynchronizer implements ElasticsearchSynchronizer {
                                                               final LocalDateTime previousSync,
                                                               final LocalDateTime syncStart) {
         try {
-            final String commonRunBillingIndexName = indexPrefix + storageIndexName;
-            return buildDocRequests(storages, commonRunBillingIndexName, previousSync, syncStart);
+            return buildDocRequests(storages, previousSync, syncStart);
         } catch (Exception e) {
             log.error("An error during storage billing synchronization: {}", e.getMessage());
             return Collections.emptyList();
@@ -106,10 +103,9 @@ public class StorageSynchronizer implements ElasticsearchSynchronizer {
     }
 
     private List<DocWriteRequest> buildDocRequests(final List<EntityContainer<AbstractDataStorage>> storages,
-                                                   final String indexNameForStorage,
                                                    final LocalDateTime previousSync,
                                                    final LocalDateTime syncStart) {
-        return storageToBillingRequestConverter.convertEntitiesToRequests(storages, indexNameForStorage,
+        return storageToBillingRequestConverter.convertEntitiesToRequests(storages, indexPrefix,
                                                                           previousSync, syncStart);
     }
 }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/synchronizer/StorageSynchronizer.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/synchronizer/StorageSynchronizer.java
@@ -72,7 +72,7 @@ public class StorageSynchronizer implements ElasticsearchSynchronizer {
 
     @Override
     public void synchronize(LocalDateTime lastSyncTime, LocalDateTime syncStart) {
-        log.debug("Started storages billing synchronization");
+        log.debug("Started {} storage billing synchronization", storageType);
         final List<EntityContainer<AbstractDataStorage>> entityContainers = loader.loadAllEntities();
         final List<DocWriteRequest> storageBillingRequests = entityContainers.stream()
             .filter(storage -> storage.getEntity().getType() == storageType)
@@ -94,7 +94,7 @@ public class StorageSynchronizer implements ElasticsearchSynchronizer {
             });
 
         requestSender.indexDocuments(storageBillingRequests);
-        log.debug("Successfully finished storage billing synchronization.");
+        log.debug("Successfully finished {} storage billing synchronization.", storageType);
     }
 
     private List<DocWriteRequest> createStorageBillingRequest(final EntityContainer<AbstractDataStorage> storage,

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/synchronizer/StorageSynchronizer.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/synchronizer/StorageSynchronizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/synchronizer/StorageSynchronizer.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/synchronizer/StorageSynchronizer.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.billingreportagent.service.impl.synchronizer;
+
+import com.epam.pipeline.billingreportagent.exception.ElasticClientException;
+import com.epam.pipeline.billingreportagent.model.EntityContainer;
+import com.epam.pipeline.billingreportagent.service.ElasticsearchServiceClient;
+import com.epam.pipeline.billingreportagent.service.ElasticsearchSynchronizer;
+import com.epam.pipeline.billingreportagent.service.EntityLoader;
+import com.epam.pipeline.billingreportagent.service.EntityToBillingRequestConverter;
+import com.epam.pipeline.billingreportagent.service.impl.BulkRequestSender;
+import com.epam.pipeline.billingreportagent.service.impl.ElasticIndexService;
+import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
+import com.epam.pipeline.entity.datastorage.DataStorageType;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.elasticsearch.action.DocWriteRequest;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+@Slf4j
+@SuppressWarnings("PMD.AvoidCatchingGenericException")
+public class StorageSynchronizer implements ElasticsearchSynchronizer {
+
+    private final  String storageIndexMappingFile;
+    private final String indexPrefix;
+    private final String storageIndexName;
+    private final EntityLoader<AbstractDataStorage> loader;
+    private final EntityToBillingRequestConverter<AbstractDataStorage> storageToBillingRequestConverter;
+    private final ElasticIndexService indexService;
+    private final BulkRequestSender requestSender;
+    private final DataStorageType storageType;
+
+    public StorageSynchronizer(final @Value("${sync.storage.index.mapping}") String storageIndexMappingFile,
+                               final @Value("${sync.index.common.prefix}") String indexPrefix,
+                               final @Value("${sync.storage.index.name}") String storageIndexName,
+                               final @Value("${sync.bulk.insert.size:1000}") Integer bulkInsertSize,
+                               final ElasticsearchServiceClient elasticsearchServiceClient,
+                               final EntityLoader<AbstractDataStorage> loader,
+                               final ElasticIndexService indexService,
+                               final EntityToBillingRequestConverter<AbstractDataStorage> storageToBillingReqConverter,
+                               final DataStorageType storageType) {
+        this.storageIndexMappingFile = storageIndexMappingFile;
+        this.indexPrefix = indexPrefix;
+        this.storageIndexName = storageIndexName;
+        this.loader = loader;
+        this.storageToBillingRequestConverter = storageToBillingReqConverter;
+        this.indexService = indexService;
+        this.requestSender = new BulkRequestSender(elasticsearchServiceClient, bulkInsertSize);
+        this.storageType = storageType;
+    }
+
+    @Override
+    public void synchronize(LocalDateTime lastSyncTime, LocalDateTime syncStart) {
+        log.debug("Started storages billing synchronization");
+        final List<EntityContainer<AbstractDataStorage>> entityContainers = loader.loadAllEntities();
+        final List<DocWriteRequest> storageBillingRequests = entityContainers.stream()
+            .filter(storage -> storage.getEntity().getType() == storageType)
+            .map(storage -> createStorageBillings(storage, lastSyncTime, syncStart))
+            .flatMap(Collection::stream)
+            .collect(Collectors.toList());
+
+        log.info("{} document requests created", storageBillingRequests.size());
+
+        storageBillingRequests.stream()
+            .map(DocWriteRequest::index)
+            .distinct()
+            .forEach(index -> {
+                try {
+                    indexService.createIndexIfNotExists(index, storageIndexMappingFile);
+                } catch (ElasticClientException e) {
+                    log.warn("Can't create index {}!", index);
+                }
+            });
+
+        requestSender.indexDocuments(storageBillingRequests);
+        log.debug("Successfully finished storage billing synchronization.");
+    }
+
+    private List<DocWriteRequest> createStorageBillings(final EntityContainer<AbstractDataStorage> storage,
+                                                        final LocalDateTime previousSync,
+                                                        final LocalDateTime syncStart) {
+        try {
+            final String commonRunBillingIndexName = indexPrefix + storageIndexName;
+            return buildDocRequests(storage, commonRunBillingIndexName, previousSync, syncStart);
+        } catch (Exception e) {
+            log.error("An error during storage billing {} synchronization: {}",
+                      storage.getEntity().getId(), e.getMessage());
+            log.error(e.getMessage(), e);
+            return Collections.emptyList();
+        }
+    }
+
+    private List<DocWriteRequest> buildDocRequests(final EntityContainer<AbstractDataStorage> storage,
+                                                   final String indexNameForStorage,
+                                                   final LocalDateTime previousSync,
+                                                   final LocalDateTime syncStart) {
+        log.debug("Processing storage {} billings", storage.getEntity().getId());
+        return storageToBillingRequestConverter.convertEntityToRequests(storage, indexNameForStorage,
+                                                                        previousSync, syncStart);
+    }
+
+
+}

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/synchronizer/StorageSynchronizer.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/synchronizer/StorageSynchronizer.java
@@ -76,7 +76,7 @@ public class StorageSynchronizer implements ElasticsearchSynchronizer {
         final List<EntityContainer<AbstractDataStorage>> entityContainers = loader.loadAllEntities();
         final List<DocWriteRequest> storageBillingRequests = entityContainers.stream()
             .filter(storage -> storage.getEntity().getType() == storageType)
-            .map(storage -> createStorageBillings(storage, lastSyncTime, syncStart))
+            .map(storage -> createStorageBillingRequest(storage, lastSyncTime, syncStart))
             .flatMap(Collection::stream)
             .collect(Collectors.toList());
 
@@ -97,9 +97,9 @@ public class StorageSynchronizer implements ElasticsearchSynchronizer {
         log.debug("Successfully finished storage billing synchronization.");
     }
 
-    private List<DocWriteRequest> createStorageBillings(final EntityContainer<AbstractDataStorage> storage,
-                                                        final LocalDateTime previousSync,
-                                                        final LocalDateTime syncStart) {
+    private List<DocWriteRequest> createStorageBillingRequest(final EntityContainer<AbstractDataStorage> storage,
+                                                              final LocalDateTime previousSync,
+                                                              final LocalDateTime syncStart) {
         try {
             final String commonRunBillingIndexName = indexPrefix + storageIndexName;
             return buildDocRequests(storage, commonRunBillingIndexName, previousSync, syncStart);
@@ -119,6 +119,4 @@ public class StorageSynchronizer implements ElasticsearchSynchronizer {
         return storageToBillingRequestConverter.convertEntityToRequests(storage, indexNameForStorage,
                                                                         previousSync, syncStart);
     }
-
-
 }

--- a/billing-report-agent/src/main/resources/application.properties
+++ b/billing-report-agent/src/main/resources/application.properties
@@ -12,9 +12,15 @@ sync.index.common.prefix=cp-billing-
 sync.last.synchronization.file=lastSynchronizationTime.txt
 sync.submit.threads=1
 sync.billing.schedule=0 0 0 ? * *
+sync.bulk.insert.size=1000
 
 #Pipeline Run Settings
 #sync.run.disable=true
 sync.run.index.mapping=classpath:/templates/pipeline_run_billing.json
 sync.run.index.name=pipeline-run
-sync.run.bulk.insert.size=1000
+
+#Storage Settings
+#sync.storage.disable=true
+sync.storage.index.mapping=classpath:/templates/storage_billing.json
+sync.storage.index.name=storage
+#sync.s3.storage.disable=true

--- a/billing-report-agent/src/main/resources/application.properties
+++ b/billing-report-agent/src/main/resources/application.properties
@@ -24,3 +24,4 @@ sync.run.index.name=pipeline-run
 sync.storage.index.mapping=classpath:/templates/storage_billing.json
 sync.storage.index.name=storage
 #sync.s3.storage.disable=true
+#sync.nfs.storage.disable=true

--- a/billing-report-agent/src/main/resources/application.properties
+++ b/billing-report-agent/src/main/resources/application.properties
@@ -17,11 +17,10 @@ sync.bulk.insert.size=1000
 #Pipeline Run Settings
 #sync.run.disable=true
 sync.run.index.mapping=classpath:/templates/pipeline_run_billing.json
-sync.run.index.name=pipeline-run
+sync.run.index.name=pipeline-run-
 
 #Storage Settings
-#sync.storage.disable=true
 sync.storage.index.mapping=classpath:/templates/storage_billing.json
-sync.storage.index.name=storage
+sync.storage.index.name=storage-
 #sync.s3.storage.disable=true
 #sync.nfs.storage.disable=true

--- a/billing-report-agent/src/main/resources/templates/pipeline_run_billing.json
+++ b/billing-report-agent/src/main/resources/templates/pipeline_run_billing.json
@@ -15,7 +15,8 @@
         "tool": {"type": "keyword"},
         "instance_type":  { "type": "keyword" },
         "billing_center":  { "type": "keyword" },
-        "cloudRegionId": { "type": "keyword" }
+        "cloudRegionId": { "type": "keyword" },
+        "created_date": {"type": "date"}
       }
     }
   },

--- a/billing-report-agent/src/main/resources/templates/storage_billing.json
+++ b/billing-report-agent/src/main/resources/templates/storage_billing.json
@@ -1,0 +1,26 @@
+{
+  "mappings": {
+    "_doc": {
+      "properties": {
+        "doc_type": { "type": "keyword", "store": true },
+        "id": { "type": "keyword", "store": true },
+        "resource_type": { "type": "keyword" },
+        "region": { "type": "keyword" },
+        "provider": { "type": "keyword" },
+        "storage_type": { "type": "keyword" },
+        "owner": { "type": "keyword" },
+        "groups": { "type": "keyword" },
+        "billing_center":  { "type": "keyword" },
+        "usage": {"type": "long"},
+        "cost": {"type": "long"},
+        "created_date": {"type": "date"}
+      }
+    }
+  },
+  "settings": {
+    "index": {
+      "number_of_shards" : 1,
+      "number_of_replicas": 0
+    }
+  }
+}

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/TestUtils.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/TestUtils.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/TestUtils.java
@@ -16,6 +16,7 @@
 
 package com.epam.pipeline.billingreportagent.service.impl;
 
+import com.epam.pipeline.billingreportagent.service.EntityToBillingRequestConverter;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.fasterxml.jackson.core.JsonFactory;
@@ -28,11 +29,17 @@ import org.junit.Assert;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 
 public final class TestUtils {
+
+    public static final String COMMON_INDEX_PREFIX = "cp-billing-";
+    public static final String RUN_BILLING_PREFIX = COMMON_INDEX_PREFIX + "pipeline-run-";
+    public static final String STORAGE_BILLING_PREFIX = COMMON_INDEX_PREFIX + "storage-";
+
     private TestUtils() {
     }
 
@@ -57,12 +64,8 @@ public final class TestUtils {
         return parser.map();
     }
 
-    private static ArrayList<String> toStringArray(final Object object) {
-        return new ArrayList<>((Collection<? extends String>) object);
-    }
-
     public static PipelineRun createTestPipelineRun(final Long runId, final String pipeline, final String tool,
-                                              final BigDecimal price, final RunInstance instance) {
+                                                    final BigDecimal price, final RunInstance instance) {
         final PipelineRun run = new PipelineRun();
         run.setId(runId);
         run.setPipelineName(pipeline);
@@ -77,5 +80,14 @@ public final class TestUtils {
         instance.setCloudRegionId(regionId);
         instance.setNodeType(nodeType);
         return instance;
+    }
+
+    public static String buildBillingIndex(final String prefix, final LocalDateTime syncDate) {
+        return prefix
+               + EntityToBillingRequestConverter.SIMPLE_DATE_FORMAT.format(syncDate.toLocalDate());
+    }
+
+    private static ArrayList<String> toStringArray(final Object object) {
+        return new ArrayList<>((Collection<? extends String>) object);
     }
 }

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/TestUtils.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/TestUtils.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.billingreportagent.service.impl;
+
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.pipeline.RunInstance;
+import com.fasterxml.jackson.core.JsonFactory;
+import org.apache.commons.collections.CollectionUtils;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.json.JsonXContentParser;
+import org.junit.Assert;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+public final class TestUtils {
+    private TestUtils() {
+    }
+
+    public static void verifyStringArray(final Collection<String> expected, final Object object) {
+        ArrayList<String> actual = toStringArray(object);
+
+        if (CollectionUtils.isEmpty(expected)) {
+            if (CollectionUtils.isNotEmpty(actual)) {
+                throw new IllegalArgumentException("Expected list is empty but actual not");
+            }
+            return;
+        }
+
+        Assert.assertEquals(expected.size(), actual.size());
+        expected.forEach(element -> Assert.assertTrue(actual.contains(element)));
+    }
+
+    public static Map<String, Object> getPuttedObject(final XContentBuilder contentBuilder) throws IOException {
+        JsonFactory factory = new JsonFactory();
+        JsonXContentParser parser = new JsonXContentParser(NamedXContentRegistry.EMPTY, null,
+                                                           factory.createParser(Strings.toString(contentBuilder)));
+        return parser.map();
+    }
+
+    private static ArrayList<String> toStringArray(final Object object) {
+        return new ArrayList<>((Collection<? extends String>) object);
+    }
+
+    public static PipelineRun createTestPipelineRun(final Long runId, final String pipeline, final String tool,
+                                              final BigDecimal price, final RunInstance instance) {
+        final PipelineRun run = new PipelineRun();
+        run.setId(runId);
+        run.setPipelineName(pipeline);
+        run.setDockerImage(tool);
+        run.setPricePerHour(price);
+        run.setInstance(instance);
+        return run;
+    }
+
+    public static RunInstance createTestInstance(final Long regionId, final String nodeType) {
+        final RunInstance instance = new RunInstance();
+        instance.setCloudRegionId(regionId);
+        instance.setNodeType(nodeType);
+        return instance;
+    }
+}

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/AwsStorageServicePricingTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/AwsStorageServicePricingTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.billingreportagent.service.impl.converter;
+
+import com.amazonaws.regions.Regions;
+import com.epam.pipeline.billingreportagent.model.billing.StoragePricing;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+public class AwsStorageServicePricingTest {
+
+    private static final long STORAGE_LIMIT_TIER_1 = 51200L;
+    private static final long STORAGE_LIMIT_TIER_2 = STORAGE_LIMIT_TIER_1 * 10;
+
+    @Test
+    public void testDefaultPriceCalculation() {
+        final StoragePricing pricingUsEast1 = new StoragePricing();
+        pricingUsEast1.addPrice(new StoragePricing.StoragePricingEntity(0L,
+                                                                        STORAGE_LIMIT_TIER_1,
+                                                                        BigDecimal.TEN));
+        final StoragePricing pricingUsEast2 = new StoragePricing();
+        final long endRangeBytesTier1 = STORAGE_LIMIT_TIER_1;
+        final long endRangeBytesTier2 = STORAGE_LIMIT_TIER_2;
+        pricingUsEast2.addPrice(new StoragePricing.StoragePricingEntity(0L,
+                                                                        endRangeBytesTier1,
+                                                                        BigDecimal.valueOf(7)));
+        pricingUsEast2.addPrice(new StoragePricing.StoragePricingEntity(endRangeBytesTier1,
+                                                                        endRangeBytesTier2,
+                                                                        BigDecimal.valueOf(5)));
+        pricingUsEast2.addPrice(new StoragePricing.StoragePricingEntity(endRangeBytesTier2,
+                                                                        Long.MAX_VALUE,
+                                                                        BigDecimal.ONE));
+        final Map<Regions, StoragePricing> testPriceList = new HashMap<>();
+        testPriceList.put(Regions.US_EAST_1, pricingUsEast1);
+        testPriceList.put(Regions.US_EAST_2, pricingUsEast2);
+        final AwsStorageServicePricing testStoragePricing =
+            new AwsStorageServicePricing(StringUtils.EMPTY, testPriceList);
+
+        Assert.assertEquals(BigDecimal.TEN, testStoragePricing.getDefaultPriceGb());
+    }
+}

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/AwsStorageToRequestConverterTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/AwsStorageToRequestConverterTest.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.billingreportagent.service.impl.converter;
+
+import com.amazonaws.regions.Regions;
+import com.epam.pipeline.billingreportagent.model.EntityContainer;
+import com.epam.pipeline.billingreportagent.model.ResourceType;
+import com.epam.pipeline.billingreportagent.model.StorageType;
+import com.epam.pipeline.billingreportagent.service.ElasticsearchServiceClient;
+import com.epam.pipeline.billingreportagent.service.ElasticsearchSynchronizer;
+import com.epam.pipeline.billingreportagent.service.impl.TestUtils;
+import com.epam.pipeline.billingreportagent.service.impl.mapper.StorageBillingMapper;
+import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
+import com.epam.pipeline.entity.datastorage.DataStorageType;
+import com.epam.pipeline.entity.datastorage.NFSDataStorage;
+import com.epam.pipeline.entity.datastorage.S3bucketDataStorage;
+import com.epam.pipeline.entity.search.SearchDocumentType;
+import com.epam.pipeline.entity.user.PipelineUser;
+import org.apache.commons.lang3.StringUtils;
+import org.assertj.core.util.Arrays;
+import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.text.Text;
+import org.elasticsearch.common.xcontent.DeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.metrics.sum.ParsedSum;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RunWith(MockitoJUnitRunner.class)
+@SuppressWarnings("checkstyle:MagicNumber")
+public class AwsStorageToRequestConverterTest {
+
+    private static final String INDEX_S3 = "cp-test-index-s3";
+    private static final String INDEX_EFS = "cp-test-index-efs";
+    private static final Long STORAGE_ID = 1L;
+    private static final String STORAGE_NAME = "TestStorage";
+    private static final int DOC_ID = 2;
+
+    private static final long BYTES_IN_1_GB = 1L << 30;
+    private static final String SIZE_SUM_SEARCH = "sizeSumSearch";
+    private static final String REGION_FIELD = "storage_region";
+    private static final String INDEX_PATTERN = "%s-daily-%d-%s";
+
+    private static final String VALUE_RESULT_PATTERN_JSON = "{\"value\" : \"%d\"}";
+    private static final String UNKNOWN_REGION = "unknownRegion";
+    private static final String USER_NAME = "TestUser";
+    private static final String GROUP_1 = "TestGroup1";
+    private static final String GROUP_2 = "TestGroup2";
+    private static final List<String> USER_GROUPS = java.util.Arrays.asList(GROUP_1, GROUP_2);
+
+    private final PipelineUser testUser = PipelineUser.builder()
+        .userName(USER_NAME)
+        .groups(USER_GROUPS)
+        .build();
+
+    private final Map<Regions, BigDecimal> testPriceList = new HashMap<>();
+    private BigDecimal defaultPrice;
+    private ElasticsearchServiceClient elasticsearchClient = Mockito.mock(ElasticsearchServiceClient.class);
+
+    @BeforeEach
+    public void init() {
+        testPriceList.put(Regions.US_EAST_1, BigDecimal.ONE);
+        testPriceList.put(Regions.US_EAST_2, BigDecimal.TEN);
+        defaultPrice = BigDecimal.TEN;
+    }
+
+    @Test
+    public void convertStorageToBilling() {
+        final StorageBillingMapper mapper = new StorageBillingMapper(SearchDocumentType.S3_STORAGE);
+        final AwsStorageToBillingRequestConverter s3converter =
+            new AwsStorageToBillingRequestConverter(mapper, elasticsearchClient, StorageType.OBJECT_STORAGE,
+                                                    testPriceList);
+        final LocalDate syncDate = LocalDate.now();
+        final int daysInMonth = YearMonth.of(syncDate.getYear(), syncDate.getMonthValue()).lengthOfMonth();
+
+        final BigDecimal priceGbMonth = BigDecimal.TEN.multiply(BigDecimal.valueOf(daysInMonth));
+        final long dailyCost1Gb = s3converter.calculateDailyCost(BYTES_IN_1_GB, priceGbMonth, syncDate);
+        Assert.assertEquals(BigDecimal.TEN.scaleByPowerOfTen(2).longValue(), dailyCost1Gb);
+
+        final long dailyCost1Byte = s3converter.calculateDailyCost(1L, priceGbMonth, syncDate);
+        Assert.assertEquals(BigDecimal.ONE.longValue(), dailyCost1Byte);
+    }
+
+    @Test
+    public void testS3StorageConverting() throws IOException {
+        final StorageBillingMapper mapper = new StorageBillingMapper(SearchDocumentType.S3_STORAGE);
+        final AwsStorageToBillingRequestConverter converter =
+            new AwsStorageToBillingRequestConverter(mapper, elasticsearchClient, StorageType.OBJECT_STORAGE,
+                                                    testPriceList);
+        final LocalDateTime syncEnd = LocalDateTime.now();
+        final LocalDateTime syncStart = syncEnd.minusDays(1);
+
+        final EntityContainer<AbstractDataStorage> s3StorageContainer =
+            getStorageContainer(STORAGE_ID, STORAGE_NAME, STORAGE_NAME, DataStorageType.S3);
+        final AbstractDataStorage s3Storage = s3StorageContainer.getEntity();
+
+        createElasticsearchSearchContext(BYTES_IN_1_GB, Regions.US_EAST_1.getName().toLowerCase());
+
+        final DocWriteRequest request = converter.convertEntityToRequests(s3StorageContainer, INDEX_S3,
+                                                                          syncStart, syncEnd).get(0);
+        final String expectedIndex = String.format(INDEX_PATTERN,
+                                                   INDEX_S3,
+                                                   s3Storage.getId(),
+                                                   converter.parseDateToString(syncStart.toLocalDate()));
+        final Map<String, Object> requestFieldsMap = ((IndexRequest) request).sourceAsMap();
+        Assert.assertEquals(expectedIndex, request.index());
+        Assert.assertEquals(SearchDocumentType.S3_STORAGE.name(),
+                            requestFieldsMap.get(ElasticsearchSynchronizer.DOC_TYPE_FIELD));
+        final Long expectedCost =
+            converter.calculateDailyCost(BYTES_IN_1_GB, testPriceList.get(Regions.US_EAST_1), syncEnd.toLocalDate());
+        assertFields(s3Storage, requestFieldsMap, Regions.US_EAST_1.getName().toLowerCase(), StorageType.OBJECT_STORAGE,
+                     BYTES_IN_1_GB, expectedCost);
+    }
+
+    @Test
+    public void testEFSStorageConverting() throws IOException {
+        final StorageBillingMapper mapper = new StorageBillingMapper(SearchDocumentType.NFS_STORAGE);
+        final AwsStorageToBillingRequestConverter converter =
+            new AwsStorageToBillingRequestConverter(mapper, elasticsearchClient, StorageType.FILE_STORAGE,
+                                                    testPriceList);
+        final LocalDateTime syncEnd = LocalDateTime.now();
+        final LocalDateTime syncStart = syncEnd.minusDays(1);
+
+        final EntityContainer<AbstractDataStorage> nfsStorageContainer =
+            getStorageContainer(STORAGE_ID, STORAGE_NAME, STORAGE_NAME, DataStorageType.NFS);
+        final AbstractDataStorage nfsStorage = nfsStorageContainer.getEntity();
+
+        createElasticsearchSearchContext(BYTES_IN_1_GB, Regions.US_EAST_1.getName().toLowerCase());
+
+        final DocWriteRequest request = converter.convertEntityToRequests(nfsStorageContainer, INDEX_EFS,
+                                                                          syncStart, syncEnd).get(0);
+        final String expectedIndex = String.format(INDEX_PATTERN,
+                                                   INDEX_EFS,
+                                                   nfsStorage.getId(),
+                                                   converter.parseDateToString(syncStart.toLocalDate()));
+        final Map<String, Object> requestFieldsMap = ((IndexRequest) request).sourceAsMap();
+        Assert.assertEquals(expectedIndex, request.index());
+        Assert.assertEquals(SearchDocumentType.NFS_STORAGE.name(),
+                            requestFieldsMap.get(ElasticsearchSynchronizer.DOC_TYPE_FIELD));
+        final Long expectedCost =
+            converter.calculateDailyCost(BYTES_IN_1_GB, testPriceList.get(Regions.US_EAST_1), syncEnd.toLocalDate());
+        assertFields(nfsStorage, requestFieldsMap, Regions.US_EAST_1.getName().toLowerCase(), StorageType.FILE_STORAGE,
+                     BYTES_IN_1_GB, expectedCost);
+    }
+
+
+    @Test
+    public void testStorageWithUnknownRegionConverting() throws IOException {
+        final StorageBillingMapper mapper = new StorageBillingMapper(SearchDocumentType.S3_STORAGE);
+        final AwsStorageToBillingRequestConverter converter =
+            new AwsStorageToBillingRequestConverter(mapper, elasticsearchClient, StorageType.OBJECT_STORAGE,
+                                                    testPriceList);
+        final LocalDateTime syncEnd = LocalDateTime.now();
+        final LocalDateTime syncStart = syncEnd.minusDays(1);
+
+        final EntityContainer<AbstractDataStorage> s3StorageContainer =
+            getStorageContainer(STORAGE_ID, STORAGE_NAME, STORAGE_NAME, DataStorageType.S3);
+        final AbstractDataStorage s3Storage = s3StorageContainer.getEntity();
+
+        createElasticsearchSearchContext(BYTES_IN_1_GB, UNKNOWN_REGION);
+
+        final DocWriteRequest request = converter.convertEntityToRequests(s3StorageContainer, INDEX_S3,
+                                                                          syncStart, syncEnd).get(0);
+        final String expectedIndex = String.format(INDEX_PATTERN,
+                                                   INDEX_S3,
+                                                   s3Storage.getId(),
+                                                   converter.parseDateToString(syncStart.toLocalDate()));
+        final Map<String, Object> requestFieldsMap = ((IndexRequest) request).sourceAsMap();
+        Assert.assertEquals(expectedIndex, request.index());
+        Assert.assertEquals(SearchDocumentType.S3_STORAGE.name(),
+                            requestFieldsMap.get(ElasticsearchSynchronizer.DOC_TYPE_FIELD));
+        final Long expectedCost =
+            converter.calculateDailyCost(BYTES_IN_1_GB, defaultPrice, syncEnd.toLocalDate());
+        assertFields(s3Storage, requestFieldsMap, null, StorageType.OBJECT_STORAGE, BYTES_IN_1_GB,
+                     expectedCost);
+    }
+
+    private void createElasticsearchSearchContext(final Long storageSize, final String region) throws IOException {
+        final XContentParser parser =
+            XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY,
+                                                      DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                                                      String.format(VALUE_RESULT_PATTERN_JSON, storageSize));
+        final ParsedSum sumAgg = ParsedSum.fromXContent(parser, SIZE_SUM_SEARCH);
+        final Aggregations aggregations = new Aggregations(Collections.singletonList(sumAgg));
+        final SearchHit hit = new SearchHit(DOC_ID,
+                                            StringUtils.EMPTY,
+                                            new Text(StringUtils.EMPTY),
+                                            Collections.emptyMap());
+        final XContentBuilder jsonBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(REGION_FIELD, region)
+            .endObject();
+
+        hit.sourceRef(BytesReference.bytes(jsonBuilder));
+        final SearchHits hits = new SearchHits(Arrays.array(hit), 1, 1);
+
+        final SearchResponse response = Mockito.mock(SearchResponse.class);
+        Mockito.when(response.getAggregations()).thenReturn(aggregations);
+        Mockito.when(response.getHits()).thenReturn(hits);
+        Mockito.when(elasticsearchClient.search(Mockito.any())).thenReturn(response);
+    }
+
+    private void assertFields(final AbstractDataStorage storage, final Map<String, Object> fieldMap,
+                              final String region, final StorageType storageType, final Long usage, final Long cost) {
+        Assert.assertEquals(storage.getId().intValue(), fieldMap.get("id"));
+        Assert.assertEquals(ResourceType.STORAGE.toString(), fieldMap.get("resource_type"));
+        Assert.assertEquals(region, fieldMap.get("region"));
+        Assert.assertEquals(storage.getType().toString(), fieldMap.get("provider"));
+        Assert.assertEquals(storageType.toString(), fieldMap.get("storage_type"));
+        Assert.assertEquals(testUser.getUserName(), fieldMap.get("owner"));
+        Assert.assertEquals(usage.intValue(), fieldMap.get("usage"));
+        Assert.assertEquals(cost.intValue(), fieldMap.get("cost"));
+        TestUtils.verifyStringArray(USER_GROUPS, fieldMap.get("groups"));
+    }
+
+    public EntityContainer<AbstractDataStorage> getStorageContainer(final Long id,
+                                                                    final String name,
+                                                                    final String path,
+                                                                    final DataStorageType storageType) {
+        final AbstractDataStorage storage;
+        if (storageType.equals(DataStorageType.S3)) {
+            storage = new S3bucketDataStorage(id, name, path);
+        } else {
+            storage = new NFSDataStorage(id, name, path);
+        }
+        return EntityContainer.<AbstractDataStorage>builder()
+            .entity(storage)
+            .owner(testUser)
+            .build();
+    }
+}

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/AwsStorageToRequestConverterTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/AwsStorageToRequestConverterTest.java
@@ -237,6 +237,17 @@ public class AwsStorageToRequestConverterTest {
         Assert.assertEquals(0, requests.size());
     }
 
+    @Test
+    public void testStorageWithNoInfoConverting() throws IOException {
+        final EntityContainer<AbstractDataStorage> s3StorageContainer =
+            getStorageContainer(STORAGE_ID, STORAGE_NAME, STORAGE_NAME, DataStorageType.S3);
+        createElasticsearchSearchContext(0L, false, US_EAST_1);
+        Mockito.when(elasticsearchClient.isIndexExists(Mockito.anyString())).thenReturn(false);
+        final List<DocWriteRequest> requests = s3Converter.convertEntityToRequests(s3StorageContainer, INDEX_S3,
+                                                                                   SYNC_START, SYNC_END);
+        Assert.assertEquals(0, requests.size());
+    }
+
     private void createElasticsearchSearchContext(final Long storageSize,
                                                   final boolean isEmptyResponse,
                                                   final String region) throws IOException {
@@ -263,6 +274,7 @@ public class AwsStorageToRequestConverterTest {
         final SearchResponse response = Mockito.mock(SearchResponse.class);
         Mockito.when(response.getAggregations()).thenReturn(aggregations);
         Mockito.when(response.getHits()).thenReturn(hits);
+        Mockito.when(elasticsearchClient.isIndexExists(Mockito.anyString())).thenReturn(true);
         Mockito.when(elasticsearchClient.search(Mockito.any())).thenReturn(response);
     }
 

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/AwsStorageToRequestConverterTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/AwsStorageToRequestConverterTest.java
@@ -79,7 +79,7 @@ public class AwsStorageToRequestConverterTest {
     private static final long BYTES_IN_1_GB = 1L << 30;
     private static final String SIZE_SUM_SEARCH = "sizeSumSearch";
     private static final String REGION_FIELD = "storage_region";
-    private static final String INDEX_PATTERN = "%s-daily-%d-%s";
+    private static final String INDEX_PATTERN = "%s-daily-%s";
 
     private static final String VALUE_RESULT_PATTERN_JSON = "{\"value\" : \"%d\"}";
     private static final String UNKNOWN_REGION = "unknownRegion";
@@ -183,7 +183,6 @@ public class AwsStorageToRequestConverterTest {
                                                                             SYNC_START, SYNC_END).get(0);
         final String expectedIndex = String.format(INDEX_PATTERN,
                                                    INDEX_S3,
-                                                   s3Storage.getId(),
                                                    s3Converter.parseDateToString(SYNC_START.toLocalDate()));
         final Map<String, Object> requestFieldsMap = ((IndexRequest) request).sourceAsMap();
         Assert.assertEquals(expectedIndex, request.index());
@@ -202,7 +201,6 @@ public class AwsStorageToRequestConverterTest {
                                                                              SYNC_START, SYNC_END).get(0);
         final String expectedIndex = String.format(INDEX_PATTERN,
                                                    INDEX_EFS,
-                                                   nfsStorage.getId(),
                                                    nfsConverter.parseDateToString(SYNC_START.toLocalDate()));
         final Map<String, Object> requestFieldsMap = ((IndexRequest) request).sourceAsMap();
         Assert.assertEquals(expectedIndex, request.index());
@@ -220,7 +218,6 @@ public class AwsStorageToRequestConverterTest {
                                                                             SYNC_START, SYNC_END).get(0);
         final String expectedIndex = String.format(INDEX_PATTERN,
                                                    INDEX_S3,
-                                                   s3Storage.getId(),
                                                    s3Converter.parseDateToString(SYNC_START.toLocalDate()));
         final Map<String, Object> requestFieldsMap = ((IndexRequest) request).sourceAsMap();
         Assert.assertEquals(expectedIndex, request.index());

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverterImplTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverterImplTest.java
@@ -17,15 +17,18 @@
 package com.epam.pipeline.billingreportagent.service.impl.converter;
 
 import com.epam.pipeline.billingreportagent.model.EntityContainer;
+import com.epam.pipeline.billingreportagent.model.ResourceType;
 import com.epam.pipeline.billingreportagent.model.billing.PipelineRunBillingInfo;
+import com.epam.pipeline.billingreportagent.service.impl.TestUtils;
 import com.epam.pipeline.billingreportagent.service.impl.mapper.RunBillingMapper;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.epam.pipeline.entity.pipeline.run.RunStatus;
+import com.epam.pipeline.entity.user.PipelineUser;
+import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.index.IndexRequest;
 import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -37,17 +40,30 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-@RunWith(MockitoJUnitRunner.class)
 @SuppressWarnings("checkstyle:magicnumber")
 public class RunToBillingRequestConverterImplTest {
 
+    private static final long REGION_ID = 1;
+    private static final String NODE_TYPE = "nodetype.medium";
     private static final Long RUN_ID = 1L;
+    private static final String USER_NAME = "TestUser";
+    private static final String GROUP_1 = "TestGroup1";
+    private static final String GROUP_2 = "TestGroup2";
+    private static final String PIPELINE_NAME = "TestPipeline";
+    private static final String TOOL_IMAGE = "cp/tool:latest";
+    private static final BigDecimal PRICE = BigDecimal.valueOf(4, 2);
+    private static final List<String> USER_GROUPS = java.util.Arrays.asList(GROUP_1, GROUP_2);
+
+    private final PipelineUser testUser = PipelineUser.builder()
+        .userName(USER_NAME)
+        .groups(USER_GROUPS)
+        .build();
 
     private final RunToBillingRequestConverter converter =
         new RunToBillingRequestConverter(new RunBillingMapper());
 
     @Test
-    public void convertRunBillings() {
+    public void convertRunToBillings() {
         final PipelineRun run = new PipelineRun();
         run.setId(RUN_ID);
         run.setPricePerHour(BigDecimal.valueOf(4, 2));
@@ -76,7 +92,7 @@ public class RunToBillingRequestConverterImplTest {
     }
 
     @Test
-    public void convertRunBillingWithNoStatuses() {
+    public void convertRunWithNoStatusesToBilling() {
         final PipelineRun run = new PipelineRun();
         run.setId(RUN_ID);
         run.setPricePerHour(BigDecimal.valueOf(4, 2));
@@ -91,5 +107,36 @@ public class RunToBillingRequestConverterImplTest {
         final Map<LocalDate, PipelineRunBillingInfo> reports =
             billings.stream().collect(Collectors.toMap(PipelineRunBillingInfo::getDate, Function.identity()));
         Assert.assertEquals(96, reports.get(LocalDate.of(2019, 12, 4)).getCost().longValue());
+    }
+
+    @Test
+    public void testRunConverting() {
+        final PipelineRun run = TestUtils.createTestPipelineRun(RUN_ID, PIPELINE_NAME, TOOL_IMAGE, PRICE,
+                                                                TestUtils.createTestInstance(REGION_ID, NODE_TYPE));
+
+        final EntityContainer<PipelineRun> runContainer =
+            EntityContainer.<PipelineRun>builder()
+                .entity(run)
+                .owner(testUser)
+                .build();
+
+        final LocalDateTime prevSync = LocalDateTime.of(2019, 12, 4, 0, 0);
+        final LocalDateTime syncStart = LocalDateTime.of(2019, 12, 5, 0, 0);
+        final List<DocWriteRequest> billings =
+            converter.convertEntityToRequests(runContainer, "cp-run-test-index", prevSync, syncStart);
+        Assert.assertEquals(1, billings.size());
+
+        final Map<String, Object> requestFieldsMap = ((IndexRequest) billings.get(0)).sourceAsMap();
+        Assert.assertEquals(run.getId().intValue(), requestFieldsMap.get("id"));
+        Assert.assertEquals(ResourceType.COMPUTE.toString(), requestFieldsMap.get("resource_type"));
+        Assert.assertEquals(run.getPipelineName(), requestFieldsMap.get("pipeline"));
+        Assert.assertEquals(run.getDockerImage(), requestFieldsMap.get("tool"));
+        Assert.assertEquals(run.getInstance().getNodeType(), requestFieldsMap.get("instance_type"));
+        Assert.assertEquals(96, requestFieldsMap.get("cost"));
+        Assert.assertEquals(1441, requestFieldsMap.get("usage"));
+        Assert.assertEquals(PRICE.unscaledValue().intValue(), requestFieldsMap.get("run_price"));
+        Assert.assertEquals(run.getInstance().getCloudRegionId().intValue(), requestFieldsMap.get("cloudRegionId"));
+        Assert.assertEquals(USER_NAME, requestFieldsMap.get("owner"));
+        TestUtils.verifyStringArray(USER_GROUPS, requestFieldsMap.get("groups"));
     }
 }

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverterImplTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverterImplTest.java
@@ -17,8 +17,8 @@
 package com.epam.pipeline.billingreportagent.service.impl.converter;
 
 import com.epam.pipeline.billingreportagent.model.EntityContainer;
-import com.epam.pipeline.billingreportagent.model.PipelineRunBillingInfo;
-import com.epam.pipeline.billingreportagent.service.impl.converter.run.BillingMapper;
+import com.epam.pipeline.billingreportagent.model.billing.PipelineRunBillingInfo;
+import com.epam.pipeline.billingreportagent.service.impl.mapper.RunBillingMapper;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.epam.pipeline.entity.pipeline.run.RunStatus;
@@ -41,11 +41,10 @@ import java.util.stream.Collectors;
 @SuppressWarnings("checkstyle:magicnumber")
 public class RunToBillingRequestConverterImplTest {
 
-    private static final String TEST_INDEX = "test-index-1";
     private static final Long RUN_ID = 1L;
 
     private final RunToBillingRequestConverter converter =
-        new RunToBillingRequestConverter(TEST_INDEX, new BillingMapper());
+        new RunToBillingRequestConverter(new RunBillingMapper());
 
     @Test
     public void convertRunBillings() {

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverterImplTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverterImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapperTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapperTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.billingreportagent.service.impl.mapper;
+
+import com.epam.pipeline.billingreportagent.model.EntityContainer;
+import com.epam.pipeline.billingreportagent.model.ResourceType;
+import com.epam.pipeline.billingreportagent.model.billing.PipelineRunBillingInfo;
+import com.epam.pipeline.billingreportagent.service.impl.TestUtils;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.user.PipelineUser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class RunBillingMapperTest {
+
+    private static final String TEST_PIPELINE = "TestPipeline";
+    private static final String TEST_USER_NAME = "User";
+    private static final String TEST_TOOL_IMAGE = "cp/tool:latest";
+    private static final String TEST_NODE_TYPE = "nodetype.medium";
+    private static final String TEST_GROUP_1 = "TestGroup1";
+    private static final String TEST_GROUP_2 = "TestGroup2";
+    private static final long TEST_COST = 10;
+    private static final long TEST_RUN_ID = 1;
+    private static final long TEST_REGION_ID = 1;
+    private static final BigDecimal TEST_PRICE = BigDecimal.ONE;
+    private static final long TEST_USAGE_MINUTES = 600;
+    private static final List<String> TEST_GROUPS = Arrays.asList(TEST_GROUP_1, TEST_GROUP_2);
+    private static final LocalDate TEST_DATE = LocalDate.now();
+
+    private final RunBillingMapper mapper = new RunBillingMapper();
+    private final PipelineUser testUser = PipelineUser.builder()
+        .userName(TEST_USER_NAME)
+        .groups(TEST_GROUPS)
+        .build();
+
+    @Test
+    public void testRunMapperMap() throws IOException {
+        final PipelineRun run =
+            TestUtils.createTestPipelineRun(TEST_RUN_ID, TEST_PIPELINE, TEST_TOOL_IMAGE, TEST_PRICE,
+                                            TestUtils.createTestInstance(TEST_REGION_ID, TEST_NODE_TYPE));
+        final PipelineRunBillingInfo billing = PipelineRunBillingInfo.builder()
+            .run(run)
+            .date(TEST_DATE)
+            .cost(TEST_COST)
+            .usageMinutes(TEST_USAGE_MINUTES)
+            .build();
+        final EntityContainer<PipelineRunBillingInfo> billingContainer =
+            EntityContainer.<PipelineRunBillingInfo>builder()
+            .entity(billing)
+            .owner(testUser)
+            .build();
+
+        final XContentBuilder mappedBilling = mapper.map(billingContainer);
+
+        final Map<String, Object> mappedFields = TestUtils.getPuttedObject(mappedBilling);
+
+        Assert.assertEquals(run.getId().intValue(), mappedFields.get("id"));
+        Assert.assertEquals(ResourceType.COMPUTE.toString(), mappedFields.get("resource_type"));
+        Assert.assertEquals(run.getPipelineName(), mappedFields.get("pipeline"));
+        Assert.assertEquals(run.getDockerImage(), mappedFields.get("tool"));
+        Assert.assertEquals(run.getInstance().getNodeType(), mappedFields.get("instance_type"));
+        Assert.assertEquals(billing.getCost().intValue(), mappedFields.get("cost"));
+        Assert.assertEquals(billing.getUsageMinutes().intValue(), mappedFields.get("usage"));
+        Assert.assertEquals(run.getPricePerHour().intValue(), mappedFields.get("run_price"));
+        Assert.assertEquals(run.getInstance().getCloudRegionId().intValue(), mappedFields.get("cloudRegionId"));
+        Assert.assertEquals(TEST_USER_NAME, mappedFields.get("owner"));
+        TestUtils.verifyStringArray(TEST_GROUPS, mappedFields.get("groups"));
+    }
+}

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapperTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapperTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapperTest.java
@@ -76,15 +76,15 @@ public class RunBillingMapperTest {
 
         final Map<String, Object> mappedFields = TestUtils.getPuttedObject(mappedBilling);
 
-        Assert.assertEquals(run.getId().intValue(), mappedFields.get("id"));
+        Assert.assertEquals((int) TEST_RUN_ID, mappedFields.get("id"));
         Assert.assertEquals(ResourceType.COMPUTE.toString(), mappedFields.get("resource_type"));
-        Assert.assertEquals(run.getPipelineName(), mappedFields.get("pipeline"));
-        Assert.assertEquals(run.getDockerImage(), mappedFields.get("tool"));
-        Assert.assertEquals(run.getInstance().getNodeType(), mappedFields.get("instance_type"));
-        Assert.assertEquals(billing.getCost().intValue(), mappedFields.get("cost"));
-        Assert.assertEquals(billing.getUsageMinutes().intValue(), mappedFields.get("usage"));
+        Assert.assertEquals(TEST_PIPELINE, mappedFields.get("pipeline"));
+        Assert.assertEquals(TEST_TOOL_IMAGE, mappedFields.get("tool"));
+        Assert.assertEquals(TEST_NODE_TYPE, mappedFields.get("instance_type"));
+        Assert.assertEquals((int) TEST_COST, mappedFields.get("cost"));
+        Assert.assertEquals((int) TEST_USAGE_MINUTES, mappedFields.get("usage"));
         Assert.assertEquals(run.getPricePerHour().intValue(), mappedFields.get("run_price"));
-        Assert.assertEquals(run.getInstance().getCloudRegionId().intValue(), mappedFields.get("cloudRegionId"));
+        Assert.assertEquals((int) TEST_REGION_ID, mappedFields.get("cloudRegionId"));
         Assert.assertEquals(TEST_USER_NAME, mappedFields.get("owner"));
         TestUtils.verifyStringArray(TEST_GROUPS, mappedFields.get("groups"));
     }

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapperTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapperTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.billingreportagent.service.impl.mapper;
+
+import com.epam.pipeline.billingreportagent.model.EntityContainer;
+import com.epam.pipeline.billingreportagent.model.ResourceType;
+import com.epam.pipeline.billingreportagent.model.StorageType;
+import com.epam.pipeline.billingreportagent.model.billing.StorageBillingInfo;
+import com.epam.pipeline.billingreportagent.service.ElasticsearchSynchronizer;
+import com.epam.pipeline.billingreportagent.service.impl.TestUtils;
+import com.epam.pipeline.entity.datastorage.NFSDataStorage;
+import com.epam.pipeline.entity.datastorage.S3bucketDataStorage;
+import com.epam.pipeline.entity.search.SearchDocumentType;
+import com.epam.pipeline.entity.user.PipelineUser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class StorageBillingMapperTest {
+
+    private static final String TEST_USER_NAME = "User";
+    private static final String TEST_GROUP_1 = "TestGroup1";
+    private static final String TEST_GROUP_2 = "TestGroup2";
+    private static final String TEST_REGION = "region-1";
+    private static final long TEST_COST = 10;
+    private static final long TEST_USAGE_BYTES = 600;
+    private static final List<String> TEST_GROUPS = Arrays.asList(TEST_GROUP_1, TEST_GROUP_2);
+
+    private final StorageBillingMapper s3Mapper = new StorageBillingMapper(SearchDocumentType.S3_STORAGE);
+    private final StorageBillingMapper efsMapper = new StorageBillingMapper(SearchDocumentType.NFS_STORAGE);
+
+    private final PipelineUser testUser = PipelineUser.builder()
+        .userName(TEST_USER_NAME)
+        .groups(TEST_GROUPS)
+        .build();
+
+    @Test
+    public void testStorageMapperMapS3Storage() throws IOException {
+        final S3bucketDataStorage s3Storage = new S3bucketDataStorage();
+        final StorageBillingInfo billing = StorageBillingInfo.builder()
+            .storage(s3Storage)
+            .storageType(StorageType.OBJECT_STORAGE)
+            .regionName(TEST_REGION)
+            .usageBytes(TEST_USAGE_BYTES)
+            .cost(TEST_COST)
+            .build();
+
+        final EntityContainer<StorageBillingInfo> billingContainer = EntityContainer.<StorageBillingInfo>builder()
+            .entity(billing)
+            .owner(testUser)
+            .build();
+
+        final XContentBuilder mappedBilling = s3Mapper.map(billingContainer);
+
+        final Map<String, Object> mappedFields = TestUtils.getPuttedObject(mappedBilling);
+
+        Assert.assertEquals(SearchDocumentType.S3_STORAGE.name(),
+                            mappedFields.get(ElasticsearchSynchronizer.DOC_TYPE_FIELD));
+        Assert.assertEquals(s3Storage.getId(), mappedFields.get("id"));
+        Assert.assertEquals(ResourceType.STORAGE.toString(), mappedFields.get("resource_type"));
+        Assert.assertEquals(billing.getRegionName(), mappedFields.get("region"));
+        Assert.assertEquals(s3Storage.getType().toString(), mappedFields.get("provider"));
+        Assert.assertEquals(StorageType.OBJECT_STORAGE.toString(), mappedFields.get("storage_type"));
+        Assert.assertEquals(testUser.getUserName(), mappedFields.get("owner"));
+        Assert.assertEquals(billing.getUsageBytes().intValue(), mappedFields.get("usage"));
+        Assert.assertEquals(billing.getCost().intValue(), mappedFields.get("cost"));
+        TestUtils.verifyStringArray(TEST_GROUPS, mappedFields.get("groups"));
+    }
+
+    @Test
+    public void testStorageMapperMapEFSStorage() throws IOException {
+        final NFSDataStorage efsStorage = new NFSDataStorage();
+        final StorageBillingInfo billing = StorageBillingInfo.builder()
+            .storage(efsStorage)
+            .storageType(StorageType.FILE_STORAGE)
+            .regionName(TEST_REGION)
+            .usageBytes(TEST_USAGE_BYTES)
+            .cost(TEST_COST)
+            .build();
+
+        final EntityContainer<StorageBillingInfo> billingContainer = EntityContainer.<StorageBillingInfo>builder()
+            .entity(billing)
+            .owner(testUser)
+            .build();
+
+        final XContentBuilder mappedBilling = efsMapper.map(billingContainer);
+
+        final Map<String, Object> mappedFields = TestUtils.getPuttedObject(mappedBilling);
+
+        Assert.assertEquals(SearchDocumentType.NFS_STORAGE.name(),
+                            mappedFields.get(ElasticsearchSynchronizer.DOC_TYPE_FIELD));
+        Assert.assertEquals(efsStorage.getId(), mappedFields.get("id"));
+        Assert.assertEquals(ResourceType.STORAGE.toString(), mappedFields.get("resource_type"));
+        Assert.assertEquals(billing.getRegionName(), mappedFields.get("region"));
+        Assert.assertEquals(efsStorage.getType().toString(), mappedFields.get("provider"));
+        Assert.assertEquals(StorageType.FILE_STORAGE.toString(), mappedFields.get("storage_type"));
+        Assert.assertEquals(testUser.getUserName(), mappedFields.get("owner"));
+        Assert.assertEquals(billing.getUsageBytes().intValue(), mappedFields.get("usage"));
+        Assert.assertEquals(billing.getCost().intValue(), mappedFields.get("cost"));
+        TestUtils.verifyStringArray(TEST_GROUPS, mappedFields.get("groups"));
+    }
+}

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapperTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
@@ -201,5 +201,5 @@ public interface CloudPipelineAPI {
     Call<Result<NotificationMessage>> createNotification(@Body NotificationMessageVO notification);
 
     @GET("run/activity")
-    Call<Result<List<PipelineRun>>> loadRunsActivityStats(@Query(FROM) LocalDateTime from, @Query(TO) LocalDateTime to);
+    Call<Result<List<PipelineRun>>> loadRunsActivityStats(@Query(FROM) String from, @Query(TO) String to);
 }


### PR DESCRIPTION
This PR is related to issue #761.

It brings the implementation of cost reporting for AWS storages according to approach from #873: storage cost is calculated as `data size in GB` * `price GB/Month`. 

- The price list is built using `aws-java-sdk-pricing` 
- General loader and mapper services are implemented
- Specific `AwsStorageToBillingRequestConverter` is provided
- Daily costs are indexed to Elasticsearch