### PR TITLE
Add main disks resizing support for AWS

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
@@ -30,6 +30,7 @@ import com.epam.pipeline.dao.filter.FilterRunParameters;
 import com.epam.pipeline.entity.cluster.PipelineRunPrice;
 import com.epam.pipeline.entity.pipeline.CommitStatus;
 import com.epam.pipeline.entity.pipeline.DiskAttachRequest;
+import com.epam.pipeline.entity.pipeline.DiskResizeRequest;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.PipelineTask;
 import com.epam.pipeline.entity.pipeline.RunInstance;
@@ -281,5 +282,11 @@ public class RunApiService {
     @AclMask
     public PipelineRun attachDisk(final Long runId, final DiskAttachRequest request) {
         return runManager.attachDisk(runId, request);
+    }
+
+    @PreAuthorize(RUN_ID_OWNER)
+    @AclMask
+    public PipelineRun resizeDisk(final Long runId, final DiskResizeRequest request) {
+        return runManager.resizeDisk(runId, request);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -142,6 +142,7 @@ public final class MessageConstants {
     public static final String WARN_RESUME_RUN_FAILED = "warn.resume.run.failed";
     public static final String INFO_INSTANCE_STARTED = "info.instance.started";
     public static final String ERROR_RUN_DISK_ATTACHING_WRONG_STATUS = "error.run.attaching.wrong.status";
+    public static final String ERROR_RUN_DISK_RESIZING_WRONG_STATUS = "error.run.resizing.wrong.status";
     public static final String ERROR_RUN_DISK_SIZE_NOT_FOUND = "error.run.disk.size.not.found";
 
     //Run schedule

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
@@ -506,8 +506,8 @@ public class PipelineRunController extends AbstractRestController {
     @PostMapping(value = "/run/{runId}/disk/resize")
     @ResponseBody
     @ApiOperation(
-            value = "Resizes pipeline run root disk.",
-            notes = "Resizes pipeline run root disk by the given request. " +
+            value = "Resizes pipeline run main disk.",
+            notes = "Resizes pipeline run main disk by the given request. " +
                     "Disk size should be specified in GB.",
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
@@ -32,6 +32,7 @@ import com.epam.pipeline.controller.vo.TagsVO;
 import com.epam.pipeline.controller.vo.configuration.RunConfigurationWithEntitiesVO;
 import com.epam.pipeline.entity.cluster.PipelineRunPrice;
 import com.epam.pipeline.entity.pipeline.DiskAttachRequest;
+import com.epam.pipeline.entity.pipeline.DiskResizeRequest;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.PipelineTask;
 import com.epam.pipeline.entity.pipeline.RunInstance;
@@ -500,6 +501,19 @@ public class PipelineRunController extends AbstractRestController {
     public Result<PipelineRun> attachDisk(@PathVariable(value = RUN_ID) final Long runId,
                                           @RequestBody final DiskAttachRequest request) {
         return Result.success(runApiService.attachDisk(runId, request));
+    }
+
+    @PostMapping(value = "/run/{runId}/disk/resize")
+    @ResponseBody
+    @ApiOperation(
+            value = "Resizes pipeline run root disk.",
+            notes = "Resizes pipeline run root disk by the given request. " +
+                    "Disk size should be specified in GB.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<PipelineRun> resizeDisk(@PathVariable(value = RUN_ID) final Long runId,
+                                          @RequestBody final DiskResizeRequest request) {
+        return Result.success(runApiService.resizeDisk(runId, request));
     }
 
     @GetMapping(value = "/run/activity")

--- a/api/src/main/java/com/epam/pipeline/entity/pipeline/DiskResizeRequest.java
+++ b/api/src/main/java/com/epam/pipeline/entity/pipeline/DiskResizeRequest.java
@@ -1,0 +1,8 @@
+package com.epam.pipeline.entity.pipeline;
+
+import lombok.Value;
+
+@Value
+public class DiskResizeRequest {
+    private final Long size;
+}

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacade.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacade.java
@@ -83,7 +83,7 @@ public interface CloudFacade {
     void attachDisk(Long regionId, Long runId, DiskAttachRequest request);
 
     /**
-     * Resizes root disk by the given request for an instance associated with the run.
+     * Resizes existing disk by the given request for an instance associated with the run.
      */
     void resizeDisk(Long regionId, Long runId, DiskResizeRequest request);
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacade.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacade.java
@@ -21,6 +21,7 @@ import com.epam.pipeline.entity.cloud.CloudInstanceOperationResult;
 import com.epam.pipeline.entity.cluster.InstanceOffer;
 import com.epam.pipeline.entity.cluster.InstanceType;
 import com.epam.pipeline.entity.pipeline.DiskAttachRequest;
+import com.epam.pipeline.entity.pipeline.DiskResizeRequest;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.region.AbstractCloudRegion;
 
@@ -77,7 +78,12 @@ public interface CloudFacade {
     List<InstanceType> getAllInstanceTypes(Long regionId, boolean spot);
 
     /**
-     * Creates and attaches new disk by the given request to an instance associated with run.
+     * Creates and attaches new disk by the given request to an instance associated with the run.
      */
     void attachDisk(Long regionId, Long runId, DiskAttachRequest request);
+
+    /**
+     * Resizes root disk by the given request for an instance associated with the run.
+     */
+    void resizeDisk(Long regionId, Long runId, DiskResizeRequest request);
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacadeImpl.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacadeImpl.java
@@ -24,6 +24,7 @@ import com.epam.pipeline.entity.cluster.InstanceOffer;
 import com.epam.pipeline.entity.cluster.InstanceType;
 import com.epam.pipeline.entity.cluster.NodeRegionLabels;
 import com.epam.pipeline.entity.pipeline.DiskAttachRequest;
+import com.epam.pipeline.entity.pipeline.DiskResizeRequest;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.region.AbstractCloudRegion;
@@ -216,6 +217,12 @@ public class CloudFacadeImpl implements CloudFacade {
     public void attachDisk(final Long regionId, final Long runId, final DiskAttachRequest request) {
         final AbstractCloudRegion region = regionManager.loadOrDefault(regionId);
         getInstanceService(region).attachDisk(region, runId, request);
+    }
+
+    @Override
+    public void resizeDisk(final Long regionId, final Long runId, final DiskResizeRequest request) {
+        final AbstractCloudRegion region = regionManager.loadOrDefault(regionId);
+        getInstanceService(region).resizeDisk(region, runId, request);
     }
 
     private AbstractCloudRegion getRegionByRunId(final Long runId) {

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/CloudInstanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/CloudInstanceService.java
@@ -19,6 +19,7 @@ package com.epam.pipeline.manager.cloud;
 import com.epam.pipeline.entity.cloud.InstanceTerminationState;
 import com.epam.pipeline.entity.cloud.CloudInstanceOperationResult;
 import com.epam.pipeline.entity.pipeline.DiskAttachRequest;
+import com.epam.pipeline.entity.pipeline.DiskResizeRequest;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.region.AbstractCloudRegion;
 import com.epam.pipeline.manager.cluster.AutoscalerServiceImpl;
@@ -178,4 +179,12 @@ public interface CloudInstanceService<T extends AbstractCloudRegion>
      * @param request
      */
     void attachDisk(T region, Long runId, DiskAttachRequest request);
+
+    /**
+     * Resizes cloud instance root disk by the given request.
+     * @param region
+     * @param runId
+     * @param request
+     */
+    void resizeDisk(T region, Long runId, DiskResizeRequest request);
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSInstanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSInstanceService.java
@@ -22,6 +22,7 @@ import com.amazonaws.services.ec2.model.Instance;
 import com.epam.pipeline.entity.cloud.InstanceTerminationState;
 import com.epam.pipeline.entity.cloud.CloudInstanceOperationResult;
 import com.epam.pipeline.entity.pipeline.DiskAttachRequest;
+import com.epam.pipeline.entity.pipeline.DiskResizeRequest;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.region.AwsRegion;
 import com.epam.pipeline.entity.region.CloudProvider;
@@ -223,6 +224,11 @@ public class AWSInstanceService implements CloudInstanceService<AwsRegion> {
     @Override
     public void attachDisk(final AwsRegion region, final Long runId, final DiskAttachRequest request) {
         ec2Helper.createAndAttachVolume(String.valueOf(runId), request.getSize(), region.getRegionCode());
+    }
+
+    @Override
+    public void resizeDisk(final AwsRegion region, final Long runId, final DiskResizeRequest request) {
+        ec2Helper.resizeRootVolume(String.valueOf(runId), request.getSize(), region.getRegionCode());
     }
 
     private String buildNodeUpCommand(final AwsRegion region,

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSInstanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSInstanceService.java
@@ -228,7 +228,7 @@ public class AWSInstanceService implements CloudInstanceService<AwsRegion> {
 
     @Override
     public void resizeDisk(final AwsRegion region, final Long runId, final DiskResizeRequest request) {
-        ec2Helper.resizeRootVolume(String.valueOf(runId), request.getSize(), region.getRegionCode());
+        ec2Helper.resizeMainVolume(String.valueOf(runId), request.getSize(), region.getRegionCode());
     }
 
     private String buildNodeUpCommand(final AwsRegion region,

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/aws/EC2Helper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/aws/EC2Helper.java
@@ -27,7 +27,9 @@ import com.amazonaws.services.ec2.model.DeleteVolumeRequest;
 import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
 import com.amazonaws.services.ec2.model.DescribeSpotPriceHistoryRequest;
 import com.amazonaws.services.ec2.model.DescribeSpotPriceHistoryResult;
+import com.amazonaws.services.ec2.model.DescribeVolumesModificationsRequest;
 import com.amazonaws.services.ec2.model.DescribeVolumesRequest;
+import com.amazonaws.services.ec2.model.EbsInstanceBlockDevice;
 import com.amazonaws.services.ec2.model.EbsInstanceBlockDeviceSpecification;
 import com.amazonaws.services.ec2.model.Filter;
 import com.amazonaws.services.ec2.model.Instance;
@@ -35,6 +37,7 @@ import com.amazonaws.services.ec2.model.InstanceBlockDeviceMapping;
 import com.amazonaws.services.ec2.model.InstanceBlockDeviceMappingSpecification;
 import com.amazonaws.services.ec2.model.InstanceStateName;
 import com.amazonaws.services.ec2.model.ModifyInstanceAttributeRequest;
+import com.amazonaws.services.ec2.model.ModifyVolumeRequest;
 import com.amazonaws.services.ec2.model.Placement;
 import com.amazonaws.services.ec2.model.Reservation;
 import com.amazonaws.services.ec2.model.SpotPrice;
@@ -43,6 +46,8 @@ import com.amazonaws.services.ec2.model.StateReason;
 import com.amazonaws.services.ec2.model.StopInstancesRequest;
 import com.amazonaws.services.ec2.model.TerminateInstancesRequest;
 import com.amazonaws.services.ec2.model.Volume;
+import com.amazonaws.services.ec2.model.VolumeModification;
+import com.amazonaws.services.ec2.model.VolumeModificationState;
 import com.amazonaws.services.ec2.model.VolumeType;
 import com.amazonaws.waiters.Waiter;
 import com.amazonaws.waiters.WaiterParameters;
@@ -68,9 +73,11 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -90,6 +97,10 @@ public class EC2Helper {
     private static final String INSUFFICIENT_INSTANCE_CAPACITY = "InsufficientInstanceCapacity";
     private static final String ALLOWED_DEVICE_PREFIX = "/dev/sd";
     private static final String ALLOWED_DEVICE_SUFFIXES = "defghijklmnopqrstuvwxyz";
+    private static final String FALLBACK_ROOT_DEVICE = "/dev/xvda";
+    private static final TimeUnit TIMEOUT_UNIT = TimeUnit.SECONDS;
+    private static final int FALLBACK_VOLUME_RESIZE_TIMEOUT = 60;
+    private static final int FALLBACK_POLLING_DELAY = 5;
 
     private final PreferenceManager preferenceManager;
     private final MessageHelper messageHelper;
@@ -268,6 +279,13 @@ public class EC2Helper {
         enableVolumeDeletionOnInstanceTermination(client, instance.getInstanceId(), device);
     }
 
+    public void resizeRootVolume(final String runId, final Long size, final String awsRegion) {
+        final AmazonEC2 client = getEC2Client(awsRegion);
+        final Instance instance = getAliveInstance(runId, awsRegion);
+        final String volumeId = getRootVolume(instance);
+        modifyVolume(client, volumeId, size);
+    }
+
     private String getVacantDeviceName(final Instance instance) {
         final List<String> attachedDevices = getAttachedDevices(instance);
         return allowedDeviceNames()
@@ -350,6 +368,103 @@ public class EC2Helper {
     private void deleteVolume(final AmazonEC2 client, final String volumeId) {
         client.deleteVolume(new DeleteVolumeRequest()
                 .withVolumeId(volumeId));
+    }
+
+    private String getRootVolume(final Instance instance) {
+        final Collection<InstanceBlockDeviceMapping> mappings = CollectionUtils.emptyIfNull(
+                instance.getBlockDeviceMappings());
+        final String configuredRootDevice = getConfiguredRootDeviceName();
+        final Optional<String> actualRootDevice = Optional.ofNullable(instance.getRootDeviceName());
+        return getDeviceVolume(mappings, configuredRootDevice).map(Optional::of)
+                .orElseGet(() -> actualRootDevice.flatMap(device -> getDeviceVolume(mappings, device)))
+                .orElseThrow(() -> new AwsEc2Exception(String.format("Root volume wasn't found for instance " +
+                        "with id '%s'", instance.getInstanceId())));
+    }
+
+    private String getConfiguredRootDeviceName() {
+        return Optional.ofNullable(preferenceManager.getPreference(SystemPreferences.CLUSTER_INSTANCE_ROOT_DEVICE))
+                .orElse(FALLBACK_ROOT_DEVICE);
+    }
+
+    private Optional<String> getDeviceVolume(final Collection<InstanceBlockDeviceMapping> mappings,
+                                             final String device) {
+        return mappings.stream()
+                .filter(mapping -> device.equals(mapping.getDeviceName()))
+                .map(mapping -> Optional.ofNullable(mapping.getEbs())
+                        .map(EbsInstanceBlockDevice::getVolumeId))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .findFirst();
+    }
+
+    private void modifyVolume(final AmazonEC2 client, final String volumeId, final Long size) {
+        modifyVolumeAsync(client, volumeId, size);
+        waitForVolumeModification(client, volumeId);
+    }
+
+    private void modifyVolumeAsync(final AmazonEC2 client, final String volumeId, final Long size) {
+        client.modifyVolume(new ModifyVolumeRequest()
+                .withVolumeId(volumeId)
+                .withSize(size.intValue()));
+    }
+
+    private void waitForVolumeModification(final AmazonEC2 client, final String volumeId) {
+        final int pollingTimeout = getPollingTimeout();
+        final int pollingDelay = getPollingDelay();
+        final int allowedAttempts = pollingTimeout / pollingDelay;
+        int attempt = 0;
+        while (attempt < allowedAttempts) {
+            try {
+                TIMEOUT_UNIT.sleep(pollingDelay);
+            } catch (InterruptedException e) {
+                throw new AwsEc2Exception(String.format("Volume with id '%s' modification has been interrupted.",
+                        volumeId), e);
+            }
+            if (volumeModificationHasFinished(client, volumeId)) {
+                return;
+            }
+            attempt += 1;
+        }
+        throw new AwsEc2Exception(String.format("Volume with id '%s' wasn't modified after %s %s.",
+                volumeId, pollingTimeout, TIMEOUT_UNIT));
+    }
+
+    private int getPollingTimeout() {
+        return Optional.ofNullable(preferenceManager.getPreference(
+                SystemPreferences.CLUSTER_INSTANCE_DISK_RESIZE_TIMEOUT))
+                .orElse(FALLBACK_VOLUME_RESIZE_TIMEOUT);
+    }
+
+    private int getPollingDelay() {
+        return FALLBACK_POLLING_DELAY;
+    }
+
+    private boolean volumeModificationHasFinished(final AmazonEC2 client, final String volumeId) {
+        switch (getLatestVolumeModificationState(client, volumeId)) {
+            case Optimizing:
+            case Completed:
+                return true;
+            case Failed:
+                throw new AwsEc2Exception(String.format("Volume with id '%s' modification has failed.", volumeId));
+            default:
+                return false;
+        }
+    }
+
+    private VolumeModificationState getLatestVolumeModificationState(final AmazonEC2 client, final String volumeId) {
+        return getLatestVolumeModification(client, volumeId)
+                .map(VolumeModification::getModificationState)
+                .map(VolumeModificationState::fromValue)
+                .orElseThrow(() -> new AwsEc2Exception("Volume with id '%s' modification has invalid state."));
+    }
+
+    private Optional<VolumeModification> getLatestVolumeModification(final AmazonEC2 client, final String volumeId) {
+        final List<VolumeModification> modifications = client.describeVolumesModifications(
+                new DescribeVolumesModificationsRequest()
+                        .withVolumeIds(volumeId))
+                .getVolumesModifications();
+        return CollectionUtils.emptyIfNull(modifications).stream()
+                .max(Comparator.comparing(VolumeModification::getStartTime));
     }
 
     private double getMeanValue(List<SpotPrice> value) {

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzureInstanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzureInstanceService.java
@@ -20,6 +20,7 @@ import com.epam.pipeline.entity.cloud.InstanceTerminationState;
 import com.epam.pipeline.entity.cloud.CloudInstanceOperationResult;
 import com.epam.pipeline.entity.cloud.azure.AzureVirtualMachineStats;
 import com.epam.pipeline.entity.pipeline.DiskAttachRequest;
+import com.epam.pipeline.entity.pipeline.DiskResizeRequest;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.region.AzureRegion;
 import com.epam.pipeline.entity.region.AzureRegionCredentials;
@@ -211,6 +212,11 @@ public class AzureInstanceService implements CloudInstanceService<AzureRegion> {
     @Override
     public void attachDisk(final AzureRegion region, final Long runId, final DiskAttachRequest request) {
         throw new UnsupportedOperationException("Disk attaching doesn't work with Azure provider yet.");
+    }
+
+    @Override
+    public void resizeDisk(final AzureRegion region, final Long runId, final DiskResizeRequest request) {
+        throw new UnsupportedOperationException("Disk resizing doesn't work with Azure provider yet.");
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPInstanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPInstanceService.java
@@ -19,6 +19,7 @@ package com.epam.pipeline.manager.cloud.gcp;
 import com.epam.pipeline.entity.cloud.InstanceTerminationState;
 import com.epam.pipeline.entity.cloud.CloudInstanceOperationResult;
 import com.epam.pipeline.entity.pipeline.DiskAttachRequest;
+import com.epam.pipeline.entity.pipeline.DiskResizeRequest;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.region.CloudProvider;
 import com.epam.pipeline.entity.region.GCPRegion;
@@ -207,6 +208,11 @@ public class GCPInstanceService implements CloudInstanceService<GCPRegion> {
     @Override
     public void attachDisk(final GCPRegion region, final Long runId, final DiskAttachRequest request) {
         throw new UnsupportedOperationException("Disk attaching doesn't work with GCP provider yet.");
+    }
+
+    @Override
+    public void resizeDisk(final GCPRegion region, final Long runId, final DiskResizeRequest request) {
+        throw new UnsupportedOperationException("Disk resizing doesn't work with GCP provider yet.");
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/NodesManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/NodesManager.java
@@ -26,6 +26,7 @@ import com.epam.pipeline.entity.cluster.NodeInstance;
 import com.epam.pipeline.entity.cluster.NodeInstanceAddress;
 import com.epam.pipeline.entity.cluster.PodInstance;
 import com.epam.pipeline.entity.pipeline.DiskAttachRequest;
+import com.epam.pipeline.entity.pipeline.DiskResizeRequest;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
@@ -310,11 +311,21 @@ public class NodesManager {
      * Creates and attaches new disk to the run cloud instance.
      */
     public void attachDisk(final PipelineRun run, final DiskAttachRequest request) {
-        final Optional<RunInstance> instance = Optional.ofNullable(run.getInstance());
-        final AbstractCloudRegion region = instance.map(RunInstance::getCloudRegionId)
+        cloudFacade.attachDisk(region(run).getId(), run.getId(), request);
+    }
+
+    /**
+     * Resizes root disk of the run cloud instance.
+     */
+    public void resizeDisk(final PipelineRun run, final DiskResizeRequest request) {
+        cloudFacade.resizeDisk(region(run).getId(), run.getId(), request);
+    }
+
+    private AbstractCloudRegion region(final PipelineRun run) {
+        return Optional.ofNullable(run.getInstance())
+                .map(RunInstance::getCloudRegionId)
                 .map(regionManager::load)
                 .orElseGet(regionManager::loadDefaultRegion);
-        cloudFacade.attachDisk(region.getId(), run.getId(), request);
     }
 
     private boolean isNodeProtected(NodeInstance nodeInstance) {

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/NodesManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/NodesManager.java
@@ -315,7 +315,7 @@ public class NodesManager {
     }
 
     /**
-     * Resizes root disk of the run cloud instance.
+     * Resizes existing disk of the run cloud instance.
      */
     public void resizeDisk(final PipelineRun run, final DiskResizeRequest request) {
         cloudFacade.resizeDisk(region(run).getId(), run.getId(), request);

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -35,6 +35,7 @@ import com.epam.pipeline.entity.contextual.ContextualPreferenceExternalResource;
 import com.epam.pipeline.entity.contextual.ContextualPreferenceLevel;
 import com.epam.pipeline.entity.pipeline.CommitStatus;
 import com.epam.pipeline.entity.pipeline.DiskAttachRequest;
+import com.epam.pipeline.entity.pipeline.DiskResizeRequest;
 import com.epam.pipeline.entity.pipeline.DockerRegistry;
 import com.epam.pipeline.entity.pipeline.Folder;
 import com.epam.pipeline.entity.pipeline.Pipeline;
@@ -1032,6 +1033,29 @@ public class PipelineRunManager {
         Assert.isTrue(request.getSize() > 0,
                 messageHelper.getMessage(MessageConstants.ERROR_INSTANCE_DISK_IS_INVALID, request.getSize()));
         nodesManager.attachDisk(pipelineRun, request);
+        return pipelineRun;
+    }
+
+    /**
+     * Resizes run root disk by the given request.
+     *
+     * @param runId {@link PipelineRun} id for pipeline run.
+     * @param request Disk resize request.
+     * @return Updated pipeline run.
+     */
+    @Transactional(propagation = Propagation.REQUIRED)
+    public PipelineRun resizeDisk(final Long runId, final DiskResizeRequest request) {
+        final PipelineRun pipelineRun = pipelineRunDao.loadPipelineRun(runId);
+        Assert.notNull(pipelineRun,
+                messageHelper.getMessage(MessageConstants.ERROR_RUN_PIPELINES_NOT_FOUND, runId));
+        Assert.state(pipelineRun.getStatus() == TaskStatus.RUNNING || pipelineRun.getStatus().isPause(),
+                messageHelper.getMessage(MessageConstants.ERROR_RUN_DISK_RESIZING_WRONG_STATUS, runId,
+                        pipelineRun.getStatus()));
+        Assert.notNull(request.getSize(),
+                messageHelper.getMessage(MessageConstants.ERROR_RUN_DISK_SIZE_NOT_FOUND));
+        Assert.isTrue(request.getSize() > 0,
+                messageHelper.getMessage(MessageConstants.ERROR_INSTANCE_DISK_IS_INVALID, request.getSize()));
+        nodesManager.resizeDisk(pipelineRun, request);
         return pipelineRun;
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -1037,7 +1037,7 @@ public class PipelineRunManager {
     }
 
     /**
-     * Resizes run root disk by the given request.
+     * Resizes run disk by the given request.
      *
      * @param runId {@link PipelineRun} id for pipeline run.
      * @param request Disk resize request.

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -279,8 +279,8 @@ public class SystemPreferences {
     public static final StringPreference CLUSTER_INSTANCE_DEVICE_SUFFIXES = new StringPreference(
             "cluster.instance.device.suffixes", "defghijklmnopqrstuvwxyz", CLUSTER_GROUP,
             PreferenceValidators.isNotBlank);
-    public static final StringPreference CLUSTER_INSTANCE_ROOT_DEVICE = new StringPreference(
-            "cluster.instance.root.device", "/dev/xvda", CLUSTER_GROUP,
+    public static final StringPreference CLUSTER_INSTANCE_MAIN_DEVICE = new StringPreference(
+            "cluster.instance.main.device", "/dev/sdb", CLUSTER_GROUP,
             PreferenceValidators.isNotBlank);
     public static final IntPreference CLUSTER_INSTANCE_DISK_RESIZE_TIMEOUT = new IntPreference(
             "cluster.instance.disk.resize.timeout", 60, CLUSTER_GROUP,

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -279,6 +279,12 @@ public class SystemPreferences {
     public static final StringPreference CLUSTER_INSTANCE_DEVICE_SUFFIXES = new StringPreference(
             "cluster.instance.device.suffixes", "defghijklmnopqrstuvwxyz", CLUSTER_GROUP,
             PreferenceValidators.isNotBlank);
+    public static final StringPreference CLUSTER_INSTANCE_ROOT_DEVICE = new StringPreference(
+            "cluster.instance.root.device", "/dev/xvda", CLUSTER_GROUP,
+            PreferenceValidators.isNotBlank);
+    public static final IntPreference CLUSTER_INSTANCE_DISK_RESIZE_TIMEOUT = new IntPreference(
+            "cluster.instance.disk.resize.timeout", 60, CLUSTER_GROUP,
+            isGreaterThan(0));
     public static final ObjectPreference<CloudRegionsConfiguration> CLUSTER_NETWORKS_CONFIG =
         new ObjectPreference<>("cluster.networks.config", null, new TypeReference<CloudRegionsConfiguration>() {},
                                CLUSTER_GROUP, isNullOrValidJson(new TypeReference<CloudRegionsConfiguration>() {}));

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -107,6 +107,7 @@ error.run.termination.wrong.status=Only paused runs can be terminated. Given run
 warn.resume.run.failed=Could not resume run. Operation failed with message ''{0}''
 info.instance.started=Instance ''{0}'' successfully started.
 error.run.attaching.wrong.status=Disks can be attached to running or paused runs. Given run ''{0}'' has ''{1}'' status.
+error.run.resizing.wrong.status=Disks can be resized for only running or paused runs. Given run ''{0}'' has ''{1}'' status.
 error.run.disk.size.not.found=Pipeline run disk size should be specified.
 
 #Run schedule


### PR DESCRIPTION
Relates to #837.

## Description

The pull request brings new API method that can be used to resize main disks of running or paused runs. *Currently only AWS provider is supported.*

Method `POST /run/{run_id}/disk/resize` accepts requests for disks resizing with the following body where size should be specified in GB
```json
{
    "size": 100
}
```

Notice that only *main disk* can be resized using the new API method for now. Main disk is the one that is attached to the instance along with the root one (and optionally a swap one) on node startup. New system preference `cluster.instance.main.device` can be used to specify the predefined main device name.

Also notice that since the volume resizing is an asynchronous operation a new system preference `cluster.instance.disk.resize.timeout` is added in order to control how long the server should wait for a disk resize to complete. Moreover as long as disk modification requests can take up to several hours to increase both disk capacity and performance the server waits for only disk capacity modification to complete before return. 

Usually the operation takes about 11 seconds to complete and it looks like it works in a constant time just the same way as disk attach operation performs.

Two system preferences mentioned above:
- `cluster.instance.main.device` defines main device name. Defaults to `/dev/sdb`.
- `cluster.instance.disk.resize.timeout` defines a number of seconds for server to wait for disk resize operation to complete. Defaults to `60`.

## Limitations

According to AWS EC2 [docs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/modify-volume-requirements.html) volume modifications can be performed only once in 6 hours per volume and volume modifications cannot be performed simultaneously. In other words the new API method can be called at least six hours after the previous call.

## Performance

From the manual testing it seems that complete volume modification time (including optimization which is skipped in the API method) depends on the occupied disk size and both modification initial and target disk sizes. In the table below \* stands for the fully occupied disk (no space left on the device).

| Size | Time, s | Time, m|
| ---- | -------- | -------- |
| 50 -> 100 | 308 | 5 |
| 50 -> 1000 | 324 | 5 |
| 500 -> 1000 | 925 | 15 |
| 500* -> 1000 | 577 | 10 |
