### PR TITLE
Allow to generate the `pipe run` command from the GUI

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
@@ -284,7 +284,7 @@ public class RunApiService {
         return runManager.attachDisk(runId, request);
     }
 
-    @PreAuthorize(RUN_ID_OWNER)
+    @PreAuthorize(RUN_ID_READ)
     public String generateLaunchCommand(final PipeRunCmdStartVO runVO) {
         return runManager.generateLaunchCommand(runVO);
     }

--- a/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
@@ -284,7 +284,7 @@ public class RunApiService {
         return runManager.attachDisk(runId, request);
     }
 
-    @PreAuthorize(RUN_ID_READ)
+    @PreAuthorize("hasRole('ADMIN') OR @grantPermissionManager.hasPermissionToRun(#runVO.pipelineStart, 'EXECUTE')")
     public String generateLaunchCommand(final PipeRunCmdStartVO runVO) {
         return runManager.generateLaunchCommand(runVO);
     }

--- a/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
@@ -35,6 +35,7 @@ import com.epam.pipeline.entity.pipeline.PipelineTask;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.RunLog;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
+import com.epam.pipeline.entity.pipeline.run.PipeRunCmdStartVO;
 import com.epam.pipeline.entity.pipeline.run.PipelineStart;
 import com.epam.pipeline.entity.pipeline.run.parameter.RunSid;
 import com.epam.pipeline.entity.utils.DefaultSystemParameter;
@@ -281,5 +282,10 @@ public class RunApiService {
     @AclMask
     public PipelineRun attachDisk(final Long runId, final DiskAttachRequest request) {
         return runManager.attachDisk(runId, request);
+    }
+
+    @PreAuthorize(RUN_ID_OWNER)
+    public String generateLaunchCommand(final PipeRunCmdStartVO runVO) {
+        return runManager.generateLaunchCommand(runVO);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
@@ -36,6 +36,7 @@ import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.PipelineTask;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.RunLog;
+import com.epam.pipeline.entity.pipeline.run.PipeRunCmdStartVO;
 import com.epam.pipeline.entity.pipeline.run.PipelineStart;
 import com.epam.pipeline.entity.pipeline.run.parameter.RunSid;
 import com.epam.pipeline.entity.utils.DefaultSystemParameter;
@@ -513,5 +514,16 @@ public class PipelineRunController extends AbstractRestController {
     public Result<List<PipelineRun>> loadRunsActivityStats(@RequestParam(value = "from") final LocalDateTime start,
                                                            @RequestParam(value = "to") final LocalDateTime end) {
         return Result.success(runApiService.loadRunsActivityStats(start, end));
+    }
+
+    @PostMapping(value = "/run/cmd")
+    @ResponseBody
+    @ApiOperation(
+            value = "Returns launch command for specified run",
+            notes = "Returns launch command for specified run",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<String> generateLaunchCommand(@RequestBody final PipeRunCmdStartVO runVO) {
+        return Result.success(runApiService.generateLaunchCommand(runVO));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -43,6 +43,7 @@ import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.epam.pipeline.entity.pipeline.Tool;
 import com.epam.pipeline.entity.pipeline.run.ExecutionPreferences;
+import com.epam.pipeline.entity.pipeline.run.PipeRunCmdStartVO;
 import com.epam.pipeline.entity.pipeline.run.PipelineStart;
 import com.epam.pipeline.entity.pipeline.run.RestartRun;
 import com.epam.pipeline.entity.pipeline.run.RunStatus;
@@ -63,6 +64,7 @@ import com.epam.pipeline.manager.docker.scan.ToolSecurityPolicyCheck;
 import com.epam.pipeline.manager.execution.PipelineLauncher;
 import com.epam.pipeline.manager.git.GitManager;
 import com.epam.pipeline.manager.pipeline.runner.ConfigurationProviderManager;
+import com.epam.pipeline.manager.pipeline.runner.PipeRunCmdBuilder;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.manager.region.CloudRegionManager;
@@ -1033,6 +1035,28 @@ public class PipelineRunManager {
                 messageHelper.getMessage(MessageConstants.ERROR_INSTANCE_DISK_IS_INVALID, request.getSize()));
         nodesManager.attachDisk(pipelineRun, request);
         return pipelineRun;
+    }
+
+    public String generateLaunchCommand(final PipeRunCmdStartVO runVO) {
+        Assert.notNull(runVO.getPipelineStart(), "Pipeline start must be specified");
+        return new PipeRunCmdBuilder(runVO)
+                .name()
+                .config()
+                .runParameters()
+                .parameters()
+                .yes()
+                .instanceDisk()
+                .instanceType()
+                .dockerImage()
+                .cmdTemplate()
+                .timeout()
+                .quite()
+                .instanceCount()
+                .sync()
+                .priceType()
+                .regionId()
+                .parentNode()
+                .build();
     }
 
     private void adjustInstanceDisk(final PipelineConfiguration configuration) {

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -1037,6 +1037,12 @@ public class PipelineRunManager {
         return pipelineRun;
     }
 
+    /**
+     * Generates launch command for 'pipe run' CLI method.
+     *
+     * @param runVO {@link PipeRunCmdStartVO} contains input arguments for launch command
+     * @return launch command
+     */
     public String generateLaunchCommand(final PipeRunCmdStartVO runVO) {
         Assert.notNull(runVO.getPipelineStart(), "Pipeline start must be specified");
         return new PipeRunCmdBuilder(runVO)

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilder.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilder.java
@@ -28,6 +28,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+/**
+ * This class builds 'pipe run' CLI command according to specified input arguments {@link PipeRunCmdStartVO}
+ */
 public class PipeRunCmdBuilder {
 
     private static final String WHITESPACE = " ";

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilder.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilder.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.pipeline.runner;
+
+import com.epam.pipeline.entity.configuration.PipeConfValueVO;
+import com.epam.pipeline.entity.pipeline.run.PipeRunCmdStartVO;
+import com.epam.pipeline.entity.pipeline.run.PipelineStart;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class PipeRunCmdBuilder {
+
+    private static final String WHITESPACE = " ";
+
+    private final PipelineStart runVO;
+    private final PipeRunCmdStartVO startVO;
+    private final List<String> cmd;
+
+    public PipeRunCmdBuilder(final PipeRunCmdStartVO startVO) {
+        this.startVO = startVO;
+        this.runVO = startVO.getPipelineStart();
+        this.cmd = new ArrayList<>();
+        this.cmd.add("pipe run");
+    }
+
+    public String build() {
+        return String.join(WHITESPACE, cmd);
+    }
+
+    public PipeRunCmdBuilder name() {
+        if (StringUtils.isNotBlank(runVO.getVersion())) {
+            cmd.add(String.format("%d@%s", runVO.getPipelineId(), runVO.getVersion()));
+        } else {
+            cmd.add(String.valueOf(runVO.getPipelineId()));
+        }
+        return this;
+    }
+
+    public PipeRunCmdBuilder instanceDisk() {
+        buildObjectCmdArg("-id", runVO.getHddSize());
+        return this;
+    }
+
+    public PipeRunCmdBuilder instanceType() {
+        buildStringCmdArg("-it", runVO.getInstanceType());
+        return this;
+    }
+
+    public PipeRunCmdBuilder dockerImage() {
+        buildStringCmdArg("-di", runVO.getDockerImage());
+        return this;
+    }
+
+    public PipeRunCmdBuilder cmdTemplate() {
+        if (StringUtils.isNotBlank(runVO.getCmdTemplate())) {
+            cmd.add("-cmd");
+            cmd.add(quoteStringArgument(runVO.getCmdTemplate()));
+        }
+        return this;
+    }
+
+    public PipeRunCmdBuilder timeout() {
+        buildObjectCmdArg("-t", runVO.getTimeout());
+        return this;
+    }
+
+    public PipeRunCmdBuilder instanceCount() {
+        buildObjectCmdArg("-ic", runVO.getNodeCount());
+        return this;
+    }
+
+    public PipeRunCmdBuilder priceType() {
+        cmd.add("-pt");
+        if (Objects.nonNull(runVO.getIsSpot()) && !runVO.getIsSpot()) {
+            cmd.add("on-demand");
+        } else {
+            cmd.add("spot");
+        }
+        return this;
+    }
+
+    public PipeRunCmdBuilder regionId() {
+        buildObjectCmdArg("-r", runVO.getCloudRegionId());
+        return this;
+    }
+
+    public PipeRunCmdBuilder parentNode() {
+        buildObjectCmdArg("-pn", runVO.getParentNodeId());
+        return this;
+    }
+
+    public PipeRunCmdBuilder config() {
+        buildStringCmdArg("-c", runVO.getConfigurationName());
+        return this;
+    }
+
+    public PipeRunCmdBuilder yes() {
+        if (startVO.isYes()) {
+            cmd.add("-y");
+        }
+        return this;
+    }
+
+    public PipeRunCmdBuilder quite() {
+        if (startVO.isQuite()) {
+            cmd.add("-q");
+        }
+        return this;
+    }
+
+    public PipeRunCmdBuilder sync() {
+        if (startVO.isSync()) {
+            cmd.add("-s");
+        }
+        return this;
+    }
+
+    public PipeRunCmdBuilder parameters() {
+        if (startVO.isShowParams()) {
+            cmd.add("-p");
+        }
+        return this;
+    }
+
+    public PipeRunCmdBuilder runParameters() {
+        if (MapUtils.isNotEmpty(runVO.getParams())) {
+            final String parametersCommand = runVO.getParams().entrySet()
+                    .stream()
+                    .map(this::prepareParams)
+                    .collect(Collectors.joining(WHITESPACE));
+            cmd.add(parametersCommand);
+        }
+        if (Objects.nonNull(runVO.getParentRunId())) {
+            cmd.add(String.format("parent-id %d", runVO.getParentRunId()));
+        }
+        return this;
+    }
+
+    private String prepareParams(final Map.Entry<String, PipeConfValueVO> entry) {
+        String value = entry.getValue().getValue();
+        if (entry.getValue().getType().equalsIgnoreCase("string")) {
+            value = quoteStringArgument(value);
+        }
+        return entry.getKey() + WHITESPACE + value;
+    }
+
+    private void buildObjectCmdArg(final String argumentName, final Object argumentValue) {
+        if (Objects.nonNull(argumentValue)) {
+            cmd.add(argumentName);
+            cmd.add(String.valueOf(argumentValue));
+        }
+    }
+
+    private void buildStringCmdArg(final String argumentName, final String argumentValue) {
+        if (StringUtils.isNotBlank(argumentValue)) {
+            cmd.add(argumentName);
+            cmd.add(argumentValue);
+        }
+    }
+
+    private String quoteStringArgument(final String value) {
+        return String.format("'%s'", value);
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/com/epam/pipeline/acl/run/RunApiServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/acl/run/RunApiServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/com/epam/pipeline/acl/run/RunApiServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/acl/run/RunApiServiceTest.java
@@ -22,11 +22,16 @@ import com.epam.pipeline.controller.vo.PagingRunFilterVO;
 import com.epam.pipeline.entity.contextual.ContextualPreference;
 import com.epam.pipeline.entity.pipeline.Pipeline;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.pipeline.Tool;
+import com.epam.pipeline.entity.pipeline.run.PipeRunCmdStartVO;
+import com.epam.pipeline.entity.pipeline.run.PipelineStart;
 import com.epam.pipeline.entity.preference.PreferenceType;
+import com.epam.pipeline.entity.security.acl.AclClass;
 import com.epam.pipeline.manager.EntityManager;
 import com.epam.pipeline.manager.contextual.ContextualPreferenceManager;
 import com.epam.pipeline.manager.pipeline.PipelineManager;
 import com.epam.pipeline.manager.pipeline.PipelineRunManager;
+import com.epam.pipeline.manager.pipeline.ToolManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.manager.security.AuthManager;
 import com.epam.pipeline.manager.security.GrantPermissionManager;
@@ -49,6 +54,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import static com.epam.pipeline.acl.run.PipelineAclFactory.TEST_PIPELINE_ID;
 import static com.epam.pipeline.acl.run.RunAclFactory.TEST_RUN_ID;
@@ -68,6 +74,7 @@ public class RunApiServiceTest {
     private static final String TEST_ADMIN_NAME = "ADMIN";
     private static final String TEST_ADMIN_ROLE = "ADMIN";
     private static final String VISIBILITY_PREFERENCE_KEY = SystemPreferences.RUN_VISIBILITY_POLICY.getKey();
+    private static final String TEST_PIPE_RUN_CMD = "pipe run";
 
     @Autowired
     private RunApiService runApiService;
@@ -84,8 +91,12 @@ public class RunApiServiceTest {
     @Autowired
     private ContextualPreferenceManager mockPreferenceManager;
 
+    @Autowired
+    private EntityManager mockEntityManager;
+
     private RunAclFactory runAclFactory;
     private PipelineAclFactory pipelineAclFactory;
+    private ToolAclFactory toolAclFactory;
 
     @Autowired
     public void setRunAclFactory(final AuthManager authManager,
@@ -103,6 +114,11 @@ public class RunApiServiceTest {
         this.pipelineAclFactory = new PipelineAclFactory(authManager,
                 grantPermissionManager, aclService, mockUserManager,
                 mockPipelineManager, mockEntityManager);
+    }
+
+    @Autowired
+    public void setToolAclFactory(final AuthManager authManager, final ToolManager mockToolManager) {
+        this.toolAclFactory = new ToolAclFactory(authManager, mockToolManager);
     }
 
     @After
@@ -202,6 +218,73 @@ public class RunApiServiceTest {
         assertThat(filter.getAllowedPipelines(), contains(TEST_PIPELINE_ID));
         assertThat(result.getTotalCount(), equalTo(1));
         assertThat(result.getElements(), contains(run));
+    }
+
+    @Test
+    @WithMockUser(username = TEST_USER1)
+    public void generateRunCmdShouldGenerateCmdIfUserHasPermissionOnPipeline() {
+        final Pipeline pipeline = pipelineAclFactory.initPipelineForCurrentUser();
+        final PipeRunCmdStartVO pipeRunCmdStartVO = initPipeRunCmdStartVO(pipeline, null);
+
+        doReturn(pipeline).when(mockEntityManager).load(AclClass.PIPELINE, pipeline.getId());
+        doReturn(TEST_PIPE_RUN_CMD).when(mockRunManager).generateLaunchCommand(pipeRunCmdStartVO);
+
+        assertThat(runApiService.generateLaunchCommand(pipeRunCmdStartVO), equalTo(TEST_PIPE_RUN_CMD));
+    }
+
+    @Test
+    @WithMockUser(username = TEST_USER1)
+    public void generateRunCmdShouldGenerateCmdIfUserHasPermissionOnTool() {
+        final Tool tool = toolAclFactory.initToolForCurrentUser();
+        final PipeRunCmdStartVO pipeRunCmdStartVO = initPipeRunCmdStartVO(null, tool);
+
+        doReturn(TEST_PIPE_RUN_CMD).when(mockRunManager).generateLaunchCommand(pipeRunCmdStartVO);
+
+        assertThat(runApiService.generateLaunchCommand(pipeRunCmdStartVO), equalTo(TEST_PIPE_RUN_CMD));
+    }
+
+    @Test(expected = AccessDeniedException.class)
+    @WithMockUser(username = TEST_USER1)
+    public void generateRunCmdShouldFailIfUserHasNoPermissionOnPipeline() {
+        final Pipeline pipeline = pipelineAclFactory.initPipelineForOwner(TEST_OWNER);
+        final PipeRunCmdStartVO pipeRunCmdStartVO = initPipeRunCmdStartVO(pipeline, null);
+
+        doReturn(pipeline).when(mockEntityManager).load(AclClass.PIPELINE, pipeline.getId());
+
+        runApiService.generateLaunchCommand(pipeRunCmdStartVO);
+    }
+
+    @Test(expected = AccessDeniedException.class)
+    @WithMockUser(username = TEST_USER1)
+    public void generateRunCmdShouldFailIfUserHasNoPermissionOnTool() {
+        final Tool tool = toolAclFactory.initToolForOwner(TEST_OWNER);
+        final PipeRunCmdStartVO pipeRunCmdStartVO = initPipeRunCmdStartVO(null, tool);
+
+        runApiService.generateLaunchCommand(pipeRunCmdStartVO);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    @WithMockUser(username = TEST_USER1)
+    public void generateRunCmdShouldFailIfNoPipelineOrToolSpecified() {
+        final PipeRunCmdStartVO pipeRunCmdStartVO = initPipeRunCmdStartVO(null, null);
+
+        runApiService.generateLaunchCommand(pipeRunCmdStartVO);
+    }
+
+    private PipeRunCmdStartVO initPipeRunCmdStartVO(final Pipeline pipeline, final Tool tool) {
+        final PipelineStart pipelineStart = new PipelineStart();
+        final PipeRunCmdStartVO pipeRunCmdStartVO = new PipeRunCmdStartVO();
+
+        if (Objects.nonNull(pipeline)) {
+            pipelineStart.setPipelineId(pipeline.getId());
+        }
+
+        if (Objects.nonNull(tool)) {
+            pipelineStart.setDockerImage(tool.getImage());
+        }
+
+        pipeRunCmdStartVO.setPipelineStart(pipelineStart);
+        return pipeRunCmdStartVO;
     }
 
     private void enableVisibilityPolicy(final RunVisibilityPolicy policy) {

--- a/api/src/test/java/com/epam/pipeline/acl/run/ToolAclFactory.java
+++ b/api/src/test/java/com/epam/pipeline/acl/run/ToolAclFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.acl.run;
+
+import com.epam.pipeline.entity.pipeline.Tool;
+import com.epam.pipeline.manager.pipeline.ToolManager;
+import com.epam.pipeline.manager.security.AuthManager;
+import lombok.RequiredArgsConstructor;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+
+@RequiredArgsConstructor
+public class ToolAclFactory {
+    public static final Long TEST_TOOL_ID = 10L;
+    public static final String TEST_TOOL_NAME = "image";
+
+    private final AuthManager authManager;
+    private final ToolManager mockToolManager;
+
+    public Tool initToolForCurrentUser() {
+        return initToolForOwner(authManager.getAuthorizedUser());
+    }
+
+    public Tool initToolForOwner(final String owner) {
+        final Tool tool = new Tool();
+        tool.setId(TEST_TOOL_ID);
+        tool.setImage(TEST_TOOL_NAME);
+        tool.setOwner(owner);
+        doReturn(tool).when(mockToolManager).load(eq(TEST_TOOL_ID));
+        doReturn(tool).when(mockToolManager).loadByNameOrId(eq(TEST_TOOL_NAME));
+        return tool;
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilderTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilderTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.pipeline.runner;
+
+import com.epam.pipeline.entity.configuration.PipeConfValueVO;
+import com.epam.pipeline.entity.pipeline.run.PipeRunCmdStartVO;
+import com.epam.pipeline.entity.pipeline.run.PipelineStart;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PipeRunCmdBuilderTest {
+
+    private static final String TEST_VERSION = "draft";
+    private static final String TEST_PARAM_NAME_1 = "--param1";
+    private static final String TEST_PARAM_NAME_2 = "--param2";
+    private static final String TEST_PARAM_VALUE_1 = "string value";
+    private static final String TEST_PARAM_VALUE_2 = "1";
+    private static final String INSTANCE_TYPE = "type";
+    private static final String DOCKER_IMAGE = "image";
+    private static final String CMD_TEMPLATE = "sleep 100";
+
+    @Test
+    public void shouldGenerateLaunchCommand() {
+        final Map<String, PipeConfValueVO> runParameters = new HashMap<>();
+        final PipeConfValueVO pipeConfValue1 = new PipeConfValueVO(TEST_PARAM_VALUE_1, "string");
+        runParameters.put(TEST_PARAM_NAME_1, pipeConfValue1);
+        final PipeConfValueVO pipeConfValue2 = new PipeConfValueVO(TEST_PARAM_VALUE_2, "int");
+        runParameters.put(TEST_PARAM_NAME_2, pipeConfValue2);
+
+        final PipelineStart pipelineStart = new PipelineStart();
+        pipelineStart.setPipelineId(1L);
+        pipelineStart.setVersion(TEST_VERSION);
+        pipelineStart.setParams(runParameters);
+        pipelineStart.setInstanceType(INSTANCE_TYPE);
+        pipelineStart.setHddSize(10);
+        pipelineStart.setDockerImage(DOCKER_IMAGE);
+        pipelineStart.setCmdTemplate(CMD_TEMPLATE);
+        pipelineStart.setTimeout(10L);
+        pipelineStart.setNodeCount(5);
+        pipelineStart.setCloudRegionId(1L);
+        pipelineStart.setParentNodeId(1L);
+        pipelineStart.setParentRunId(1L);
+
+        final PipeRunCmdStartVO pipeRunCmdStartVO = new PipeRunCmdStartVO();
+        pipeRunCmdStartVO.setPipelineStart(pipelineStart);
+        pipeRunCmdStartVO.setYes(true);
+        pipeRunCmdStartVO.setSync(true);
+        pipeRunCmdStartVO.setQuite(true);
+        pipeRunCmdStartVO.setShowParams(true);
+
+        final PipeRunCmdBuilder pipeRunCmdBuilder = new PipeRunCmdBuilder(pipeRunCmdStartVO);
+        final String actualResult = pipeRunCmdBuilder
+                .name()
+                .config()
+                .runParameters()
+                .parameters()
+                .yes()
+                .instanceDisk()
+                .instanceType()
+                .dockerImage()
+                .cmdTemplate()
+                .timeout()
+                .quite()
+                .instanceCount()
+                .sync()
+                .priceType()
+                .regionId()
+                .parentNode()
+                .build();
+        final String expectedResult = String.format("pipe run 1@%s %s '%s' %s %s parent-id 1 -p -y -id 10 " +
+                        "-it type -di image -cmd '%s' -t 10 -q -ic 5 -s -pt spot -r 1 -pn 1",
+                TEST_VERSION, TEST_PARAM_NAME_1, TEST_PARAM_VALUE_1, TEST_PARAM_NAME_2, TEST_PARAM_VALUE_2,
+                CMD_TEMPLATE);
+        Assert.assertEquals(expectedResult, actualResult);
+    }
+}

--- a/client/src/components/pipelines/launch/form/LaunchPipelineForm.js
+++ b/client/src/components/pipelines/launch/form/LaunchPipelineForm.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/components/pipelines/launch/form/utilities/launch-command.css
+++ b/client/src/components/pipelines/launch/form/utilities/launch-command.css
@@ -1,0 +1,100 @@
+.container {
+  width: 100%;
+}
+
+.container .header {
+  line-height: 30px;
+  margin: 0;
+  padding: 5px 10px;
+  background-color: #fafafa;
+  border: 1px solid #ddd;
+  border-radius: 5px 5px 0 0;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.container .content {
+  margin: 0;
+  padding: 0;
+  border: 1px solid #ddd;
+  border-top: none;
+  border-radius: 0 0 5px 5px;
+}
+
+.md-preview {
+  flex: 1;
+  overflow-y: auto;
+  font-size: 10pt;
+}
+
+.md-preview code {
+  padding: 2px 4px;
+  font-size: 90%;
+  color: #c7254e;
+  background-color: #f9f2f4;
+  border-radius: 4px;
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25);
+}
+
+.md-preview p {
+  margin: 5px 0;
+}
+
+.md-preview p a {
+  margin: 0 2px;
+}
+
+.md-preview pre {
+  display: block;
+  padding: 10px;
+  margin: 0;
+  line-height: 1.5;
+  word-break: break-all;
+  word-wrap: break-word;
+  color: #333;
+  background-color: #f5f5f5;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.md-preview pre > code {
+  padding: 0;
+  font-size: inherit;
+  color: inherit;
+  white-space: pre-wrap;
+  background-color: transparent;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.md-preview ul,
+.md-preview ol {
+  margin-top: 0;
+  margin-bottom: 10px;
+  display: block;
+  list-style: disc inside;
+}
+
+.md-preview li {
+  display: list-item;
+  margin: 5px;
+}
+
+.endpoint {
+  line-height: 30px;
+}
+
+.endpoint span {
+  margin-right: 5px;
+}
+
+.method {
+  font-size: small;
+  font-weight: bold;
+}
+
+.url {
+  color: rgb(0, 143, 229);
+}

--- a/client/src/components/pipelines/launch/form/utilities/launch-command.js
+++ b/client/src/components/pipelines/launch/form/utilities/launch-command.js
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import PipelineRunCmd from '../../../../../models/pipelines/PipelineRunCmd';
+import {Alert, Modal, Row, Tabs} from 'antd';
+import hljs from 'highlight.js';
+import 'highlight.js/styles/github.css';
+import styles from './launch-command.css';
+import {API_PATH, SERVER} from '../../../../../config';
+
+function wrapCommand (command) {
+  return `# PIPE CLI command: \n${command || ''}`;
+}
+
+function generateRunMethodUrl () {
+  const el = document.createElement('div');
+  el.innerHTML = '<a href="' + (SERVER + API_PATH) + '/run"></a>';
+  return el.firstChild.href;
+}
+
+function processBashScript (script) {
+  let command = hljs.highlight('bash', script).value;
+  const r = /\[URL\](.+)\[\/URL\]/ig;
+  let e = r.exec(command);
+  while (e) {
+    command = command.substring(0, e.index) +
+      `<a href="${e[1]}" target="_blank">${e[1]}</a>` +
+      command.substring(e.index + e[0].length);
+    e = r.exec(command);
+  }
+  return command;
+}
+
+class LaunchCommand extends React.Component {
+  static propTypes = {
+    onInitialized: PropTypes.func,
+    payload: PropTypes.object,
+    visible: PropTypes.bool,
+    onClose: PropTypes.func
+  };
+
+  static requestIdentifier = 0;
+
+  state = {
+    pending: false,
+    code: null,
+    error: false
+  };
+
+  componentDidMount () {
+    this.props.onInitialized && this.props.onInitialized(this);
+    if (this.props.payload) {
+      this.rebuild(this.props.payload);
+    }
+  }
+
+  componentWillReceiveProps (nextProps, nextContext) {
+    if (nextProps.visible !== this.props.visible && nextProps.visible) {
+      this.rebuild(nextProps.payload);
+    }
+  }
+
+  rebuild = (payload) => {
+    LaunchCommand.requestIdentifier += 1;
+    const identifier = LaunchCommand.requestIdentifier;
+    this.setState({pending: true}, async () => {
+      const request = new PipelineRunCmd();
+      await request.send({
+        pipelineStart: payload,
+        quite: false,
+        yes: true,
+        showParams: false,
+        sync: false
+      });
+      if (identifier === LaunchCommand.requestIdentifier) {
+        if (request.error) {
+          this.setState({pending: false, code: null, error: request.error, payload});
+        } else {
+          this.setState({pending: false, code: request.value, error: false, payload});
+        }
+      }
+    });
+  };
+
+  renderCLICommand () {
+    const {
+      code,
+      error
+    } = this.state;
+    if (error) {
+      return (
+        <Alert type="warning" message={error} />
+      );
+    }
+    return (
+      <Row type="flex" className={styles.mdPreview}>
+        <pre style={{width: '100%', fontSize: 'smaller'}}>
+          <code
+            id="launch-command"
+            dangerouslySetInnerHTML={{
+              __html: processBashScript(wrapCommand(code))
+            }} />
+        </pre>
+      </Row>
+    );
+  }
+
+  renderAPICommand () {
+    const {payload} = this.state;
+    if (!payload) {
+      return (
+        <Alert type="warning" message="Payload is not set" />
+      );
+    }
+    return (
+      <Row type="flex" className={styles.mdPreview}>
+        <Row className={styles.endpoint} type="flex" align="center">
+          <span className={styles.method}>POST</span>
+          <span className={styles.url}>{generateRunMethodUrl()}</span>
+        </Row>
+        <pre style={{width: '100%', fontSize: 'smaller', maxHeight: '50vh', overflow: 'auto'}}>
+          <code
+            id="launch-command"
+            dangerouslySetInnerHTML={{
+              __html: processBashScript(JSON.stringify(payload, null, ' '))
+            }} />
+        </pre>
+      </Row>
+    );
+  }
+
+  render () {
+    const {visible, onClose} = this.props;
+    return (
+      <Modal
+        onCancel={onClose}
+        title="Launch commands"
+        visible={visible}
+        width="50%"
+        footer={false}
+      >
+        <Tabs>
+          <Tabs.TabPane key="CLI" tab="CLI">
+            {this.renderCLICommand()}
+          </Tabs.TabPane>
+          <Tabs.TabPane key="API" tab="API">
+            {this.renderAPICommand()}
+          </Tabs.TabPane>
+        </Tabs>
+      </Modal>
+    );
+  }
+}
+
+export default LaunchCommand;

--- a/client/src/components/pipelines/launch/form/utilities/launch-command.js
+++ b/client/src/components/pipelines/launch/form/utilities/launch-command.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/components/runs/logs/Log.js
+++ b/client/src/components/runs/logs/Log.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/components/runs/logs/Log.js
+++ b/client/src/components/runs/logs/Log.js
@@ -72,6 +72,7 @@ import UpdateRunSchedules from '../../../models/runSchedule/UpdateRunSchedules';
 import RemoveRunSchedules from '../../../models/runSchedule/RemoveRunSchedules';
 import CreateRunSchedules from '../../../models/runSchedule/CreateRunSchedules';
 import RunSchedulingList from '../run-scheduling/run-sheduling-list';
+import LaunchCommand from '../../pipelines/launch/form/utilities/launch-command';
 
 const FIRE_CLOUD_ENVIRONMENT = 'FIRECLOUD';
 const DTS_ENVIRONMENT = 'DTS';
@@ -124,7 +125,8 @@ class Logs extends localization.LocalizedReactComponent {
     operationInProgress: false,
     openedPanels: [],
     shareDialogOpened: false,
-    scheduleSaveInProgress: false
+    scheduleSaveInProgress: false,
+    showLaunchCommands: false
   };
 
   componentDidMount () {
@@ -149,6 +151,53 @@ class Logs extends localization.LocalizedReactComponent {
     }
 
     return (runSchedule.value || []).map(i => i);
+  }
+
+  @computed
+  get runPayload () {
+    const {run, preferences} = this.props;
+    if (run.loaded && preferences.loaded) {
+      const payload = {
+        instanceType: undefined,
+        hddSize: undefined,
+        timeout: run.value.timeout,
+        cmdTemplate: run.value.cmdTemplate,
+        nodeCount: run.value.nodeCount,
+        dockerImage: run.value.dockerImage,
+        pipelineId: run.value.pipelineId,
+        version: run.value.version,
+        params: {},
+        isSpot: preferences.useSpot,
+        cloudRegionId: undefined,
+        prettyUrl: run.value.prettyUrl,
+        nonPause: run.value.nonPause,
+        configurationName: run.value.configName,
+        executionEnvironment: undefined
+      };
+      if (run.value.instance) {
+        payload.instanceType = run.value.instance.nodeType;
+        payload.hddSize = run.value.instance.nodeDisk;
+        payload.isSpot = run.value.instance.spot;
+        payload.cloudRegionId = run.value.instance.cloudRegionId;
+      }
+      if (run.value.executionPreferences) {
+        payload.executionEnvironment = run.value.executionPreferences.environment;
+      }
+      if (run.value.pipelineRunParameters) {
+        for (let i = 0; i < run.value.pipelineRunParameters.length; i++) {
+          const param = run.value.pipelineRunParameters[i];
+          if (param.name && param.value) {
+            payload.params[param.name] = {
+              value: param.value,
+              type: param.type,
+              enum: param.enum
+            };
+          }
+        }
+      }
+      return payload;
+    }
+    return null;
   }
 
   exportLog = async () => {
@@ -940,6 +989,14 @@ class Logs extends localization.LocalizedReactComponent {
     this.setState({timings: !this.state.timings});
   };
 
+  showLaunchCommands = () => {
+    this.setState({showLaunchCommands: true});
+  };
+
+  hideLaunchCommands = () => {
+    this.setState({showLaunchCommands: false});
+  };
+
   switchResolvedValues = () => {
     this.setState({resolvedValues: !this.state.resolvedValues});
   };
@@ -1179,6 +1236,7 @@ class Logs extends localization.LocalizedReactComponent {
     let FSBrowserButton;
     let ExportLogsButton;
     let SwitchTimingsButton;
+    let ShowLaunchCommandsButton;
     let SwitchModeButton;
     let CommitStatusButton;
     let dockerImage;
@@ -1558,6 +1616,14 @@ class Logs extends localization.LocalizedReactComponent {
       }
 
       SwitchTimingsButton = <a onClick={this.switchTimings}>{this.state.timings ? 'HIDE TIMINGS' : 'SHOW TIMINGS'}</a>;
+      if (this.runPayload) {
+        ShowLaunchCommandsButton = (
+          <a
+            onClick={this.showLaunchCommands}>
+            LAUNCH COMMAND
+          </a>
+        );
+      }
 
       SwitchModeButton = switchModeUrl &&
         <AdaptedLink to={switchModeUrl} location={location}>
@@ -1599,7 +1665,7 @@ class Logs extends localization.LocalizedReactComponent {
             </Row>
             <br />
             <Row type="flex" justify="end" className={styles.actionButtonsContainer}>
-              {SwitchTimingsButton}{SwitchModeButton}
+              {SwitchTimingsButton}{SwitchModeButton}{ShowLaunchCommandsButton}
             </Row>
             <br />
             <Row type="flex" justify="end" className={styles.actionButtonsContainer}>
@@ -1635,6 +1701,11 @@ class Logs extends localization.LocalizedReactComponent {
           commitCheck={this.commitCheck}
           onCancel={this.closeCommitRunForm}
           onSubmit={this.operationWrapper(this.commitRun)} />
+        <LaunchCommand
+          payload={this.runPayload}
+          visible={this.state.showLaunchCommands}
+          onClose={this.hideLaunchCommands}
+        />
       </Card>);
   }
 

--- a/client/src/models/pipelines/PipelineRunCmd.js
+++ b/client/src/models/pipelines/PipelineRunCmd.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/models/pipelines/PipelineRunCmd.js
+++ b/client/src/models/pipelines/PipelineRunCmd.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import RemotePost from '../basic/RemotePost';
+
+export default class PipelineRunCmd extends RemotePost {
+  constructor () {
+    super();
+    this.url = '/run/cmd';
+  }
+}

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/run/PipeRunCmdStartVO.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/run/PipeRunCmdStartVO.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.pipeline.run;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class PipeRunCmdStartVO {
+    private PipelineStart pipelineStart;
+    private boolean quite;
+    private boolean yes;
+    private boolean showParams;
+    private boolean sync;
+}

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/run/PipeRunCmdStartVO.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/run/PipeRunCmdStartVO.java
@@ -19,6 +19,9 @@ package com.epam.pipeline.entity.pipeline.run;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * This class supplements {@link PipelineStart} to provide ability to specify additional CLI specific options
+ */
 @Data
 @NoArgsConstructor
 public class PipeRunCmdStartVO {


### PR DESCRIPTION
This PR provides implementation for issue #892 
The following changes were added:
- implemented a new one API method `POST /run/cmd` that generates `pipe run` CLI command for specified pipeline run configuration.