### PR TITLE
Issue #761 Billing report agent: API.

### DIFF
--- a/api/profiles/dev/application.properties
+++ b/api/profiles/dev/application.properties
@@ -138,3 +138,6 @@ firecloud.auth.client.secret=
 
 cluster.disable.task.monitoring=${CP_API_DISABLE_POD_MONITOR:false}
 cluster.disable.autoscaling=${CP_API_DISABLE_AUTOSCALER:false}
+
+#Billing API
+billing.index.common.prefix=cp-billing

--- a/api/src/main/java/com/epam/pipeline/acl/billing/BillingApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/billing/BillingApiService.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.acl.billing;
+
+import com.epam.pipeline.controller.vo.billing.BillingChartRequest;
+import com.epam.pipeline.entity.billing.BillingChartInfo;
+import com.epam.pipeline.manager.BillingManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BillingApiService {
+
+    private final BillingManager billingManager;
+
+    public List<BillingChartInfo> getBillingChartInfo(final BillingChartRequest request) {
+        return billingManager.getBillingChartInfo(request);
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/controller/billing/BillingController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/billing/BillingController.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.controller.billing;
+
+import com.epam.pipeline.acl.billing.BillingApiService;
+import com.epam.pipeline.controller.AbstractRestController;
+import com.epam.pipeline.controller.Result;
+import com.epam.pipeline.controller.vo.billing.BillingChartRequest;
+import com.epam.pipeline.entity.billing.BillingChartInfo;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class BillingController extends AbstractRestController {
+
+    private final BillingApiService billingApi;
+
+    @RequestMapping(value = "/billing/charts", method = RequestMethod.POST)
+    @ResponseBody
+    @ApiOperation(
+        value = "Get info for building expenses charts.",
+        notes = "Get info for building expenses charts.",
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+        value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+        })
+    public Result<List<BillingChartInfo>> getBillingChartInfo(@RequestBody final BillingChartRequest request) {
+        return Result.success(billingApi.getBillingChartInfo(request));
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/controller/vo/billing/BillingChartRequest.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/billing/BillingChartRequest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.controller.vo.billing;
+
+import lombok.Value;
+import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+@Value
+public class BillingChartRequest {
+
+    private LocalDate from;
+    private LocalDate to;
+    private Map<String, List<String>> filters;
+    private DateHistogramInterval interval;
+    private List<String> grouping;
+}

--- a/api/src/main/java/com/epam/pipeline/entity/billing/BillingChartInfo.java
+++ b/api/src/main/java/com/epam/pipeline/entity/billing/BillingChartInfo.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.billing;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Value
+@Builder
+public class BillingChartInfo {
+
+    private Map<String, String> groupingInfo;
+    private LocalDateTime periodStart;
+    private LocalDateTime periodEnd;
+    private Long cost;
+}

--- a/api/src/main/java/com/epam/pipeline/manager/BillingManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/BillingManager.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager;
+
+import com.epam.pipeline.controller.vo.billing.BillingChartRequest;
+import com.epam.pipeline.entity.billing.BillingChartInfo;
+import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.exception.search.SearchException;
+import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.epam.pipeline.manager.preference.SystemPreferences;
+import com.epam.pipeline.manager.security.AuthManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpHost;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
+import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
+import org.elasticsearch.search.aggregations.bucket.histogram.ParsedDateHistogram;
+import org.elasticsearch.search.aggregations.bucket.terms.ParsedStringTerms;
+import org.elasticsearch.search.aggregations.metrics.sum.ParsedSum;
+import org.elasticsearch.search.aggregations.metrics.sum.SumAggregationBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.joda.time.DateTime;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.temporal.TemporalAdjuster;
+import java.time.temporal.TemporalAdjusters;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import javax.annotation.PostConstruct;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class BillingManager {
+
+    private static final String COST_FIELD = "cost";
+    private static final String BILLING_DATE_FIELD = "created_date";
+    private static final String HISTOGRAM_AGGREGATION_NAME = "hist_agg";
+
+    private final AuthManager authManager;
+    private final PreferenceManager preferenceManager;
+    private RestHighLevelClient elasticsearchClient;
+
+    private final Map<DateHistogramInterval, TemporalAdjuster> periodAdjusters =
+        new HashMap<DateHistogramInterval, TemporalAdjuster>() {{
+            put(DateHistogramInterval.MONTH, TemporalAdjusters.lastDayOfMonth());
+            put(DateHistogramInterval.YEAR, TemporalAdjusters.lastDayOfYear());
+        }};
+    private List<DateHistogramInterval> validIntervals = Arrays.asList(DateHistogramInterval.DAY,
+                                                                       DateHistogramInterval.MONTH,
+                                                                       DateHistogramInterval.YEAR);
+    private final SumAggregationBuilder costAggregation = AggregationBuilders.sum(COST_FIELD).field(COST_FIELD);
+
+    @PostConstruct
+    public void init() {
+        final RestClient lowLevelClient =
+            RestClient.builder(new HttpHost(preferenceManager.getPreference(SystemPreferences.SEARCH_ELASTIC_HOST),
+                                            preferenceManager.getPreference(SystemPreferences.SEARCH_ELASTIC_PORT),
+                                            preferenceManager.getPreference(SystemPreferences.SEARCH_ELASTIC_SCHEME)))
+                .build();
+        elasticsearchClient = new RestHighLevelClient(lowLevelClient);
+    }
+
+    public List<BillingChartInfo> getBillingChartInfo(final BillingChartRequest request) {
+        final LocalDate from = request.getFrom();
+        final LocalDate to = request.getTo();
+        final List<String> grouping = request.getGrouping();
+        final DateHistogramInterval interval = request.getInterval();
+        final Map<String, List<String>> filters = request.getFilters();
+        setAuthorizationFilters(filters);
+        if (interval != null) {
+            if (grouping != null) {
+                throw new UnsupportedOperationException("Currently field and date grouping at"
+                                                        + " the same time isn't supporting!");
+            }
+            return getBillingStats(from, to, filters, interval);
+        } else {
+            return getBillingStats(from, to, filters, grouping);
+        }
+    }
+
+    private void setAuthorizationFilters(Map<String, List<String>> filters) {
+        final PipelineUser authorizedUser = authManager.getCurrentUser();
+        if (authorizedUser.isAdmin()) {
+            return;
+        }
+        filters.put("owner", Collections.singletonList(authorizedUser.getUserName()));
+        filters.put("groups", authorizedUser.getGroups());
+    }
+
+    private List<BillingChartInfo> getBillingStats(final LocalDate from, final LocalDate to,
+                                                   final Map<String, List<String>> filters,
+                                                   final DateHistogramInterval interval) {
+        if (!validIntervals.contains(interval)) {
+            throw new IllegalArgumentException("Given interval is not supported!");
+        }
+        final SearchRequest searchRequest = new SearchRequest();
+        final SearchSourceBuilder searchSource = new SearchSourceBuilder();
+
+        final AggregationBuilder intervalAgg = AggregationBuilders.dateHistogram(
+            HISTOGRAM_AGGREGATION_NAME)
+            .field(BILLING_DATE_FIELD)
+            .dateHistogramInterval(interval)
+            .subAggregation(costAggregation);
+
+        searchSource.aggregation(intervalAgg);
+
+        setFiltersAndPeriodForSearchRequest(from, to, filters, searchSource, searchRequest);
+
+        try {
+            final SearchResponse searchResponse = elasticsearchClient.search(searchRequest);
+            final ParsedDateHistogram histogram = searchResponse.getAggregations().get(HISTOGRAM_AGGREGATION_NAME);
+            return parseHistogram(interval, histogram);
+        } catch (IOException e) {
+            log.error(e.getMessage(), e);
+            throw new SearchException(e.getMessage(), e);
+        }
+    }
+
+    private List<BillingChartInfo> getBillingStats(final LocalDate from, final LocalDate to,
+                                                   final Map<String, List<String>> filters,
+                                                   final List<String> grouping) {
+        final SearchRequest searchRequest = new SearchRequest();
+        final SearchSourceBuilder searchSource = new SearchSourceBuilder();
+
+        grouping.forEach(field -> {
+            final AggregationBuilder fieldAgg = AggregationBuilders.terms(field)
+                .field(field).subAggregation(costAggregation);
+            searchSource.aggregation(fieldAgg);
+        });
+        searchSource.aggregation(costAggregation);
+        setFiltersAndPeriodForSearchRequest(from, to, filters, searchSource, searchRequest);
+
+        try {
+            final SearchResponse searchResponse = elasticsearchClient.search(searchRequest);
+            return getBillingChartInfoForGrouping(from, to, grouping, searchResponse);
+        } catch (IOException e) {
+            log.error(e.getMessage(), e);
+            throw new SearchException(e.getMessage(), e);
+        }
+    }
+
+    private List<BillingChartInfo> getBillingChartInfoForGrouping(final LocalDate from, final LocalDate to,
+                                                                  final List<String> grouping,
+                                                                  final SearchResponse searchResponse) {
+        if (grouping.size() > 0) {
+            return grouping.stream()
+                .map(field -> {
+                    final ParsedStringTerms terms = searchResponse.getAggregations().get(field);
+                    return terms.getBuckets().stream().map(bucket -> {
+                        final Aggregations aggregations = bucket.getAggregations();
+                        return getCostAggregation(from, to, field, (String) bucket.getKey(), aggregations);
+                    });
+                })
+                .flatMap(Function.identity())
+                .collect(Collectors.toList());
+        } else {
+            return Collections
+                .singletonList(getCostAggregation(from, to, null, null, searchResponse.getAggregations()));
+        }
+    }
+
+    private BillingChartInfo getCostAggregation(final LocalDate from, final LocalDate to,
+                                                final String groupField,
+                                                final String groupValue,
+                                                final Aggregations aggregations) {
+        final ParsedSum sumAggResult = aggregations.get(COST_FIELD);
+        final long costVal = new Double(sumAggResult.getValue()).longValue();
+        final BillingChartInfo.BillingChartInfoBuilder builder = BillingChartInfo.builder()
+            .periodStart(from.atStartOfDay())
+            .periodEnd(to.atTime(LocalTime.MAX))
+            .cost(costVal);
+        if (groupField != null) {
+            builder.groupingInfo(Collections.singletonMap(groupField, groupValue));
+        }
+        return builder.build();
+    }
+
+    private void setFiltersAndPeriodForSearchRequest(final LocalDate from, final LocalDate to,
+                                                     final Map<String, List<String>> filters,
+                                                     final SearchSourceBuilder searchSource,
+                                                     final SearchRequest searchRequest) {
+        filters.forEach((k, v) -> searchSource.query(QueryBuilders.termsQuery(k, v)));
+        searchSource.query(QueryBuilders.rangeQuery(BILLING_DATE_FIELD).from(from, true).to(to, true));
+        searchRequest.source(searchSource);
+    }
+
+    private List<BillingChartInfo> parseHistogram(final DateHistogramInterval interval,
+                                                  final ParsedDateHistogram histogram) {
+        return histogram.getBuckets().stream()
+            .map(bucket -> getChartInfo(bucket, interval))
+            .collect(Collectors.toList());
+    }
+
+    private BillingChartInfo getChartInfo(final Histogram.Bucket bucket, final DateHistogramInterval interval) {
+        final BillingChartInfo.BillingChartInfoBuilder builder = BillingChartInfo.builder()
+            .groupingInfo(null);
+        final ParsedSum sumAggResult = bucket.getAggregations().get(COST_FIELD);
+        final long costVal = new Double(sumAggResult.getValue()).longValue();
+        builder.cost(costVal);
+        final DateTime date = (DateTime) bucket.getKey();
+        final LocalDate periodStart = LocalDate.of(date.getYear(), date.getMonthOfYear(), date.getDayOfMonth());
+        builder.periodStart(periodStart.atStartOfDay());
+        final TemporalAdjuster adjuster = periodAdjusters.get(interval);
+        if (adjuster != null) {
+            builder.periodEnd(periodStart.with(adjuster).atTime(LocalTime.MAX));
+        } else {
+            builder.periodEnd(periodStart.atTime(LocalTime.MAX));
+        }
+        return builder.build();
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/BillingManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/BillingManager.java
@@ -25,6 +25,7 @@ import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.manager.security.AuthManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.http.HttpHost;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
@@ -99,7 +100,7 @@ public class BillingManager {
         final Map<String, List<String>> filters = request.getFilters();
         setAuthorizationFilters(filters);
         if (interval != null) {
-            if (grouping != null) {
+            if (CollectionUtils.isNotEmpty(grouping)) {
                 throw new UnsupportedOperationException("Currently field and date grouping at"
                                                         + " the same time isn't supporting!");
             }
@@ -173,7 +174,7 @@ public class BillingManager {
     private List<BillingChartInfo> getBillingChartInfoForGrouping(final LocalDate from, final LocalDate to,
                                                                   final List<String> grouping,
                                                                   final SearchResponse searchResponse) {
-        if (grouping.size() > 0) {
+        if (CollectionUtils.isNotEmpty(grouping)) {
             return grouping.stream()
                 .map(field -> {
                     final ParsedStringTerms terms = searchResponse.getAggregations().get(field);


### PR DESCRIPTION
This PR is related to issue #761.

It brings API for the `billing-report-agent` module.
Currently allows to receive information for building charts due to the approach described in #873;

Request parameters:
- from [date] required - calculate expenses from this date (including)
- to [date] required - calculate expenses up to this date (including)
- interval [day, month, year, total] - expenses shall be grouped using this time interval
- groupBy [List<String>] optional - expenses shall be grouped by this field (**currently, multifield aggregation is not supported**)
- filter [_Map<String, List<String>>_] optional - expenses shall be filtered by this key-values
