### PR TITLE
Issue #857 Historical resources utilization: reports

### DIFF
--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -143,6 +143,7 @@ public final class MessageConstants {
     public static final String INFO_INSTANCE_STARTED = "info.instance.started";
     public static final String ERROR_RUN_DISK_ATTACHING_WRONG_STATUS = "error.run.attaching.wrong.status";
     public static final String ERROR_RUN_DISK_SIZE_NOT_FOUND = "error.run.disk.size.not.found";
+    public static final String ERROR_BAD_STATS_FILE_ENCODING = "error.run.stats.file.bad.encoding";
 
     //Run schedule
     public static final String CRON_EXPRESSION_IS_NOT_PROVIDED = "cron.expression.is.not.provided";

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -260,7 +260,7 @@ public final class MessageConstants {
     //CAdvicer
     public static final String DEBUG_SEND_CADVISOR_REQUEST = "cadvisor.send.request";
     public static final String DEBUG_RECEIVE_CADVISOR_RESPONSE = "cadvisor.receive.response";
-
+    public static final String CADVISOR_STATS_REPORTS_NOT_SUPPORTED = "cadvisor.reports.not.supported";
 
     // Users
     public static final String ERROR_USER_ID_NOT_FOUND = "user.id.not.found";

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/ClusterApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/ClusterApiService.java
@@ -76,7 +76,7 @@ public class ClusterApiService {
         return usageMonitoringManager.getStatsForNode(nodeName, from, to);
     }
 
-    @PreAuthorize("hasRole('ADMIN') OR @grantPermissionManager.nodePermission(#nodeName, 'READ')")
+    @PreAuthorize("hasRole('ADMIN') OR @grantPermissionManager.nodePermission(#name, 'READ')")
     public InputStream getUsageStatisticsFile(final String name, final LocalDateTime from, final LocalDateTime to,
                                               final Duration interval) {
         return usageMonitoringManager.getStatsForNodeAsInputStream(name, from, to, interval);

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/ClusterApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/ClusterApiService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package com.epam.pipeline.manager.cluster;
 
+import java.io.InputStream;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -72,6 +74,12 @@ public class ClusterApiService {
     @PreAuthorize("hasRole('ADMIN') OR @grantPermissionManager.nodePermission(#nodeName, 'READ')")
     public List<MonitoringStats> getStatsForNode(String nodeName, final LocalDateTime from, final LocalDateTime to) {
         return usageMonitoringManager.getStatsForNode(nodeName, from, to);
+    }
+
+    @PreAuthorize("hasRole('ADMIN') OR @grantPermissionManager.nodePermission(#nodeName, 'READ')")
+    public InputStream getUsageStatisticsFile(final String name, final LocalDateTime from, final LocalDateTime to,
+                                              final Duration interval) {
+        return usageMonitoringManager.getStatsForNodeAsInputStream(name, from, to, interval);
     }
 
     public List<InstanceType> getAllowedInstanceTypes(final Long regionId, final Boolean spot) {

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/CAdvisorMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/CAdvisorMonitoringManager.java
@@ -118,7 +118,8 @@ public class CAdvisorMonitoringManager implements UsageMonitoringManager {
                                                     final LocalDateTime from,
                                                     final LocalDateTime to,
                                                     final Duration interval) {
-        throw new UnsupportedOperationException("Currently not supported operation!");
+        throw new UnsupportedOperationException(messageHelper.getMessage(
+            MessageConstants.CADVISOR_STATS_REPORTS_NOT_SUPPORTED));
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/CAdvisorMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/CAdvisorMonitoringManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,9 @@ import retrofit2.Retrofit;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.Proxy;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -109,6 +111,14 @@ public class CAdvisorMonitoringManager implements UsageMonitoringManager {
         final LocalDateTime start = Optional.ofNullable(from).orElse(LocalDateTime.MIN);
         final LocalDateTime end = Optional.ofNullable(to).orElse(LocalDateTime.MAX);
         return getStats(nodeName, start, end);
+    }
+
+    @Override
+    public InputStream getStatsForNodeAsInputStream(final String nodeName,
+                                                    final LocalDateTime from,
+                                                    final LocalDateTime to,
+                                                    final Duration interval) {
+        throw new UnsupportedOperationException("Currently not supported operation!");
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ESMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ESMonitoringManager.java
@@ -86,7 +86,11 @@ public class ESMonitoringManager implements UsageMonitoringManager {
         final LocalDateTime oldestMonitoring = oldestMonitoringDate();
         final LocalDateTime start = requestedStart.isAfter(oldestMonitoring) ? requestedStart : oldestMonitoring;
         final LocalDateTime end = Optional.ofNullable(to).orElseGet(DateUtils::nowUTC);
-        final List<MonitoringStats> monitoringStats = getStats(nodeName, start, end, interval);
+        final Duration minDuration = minimalDuration();
+        final Duration adjustedDuration = interval.compareTo(minDuration) < 0
+                                          ? minDuration
+                                          : interval;
+        final List<MonitoringStats> monitoringStats = getStats(nodeName, start, end, adjustedDuration);
         final MonitoringStatsWriter statsWriter = new MonitoringStatsWriter();
         try {
             return new StringInputStream(statsWriter.convertStatsToCsvString(monitoringStats));

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ESMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ESMonitoringManager.java
@@ -95,7 +95,8 @@ public class ESMonitoringManager implements UsageMonitoringManager {
         try {
             return new StringInputStream(statsWriter.convertStatsToCsvString(monitoringStats));
         } catch (IOException e) {
-            throw new IllegalStateException("Written csv stats file encoding differs from UTF-8.", e);
+            throw new IllegalStateException(messageHelper.getMessage(MessageConstants.ERROR_BAD_STATS_FILE_ENCODING),
+                                            e);
         }
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ESMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ESMonitoringManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.epam.pipeline.manager.cluster.performancemonitoring;
 
+import com.amazonaws.util.StringInputStream;
 import com.epam.pipeline.common.MessageConstants;
 import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.dao.monitoring.MonitoringESDao;
@@ -26,6 +27,7 @@ import com.epam.pipeline.entity.cluster.monitoring.MonitoringStats;
 import com.epam.pipeline.entity.utils.DateUtils;
 import com.epam.pipeline.manager.cluster.KubernetesConstants;
 import com.epam.pipeline.manager.cluster.NodesManager;
+import com.epam.pipeline.manager.cluster.writer.MonitoringStatsWriter;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +35,8 @@ import org.elasticsearch.client.RestHighLevelClient;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Collections;
@@ -67,9 +71,28 @@ public class ESMonitoringManager implements UsageMonitoringManager {
         final LocalDateTime oldestMonitoring = oldestMonitoringDate();
         final LocalDateTime start = requestedStart.isAfter(oldestMonitoring) ? requestedStart : oldestMonitoring;
         final LocalDateTime end = Optional.ofNullable(to).orElseGet(DateUtils::nowUTC);
+        final Duration interval = interval(start, end);
         return end.isAfter(start) && end.isAfter(oldestMonitoring)
-                ? getStats(nodeName, start, end)
+                ? getStats(nodeName, start, end, interval)
                 : Collections.emptyList();
+    }
+
+    @Override
+    public InputStream getStatsForNodeAsInputStream(final String nodeName,
+                                                    final LocalDateTime from,
+                                                    final LocalDateTime to,
+                                                    final Duration interval) {
+        final LocalDateTime requestedStart = Optional.ofNullable(from).orElseGet(() -> creationDate(nodeName));
+        final LocalDateTime oldestMonitoring = oldestMonitoringDate();
+        final LocalDateTime start = requestedStart.isAfter(oldestMonitoring) ? requestedStart : oldestMonitoring;
+        final LocalDateTime end = Optional.ofNullable(to).orElseGet(DateUtils::nowUTC);
+        final List<MonitoringStats> monitoringStats = getStats(nodeName, start, end, interval);
+        final MonitoringStatsWriter statsWriter = new MonitoringStatsWriter();
+        try {
+            return new StringInputStream(statsWriter.convertStatsToCsvString(monitoringStats));
+        } catch (IOException e) {
+            throw new IllegalStateException("Written csv stats file encoding differs from UTF-8.", e);
+        }
     }
 
     @Override
@@ -112,8 +135,8 @@ public class ESMonitoringManager implements UsageMonitoringManager {
         return DateUtils.nowUTC().minus(FALLBACK_MONITORING_PERIOD);
     }
 
-    private List<MonitoringStats> getStats(final String nodeName, final LocalDateTime start, final LocalDateTime end) {
-        final Duration interval = interval(start, end);
+    private List<MonitoringStats> getStats(final String nodeName, final LocalDateTime start, final LocalDateTime end,
+                                           final Duration interval) {
         return Stream.of(MONITORING_METRICS)
                 .map(it -> AbstractMetricRequester.getStatsRequester(it, client))
                 .map(it -> it.requestStats(nodeName, start, end, interval))

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/UsageMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/UsageMonitoringManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ package com.epam.pipeline.manager.cluster.performancemonitoring;
 import com.epam.pipeline.entity.cluster.monitoring.MonitoringStats;
 
 import javax.annotation.Nullable;
+import java.io.InputStream;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -48,6 +50,20 @@ public interface UsageMonitoringManager {
     List<MonitoringStats> getStatsForNode(String nodeName,
                                           @Nullable LocalDateTime from,
                                           @Nullable LocalDateTime to);
+
+    /**
+     * Retrieves monitoring stats for node as input stream.
+     *
+     * @param nodeName Cluster node name.
+     * @param from Minimal date for collecting stats.
+     * @param to Maximal date for collecting stats.
+     * @param interval period of stats collecting
+     * @return stream, containing required information in .csv format
+     */
+    InputStream getStatsForNodeAsInputStream(String nodeName,
+                                             @Nullable LocalDateTime from,
+                                             @Nullable LocalDateTime to,
+                                             Duration interval);
 
     /**
      * Retrieves number of bytes that available on a pod disk .

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/writer/MonitoringStatsWriter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/writer/MonitoringStatsWriter.java
@@ -20,15 +20,17 @@ import com.epam.pipeline.entity.cluster.monitoring.MonitoringStats;
 import com.opencsv.CSVWriter;
 import lombok.NoArgsConstructor;
 import lombok.Value;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @NoArgsConstructor
 public class MonitoringStatsWriter {
@@ -42,6 +44,9 @@ public class MonitoringStatsWriter {
     private static final double HUNDRED_PERCENTS = 100.0;
 
     public String convertStatsToCsvString(final List<MonitoringStats> stats) {
+        if (CollectionUtils.isEmpty(stats)) {
+            return StringUtils.EMPTY;
+        }
         final StringWriter stringWriter = new StringWriter();
         final CSVWriter csvWriter = new CSVWriter(stringWriter);
         final List<String[]> allLines = extractTable(stats);
@@ -52,22 +57,15 @@ public class MonitoringStatsWriter {
     private List<String[]> extractTable(final List<MonitoringStats> stats) {
         final List<String[]> allLines = new ArrayList<>();
         final MonitoringStatsHeader header = extractHeader(stats);
-        if (!header.getColumnNames().isEmpty()) {
-            allLines.add(header.getColumnNames().toArray(new String[0]));
-            final List<String[]> entities = stats.stream()
-                .map(stat -> createNewLine(header, stat))
-                .collect(Collectors.toList());
-            allLines.addAll(entities);
-            return allLines;
-        } else {
-            return Collections.emptyList();
-        }
+        allLines.add(header.getColumnNames().toArray(new String[0]));
+        final List<String[]> entities = stats.stream()
+            .map(stat -> createNewLine(header, stat))
+            .collect(Collectors.toList());
+        allLines.addAll(entities);
+        return allLines;
     }
 
     private MonitoringStatsHeader extractHeader(final List<MonitoringStats> stats) {
-        if (stats.size() == 0) {
-            return MonitoringStatsHeader.EMPTY_HEADER;
-        }
         final List<String> headerColumns = new ArrayList<>(COMMON_STATS_HEADER);
         final List<String> disks = stats.stream()
             .map(MonitoringStats::getDisksUsage)
@@ -97,52 +95,57 @@ public class MonitoringStatsWriter {
     }
 
     private String[] createNewLine(final MonitoringStatsHeader header, final MonitoringStats stat) {
-        final String[] newLine = new String[header.getColumnNames().size()];
+        final List<String> newLine = new ArrayList<>();
         fillGeneralColumns(stat, newLine);
         fillDisksColumns(stat, header, newLine);
         fillNetworkingColumns(stat, header, newLine);
-        return newLine;
+        return newLine.toArray(new String[0]);
     }
 
-    private void fillGeneralColumns(final MonitoringStats stat, final String[] newLine) {
-        newLine[0] = stat.getEndTime();
-        newLine[1] = Integer.toString(stat.getContainerSpec().getNumberOfCores());
-        newLine[2] = Double.toString(HUNDRED_PERCENTS * stat.getCpuUsage().getLoad());
+    private void fillGeneralColumns(final MonitoringStats stat, final List<String> newLine) {
+        newLine.add(stat.getEndTime());
+        newLine.add(Integer.toString(stat.getContainerSpec().getNumberOfCores()));
+        newLine.add(Double.toString(HUNDRED_PERCENTS * stat.getCpuUsage().getLoad()));
         final long memCapacity = stat.getMemoryUsage().getCapacity();
-        newLine[3] = Long.toString(memCapacity);
-        newLine[4] = Double.toString(HUNDRED_PERCENTS * stat.getMemoryUsage().getUsage() / memCapacity);
+        newLine.add(Long.toString(memCapacity));
+        newLine.add(Double.toString(HUNDRED_PERCENTS * stat.getMemoryUsage().getUsage() / memCapacity));
     }
 
     private void fillDisksColumns(final MonitoringStats stat, final MonitoringStatsHeader header,
-                                  final String[] newLine) {
+                                  final List<String> newLine) {
         final List<String> diskNames = header.getDiskNames();
+        final List<String> newEmptyColumns = IntStream.range(0, 2 * diskNames.size())
+            .mapToObj(i -> StringUtils.EMPTY)
+            .collect(Collectors.toList());
+        newLine.addAll(newEmptyColumns);
         stat.getDisksUsage().getStatsByDevices().forEach((diskName, diskStatValue) -> {
             final long diskCapacity = diskStatValue.getCapacity();
             final double diskUsage = HUNDRED_PERCENTS * diskStatValue.getUsableSpace() / diskCapacity;
             final int columnIndex = COMMON_STATS_HEADER.size() + 2 * diskNames.indexOf(diskName);
-            newLine[columnIndex] = Long.toString(diskCapacity);
-            newLine[columnIndex + 1] = Double.toString(diskUsage);
+            newLine.set(columnIndex, Long.toString(diskCapacity));
+            newLine.set(columnIndex + 1, Double.toString(diskUsage));
         });
     }
 
     private void fillNetworkingColumns(final MonitoringStats stat, final MonitoringStatsHeader header,
-                                       final String[] newLine) {
+                                       final List<String> newLine) {
+        final int disksColumnShift = 2 * header.getDiskNames().size();
+        final List<String> interfaceNames = header.getInterfaceNames();
+        final List<String> newEmptyColumns = IntStream.range(0, 2 * interfaceNames.size())
+            .mapToObj(i -> StringUtils.EMPTY)
+            .collect(Collectors.toList());
+        newLine.addAll(newEmptyColumns);
         stat.getNetworkUsage().getStatsByInterface().forEach((interfaceName, networkStats) -> {
-            final int disksColumnShift = 2 * header.getDiskNames().size();
-            final List<String> interfaceNames = header.getInterfaceNames();
             final int columnIndex =
                 COMMON_STATS_HEADER.size() + disksColumnShift + 2 * interfaceNames.indexOf(interfaceName);
-            newLine[columnIndex] = Long.toString(networkStats.getRxBytes());
-            newLine[columnIndex + 1] = Long.toString(networkStats.getTxBytes());
+            newLine.set(columnIndex, Long.toString(networkStats.getRxBytes()));
+            newLine.set(columnIndex + 1, Long.toString(networkStats.getTxBytes()));
         });
     }
 
     @Value
     private static class MonitoringStatsHeader {
 
-        private static final MonitoringStatsHeader EMPTY_HEADER = new MonitoringStatsHeader(Collections.emptyList(),
-                                                                                            Collections.emptyList(),
-                                                                                            Collections.emptyList());
         private List<String> diskNames;
         private List<String> interfaceNames;
         private List<String> columnNames;

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/writer/MonitoringStatsWriter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/writer/MonitoringStatsWriter.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster.writer;
+
+import com.epam.pipeline.entity.cluster.monitoring.MonitoringStats;
+import com.opencsv.CSVWriter;
+import lombok.NoArgsConstructor;
+import lombok.Value;
+
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@NoArgsConstructor
+public class MonitoringStatsWriter {
+
+    private static final List<String> COMMON_STATS_HEADER =
+        Arrays.asList("Timestamp", "CPU_cores", "CPU_usage[%]", "MEM_capacity[bytes]", "MEM_usage[%]");
+    private static final String DISK_TOTAL_HEADER_TEMPLATE = "%s_total[bytes]";
+    private static final String DISK_USAGE_HEADER_TEMPLATE = "%s_usage[%%]";
+    private static final String NETWORK_USAGE_IN_HEADER_TEMPLATE = "%s_in[bytes]";
+    private static final String NETWORK_USAGE_OUT_HEADER_TEMPLATE = "%s_out[bytes]";
+    private static final double HUNDRED_PERCENTS = 100.0;
+
+    public String convertStatsToCsvString(final List<MonitoringStats> stats) {
+        final StringWriter stringWriter = new StringWriter();
+        final CSVWriter csvWriter = new CSVWriter(stringWriter);
+        final List<String[]> allLines = extractTable(stats);
+        csvWriter.writeAll(allLines);
+        return stringWriter.toString();
+    }
+
+    private List<String[]> extractTable(final List<MonitoringStats> stats) {
+        final List<String[]> allLines = new ArrayList<>();
+        final MonitoringStatsHeader header = extractHeader(stats);
+        if (!header.getColumnNames().isEmpty()) {
+            allLines.add(header.getColumnNames().toArray(new String[0]));
+            final List<String[]> entities = stats.stream()
+                .map(stat -> createNewLine(header, stat))
+                .collect(Collectors.toList());
+            allLines.addAll(entities);
+            return allLines;
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    private MonitoringStatsHeader extractHeader(final List<MonitoringStats> stats) {
+        if (stats.size() == 0) {
+            return MonitoringStatsHeader.EMPTY_HEADER;
+        }
+        final List<String> headerColumns = new ArrayList<>(COMMON_STATS_HEADER);
+        final List<String> disks = stats.stream()
+            .map(MonitoringStats::getDisksUsage)
+            .map(MonitoringStats.DisksUsage::getStatsByDevices)
+            .map(Map::keySet)
+            .flatMap(Set::stream)
+            .distinct()
+            .sorted()
+            .peek(disk -> {
+                headerColumns.add(String.format(DISK_TOTAL_HEADER_TEMPLATE, disk));
+                headerColumns.add(String.format(DISK_USAGE_HEADER_TEMPLATE, disk));
+            })
+            .collect(Collectors.toList());
+        final List<String> networkInterfaces = stats.stream()
+            .map(MonitoringStats::getNetworkUsage)
+            .map(MonitoringStats.NetworkUsage::getStatsByInterface)
+            .map(Map::keySet)
+            .flatMap(Set::stream)
+            .distinct()
+            .sorted()
+            .peek(netInterface -> {
+                headerColumns.add(String.format(NETWORK_USAGE_IN_HEADER_TEMPLATE, netInterface));
+                headerColumns.add(String.format(NETWORK_USAGE_OUT_HEADER_TEMPLATE, netInterface));
+            })
+            .collect(Collectors.toList());
+        return new MonitoringStatsHeader(disks, networkInterfaces, headerColumns);
+    }
+
+    private String[] createNewLine(final MonitoringStatsHeader header, final MonitoringStats stat) {
+        final String[] newLine = new String[header.getColumnNames().size()];
+        fillGeneralColumns(stat, newLine);
+        fillDisksColumns(stat, header, newLine);
+        fillNetworkingColumns(stat, header, newLine);
+        return newLine;
+    }
+
+    private void fillGeneralColumns(final MonitoringStats stat, final String[] newLine) {
+        newLine[0] = stat.getEndTime();
+        newLine[1] = Integer.toString(stat.getContainerSpec().getNumberOfCores());
+        newLine[2] = Double.toString(HUNDRED_PERCENTS * stat.getCpuUsage().getLoad());
+        final long memCapacity = stat.getMemoryUsage().getCapacity();
+        newLine[3] = Long.toString(memCapacity);
+        newLine[4] = Double.toString(HUNDRED_PERCENTS * stat.getMemoryUsage().getUsage() / memCapacity);
+    }
+
+    private void fillDisksColumns(final MonitoringStats stat, final MonitoringStatsHeader header,
+                                  final String[] newLine) {
+        final List<String> diskNames = header.getDiskNames();
+        stat.getDisksUsage().getStatsByDevices().forEach((diskName, diskStatValue) -> {
+            final long diskCapacity = diskStatValue.getCapacity();
+            final double diskUsage = HUNDRED_PERCENTS * diskStatValue.getUsableSpace() / diskCapacity;
+            final int columnIndex = COMMON_STATS_HEADER.size() + 2 * diskNames.indexOf(diskName);
+            newLine[columnIndex] = Long.toString(diskCapacity);
+            newLine[columnIndex + 1] = Double.toString(diskUsage);
+        });
+    }
+
+    private void fillNetworkingColumns(final MonitoringStats stat, final MonitoringStatsHeader header,
+                                       final String[] newLine) {
+        stat.getNetworkUsage().getStatsByInterface().forEach((interfaceName, networkStats) -> {
+            final int disksColumnShift = 2 * header.getDiskNames().size();
+            final List<String> interfaceNames = header.getInterfaceNames();
+            final int columnIndex =
+                COMMON_STATS_HEADER.size() + disksColumnShift + 2 * interfaceNames.indexOf(interfaceName);
+            newLine[columnIndex] = Long.toString(networkStats.getRxBytes());
+            newLine[columnIndex + 1] = Long.toString(networkStats.getTxBytes());
+        });
+    }
+
+    @Value
+    private static class MonitoringStatsHeader {
+
+        private static final MonitoringStatsHeader EMPTY_HEADER = new MonitoringStatsHeader(Collections.emptyList(),
+                                                                                            Collections.emptyList(),
+                                                                                            Collections.emptyList());
+        private List<String> diskNames;
+        private List<String> interfaceNames;
+        private List<String> columnNames;
+    }
+}

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -249,6 +249,7 @@ cloud.bucket.already.exists=Bucket with this name already exists: '{0}'
 
 cadvisor.send.request=Get next batch of statistics for the node with IP ''{0}''
 cadvisor.receive.response=Receive result from cAdvisor for the node with IP ''{0}''
+cadvisor.reports.not.supported=Resource usage reports export is not supported for CAdvisor!
 
 # Users and security
 user.id.not.found=Failed to find user by id ''{0}''.

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -108,6 +108,7 @@ warn.resume.run.failed=Could not resume run. Operation failed with message ''{0}
 info.instance.started=Instance ''{0}'' successfully started.
 error.run.attaching.wrong.status=Disks can be attached to running or paused runs. Given run ''{0}'' has ''{1}'' status.
 error.run.disk.size.not.found=Pipeline run disk size should be specified.
+error.run.stats.file.bad.encoding=Written csv stats file encoding differs from UTF-8.
 
 #Run schedule
 cron.expression.is.not.provided=Cron expression for pipeline run id ''{0}'' is not provided.

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/writer/MonitoringStatsWriterTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/writer/MonitoringStatsWriterTest.java
@@ -17,7 +17,6 @@
 package com.epam.pipeline.manager.cluster.writer;
 
 import com.epam.pipeline.entity.cluster.monitoring.MonitoringStats;
-import lombok.AllArgsConstructor;
 import lombok.Value;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
@@ -174,7 +173,6 @@ public class MonitoringStatsWriterTest {
     }
 
     @Value
-    @AllArgsConstructor
     private static class DiskInfo {
 
         private String name;

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/writer/MonitoringStatsWriterTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/writer/MonitoringStatsWriterTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster.writer;
+
+import com.epam.pipeline.entity.cluster.monitoring.MonitoringStats;
+import lombok.AllArgsConstructor;
+import lombok.Value;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@SuppressWarnings("checkstyle:MagicNumber")
+public class MonitoringStatsWriterTest {
+
+    private static final int NUM_CORES = 2;
+    private static final long MAX_MEM = 1024;
+    private static final MonitoringStats.ContainerSpec CONTAINER_SPEC = getContainerSpec(NUM_CORES, MAX_MEM);
+    private static final List<String> END_TIMES = Arrays.asList("2020-01-23T10:18:00", "2020-01-23T10:19:00");
+    private static final List<Double> CPU_LOADS = Arrays.asList(0.01, 0.02);
+    private static final List<Long> MEM_USAGES = Arrays.asList(256L, 512L);
+    private static final List<DiskInfo> DISK_INFOS =
+        Arrays.asList(new DiskInfo("disk1", 1000, 255),
+                      new DiskInfo("disk2", 500, 417));
+    private static final List<String> NETWORK_INTERFACES = Arrays.asList("int1", "int2");
+    private static final List<Long> NETWORK_INTERFACES_RX = Arrays.asList(101L, 201L);
+    private static final List<Long> NETWORK_INTERFACES_TX = Arrays.asList(102L, 202L);
+    private static final double HUNDRED_PERCENTS = 100.0;
+
+    @Test
+    public void testMonitoringStatsToCsvConversion() {
+        final List<MonitoringStats> stats = createStatsList();
+        final MonitoringStatsWriter monitoringStatsWriter = new MonitoringStatsWriter();
+        final String csvInfo = monitoringStatsWriter.convertStatsToCsvString(stats);
+        final String[] linesOfTables = csvInfo.split("\\n");
+        Assert.assertEquals(3, linesOfTables.length);
+        final List<String[]> table = Arrays.stream(linesOfTables)
+            .map(line -> line.replaceAll("\"", ""))
+            .map(line -> line.split(",", -1))
+            .peek(cells ->
+                      Assert.assertEquals(5 + 2 * DISK_INFOS.size() + 2 * NETWORK_INTERFACES.size(),
+                                          cells.length)
+            )
+            .collect(Collectors.toList());
+
+        final String[] firstStatEntry = table.get(1);
+        final long totalSpace1 = DISK_INFOS.get(0).totalSpace;
+        final long usedSpace1 = DISK_INFOS.get(0).usedSpace;
+        Assert.assertEquals(totalSpace1, Long.parseLong(firstStatEntry[5]));
+        Assert.assertEquals(0,
+                            Double.compare(HUNDRED_PERCENTS * usedSpace1 / totalSpace1,
+                                           Double.parseDouble(firstStatEntry[6])));
+        Assert.assertEquals(StringUtils.EMPTY, firstStatEntry[7]);
+        Assert.assertEquals(StringUtils.EMPTY, firstStatEntry[8]);
+        final long inBytes1 = NETWORK_INTERFACES_RX.get(0);
+        final long outBytes1 = NETWORK_INTERFACES_TX.get(0);
+        Assert.assertEquals(inBytes1, Long.parseLong(firstStatEntry[9]));
+        Assert.assertEquals(outBytes1, Long.parseLong(firstStatEntry[10]));
+        Assert.assertEquals(StringUtils.EMPTY, firstStatEntry[11]);
+        Assert.assertEquals(StringUtils.EMPTY, firstStatEntry[12]);
+
+        final String[] secondStatEntry = table.get(2);
+        Assert.assertEquals(StringUtils.EMPTY, secondStatEntry[5]);
+        Assert.assertEquals(StringUtils.EMPTY, secondStatEntry[6]);
+        final long totalSpace2 = DISK_INFOS.get(1).totalSpace;
+        final long usedSpace2 = DISK_INFOS.get(1).usedSpace;
+        Assert.assertEquals(totalSpace2, Long.parseLong(secondStatEntry[7]));
+        Assert.assertEquals(0,
+                            Double.compare(HUNDRED_PERCENTS * usedSpace2 / totalSpace2,
+                                           Double.parseDouble(secondStatEntry[8])));
+        Assert.assertEquals(StringUtils.EMPTY, secondStatEntry[9]);
+        Assert.assertEquals(StringUtils.EMPTY, secondStatEntry[10]);
+        final long inBytes2 = NETWORK_INTERFACES_RX.get(1);
+        final long outBytes2 = NETWORK_INTERFACES_TX.get(1);
+        Assert.assertEquals(inBytes2, Long.parseLong(secondStatEntry[11]));
+        Assert.assertEquals(outBytes2, Long.parseLong(secondStatEntry[12]));
+    }
+
+    private List<MonitoringStats> createStatsList() {
+        return IntStream.range(0, 2).mapToObj(i -> createMonitoringStats(END_TIMES.get(i),
+                                                                         CPU_LOADS.get(i),
+                                                                         MAX_MEM,
+                                                                         MEM_USAGES.get(i),
+                                                                         getStatsByDisk(DISK_INFOS.get(i)),
+                                                                         NETWORK_INTERFACES.get(i),
+                                                                         NETWORK_INTERFACES_RX.get(i),
+                                                                         NETWORK_INTERFACES_TX.get(i))
+        ).collect(Collectors.toList());
+    }
+
+    private Map<String, MonitoringStats.DisksUsage.DiskStats> getStatsByDisk(final DiskInfo... infos) {
+        return Arrays.stream(infos)
+            .collect(Collectors.toMap(DiskInfo::getName, i -> getDiskStats(i.getTotalSpace(), i.getUsedSpace())));
+    }
+
+    private MonitoringStats createMonitoringStats(final String endTime, final double cpuLoad, final long maxMem,
+                                                  final long memUsage,
+                                                  final Map<String, MonitoringStats.DisksUsage.DiskStats> statsByDevice,
+                                                  final String interfaceName, final long bytesRx, final long bytesTx) {
+        final MonitoringStats monitoringStat1 = new MonitoringStats();
+        monitoringStat1.setEndTime(endTime);
+        monitoringStat1.setContainerSpec(CONTAINER_SPEC);
+        monitoringStat1.setCpuUsage(getCpuUsage(cpuLoad));
+        monitoringStat1.setMemoryUsage(createMemoryUsage(maxMem, memUsage));
+        setDiskUsageStats(monitoringStat1, statsByDevice);
+        setUsageForOneInterface(monitoringStat1, interfaceName, bytesRx, bytesTx);
+        return monitoringStat1;
+    }
+
+    private static void setDiskUsageStats(final MonitoringStats stats,
+                                          final Map<String, MonitoringStats.DisksUsage.DiskStats> statsByDevice) {
+        final MonitoringStats.DisksUsage disksUsage = new MonitoringStats.DisksUsage();
+        disksUsage.setStatsByDevices(statsByDevice);
+        stats.setDisksUsage(disksUsage);
+    }
+
+    private static MonitoringStats.CPUUsage getCpuUsage(final double load) {
+        final MonitoringStats.CPUUsage cpuUsage = new MonitoringStats.CPUUsage();
+        cpuUsage.setLoad(load);
+        return cpuUsage;
+    }
+
+    private static MonitoringStats.ContainerSpec getContainerSpec(final int numCores, final long maxMem) {
+        final MonitoringStats.ContainerSpec containerSpec = new MonitoringStats.ContainerSpec();
+        containerSpec.setNumberOfCores(numCores);
+        containerSpec.setMaxMemory(maxMem);
+        return containerSpec;
+    }
+
+    private static MonitoringStats.DisksUsage.DiskStats getDiskStats(final long capacity, final long usable) {
+        final MonitoringStats.DisksUsage.DiskStats value3 = new MonitoringStats.DisksUsage.DiskStats();
+        value3.setCapacity(capacity);
+        value3.setUsableSpace(usable);
+        return value3;
+    }
+
+    private static void setUsageForOneInterface(final MonitoringStats stats,
+                                                final String interfaceName,
+                                                final long bytesRx,
+                                                final long bytesTx) {
+        final MonitoringStats.NetworkUsage networkUsage = new MonitoringStats.NetworkUsage();
+        final MonitoringStats.NetworkUsage.NetworkStats value = new MonitoringStats.NetworkUsage.NetworkStats();
+        value.setRxBytes(bytesRx);
+        value.setTxBytes(bytesTx);
+        networkUsage.setStatsByInterface(Collections.singletonMap(interfaceName, value));
+        stats.setNetworkUsage(networkUsage);
+    }
+
+    private static MonitoringStats.MemoryUsage createMemoryUsage(final long capacity, final long usage) {
+        final MonitoringStats.MemoryUsage memoryUsage = new MonitoringStats.MemoryUsage();
+        memoryUsage.setCapacity(capacity);
+        memoryUsage.setUsage(usage);
+        return memoryUsage;
+    }
+
+    @Value
+    @AllArgsConstructor
+    private static class DiskInfo {
+
+        private String name;
+        private long totalSpace;
+        private long usedSpace;
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/writer/MonitoringStatsWriterTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/writer/MonitoringStatsWriterTest.java
@@ -45,6 +45,7 @@ public class MonitoringStatsWriterTest {
     private static final List<Long> NETWORK_INTERFACES_RX = Arrays.asList(101L, 201L);
     private static final List<Long> NETWORK_INTERFACES_TX = Arrays.asList(102L, 202L);
     private static final double HUNDRED_PERCENTS = 100.0;
+    private static final int COMMON_INFO_SIZE = 5;
 
     @Test
     public void testMonitoringStatsToCsvConversion() {
@@ -57,7 +58,7 @@ public class MonitoringStatsWriterTest {
             .map(line -> line.replaceAll("\"", ""))
             .map(line -> line.split(",", -1))
             .peek(cells ->
-                      Assert.assertEquals(5 + 2 * DISK_INFOS.size() + 2 * NETWORK_INTERFACES.size(),
+                      Assert.assertEquals(COMMON_INFO_SIZE + 2 * DISK_INFOS.size() + 2 * NETWORK_INTERFACES.size(),
                                           cells.length)
             )
             .collect(Collectors.toList());
@@ -93,6 +94,13 @@ public class MonitoringStatsWriterTest {
         final long outBytes2 = NETWORK_INTERFACES_TX.get(1);
         Assert.assertEquals(inBytes2, Long.parseLong(secondStatEntry[11]));
         Assert.assertEquals(outBytes2, Long.parseLong(secondStatEntry[12]));
+    }
+
+    @Test
+    public void testEmptyStatsConversion() {
+        final List<MonitoringStats> stats = Collections.emptyList();
+        final MonitoringStatsWriter monitoringStatsWriter = new MonitoringStatsWriter();
+        Assert.assertEquals(StringUtils.EMPTY, monitoringStatsWriter.convertStatsToCsvString(stats));
     }
 
     private List<MonitoringStats> createStatsList() {


### PR DESCRIPTION
This PR is related to issue #857 

It brings export of the utilization information as a CSV file

- stats are exported as a single table, containing information about CPU, memory, disks and network interfaces usage split into intervals
- MonitoringStatsWriter for `List<MonitoringStats>` -> `CSV table` conversion is introduced  
- necessary changes made in ClusterController and underlying layers
