### PR TITLE
Issue #928: `pipe`: the `run` command works not fully correct with `--instance-count` option

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -623,7 +623,7 @@ def view_cluster_for_node(node_name):
 @click.option('-t', '--timeout', help='Timeout (in minutes), when elapsed - run will be stopped', type=int)
 @click.option('-q', '--quiet', help='Quiet mode', is_flag=True)
 @click.option('-ic', '--instance-count', help='Number of worker instances to launch in a cluster',
-              type=click.IntRange(1, MAX_INSTANCE_COUNT, clamp=True), required=False)
+              type=click.IntRange(0, MAX_INSTANCE_COUNT, clamp=True), required=False)
 @click.option('-nc', '--cores', help='Number of cores that a cluster shall contain. This option will be ignored '
                                      'if -ic (--instance-count) option was specified',
               type=click.IntRange(2, MAX_CORES_COUNT, clamp=True), required=False)

--- a/pipe-cli/src/utilities/pipeline_run_operations.py
+++ b/pipe-cli/src/utilities/pipeline_run_operations.py
@@ -69,6 +69,9 @@ class PipelineRunOperations(object):
 
         run_params_dict = dict([(k.strip('-'), v) for k, v in zip(run_params[::2], run_params[1::2])])
 
+        if instance_count == 0:
+            instance_count = None
+
         # Calculate instance_type and instance_count if only cores specified
         if not instance_count and cores:
             nodes_spec = ClusterManager.calculate_cluster_from_cores(cores, core_type=instance_type)


### PR DESCRIPTION
This PR provides fix for issue #928 