### PR TITLE
`pipe`: the `run` command works not fully correct with `--instance-count` option

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilder.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilder.java
@@ -91,7 +91,11 @@ public class PipeRunCmdBuilder {
     }
 
     public PipeRunCmdBuilder instanceCount() {
-        buildObjectCmdArg("-ic", runVO.getNodeCount());
+        final Integer nodeCount = runVO.getNodeCount();
+        if (Objects.nonNull(nodeCount) && nodeCount == 0) {
+            return this;
+        }
+        buildObjectCmdArg("-ic", nodeCount);
         return this;
     }
 

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilderTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilderTest.java
@@ -90,4 +90,35 @@ public class PipeRunCmdBuilderTest {
                 CMD_TEMPLATE);
         Assert.assertEquals(expectedResult, actualResult);
     }
+
+    @Test
+    public void shouldIgnoreInstanceCountOptionIf0() {
+        final PipelineStart pipelineStart = new PipelineStart();
+        pipelineStart.setPipelineId(1L);
+        pipelineStart.setNodeCount(0);
+
+        final PipeRunCmdStartVO pipeRunCmdStartVO = new PipeRunCmdStartVO();
+        pipeRunCmdStartVO.setPipelineStart(pipelineStart);
+
+        final PipeRunCmdBuilder pipeRunCmdBuilder = new PipeRunCmdBuilder(pipeRunCmdStartVO);
+        final String actualResult = pipeRunCmdBuilder
+                .name()
+                .config()
+                .runParameters()
+                .parameters()
+                .yes()
+                .instanceDisk()
+                .instanceType()
+                .dockerImage()
+                .cmdTemplate()
+                .timeout()
+                .quite()
+                .instanceCount()
+                .sync()
+                .priceType()
+                .regionId()
+                .parentNode()
+                .build();
+        Assert.assertEquals("pipe run -n 1 -pt spot", actualResult);
+    }
 }


### PR DESCRIPTION
This PR provides fix for pipe run command generation according to this https://github.com/epam/cloud-pipeline/issues/928#issuecomment-580678023

The following changes were added:
 - If nodes count is zero `-ic 0` will not be added to launch command