### PR TITLE
Issue #761 Billing API improvements

### DIFF
--- a/api/src/main/java/com/epam/pipeline/controller/vo/billing/BillingChartRequest.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/billing/BillingChartRequest.java
@@ -30,5 +30,6 @@ public class BillingChartRequest {
     private LocalDate to;
     private Map<String, List<String>> filters;
     private DateHistogramInterval interval;
+    private DateHistogramInterval prevPeriodShift;
     private List<String> grouping;
 }

--- a/api/src/main/java/com/epam/pipeline/entity/billing/BillingChartInfo.java
+++ b/api/src/main/java/com/epam/pipeline/entity/billing/BillingChartInfo.java
@@ -17,12 +17,12 @@
 package com.epam.pipeline.entity.billing;
 
 import lombok.Builder;
-import lombok.Value;
+import lombok.Data;
 
 import java.time.LocalDateTime;
 import java.util.Map;
 
-@Value
+@Data
 @Builder
 public class BillingChartInfo {
 
@@ -30,4 +30,7 @@ public class BillingChartInfo {
     private LocalDateTime periodStart;
     private LocalDateTime periodEnd;
     private Long cost;
+    private LocalDateTime previousStart;
+    private LocalDateTime previousEnd;
+    private Long previousCost;
 }

--- a/api/src/main/java/com/epam/pipeline/manager/BillingManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/BillingManager.java
@@ -27,6 +27,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHost;
 import org.elasticsearch.action.search.SearchRequest;
@@ -159,9 +160,11 @@ public class BillingManager {
     }
 
     private BillingChartRequest verifyRequest(final BillingChartRequest request) {
-        final LocalDate to = (request.getTo() == null)
-                             ? LocalDate.now()
-                             : request.getTo();
+        final LocalDate yesterday = LocalDate.now().minusDays(1);
+        final LocalDate requestedTo = request.getTo();
+        final LocalDate to = (requestedTo == null)
+                             ? yesterday
+                             : ObjectUtils.min(requestedTo, yesterday);
         final DateHistogramInterval prevPeriodShift = request.getPrevPeriodShift();
         final LocalDate from = (request.getFrom() == null)
                                ? calculatePeriodStart(to, prevPeriodShift)

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/EntityMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/EntityMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,19 +19,24 @@ package com.epam.pipeline.billingreportagent.service;
 import com.epam.pipeline.billingreportagent.model.EntityContainer;
 import com.epam.pipeline.entity.user.PipelineUser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.io.IOException;
 
-public interface EntityMapper<T> {
+public abstract class EntityMapper<T> {
 
-    XContentBuilder map(EntityContainer<T> doc);
+    @Value("${sync.billing.center.key}")
+    String billingCenterKey;
 
-    default XContentBuilder buildUserContent(final PipelineUser user,
+    abstract public XContentBuilder map(EntityContainer<T> doc);
+
+    protected XContentBuilder buildUserContent(final PipelineUser user,
                                              final XContentBuilder jsonBuilder) throws IOException {
         if (user != null) {
             jsonBuilder
                     .field("owner", user.getUserName())
-                    .field("groups", user.getGroups());
+                    .field("groups", user.getGroups())
+                    .field("billing_center", user.getAttributes().get(billingCenterKey));
         }
         return jsonBuilder;
     }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/EntityMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/EntityMapper.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 public abstract class EntityMapper<T> {
 
     @Value("${sync.billing.center.key}")
-    String billingCenterKey;
+    private String billingCenterKey;
 
     abstract public XContentBuilder map(EntityContainer<T> doc);
 

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapper.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 
 @Component
 @NoArgsConstructor
-public class RunBillingMapper implements EntityMapper<PipelineRunBillingInfo> {
+public class RunBillingMapper extends EntityMapper<PipelineRunBillingInfo> {
 
     @Override
     public XContentBuilder map(final EntityContainer<PipelineRunBillingInfo> container) {
@@ -53,7 +53,6 @@ public class RunBillingMapper implements EntityMapper<PipelineRunBillingInfo> {
                 .field("usage", billingInfo.getUsageMinutes())
                 .field("run_price", run.getPricePerHour().unscaledValue().longValue())
                 .field("cloudRegionId", run.getInstance().getCloudRegionId())
-                .field("billing_center", "TBD")
                 .field("created_date", billingInfo.getDate());
             buildUserContent(container.getOwner(), jsonBuilder);
             jsonBuilder.endObject();

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapper.java
@@ -30,7 +30,7 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import java.io.IOException;
 
 @RequiredArgsConstructor
-public class StorageBillingMapper implements EntityMapper<StorageBillingInfo> {
+public class StorageBillingMapper extends EntityMapper<StorageBillingInfo> {
 
     private final SearchDocumentType documentType;
 
@@ -47,7 +47,6 @@ public class StorageBillingMapper implements EntityMapper<StorageBillingInfo> {
                 .field("region", billingInfo.getRegionName())
                 .field("provider", storage.getType())
                 .field("storage_type", billingInfo.getStorageType())
-                .field("billing_center", "TBD")
                 .field("usage", billingInfo.getUsageBytes())
                 .field("cost", billingInfo.getCost())
                 .field("created_date", billingInfo.getDate());

--- a/billing-report-agent/src/main/resources/application.properties
+++ b/billing-report-agent/src/main/resources/application.properties
@@ -13,6 +13,7 @@ sync.last.synchronization.file=lastSynchronizationTime.txt
 sync.submit.threads=1
 sync.billing.schedule=0 0 0 ? * *
 sync.bulk.insert.size=1000
+sync.billing.center.key=
 
 #Pipeline Run Settings
 #sync.run.disable=true


### PR DESCRIPTION
This PR is related to issue #761

It brings calculation of previous period spending and adds billing center info extraction.

- billing center name is taken from the owner's attributes
- new request parameter `prevPeriodShift` is introduced: currently, month and year shifts are supported
- response structure is changed: if a timestamp has a corresponding value in the requested previous period, the response contains `previousStart`, `previousEnd`, `previousСost` fields