### PR TITLE
Issue #761 Implement GPU instances and billing centers handling

### DIFF
--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/ComputeType.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/ComputeType.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.billingreportagent.model;
+
+public enum ComputeType {
+    CPU,
+    GPU
+}

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/PipelineRunWithType.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/PipelineRunWithType.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.billingreportagent.model;
+
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import lombok.Value;
+
+@Value
+public class PipelineRunWithType {
+
+    private PipelineRun pipelineRun;
+    private ComputeType runType;
+}

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/PipelineRunBillingInfo.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/PipelineRunBillingInfo.java
@@ -16,8 +16,8 @@
 
 package com.epam.pipeline.billingreportagent.model.billing;
 
+import com.epam.pipeline.billingreportagent.model.PipelineRunWithType;
 import com.epam.pipeline.billingreportagent.model.ResourceType;
-import com.epam.pipeline.entity.pipeline.PipelineRun;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -26,12 +26,12 @@ import java.time.LocalDate;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-public class PipelineRunBillingInfo extends AbstractBillingInfo<PipelineRun> {
+public class PipelineRunBillingInfo extends AbstractBillingInfo<PipelineRunWithType> {
 
     private Long usageMinutes;
 
     @Builder
-    public PipelineRunBillingInfo(final LocalDate date, final PipelineRun run,
+    public PipelineRunBillingInfo(final LocalDate date, final PipelineRunWithType run,
                                   final Long cost, final Long usageMinutes) {
         super(date, run, cost, ResourceType.COMPUTE);
         this.usageMinutes = usageMinutes;

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/AbstractEntityMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/AbstractEntityMapper.java
@@ -23,15 +23,15 @@ import org.springframework.beans.factory.annotation.Value;
 
 import java.io.IOException;
 
-public abstract class EntityMapper<T> {
+public abstract class AbstractEntityMapper<T> {
 
     @Value("${sync.billing.center.key}")
     private String billingCenterKey;
 
-    abstract public XContentBuilder map(EntityContainer<T> doc);
+    public abstract XContentBuilder map(EntityContainer<T> doc);
 
     protected XContentBuilder buildUserContent(final PipelineUser user,
-                                             final XContentBuilder jsonBuilder) throws IOException {
+                                               final XContentBuilder jsonBuilder) throws IOException {
         if (user != null) {
             jsonBuilder
                     .field("owner", user.getUserName())

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/EntityMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/EntityMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,19 +19,24 @@ package com.epam.pipeline.billingreportagent.service;
 import com.epam.pipeline.billingreportagent.model.EntityContainer;
 import com.epam.pipeline.entity.user.PipelineUser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.io.IOException;
 
-public interface EntityMapper<T> {
+public abstract class EntityMapper<T> {
 
-    XContentBuilder map(EntityContainer<T> doc);
+    @Value("${sync.billing.center.key}")
+    private String billingCenterKey;
 
-    default XContentBuilder buildUserContent(final PipelineUser user,
+    abstract public XContentBuilder map(EntityContainer<T> doc);
+
+    protected XContentBuilder buildUserContent(final PipelineUser user,
                                              final XContentBuilder jsonBuilder) throws IOException {
         if (user != null) {
             jsonBuilder
                     .field("owner", user.getUserName())
-                    .field("groups", user.getGroups());
+                    .field("groups", user.getGroups())
+                    .field("billing_center", user.getAttributes().get(billingCenterKey));
         }
         return jsonBuilder;
     }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/CloudPipelineAPIClient.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/CloudPipelineAPIClient.java
@@ -18,15 +18,17 @@ package com.epam.pipeline.billingreportagent.service.impl;
 
 import com.epam.pipeline.client.pipeline.CloudPipelineAPI;
 import com.epam.pipeline.client.pipeline.CloudPipelineApiBuilder;
+import com.epam.pipeline.entity.cluster.InstanceType;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 
 import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.exception.PipelineResponseException;
 import com.epam.pipeline.utils.QueryUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -53,4 +55,11 @@ public class CloudPipelineAPIClient {
         return QueryUtils.execute(cloudPipelineAPI.loadAllDataStorages());
     }
 
+    public List<InstanceType> loadAllInstanceTypesForRegion(final Long regionId) {
+        try {
+            return QueryUtils.execute(cloudPipelineAPI.loadAllInstanceTypesForRegion(regionId));
+        } catch (PipelineResponseException e) {
+            return Collections.emptyList();
+        }
+    }
 }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/AwsStorageToBillingRequestConverter.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/AwsStorageToBillingRequestConverter.java
@@ -21,7 +21,7 @@ import com.epam.pipeline.billingreportagent.model.EntityContainer;
 import com.epam.pipeline.billingreportagent.model.StorageType;
 import com.epam.pipeline.billingreportagent.model.billing.StorageBillingInfo;
 import com.epam.pipeline.billingreportagent.service.ElasticsearchServiceClient;
-import com.epam.pipeline.billingreportagent.service.EntityMapper;
+import com.epam.pipeline.billingreportagent.service.AbstractEntityMapper;
 import com.epam.pipeline.billingreportagent.service.EntityToBillingRequestConverter;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.DataStorageType;
@@ -57,12 +57,12 @@ public class AwsStorageToBillingRequestConverter implements EntityToBillingReque
     private static final String ES_FILE_INDEX_PATTERN = "cp-%s-file-%d";
     private static final RoundingMode ROUNDING_MODE = RoundingMode.CEILING;
 
-    private final EntityMapper<StorageBillingInfo> mapper;
+    private final AbstractEntityMapper<StorageBillingInfo> mapper;
     private final ElasticsearchServiceClient elasticsearchService;
     private final StorageType storageType;
     private final AwsStorageServicePricing storagePricing;
 
-    public AwsStorageToBillingRequestConverter(final EntityMapper<StorageBillingInfo> mapper,
+    public AwsStorageToBillingRequestConverter(final AbstractEntityMapper<StorageBillingInfo> mapper,
                                                final ElasticsearchServiceClient elasticsearchService,
                                                final String awsStorageServiceName,
                                                final StorageType storageType) {
@@ -72,7 +72,7 @@ public class AwsStorageToBillingRequestConverter implements EntityToBillingReque
         this.storagePricing = new AwsStorageServicePricing(awsStorageServiceName);
     }
 
-    public AwsStorageToBillingRequestConverter(final EntityMapper<StorageBillingInfo> mapper,
+    public AwsStorageToBillingRequestConverter(final AbstractEntityMapper<StorageBillingInfo> mapper,
                                                final ElasticsearchServiceClient elasticsearchService,
                                                final StorageType storageType,
                                                final AwsStorageServicePricing storagePricing) {

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverter.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverter.java
@@ -17,10 +17,10 @@
 package com.epam.pipeline.billingreportagent.service.impl.converter;
 
 import com.epam.pipeline.billingreportagent.model.EntityContainer;
+import com.epam.pipeline.billingreportagent.model.PipelineRunWithType;
 import com.epam.pipeline.billingreportagent.model.billing.PipelineRunBillingInfo;
-import com.epam.pipeline.billingreportagent.service.EntityMapper;
+import com.epam.pipeline.billingreportagent.service.AbstractEntityMapper;
 import com.epam.pipeline.billingreportagent.service.EntityToBillingRequestConverter;
-import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.epam.pipeline.entity.pipeline.run.RunStatus;
 import com.epam.pipeline.entity.user.PipelineUser;
@@ -48,9 +48,9 @@ import java.util.stream.Collectors;
 @Data
 @Slf4j
 @RequiredArgsConstructor
-public class RunToBillingRequestConverter implements EntityToBillingRequestConverter<PipelineRun> {
+public class RunToBillingRequestConverter implements EntityToBillingRequestConverter<PipelineRunWithType> {
 
-    private final EntityMapper<PipelineRunBillingInfo> mapper;
+    private final AbstractEntityMapper<PipelineRunBillingInfo> mapper;
 
     /**
      * Creates billing requests for given run
@@ -61,7 +61,7 @@ public class RunToBillingRequestConverter implements EntityToBillingRequestConve
      * @return list of requests to be performed (deletion index request if no billing requests created)
      */
     @Override
-    public List<DocWriteRequest> convertEntityToRequests(final EntityContainer<PipelineRun> runContainer,
+    public List<DocWriteRequest> convertEntityToRequests(final EntityContainer<PipelineRunWithType> runContainer,
                                                          final String indexPrefix,
                                                          final LocalDateTime previousSync,
                                                          final LocalDateTime syncStart) {
@@ -70,11 +70,12 @@ public class RunToBillingRequestConverter implements EntityToBillingRequestConve
             .collect(Collectors.toList());
     }
 
-    protected Collection<PipelineRunBillingInfo> convertRunToBillings(final EntityContainer<PipelineRun> runContainer,
-                                                                      final LocalDateTime previousSync,
-                                                                      final LocalDateTime syncStart) {
-        final BigDecimal pricePerHour = runContainer.getEntity().getPricePerHour();
-        final List<RunStatus> statuses = adjustStatuses(runContainer.getEntity().getRunStatuses(),
+    protected Collection<PipelineRunBillingInfo> convertRunToBillings(
+        final EntityContainer<PipelineRunWithType> runContainer,
+        final LocalDateTime previousSync,
+        final LocalDateTime syncStart) {
+        final BigDecimal pricePerHour = runContainer.getEntity().getPipelineRun().getPricePerHour();
+        final List<RunStatus> statuses = adjustStatuses(runContainer.getEntity().getPipelineRun().getRunStatuses(),
                                                         previousSync,
                                                         syncStart);
 
@@ -104,7 +105,7 @@ public class RunToBillingRequestConverter implements EntityToBillingRequestConve
         return statuses;
     }
 
-    private List<PipelineRunBillingInfo> createBillingsForPeriod(final PipelineRun run,
+    private List<PipelineRunBillingInfo> createBillingsForPeriod(final PipelineRunWithType run,
                                                                  final BigDecimal pricePerHour,
                                                                  final List<RunStatus> statuses) {
         final List<PipelineRunBillingInfo> billings = new ArrayList<>();
@@ -135,7 +136,7 @@ public class RunToBillingRequestConverter implements EntityToBillingRequestConve
 
     private List<PipelineRunBillingInfo> createRunBillingsForActivePeriod(final LocalDateTime start,
                                                                           final LocalDateTime end,
-                                                                          final PipelineRun run,
+                                                                          final PipelineRunWithType run,
                                                                           final BigDecimal pricePerHour) {
         final List<LocalDateTime> timePoints = new ArrayList<>();
         final List<PipelineRunBillingInfo> billings = new ArrayList<>();

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapper.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 
 @Component
 @NoArgsConstructor
-public class RunBillingMapper implements EntityMapper<PipelineRunBillingInfo> {
+public class RunBillingMapper extends EntityMapper<PipelineRunBillingInfo> {
 
     @Override
     public XContentBuilder map(final EntityContainer<PipelineRunBillingInfo> container) {
@@ -53,7 +53,6 @@ public class RunBillingMapper implements EntityMapper<PipelineRunBillingInfo> {
                 .field("usage", billingInfo.getUsageMinutes())
                 .field("run_price", run.getPricePerHour().unscaledValue().longValue())
                 .field("cloudRegionId", run.getInstance().getCloudRegionId())
-                .field("billing_center", "TBD")
                 .field("created_date", billingInfo.getDate());
             buildUserContent(container.getOwner(), jsonBuilder);
             jsonBuilder.endObject();

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapper.java
@@ -20,9 +20,8 @@ import static com.epam.pipeline.billingreportagent.service.ElasticsearchSynchron
 
 import com.epam.pipeline.billingreportagent.model.EntityContainer;
 import com.epam.pipeline.billingreportagent.model.billing.PipelineRunBillingInfo;
-import com.epam.pipeline.billingreportagent.service.EntityMapper;
+import com.epam.pipeline.billingreportagent.service.AbstractEntityMapper;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
-import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.search.SearchDocumentType;
 import lombok.NoArgsConstructor;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -33,13 +32,13 @@ import java.io.IOException;
 
 @Component
 @NoArgsConstructor
-public class RunBillingMapper extends EntityMapper<PipelineRunBillingInfo> {
+public class RunBillingMapper extends AbstractEntityMapper<PipelineRunBillingInfo> {
 
     @Override
     public XContentBuilder map(final EntityContainer<PipelineRunBillingInfo> container) {
         try (XContentBuilder jsonBuilder = XContentFactory.jsonBuilder()) {
             final PipelineRunBillingInfo billingInfo = container.getEntity();
-            final PipelineRun run = billingInfo.getEntity();
+            final PipelineRun run = billingInfo.getEntity().getPipelineRun();
             jsonBuilder
                 .startObject()
                 .field(DOC_TYPE_FIELD, SearchDocumentType.PIPELINE_RUN.name())
@@ -48,7 +47,7 @@ public class RunBillingMapper extends EntityMapper<PipelineRunBillingInfo> {
                 .field("pipeline", run.getPipelineName())
                 .field("tool", run.getDockerImage())
                 .field("instance_type", run.getInstance().getNodeType())
-                .field("compute_type", getComputeType(run.getInstance()))
+                .field("compute_type", billingInfo.getEntity().getRunType())
                 .field("cost", billingInfo.getCost())
                 .field("usage", billingInfo.getUsageMinutes())
                 .field("run_price", run.getPricePerHour().unscaledValue().longValue())
@@ -60,10 +59,5 @@ public class RunBillingMapper extends EntityMapper<PipelineRunBillingInfo> {
         } catch (IOException e) {
             throw new IllegalArgumentException("Failed to create elasticsearch document for pipeline run: ", e);
         }
-    }
-
-    private String getComputeType(final RunInstance instance) {
-        // TODO parse real compute type (CPU, GPU)
-        return instance.getNodeType();
     }
 }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapper.java
@@ -20,7 +20,7 @@ import static com.epam.pipeline.billingreportagent.service.ElasticsearchSynchron
 
 import com.epam.pipeline.billingreportagent.model.EntityContainer;
 import com.epam.pipeline.billingreportagent.model.billing.StorageBillingInfo;
-import com.epam.pipeline.billingreportagent.service.EntityMapper;
+import com.epam.pipeline.billingreportagent.service.AbstractEntityMapper;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.search.SearchDocumentType;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +30,7 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import java.io.IOException;
 
 @RequiredArgsConstructor
-public class StorageBillingMapper extends EntityMapper<StorageBillingInfo> {
+public class StorageBillingMapper extends AbstractEntityMapper<StorageBillingInfo> {
 
     private final SearchDocumentType documentType;
 

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapper.java
@@ -30,7 +30,7 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import java.io.IOException;
 
 @RequiredArgsConstructor
-public class StorageBillingMapper implements EntityMapper<StorageBillingInfo> {
+public class StorageBillingMapper extends EntityMapper<StorageBillingInfo> {
 
     private final SearchDocumentType documentType;
 
@@ -47,7 +47,6 @@ public class StorageBillingMapper implements EntityMapper<StorageBillingInfo> {
                 .field("region", billingInfo.getRegionName())
                 .field("provider", storage.getType())
                 .field("storage_type", billingInfo.getStorageType())
-                .field("billing_center", "TBD")
                 .field("usage", billingInfo.getUsageBytes())
                 .field("cost", billingInfo.getCost())
                 .field("created_date", billingInfo.getDate());

--- a/billing-report-agent/src/main/resources/application.properties
+++ b/billing-report-agent/src/main/resources/application.properties
@@ -13,6 +13,7 @@ sync.last.synchronization.file=lastSynchronizationTime.txt
 sync.submit.threads=1
 sync.billing.schedule=0 0 0 ? * *
 sync.bulk.insert.size=1000
+sync.billing.center.key=
 
 #Pipeline Run Settings
 #sync.run.disable=true

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverterImplTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverterImplTest.java
@@ -16,7 +16,9 @@
 
 package com.epam.pipeline.billingreportagent.service.impl.converter;
 
+import com.epam.pipeline.billingreportagent.model.ComputeType;
 import com.epam.pipeline.billingreportagent.model.EntityContainer;
+import com.epam.pipeline.billingreportagent.model.PipelineRunWithType;
 import com.epam.pipeline.billingreportagent.model.ResourceType;
 import com.epam.pipeline.billingreportagent.model.billing.PipelineRunBillingInfo;
 import com.epam.pipeline.billingreportagent.service.impl.TestUtils;
@@ -35,6 +37,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -57,6 +60,7 @@ public class RunToBillingRequestConverterImplTest {
     private final PipelineUser testUser = PipelineUser.builder()
         .userName(USER_NAME)
         .groups(USER_GROUPS)
+        .attributes(Collections.emptyMap())
         .build();
 
     private final RunToBillingRequestConverter converter =
@@ -78,7 +82,8 @@ public class RunToBillingRequestConverterImplTest {
         statuses.add(new RunStatus(RUN_ID, TaskStatus.STOPPED, LocalDateTime.of(2019, 12, 4, 15, 0)));
         run.setRunStatuses(statuses);
 
-        final EntityContainer<PipelineRun> runContainer = EntityContainer.<PipelineRun>builder().entity(run).build();
+        final EntityContainer<PipelineRunWithType> runContainer = EntityContainer.<PipelineRunWithType>builder()
+            .entity(new PipelineRunWithType(run, ComputeType.CPU)).build();
         final Collection<PipelineRunBillingInfo> billings =
             converter.convertRunToBillings(runContainer,
                                            LocalDateTime.of(2019, 12, 1, 0, 0),
@@ -96,7 +101,8 @@ public class RunToBillingRequestConverterImplTest {
         final PipelineRun run = new PipelineRun();
         run.setId(RUN_ID);
         run.setPricePerHour(BigDecimal.valueOf(4, 2));
-        final EntityContainer<PipelineRun> runContainer = EntityContainer.<PipelineRun>builder().entity(run).build();
+        final EntityContainer<PipelineRunWithType> runContainer = EntityContainer.<PipelineRunWithType>builder()
+            .entity(new PipelineRunWithType(run, ComputeType.CPU)).build();
 
         final Collection<PipelineRunBillingInfo> billings =
             converter.convertRunToBillings(runContainer,
@@ -114,9 +120,9 @@ public class RunToBillingRequestConverterImplTest {
         final PipelineRun run = TestUtils.createTestPipelineRun(RUN_ID, PIPELINE_NAME, TOOL_IMAGE, PRICE,
                                                                 TestUtils.createTestInstance(REGION_ID, NODE_TYPE));
 
-        final EntityContainer<PipelineRun> runContainer =
-            EntityContainer.<PipelineRun>builder()
-                .entity(run)
+        final EntityContainer<PipelineRunWithType> runContainer =
+            EntityContainer.<PipelineRunWithType>builder()
+                .entity(new PipelineRunWithType(run, ComputeType.CPU))
                 .owner(testUser)
                 .build();
 

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapperTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapperTest.java
@@ -16,7 +16,9 @@
 
 package com.epam.pipeline.billingreportagent.service.impl.mapper;
 
+import com.epam.pipeline.billingreportagent.model.ComputeType;
 import com.epam.pipeline.billingreportagent.model.EntityContainer;
+import com.epam.pipeline.billingreportagent.model.PipelineRunWithType;
 import com.epam.pipeline.billingreportagent.model.ResourceType;
 import com.epam.pipeline.billingreportagent.model.billing.PipelineRunBillingInfo;
 import com.epam.pipeline.billingreportagent.service.impl.TestUtils;
@@ -30,6 +32,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -53,6 +56,7 @@ public class RunBillingMapperTest {
     private final PipelineUser testUser = PipelineUser.builder()
         .userName(TEST_USER_NAME)
         .groups(TEST_GROUPS)
+        .attributes(Collections.emptyMap())
         .build();
 
     @Test
@@ -61,7 +65,7 @@ public class RunBillingMapperTest {
             TestUtils.createTestPipelineRun(TEST_RUN_ID, TEST_PIPELINE, TEST_TOOL_IMAGE, TEST_PRICE,
                                             TestUtils.createTestInstance(TEST_REGION_ID, TEST_NODE_TYPE));
         final PipelineRunBillingInfo billing = PipelineRunBillingInfo.builder()
-            .run(run)
+            .run(new PipelineRunWithType(run, ComputeType.CPU))
             .date(TEST_DATE)
             .cost(TEST_COST)
             .usageMinutes(TEST_USAGE_MINUTES)

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.epam.pipeline.client.pipeline;
 
+import com.epam.pipeline.entity.cluster.InstanceType;
 import com.epam.pipeline.entity.cluster.NodeInstance;
 import com.epam.pipeline.entity.configuration.RunConfiguration;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
@@ -55,7 +56,6 @@ import retrofit2.http.Part;
 import retrofit2.http.Path;
 import retrofit2.http.Query;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 public interface CloudPipelineAPI {
@@ -74,6 +74,7 @@ public interface CloudPipelineAPI {
     String PATH = "path";
     String FROM = "from";
     String TO = "to";
+    String REGION_ID = "regionId";
 
     @POST("run/{runId}/status")
     Call<Result<PipelineRun>> updateRunStatus(@Path(RUN_ID) Long runId,
@@ -202,4 +203,7 @@ public interface CloudPipelineAPI {
 
     @GET("run/activity")
     Call<Result<List<PipelineRun>>> loadRunsActivityStats(@Query(FROM) String from, @Query(TO) String to);
+
+    @GET("cluster/instance/loadAll")
+    Call<Result<List<InstanceType>>> loadAllInstanceTypesForRegion(@Query(REGION_ID) Long regionId);
 }


### PR DESCRIPTION
This PR is related to issue #761

It brings proceeding of `billing_center` and `compute_type` fields.

- billing center is taken from the owner's attributes
- compute type is identified by comparing run instance node type with instance offers from its region