### PR TITLE
Issue #761 Accumulated cost calculation for requests with interval

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/billing/BillingChartInfo.java
+++ b/api/src/main/java/com/epam/pipeline/entity/billing/BillingChartInfo.java
@@ -30,4 +30,5 @@ public class BillingChartInfo {
     private LocalDateTime periodStart;
     private LocalDateTime periodEnd;
     private Long cost;
+    private Long accumulatedCost;
 }

--- a/api/src/main/java/com/epam/pipeline/manager/BillingManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/BillingManager.java
@@ -43,6 +43,8 @@ import org.elasticsearch.search.aggregations.bucket.histogram.ParsedDateHistogra
 import org.elasticsearch.search.aggregations.bucket.terms.ParsedStringTerms;
 import org.elasticsearch.search.aggregations.metrics.sum.ParsedSum;
 import org.elasticsearch.search.aggregations.metrics.sum.SumAggregationBuilder;
+import org.elasticsearch.search.aggregations.pipeline.ParsedSimpleValue;
+import org.elasticsearch.search.aggregations.pipeline.PipelineAggregatorBuilders;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -71,6 +73,7 @@ import java.util.stream.Stream;
 public class BillingManager {
 
     private static final String COST_FIELD = "cost";
+    private static final String ACCUMULATED_COST = "accumulatedCost";
     private static final String BILLING_DATE_FIELD = "created_date";
     private static final String HISTOGRAM_AGGREGATION_NAME = "hist_agg";
     private static final String ES_MONTHLY_DATE_REGEXP = "%d-%02d-*";
@@ -149,7 +152,8 @@ public class BillingManager {
             HISTOGRAM_AGGREGATION_NAME)
             .field(BILLING_DATE_FIELD)
             .dateHistogramInterval(interval)
-            .subAggregation(costAggregation);
+            .subAggregation(costAggregation)
+            .subAggregation(PipelineAggregatorBuilders.cumulativeSum(ACCUMULATED_COST, COST_FIELD));
 
         searchSource.aggregation(intervalAgg);
 
@@ -258,6 +262,9 @@ public class BillingManager {
         final ParsedSum sumAggResult = bucket.getAggregations().get(COST_FIELD);
         final long costVal = new Double(sumAggResult.getValue()).longValue();
         builder.cost(costVal);
+        final ParsedSimpleValue accumulatedSumAggResult = bucket.getAggregations().get(ACCUMULATED_COST);
+        final long accumulatedCostVal = new Double(accumulatedSumAggResult.getValueAsString()).longValue();
+        builder.accumulatedCost(accumulatedCostVal);
         final DateTime date = (DateTime) bucket.getKey();
         final LocalDate periodStart = LocalDate.of(date.getYear(), date.getMonthOfYear(), date.getDayOfMonth());
         builder.periodStart(periodStart.atStartOfDay());


### PR DESCRIPTION
This PR is related to issue #761

It brings additional `accumulatedCost` field in response to requests with interval value enabled, which is used for charts building.

- `cumulativeSum` sub aggregation for results of `cost` aggregation is used