### PR TITLE
Issue #761 Use pipeline id instead of name in run billing docs.

### DIFF
--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapper.java
@@ -44,7 +44,7 @@ public class RunBillingMapper extends AbstractEntityMapper<PipelineRunBillingInf
                 .field(DOC_TYPE_FIELD, SearchDocumentType.PIPELINE_RUN.name())
                 .field("id", run.getId())
                 .field("resource_type", billingInfo.getResourceType())
-                .field("pipeline", run.getPipelineName())
+                .field("pipeline", run.getPipelineId())
                 .field("tool", run.getDockerImage())
                 .field("instance_type", run.getInstance().getNodeType())
                 .field("compute_type", billingInfo.getEntity().getRunType())

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/TestUtils.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/TestUtils.java
@@ -64,11 +64,11 @@ public final class TestUtils {
         return parser.map();
     }
 
-    public static PipelineRun createTestPipelineRun(final Long runId, final String pipeline, final String tool,
+    public static PipelineRun createTestPipelineRun(final Long runId, final Long pipelineId, final String tool,
                                                     final BigDecimal price, final RunInstance instance) {
         final PipelineRun run = new PipelineRun();
         run.setId(runId);
-        run.setPipelineName(pipeline);
+        run.setPipelineId(pipelineId);
         run.setDockerImage(tool);
         run.setPricePerHour(price);
         run.setInstance(instance);

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/AwsStorageToRequestConverterTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/AwsStorageToRequestConverterTest.java
@@ -94,6 +94,7 @@ public class AwsStorageToRequestConverterTest {
     private final PipelineUser testUser = PipelineUser.builder()
         .userName(USER_NAME)
         .groups(USER_GROUPS)
+        .attributes(Collections.emptyMap())
         .build();
 
     private ElasticsearchServiceClient elasticsearchClient = Mockito.mock(ElasticsearchServiceClient.class);

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverterImplTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverterImplTest.java
@@ -46,13 +46,13 @@ import java.util.stream.Collectors;
 @SuppressWarnings("checkstyle:magicnumber")
 public class RunToBillingRequestConverterImplTest {
 
-    private static final long REGION_ID = 1;
+    private static final Long REGION_ID = 1L;
     private static final String NODE_TYPE = "nodetype.medium";
     private static final Long RUN_ID = 1L;
     private static final String USER_NAME = "TestUser";
     private static final String GROUP_1 = "TestGroup1";
     private static final String GROUP_2 = "TestGroup2";
-    private static final String PIPELINE_NAME = "TestPipeline";
+    private static final Long PIPELINE_ID = 1L;
     private static final String TOOL_IMAGE = "cp/tool:latest";
     private static final BigDecimal PRICE = BigDecimal.valueOf(4, 2);
     private static final List<String> USER_GROUPS = java.util.Arrays.asList(GROUP_1, GROUP_2);
@@ -117,7 +117,7 @@ public class RunToBillingRequestConverterImplTest {
 
     @Test
     public void testRunConverting() {
-        final PipelineRun run = TestUtils.createTestPipelineRun(RUN_ID, PIPELINE_NAME, TOOL_IMAGE, PRICE,
+        final PipelineRun run = TestUtils.createTestPipelineRun(RUN_ID, PIPELINE_ID, TOOL_IMAGE, PRICE,
                                                                 TestUtils.createTestInstance(REGION_ID, NODE_TYPE));
 
         final EntityContainer<PipelineRunWithType> runContainer =
@@ -138,7 +138,7 @@ public class RunToBillingRequestConverterImplTest {
         Assert.assertEquals(expectedIndex, billing.index());
         Assert.assertEquals(run.getId().intValue(), requestFieldsMap.get("id"));
         Assert.assertEquals(ResourceType.COMPUTE.toString(), requestFieldsMap.get("resource_type"));
-        Assert.assertEquals(run.getPipelineName(), requestFieldsMap.get("pipeline"));
+        Assert.assertEquals(run.getPipelineId().intValue(), requestFieldsMap.get("pipeline"));
         Assert.assertEquals(run.getDockerImage(), requestFieldsMap.get("tool"));
         Assert.assertEquals(run.getInstance().getNodeType(), requestFieldsMap.get("instance_type"));
         Assert.assertEquals(9600, requestFieldsMap.get("cost"));

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapperTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapperTest.java
@@ -38,17 +38,17 @@ import java.util.Map;
 
 public class RunBillingMapperTest {
 
-    private static final String TEST_PIPELINE = "TestPipeline";
+    private static final Long TEST_PIPELINE_ID = 1L;
     private static final String TEST_USER_NAME = "User";
     private static final String TEST_TOOL_IMAGE = "cp/tool:latest";
     private static final String TEST_NODE_TYPE = "nodetype.medium";
     private static final String TEST_GROUP_1 = "TestGroup1";
     private static final String TEST_GROUP_2 = "TestGroup2";
-    private static final long TEST_COST = 10;
-    private static final long TEST_RUN_ID = 1;
-    private static final long TEST_REGION_ID = 1;
+    private static final Long TEST_COST = 10L;
+    private static final Long TEST_RUN_ID = 1L;
+    private static final Long TEST_REGION_ID = 1L;
     private static final BigDecimal TEST_PRICE = BigDecimal.ONE;
-    private static final long TEST_USAGE_MINUTES = 600;
+    private static final Long TEST_USAGE_MINUTES = 600L;
     private static final List<String> TEST_GROUPS = Arrays.asList(TEST_GROUP_1, TEST_GROUP_2);
     private static final LocalDate TEST_DATE = LocalDate.now();
 
@@ -62,7 +62,7 @@ public class RunBillingMapperTest {
     @Test
     public void testRunMapperMap() throws IOException {
         final PipelineRun run =
-            TestUtils.createTestPipelineRun(TEST_RUN_ID, TEST_PIPELINE, TEST_TOOL_IMAGE, TEST_PRICE,
+            TestUtils.createTestPipelineRun(TEST_RUN_ID, TEST_PIPELINE_ID, TEST_TOOL_IMAGE, TEST_PRICE,
                                             TestUtils.createTestInstance(TEST_REGION_ID, TEST_NODE_TYPE));
         final PipelineRunBillingInfo billing = PipelineRunBillingInfo.builder()
             .run(new PipelineRunWithType(run, ComputeType.CPU))
@@ -80,15 +80,15 @@ public class RunBillingMapperTest {
 
         final Map<String, Object> mappedFields = TestUtils.getPuttedObject(mappedBilling);
 
-        Assert.assertEquals((int) TEST_RUN_ID, mappedFields.get("id"));
+        Assert.assertEquals(TEST_RUN_ID.intValue(), mappedFields.get("id"));
         Assert.assertEquals(ResourceType.COMPUTE.toString(), mappedFields.get("resource_type"));
-        Assert.assertEquals(TEST_PIPELINE, mappedFields.get("pipeline"));
+        Assert.assertEquals(TEST_PIPELINE_ID.intValue(), mappedFields.get("pipeline"));
         Assert.assertEquals(TEST_TOOL_IMAGE, mappedFields.get("tool"));
         Assert.assertEquals(TEST_NODE_TYPE, mappedFields.get("instance_type"));
-        Assert.assertEquals((int) TEST_COST, mappedFields.get("cost"));
-        Assert.assertEquals((int) TEST_USAGE_MINUTES, mappedFields.get("usage"));
+        Assert.assertEquals(TEST_COST.intValue(), mappedFields.get("cost"));
+        Assert.assertEquals(TEST_USAGE_MINUTES.intValue(), mappedFields.get("usage"));
         Assert.assertEquals(run.getPricePerHour().intValue(), mappedFields.get("run_price"));
-        Assert.assertEquals((int) TEST_REGION_ID, mappedFields.get("cloudRegionId"));
+        Assert.assertEquals(TEST_REGION_ID.intValue(), mappedFields.get("cloudRegionId"));
         Assert.assertEquals(TEST_USER_NAME, mappedFields.get("owner"));
         TestUtils.verifyStringArray(TEST_GROUPS, mappedFields.get("groups"));
     }

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapperTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapperTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -54,6 +55,7 @@ public class StorageBillingMapperTest {
     private final PipelineUser testUser = PipelineUser.builder()
         .userName(TEST_USER_NAME)
         .groups(TEST_GROUPS)
+        .attributes(Collections.emptyMap())
         .build();
 
     @Test


### PR DESCRIPTION
This PR is related to issue #761

It fixes `null` value in `pipeline` field of run billings. 
Pipeline's name is not returned, because the corresponding method used in PipelineRunDao doesn't extract pipeline's name for a run.