### PR TITLE
Handle dead additional workers in GE autoscaler

### DIFF
--- a/workflows/pipe-common/pipeline/api/api.py
+++ b/workflows/pipe-common/pipeline/api/api.py
@@ -248,7 +248,7 @@ class PipelineAPI:
                     result = response.json()
                     return result['payload'] if 'payload' in result else None
             except Exception as e:
-                sys.stderr.write('An error has occurred during request to API: {}', str(e.message))
+                sys.stderr.write('An error has occurred during request to API: {}'.format(str(e.message)))
             time.sleep(self.timeout)
         raise RuntimeError('Exceeded maximum retry count {} for API request'.format(self.attempts))
 

--- a/workflows/pipe-common/scripts/autoscale_sge.py
+++ b/workflows/pipe-common/scripts/autoscale_sge.py
@@ -488,7 +488,7 @@ class GridEngineScaleUpHandler:
             return name
         else:
             error_msg = 'Worker with run_id=%s has no pod name specified.'
-            Logger.warn(error_msg)
+            Logger.warn(error_msg, crucial=True)
             raise ScalingError(error_msg)
 
     def _await_pod_initialization(self, run_id):
@@ -506,7 +506,7 @@ class GridEngineScaleUpHandler:
             attempts -= 1
             time.sleep(self.polling_delay)
         error_msg = 'Pod with run_id=%s hasn\'t started after %s seconds.' % (run_id, self.polling_timeout)
-        Logger.warn(error_msg)
+        Logger.warn(error_msg, crucial=True)
         raise ScalingError(error_msg)
 
     def _add_worker_to_master_hosts(self, pod):
@@ -527,7 +527,7 @@ class GridEngineScaleUpHandler:
             attempts -= 1
             time.sleep(self.polling_delay)
         error_msg = 'Additional worker hasn\'t been initialized after %s seconds.' % self.polling_timeout
-        Logger.warn(error_msg)
+        Logger.warn(error_msg, crucial=True)
         raise ScalingError(error_msg)
 
     def _increase_parallel_environment_slots(self, slots_to_append):
@@ -857,7 +857,7 @@ class GridEngineWorkerValidator:
             if (not self.grid_engine.is_valid(host)) or (not self._is_running(run_id)):
                 invalid_hosts.append((host, run_id))
         for host, run_id in invalid_hosts:
-            Logger.warn('Invalid additional host %s was found. It will be downscaled.' % host)
+            Logger.warn('Invalid additional host %s was found. It will be downscaled.' % host, crucial=True)
             self._try_stop_worker(run_id)
             self._try_disable_worker(host, run_id)
             self._try_kill_invalid_host_jobs(host)
@@ -926,7 +926,7 @@ class GridEngineAutoscalingDaemon:
                 Logger.warn('Manual stop of the autoscaler daemon.')
                 break
             except Exception as e:
-                Logger.warn('Scaling step has failed due to %s.' % e)
+                Logger.warn('Scaling step has failed due to %s.' % e, crucial=True)
 
 
 def make_dirs(path):

--- a/workflows/pipe-common/scripts/autoscale_sge.py
+++ b/workflows/pipe-common/scripts/autoscale_sge.py
@@ -488,7 +488,7 @@ class GridEngineScaleUpHandler:
             return name
         else:
             error_msg = 'Worker with run_id=%s has no pod name specified.'
-            Logger.fail(error_msg)
+            Logger.warn(error_msg)
             raise ScalingError(error_msg)
 
     def _await_pod_initialization(self, run_id):
@@ -506,7 +506,7 @@ class GridEngineScaleUpHandler:
             attempts -= 1
             time.sleep(self.polling_delay)
         error_msg = 'Pod with run_id=%s hasn\'t started after %s seconds.' % (run_id, self.polling_timeout)
-        Logger.fail(error_msg)
+        Logger.warn(error_msg)
         raise ScalingError(error_msg)
 
     def _add_worker_to_master_hosts(self, pod):
@@ -527,7 +527,7 @@ class GridEngineScaleUpHandler:
             attempts -= 1
             time.sleep(self.polling_delay)
         error_msg = 'Additional worker hasn\'t been initialized after %s seconds.' % self.polling_timeout
-        Logger.fail(error_msg)
+        Logger.warn(error_msg)
         raise ScalingError(error_msg)
 
     def _increase_parallel_environment_slots(self, slots_to_append):
@@ -923,10 +923,10 @@ class GridEngineAutoscalingDaemon:
                 self.worker_validator.validate_hosts()
                 self.autoscaler.scale()
             except KeyboardInterrupt:
-                Logger.warn('Manual stop the autoscaler daemon.')
+                Logger.warn('Manual stop of the autoscaler daemon.')
                 break
             except Exception as e:
-                Logger.fail('Scaling step has failed due to %s.' % e)
+                Logger.warn('Scaling step has failed due to %s.' % e)
 
 
 def make_dirs(path):

--- a/workflows/pipe-common/scripts/autoscale_sge.py
+++ b/workflows/pipe-common/scripts/autoscale_sge.py
@@ -568,8 +568,8 @@ class GridEngineScaleDownHandler:
             Logger.info('Enable additional worker with host=%s again.' % child_host)
             self.grid_engine.enable_host(child_host)
             return False
-        self._decrease_parallel_environment_slots(self.instance_cores)
         self._remove_host_from_grid_engine_configuration(child_host)
+        self._decrease_parallel_environment_slots(self.instance_cores)
         self._stop_pipeline(child_host)
         self._remove_host_from_hosts(child_host)
         self._remove_host_from_default_hostfile(child_host)

--- a/workflows/pipe-common/scripts/autoscale_sge.py
+++ b/workflows/pipe-common/scripts/autoscale_sge.py
@@ -95,8 +95,8 @@ class CmdExecutor:
         out, err = process.communicate()
         exit_code = process.wait()
         if exit_code != 0:
-            Logger.warn('Command \'%s\' execution has failed due to %s.' % (command, err))
-            raise ExecutionError('Command \'%s\' execution has failed due to %s.' % (command, err))
+            Logger.warn('Command \'%s\' execution has failed due to %s.' % (command, err.rstrip()))
+            raise ExecutionError('Command \'%s\' execution has failed due to %s.' % (command, err.rstrip()))
         return out
 
     def execute_to_lines(self, command):

--- a/workflows/pipe-common/scripts/autoscale_sge.py
+++ b/workflows/pipe-common/scripts/autoscale_sge.py
@@ -885,7 +885,7 @@ class GridEngineWorkerValidator:
             Logger.warn('Additional host with run_id=%s status is not running but %s.' % (run_id, status))
             return False
         except:
-            Logger.warn('Additional host with run_id=%s status retrieving has failed.')
+            Logger.warn('Additional host with run_id=%s status retrieving has failed.' % run_id)
             return False
 
     def _try_stop_worker(self, run_id):

--- a/workflows/pipe-common/scripts/autoscale_sge.py
+++ b/workflows/pipe-common/scripts/autoscale_sge.py
@@ -158,6 +158,7 @@ class GridEngine:
     _REMOVE_HOST_FROM_HOST_GROUP = 'qconf -dattr hostgroup hostlist %s %s'
     _REMOVE_HOST_FROM_QUEUE_SETTINGS = 'qconf -purge queue slots %s@%s'
     _SHUTDOWN_HOST_EXECUTION_DAEMON = 'qconf -ke %s'
+    _REMOVE_HOST_FROM_ADMINISTRATIVE_HOSTS = 'qconf -dh %s'
     _QSTAT = 'qstat -u "*"'
     _QSTAT_DATETIME_FORMAT = '%m/%d/%Y %H:%M:%S'
     _QSTAT_COLUMNS = ['job-ID', 'prior', 'name', 'user', 'state', 'submit/start at', 'queue', 'slots', 'ja-task-ID']
@@ -280,7 +281,8 @@ class GridEngine:
         1. Shutdown host execution daemon.
         2. Removes host from queue settings.
         3. Removes host from host group.
-        4. Removes host from GE.
+        4. Removes host from administrative hosts.
+        5. Removes host from GE.
 
         :param host: Host to be removed.
         :param queue: Queue host is a part of.
@@ -291,6 +293,7 @@ class GridEngine:
         self._shutdown_execution_host(host, skip_on_failure=skip_on_failure)
         self._remove_host_from_queue_settings(host, queue, skip_on_failure=skip_on_failure)
         self._remove_host_from_host_group(host, hostgroup, skip_on_failure=skip_on_failure)
+        self._remove_host_from_administrative_hosts(host, skip_on_failure=skip_on_failure)
         self._remove_host_from_grid_engine(host, skip_on_failure=skip_on_failure)
 
     def _shutdown_execution_host(self, host, skip_on_failure):
@@ -322,6 +325,14 @@ class GridEngine:
             action=lambda: self.cmd_executor.execute(GridEngine._DELETE_HOST % host),
             msg='Remove host from GE.',
             error_msg='Removing host from GE has failed.',
+            skip_on_failure=skip_on_failure
+        )
+
+    def _remove_host_from_administrative_hosts(self, host, skip_on_failure):
+        self._perform_command(
+            action=lambda: self.cmd_executor.execute(GridEngine._REMOVE_HOST_FROM_ADMINISTRATIVE_HOSTS % host),
+            msg='Remove host from list of administrative hosts.',
+            error_msg='Removing host from list of administrative hosts has failed.',
             skip_on_failure=skip_on_failure
         )
 

--- a/workflows/pipe-common/test/test_worker_validator.py
+++ b/workflows/pipe-common/test/test_worker_validator.py
@@ -17,9 +17,12 @@ from mock import Mock, MagicMock
 from scripts.autoscale_sge import GridEngineWorkerValidator, MemoryHostStorage, GridEngineJob
 from utils import assert_first_argument_contained, assert_first_argument_not_contained
 
-HOST1 = 'HOST1'
-HOST2 = 'HOST2'
-HOST3 = 'HOST3'
+HOST1 = 'HOST-1'
+HOST2 = 'HOST-2'
+HOST3 = 'HOST-3'
+HOST1_RUN_ID = '1'
+HOST2_RUN_ID = '2'
+HOST3_RUN_ID = '3'
 
 executor = Mock()
 host_storage = MemoryHostStorage()
@@ -34,11 +37,11 @@ def setup_function():
     host_storage.clear()
     for host in [HOST1, HOST2, HOST3]:
         host_storage.add_host(host)
-    executor.execute = MagicMock()
+    executor.execute = MagicMock(return_value='RUNNING')
     grid_engine.is_valid = MagicMock(side_effect=[True, False, True])
     grid_engine.get_jobs = MagicMock(return_value=[])
     grid_engine.kill_jobs = MagicMock()
-    scale_down_handler._get_run_id_from_host = MagicMock(side_effect=lambda x: x)
+    scale_down_handler._get_run_id_from_host = MagicMock(side_effect=[HOST1_RUN_ID, HOST2_RUN_ID, HOST3_RUN_ID])
 
 
 def test_stopping_hosts_that_are_invalid_in_grid_engine():
@@ -50,10 +53,9 @@ def test_stopping_hosts_that_are_invalid_in_grid_engine():
 def test_stopping_invalid_worker_pipeline():
     worker_validator.validate_hosts()
 
-    assert_first_argument_contained(executor.execute, 'pipe stop ')
-    assert_first_argument_contained(executor.execute, HOST2)
-    assert_first_argument_not_contained(executor.execute, HOST1)
-    assert_first_argument_not_contained(executor.execute, HOST3)
+    assert_first_argument_contained(executor.execute, 'pipe stop --yes ' + HOST2_RUN_ID)
+    assert_first_argument_not_contained(executor.execute, 'pipe stop --yes ' + HOST1_RUN_ID)
+    assert_first_argument_not_contained(executor.execute, 'pipe stop --yes ' + HOST3_RUN_ID)
 
 
 def test_force_killing_invalid_host_jobs():
@@ -63,3 +65,11 @@ def test_force_killing_invalid_host_jobs():
     worker_validator.validate_hosts()
 
     grid_engine.kill_jobs.assert_called_with(jobs, force=True)
+
+
+def test_stopping_dead_worker_hosts():
+    executor.execute = MagicMock(side_effect=['STOPPED', 'RUNNING', 'FAILURE'])
+    grid_engine.is_valid = MagicMock(return_value=True)
+    worker_validator.validate_hosts()
+
+    assert [HOST2] == host_storage.load_hosts()


### PR DESCRIPTION
Resolves issue #946.

The following pull request brings support for so called dead additional workers handling. From now on Grid Engine Autoscaler will consider not running workers or unheard workers (see #494) as invalid ones and remove them from an autoscaled cluster.

Several minor updates were performed as well. Firstly parallel environment slots reduction was moved after the host removal from grid engine in order to prevent any possible issues regarding parallel environment slots. Secondly the pull request resolves minor pipe-commons errors formatting bug and improves grid engine autoscaler logs formatting. Also error log messages were replaced with warning log messages because it makes more sense since grid engine autoscaler keeps working besides the errors. Moreover the pull request adds host removal from a list of administrative hosts on scaling down.