### PR TITLE
Issue 911 api method to load all objects with permissions

### DIFF
--- a/api/src/main/java/com/epam/pipeline/controller/entity/EntityController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/entity/EntityController.java
@@ -36,6 +36,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import java.util.List;
+import java.util.Map;
 
 @Controller
 @Api(value = "Entities")
@@ -66,7 +67,7 @@ public class EntityController extends AbstractRestController {
     @ApiResponses(
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
             })
-    public Result<List<AbstractSecuredEntity>> loadEntities(@RequestBody AclSid aclSid) {
+    public Result<Map<AclClass, List<AbstractSecuredEntity>>> loadEntities(@RequestBody AclSid aclSid) {
         return Result.success(entityApiService.loadAvailable(aclSid));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/entity/EntityController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/entity/EntityController.java
@@ -67,7 +67,9 @@ public class EntityController extends AbstractRestController {
     @ApiResponses(
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
             })
-    public Result<Map<AclClass, List<AbstractSecuredEntity>>> loadEntities(@RequestBody AclSid aclSid) {
-        return Result.success(entityApiService.loadAvailable(aclSid));
+    public Result<Map<AclClass, List<AbstractSecuredEntity>>> loadEntities(
+            @RequestParam(required = false) final AclClass aclClass,
+            @RequestBody final AclSid aclSid) {
+        return Result.success(entityApiService.loadAvailable(aclSid, aclClass));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/entity/EntityController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/entity/EntityController.java
@@ -67,6 +67,6 @@ public class EntityController extends AbstractRestController {
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
             })
     public Result<List<AbstractSecuredEntity>> loadEntities(@RequestBody AclSid aclSid) {
-        return Result.success(entityApiService.loadEntitiesBySids(aclSid));
+        return Result.success(entityApiService.loadAvailable(aclSid));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/entity/EntityController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/entity/EntityController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import com.epam.pipeline.controller.AbstractRestController;
 import com.epam.pipeline.controller.Result;
 import com.epam.pipeline.entity.AbstractSecuredEntity;
 import com.epam.pipeline.entity.security.acl.AclClass;
+import com.epam.pipeline.entity.security.acl.AclSid;
 import com.epam.pipeline.manager.entity.EntityApiService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -29,8 +30,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.List;
 
 @Controller
 @Api(value = "Entities")
@@ -50,5 +55,18 @@ public class EntityController extends AbstractRestController {
             })
     public Result<AbstractSecuredEntity> loadEntity(@RequestParam String identifier, @RequestParam AclClass aclClass) {
         return Result.success(entityApiService.loadByNameOrId(aclClass, identifier));
+    }
+
+    @PostMapping(value = "entities")
+    @ResponseBody
+    @ApiOperation(
+            value = "Loads all entities with their permissions.",
+            notes = "Loads all entities with their permissions.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public Result<List<AbstractSecuredEntity>> loadEntities(@RequestBody AclSid aclSid) {
+        return Result.success(entityApiService.loadEntitiesBySids(aclSid));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/entity/docker/DockerRegistryList.java
+++ b/api/src/main/java/com/epam/pipeline/entity/docker/DockerRegistryList.java
@@ -77,8 +77,8 @@ public class DockerRegistryList extends AbstractHierarchicalEntity {
     @SuppressWarnings("unchecked")
     @Override
     public DockerRegistryList copyView() {
-       return new DockerRegistryList(
-                this.getRegistries().stream().map(DockerRegistry::copyView).collect(Collectors.toList())
+        return new DockerRegistryList(
+            this.getRegistries().stream().map(DockerRegistry::copyView).collect(Collectors.toList())
         );
     }
 }

--- a/api/src/main/java/com/epam/pipeline/entity/docker/DockerRegistryList.java
+++ b/api/src/main/java/com/epam/pipeline/entity/docker/DockerRegistryList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * {@link DockerRegistryList} represents a pseudo root entity for returning list of
@@ -71,5 +72,13 @@ public class DockerRegistryList extends AbstractHierarchicalEntity {
     @Override
     public AclClass getAclClass() {
         return AclClass.DOCKER_REGISTRY;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public DockerRegistryList copyView() {
+       return new DockerRegistryList(
+                this.getRegistries().stream().map(DockerRegistry::copyView).collect(Collectors.toList())
+        );
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/HierarchicalEntityManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/HierarchicalEntityManager.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager;
+
+import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.entity.AbstractHierarchicalEntity;
+import com.epam.pipeline.entity.AbstractSecuredEntity;
+import com.epam.pipeline.entity.security.acl.AclSid;
+import com.epam.pipeline.manager.docker.DockerRegistryManager;
+import com.epam.pipeline.manager.pipeline.FolderManager;
+import com.epam.pipeline.manager.security.GrantPermissionManager;
+import com.epam.pipeline.security.acl.AclPermission;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Service
+public class HierarchicalEntityManager {
+
+    @Autowired
+    private MessageHelper messageHelper;
+
+    @Autowired
+    private GrantPermissionManager permissionManager;
+
+    @Autowired
+    private FolderManager folderManager;
+
+    @Autowired
+    private DockerRegistryManager registryManager;
+
+    public List<AbstractSecuredEntity> loadAll(final AclSid aclSid) {
+        final List<AbstractHierarchicalEntity> allHierarchy =
+                Stream.of(folderManager.loadTree(), registryManager.loadAllRegistriesContent())
+                        .peek(h -> permissionManager.filterTree(aclSid, h, AclPermission.READ))
+                        .collect(Collectors.toList());
+
+        return flattenHierarchy(allHierarchy);
+    }
+
+    private List<AbstractSecuredEntity> flattenHierarchy(final List<? extends AbstractHierarchicalEntity> allHierarchy) {
+        final List<AbstractSecuredEntity> collector = new ArrayList<>();
+        flattenHierarchy(allHierarchy, collector);
+        return collector;
+    }
+
+    private void flattenHierarchy(final List<? extends AbstractHierarchicalEntity> allHierarchy,
+                                  final List<AbstractSecuredEntity> collector) {
+        if (CollectionUtils.isEmpty(allHierarchy)) {
+            return;
+        }
+
+        for (final AbstractHierarchicalEntity entity : allHierarchy) {
+            List<? extends AbstractHierarchicalEntity> children = entity.getChildren();
+
+            for (AbstractHierarchicalEntity child : children) {
+                AbstractHierarchicalEntity copyView = child.copyView();
+                collector.add(copyView);
+            }
+            collector.addAll(entity.getLeaves());
+            flattenHierarchy(children, collector);
+        }
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/entity/EntityApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/entity/EntityApiService.java
@@ -43,7 +43,7 @@ public class EntityApiService {
     }
 
     @PostAuthorize("hasRole('ADMIN')")
-    public Map<AclClass, List<AbstractSecuredEntity>> loadAvailable(final AclSid aclSid) {
-        return hierarchicalEntityManager.loadAvailable(aclSid);
+    public Map<AclClass, List<AbstractSecuredEntity>> loadAvailable(final AclSid aclSid, final AclClass aclClass) {
+        return hierarchicalEntityManager.loadAvailable(aclSid, aclClass);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/entity/EntityApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/entity/EntityApiService.java
@@ -23,10 +23,10 @@ import com.epam.pipeline.manager.EntityManager;
 import com.epam.pipeline.manager.HierarchicalEntityManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PostAuthorize;
-import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 
 @Service
 public class EntityApiService {
@@ -42,8 +42,8 @@ public class EntityApiService {
         return entityManager.loadByNameOrId(entityClass, identifier);
     }
 
-    @PostFilter("hasRole('ADMIN')")
-    public List<AbstractSecuredEntity> loadAvailable(final AclSid aclSid) {
+    @PostAuthorize("hasRole('ADMIN')")
+    public Map<AclClass, List<AbstractSecuredEntity>> loadAvailable(final AclSid aclSid) {
         return hierarchicalEntityManager.loadAvailable(aclSid);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/entity/EntityApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/entity/EntityApiService.java
@@ -23,6 +23,7 @@ import com.epam.pipeline.manager.EntityManager;
 import com.epam.pipeline.manager.HierarchicalEntityManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PostAuthorize;
+import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -41,7 +42,8 @@ public class EntityApiService {
         return entityManager.loadByNameOrId(entityClass, identifier);
     }
 
-    public List<AbstractSecuredEntity> loadEntitiesBySids(final AclSid aclSid) {
-        return hierarchicalEntityManager.loadAll(aclSid);
+    @PostFilter("hasRole('ADMIN')")
+    public List<AbstractSecuredEntity> loadAvailable(final AclSid aclSid) {
+        return hierarchicalEntityManager.loadAvailable(aclSid);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/entity/EntityApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/entity/EntityApiService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,14 @@ package com.epam.pipeline.manager.entity;
 
 import com.epam.pipeline.entity.AbstractSecuredEntity;
 import com.epam.pipeline.entity.security.acl.AclClass;
+import com.epam.pipeline.entity.security.acl.AclSid;
 import com.epam.pipeline.manager.EntityManager;
+import com.epam.pipeline.manager.HierarchicalEntityManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PostAuthorize;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class EntityApiService {
@@ -29,8 +33,15 @@ public class EntityApiService {
     @Autowired
     private EntityManager entityManager;
 
+    @Autowired
+    private HierarchicalEntityManager hierarchicalEntityManager;
+
     @PostAuthorize("hasRole('ADMIN') OR @grantPermissionManager.entityPermission(returnObject, 'READ')")
     public AbstractSecuredEntity loadByNameOrId(AclClass entityClass, String identifier) {
         return entityManager.loadByNameOrId(entityClass, identifier);
+    }
+
+    public List<AbstractSecuredEntity> loadEntitiesBySids(final AclSid aclSid) {
+        return hierarchicalEntityManager.loadAll(aclSid);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionManager.java
@@ -366,6 +366,14 @@ public class GrantPermissionManager {
         filterTree(getSids(), entity, permission);
     }
 
+    public void filterTree(AclSid aclSid, AbstractHierarchicalEntity entity, Permission permission) {
+        if (aclSid.isPrincipal()) {
+            filterTree(aclSid.getName(), entity, permission);
+        } else {
+            filterTree(Collections.singletonList(new GrantedAuthoritySid(aclSid.getName())), entity, permission);
+        }
+    }
+
     public void filterTree(String userName, AbstractHierarchicalEntity entity, Permission permission) {
         filterTree(convertUserToSids(userName), entity, permission);
     }

--- a/api/src/test/java/com/epam/pipeline/manager/HierarchicalEntityManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/HierarchicalEntityManagerTest.java
@@ -59,7 +59,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static com.epam.pipeline.manager.ObjectCreatorUtils.*;
 
 @DirtiesContext
 @Transactional
@@ -122,16 +121,18 @@ public class HierarchicalEntityManagerTest extends AbstractManagerTest {
 
         userVO.setUserName(USER2);
         userManager.createUser(userVO);
-
+        Mockito.when(kubernetesManager.createDockerRegistrySecret(Mockito.any())).thenReturn("");
         Mockito.when(dockerClientFactory.getDockerClient(Mockito.any(), Mockito.any())).thenReturn(client);
     }
 
     @Test
     @WithMockUser(username = USER)
     public void testToolInheritPermissionsFromRegistry() {
-        DockerRegistry registry = registryManager.create(createDockerRegistryVO(TEST_NAME, USER, USER));
-        ToolGroup toolGroup = toolGroupManager.create(createToolGroup(TEST_NAME, registry.getId()));
-        toolManager.create(createTool(TEST_NAME, toolGroup.getId()), false);
+        DockerRegistry registry = registryManager.create(
+                ObjectCreatorUtils.createDockerRegistryVO(TEST_NAME, USER, USER));
+        ToolGroup toolGroup = toolGroupManager.create(
+                ObjectCreatorUtils.createToolGroup(TEST_NAME, registry.getId()));
+        toolManager.create(ObjectCreatorUtils.createTool(TEST_NAME, toolGroup.getId()), false);
         grantPermission(registry.getId(), AclClass.DOCKER_REGISTRY, USER2, true, AclPermission.READ.getMask());
 
         Map<AclClass, List<AbstractSecuredEntity>> available = hierarchicalEntityManager
@@ -143,9 +144,12 @@ public class HierarchicalEntityManagerTest extends AbstractManagerTest {
     @Test
     @WithMockUser(username = USER)
     public void testIfOnlyToolAllowedGroupAndRegistryDontPresetInResult() {
-        DockerRegistry registry = registryManager.create(createDockerRegistryVO(TEST_NAME, USER, USER));
-        ToolGroup toolGroup = toolGroupManager.create(createToolGroup(TEST_NAME, registry.getId()));
-        Tool tool = toolManager.create(createTool(TEST_NAME, toolGroup.getId()), false);
+        DockerRegistry registry = registryManager.create(
+                ObjectCreatorUtils.createDockerRegistryVO(TEST_NAME, USER, USER));
+        ToolGroup toolGroup = toolGroupManager.create(
+                ObjectCreatorUtils.createToolGroup(TEST_NAME, registry.getId()));
+        Tool tool = toolManager.create(
+                ObjectCreatorUtils.createTool(TEST_NAME, toolGroup.getId()), false);
         grantPermission(tool.getId(), AclClass.TOOL, USER2, true, AclPermission.READ.getMask());
 
         Map<AclClass, List<AbstractSecuredEntity>> available = hierarchicalEntityManager
@@ -157,9 +161,12 @@ public class HierarchicalEntityManagerTest extends AbstractManagerTest {
     @Test
     @WithMockUser(username = USER)
     public void testLoadingByRoleSidWorks() {
-        DockerRegistry registry = registryManager.create(createDockerRegistryVO(TEST_NAME, USER, USER));
-        ToolGroup toolGroup = toolGroupManager.create(createToolGroup(TEST_NAME, registry.getId()));
-        Tool tool = toolManager.create(createTool(TEST_NAME, toolGroup.getId()), false);
+        DockerRegistry registry = registryManager.create(
+                ObjectCreatorUtils.createDockerRegistryVO(TEST_NAME, USER, USER));
+        ToolGroup toolGroup = toolGroupManager.create(
+                ObjectCreatorUtils.createToolGroup(TEST_NAME, registry.getId()));
+        Tool tool = toolManager.create(
+                ObjectCreatorUtils.createTool(TEST_NAME, toolGroup.getId()), false);
         grantPermission(tool.getId(), AclClass.TOOL, DefaultRoles.ROLE_USER.getName(),
                 false, AclPermission.READ.getMask());
 
@@ -177,9 +184,12 @@ public class HierarchicalEntityManagerTest extends AbstractManagerTest {
     @Test
     @WithMockUser(username = USER)
     public void testLoadingByRoleSidWorksWhenLoadForUser() {
-        DockerRegistry registry = registryManager.create(createDockerRegistryVO(TEST_NAME, USER, USER));
-        ToolGroup toolGroup = toolGroupManager.create(createToolGroup(TEST_NAME, registry.getId()));
-        Tool tool = toolManager.create(createTool(TEST_NAME, toolGroup.getId()), false);
+        DockerRegistry registry = registryManager.create(
+                ObjectCreatorUtils.createDockerRegistryVO(TEST_NAME, USER, USER));
+        ToolGroup toolGroup = toolGroupManager.create(
+                ObjectCreatorUtils.createToolGroup(TEST_NAME, registry.getId()));
+        Tool tool = toolManager.create(
+                ObjectCreatorUtils.createTool(TEST_NAME, toolGroup.getId()), false);
         grantPermission(tool.getId(), AclClass.TOOL, DefaultRoles.ROLE_USER.getName(),
                 false, AclPermission.READ.getMask());
 
@@ -197,9 +207,12 @@ public class HierarchicalEntityManagerTest extends AbstractManagerTest {
     @Test
     @WithMockUser(username = USER)
     public void testLoadingByGroupSidWorksWhenLoadForUser() {
-        DockerRegistry registry = registryManager.create(createDockerRegistryVO(TEST_NAME, USER, USER));
-        ToolGroup toolGroup = toolGroupManager.create(createToolGroup(TEST_NAME, registry.getId()));
-        Tool tool = toolManager.create(createTool(TEST_NAME, toolGroup.getId()), false);
+        DockerRegistry registry = registryManager.create(
+                ObjectCreatorUtils.createDockerRegistryVO(TEST_NAME, USER, USER));
+        ToolGroup toolGroup = toolGroupManager.create(
+                ObjectCreatorUtils.createToolGroup(TEST_NAME, registry.getId()));
+        Tool tool = toolManager.create(
+                ObjectCreatorUtils.createTool(TEST_NAME, toolGroup.getId()), false);
         Role role = roleManager.createRole(TEST_ROLE, false, false, null);
         grantPermission(tool.getId(), AclClass.TOOL, role.getName(),
                 false, AclPermission.READ.getMask());
@@ -324,11 +337,9 @@ public class HierarchicalEntityManagerTest extends AbstractManagerTest {
         //create
         PipelineConfiguration pipelineConfiguration = new PipelineConfiguration();
         pipelineConfiguration.setCmdTemplate("sleep 10");
-        RunConfigurationEntry entry =
-                createConfigEntry("entry", true, pipelineConfiguration);
+        RunConfigurationEntry entry = ObjectCreatorUtils.createConfigEntry("entry", true, pipelineConfiguration);
 
-        RunConfigurationVO configuration =
-                createRunConfigurationVO(name, null, parentId,
+        RunConfigurationVO configuration = ObjectCreatorUtils.createRunConfigurationVO(name, null, parentId,
                         Collections.singletonList(entry));
         return configurationManager.create(configuration);
     }

--- a/api/src/test/java/com/epam/pipeline/manager/HierarchicalEntityManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/HierarchicalEntityManagerTest.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager;
+
+import com.epam.pipeline.app.TestApplicationWithAclSecurity;
+import com.epam.pipeline.controller.vo.PermissionGrantVO;
+import com.epam.pipeline.controller.vo.PipelineUserVO;
+import com.epam.pipeline.controller.vo.configuration.RunConfigurationVO;
+import com.epam.pipeline.entity.AbstractSecuredEntity;
+import com.epam.pipeline.entity.configuration.PipelineConfiguration;
+import com.epam.pipeline.entity.configuration.RunConfiguration;
+import com.epam.pipeline.entity.configuration.RunConfigurationEntry;
+import com.epam.pipeline.entity.pipeline.DockerRegistry;
+import com.epam.pipeline.entity.pipeline.Folder;
+import com.epam.pipeline.entity.pipeline.Tool;
+import com.epam.pipeline.entity.pipeline.ToolGroup;
+import com.epam.pipeline.entity.security.acl.AclClass;
+import com.epam.pipeline.entity.security.acl.AclSid;
+import com.epam.pipeline.entity.user.DefaultRoles;
+import com.epam.pipeline.manager.cluster.KubernetesManager;
+import com.epam.pipeline.manager.configuration.RunConfigurationManager;
+import com.epam.pipeline.manager.docker.DockerClient;
+import com.epam.pipeline.manager.docker.DockerClientFactory;
+import com.epam.pipeline.manager.docker.DockerRegistryManager;
+import com.epam.pipeline.manager.pipeline.FolderCrudManager;
+import com.epam.pipeline.manager.pipeline.ToolGroupManager;
+import com.epam.pipeline.manager.pipeline.ToolManager;
+import com.epam.pipeline.manager.security.GrantPermissionManager;
+import com.epam.pipeline.manager.user.UserManager;
+import com.epam.pipeline.security.acl.AclPermission;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+
+@DirtiesContext
+@Transactional
+@ContextConfiguration(classes = TestApplicationWithAclSecurity.class)
+public class HierarchicalEntityManagerTest extends AbstractManagerTest {
+
+    private static final String USER = "OWNER";
+    private static final String USER2 = "VIEWER";
+
+    private static final String TEST_NAME = "name";
+    private static final int ALL_PERMISSIONS = AclPermission.READ.getMask()
+                                                | AclPermission.WRITE.getMask()
+                                                | AclPermission.EXECUTE.getMask();
+    private static final int ALL_PERMISSIONS_SIMPLE = AclPermission.getBasicPermissions().stream()
+            .map(AclPermission::getSimpleMask).reduce((m, m2) -> m | m2).get();
+
+
+    @Autowired
+    private HierarchicalEntityManager hierarchicalEntityManager;
+
+    @Autowired
+    private RunConfigurationManager configurationManager;
+
+    @Autowired
+    private DockerRegistryManager registryManager;
+
+    @Autowired
+    private ToolGroupManager toolGroupManager;
+
+    @Autowired
+    private ToolManager toolManager;
+
+    @Autowired
+    private UserManager userManager;
+
+    @Autowired
+    private GrantPermissionManager permissionManager;
+
+    @Autowired
+    private FolderCrudManager folderCrudManager;
+
+    @MockBean
+    private DockerClientFactory dockerClientFactory;
+
+    @MockBean
+    private KubernetesManager kubernetesManager;
+
+    private DockerClient client = Mockito.mock(DockerClient.class);
+
+    @Before
+    public void setUp() {
+        PipelineUserVO userVO = new PipelineUserVO();
+        userVO.setRoleIds(Collections.singletonList(DefaultRoles.ROLE_USER.getId()));
+        userVO.setUserName(USER);
+        userManager.createUser(userVO);
+
+        userVO.setUserName(USER2);
+        userManager.createUser(userVO);
+
+        Mockito.when(dockerClientFactory.getDockerClient(Mockito.any(), Mockito.any())).thenReturn(client);
+    }
+
+    @Test
+    @WithMockUser(username = USER)
+    public void testToolInheritPermissionsFromRegistry() {
+        DockerRegistry registry = registryManager.create(ObjectCreatorUtils.createDockerRegistryVO(TEST_NAME, USER, USER));
+        ToolGroup toolGroup = toolGroupManager.create(ObjectCreatorUtils.createToolGroup(TEST_NAME, registry.getId()));
+        toolManager.create(ObjectCreatorUtils.createTool(TEST_NAME, toolGroup.getId()), false);
+        grantPermission(registry.getId(), AclClass.DOCKER_REGISTRY, USER2, true, AclPermission.READ.getMask());
+
+        List<AbstractSecuredEntity> entityList = hierarchicalEntityManager.loadAvailable(new AclSid(USER2, true));
+        Assert.assertEquals(3, entityList.size());
+        Assert.assertTrue(entityList.stream()
+                .filter(se -> se.getAclClass() == AclClass.TOOL)
+                .findFirst().map(se -> se.getMask() == AclPermission.READ.getMask()).get());
+    }
+
+    @Test
+    @WithMockUser(username = USER)
+    public void testIfOnlyToolAllowedGroupAndRegistryDontPresetInResult() {
+        DockerRegistry registry = registryManager.create(ObjectCreatorUtils.createDockerRegistryVO(TEST_NAME, USER, USER));
+        ToolGroup toolGroup = toolGroupManager.create(ObjectCreatorUtils.createToolGroup(TEST_NAME, registry.getId()));
+        Tool tool = toolManager.create(ObjectCreatorUtils.createTool(TEST_NAME, toolGroup.getId()), false);
+        grantPermission(tool.getId(), AclClass.TOOL, USER2, true, AclPermission.READ.getMask());
+
+        List<AbstractSecuredEntity> entityList = hierarchicalEntityManager.loadAvailable(new AclSid(USER2, true));
+        Assert.assertEquals(1, entityList.size());
+        Assert.assertTrue(entityList.stream()
+                .filter(se -> se.getAclClass() == AclClass.TOOL)
+                .findFirst().map(se -> se.getMask() == AclPermission.READ.getMask()).get());
+    }
+
+    @Test
+    @WithMockUser(username = USER)
+    public void testLoadingByRoleSidWorks() {
+        DockerRegistry registry = registryManager.create(ObjectCreatorUtils.createDockerRegistryVO(TEST_NAME, USER, USER));
+        ToolGroup toolGroup = toolGroupManager.create(ObjectCreatorUtils.createToolGroup(TEST_NAME, registry.getId()));
+        Tool tool = toolManager.create(ObjectCreatorUtils.createTool(TEST_NAME, toolGroup.getId()), false);
+        grantPermission(tool.getId(), AclClass.TOOL, DefaultRoles.ROLE_USER.getName(),
+                false, AclPermission.READ.getMask());
+
+        Folder folder = createFolder(TEST_NAME, null);
+        RunConfiguration runConfiguration = createRunConfiguration(TEST_NAME, folder.getId());
+        grantPermission(runConfiguration.getId(), AclClass.CONFIGURATION, DefaultRoles.ROLE_USER.getName(),
+                false, AclPermission.READ.getMask());
+
+        List<AbstractSecuredEntity> entityList = hierarchicalEntityManager.loadAvailable(
+                new AclSid(DefaultRoles.ROLE_USER.getName(), false));
+        Assert.assertEquals(2, entityList.size());
+        Assert.assertTrue(entityList.stream()
+                .filter(se -> se.getAclClass() == AclClass.TOOL)
+                .findFirst().map(se -> se.getMask() == AclPermission.READ.getMask()).get());
+    }
+
+    @Test
+    @WithMockUser(username = USER)
+    public void testLoadingByRoleSidWorksWhenLoadForUser() {
+        DockerRegistry registry = registryManager.create(ObjectCreatorUtils.createDockerRegistryVO(TEST_NAME, USER, USER));
+        ToolGroup toolGroup = toolGroupManager.create(ObjectCreatorUtils.createToolGroup(TEST_NAME, registry.getId()));
+        Tool tool = toolManager.create(ObjectCreatorUtils.createTool(TEST_NAME, toolGroup.getId()), false);
+        grantPermission(tool.getId(), AclClass.TOOL, DefaultRoles.ROLE_USER.getName(),
+                false, AclPermission.READ.getMask());
+
+        Folder folder = createFolder(TEST_NAME, null);
+        RunConfiguration runConfiguration = createRunConfiguration(TEST_NAME, folder.getId());
+        grantPermission(runConfiguration.getId(), AclClass.CONFIGURATION, DefaultRoles.ROLE_USER.getName(),
+                false, AclPermission.READ.getMask());
+
+        List<AbstractSecuredEntity> entityList = hierarchicalEntityManager.loadAvailable(new AclSid(USER2, true));
+        Assert.assertEquals(2, entityList.size());
+        Assert.assertTrue(entityList.stream()
+                .filter(se -> se.getAclClass() == AclClass.TOOL)
+                .findFirst().map(se -> se.getMask() == AclPermission.READ.getMask()).get());
+    }
+
+    @Test
+    @WithMockUser(username = USER)
+    public void testInheritPermissions() {
+        Folder folder = createFolder(TEST_NAME, null);
+        createRunConfiguration(TEST_NAME, folder.getId());
+
+        grantPermission(folder.getId(), AclClass.FOLDER, USER2, true, AclPermission.READ.getMask());
+
+        List<AbstractSecuredEntity> entityList = hierarchicalEntityManager.loadAvailable(new AclSid(USER2, true));
+        Assert.assertEquals(2, entityList.size());
+        Assert.assertTrue(entityList.stream()
+                .filter(se -> se.getAclClass() == AclClass.CONFIGURATION)
+                .findFirst().map(se -> se.getMask() == AclPermission.READ.getMask()).get());
+    }
+
+    @Test
+    @WithMockUser(username = USER)
+    public void testUseItsOwnPermissions() {
+        Folder folder = createFolder(TEST_NAME, null);
+        RunConfiguration runConfiguration = createRunConfiguration(TEST_NAME, folder.getId());
+
+        grantPermission(folder.getId(), AclClass.FOLDER, USER2, true, AclPermission.READ.getMask());
+
+        List<AbstractSecuredEntity> entityList = hierarchicalEntityManager.loadAvailable(new AclSid(USER2, true));
+        Assert.assertEquals(2, entityList.size());
+        Assert.assertTrue(entityList.stream()
+                .filter(se -> se.getAclClass() == AclClass.CONFIGURATION)
+                .findFirst().map(se -> se.getMask() == AclPermission.READ.getMask()).get());
+
+        grantPermission(runConfiguration.getId(), AclClass.CONFIGURATION, USER2, true,
+                ALL_PERMISSIONS);
+
+        entityList = hierarchicalEntityManager.loadAvailable(new AclSid(USER2, true));
+        Assert.assertEquals(2, entityList.size());
+        Assert.assertTrue(entityList.stream()
+                .filter(se -> se.getAclClass() == AclClass.CONFIGURATION)
+                .findFirst().map(se -> se.getMask() == ALL_PERMISSIONS_SIMPLE).get());
+    }
+
+    @Test
+    @WithMockUser(username = USER)
+    public void testUseItOwnPermissionsIfParentRestricted() {
+        Folder folder = createFolder(TEST_NAME, null);
+        RunConfiguration runConfiguration = createRunConfiguration(TEST_NAME, folder.getId());
+
+        grantPermission(folder.getId(), AclClass.FOLDER, USER2, true, AclPermission.NO_READ.getMask());
+        grantPermission(runConfiguration.getId(), AclClass.CONFIGURATION, USER2, true,
+                ALL_PERMISSIONS);
+
+        List<AbstractSecuredEntity> entityList = hierarchicalEntityManager.loadAvailable(new AclSid(USER2, true));
+        //folder should be filtered because it forbidden
+        Assert.assertEquals(1, entityList.size());
+        Assert.assertTrue(entityList.stream()
+                .filter(se -> se.getAclClass() == AclClass.CONFIGURATION)
+                .findFirst().map(se -> se.getMask() == ALL_PERMISSIONS_SIMPLE).get());
+    }
+
+    @Test
+    @WithMockUser(username = USER)
+    public void testUseItOwnRestrictedPermissionsIfParentAllowed() {
+        Folder folder = createFolder(TEST_NAME, null);
+        RunConfiguration runConfiguration = createRunConfiguration(TEST_NAME, folder.getId());
+
+        grantPermission(folder.getId(), AclClass.FOLDER, USER2, true, ALL_PERMISSIONS);
+        grantPermission(runConfiguration.getId(), AclClass.CONFIGURATION, USER2, true,
+                AclPermission.NO_READ.getMask());
+
+        List<AbstractSecuredEntity> entityList = hierarchicalEntityManager.loadAvailable(new AclSid(USER2, true));
+        //folder should be filtered because it forbidden
+        Assert.assertEquals(1, entityList.size());
+        Assert.assertTrue(entityList.stream()
+                .filter(se -> se.getAclClass() == AclClass.FOLDER)
+                .findFirst().map(se -> se.getMask() == ALL_PERMISSIONS_SIMPLE).get());
+    }
+
+    @Test
+    @WithMockUser(username = USER)
+    public void testUseItOwnPermissionsIfParentRestrictedByInheritance() {
+        Folder folder = createFolder(TEST_NAME, null);
+        Folder subFolder = createFolder(TEST_NAME, folder.getId());
+        RunConfiguration runConfiguration = createRunConfiguration(TEST_NAME, subFolder.getId());
+
+        grantPermission(folder.getId(), AclClass.FOLDER, USER2, true, AclPermission.NO_READ.getMask());
+        grantPermission(runConfiguration.getId(), AclClass.CONFIGURATION, USER2, true,
+                ALL_PERMISSIONS);
+
+        List<AbstractSecuredEntity> entityList = hierarchicalEntityManager.loadAvailable(new AclSid(USER2, true));
+        //folder should be filtered because it forbidden
+        Assert.assertEquals(1, entityList.size());
+        Assert.assertTrue(entityList.stream()
+                .filter(se -> se.getAclClass() == AclClass.CONFIGURATION)
+                .findFirst().map(se -> se.getMask() == ALL_PERMISSIONS_SIMPLE).get());
+    }
+
+    private void grantPermission(Long id, AclClass aclClass, String user, boolean principal, int mask) {
+        PermissionGrantVO grantVO = new PermissionGrantVO();
+        grantVO.setAclClass(aclClass);
+        grantVO.setUserName(user);
+        grantVO.setPrincipal(principal);
+        grantVO.setMask(mask);
+        grantVO.setId(id);
+        permissionManager.setPermissions(grantVO);
+    }
+
+    private Folder createFolder(String name, Long parentId) {
+        Folder folder = ObjectCreatorUtils.createFolder(name, parentId);
+        folderCrudManager.create(folder);
+        return folder;
+    }
+
+    private RunConfiguration createRunConfiguration(String name, Long parentId) {
+        //create
+        PipelineConfiguration pipelineConfiguration = new PipelineConfiguration();
+        pipelineConfiguration.setCmdTemplate("sleep 10");
+        RunConfigurationEntry entry =
+                ObjectCreatorUtils.createConfigEntry("entry", true, pipelineConfiguration);
+
+        RunConfigurationVO configuration =
+                ObjectCreatorUtils.createRunConfigurationVO(name, null, parentId,
+                        Collections.singletonList(entry));
+        return configurationManager.create(configuration);
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/manager/HierarchicalEntityManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/HierarchicalEntityManagerTest.java
@@ -136,7 +136,7 @@ public class HierarchicalEntityManagerTest extends AbstractManagerTest {
         grantPermission(registry.getId(), AclClass.DOCKER_REGISTRY, USER2, true, AclPermission.READ.getMask());
 
         Map<AclClass, List<AbstractSecuredEntity>> available = hierarchicalEntityManager
-                .loadAvailable(new AclSid(USER2, true));
+                .loadAvailable(new AclSid(USER2, true), null);
         Assert.assertEquals(3, available.size());
         Assert.assertEquals((int) available.get(AclClass.TOOL).get(0).getMask(), AclPermission.READ.getMask());
     }
@@ -153,7 +153,7 @@ public class HierarchicalEntityManagerTest extends AbstractManagerTest {
         grantPermission(tool.getId(), AclClass.TOOL, USER2, true, AclPermission.READ.getMask());
 
         Map<AclClass, List<AbstractSecuredEntity>> available = hierarchicalEntityManager
-                .loadAvailable(new AclSid(USER2, true));
+                .loadAvailable(new AclSid(USER2, true), null);
         Assert.assertEquals(1, available.size());
         Assert.assertEquals((int) available.get(AclClass.TOOL).get(0).getMask(), AclPermission.READ.getMask());
     }
@@ -176,7 +176,7 @@ public class HierarchicalEntityManagerTest extends AbstractManagerTest {
                 false, AclPermission.READ.getMask());
 
         Map<AclClass, List<AbstractSecuredEntity>> available = hierarchicalEntityManager.loadAvailable(
-                new AclSid(DefaultRoles.ROLE_USER.getName(), false));
+                new AclSid(DefaultRoles.ROLE_USER.getName(), false), null);
         Assert.assertEquals(2, available.size());
         Assert.assertEquals((int) available.get(AclClass.TOOL).get(0).getMask(), AclPermission.READ.getMask());
     }
@@ -199,7 +199,7 @@ public class HierarchicalEntityManagerTest extends AbstractManagerTest {
                 false, AclPermission.READ.getMask());
 
         Map<AclClass, List<AbstractSecuredEntity>> available = hierarchicalEntityManager
-                .loadAvailable(new AclSid(USER2, true));
+                .loadAvailable(new AclSid(USER2, true), null);
         Assert.assertEquals(2, available.size());
         Assert.assertEquals((int) available.get(AclClass.TOOL).get(0).getMask(), AclPermission.READ.getMask());
     }
@@ -224,7 +224,7 @@ public class HierarchicalEntityManagerTest extends AbstractManagerTest {
                 false, AclPermission.READ.getMask());
 
         Map<AclClass, List<AbstractSecuredEntity>> available = hierarchicalEntityManager
-                .loadAvailable(new AclSid(USER2, true));
+                .loadAvailable(new AclSid(USER2, true), null);
         Assert.assertEquals(2, available.size());
         Assert.assertEquals((int) available.get(AclClass.TOOL).get(0).getMask(), AclPermission.READ.getMask());
     }
@@ -238,7 +238,7 @@ public class HierarchicalEntityManagerTest extends AbstractManagerTest {
         grantPermission(folder.getId(), AclClass.FOLDER, USER2, true, AclPermission.READ.getMask());
 
         Map<AclClass, List<AbstractSecuredEntity>> available = hierarchicalEntityManager
-                .loadAvailable(new AclSid(USER2, true));
+                .loadAvailable(new AclSid(USER2, true), null);
         Assert.assertEquals(2, available.size());
         Assert.assertEquals((int) available.get(AclClass.CONFIGURATION).get(0).getMask(), AclPermission.READ.getMask());
     }
@@ -252,7 +252,7 @@ public class HierarchicalEntityManagerTest extends AbstractManagerTest {
         grantPermission(folder.getId(), AclClass.FOLDER, USER2, true, AclPermission.READ.getMask());
 
         Map<AclClass, List<AbstractSecuredEntity>> available = hierarchicalEntityManager
-                .loadAvailable(new AclSid(USER2, true));
+                .loadAvailable(new AclSid(USER2, true), null);
         Assert.assertEquals(2, available.size());
         Assert.assertEquals((int) available.get(AclClass.CONFIGURATION).get(0).getMask(), AclPermission.READ.getMask());
 
@@ -260,7 +260,7 @@ public class HierarchicalEntityManagerTest extends AbstractManagerTest {
         grantPermission(runConfiguration.getId(), AclClass.CONFIGURATION, USER2, true,
                 ALL_PERMISSIONS);
 
-        available = hierarchicalEntityManager.loadAvailable(new AclSid(USER2, true));
+        available = hierarchicalEntityManager.loadAvailable(new AclSid(USER2, true), null);
         Assert.assertEquals(2, available.size());
         Assert.assertEquals((int) available.get(AclClass.CONFIGURATION).get(0).getMask(), ALL_PERMISSIONS_SIMPLE);
     }
@@ -276,7 +276,7 @@ public class HierarchicalEntityManagerTest extends AbstractManagerTest {
                 ALL_PERMISSIONS);
 
         Map<AclClass, List<AbstractSecuredEntity>> available = hierarchicalEntityManager
-                .loadAvailable(new AclSid(USER2, true));
+                .loadAvailable(new AclSid(USER2, true), null);
         //folder should be filtered because it forbidden
         Assert.assertEquals(1, available.size());
         Assert.assertEquals((int) available.get(AclClass.CONFIGURATION).get(0).getMask(), ALL_PERMISSIONS_SIMPLE);
@@ -293,7 +293,7 @@ public class HierarchicalEntityManagerTest extends AbstractManagerTest {
                 AclPermission.NO_READ.getMask());
 
         Map<AclClass, List<AbstractSecuredEntity>> available = hierarchicalEntityManager
-                .loadAvailable(new AclSid(USER2, true));
+                .loadAvailable(new AclSid(USER2, true), null);
         //folder should be filtered because it forbidden
         Assert.assertEquals(1, available.size());
         Assert.assertEquals((int) available.get(AclClass.FOLDER).get(0).getMask(), ALL_PERMISSIONS_SIMPLE);
@@ -311,8 +311,25 @@ public class HierarchicalEntityManagerTest extends AbstractManagerTest {
                 ALL_PERMISSIONS);
 
         Map<AclClass, List<AbstractSecuredEntity>> available = hierarchicalEntityManager
-                .loadAvailable(new AclSid(USER2, true));
+                .loadAvailable(new AclSid(USER2, true), null);
         //folder should be filtered because it forbidden
+        Assert.assertEquals(1, available.size());
+        Assert.assertEquals((int) available.get(AclClass.CONFIGURATION).get(0).getMask(), ALL_PERMISSIONS_SIMPLE);
+    }
+
+    @Test
+    @WithMockUser(username = USER)
+    public void shouldReturnOneAclClassOnly() {
+        Folder folder = createFolder(TEST_NAME, null);
+        Folder subFolder = createFolder(TEST_NAME, folder.getId());
+        RunConfiguration runConfiguration = createRunConfiguration(TEST_NAME, subFolder.getId());
+
+        grantPermission(folder.getId(), AclClass.FOLDER, USER2, true, ALL_PERMISSIONS);
+        grantPermission(runConfiguration.getId(), AclClass.CONFIGURATION, USER2, true,
+                ALL_PERMISSIONS);
+
+        Map<AclClass, List<AbstractSecuredEntity>> available = hierarchicalEntityManager
+                .loadAvailable(new AclSid(USER2, true), AclClass.CONFIGURATION);
         Assert.assertEquals(1, available.size());
         Assert.assertEquals((int) available.get(AclClass.CONFIGURATION).get(0).getMask(), ALL_PERMISSIONS_SIMPLE);
     }

--- a/api/src/test/java/com/epam/pipeline/manager/ObjectCreatorUtils.java
+++ b/api/src/test/java/com/epam/pipeline/manager/ObjectCreatorUtils.java
@@ -19,6 +19,7 @@ package com.epam.pipeline.manager;
 import com.epam.pipeline.controller.vo.DataStorageVO;
 import com.epam.pipeline.controller.vo.PipelineVO;
 import com.epam.pipeline.controller.vo.configuration.RunConfigurationVO;
+import com.epam.pipeline.controller.vo.docker.DockerRegistryVO;
 import com.epam.pipeline.controller.vo.metadata.MetadataEntityVO;
 import com.epam.pipeline.entity.configuration.AbstractRunConfigurationEntry;
 import com.epam.pipeline.entity.configuration.FirecloudRunConfigurationEntry;
@@ -39,6 +40,8 @@ import com.epam.pipeline.entity.pipeline.Pipeline;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
+import com.epam.pipeline.entity.pipeline.Tool;
+import com.epam.pipeline.entity.pipeline.ToolGroup;
 import com.epam.pipeline.entity.region.AwsRegion;
 import com.epam.pipeline.entity.region.AzureRegion;
 import com.epam.pipeline.entity.region.AzureRegionCredentials;
@@ -169,6 +172,21 @@ public final class ObjectCreatorUtils {
         return runConfigurationVO;
     }
 
+    public static DockerRegistryVO createDockerRegistryVO(String name, String user, String password) {
+        DockerRegistryVO dockerRegistryVO = new DockerRegistryVO();
+        dockerRegistryVO.setPath(name);
+        dockerRegistryVO.setUserName(user);
+        dockerRegistryVO.setPassword(password);
+        return dockerRegistryVO;
+    }
+
+    public static ToolGroup createToolGroup(String name, Long registryId) {
+        ToolGroup toolGroup = new ToolGroup();
+        toolGroup.setName(name);
+        toolGroup.setRegistryId(registryId);
+        return toolGroup;
+    }
+
     public static Folder createFolder(String name, Long parentId) {
         Folder folder = new Folder();
         folder.setName(name);
@@ -282,5 +300,15 @@ public final class ObjectCreatorUtils {
         AzureRegionCredentials creds = new AzureRegionCredentials();
         creds.setStorageAccountKey(storageKey);
         return creds;
+    }
+
+    public static Tool createTool(final String image, final Long toolGroupId) {
+        Tool tool = new Tool();
+        tool.setImage(image);
+        tool.setToolGroupId(toolGroupId);
+        tool.setCpu("100");
+        tool.setDisk(100);
+        tool.setRam("100");
+        return tool;
     }
 }

--- a/api/src/test/java/com/epam/pipeline/manager/ObjectCreatorUtils.java
+++ b/api/src/test/java/com/epam/pipeline/manager/ObjectCreatorUtils.java
@@ -58,6 +58,7 @@ public final class ObjectCreatorUtils {
     private static final String TEST_NAME = "TEST";
     private static final String TEST_POD_ID = "pod1";
     private static final String TEST_SERVICE_URL = "service_url";
+    public static final int TEST_DISK_SIZE = 100;
 
     private ObjectCreatorUtils() {
     }
@@ -307,7 +308,7 @@ public final class ObjectCreatorUtils {
         tool.setImage(image);
         tool.setToolGroupId(toolGroupId);
         tool.setCpu("100");
-        tool.setDisk(100);
+        tool.setDisk(TEST_DISK_SIZE);
         tool.setRam("100");
         return tool;
     }

--- a/core/src/main/java/com/epam/pipeline/entity/AbstractHierarchicalEntity.java
+++ b/core/src/main/java/com/epam/pipeline/entity/AbstractHierarchicalEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,4 +108,6 @@ public abstract class AbstractHierarchicalEntity extends AbstractSecuredEntity {
     public void clearForReadOnlyView() {
         // no operations by default
     }
+
+    public abstract <T extends AbstractHierarchicalEntity> T copyView();
 }

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/DockerRegistry.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/DockerRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import lombok.Setter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;;
+import java.util.Set;
 
 @Getter
 @Setter
@@ -117,5 +117,24 @@ public class DockerRegistry extends AbstractHierarchicalEntity {
     @JsonIgnore
     public String getCaCert() {
         return caCert;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public DockerRegistry copyView() {
+        final DockerRegistry registry = new DockerRegistry();
+        registry.setId(this.getId());
+        registry.setPath(this.getPath());
+        registry.setDescription(this.getDescription());
+        registry.setOwner(this.getOwner());
+        registry.setMask(this.getMask());
+        registry.setSecretName(this.getSecretName());
+        registry.setCaCert(this.getCaCert());
+        registry.setUserName(this.getUserName());
+        registry.setPipelineAuth(this.isPipelineAuth());
+        registry.setExternalUrl(this.getExternalUrl());
+        registry.setPassword(this.getPassword());
+        registry.setSecurityScanEnabled(this.isSecurityScanEnabled());
+        return registry;
     }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/Folder.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/Folder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -147,6 +147,19 @@ public class Folder extends AbstractHierarchicalEntity {
     @Override
     public void clearForReadOnlyView() {
         metadata = new HashMap<>();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Folder copyView() {
+        final Folder folder = new Folder(this.getId());
+        folder.setName(this.getName());
+        folder.setOwner(this.getOwner());
+        folder.setMask(this.getMask());
+        folder.setParentId(this.getParentId());
+        folder.setParent(this.getParent());
+        folder.setMetadata(this.getMetadata());
+        return folder;
     }
 
     private void addChildren(Map<AclClass, List<Long>> result,

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/ToolGroup.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/ToolGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,5 +88,10 @@ public class ToolGroup extends AbstractHierarchicalEntity {
             return parent;
         }
         return registryId == null ? null : new DockerRegistry(registryId);
+    }
+
+    @Override
+    public AbstractHierarchicalEntity copyView() {
+        return this;
     }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/ToolGroup.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/ToolGroup.java
@@ -92,6 +92,12 @@ public class ToolGroup extends AbstractHierarchicalEntity {
 
     @Override
     public AbstractHierarchicalEntity copyView() {
-        return this;
+        final ToolGroup result = new ToolGroup(this.getId());
+        result.setRegistryId(this.getRegistryId());
+        result.setName(this.getName());
+        result.setDescription(this.getDescription());
+        result.setPrivateGroup(this.isPrivateGroup());
+        result.setParent(this.getParent());
+        return result;
     }
 }

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1055,7 +1055,7 @@ def view_user_objects(username, object_type):
     type=click.Choice(['pipeline', 'folder', 'data_storage'])
 )
 @Config.validate_access_token
-def view_user_objects(group_name, object_type):
+def view_group_objects(group_name, object_type):
     ACLOperations.print_sid_objects(group_name, False, object_type)
 
 

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1033,6 +1033,32 @@ def set_acl(identifier, object_type, sid, group, allow, deny, inherit):
     ACLOperations.set_acl(identifier, object_type, sid, group, allow, deny, inherit)
 
 
+@cli.command(name='view-user-objects')
+@click.argument('username')
+@click.option(
+    '-t', '--object-type',
+    help='Object type',
+    required=True,
+    type=click.Choice(['pipeline', 'folder', 'data_storage'])
+)
+@Config.validate_access_token
+def view_user_objects(username, object_type):
+    ACLOperations.print_sid_objects(username, True, object_type)
+
+
+@cli.command(name='view-group-objects')
+@click.argument('group_name')
+@click.option(
+    '-t', '--object-type',
+    help='Object type',
+    required=True,
+    type=click.Choice(['pipeline', 'folder', 'data_storage'])
+)
+@Config.validate_access_token
+def view_user_objects(group_name, object_type):
+    ACLOperations.print_sid_objects(group_name, False, object_type)
+
+
 @cli.group()
 def tag():
     """ Operations with tags

--- a/pipe-cli/src/api/entity.py
+++ b/pipe-cli/src/api/entity.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 
 from src.api.base import API
 
@@ -31,3 +32,21 @@ class Entity(API):
             raise RuntimeError(response_data['message'])
         else:
             raise RuntimeError("Failed to load entity by entity id or entity name.")
+
+    @classmethod
+    def load_available_entities(cls, sid_name, principal, acl_class=None):
+        api = cls.instance()
+        body = {
+            "name": sid_name,
+            "principal": principal
+        }
+        query = 'entities'
+        if acl_class:
+            query += '?aclClass=' + str(acl_class).upper()
+        response_data = api.call(query, json.dumps(body))
+        if 'payload' in response_data:
+            return response_data['payload']
+        if 'message' in response_data:
+            raise RuntimeError(response_data['message'])
+        else:
+            raise RuntimeError("Failed to load entities available for '{}'".format(sid_name))


### PR DESCRIPTION
PR related to issue #911 
It brings functionality to load whole collection of objects (`Folder`, `Pipeline`, `RunConfiguration`, `DataStorage`, `DockerRegistry`, `ToolGroup`, `Tool`) available for specified AclSid (User or Group)