### PR TITLE
Issue #761 Grouping result pagination

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/billing/BillingApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/billing/BillingApiService.java
@@ -33,4 +33,8 @@ public class BillingApiService {
     public List<BillingChartInfo> getBillingChartInfo(final BillingChartRequest request) {
         return billingManager.getBillingChartInfo(request);
     }
+
+    public List<BillingChartInfo> getBillingChartInfoPaginated(final BillingChartRequest request) {
+        return billingManager.getBillingChartInfoPaginated(request);
+    }
 }

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -477,6 +477,7 @@ public final class MessageConstants {
         "error.billing.entity.for.grouping.not.found";
     public static final String ERROR_BILLING_DETAILS_NOT_SUPPORTED = "error.billing.details.not.supported";
     public static final String ERROR_BILLING_INTERVAL_NOT_SUPPORTED = "error.billing.interval.not.supported";
+    public static final String ERROR_ILLEGAL_PAGING_PARAMETERS = "error.billing.invalid.paging";
 
     private MessageConstants() {
         // no-op

--- a/api/src/main/java/com/epam/pipeline/controller/billing/BillingController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/billing/BillingController.java
@@ -52,4 +52,17 @@ public class BillingController extends AbstractRestController {
     public Result<List<BillingChartInfo>> getBillingChartInfo(@RequestBody final BillingChartRequest request) {
         return Result.success(billingApi.getBillingChartInfo(request));
     }
+
+    @RequestMapping(value = "/billing/charts/pagination", method = RequestMethod.POST)
+    @ResponseBody
+    @ApiOperation(
+        value = "Get paginated info about billing expenses.",
+        notes = "Get paginated info about billing expenses.",
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+        value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+        })
+    public Result<List<BillingChartInfo>> getBillingChartInfoPaginated(@RequestBody final BillingChartRequest request) {
+        return Result.success(billingApi.getBillingChartInfoPaginated(request));
+    }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/vo/billing/BillingChartRequest.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/billing/BillingChartRequest.java
@@ -33,4 +33,6 @@ public class BillingChartRequest {
     private DateHistogramInterval interval;
     private BillingGrouping grouping;
     private boolean loadDetails;
+    private Long pageSize;
+    private Long pageNum;
 }

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
@@ -163,6 +163,13 @@ public class BillingManager {
             throw new IllegalArgumentException(messageHelper
                                                    .getMessage(MessageConstants.ERROR_BILLING_DETAILS_NOT_SUPPORTED));
         }
+        final Long pageSize = request.getPageSize();
+        final Long pageNum = request.getPageNum();
+        if (pageNum != null && pageNum < 0
+            || pageSize != null && pageSize <= 0) {
+            throw new IllegalArgumentException(messageHelper
+                                                   .getMessage(MessageConstants.ERROR_ILLEGAL_PAGING_PARAMETERS));
+        }
     }
 
     private RestHighLevelClient buildClient(final PreferenceManager preferenceManager) {

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
@@ -85,6 +85,8 @@ public class BillingManager {
     private static final String USAGE_FIELD = "usage";
     private static final String ID_FIELD = "id";
     private static final String UNIQUE_RUNS = "runs";
+    private static final String PAGE = "page";
+    private static final String TOTAL_PAGES = "totalPages";
     private static final String BILLING_DATE_FIELD = "created_date";
     private static final String HISTOGRAM_AGGREGATION_NAME = "hist_agg";
     private static final String ES_MONTHLY_DATE_REGEXP = "%d-%02d-*";
@@ -284,7 +286,14 @@ public class BillingManager {
                 if (from > resultSize) {
                     return getEmptyGroupingResponse(grouping);
                 }
-                return fullResult.subList(from, Math.min(to, resultSize));
+                final List<BillingChartInfo> finalBilling = fullResult.subList(from, Math.min(to, resultSize));
+                final String totalPagesVal = Long.toString((long) Math.ceil(1.0 * resultSize / pageSize));
+                final String pageNumVal = Long.toString(requiredPageNum);
+                finalBilling.forEach(record -> {
+                    record.getGroupingInfo().put(PAGE, pageNumVal);
+                    record.getGroupingInfo().put(TOTAL_PAGES, totalPagesVal);
+                });
+                return finalBilling;
             }
         } else {
             return getEmptyGroupingResponse(grouping);

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
@@ -46,6 +46,7 @@ import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInter
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.histogram.ParsedDateHistogram;
 import org.elasticsearch.search.aggregations.bucket.terms.ParsedStringTerms;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.sum.ParsedSum;
 import org.elasticsearch.search.aggregations.metrics.sum.SumAggregationBuilder;
@@ -231,7 +232,8 @@ public class BillingManager {
                     return l1;
                 }));
             final AggregationBuilder fieldAgg = AggregationBuilders.terms(grouping.getCorrespondingField())
-                .field(grouping.getCorrespondingField());
+                .field(grouping.getCorrespondingField())
+                .order(Terms.Order.aggregation(COST_FIELD, false));
             fieldAgg.subAggregation(costAggregation);
             if (grouping.usageDetailsRequired()) {
                 fieldAgg.subAggregation(usageAggregation);

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -442,3 +442,4 @@ error.billing.date.field.grouping.not.supported="Currently field and date groupi
 error.billing.details.not.supported="Details are supported for grouping requests only!"
 error.billing.interval.not.supported="Given interval is not supported!"
 error.billing.entity.for.grouping.not.found="''{0}'' entity for ''{1}'' grouping is not found."
+error.billing.invalid.paging='Paging parameters can't be negative!'


### PR DESCRIPTION
This PR is related to issue #761 

Some report views require pagination for spending tables.

- grouped buckets are sorted by cost descending
- new parameters `pageSize` and `pageNum` are introduced in BillingChartRequest
- paging info is stored in `BillingChartInfo` metadata with keys `page` (current page) and `totalPages` (total amount of pages for requested grouping)
- new functionality is available at `/billing/charts/pagination`
- API [description](https://github.com/epam/cloud-pipeline/issues/761#issuecomment-583501889) is updated