### PR TITLE
Allow to generate the `pipe run` command from the GUI - auto-pause support

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -1066,6 +1066,7 @@ public class PipelineRunManager {
                 .priceType()
                 .regionId()
                 .parentNode()
+                .nonPause()
                 .build();
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilder.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilder.java
@@ -101,11 +101,7 @@ public class PipeRunCmdBuilder {
 
     public PipeRunCmdBuilder priceType() {
         cmd.add("-pt");
-        if (Objects.nonNull(runVO.getIsSpot()) && !runVO.getIsSpot()) {
-            cmd.add("on-demand");
-        } else {
-            cmd.add("spot");
-        }
+        cmd.add(isOnDemand() ? "on-demand" : "spot");
         return this;
     }
 
@@ -166,6 +162,13 @@ public class PipeRunCmdBuilder {
         return this;
     }
 
+    public PipeRunCmdBuilder nonPause() {
+        if (isOnDemand() && runVO.isNonPause()) {
+            cmd.add("-np");
+        }
+        return this;
+    }
+
     private String prepareParams(final Map.Entry<String, PipeConfValueVO> entry) {
         String value = entry.getValue().getValue();
         if (entry.getValue().getType().equalsIgnoreCase("string")) {
@@ -190,5 +193,9 @@ public class PipeRunCmdBuilder {
 
     private String quoteStringArgument(final String value) {
         return String.format("'%s'", value);
+    }
+
+    private boolean isOnDemand() {
+        return Objects.nonNull(runVO.getIsSpot()) && !runVO.getIsSpot();
     }
 }

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilderTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilderTest.java
@@ -66,24 +66,7 @@ public class PipeRunCmdBuilderTest {
         pipeRunCmdStartVO.setShowParams(true);
 
         final PipeRunCmdBuilder pipeRunCmdBuilder = new PipeRunCmdBuilder(pipeRunCmdStartVO);
-        final String actualResult = pipeRunCmdBuilder
-                .name()
-                .config()
-                .runParameters()
-                .parameters()
-                .yes()
-                .instanceDisk()
-                .instanceType()
-                .dockerImage()
-                .cmdTemplate()
-                .timeout()
-                .quite()
-                .instanceCount()
-                .sync()
-                .priceType()
-                .regionId()
-                .parentNode()
-                .build();
+        final String actualResult = buildCmd(pipeRunCmdBuilder);
         final String expectedResult = String.format("pipe run -n 1@%s %s '%s' %s %s parent-id 1 -p -y -id 10 " +
                         "-it type -di image -cmd '%s' -t 10 -q -ic 5 -s -pt spot -r 1 -pn 1",
                 TEST_VERSION, TEST_PARAM_NAME_1, TEST_PARAM_VALUE_1, TEST_PARAM_NAME_2, TEST_PARAM_VALUE_2,
@@ -101,7 +84,43 @@ public class PipeRunCmdBuilderTest {
         pipeRunCmdStartVO.setPipelineStart(pipelineStart);
 
         final PipeRunCmdBuilder pipeRunCmdBuilder = new PipeRunCmdBuilder(pipeRunCmdStartVO);
-        final String actualResult = pipeRunCmdBuilder
+        final String actualResult = buildCmd(pipeRunCmdBuilder);
+        Assert.assertEquals("pipe run -n 1 -pt spot", actualResult);
+    }
+
+    @Test
+    public void shouldAddNonPauseOption() {
+        final PipelineStart pipelineStart = new PipelineStart();
+        pipelineStart.setPipelineId(1L);
+        pipelineStart.setIsSpot(false);
+        pipelineStart.setNonPause(true);
+
+        final PipeRunCmdStartVO pipeRunCmdStartVO = new PipeRunCmdStartVO();
+        pipeRunCmdStartVO.setPipelineStart(pipelineStart);
+
+        final PipeRunCmdBuilder pipeRunCmdBuilder = new PipeRunCmdBuilder(pipeRunCmdStartVO);
+        final String actualResult = buildCmd(pipeRunCmdBuilder);
+        Assert.assertEquals("pipe run -n 1 -pt on-demand -np", actualResult);
+    }
+
+    @Test
+    public void shouldIgnoreNonPauseOptionIfSpot() {
+        final PipelineStart pipelineStart = new PipelineStart();
+        pipelineStart.setPipelineId(1L);
+        pipelineStart.setIsSpot(true);
+        pipelineStart.setNonPause(true);
+
+        final PipeRunCmdStartVO pipeRunCmdStartVO = new PipeRunCmdStartVO();
+        pipeRunCmdStartVO.setPipelineStart(pipelineStart);
+
+        final PipeRunCmdBuilder pipeRunCmdBuilder = new PipeRunCmdBuilder(pipeRunCmdStartVO);
+        final String actualResult = buildCmd(pipeRunCmdBuilder);
+        Assert.assertEquals("pipe run -n 1 -pt spot", actualResult);
+    }
+
+
+    private String buildCmd(final PipeRunCmdBuilder pipeRunCmdBuilder) {
+        return pipeRunCmdBuilder
                 .name()
                 .config()
                 .runParameters()
@@ -118,7 +137,7 @@ public class PipeRunCmdBuilderTest {
                 .priceType()
                 .regionId()
                 .parentNode()
+                .nonPause()
                 .build();
-        Assert.assertEquals("pipe run -n 1 -pt spot", actualResult);
     }
 }

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -634,6 +634,8 @@ def view_cluster_for_node(node_name):
               type=click.Choice([PriceType.SPOT, PriceType.ON_DEMAND]), required=False)
 @click.option('-r', '--region-id', help='Instance cloud region', type=int, required=False)
 @click.option('-pn', '--parent-node', help='Parent instance Run ID. That allows to run a pipeline as a child job on the existing running instance', type=int, required=False)
+@click.option('-np', '--non-pause', help='Allow to switch off auto-pause option. Supported for on-demand runs only',
+              is_flag=True)
 @Config.validate_access_token(quiet_flag_property_name='quiet')
 def run(pipeline,
         config,
@@ -651,12 +653,13 @@ def run(pipeline,
         sync,
         price_type,
         region_id,
-        parent_node):
+        parent_node,
+        non_pause):
     """Schedules a pipeline execution
     """
     PipelineRunOperations.run(pipeline, config, parameters, yes, run_params, instance_disk, instance_type,
                               docker_image, cmd_template, timeout, quiet, instance_count, cores, sync, price_type,
-                              region_id, parent_node)
+                              region_id, parent_node, non_pause)
 
 
 @cli.command(name='stop')

--- a/pipe-cli/src/api/pipeline.py
+++ b/pipe-cli/src/api/pipeline.py
@@ -99,7 +99,7 @@ class Pipeline(API):
                         instance_disk=None, instance_type=None,
                         docker_image=None, cmd_template=None,
                         timeout=None, config_name=None, instance_count=None,
-                        price_type=None, region_id=None, parent_node=None):
+                        price_type=None, region_id=None, parent_node=None, non_pause=None):
         api = cls.instance()
         params = {}
         for parameter in parameters:
@@ -127,6 +127,8 @@ class Pipeline(API):
             payload['cloudRegionId'] = region_id
         if parent_node is not None:
             cls.__add_parent_node_params(payload, parent_node)
+        if non_pause is not None:
+            payload['nonPause'] = non_pause
         data = json.dumps(payload)
         response_data = api.call('run', data)
         return PipelineRunModel.load(response_data['payload'])
@@ -135,7 +137,7 @@ class Pipeline(API):
     def launch_command(cls, instance_disk, instance_type,
                        docker_image, cmd_template, parameters,
                        timeout=None, instance_count=None, price_type=None,
-                       region_id=None, parent_node=None):
+                       region_id=None, parent_node=None, non_pause=None):
         api = cls.instance()
         payload = {}
         if instance_disk is not None:
@@ -156,6 +158,8 @@ class Pipeline(API):
             payload['cloudRegionId'] = region_id
         if parent_node is not None:
             cls.__add_parent_node_params(payload, parent_node)
+        if non_pause is not None:
+            payload['nonPause'] = non_pause
         if parameters is not None:
             params = {}
             for key in parameters.keys():


### PR DESCRIPTION
Implementation for https://github.com/epam/cloud-pipeline/issues/892#issuecomment-585181746

The following changes were added:
1. introduced a new CLI option `--non-pause` that allows to configure `auto-pause` option via command line. True if `auto-pause` must be disabled.
2. new option added to `pipe run` command generation