### PR TITLE
Allow to configure keep-alive policy for Autoscaler

### DIFF
--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -478,6 +478,10 @@ public final class MessageConstants {
     public static final String ERROR_BILLING_DETAILS_NOT_SUPPORTED = "error.billing.details.not.supported";
     public static final String ERROR_BILLING_INTERVAL_NOT_SUPPORTED = "error.billing.interval.not.supported";
 
+
+    //Other
+    public static final String ERROR_KEEP_ALIVE_POLICY_NOT_SUPPORTED = "error.keep.alive.policy.not.supported";
+
     private MessageConstants() {
         // no-op
     }

--- a/api/src/main/java/com/epam/pipeline/entity/cluster/ClusterKeepAlivePolicy.java
+++ b/api/src/main/java/com/epam/pipeline/entity/cluster/ClusterKeepAlivePolicy.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.cluster;
+
+public enum ClusterKeepAlivePolicy {
+    MINUTES_TILL_HOUR, IDLE_MINUTES;
+}

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/CloudInstanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/CloudInstanceService.java
@@ -139,6 +139,8 @@ public interface CloudInstanceService<T extends AbstractCloudRegion>
      */
     Map<String, String> buildContainerCloudEnvVars(T region);
 
+    // TODO: this logic is moved to NodeExpirationService class, remove this method
+    //  if it is not needed anymore
     default boolean isNodeExpired(T region, Long runId, Integer keepAliveMinutes) {
         if (keepAliveMinutes == null) {
             return true;

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/alive/policy/IdleMinutesNodeExpirationService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/alive/policy/IdleMinutesNodeExpirationService.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster.alive.policy;
+
+import com.epam.pipeline.entity.cluster.ClusterKeepAlivePolicy;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.manager.pipeline.PipelineRunManager;
+import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.epam.pipeline.manager.preference.SystemPreferences;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class IdleMinutesNodeExpirationService implements NodeExpirationService {
+
+    private final PipelineRunManager runManager;
+    private final PreferenceManager preferenceManager;
+
+    @Override
+    public boolean isNodeExpired(final Long runId, final LocalDateTime nodeLaunchTime) {
+        try {
+            final Integer keepAliveMinutes = preferenceManager.getPreference(
+                    SystemPreferences.CLUSTER_KEEP_ALIVE_MINUTES);
+            if (keepAliveMinutes == null) {
+                return true;
+            }
+            final PipelineRun pipelineRun = runManager.loadPipelineRun(runId);
+            final Date endDate = pipelineRun.getEndDate();
+            if (endDate == null) {
+                return true;
+            }
+            return Instant.ofEpochMilli(endDate.getTime())
+                    .atZone(ZoneId.systemDefault())
+                    .toLocalDate()
+                    .plus(keepAliveMinutes, ChronoUnit.MINUTES)
+                    .isAfter(LocalDate.now());
+        } catch (IllegalArgumentException e) {
+            log.trace(e.getMessage(), e);
+            return true;
+        }
+    }
+
+    @Override
+    public ClusterKeepAlivePolicy policy() {
+        return ClusterKeepAlivePolicy.IDLE_MINUTES;
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/alive/policy/IdleMinutesNodeExpirationService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/alive/policy/IdleMinutesNodeExpirationService.java
@@ -53,6 +53,8 @@ public class IdleMinutesNodeExpirationService implements NodeExpirationService {
             if (endDate == null) {
                 return true;
             }
+            log.debug("Node for run {} is idle from {}. Checking preference: keep alive for {} minutes.",
+                    runId, endDate, keepAliveMinutes);
             return Instant.ofEpochMilli(endDate.getTime())
                     .atZone(ZoneId.systemDefault())
                     .toLocalDate()

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/alive/policy/IdleMinutesNodeExpirationService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/alive/policy/IdleMinutesNodeExpirationService.java
@@ -26,7 +26,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
@@ -57,9 +56,9 @@ public class IdleMinutesNodeExpirationService implements NodeExpirationService {
                     runId, endDate, keepAliveMinutes);
             return Instant.ofEpochMilli(endDate.getTime())
                     .atZone(ZoneId.systemDefault())
-                    .toLocalDate()
+                    .toLocalDateTime()
                     .plus(keepAliveMinutes, ChronoUnit.MINUTES)
-                    .isAfter(LocalDate.now());
+                    .isAfter(LocalDateTime.now());
         } catch (IllegalArgumentException e) {
             log.trace(e.getMessage(), e);
             return true;

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/alive/policy/MinutesTillHourNodeExpirationService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/alive/policy/MinutesTillHourNodeExpirationService.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster.alive.policy;
+
+import com.epam.pipeline.entity.cluster.ClusterKeepAlivePolicy;
+import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.epam.pipeline.manager.preference.SystemPreferences;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MinutesTillHourNodeExpirationService implements NodeExpirationService {
+
+    private static final int TIME_DELIMITER = 60;
+    private static final int TIME_TO_SHUT_DOWN_NODE = 1;
+
+    private final PreferenceManager preferenceManager;
+
+    @Override
+    public boolean isNodeExpired(final Long runId, final LocalDateTime nodeLaunchTime) {
+        if (nodeLaunchTime == null) {
+            return true;
+        }
+        final Integer keepAliveMinutes = preferenceManager.getPreference(
+                SystemPreferences.CLUSTER_KEEP_ALIVE_MINUTES);
+        if (keepAliveMinutes == null) {
+            return true;
+        }
+        try {
+            log.debug("Node {} launch time {}.", runId, nodeLaunchTime);
+            LocalDateTime now = LocalDateTime.now(Clock.systemUTC());
+            long aliveTime = Duration.between(nodeLaunchTime, now).getSeconds() / TIME_DELIMITER;
+            log.debug("Node {} is alive for {} minutes.", runId, aliveTime);
+            long minutesToWholeHour = aliveTime % TIME_DELIMITER;
+            long minutesLeft = TIME_DELIMITER - minutesToWholeHour;
+            log.debug("Node {} has {} minutes left until next hour.", runId, minutesLeft);
+            return minutesLeft <= keepAliveMinutes && minutesLeft > TIME_TO_SHUT_DOWN_NODE;
+        } catch (DateTimeParseException e) {
+            log.error(e.getMessage(), e);
+            return true;
+        }
+    }
+
+    @Override
+    public ClusterKeepAlivePolicy policy() {
+        return ClusterKeepAlivePolicy.MINUTES_TILL_HOUR;
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/alive/policy/NodeExpirationService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/alive/policy/NodeExpirationService.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster.alive.policy;
+
+import com.epam.pipeline.entity.cluster.ClusterKeepAlivePolicy;
+
+import java.time.LocalDateTime;
+
+public interface NodeExpirationService {
+
+    boolean isNodeExpired(Long runId, LocalDateTime nodeLaunchTime);
+    ClusterKeepAlivePolicy policy();
+}

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -19,6 +19,7 @@ package com.epam.pipeline.manager.preference;
 import com.epam.pipeline.common.MessageConstants;
 import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.entity.cluster.CloudRegionsConfiguration;
+import com.epam.pipeline.entity.cluster.ClusterKeepAlivePolicy;
 import com.epam.pipeline.entity.cluster.DockerMount;
 import com.epam.pipeline.entity.cluster.EnvVarsSettings;
 import com.epam.pipeline.entity.cluster.PriceType;
@@ -74,6 +75,7 @@ import static com.epam.pipeline.manager.preference.PreferenceValidators.isLessTh
 import static com.epam.pipeline.manager.preference.PreferenceValidators.isNotLessThanValueOrNull;
 import static com.epam.pipeline.manager.preference.PreferenceValidators.isNullOrGreaterThan;
 import static com.epam.pipeline.manager.preference.PreferenceValidators.isNullOrValidJson;
+import static com.epam.pipeline.manager.preference.PreferenceValidators.isValidEnum;
 import static com.epam.pipeline.manager.preference.PreferenceValidators.pass;
 
 /**
@@ -296,6 +298,8 @@ public class SystemPreferences {
         "cluster.high.non.batch.priority", false, CLUSTER_GROUP, pass);
     public static final IntPreference CLUSTER_KEEP_ALIVE_MINUTES = new IntPreference("cluster.keep.alive.minutes",
                                                                                 10, CLUSTER_GROUP, isGreaterThan(0));
+    public static final StringPreference CLUSTER_KEEP_ALIVE_POLICY = new StringPreference("cluster.keep.alive.policy",
+            ClusterKeepAlivePolicy.MINUTES_TILL_HOUR.name(), CLUSTER_GROUP, isValidEnum(ClusterKeepAlivePolicy.class));
     public static final BooleanPreference CLUSTER_SPOT = new BooleanPreference("cluster.spot", true, CLUSTER_GROUP,
                                                                                pass);
     public static final StringPreference CLUSTER_SPOT_ALLOC_STRATEGY = new StringPreference(
@@ -340,9 +344,8 @@ public class SystemPreferences {
     public static final ObjectPreference<List<DockerMount>> DOCKER_IN_DOCKER_MOUNTS = new ObjectPreference<>(
             "launch.dind.mounts", null, new TypeReference<List<DockerMount>>() {},
             LAUNCH_GROUP, isNullOrValidJson(new TypeReference<List<DockerMount>>() {}));
-    public static final StringPreference RUN_VISIBILITY_POLICY = new StringPreference(
-            "launch.run.visibility", RunVisibilityPolicy.INHERIT.name(), LAUNCH_GROUP,
-            PreferenceValidators.isValidEnum(RunVisibilityPolicy.class));
+    public static final StringPreference RUN_VISIBILITY_POLICY = new StringPreference("launch.run.visibility",
+            RunVisibilityPolicy.INHERIT.name(), LAUNCH_GROUP, isValidEnum(RunVisibilityPolicy.class));
     public static final IntPreference LAUNCH_CONTAINER_CPU_RESOURCE = new IntPreference(
             "launch.container.cpu.resource", 0, LAUNCH_GROUP, isGreaterThan(-1));
 

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -442,3 +442,6 @@ error.billing.date.field.grouping.not.supported="Currently field and date groupi
 error.billing.details.not.supported="Details are supported for grouping requests only!"
 error.billing.interval.not.supported="Given interval is not supported!"
 error.billing.entity.for.grouping.not.found="''{0}'' entity for ''{1}'' grouping is not found."
+
+#Other
+error.keep.alive.policy.not.supported=Unsupported node keep alive policy: {0}.


### PR DESCRIPTION
This PR introduces a new `SystemPreference` `cluster.keep.alive.policy` with two supported values: `MINUTES_TILL_HOUR` (default) and `IDLE_MINUTES`.

#### MINUTES_TILL_HOUR
Default value, corresponds to previous behaviour: free node is kept in the cluster until it's live time till the next whole hour is greater than `cluster.keep.alive.minutes`.

#### IDLE_MINUTES
Free node is kept in the cluster until it's idle time (without any pod's assigned) is less than `cluster.keep.alive.minutes`.