### PR TITLE
Issue #761 Fix filters and grouping incorrect response

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/billing/BillingGrouping.java
+++ b/api/src/main/java/com/epam/pipeline/entity/billing/BillingGrouping.java
@@ -16,7 +16,9 @@
 
 package com.epam.pipeline.entity.billing;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -26,7 +28,7 @@ public enum BillingGrouping {
     RUN_COMPUTE_TYPE("compute_type", false),
     PIPELINE("pipeline", true),
     TOOL("tool", true),
-    STORAGE("id", Collections.singletonMap("resource_type", Collections.singletonList("STORAGE")), false),
+    STORAGE("id", Collections.singletonMap("resource_type", Arrays.asList("STORAGE")), false),
     STORAGE_TYPE("storage_type", false),
     USER("owner", false),
     BILLING_CENTER("biling_center", false);
@@ -42,7 +44,7 @@ public enum BillingGrouping {
     BillingGrouping(final String correspondingField, final Map<String, List<String>> requiredDefaultFilters,
                     final boolean usageDetailsRequired) {
         this.correspondingField = correspondingField;
-        this.requiredDefaultFilters = requiredDefaultFilters;
+        this.requiredDefaultFilters = new HashMap<>(requiredDefaultFilters);
         this.usageDetailsRequired = usageDetailsRequired;
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
@@ -141,7 +141,9 @@ public class BillingManager {
         final LocalDate to = request.getTo();
         final BillingGrouping grouping = request.getGrouping();
         final DateHistogramInterval interval = request.getInterval();
-        final Map<String, List<String>> filters = MapUtils.emptyIfNull(request.getFilters());
+        final Map<String, List<String>> filters = MapUtils.isEmpty(request.getFilters())
+                                                  ? new HashMap<>()
+                                                  : request.getFilters();
         setAuthorizationFilters(filters);
         if (interval != null) {
             return getBillingStats(elasticsearchClient, from, to, filters, interval);


### PR DESCRIPTION
This PR is related to issue #761 

It brings fix of incorrect response to requests with filters and grouping at the same time, which was caused by the usage of immutable collections and `Map.merge` call.