### PR TITLE
Issue #761 Merge filters from request and grouping required

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
@@ -248,9 +248,9 @@ public class BillingManager {
         final SearchRequest searchRequest = new SearchRequest();
         final SearchSourceBuilder searchSource = new SearchSourceBuilder();
         if (grouping != null) {
-            filters.forEach(
-                (key, value) -> grouping.getRequiredDefaultFilters().merge(key, value, (l1, l2) -> {
-                    l1.addAll(l2);
+            grouping.getRequiredDefaultFilters().forEach(
+                (key, value) -> filters.merge(key, value, (l1, l2) -> {
+                    l1.addAll(CollectionUtils.subtract(l2, l1));
                     return l1;
                 }));
             final AggregationBuilder fieldAgg = AggregationBuilders.terms(grouping.getCorrespondingField())


### PR DESCRIPTION
This PR is related to issue #761 

Currently, some groupings have default required filters. 
Now, these filters are merging with the ones from the request.