### PR TITLE
Issue #761 Expand detailed storage info

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/billing/BillingGrouping.java
+++ b/api/src/main/java/com/epam/pipeline/entity/billing/BillingGrouping.java
@@ -31,7 +31,7 @@ public enum BillingGrouping {
     STORAGE("id", Collections.singletonMap("resource_type", Arrays.asList("STORAGE")), false),
     STORAGE_TYPE("storage_type", false),
     USER("owner", false),
-    BILLING_CENTER("biling_center", false);
+    BILLING_CENTER("billing_center", false);
 
     private final String correspondingField;
     private final Map<String, List<String>> requiredDefaultFilters;

--- a/api/src/main/java/com/epam/pipeline/manager/billing/StorageBillingDetailsLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/StorageBillingDetailsLoader.java
@@ -18,27 +18,42 @@ package com.epam.pipeline.manager.billing;
 
 import com.epam.pipeline.entity.billing.BillingGrouping;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
+import com.epam.pipeline.entity.datastorage.aws.S3bucketDataStorage;
+import com.epam.pipeline.entity.datastorage.azure.AzureBlobStorage;
+import com.epam.pipeline.entity.datastorage.gcp.GSBucketStorage;
+import com.epam.pipeline.entity.region.AbstractCloudRegion;
 import com.epam.pipeline.manager.datastorage.DataStorageManager;
+import com.epam.pipeline.manager.region.CloudRegionManager;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class StorageBillingDetailsLoader implements EntityBillingDetailsLoader {
 
     private static final String PROVIDER = "provider";
+    private static final String REGION = "region";
+    private static final String CREATED = "created";
 
     @Value("${billing.empty.report.value:unknown}")
     private String emptyValue;
 
     @Autowired
     private final DataStorageManager dataStorageManager;
+
+    @Autowired
+    private final CloudRegionManager regionManager;
 
     @Override
     public BillingGrouping getGrouping() {
@@ -56,14 +71,48 @@ public class StorageBillingDetailsLoader implements EntityBillingDetailsLoader {
 
     @Override
     public Map<String, String> loadDetails(final String entityIdentifier) {
-        final Map<String, String> details = new HashMap<>();
         final AbstractDataStorage storage = dataStorageManager.loadByNameOrId(entityIdentifier);
-        details.put(PROVIDER, storage.getType().toString());
+        final Map<String, String> details = getRegionDetails(storage);
+        details.put(OWNER, storage.getOwner());
+        details.put(CREATED, DateTimeFormatter.ISO_DATE.format(storage.getCreatedDate().toInstant()));
         return details;
     }
 
     @Override
     public Map<String, String> getEmptyDetails() {
-        return Collections.singletonMap(PROVIDER, emptyValue);
+        return Stream.of(PROVIDER, REGION, OWNER, CREATED)
+            .collect(Collectors.toMap(Function.identity(), k -> emptyValue));
+    }
+
+    private Map<String, String> getRegionDetails(final AbstractDataStorage storage) {
+        final Map<String, String> details = new HashMap<>();
+        final Long regionId;
+        switch (storage.getType()) {
+            case S3:
+                regionId = ((S3bucketDataStorage) storage).getRegionId();
+                break;
+            case AZ:
+                regionId = ((AzureBlobStorage) storage).getRegionId();
+                break;
+            case GS:
+                regionId = ((GSBucketStorage) storage).getRegionId();
+                break;
+            default:
+                regionId = -1L;
+                break;
+        }
+        if (regionId != -1) {
+            try {
+                final AbstractCloudRegion region = regionManager.load(regionId);
+                details.put(PROVIDER, region.getProvider().name());
+                details.put(REGION, region.getName());
+                return details;
+            } catch (IllegalArgumentException e) {
+                log.warn("Can't load from DB info about region id={}!", regionId);
+            }
+        }
+        details.put(PROVIDER, storage.getType().name());
+        details.put(REGION, emptyValue);
+        return details;
     }
 }


### PR DESCRIPTION
This PR is related to issue #761 

It expands detailed info about data storage: `owner`, `created date`, `region` is provided now.