### PR TITLE
Issue #761 Fix loading of runs active in period

### DIFF
--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,6 +69,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -540,7 +541,7 @@ public class PipelineRunManagerTest extends AbstractManagerTest {
                 .collect(Collectors.toMap(BaseEntity::getId,
                                           Function.identity()));
 
-        Assert.assertEquals(4, stats.size());
+        Assert.assertEquals(5, stats.size());
         Assert.assertNull(stats.get(run1.getId()));
         Assert.assertEquals(2, stats.get(run2.getId()).getRunStatuses().size());
         Assert.assertEquals(2, stats.get(run3.getId()).getRunStatuses().size());
@@ -571,6 +572,58 @@ public class PipelineRunManagerTest extends AbstractManagerTest {
 
         Assert.assertEquals(TaskStatus.RUNNING, adjustedStatuses.get(2).getStatus());
         Assert.assertEquals(SYNC_PERIOD_START.plusHours(HOURS_18), adjustedStatuses.get(2).getTimestamp());
+    }
+
+    @Test
+    public void testCreateRunStatuses() {
+        final LocalDateTime syncStartMinus24 = SYNC_PERIOD_START.minusHours(HOURS_24);
+        final LocalDateTime syncStartMinus12 = SYNC_PERIOD_START.minusHours(HOURS_12);
+        final LocalDateTime syncStartPlus12 = SYNC_PERIOD_START.plusHours(HOURS_12);
+        final LocalDateTime syncStartPlus18 = SYNC_PERIOD_START.plusHours(HOURS_18);
+        final LocalDateTime syncEndPlus12 = SYNC_PERIOD_END.plusHours(HOURS_12);
+        final LocalDateTime syncEndPlus18 = SYNC_PERIOD_END.plusHours(HOURS_18);
+
+        final PipelineRun run1 = launchPipeline(configuration, INSTANCE_TYPE, null);
+        run1.setStartDate(Timestamp.valueOf(syncStartMinus12));
+        pipelineRunManager.createRunStatusesForRun(run1, SYNC_PERIOD_START, SYNC_PERIOD_END);
+        assertCreatedRunStatuses(run1, SYNC_PERIOD_START, SYNC_PERIOD_END);
+
+        final PipelineRun run2 = launchRunWithStartEndDate(syncStartMinus24, syncStartMinus12);
+        pipelineRunManager.createRunStatusesForRun(run2, SYNC_PERIOD_START, SYNC_PERIOD_END);
+        final List<RunStatus> runStatuses2 = run2.getRunStatuses();
+        Assert.assertNull(runStatuses2);
+
+        final PipelineRun run3 = launchRunWithStartEndDate(syncStartMinus24, syncStartPlus12);
+        pipelineRunManager.createRunStatusesForRun(run3, SYNC_PERIOD_START, SYNC_PERIOD_END);
+        assertCreatedRunStatuses(run3, SYNC_PERIOD_START, syncStartPlus12);
+
+        final PipelineRun run4 = launchRunWithStartEndDate(syncStartPlus12, syncStartPlus18);
+        pipelineRunManager.createRunStatusesForRun(run4, SYNC_PERIOD_START, SYNC_PERIOD_END);
+        assertCreatedRunStatuses(run4, syncStartPlus12, syncStartPlus18);
+
+        final PipelineRun run5 = launchRunWithStartEndDate(syncStartPlus12, syncEndPlus18);
+        pipelineRunManager.createRunStatusesForRun(run5, SYNC_PERIOD_START, SYNC_PERIOD_END);
+        assertCreatedRunStatuses(run5, syncStartPlus12, SYNC_PERIOD_END);
+
+        final PipelineRun run6 = launchRunWithStartEndDate(syncEndPlus12, syncEndPlus18);
+        pipelineRunManager.createRunStatusesForRun(run6, SYNC_PERIOD_START, SYNC_PERIOD_END);
+        Assert.assertNull(run6.getRunStatuses());
+    }
+
+    private PipelineRun launchRunWithStartEndDate(final LocalDateTime startDate, final LocalDateTime endDate) {
+        final PipelineRun run = launchPipeline(configuration, INSTANCE_TYPE, null);
+        run.setStartDate(Timestamp.valueOf(startDate));
+        run.setEndDate(Timestamp.valueOf(endDate));
+        return run;
+    }
+
+    private void assertCreatedRunStatuses(final PipelineRun run,
+                                          final LocalDateTime firstStatusTimestamp,
+                                          final LocalDateTime secondStatusTimestamp) {
+        final List<RunStatus> runStatuses = run.getRunStatuses();
+        Assert.assertEquals(2, runStatuses.size());
+        Assert.assertEquals(firstStatusTimestamp, runStatuses.get(0).getTimestamp());
+        Assert.assertEquals(secondStatusTimestamp, runStatuses.get(1).getTimestamp());
     }
 
     private PipelineRun launchPipelineRun(final LocalDateTime startDate, final LocalDateTime stopDate) {

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunManagerTest.java
@@ -531,6 +531,9 @@ public class PipelineRunManagerTest extends AbstractManagerTest {
         final PipelineRun run5 = launchPipelineRun(beforeSyncStart.minusHours(HOURS_24), null);
         saveStatusForRun(run5.getId(), TaskStatus.PAUSED, beforeSyncStart.minusHours(HOURS_18));
         saveStatusForRun(run5.getId(), TaskStatus.RUNNING, beforeSyncStart.minusHours(HOURS_12));
+        final PipelineRun run6 = launchPipelineRun(beforeSyncStart.minusHours(HOURS_24), null);
+        saveStatusForRun(run6.getId(), TaskStatus.RUNNING, beforeSyncStart.minusHours(HOURS_24));
+        saveStatusForRun(run6.getId(), TaskStatus.PAUSED, beforeSyncStart.minusHours(HOURS_12));
 
         final Map<Long, PipelineRun> stats =
             pipelineRunManager.loadRunsActivityStats(SYNC_PERIOD_START, SYNC_PERIOD_END).stream()

--- a/core/src/main/java/com/epam/pipeline/entity/utils/DateUtils.java
+++ b/core/src/main/java/com/epam/pipeline/entity/utils/DateUtils.java
@@ -21,6 +21,7 @@ import org.joda.time.DateTimeZone;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Date;
 
 public final class DateUtils {
@@ -36,5 +37,9 @@ public final class DateUtils {
 
     public static LocalDateTime nowUTC() {
         return LocalDateTime.now(Clock.systemUTC());
+    }
+
+    public static LocalDateTime convertDateToLocalDateTime(final Date date) {
+        return date.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
     }
 }


### PR DESCRIPTION
This PR is related to issue #761

During billing manager testing we discovered, that some unnecessary runs activity is pulling during request and indexed.

It happened due to missed last status condition check: if the last status before sync start is not `RUNNING` then this status should be removed from a list of statuses for run potentially producing spending. Potential runs without statuses for the required period shouldn't be returned.