### PR TITLE
Allow to set permissions for `pipe` mount

### DIFF
--- a/pipe-cli/mount/pipe-fuse.py
+++ b/pipe-cli/mount/pipe-fuse.py
@@ -102,7 +102,7 @@ if __name__ == '__main__':
                         help="Listing cache time to live, seconds")
     parser.add_argument("-s", "--cache-size", type=int, required=False, default=100,
                         help="Number of simultaneous listing caches")
-    parser.add_argument("-m", "--mode", type=str, required=False, default="775",
+    parser.add_argument("-m", "--mode", type=str, required=False, default="700",
                         help="Default mode for files")
     parser.add_argument("-o", "--options", type=str, required=False,
                         help="String with mount options supported by FUSE")

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -971,8 +971,9 @@ def storage_delete_object_tags(path, tags, version):
 @click.option('-l', '--log-file', required=False, help='Specify log file for mount operation')
 @click.option('-q', '--quiet', help='Quiet mode', is_flag=True)
 @click.option('-t', '--threads', help='Enables multithreading', is_flag=True)
+@click.option('-m', '--mode', required=False, help='Default file permissions',  default=700, type=int)
 @Config.validate_access_token
-def mount_storage(mountpoint, file, bucket, options, log_file, quiet, threads):
+def mount_storage(mountpoint, file, bucket, options, log_file, quiet, threads, mode):
     """ Mounts either all available file systems or a single bucket into a local folder.
         Either -f\\--file flag or -b\\--bucket argument should be specified.
         Command is supported for Linux distributions and MacOS and requires
@@ -981,9 +982,13 @@ def mount_storage(mountpoint, file, bucket, options, log_file, quiet, threads):
         - file - enables file system mount mode.
         - bucket - name of the bucket to mount.
         - options - any mount options supported by underlying FUSE implementation.
+        - log-file - path to FUSE log file.
+        - threads - start FUSE in a multithreaded mode.
+        - mode - file permissions mask
     """
     DataStorageOperations.mount_storage(mountpoint, file=file, log_file=log_file,
-                                        bucket=bucket, options=options, quiet=quiet, threading=threads)
+                                        bucket=bucket, options=options, quiet=quiet,
+                                        threading=threads, mode=mode)
 
 
 @storage.command('umount')

--- a/pipe-cli/src/utilities/datastorage_operations.py
+++ b/pipe-cli/src/utilities/datastorage_operations.py
@@ -451,7 +451,7 @@ class DataStorageOperations(object):
 
     @classmethod
     def mount_storage(cls, mountpoint, file=False, bucket=None, log_file=None, options=None, quiet=False,
-                      threading=False):
+                      threading=False, mode=700):
         try:
             if not file and not bucket:
                 click.echo('Either file system mode should be enabled (-f/--file) '
@@ -459,7 +459,7 @@ class DataStorageOperations(object):
                 sys.exit(1)
             cls.check_platform("mount")
             Mount().mount_storages(mountpoint, file, bucket, options, quiet=quiet, log_file=log_file,
-                                   threading=threading)
+                                   threading=threading, mode=mode)
         except ALL_ERRORS as error:
             click.echo('Error: %s' % str(error), err=True)
             sys.exit(1)

--- a/pipe-cli/src/utilities/storage/mount.py
+++ b/pipe-cli/src/utilities/storage/mount.py
@@ -33,35 +33,35 @@ class AbstractMount(object):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def get_mount_webdav_cmd(self, config, mountpoint, options, web_dav_url, threading=False):
+    def get_mount_webdav_cmd(self, config, mountpoint, options, web_dav_url, mode, threading=False):
         pass
 
     @abstractmethod
-    def get_mount_storage_cmd(self, config, mountpoint, options, bucket, threading=False):
+    def get_mount_storage_cmd(self, config, mountpoint, options, bucket, mode, threading=False):
         pass
 
 
 class FrozenMount(AbstractMount):
 
-    def get_mount_webdav_cmd(self, config, mountpoint, options, web_dav_url, threading=False):
+    def get_mount_webdav_cmd(self, config, mountpoint, options, web_dav_url, mode, threading=False):
         additional_args = self._append_threading('--webdav ' + web_dav_url, threading)
-        return self._get_mount_cmd(config, mountpoint, options, additional_args)
+        return self._get_mount_cmd(config, mountpoint, options, additional_args, mode)
 
-    def get_mount_storage_cmd(self, config, mountpoint, options, bucket, threading=False):
+    def get_mount_storage_cmd(self, config, mountpoint, options, bucket, mode, threading=False):
         additional_args = self._append_threading('--bucket ' + bucket, threading)
-        return self._get_mount_cmd(config, mountpoint, options, additional_args)
+        return self._get_mount_cmd(config, mountpoint, options, additional_args, mode)
 
     def _append_threading(self, args, threading):
         return args + ' --threads' if threading else args
 
-    def _get_mount_cmd(self, config, mountpoint, options, additional_arguments):
+    def _get_mount_cmd(self, config, mountpoint, options, additional_arguments, mode):
         mount_bin = self.get_mount_executable(config)
         mount_script = self.create_mount_script(os.path.dirname(Config.config_path()), mount_bin,
-                                                mountpoint, options, additional_arguments)
+                                                mountpoint, options, additional_arguments, mode)
         return ['bash', mount_script]
 
-    def create_mount_script(self, config_folder, mount_bin, mountpoint, options, additional_arguments):
-        mount_cmd = '%s --mountpoint %s %s' % (mount_bin, mountpoint, additional_arguments)
+    def create_mount_script(self, config_folder, mount_bin, mountpoint, options, additional_arguments, mode):
+        mount_cmd = '%s --mountpoint %s %s --mode %d' % (mount_bin, mountpoint, additional_arguments, mode)
         if options:
             mount_cmd += ' -o ' + options
         mount_script = os.path.join(config_folder, 'pipe-fuse-script' + str(uuid.uuid4()))
@@ -98,24 +98,24 @@ class FrozenMount(AbstractMount):
 
 class SourceMount(AbstractMount):
 
-    def get_mount_webdav_cmd(self, config, mountpoint, options, web_dav_url, threading=False):
+    def get_mount_webdav_cmd(self, config, mountpoint, options, web_dav_url, mode, threading=False):
         additional_args = self._append_threading(['--webdav', web_dav_url], threading)
-        return self._get_mount_cmd(config, mountpoint, options, additional_args)
+        return self._get_mount_cmd(config, mountpoint, options, additional_args, mode)
 
-    def get_mount_storage_cmd(self, config, mountpoint, options, bucket, threading=False):
+    def get_mount_storage_cmd(self, config, mountpoint, options, bucket, mode, threading=False):
         additional_args = self._append_threading(['--bucket', bucket], threading)
-        return self._get_mount_cmd(config, mountpoint, options, additional_args)
+        return self._get_mount_cmd(config, mountpoint, options, additional_args, mode)
 
     def _append_threading(self, args, threading):
         if threading:
             args.append('--threads')
         return args
 
-    def _get_mount_cmd(self, config, mountpoint, options, additional_arguments):
+    def _get_mount_cmd(self, config, mountpoint, options, additional_arguments, mode):
         python_exec = sys.executable
         script_folder = dirname(Config.get_base_source_dir())
         script_path = os.path.join(script_folder, 'mount/pipe-fuse.py')
-        mount_cmd = [python_exec, script_path, '--mountpoint', mountpoint]
+        mount_cmd = [python_exec, script_path, '--mountpoint', mountpoint, '--mode', mode]
         mount_cmd.extend(additional_arguments)
         if options:
             mount_cmd.extend(['-o', options])
@@ -125,23 +125,25 @@ class SourceMount(AbstractMount):
 class Mount(object):
 
     def mount_storages(self, mountpoint, file=False, bucket=None, options=None, quiet=False, log_file=None,
-                       threading=False):
+                       threading=False, mode=700):
         config = Config.instance()
         username = config.get_current_user()
         mount = FrozenMount() if is_frozen() else SourceMount()
         if file:
             web_dav_url = PreferenceAPI.get_preference('base.dav.auth.url').value
             web_dav_url = web_dav_url.replace('auth-sso/', username + '/')
-            self.mount_dav(mount, config, mountpoint, options, web_dav_url, log_file=log_file, threading=threading)
+            self.mount_dav(mount, config, mountpoint, options, web_dav_url, mode, log_file=log_file,
+                           threading=threading)
         else:
-            self.mount_storage(mount, config, mountpoint, options, bucket, log_file=log_file, threading=threading)
+            self.mount_storage(mount, config, mountpoint, options, bucket, mode, log_file=log_file,
+                               threading=threading)
 
-    def mount_dav(self, mount, config, mountpoint, options, web_dav_url, log_file=None, threading=False):
-        mount_cmd = mount.get_mount_webdav_cmd(config, mountpoint, options, web_dav_url, threading=threading)
+    def mount_dav(self, mount, config, mountpoint, options, web_dav_url, mode, log_file=None, threading=False):
+        mount_cmd = mount.get_mount_webdav_cmd(config, mountpoint, options, web_dav_url, mode, threading=threading)
         self.run(config, mount_cmd, log_file=log_file)
 
-    def mount_storage(self, mount, config, mountpoint, options, bucket, log_file=None, threading=False):
-        mount_cmd = mount.get_mount_storage_cmd(config, mountpoint, options, bucket, threading=threading)
+    def mount_storage(self, mount, config, mountpoint, options, bucket, mode, log_file=None, threading=False):
+        mount_cmd = mount.get_mount_storage_cmd(config, mountpoint, options, bucket, mode, threading=threading)
         self.run(config, mount_cmd, log_file=log_file)
 
     def run(self, config, mount_cmd, mount_timeout=5, log_file=None):


### PR DESCRIPTION
This PR provides implementation for issue #923.

### Implementation
A new option is added to `pipe storage mount` command `-m --mode`. It allows to specify file permissions to use for mounted filesystem. Default permission mask is `700` - user RWX, group and other - no permissions.