### PR TITLE
Issue 761 Update billing documents mapping

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/billing/BillingGrouping.java
+++ b/api/src/main/java/com/epam/pipeline/entity/billing/BillingGrouping.java
@@ -16,47 +16,37 @@
 
 package com.epam.pipeline.entity.billing;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 public enum BillingGrouping {
-    RESOURCE_TYPE("resource_type", false),
-    RUN_INSTANCE_TYPE("instance_type", true),
-    RUN_COMPUTE_TYPE("compute_type", false),
-    PIPELINE("pipeline", true),
-    TOOL("tool", true),
-    STORAGE("id", Collections.singletonMap("resource_type", Arrays.asList("STORAGE")), false),
-    STORAGE_TYPE("storage_type", false),
-    USER("owner", false),
-    BILLING_CENTER("billing_center", false);
+    RESOURCE_TYPE("resource_type", false, false),
+    RUN_INSTANCE_TYPE("instance_type", true, false),
+    RUN_COMPUTE_TYPE("compute_type", false, false),
+    PIPELINE("pipeline", true, false),
+    TOOL("tool", true, false),
+    STORAGE("storage_id", false, true),
+    STORAGE_TYPE("storage_type", false, false),
+    USER("owner", true, true),
+    BILLING_CENTER("billing_center", true, true);
 
     private final String correspondingField;
-    private final Map<String, List<String>> requiredDefaultFilters;
-    private final boolean usageDetailsRequired;
+    private final boolean runUsageDetailsRequired;
+    private final boolean storageUsageDetailsRequired;
 
-    BillingGrouping(final String correspondingField, final boolean usageDetailsRequired) {
-        this(correspondingField, Collections.emptyMap(), usageDetailsRequired);
-    }
-
-    BillingGrouping(final String correspondingField, final Map<String, List<String>> requiredDefaultFilters,
-                    final boolean usageDetailsRequired) {
+    BillingGrouping(final String correspondingField, final boolean runUsageDetailsRequired,
+                    final boolean storageUsageDetailsRequired) {
         this.correspondingField = correspondingField;
-        this.requiredDefaultFilters = new HashMap<>(requiredDefaultFilters);
-        this.usageDetailsRequired = usageDetailsRequired;
+        this.runUsageDetailsRequired = runUsageDetailsRequired;
+        this.storageUsageDetailsRequired = storageUsageDetailsRequired;
     }
 
     public String getCorrespondingField() {
         return correspondingField;
     }
 
-    public Map<String, List<String>> getRequiredDefaultFilters() {
-        return requiredDefaultFilters;
+    public boolean runUsageDetailsRequired() {
+        return runUsageDetailsRequired;
     }
 
-    public boolean usageDetailsRequired() {
-        return usageDetailsRequired;
+    public boolean storageUsageDetailsRequired() {
+        return storageUsageDetailsRequired;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
@@ -84,8 +84,8 @@ public class BillingManager {
 
     private static final String COST_FIELD = "cost";
     private static final String ACCUMULATED_COST = "accumulatedCost";
-    private static final String RUN_USAGE_FIELD = "usage_minutes";
-    private static final String STORAGE_USAGE_FIELD = "usage_bytes";
+    private static final String RUN_USAGE_FIELD = "usage_runs";
+    private static final String STORAGE_USAGE_FIELD = "usage_storages";
     private static final String RUN_ID_FIELD = "run_id";
     private static final String UNIQUE_RUNS = "runs";
     private static final String PAGE = "page";

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
@@ -84,8 +84,10 @@ public class BillingManager {
 
     private static final String COST_FIELD = "cost";
     private static final String ACCUMULATED_COST = "accumulatedCost";
-    private static final String RUN_USAGE_FIELD = "usage_runs";
-    private static final String STORAGE_USAGE_FIELD = "usage_storages";
+    private static final String RUN_USAGE_AGG = "usage_runs";
+    private static final String RUN_USAGE_FIELD = "usage_minutes";
+    private static final String STORAGE_USAGE_AGG = "usage_storages";
+    private static final String STORAGE_USAGE_FIELD = "usage_bytes";
     private static final String RUN_ID_FIELD = "run_id";
     private static final String UNIQUE_RUNS = "runs";
     private static final String PAGE = "page";
@@ -131,8 +133,8 @@ public class BillingManager {
                                             DateHistogramInterval.MONTH,
                                             DateHistogramInterval.YEAR);
         this.costAggregation = AggregationBuilders.sum(COST_FIELD).field(COST_FIELD);
-        this.runUsageAggregation = AggregationBuilders.sum(RUN_USAGE_FIELD).field(RUN_USAGE_FIELD);
-        this.storageUsageAggregation = AggregationBuilders.avg(STORAGE_USAGE_FIELD).field(STORAGE_USAGE_FIELD);
+        this.runUsageAggregation = AggregationBuilders.sum(RUN_USAGE_AGG).field(RUN_USAGE_FIELD);
+        this.storageUsageAggregation = AggregationBuilders.avg(STORAGE_USAGE_AGG).field(STORAGE_USAGE_FIELD);
         this.uniqueRunsAggregation = AggregationBuilders.terms(UNIQUE_RUNS).field(RUN_ID_FIELD);
         this.billingDetailsLoaders = billingDetailsLoaders.stream()
             .collect(Collectors.toMap(EntityBillingDetailsLoader::getGrouping,
@@ -380,19 +382,19 @@ public class BillingManager {
         }
         if (loadDetails) {
             if (grouping.runUsageDetailsRequired()) {
-                final ParsedSum usageAggResult = aggregations.get(RUN_USAGE_FIELD);
+                final ParsedSum usageAggResult = aggregations.get(RUN_USAGE_AGG);
                 final long usageVal = new Double(usageAggResult.getValue()).longValue();
-                groupingInfo.put(RUN_USAGE_FIELD, Long.toString(usageVal));
+                groupingInfo.put(RUN_USAGE_AGG, Long.toString(usageVal));
                 final ParsedStringTerms ids = aggregations.get(UNIQUE_RUNS);
                 groupingInfo.put(UNIQUE_RUNS, Integer.toString(ids.getBuckets().size()));
             }
             if (grouping.storageUsageDetailsRequired()) {
-                final ParsedAvg usageAggResult = aggregations.get(STORAGE_USAGE_FIELD);
+                final ParsedAvg usageAggResult = aggregations.get(STORAGE_USAGE_AGG);
                 final double aggValue = usageAggResult.getValue();
                 final long usageVal =  Double.isFinite(aggValue)
                                        ? new Double(aggValue).longValue()
                                        : 0L;
-                groupingInfo.put(STORAGE_USAGE_FIELD, Long.toString(usageVal));
+                groupingInfo.put(STORAGE_USAGE_AGG, Long.toString(usageVal));
             }
             if (detailsLoader != null) {
                 try {

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
@@ -48,6 +48,8 @@ import org.elasticsearch.search.aggregations.bucket.histogram.ParsedDateHistogra
 import org.elasticsearch.search.aggregations.bucket.terms.ParsedStringTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.avg.AvgAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.avg.ParsedAvg;
 import org.elasticsearch.search.aggregations.metrics.sum.ParsedSum;
 import org.elasticsearch.search.aggregations.metrics.sum.SumAggregationBuilder;
 import org.elasticsearch.search.aggregations.pipeline.ParsedSimpleValue;
@@ -82,8 +84,9 @@ public class BillingManager {
 
     private static final String COST_FIELD = "cost";
     private static final String ACCUMULATED_COST = "accumulatedCost";
-    private static final String USAGE_FIELD = "usage";
-    private static final String ID_FIELD = "id";
+    private static final String RUN_USAGE_FIELD = "usage_minutes";
+    private static final String STORAGE_USAGE_FIELD = "usage_bytes";
+    private static final String RUN_ID_FIELD = "run_id";
     private static final String UNIQUE_RUNS = "runs";
     private static final String PAGE = "page";
     private static final String TOTAL_PAGES = "totalPages";
@@ -99,8 +102,9 @@ public class BillingManager {
     private final Map<DateHistogramInterval, TemporalAdjuster> periodAdjusters;
     private final List<DateHistogramInterval> validIntervals;
     private final SumAggregationBuilder costAggregation;
-    private final SumAggregationBuilder usageAggregation;
-    private final TermsAggregationBuilder idAggregation;
+    private final SumAggregationBuilder runUsageAggregation;
+    private final AvgAggregationBuilder storageUsageAggregation;
+    private final TermsAggregationBuilder uniqueRunsAggregation;
     private final Map<BillingGrouping, EntityBillingDetailsLoader> billingDetailsLoaders;
     @Value("${billing.empty.report.value:unknown}")
     private String emptyValue;
@@ -127,8 +131,9 @@ public class BillingManager {
                                             DateHistogramInterval.MONTH,
                                             DateHistogramInterval.YEAR);
         this.costAggregation = AggregationBuilders.sum(COST_FIELD).field(COST_FIELD);
-        this.usageAggregation = AggregationBuilders.sum(USAGE_FIELD).field(USAGE_FIELD);
-        this.idAggregation = AggregationBuilders.terms(UNIQUE_RUNS).field(ID_FIELD);
+        this.runUsageAggregation = AggregationBuilders.sum(RUN_USAGE_FIELD).field(RUN_USAGE_FIELD);
+        this.storageUsageAggregation = AggregationBuilders.avg(STORAGE_USAGE_FIELD).field(STORAGE_USAGE_FIELD);
+        this.uniqueRunsAggregation = AggregationBuilders.terms(UNIQUE_RUNS).field(RUN_ID_FIELD);
         this.billingDetailsLoaders = billingDetailsLoaders.stream()
             .collect(Collectors.toMap(EntityBillingDetailsLoader::getGrouping,
                                       Function.identity()));
@@ -248,19 +253,17 @@ public class BillingManager {
         final SearchRequest searchRequest = new SearchRequest();
         final SearchSourceBuilder searchSource = new SearchSourceBuilder();
         if (grouping != null) {
-            grouping.getRequiredDefaultFilters().forEach(
-                (key, value) -> filters.merge(key, value, (l1, l2) -> {
-                    l1.addAll(CollectionUtils.subtract(l2, l1));
-                    return l1;
-                }));
             final AggregationBuilder fieldAgg = AggregationBuilders.terms(grouping.getCorrespondingField())
                 .field(grouping.getCorrespondingField())
                 .order(Terms.Order.aggregation(COST_FIELD, false))
                 .size(Integer.MAX_VALUE);
             fieldAgg.subAggregation(costAggregation);
-            if (grouping.usageDetailsRequired()) {
-                fieldAgg.subAggregation(usageAggregation);
-                fieldAgg.subAggregation(idAggregation);
+            if (grouping.runUsageDetailsRequired()) {
+                fieldAgg.subAggregation(runUsageAggregation);
+                fieldAgg.subAggregation(uniqueRunsAggregation);
+            }
+            if (grouping.storageUsageDetailsRequired()) {
+                fieldAgg.subAggregation(storageUsageAggregation);
             }
             searchSource.aggregation(fieldAgg);
         }
@@ -315,9 +318,12 @@ public class BillingManager {
     private List<BillingChartInfo> getEmptyGroupingResponse(final BillingGrouping grouping) {
         final Map<String, String> details = new HashMap<>();
         details.put(grouping.name(), emptyValue);
-        if (grouping.usageDetailsRequired()) {
-            details.put(USAGE_FIELD, emptyValue);
+        if (grouping.runUsageDetailsRequired()) {
+            details.put(RUN_USAGE_FIELD, emptyValue);
             details.put(UNIQUE_RUNS, emptyValue);
+        }
+        if (grouping.storageUsageDetailsRequired()) {
+            details.put(STORAGE_USAGE_FIELD, emptyValue);
         }
         final BillingChartInfo emptyResponse = BillingChartInfo.builder()
             .groupingInfo(details)
@@ -373,12 +379,20 @@ public class BillingManager {
             }
         }
         if (loadDetails) {
-            if (grouping.usageDetailsRequired()) {
-                final ParsedSum usageAggResult = aggregations.get(USAGE_FIELD);
+            if (grouping.runUsageDetailsRequired()) {
+                final ParsedSum usageAggResult = aggregations.get(RUN_USAGE_FIELD);
                 final long usageVal = new Double(usageAggResult.getValue()).longValue();
-                groupingInfo.put(USAGE_FIELD, Long.toString(usageVal));
+                groupingInfo.put(RUN_USAGE_FIELD, Long.toString(usageVal));
                 final ParsedStringTerms ids = aggregations.get(UNIQUE_RUNS);
                 groupingInfo.put(UNIQUE_RUNS, Integer.toString(ids.getBuckets().size()));
+            }
+            if (grouping.storageUsageDetailsRequired()) {
+                final ParsedAvg usageAggResult = aggregations.get(STORAGE_USAGE_FIELD);
+                final double aggValue = usageAggResult.getValue();
+                final long usageVal =  Double.isFinite(aggValue)
+                                       ? new Double(aggValue).longValue()
+                                       : 0L;
+                groupingInfo.put(STORAGE_USAGE_FIELD, Long.toString(usageVal));
             }
             if (detailsLoader != null) {
                 try {

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapper.java
@@ -42,14 +42,14 @@ public class RunBillingMapper extends AbstractEntityMapper<PipelineRunBillingInf
             jsonBuilder
                 .startObject()
                 .field(DOC_TYPE_FIELD, SearchDocumentType.PIPELINE_RUN.name())
-                .field("id", run.getId())
+                .field("run_id", run.getId())
                 .field("resource_type", billingInfo.getResourceType())
                 .field("pipeline", run.getPipelineId())
                 .field("tool", run.getDockerImage())
                 .field("instance_type", run.getInstance().getNodeType())
                 .field("compute_type", billingInfo.getEntity().getRunType())
                 .field("cost", billingInfo.getCost())
-                .field("usage", billingInfo.getUsageMinutes())
+                .field("usage_minutes", billingInfo.getUsageMinutes())
                 .field("run_price", run.getPricePerHour().unscaledValue().longValue())
                 .field("cloudRegionId", run.getInstance().getCloudRegionId())
                 .field("created_date", billingInfo.getDate());

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapper.java
@@ -42,12 +42,12 @@ public class StorageBillingMapper extends AbstractEntityMapper<StorageBillingInf
             jsonBuilder
                 .startObject()
                 .field(DOC_TYPE_FIELD, documentType.name())
-                .field("id", storage.getId())
+                .field("storage_id", storage.getId())
                 .field("resource_type", billingInfo.getResourceType())
                 .field("region", billingInfo.getRegionName())
                 .field("provider", storage.getType())
                 .field("storage_type", billingInfo.getStorageType())
-                .field("usage", billingInfo.getUsageBytes())
+                .field("usage_bytes", billingInfo.getUsageBytes())
                 .field("cost", billingInfo.getCost())
                 .field("created_date", billingInfo.getDate());
             buildUserContent(container.getOwner(), jsonBuilder);

--- a/billing-report-agent/src/main/resources/templates/pipeline_run_billing.json
+++ b/billing-report-agent/src/main/resources/templates/pipeline_run_billing.json
@@ -3,13 +3,13 @@
     "_doc": {
       "properties": {
         "doc_type": { "type": "keyword", "store": true },
-        "id": { "type": "keyword", "store": true },
+        "run_id": { "type": "keyword", "store": true },
         "pipeline": { "type": "keyword" },
         "resource_type": { "type": "keyword" },
         "compute_type": { "type": "keyword" },
         "cost": {"type": "long"},
         "run_price": {"type": "long"},
-        "usage": {"type": "long"},
+        "usage_minutes": {"type": "long"},
         "owner": { "type": "keyword" },
         "groups": { "type": "keyword" },
         "tool": {"type": "keyword"},

--- a/billing-report-agent/src/main/resources/templates/storage_billing.json
+++ b/billing-report-agent/src/main/resources/templates/storage_billing.json
@@ -3,7 +3,7 @@
     "_doc": {
       "properties": {
         "doc_type": { "type": "keyword", "store": true },
-        "id": { "type": "keyword", "store": true },
+        "storage_id": { "type": "keyword", "store": true },
         "resource_type": { "type": "keyword" },
         "region": { "type": "keyword" },
         "provider": { "type": "keyword" },
@@ -11,7 +11,7 @@
         "owner": { "type": "keyword" },
         "groups": { "type": "keyword" },
         "billing_center":  { "type": "keyword" },
-        "usage": {"type": "long"},
+        "usage_bytes": {"type": "long"},
         "cost": {"type": "long"},
         "created_date": {"type": "date"}
       }


### PR DESCRIPTION
This PR is related to the issue #761 

Previously both storage and run billings were using the same field name for id and usage stats (minutes for runs and bytes for storages), so grouping and collection of usage stats used to be more complicated.

Now `id` and `usage` field names for all resources are unique (`run_id`, `storage_id`, `usage_minutes`, `usage_bytes`), so complexity for operations above is less.

- field names in billing mapping are changed
- usage metrics and grouping processing are modified according to the new mapping structure