### PR TITLE
Issue #761 Load all billing centers

### DIFF
--- a/api/profiles/dev/application.properties
+++ b/api/profiles/dev/application.properties
@@ -142,3 +142,4 @@ cluster.disable.autoscaling=${CP_API_DISABLE_AUTOSCALER:false}
 #Billing API
 billing.index.common.prefix=cp-billing
 billing.empty.report.value=unknown
+billing.center.key=${CP_BILLING_CENTER_KEY:billingCenter}

--- a/api/profiles/dev/application.properties
+++ b/api/profiles/dev/application.properties
@@ -142,4 +142,4 @@ cluster.disable.autoscaling=${CP_API_DISABLE_AUTOSCALER:false}
 #Billing API
 billing.index.common.prefix=cp-billing
 billing.empty.report.value=unknown
-billing.center.key=${CP_BILLING_CENTER_KEY:billingCenter}
+billing.center.key=${CP_BILLING_CENTER_KEY:billing-center}

--- a/api/src/main/java/com/epam/pipeline/acl/billing/BillingApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/billing/BillingApiService.java
@@ -37,4 +37,8 @@ public class BillingApiService {
     public List<BillingChartInfo> getBillingChartInfoPaginated(final BillingChartRequest request) {
         return billingManager.getBillingChartInfoPaginated(request);
     }
+
+    public List<String> getAllBillingCenters() {
+        return billingManager.getAllBillingCenters();
+    }
 }

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -309,6 +309,8 @@ public final class MessageConstants {
             "error.metadata.entity.class.not.found.in.folder";
     public static final String ERROR_ENTITY_FOR_METADATA_NOT_FOUND = "error.entity.for.metadata.not.found";
     public static final String ERROR_ENTITY_FOR_METADATA_NOT_SPECIFIED = "error.entity.for.metadata.not.specified";
+    public static final String ERROR_KEY_FOR_METADATA_UNIQUE_VALUES_REQUEST_NOT_SPECIFIED =
+        "error.key.for.metadata.unique.values.not.specified";
 
     //Paging
     public static final String ERROR_PAGE_INDEX = "error.page.index";

--- a/api/src/main/java/com/epam/pipeline/controller/billing/BillingController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/billing/BillingController.java
@@ -26,6 +26,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -64,5 +65,16 @@ public class BillingController extends AbstractRestController {
         })
     public Result<List<BillingChartInfo>> getBillingChartInfoPaginated(@RequestBody final BillingChartRequest request) {
         return Result.success(billingApi.getBillingChartInfoPaginated(request));
+    }
+
+    @GetMapping(value = "/billing/centers")
+    @ResponseBody
+    @ApiOperation(
+        value = "Get list containing all billing centers.",
+        notes = "Get list containing all billing centers.",
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<List<String>> getAllBillingCenters() {
+        return Result.success(billingApi.getAllBillingCenters());
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/metadata/MetadataManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/metadata/MetadataManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import com.epam.pipeline.mapper.MetadataEntryMapper;
 import com.google.common.io.CharStreams;
 import com.google.common.io.LineProcessor;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -220,6 +221,14 @@ public class MetadataManager {
         } else {
             return updateMetadataItem(metadataVO);
         }
+    }
+
+    public List<String> loadUniqueValuesFromEntityClassMetadata(final AclClass entityClass, final String attributeKey) {
+        if (StringUtils.isEmpty(attributeKey)) {
+            throw new IllegalArgumentException(
+                messageHelper.getMessage(MessageConstants.ERROR_KEY_FOR_METADATA_UNIQUE_VALUES_REQUEST_NOT_SPECIFIED));
+        }
+        return metadataDao.loadUniqueValuesFromEntitiesAttribute(entityClass, attributeKey);
     }
 
     public MetadataEntry loadMetadataItem(Long id, AclClass aclClass) {

--- a/api/src/main/resources/dao/metadata-dao.xml
+++ b/api/src/main/resources/dao/metadata-dao.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+  ~ Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -139,6 +139,13 @@
                         m.entity_class = ?
                     AND
                         m.data @> CAST(? AS jsonb)
+                ]]>
+            </value>
+        </property>
+        <property name="loadUniqueValuesFromEntitiesAttributes">
+            <value>
+                <![CDATA[
+                    SELECT DISTINCT data -> :KEY -> :VALUE AS data FROM pipeline.metadata WHERE entity_class = :ENTITY_CLASS
                 ]]>
             </value>
         </property>

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -290,6 +290,7 @@ error.metadata.entity.writing.unsupported.format=File format ''{0}'' is not supp
 error.metadata.entity.class.not.found.in.folder=Folder ''{0}'' does not contain any metadata entities with ''{1}'' class.
 error.entity.for.metadata.not.found=Entity with requested ID ''{0}'' and class ''{1}'' was not found
 error.entity.for.metadata.not.specified=Entity ID and entity class is required for metadata
+error.key.for.metadata.unique.values.not.specified=Can't search for metadata values without key specified!
 
 #Paging
 error.page.index=Page index should be greater than 0.


### PR DESCRIPTION
This PR is related to issue #761

It allows loading billing centers of all the users.

- introduce `MetadataManager.loadUniqueValuesFromEntitiesAttribute` to search in DB through metadata of all entities of specific `AclClass` and return unique values for the given key
- `BillingManager` is using the method described above to load all billing centers from users' metadata with `AclClass.PIPELINE_USER` and key for billing center specified in application.properties