### PR TITLE
Issue #967 Error during Tool synchronisation

### DIFF
--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/tool/ToolMapper.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/tool/ToolMapper.java
@@ -31,6 +31,7 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 
 import static com.epam.pipeline.elasticsearchagent.service.ElasticsearchSynchronizer.DOC_TYPE_FIELD;
 
@@ -93,6 +94,7 @@ public class ToolMapper implements EntityMapper<ToolWithDescription> {
         if (CollectionUtils.isNotEmpty(versions)) {
             final String[] toolPackagesNames = versions.stream()
                 .map(ToolVersionAttributes::getScanResult)
+                .filter(Objects::nonNull)
                 .map(ToolVersionScanResult::getDependencies)
                 .flatMap(List::stream)
                 .map(ToolDependency::getName)

--- a/elasticsearch-agent/src/test/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/tool/ToolLoaderTest.java
+++ b/elasticsearch-agent/src/test/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/tool/ToolLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package com.epam.pipeline.elasticsearchagent.service.impl.converter.tool;
 
 import com.epam.pipeline.elasticsearchagent.exception.EntityNotFoundException;
 import com.epam.pipeline.elasticsearchagent.model.EntityContainer;
+import com.epam.pipeline.elasticsearchagent.model.ToolWithDescription;
 import com.epam.pipeline.elasticsearchagent.service.impl.CloudPipelineAPIClient;
 import com.epam.pipeline.entity.metadata.MetadataEntry;
 import com.epam.pipeline.entity.pipeline.Tool;
@@ -81,9 +82,9 @@ class ToolLoaderTest {
 
         when(apiClient.loadTool(anyString())).thenReturn(expectedTool);
 
-        Optional<EntityContainer<Tool>> container = toolLoader.loadEntity(1L);
-        EntityContainer<Tool> toolEntityContainer = container.orElseThrow(AssertionError::new);
-        Tool actualTool = toolEntityContainer.getEntity();
+        Optional<EntityContainer<ToolWithDescription>> container = toolLoader.loadEntity(1L);
+        EntityContainer<ToolWithDescription> toolEntityContainer = container.orElseThrow(AssertionError::new);
+        Tool actualTool = toolEntityContainer.getEntity().getTool();
 
         assertNotNull(actualTool);
 

--- a/elasticsearch-agent/src/test/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/tool/ToolMapperTest.java
+++ b/elasticsearch-agent/src/test/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/tool/ToolMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,9 @@
 package com.epam.pipeline.elasticsearchagent.service.impl.converter.tool;
 
 import com.epam.pipeline.elasticsearchagent.model.EntityContainer;
+import com.epam.pipeline.elasticsearchagent.model.ToolWithDescription;
+import com.epam.pipeline.entity.docker.ToolDescription;
+import com.epam.pipeline.entity.docker.ToolVersionAttributes;
 import com.epam.pipeline.entity.pipeline.Tool;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.junit.jupiter.api.Test;
@@ -54,8 +57,11 @@ class ToolMapperTest {
         tool.setToolGroupId(1L);
         tool.setLabels(Collections.singletonList(TEST_LABEL));
 
-        EntityContainer<Tool> container = EntityContainer.<Tool>builder()
-                .entity(tool)
+        final ToolDescription toolDescription = new ToolDescription();
+        toolDescription.setVersions(Collections.singletonList(new ToolVersionAttributes()));
+        toolDescription.setToolId(tool.getId());
+        EntityContainer<ToolWithDescription> container = EntityContainer.<ToolWithDescription>builder()
+                .entity(new ToolWithDescription(tool, toolDescription))
                 .owner(USER)
                 .metadata(METADATA)
                 .permissions(PERMISSIONS_CONTAINER)


### PR DESCRIPTION
This PR is related to issue #967 

It adds additional nullability check during tool mapping process to avoid NPE in `Stream.map()` call chain.

- use `.filter(Objects::nonNull)` between `Stream.map()` call sequence
- update tests