### PR TITLE
Issue #967 Global search synchronization

### DIFF
--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/AbstractCloudPipelineEntityLoader.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/AbstractCloudPipelineEntityLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,8 +54,9 @@ public abstract class AbstractCloudPipelineEntityLoader<T> implements EntityLoad
             return Optional.of(buildContainer(id));
         } catch (PipelineResponseException e) {
             log.error(e.getMessage(), e);
-            log.debug("Expected error message: {}", buildNotFoundErrorMessage(id));
-            if (e.getMessage().contains(buildNotFoundErrorMessage(id))) {
+            final String errorMessageWithId = buildNotFoundErrorMessage(id);
+            log.debug("Expected error message: {}", errorMessageWithId);
+            if (e.getMessage().replaceAll("[^\\w\\s]", "").contains(errorMessageWithId)) {
                 throw new EntityNotFoundException(e);
             }
             return Optional.empty();

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/tool/ToolMapper.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/tool/ToolMapper.java
@@ -96,8 +96,11 @@ public class ToolMapper implements EntityMapper<ToolWithDescription> {
                 .map(ToolVersionAttributes::getScanResult)
                 .filter(Objects::nonNull)
                 .map(ToolVersionScanResult::getDependencies)
+                .filter(Objects::nonNull)
                 .flatMap(List::stream)
+                .filter(Objects::nonNull)
                 .map(ToolDependency::getName)
+                .filter(Objects::nonNull)
                 .distinct()
                 .toArray(String[]::new);
             jsonBuilder.array("packages", toolPackagesNames);


### PR DESCRIPTION
This PR is related to issue #967 

It brings:
1. Additional non-nullability checks during the tool mapping process.
2. Changes to handling the situations when an entity is removed between sync ticks. We are using the approach when error message, received in API response, is parsed and its content is checking for ending with suffix string having an entity id. The problem is, that some of the IDs are sent as integer numbers and others as a string, so numbered-id responses have delimiters if the number is long. The proposed decision is to flatten the response by removing redundant symbols before the check.