### PR TITLE
Memory requests for pod containers

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/cluster/SwapConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/entity/cluster/SwapConfiguration.java
@@ -1,11 +1,10 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
- *
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,28 +16,16 @@
 package com.epam.pipeline.entity.cluster;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import java.util.List;
-import java.util.Map;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class NetworkConfiguration {
+public class SwapConfiguration {
 
-    private Long regionId;
     private String name;
-
-    @JsonProperty("default")
-    private Boolean defaultRegion;
-
-    @JsonProperty("networks")
-    private Map<String, String> allowedNetworks;
-
-    private List<SwapConfiguration> swap;
+    private String path;
 }

--- a/api/src/main/java/com/epam/pipeline/entity/cluster/container/ContainerMemoryResourcePolicy.java
+++ b/api/src/main/java/com/epam/pipeline/entity/cluster/container/ContainerMemoryResourcePolicy.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.cluster.container;
+
+public enum ContainerMemoryResourcePolicy {
+    /**
+     * No memory requests/limits shall be set for the pods
+     */
+    NO_LIMIT,
+    /**
+     * Memory request: 1Mi, memory limit: node_memory - 1Gi
+     */
+    NODE,
+    /**
+     * Memory request: 1Mi, memory limit: node_memory + swap_size - 1Gi
+     */
+    NODE_SWAP
+}

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacadeImpl.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacadeImpl.java
@@ -39,7 +39,6 @@ import com.epam.pipeline.manager.region.CloudRegionManager;
 import com.epam.pipeline.utils.CommonUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.MapUtils;
-import org.apache.commons.lang3.EnumUtils;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacadeImpl.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacadeImpl.java
@@ -105,10 +105,9 @@ public class CloudFacadeImpl implements CloudFacade {
 
     @Override
     public boolean isNodeExpired(final Long runId) {
-        final ClusterKeepAlivePolicy clusterKeepAlivePolicy = Optional.ofNullable(
-                preferenceManager.getPreference(SystemPreferences.CLUSTER_KEEP_ALIVE_POLICY))
-                .map(pref -> EnumUtils.getEnum(ClusterKeepAlivePolicy.class, pref))
-                .orElse(ClusterKeepAlivePolicy.MINUTES_TILL_HOUR);
+        final String preference = preferenceManager.getPreference(SystemPreferences.CLUSTER_KEEP_ALIVE_POLICY);
+        final ClusterKeepAlivePolicy clusterKeepAlivePolicy = CommonUtils.getEnumValueOrDefault(
+                preference, ClusterKeepAlivePolicy.MINUTES_TILL_HOUR);
         final AbstractCloudRegion region = getRegionByRunId(runId);
         final LocalDateTime nodeLaunchTime = getInstanceService(region).getNodeLaunchTime(region, runId);
         return Optional.ofNullable(MapUtils.emptyIfNull(expirationServices)

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/container/AbstractNodeContainerMemoryResourceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/container/AbstractNodeContainerMemoryResourceService.java
@@ -35,6 +35,7 @@ public abstract class AbstractNodeContainerMemoryResourceService implements Cont
 
     private static final String MEMORY_RESOURCE = "memory";
     private static final double MEMORY_LIMIT_GAP = 1.0;
+    private static final String GIBIBYTE_UNIT = "Gi";
 
     private final InstanceOfferManager instanceOfferManager;
     private final PreferenceManager preferenceManager;
@@ -50,9 +51,9 @@ public abstract class AbstractNodeContainerMemoryResourceService implements Cont
         log.debug("Calculated memory limit is {}", memoryLimit);
         final ContainerResources.ContainerResourcesBuilder requests = ContainerResources
                 .builder()
-                .requests(Collections.singletonMap(MEMORY_RESOURCE, new Quantity(String.valueOf(memoryRequest))));
+                .requests(Collections.singletonMap(MEMORY_RESOURCE, new Quantity(memoryRequest + GIBIBYTE_UNIT)));
         if (memoryLimit > 0) {
-            requests.limits(Collections.singletonMap(MEMORY_RESOURCE, new Quantity(String.valueOf(memoryLimit))));
+            requests.limits(Collections.singletonMap(MEMORY_RESOURCE, new Quantity(memoryLimit + GIBIBYTE_UNIT)));
         }
         return requests.build();
     }

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/container/AbstractNodeContainerMemoryResourceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/container/AbstractNodeContainerMemoryResourceService.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster.container;
+
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.pipeline.RunInstance;
+import com.epam.pipeline.manager.cluster.InstanceOfferManager;
+import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.epam.pipeline.manager.preference.SystemPreferences;
+import io.fabric8.kubernetes.api.model.Quantity;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.ListUtils;
+
+import java.util.Collections;
+
+@Slf4j
+@Getter
+@RequiredArgsConstructor
+public abstract class AbstractNodeContainerMemoryResourceService implements ContainerMemoryResourceService {
+
+    private static final String MEMORY_RESOURCE = "memory";
+    private static final double MEMORY_LIMIT_GAP = 1.0;
+
+    private final InstanceOfferManager instanceOfferManager;
+    private final PreferenceManager preferenceManager;
+
+    @Override
+    public ContainerResources buildResourcesForRun(final PipelineRun run) {
+        log.debug("Building memory requirements for run {}", run.getId());
+        final int memoryRequest = preferenceManager.getPreference(
+                SystemPreferences.LAUNCH_CONTAINER_MEMORY_RESOURCE_REQUEST);
+        final double nodeRam = getMemorySize(run);
+        log.debug("Node RAM is {}", nodeRam);
+        final long memoryLimit = Math.max(0, Math.round(nodeRam - MEMORY_LIMIT_GAP));
+        log.debug("Calculated memory limit is {}", memoryLimit);
+        final ContainerResources.ContainerResourcesBuilder requests = ContainerResources
+                .builder()
+                .requests(Collections.singletonMap(MEMORY_RESOURCE, new Quantity(String.valueOf(memoryRequest))));
+        if (memoryLimit > 0) {
+            requests.limits(Collections.singletonMap(MEMORY_RESOURCE, new Quantity(String.valueOf(memoryLimit))));
+        }
+        return requests.build();
+    }
+
+    abstract double getMemorySize(PipelineRun run);
+
+    protected double getNodeRam(PipelineRun run) {
+        final RunInstance instance = run.getInstance();
+        final String nodeType = instance.getNodeType();
+        return ListUtils.emptyIfNull(
+                instanceOfferManager.getAllInstanceTypes(instance.getCloudRegionId(), instance.getSpot()))
+                .stream()
+                .filter(type -> nodeType.equals(type.getName()))
+                .findFirst()
+                .map(instanceType -> (double)instanceType.getMemory())
+                .orElse(0.0);
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/container/ContainerMemoryResourceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/container/ContainerMemoryResourceService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster.container;
+
+import com.epam.pipeline.entity.cluster.container.ContainerMemoryResourcePolicy;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+
+public interface ContainerMemoryResourceService {
+
+    ContainerResources buildResourcesForRun(PipelineRun run);
+    ContainerMemoryResourcePolicy policy();
+}

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/container/ContainerResources.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/container/ContainerResources.java
@@ -1,10 +1,12 @@
 package com.epam.pipeline.manager.cluster.container;
 
+import com.epam.pipeline.utils.CommonUtils;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import lombok.Builder;
 import lombok.Data;
 
+import java.util.Collections;
 import java.util.Map;
 
 @Data
@@ -16,5 +18,21 @@ public class ContainerResources {
 
     public ResourceRequirements toContainerRequirements() {
         return new ResourceRequirements(limits, requests);
+    }
+
+    public static ContainerResources empty() {
+        return ContainerResources.builder()
+                .limits(Collections.emptyMap())
+                .requests(Collections.emptyMap())
+                .build();
+    }
+
+    public static ContainerResources merge(final ContainerResources first,
+                                           final ContainerResources second) {
+        return ContainerResources
+                .builder()
+                .limits(CommonUtils.mergeMaps(first.getLimits(), second.getLimits()))
+                .requests(CommonUtils.mergeMaps(first.getRequests(), second.getRequests()))
+                .build();
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/container/ContainerResources.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/container/ContainerResources.java
@@ -1,0 +1,20 @@
+package com.epam.pipeline.manager.cluster.container;
+
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.Map;
+
+@Data
+@Builder
+public class ContainerResources {
+
+    private final Map<String, Quantity> limits;
+    private final Map<String, Quantity> requests;
+
+    public ResourceRequirements toContainerRequirements() {
+        return new ResourceRequirements(limits, requests);
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/container/NoLimitContainerMemoryResourceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/container/NoLimitContainerMemoryResourceService.java
@@ -1,0 +1,44 @@
+/*
+ *
+ *  * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.epam.pipeline.manager.cluster.container;
+
+import com.epam.pipeline.entity.cluster.container.ContainerMemoryResourcePolicy;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@Service
+@RequiredArgsConstructor
+public class NoLimitContainerMemoryResourceService implements ContainerMemoryResourceService {
+
+    @Override
+    public ContainerResources buildResourcesForRun(final PipelineRun run) {
+        return ContainerResources.builder()
+                .limits(Collections.emptyMap())
+                .requests(Collections.emptyMap())
+                .build();
+    }
+
+    @Override
+    public ContainerMemoryResourcePolicy policy() {
+        return ContainerMemoryResourcePolicy.NO_LIMIT;
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/container/NoLimitContainerMemoryResourceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/container/NoLimitContainerMemoryResourceService.java
@@ -23,7 +23,6 @@ import com.epam.pipeline.entity.pipeline.PipelineRun;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
 
 @Service
 @RequiredArgsConstructor
@@ -31,10 +30,7 @@ public class NoLimitContainerMemoryResourceService implements ContainerMemoryRes
 
     @Override
     public ContainerResources buildResourcesForRun(final PipelineRun run) {
-        return ContainerResources.builder()
-                .limits(Collections.emptyMap())
-                .requests(Collections.emptyMap())
-                .build();
+        return ContainerResources.empty();
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/container/NodeContainerMemoryResourceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/container/NodeContainerMemoryResourceService.java
@@ -64,4 +64,3 @@ public class NodeContainerMemoryResourceService implements ContainerMemoryResour
         return ContainerMemoryResourcePolicy.NODE;
     }
 }
-x

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/container/NodeContainerMemoryResourceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/container/NodeContainerMemoryResourceService.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster.container;
+
+import com.epam.pipeline.entity.cluster.InstanceType;
+import com.epam.pipeline.entity.cluster.container.ContainerMemoryResourcePolicy;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.pipeline.RunInstance;
+import com.epam.pipeline.manager.cluster.InstanceOfferManager;
+import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.epam.pipeline.manager.preference.SystemPreferences;
+import io.fabric8.kubernetes.api.model.Quantity;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.ListUtils;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+
+@Service
+@RequiredArgsConstructor
+public class NodeContainerMemoryResourceService implements ContainerMemoryResourceService {
+
+    private static final String MEMORY_RESOURCE = "memory";
+
+    private final InstanceOfferManager instanceOfferManager;
+    private final PreferenceManager preferenceManager;
+
+    @Override
+    public ContainerResources buildResourcesForRun(final PipelineRun run) {
+        final RunInstance instance = run.getInstance();
+        final String nodeType = instance.getNodeType();
+        final Float nodeRam = ListUtils.emptyIfNull(
+                instanceOfferManager.getAllInstanceTypes(instance.getCloudRegionId(), instance.getSpot()))
+                .stream()
+                .filter(type -> nodeType.equals(type.getName()))
+                .findFirst()
+                .map(InstanceType::getMemory)
+                .orElse(0.0f);
+        final int memoryRequest = preferenceManager.getPreference(SystemPreferences.LAUNCH_CONTAINER_MEMORY_RESOURCE_REQUEST);
+        final int memoryLimit = Math.max(0, Math.round(nodeRam - 1.0f));
+        return ContainerResources
+                .builder()
+                .requests(Collections.singletonMap(MEMORY_RESOURCE, new Quantity(String.valueOf(memoryRequest))))
+                .limits(Collections.singletonMap(MEMORY_RESOURCE, new Quantity(String.valueOf(memoryLimit))))
+                .build();
+    }
+
+    @Override
+    public ContainerMemoryResourcePolicy policy() {
+        return ContainerMemoryResourcePolicy.NODE;
+    }
+}
+x

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/container/NodeSwapContainerMemoryResourceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/container/NodeSwapContainerMemoryResourceService.java
@@ -15,18 +15,52 @@
 
 package com.epam.pipeline.manager.cluster.container;
 
+import com.epam.pipeline.entity.cluster.CloudRegionsConfiguration;
+import com.epam.pipeline.entity.cluster.NetworkConfiguration;
 import com.epam.pipeline.entity.cluster.container.ContainerMemoryResourcePolicy;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
+import com.epam.pipeline.manager.cluster.InstanceOfferManager;
+import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.epam.pipeline.manager.preference.SystemPreferences;
+import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
+
 @Service
-@RequiredArgsConstructor
-public class NodeSwapContainerMemoryResourceService implements ContainerMemoryResourceService {
+public class NodeSwapContainerMemoryResourceService extends AbstractNodeContainerMemoryResourceService {
+
+    private static final String SWAP_RATIO = "swap_ratio";
+
+    public NodeSwapContainerMemoryResourceService(final InstanceOfferManager instanceOfferManager,
+                                                  final PreferenceManager preferenceManager) {
+        super(instanceOfferManager, preferenceManager);
+    }
+
     @Override
-    public ContainerResources buildResourcesForRun(PipelineRun run) {
-        return null;
+    protected double getMemorySize(final PipelineRun run) {
+        final double nodeRam = getNodeRam(run);
+        return nodeRam + getSwapSize(run, nodeRam);
+    }
+
+    private double getSwapSize(final PipelineRun run, final double nodeRam) {
+        final CloudRegionsConfiguration preference = getPreferenceManager()
+                .getPreference(SystemPreferences.CLUSTER_NETWORKS_CONFIG);
+        if (preference == null) {
+            return 0.0;
+        }
+        final double swapRatio = ListUtils.emptyIfNull(preference.getRegions()).stream()
+                .filter(regionConfig -> regionConfig.getRegionId().equals(run.getInstance().getCloudRegionId()))
+                .findFirst()
+                .map(NetworkConfiguration::getSwap)
+                .orElse(Collections.emptyList())
+                .stream()
+                .filter(swap -> SWAP_RATIO.equals(swap.getName()) && NumberUtils.isNumber(swap.getPath()))
+                .findFirst()
+                .map(swap -> NumberUtils.createDouble(swap.getPath())
+                ).orElse(0.0);
+        return swapRatio * nodeRam;
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/container/NodeSwapContainerMemoryResourceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/container/NodeSwapContainerMemoryResourceService.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster.container;
+
+import com.epam.pipeline.entity.cluster.container.ContainerMemoryResourcePolicy;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NodeSwapContainerMemoryResourceService implements ContainerMemoryResourceService {
+    @Override
+    public ContainerResources buildResourcesForRun(PipelineRun run) {
+        return null;
+    }
+
+    @Override
+    public ContainerMemoryResourcePolicy policy() {
+        return ContainerMemoryResourcePolicy.NODE_SWAP;
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/execution/SystemParams.java
+++ b/api/src/main/java/com/epam/pipeline/manager/execution/SystemParams.java
@@ -66,7 +66,9 @@ public enum SystemParams {
     FSBROWSER_TMP("cp-fsbrowser-tmp", "CP_FSBROWSER_TMP", false, true),
     FSBROWSER_STORAGE("cp-fsbrowser-storage", "CP_FSBROWSER_STORAGE", false, true),
     FSBROWSER_BLACK_LIST("cp-fsbrowser-black-list", "CP_FSBROWSER_BLACK_LIST", false, true),
-    CONTAINER_CPU_RESOURCE("container-cpu-resource", "CP_CONTAINER_CPU_RESOURCE", false, true);
+    CONTAINER_CPU_RESOURCE("container-cpu-resource", "CP_CONTAINER_CPU_RESOURCE", false, true),
+    CONTAINER_MEMORY_RESOURCE_POLICY("container-memory-resource-policy",
+            "CP_CONTAINER_MEMORY_RESOURCE_POLICY", false, true);
 
     public static final String CLOUD_REGION_PREFIX = "CP_ACCOUNT_REGION_";
     public static final String CLOUD_ACCOUNT_PREFIX = "CP_ACCOUNT_ID_";

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -23,6 +23,7 @@ import com.epam.pipeline.entity.cluster.ClusterKeepAlivePolicy;
 import com.epam.pipeline.entity.cluster.DockerMount;
 import com.epam.pipeline.entity.cluster.EnvVarsSettings;
 import com.epam.pipeline.entity.cluster.PriceType;
+import com.epam.pipeline.entity.cluster.container.ContainerMemoryResourcePolicy;
 import com.epam.pipeline.entity.git.GitlabVersion;
 import com.epam.pipeline.entity.monitoring.IdleRunAction;
 import com.epam.pipeline.entity.preference.Preference;
@@ -348,6 +349,11 @@ public class SystemPreferences {
             RunVisibilityPolicy.INHERIT.name(), LAUNCH_GROUP, isValidEnum(RunVisibilityPolicy.class));
     public static final IntPreference LAUNCH_CONTAINER_CPU_RESOURCE = new IntPreference(
             "launch.container.cpu.resource", 0, LAUNCH_GROUP, isGreaterThan(-1));
+    public static final StringPreference LAUNCH_CONTAINER_MEMORY_RESOURCE_POLICY = new StringPreference(
+            "launch.container.memory.resource.policy", ContainerMemoryResourcePolicy.NO_LIMIT.name(),
+            LAUNCH_GROUP, isValidEnum(ContainerMemoryResourcePolicy.class));
+    public static final IntPreference LAUNCH_CONTAINER_MEMORY_RESOURCE_REQUEST = new IntPreference(
+            "launch.container.memory.resource.request", 1, LAUNCH_GROUP, isGreaterThan(0));
 
     //DTS submission
     public static final StringPreference DTS_LAUNCH_CMD_TEMPLATE = new StringPreference("dts.launch.cmd",

--- a/api/src/main/java/com/epam/pipeline/utils/CommonUtils.java
+++ b/api/src/main/java/com/epam/pipeline/utils/CommonUtils.java
@@ -19,6 +19,7 @@ package com.epam.pipeline.utils;
 import com.epam.pipeline.entity.region.CloudProvider;
 import com.epam.pipeline.manager.cloud.CloudAwareService;
 import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.EnumUtils;
 
 import java.util.List;
@@ -54,7 +55,9 @@ public final class CommonUtils {
 
     public static <K, V> Map<K, V> mergeMaps(final Map<K, V> first,
                                              final Map<K, V> second) {
-        return Stream.concat(first.entrySet().stream(), second.entrySet().stream())
+        return Stream.concat(
+                MapUtils.emptyIfNull(first).entrySet().stream(),
+                MapUtils.emptyIfNull(second).entrySet().stream())
                 .collect(Collectors.toMap(
                     Map.Entry::getKey,
                     Map.Entry::getValue,

--- a/api/src/main/java/com/epam/pipeline/utils/CommonUtils.java
+++ b/api/src/main/java/com/epam/pipeline/utils/CommonUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,11 @@ package com.epam.pipeline.utils;
 import com.epam.pipeline.entity.region.CloudProvider;
 import com.epam.pipeline.manager.cloud.CloudAwareService;
 import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.lang3.EnumUtils;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -30,6 +32,13 @@ public final class CommonUtils {
 
     private CommonUtils() {
         //no op
+    }
+
+
+    public static <T extends Enum<T>> T getEnumValueOrDefault(final String enumName, final T defaultValue) {
+        return Optional.ofNullable(enumName)
+                .map(name -> EnumUtils.getEnum(defaultValue.getDeclaringClass(), enumName))
+                .orElse(defaultValue);
     }
 
     public static <T extends CloudAwareService> Map<CloudProvider, T> groupByCloudProvider(final List<T> services) {


### PR DESCRIPTION
This PR provides implementation for #971. It allows to configure how memory requests and limits shall be set for k8s pods (containers).

#### Implementation details
New `SystemPreference` `launch.container.memory.resource.policy` was added to configure memory limits and requests for k8s containers. It supports three values:
- `NO_LIMIT` - default behaviour - no limits or requests shall be applied to the container
- `NODE` - memory request is set to `1Gi` and memory limit is set to `node RAM - 1 Gi` 
- `NODE_SWAP` - memory request is set to `1Gi` and memory limit is set to `node RAM + swap - 1 Gi` 

A helper `SystemPreference` `launch.container.memory.resource.request` was also added. It configures default memory request in Gi.

It is possible to override `launch.container.memory.resource.policy` for a specific run by setting `CP_CONTAINER_MEMORY_RESOURCE_POLICY` parameter with one of supported policy names.
