### PR TITLE
Add environment variables inheritance docker wrapper

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -345,6 +345,13 @@ public class SystemPreferences {
     public static final ObjectPreference<List<DockerMount>> DOCKER_IN_DOCKER_MOUNTS = new ObjectPreference<>(
             "launch.dind.mounts", null, new TypeReference<List<DockerMount>>() {},
             LAUNCH_GROUP, isNullOrValidJson(new TypeReference<List<DockerMount>>() {}));
+    /**
+     * Specifies a comma-separated list of environment variables that should be inherited by DIND containers
+     * from run container.
+     */
+    public static final StringPreference DOCKER_IN_DOCKER_CONTAINER_VARS = new StringPreference(
+            "launch.dind.container.vars", "http_proxy,https_proxy,no_proxy,API,API_TOKEN",
+            LAUNCH_GROUP, pass);
     public static final StringPreference RUN_VISIBILITY_POLICY = new StringPreference("launch.run.visibility",
             RunVisibilityPolicy.INHERIT.name(), LAUNCH_GROUP, isValidEnum(RunVisibilityPolicy.class));
     public static final IntPreference LAUNCH_CONTAINER_CPU_RESOURCE = new IntPreference(

--- a/scripts/pipeline-launch/launch.sh
+++ b/scripts/pipeline-launch/launch.sh
@@ -423,21 +423,21 @@ function create_sys_dir {
       setfacl -d -m user::rwx -m group::rwx -m other::rx "$_DIR_NAME"
 }
 
-function initialise_restrictors {
-    local _RESTRICTING_COMMANDS="$1"
-    local _RESTRICTOR="$2"
-    local _RESTRICTORS_BIN="$3"
-    IFS=',' read -r -a RESTRICTING_COMMANDS_LIST <<< "$_RESTRICTING_COMMANDS"
-    for COMMAND in "${RESTRICTING_COMMANDS_LIST[@]}"
+function initialise_wrappers {
+    local _WRAPPING_COMMANDS="$1"
+    local _WRAPPER="$2"
+    local _WRAPPERS_BIN="$3"
+    IFS=',' read -r -a WRAPPING_COMMANDS_LIST <<< "$_WRAPPING_COMMANDS"
+    for COMMAND in "${WRAPPING_COMMANDS_LIST[@]}"
     do
         COMMAND_PATH=$(command -v "$COMMAND")
         if [[ "$?" == 0 ]]
         then
-            COMMAND_WRAPPER_PATH="$_RESTRICTORS_BIN/$COMMAND"
+            COMMAND_WRAPPER_PATH="$_WRAPPERS_BIN/$COMMAND"
             COMMAND_PERMISSIONS=$(stat -c %a "$COMMAND_PATH")
             if [[ "$?" == 0 ]]
             then
-                echo "$COMMON_REPO_DIR/shell/$_RESTRICTOR \"$COMMAND_PATH\" \"\$@\"" > "$COMMAND_WRAPPER_PATH"
+                echo "$COMMON_REPO_DIR/shell/$_WRAPPER \"$COMMAND_PATH\" \"\$@\"" > "$COMMAND_WRAPPER_PATH"
                 chmod "$COMMAND_PERMISSIONS" "$COMMAND_WRAPPER_PATH"
             fi
         fi
@@ -1164,12 +1164,12 @@ CP_USR_BIN="/usr/cpbin"
 
 mkdir -p "$CP_USR_BIN"
 
-initialise_restrictors "$CP_RESTRICTING_PACKAGE_MANAGERS" "package_manager_restrictor" "$CP_USR_BIN"
+initialise_wrappers "$CP_RESTRICTING_PACKAGE_MANAGERS" "package_manager_restrictor" "$CP_USR_BIN"
 
 if [[ "$CP_ALLOWED_MOUNT_TRANSFER_SIZE" ]]
 then
     MOUNTED_PATHS=$(list_storage_mounts "$DATA_STORAGE_MOUNT_ROOT")
-    initialise_restrictors "cp,mv" "transfer_restrictor \"$MOUNTED_PATHS\" \"$DATA_STORAGE_MOUNT_ROOT\"" "$CP_USR_BIN"
+    initialise_wrappers "cp,mv" "transfer_restrictor \"$MOUNTED_PATHS\" \"$DATA_STORAGE_MOUNT_ROOT\"" "$CP_USR_BIN"
 fi
 
 echo "export PATH=\"$CP_USR_BIN:\${PATH}\"" >> "$CP_ENV_FILE_TO_SOURCE"
@@ -1268,6 +1268,14 @@ echo "-"
 
 # Check whether there are any capabilities init scripts available and execute them before main SCRIPT
 cp_cap_init
+
+# Configure docker wrapper. See https://github.com/epam/cloud-pipeline/issues/983.
+if check_cp_cap CP_CAP_DIND_CONTAINER && ! check_cp_cap CP_CAP_DIND_CONTAINER_NO_VARS
+then
+    DEFAULT_ENV_FILE="/etc/docker/default.env.file"
+    pipe_get_preference "launch.dind.container.vars" | tr ',' '\n' > "$DEFAULT_ENV_FILE"
+    initialise_wrappers "docker" "docker_wrapper \"$DEFAULT_ENV_FILE\"" "$CP_USR_BIN"
+fi
 
 # As some environments do not support "sleep infinity" command - it is substituted with "sleep 10000d"
 SCRIPT="${SCRIPT/sleep infinity/sleep 10000d}"

--- a/scripts/pipeline-launch/launch.sh
+++ b/scripts/pipeline-launch/launch.sh
@@ -1269,7 +1269,7 @@ echo "-"
 # Check whether there are any capabilities init scripts available and execute them before main SCRIPT
 cp_cap_init
 
-# Configure docker wrapper. See https://github.com/epam/cloud-pipeline/issues/983.
+# Configure docker wrapper
 if check_cp_cap CP_CAP_DIND_CONTAINER && ! check_cp_cap CP_CAP_DIND_CONTAINER_NO_VARS
 then
     DEFAULT_ENV_FILE="/etc/docker/default.env.file"

--- a/workflows/pipe-common/shell/docker_wrapper
+++ b/workflows/pipe-common/shell/docker_wrapper
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The script is a docker cli wrapper provided by Cloud Pipeline.
+#
+# It makes several host environment variables to be available from within DIND containers by default.
+#
+# It takes an environment file which will be used with docker run command as a first argument,
+# docker executable absolute path as a second argument and all docker command arguments as the following
+# arguments.
+#
+# The given environment file is built based on the launch.dind.container.vars system preference value.
+#
+# The wrapper won't be configured and environment variables won't be available from within DIND containers
+# if CP_CAP_DIND_CONTAINER_NO_VARS system parameter is specified for the run.
+#
+# See https://github.com/epam/cloud-pipeline/issues/983 for more information.
+
+ENVIRONMENT_FILE="$1"
+UNDERLYING_DOCKER_EXECUTABLE="$2"
+shift 2
+
+DOCKER_OPTIONS=()
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+  --config | \
+    -c | --context | \
+    -H | --host | \
+    -l | --log-level | \
+    --tlscacert | \
+    --tlscert | \
+    --tlskey)
+    DOCKER_OPTIONS+=("$1" "$2")
+    shift 2
+    ;;
+  -D | --debug | \
+    --tls | \
+    --tlsverify | \
+    -v | --version)
+    DOCKER_OPTIONS+=("$1")
+    shift
+    ;;
+  *)
+    DOCKER_COMMAND="$1"
+    shift
+    break
+    ;;
+  esac
+done
+
+if [[ "$DOCKER_COMMAND" ]]; then
+  DOCKER_COMMANDS=("$DOCKER_COMMAND")
+  if [[ "$DOCKER_COMMAND" == "run" ]]; then
+    DOCKER_COMMANDS+=("--env-file" "$ENVIRONMENT_FILE")
+  fi
+fi
+
+$UNDERLYING_DOCKER_EXECUTABLE "${DOCKER_OPTIONS[@]}" "${DOCKER_COMMANDS[@]}" "$@"

--- a/workflows/pipe-common/shell/pipe_get_preference
+++ b/workflows/pipe-common/shell/pipe_get_preference
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage examples:
+#
+# pipe_get_preference "launch.dind.container.vars"
+#
+# pipe_get_preference "launch.dind.container.vars" \
+#                     "http_proxy,https_proxy,no_proxy,API,API_TOKEN"
+#
+
+# Required args
+PREFERENCE="$1"
+# Optional args
+DEFAULT_VALUE="$2"
+
+# Check global variables
+if [ -z "$LOG_DIR" ]
+  then
+    echo "[WARN] Log directory is not set, using /runs"
+	  export LOG_DIR=/runs
+fi
+
+# Check arguments
+if [ -z "$PREFERENCE" ]
+  then
+    echo "[ERROR] Preference name shall be supplied"
+	  exit 1
+fi
+
+# Call preferences API
+CMD="import pipeline.api;"
+CMD="${CMD} pipe=pipeline.api.PipelineAPI(\"${API}\", \"${LOG_DIR}\");"
+CMD="${CMD} print(pipe.get_preference('${PREFERENCE}').get('value', ''))"
+VALUE=$($CP_PYTHON2_PATH -c "$CMD")
+if [[ "$?" == "0" && "$VALUE" ]]
+then
+  echo "$VALUE"
+else
+  echo "$DEFAULT_VALUE"
+fi

--- a/workflows/pipe-common/shell/pipe_get_preference
+++ b/workflows/pipe-common/shell/pipe_get_preference
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# The script retrieves system preference from Cloud Pipeline API.
+#
+# Uses specified default value if system preference is either not configured or empty.
+#
 # Usage examples:
 #
 # pipe_get_preference "launch.dind.container.vars"


### PR DESCRIPTION
Resolves issue #983.

The following pull request introduces docker wrapper for runs with DIND capability being enabled. The wrapper is implemented just the same way it is done for #158 and #500.

A system preference and a system parameter are introduced by the pull request:

- `launch.dind.container.vars` system preference can be used to specify a comma-separated list of environment variables that will be automatically set for all launched DIND containers in all runs. Environment variable values will be inherited from the run's container.
- `CP_CAP_DIND_CONTAINER_NO_VARS` system parameter can be used for a single run to disable this environment variables inheritance capability.

Just as a neat addition `pipe_get_preference` script is added to pipe-common in order to simplify system preferences retrieving.