### PR TITLE
Issue #761 Set billing document id manually

### DIFF
--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/AwsStorageToBillingRequestConverter.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/AwsStorageToBillingRequestConverter.java
@@ -153,7 +153,8 @@ public class AwsStorageToBillingRequestConverter implements EntityToBillingReque
             .owner(owner)
             .entity(billing)
             .build();
-        return new IndexRequest(fullIndex, INDEX_TYPE).source(mapper.map(entity));
+        final String docId = billing.getEntity().getId().toString();
+        return new IndexRequest(fullIndex, INDEX_TYPE).id(docId).source(mapper.map(entity));
     }
 
     private StorageBillingInfo createBilling(final EntityContainer<AbstractDataStorage> storageContainer,

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverter.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverter.java
@@ -183,6 +183,7 @@ public class RunToBillingRequestConverter implements EntityToBillingRequestConve
             .entity(billing)
             .build();
         final String fullIndex = indexPrefix + parseDateToString(billing.getDate());
-        return new IndexRequest(fullIndex, INDEX_TYPE).source(mapper.map(entity));
+        final String docId = billing.getEntity().getPipelineRun().getId().toString();
+        return new IndexRequest(fullIndex, INDEX_TYPE).id(docId).source(mapper.map(entity));
     }
 }

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/AwsStorageToRequestConverterTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/AwsStorageToRequestConverterTest.java
@@ -190,6 +190,7 @@ public class AwsStorageToRequestConverterTest {
                                                                             SYNC_START, SYNC_END).get(0);
 
         final String expectedIndex = TestUtils.buildBillingIndex(TestUtils.STORAGE_BILLING_PREFIX, SYNC_START);
+        Assert.assertEquals(s3Storage.getId().toString(), request.id());
         final Map<String, Object> requestFieldsMap = ((IndexRequest) request).sourceAsMap();
         Assert.assertEquals(expectedIndex, request.index());
         Assert.assertEquals(SearchDocumentType.S3_STORAGE.name(),
@@ -207,6 +208,7 @@ public class AwsStorageToRequestConverterTest {
                                                                              TestUtils.STORAGE_BILLING_PREFIX,
                                                                              SYNC_START, SYNC_END).get(0);
         final String expectedIndex = TestUtils.buildBillingIndex(TestUtils.STORAGE_BILLING_PREFIX, SYNC_START);
+        Assert.assertEquals(nfsStorage.getId().toString(), request.id());
         final Map<String, Object> requestFieldsMap = ((IndexRequest) request).sourceAsMap();
         Assert.assertEquals(expectedIndex, request.index());
         Assert.assertEquals(SearchDocumentType.NFS_STORAGE.name(),
@@ -223,6 +225,7 @@ public class AwsStorageToRequestConverterTest {
                                                                             TestUtils.STORAGE_BILLING_PREFIX,
                                                                             SYNC_START, SYNC_END).get(0);
         final String expectedIndex = TestUtils.buildBillingIndex(TestUtils.STORAGE_BILLING_PREFIX, SYNC_START);
+        Assert.assertEquals(s3Storage.getId().toString(), request.id());
         final Map<String, Object> requestFieldsMap = ((IndexRequest) request).sourceAsMap();
         Assert.assertEquals(expectedIndex, request.index());
         Assert.assertEquals(SearchDocumentType.S3_STORAGE.name(),


### PR DESCRIPTION
This PR is related to issue #761.

Previously billing document id was generated during the insertion process by Elasticsearch, so synchronization for a specific period more than once produced duplicated docs and leads to incorrect spendings reports. 
We decided to use the id of a billable entity id as a document id to avoid such duplication.