### PR TITLE
`pipe` CLI shall allow to list the users/groups/objects permissions globally

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1058,8 +1058,8 @@ def set_acl(identifier, object_type, sid, group, allow, deny, inherit):
 @click.option(
     '-t', '--object-type',
     help='Object type',
-    required=True,
-    type=click.Choice(['pipeline', 'folder', 'data_storage'])
+    required=False,
+    type=click.Choice(ACLOperations.get_classes())
 )
 @Config.validate_access_token
 def view_user_objects(username, object_type):
@@ -1071,8 +1071,8 @@ def view_user_objects(username, object_type):
 @click.option(
     '-t', '--object-type',
     help='Object type',
-    required=True,
-    type=click.Choice(['pipeline', 'folder', 'data_storage'])
+    required=False,
+    type=click.Choice(ACLOperations.get_classes())
 )
 @Config.validate_access_token
 def view_group_objects(group_name, object_type):

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1022,7 +1022,7 @@ def umount_storage(mountpoint, quiet):
     '-t', '--object-type',
     help='Object type',
     required=True,
-    type=click.Choice(['pipeline', 'folder', 'data_storage'])
+    type=click.Choice(ACLOperations.get_classes())
 )
 @Config.validate_access_token
 def view_acl(identifier, object_type):
@@ -1038,7 +1038,7 @@ def view_acl(identifier, object_type):
     '-t', '--object-type',
     help='Object type',
     required=True,
-    type=click.Choice(['pipeline', 'folder', 'data_storage'])
+    type=click.Choice(ACLOperations.get_classes())
 )
 @click.option('-s', '--sid', help='User or group name', required=True)
 @click.option('-g', '--group', help='Group flag', is_flag=True)
@@ -1148,6 +1148,7 @@ def chown(user_name, entity_class, entity_name):
     - ENTITY_NAME: defines name or id of the object
     """
     PermissionsOperations.chown(user_name, entity_class, entity_name)
+
 
 @cli.command(name='ssh', context_settings=dict(
     ignore_unknown_options=True,

--- a/pipe-cli/src/api/entity.py
+++ b/pipe-cli/src/api/entity.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,8 +26,8 @@ class Entity(API):
         api = cls.instance()
         response_data = api.call('entities?identifier={}&aclClass={}'.format(identifier, str(entity_class).upper()),
                                  None)
-        if 'payload' in response_data and 'id' in response_data['payload']:
-            return response_data['payload']['id']
+        if 'payload' in response_data and 'id' in response_data['payload'] and 'aclClass' in response_data['payload']:
+            return response_data['payload']
         if 'message' in response_data:
             raise RuntimeError(response_data['message'])
         else:

--- a/pipe-cli/src/api/user.py
+++ b/pipe-cli/src/api/user.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from src.api.entity import Entity
 from .base import API
 import json
 from ..model.object_permission_model import ObjectPermissionModel
@@ -23,8 +23,13 @@ class User(API):
 
     @classmethod
     def get_permissions(cls, identifier, acl_class):
+        entity = Entity.load_by_id_or_name(identifier, acl_class)
+        return cls.permissions(entity['id'], entity['aclClass'])
+
+    @classmethod
+    def permissions(cls, id, acl_class):
         api = cls.instance()
-        response_data = api.call('grant?id={}&aclClass={}'.format(identifier, acl_class.upper()), None)
+        response_data = api.call('permissions?id={}&aclClass={}'.format(id, acl_class.upper()), None)
         if 'payload' in response_data and 'permissions' in response_data['payload']:
             permissions = []
             for permission_json in response_data['payload']['permissions']:

--- a/pipe-cli/src/utilities/acl_operations.py
+++ b/pipe-cli/src/utilities/acl_operations.py
@@ -17,12 +17,17 @@ import click
 import requests
 import prettytable
 
+
 from src.api.entity import Entity
 from src.api.user import User
 from src.config import ConfigNotFoundError
 
 
 class ACLOperations(object):
+
+    @classmethod
+    def get_classes(cls):
+        return ['pipeline', 'folder', 'data_storage', 'configuration', 'docker_registry', 'tool', 'tool_group']
 
     @classmethod
     def set_acl(cls, identifier, object_type, sid, group, allow, deny, inherit):

--- a/pipe-cli/src/utilities/permissions_operations.py
+++ b/pipe-cli/src/utilities/permissions_operations.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ class PermissionsOperations(object):
             if object_name.isdigit():
                 object_id = object_name
             else:
-                object_id = Entity.load_by_id_or_name(object_name, class_name)
+                object_id = Entity.load_by_id_or_name(object_name, class_name)['id']
             User.change_owner(user_name, class_name, object_id)
         except (ConfigNotFoundError, requests.exceptions.RequestException, RuntimeError, ValueError) as error:
             click.echo('Error: %s' % str(error), err=True)


### PR DESCRIPTION
This PR provides implementation for issue #911 : contains fixes for `pipe view-acl` command (use `GET /permissions` instead of `GET /grant`)