### PR TITLE
Issue #1007 Pass system parameters to worker nodes

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/utils/DefaultSystemParameter.java
+++ b/api/src/main/java/com/epam/pipeline/entity/utils/DefaultSystemParameter.java
@@ -28,8 +28,10 @@ public class DefaultSystemParameter {
     private String type;
     private String description;
     private String defaultValue;
+    private boolean passToWorkers;
 
     public DefaultSystemParameter() {
         this.type = PipeConfValueVO.DEFAULT_TYPE;
+        this.passToWorkers = false;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineConfigurationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineConfigurationManager.java
@@ -28,14 +28,18 @@ import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.Tool;
 import com.epam.pipeline.entity.pipeline.run.PipelineStart;
+import com.epam.pipeline.entity.utils.DefaultSystemParameter;
 import com.epam.pipeline.exception.git.GitClientException;
 import com.epam.pipeline.manager.datastorage.DataStorageApiService;
 import com.epam.pipeline.manager.docker.ToolVersionManager;
 import com.epam.pipeline.manager.git.GitManager;
+import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.manager.security.PermissionsService;
 import com.epam.pipeline.security.acl.AclPermission;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -82,6 +86,9 @@ public class PipelineConfigurationManager {
 
     @Autowired
     private MessageHelper messageHelper;
+
+    @Autowired
+    private PreferenceManager preferenceManager;
 
     private Function<AbstractDataStorage, String> mountOptionsSupplier = (ds) -> {
         if (ds instanceof NFSDataStorage) {
@@ -223,8 +230,20 @@ public class PipelineConfigurationManager {
     public void updateWorkerConfiguration(String parentId, PipelineStart runVO,
             PipelineConfiguration configuration, boolean isNFS, boolean clearParams) {
         configuration.setEraseRunEndpoints(hasBooleanParameter(configuration, ERASE_WORKER_ENDPOINTS));
-        Map<String, PipeConfValueVO> updatedParams = clearParams ?
+        final Map<String, PipeConfValueVO> configParameters = MapUtils.isEmpty(configuration.getParameters()) ?
                 new HashMap<>() : configuration.getParameters();
+        final Map<String, PipeConfValueVO> updatedParams = clearParams ? new HashMap<>() : configParameters;
+        final List<DefaultSystemParameter> systemParameters = preferenceManager.getPreference(
+                SystemPreferences.LAUNCH_SYSTEM_PARAMETERS);
+        ListUtils.emptyIfNull(systemParameters)
+                .stream()
+                .filter(param -> param.isPassToWorkers() &&
+                        configParameters.containsKey(param.getName()))
+                .forEach(param -> {
+                    final String paramName = param.getName();
+                    updatedParams.put(paramName, configParameters.get(paramName));
+                });
+
         updatedParams.put(PipelineRun.PARENT_ID_PARAM, new PipeConfValueVO(parentId));
         if (isNFS) {
             updatedParams.put(NFS_CLUSTER_ROLE, new PipeConfValueVO("true"));


### PR DESCRIPTION
This PR provides implementation for #1007 

### Implementation
A new field is added to `launch.system.parameters` preference entry - `passToWorkers` - with default value `false`. If `passToWorkers` is set to `true`, parameter will be passed to worker nodes, otherwise it will be set for master node only.