### PR TITLE
Issue #1006: Pause operation timeout

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerContainerOperationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerContainerOperationManager.java
@@ -244,7 +244,7 @@ public class DockerContainerOperationManager {
             //TODO: change SystemPreferences.COMMIT_TIMEOUT in according to
             // f_EPMCMBIBPC-2025_add_lastStatusUpdate_time branche
             boolean isFinished = sshConnection.waitFor(
-                    preferenceManager.getPreference(SystemPreferences.COMMIT_TIMEOUT), TimeUnit.SECONDS);
+                    preferenceManager.getPreference(SystemPreferences.PAUSE_TIMEOUT), TimeUnit.SECONDS);
 
             if (isFinished && sshConnection.exitValue() == COMMAND_CANNOT_EXECUTE_CODE) {
                 //TODO: change in according to f_EPMCMBIBPC-2025_add_lastStatusUpdate_time branche

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -116,6 +116,8 @@ public class SystemPreferences {
             "/root/pre_commit.sh", COMMIT_GROUP, PreferenceValidators.isNotBlank);
     public static final StringPreference POST_COMMIT_COMMAND_PATH = new StringPreference("commit.post.command.path",
             "/root/post_commit.sh", COMMIT_GROUP, PreferenceValidators.isNotBlank);
+    public static final IntPreference PAUSE_TIMEOUT = new IntPreference("pause.timeout", 24 * 60 * 60,
+            COMMIT_GROUP, isGreaterThan(0));
 
     // DATA_STORAGE_GROUP
     public static final IntPreference DATA_STORAGE_MAX_DOWNLOAD_SIZE = new IntPreference(


### PR DESCRIPTION
This PR is related to #1006.

### Implementation
A new SystemPreference `pause.timeout` is added to control time for pause operation. Default value is 24 hours (86 400 seconds).