### PR TITLE
Issue 989 Security API logs

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -116,10 +116,10 @@ dependencies {
 
     // Logging
     compile group: "org.slf4j", name: "slf4j-api", version: "1.7.24"
-    compile group: "org.apache.logging.log4j", name: "log4j-slf4j-impl", version: "2.8.2"
-    compile group: "org.apache.logging.log4j", name: "log4j-api", version: "2.8.2"
-    compile group: "org.apache.logging.log4j", name: "log4j-core", version: "2.8.2"
-    compile group: "org.apache.logging.log4j", name: "log4j-jcl", version: "2.8.2"
+    compile group: "org.apache.logging.log4j", name: "log4j-slf4j-impl", version: "2.11.2"
+    compile group: "org.apache.logging.log4j", name: "log4j-api", version: "2.11.2"
+    compile group: "org.apache.logging.log4j", name: "log4j-core", version: "2.11.2"
+    compile group: "org.apache.logging.log4j", name: "log4j-jcl", version: "2.11.2"
 
     // Core library
     compile project(":core")

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -287,6 +287,8 @@ public final class MessageConstants {
     public static final String ERROR_PERMISSION_IS_NOT_GRANTED = "error.permission.is.not.granted";
     public static final String ERROR_ENTITY_IS_LOCKED = "error.entity.is.locked";
     public static final String ERROR_USER_NOT_AUTHORIZED = "error.user.not.authorized";
+    public static final String ERROR_USER_NOT_REGISTERED_EXPLICITLY = "user.not.registered.explicitly";
+    public static final String ERROR_USER_NOT_REGISTERED_GROUP_EXPLICITLY = "user.not.registered.group.explicitly";
 
     // Metadata
     public static final String ERROR_METADATA_NOT_FOUND = "error.metadata.not.found";

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -280,6 +280,15 @@ public final class MessageConstants {
     public static final String ERROR_MUTABLE_ACL_RETURN = "error.mutable.acl.return";
     public static final String ERROR_NO_GROUP_WAS_FOUND = "error.no.group.was.found";
     public static final String ERROR_GROUP_STATUS_EXISTS = "group.status.exists";
+    public static final String INFO_ASSIGN_ROLE = "info.assign.role";
+    public static final String INFO_UNASSIGN_ROLE = "info.unassign.role";
+    public static final String INFO_CREATE_USER = "info.create.user";
+    public static final String INFO_DELETE_USER = "info.delete.user";
+    public static final String INFO_UPDATE_USER_ROLES = "info.update.user.roles";
+    public static final String INFO_UPDATE_USER_DATASTORAGE = "info.update.user.datastorage";
+    public static final String INFO_UPDATE_USER_BLOCK_STATUS= "info.update.user.block.status";
+    public static final String INFO_UPDATE_USER_SAML_INFO = "info.update.user.saml.info";
+
 
     // Security
     public static final String ERROR_PERMISSION_PARAM_REQUIRED = "permission.param.is.required";

--- a/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionManager.java
@@ -226,7 +226,8 @@ public class GrantPermissionManager {
         Permission permission = permissionFactory.buildFromMask(grantVO.getMask());
         String sidName = grantVO.getUserName().toUpperCase();
         Sid sid = aclService.createOrGetSid(sidName, grantVO.getPrincipal());
-        LOGGER.debug("Granting permissions for sid {}", sid);
+        LOGGER.info("Granting permissions. Entity: class={} id={},  mask: {}. Sid: name={} isPrincipal={}",
+                entity.getAclClass(), entity.getId(), permission.getMask(), sidName, grantVO.getPrincipal());
         int sidEntryIndex = findSidEntry(acl, sid);
         if (sidEntryIndex != -1) {
             acl.deleteAce(sidEntryIndex);
@@ -275,6 +276,8 @@ public class GrantPermissionManager {
             acl = aclService.updateAcl(acl);
         }
         AclSecuredEntry aclSecuredEntry = convertAclToEntryForUser(entity, acl, sid);
+        LOGGER.info("Deleting permissions for sid: name={} isPrincipal={}. Entity: class={} id={}",
+                user, isPrincipal, aclClass, id);
         updateEventsWithChildrenAndIssues(entity);
         return aclSecuredEntry;
     }
@@ -286,6 +289,7 @@ public class GrantPermissionManager {
                 messageHelper.getMessage(MessageConstants.ERROR_ENTITY_IS_LOCKED,
                         entity.getAclClass(), entity.getId()));
         MutableAcl acl = aclService.getOrCreateObjectIdentity(entity);
+        LOGGER.info("Deleting all permissions. Entity: class={} id={}", aclClass, id);
         acl = deleteAllAces(acl);
         return convertAclToEntry(entity, acl);
     }
@@ -311,6 +315,8 @@ public class GrantPermissionManager {
                 break;
             }
         }
+        LOGGER.info("Locking (set NO_READ NO_WRITE permission). Entity: class={} id={}",
+                entity.getAclClass(), entity.getId());
         clearAces(acl);
         acl.insertAce(0, mergedPermission, userRoleSid, true);
         acl = aclService.updateAcl(acl);
@@ -333,6 +339,8 @@ public class GrantPermissionManager {
         Permission newPermission = permissionFactory
                 .buildFromMask(permissionsService.unsetBits(ace.getPermission().getMask(),
                         AclPermission.NO_WRITE.getMask(), AclPermission.NO_EXECUTE.getMask()));
+        LOGGER.info("Unlocking (delete NO_READ NO_WRITE permission). Entity: class={} id={}",
+                entity.getAclClass(), entity.getId());
         acl.deleteAce(entryIndex);
         acl.insertAce(Math.max(entryIndex, 0), newPermission, userRoleSid, true);
         aclService.updateAcl(acl);
@@ -361,6 +369,7 @@ public class GrantPermissionManager {
         final AbstractSecuredEntity entity = entityManager.load(aclClass, id);
         final UserContext userContext = userManager.loadUserContext(userName);
         Assert.notNull(userContext, String.format("The user with name %s doesn't exist.", userName));
+        LOGGER.info("Change owner to: {}. Entity={} id={}", userName, entity.getAclClass(), entity.getId());
         aclService.changeOwner(entity, userName);
         return new AclSecuredEntry(entityManager.changeOwner(aclClass, id, userName));
     }

--- a/api/src/main/java/com/epam/pipeline/manager/user/RoleManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/RoleManager.java
@@ -26,6 +26,7 @@ import com.epam.pipeline.entity.user.PipelineUser;
 import com.epam.pipeline.entity.user.Role;
 import com.epam.pipeline.manager.datastorage.DataStorageValidator;
 import com.epam.pipeline.manager.security.GrantPermissionHandler;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
@@ -42,6 +43,7 @@ import java.util.stream.Collectors;
 /**
  * Provides methods for {@link com.epam.pipeline.entity.user.Role} entities management
  */
+@Slf4j
 @Service
 public class RoleManager {
 
@@ -109,6 +111,8 @@ public class RoleManager {
                 .filter(user -> user.getRoles().stream().noneMatch(role -> role.getId().equals(roleId)))
                 .map(PipelineUser::getId)
                 .collect(Collectors.toList());
+        log.info(messageHelper.getMessage(MessageConstants.INFO_ASSIGN_ROLE, roleId,
+                idsToAdd.stream().map(Object::toString).collect(Collectors.joining(", "))));
         if (CollectionUtils.isNotEmpty(idsToAdd)) {
             userDao.assignRoleToUsers(roleId, idsToAdd);
         }
@@ -125,6 +129,8 @@ public class RoleManager {
                 .filter(user -> user.getRoles().stream().anyMatch(role -> role.getId().equals(roleId)))
                 .map(PipelineUser::getId)
                 .collect(Collectors.toList());
+        log.info(messageHelper.getMessage(MessageConstants.INFO_UNASSIGN_ROLE, roleId,
+                idsToRemove.stream().map(Object::toString).collect(Collectors.joining(", "))));
         if (CollectionUtils.isNotEmpty(idsToRemove)) {
             userDao.removeRoleFromUsers(roleId, idsToRemove);
         }

--- a/api/src/main/java/com/epam/pipeline/manager/user/UserManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/UserManager.java
@@ -35,6 +35,7 @@ import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.manager.security.AuthManager;
 import com.epam.pipeline.security.UserContext;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.MapUtils;
@@ -56,6 +57,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 public class UserManager {
 
@@ -99,6 +101,7 @@ public class UserManager {
         user.setAttributes(attributes);
         user.setDefaultStorageId(defaultStorageId);
         storageValidator.validate(user);
+        log.info(messageHelper.getMessage(MessageConstants.INFO_CREATE_USER, userName));
         return userDao.createUser(user, userRoles);
     }
 
@@ -153,6 +156,7 @@ public class UserManager {
         PipelineUser userContext = loadUserById(id);
         userDao.deleteUserRoles(id);
         userDao.deleteUser(id);
+        log.info(messageHelper.getMessage(MessageConstants.INFO_DELETE_USER, userContext.getUserName(), id));
         return userContext;
     }
 
@@ -160,6 +164,8 @@ public class UserManager {
     public PipelineUser updateUser(Long id, List<Long> roles) {
         loadUserById(id);
         updateUserRoles(id, roles);
+        log.info(messageHelper.getMessage(MessageConstants.INFO_UPDATE_USER_ROLES,
+                id, roles.stream().map(Object::toString).collect(Collectors.joining(", "))));
         return loadUserById(id);
     }
 
@@ -175,6 +181,8 @@ public class UserManager {
         PipelineUser user = loadUserById(id);
         user.setDefaultStorageId(userVO.getDefaultStorageId());
         storageValidator.validate(user);
+        log.info(messageHelper.getMessage(MessageConstants.INFO_UPDATE_USER_DATASTORAGE,
+                id, userVO.getDefaultStorageId()));
         return userDao.updateUser(user);
     }
 
@@ -182,6 +190,7 @@ public class UserManager {
     public PipelineUser updateUserBlockingStatus(final Long id, final boolean blockStatus) {
         final PipelineUser user = loadUserById(id);
         user.setBlocked(blockStatus);
+        log.info(messageHelper.getMessage(MessageConstants.INFO_UPDATE_USER_BLOCK_STATUS, id, blockStatus));
         return userDao.updateUser(user);
     }
 
@@ -223,8 +232,10 @@ public class UserManager {
             userDao.updateUser(user);
         }
         updateUserRoles(id, roles);
+        log.info(messageHelper.getMessage(MessageConstants.INFO_UPDATE_USER_SAML_INFO, user.getUserName(), id));
         return loadUserById(id);
     }
+
 
     public PipelineUser loadUserByNameOrId(String identifier) {
         PipelineUser user;

--- a/api/src/main/java/com/epam/pipeline/security/SecurityLogAspect.java
+++ b/api/src/main/java/com/epam/pipeline/security/SecurityLogAspect.java
@@ -35,19 +35,27 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class SecurityLogAspect {
 
-    public static final String CHANGING_PERMISSION_POINTCUT =
-            "execution(* com.epam.pipeline.manager.security.GrantPermissionManager.setPermissions(..))" +
+    public static final String PERMISSION_RELATED_METHODS_POINTCUT =
+            "execution(* com.epam.pipeline.manager.security.GrantPermissionManager.*(..))" +
             "|| execution(* com.epam.pipeline.manager.security.GrantPermissionManager.deletePermissions(..))" +
             "|| execution(* com.epam.pipeline.manager.security.GrantPermissionManager.deleteAllPermissions(..))" +
             "|| execution(* com.epam.pipeline.manager.security.GrantPermissionManager.lockEntity(..))" +
             "|| execution(* com.epam.pipeline.manager.security.GrantPermissionManager.unlockEntity(..))" +
             "|| execution(* com.epam.pipeline.manager.security.GrantPermissionManager.changeOwner(..))";
 
+    public static final String USER_RELATED_METHODS_POINTCUT =
+            "execution(* com.epam.pipeline.manager.user.UserManager.update*(..)) " +
+            "|| execution(* com.epam.pipeline.manager.user.UserManager.delete*(..))" +
+            "|| execution(* com.epam.pipeline.manager.user.UserManager.create*(..))" +
+            "|| execution(* com.epam.pipeline.manager.user.RoleManager.assignRole(..))" +
+            "|| execution(* com.epam.pipeline.manager.user.RoleManager.removeRole(..))";
+
+
     public static final String ANONYMOUS = "Anonymous";
     public static final String KEY_USER = "user";
 
 
-    @Before(value = CHANGING_PERMISSION_POINTCUT)
+    @Before(value = PERMISSION_RELATED_METHODS_POINTCUT + " || " + USER_RELATED_METHODS_POINTCUT)
     public void addUserInfoFromSecurityContext() {
         SecurityContext context = SecurityContextHolder.getContext();
         if (context != null) {
@@ -80,7 +88,7 @@ public class SecurityLogAspect {
         ThreadContext.put(KEY_USER, decode.getSubject() != null ? decode.getSubject() : ANONYMOUS);
     }
 
-    @After(value = CHANGING_PERMISSION_POINTCUT +
+    @After(value = PERMISSION_RELATED_METHODS_POINTCUT +
             "|| execution(* com.epam.pipeline.security.saml.SAMLUserDetailsServiceImpl.loadUserBySAML(..)) " +
             "|| execution(* com.epam.pipeline.security.saml.SAMLProxyAuthenticationProvider.authenticate(..))" +
             "|| execution(* com.epam.pipeline.security.jwt.JwtFilterAuthenticationFilter.doFilterInternal(..))")

--- a/api/src/main/java/com/epam/pipeline/security/SecurityLogAspect.java
+++ b/api/src/main/java/com/epam/pipeline/security/SecurityLogAspect.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.security;
+
+import com.epam.pipeline.security.saml.SAMLProxyAuthentication;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.logging.log4j.ThreadContext;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.After;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.saml.SAMLCredential;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+public class SecurityLogAspect {
+
+    public static final String CHANGING_PERMISSION_POINTCUT =
+            "execution(* com.epam.pipeline.manager.security.GrantPermissionManager.setPermissions(..))" +
+            "|| execution(* com.epam.pipeline.manager.security.GrantPermissionManager.deletePermissions(..))" +
+            "|| execution(* com.epam.pipeline.manager.security.GrantPermissionManager.deleteAllPermissions(..))" +
+            "|| execution(* com.epam.pipeline.manager.security.GrantPermissionManager.lockEntity(..))" +
+            "|| execution(* com.epam.pipeline.manager.security.GrantPermissionManager.unlockEntity(..))" +
+            "|| execution(* com.epam.pipeline.manager.security.GrantPermissionManager.changeOwner(..))";
+
+    public static final String ANONYMOUS = "Anonymous";
+    public static final String KEY_USER = "user";
+
+
+    @Before(value = CHANGING_PERMISSION_POINTCUT)
+    public void addUserInfoFromSecurityContext() {
+        SecurityContext context = SecurityContextHolder.getContext();
+        if (context != null) {
+            ThreadContext.put(KEY_USER, context.getAuthentication() != null
+                    ? context.getAuthentication().getName()
+                    : ANONYMOUS);
+        }
+    }
+
+    @Before(value = "execution(* com.epam.pipeline.security.saml.SAMLProxyAuthenticationProvider.authenticate(..)) " +
+            "&& args(authentication,..)")
+    public void addUserInfoFromSAMLProxy(JoinPoint joinPoint, Authentication authentication) {
+        if (authentication != null) {
+            SAMLProxyAuthentication auth = (SAMLProxyAuthentication) authentication;
+            ThreadContext.put(KEY_USER, auth.getName() != null ? auth.getName() : ANONYMOUS);
+        }
+    }
+
+    @Before(value = "execution(* com.epam.pipeline.security.saml.SAMLUserDetailsServiceImpl.loadUserBySAML(..))" +
+            "&& args(credential,..)")
+    public void addUserInfoFromSAML(JoinPoint joinPoint, SAMLCredential credential) {
+        if (credential != null) {
+            ThreadContext.put(KEY_USER, credential.getNameID().getValue().toUpperCase());
+        }
+    }
+
+    @After(value = CHANGING_PERMISSION_POINTCUT +
+            "|| execution(* com.epam.pipeline.security.saml.SAMLUserDetailsServiceImpl.loadUserBySAML(..)) " +
+            "|| execution(* com.epam.pipeline.security.saml.SAMLProxyAuthenticationProvider.authenticate(..))")
+    public void clearUserInfo() {
+        ThreadContext.clearAll();
+    }
+
+}
+

--- a/api/src/main/java/com/epam/pipeline/security/SecurityLogAspect.java
+++ b/api/src/main/java/com/epam/pipeline/security/SecurityLogAspect.java
@@ -44,7 +44,9 @@ public class SecurityLogAspect {
             "|| execution(* com.epam.pipeline.manager.security.GrantPermissionManager.changeOwner(..))";
 
     public static final String USER_RELATED_METHODS_POINTCUT =
-            "execution(* com.epam.pipeline.manager.user.UserManager.update*(..)) " +
+            "execution(* com.epam.pipeline.manager.user.UserManager.updateUser(..)) " +
+            "|| execution(* com.epam.pipeline.manager.user.UserManager.updateUserBlockingStatus(..))" +
+            "|| execution(* com.epam.pipeline.manager.user.UserManager.updateUserSAMLInfo(..))" +
             "|| execution(* com.epam.pipeline.manager.user.UserManager.delete*(..))" +
             "|| execution(* com.epam.pipeline.manager.user.UserManager.create*(..))" +
             "|| execution(* com.epam.pipeline.manager.user.RoleManager.assignRole(..))" +

--- a/api/src/main/java/com/epam/pipeline/security/saml/SAMLProxyAuthenticationProvider.java
+++ b/api/src/main/java/com/epam/pipeline/security/saml/SAMLProxyAuthenticationProvider.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.opensaml.common.SAMLException;
@@ -40,6 +41,7 @@ import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.security.ExternalServiceEndpoint;
 
+@Slf4j
 public class SAMLProxyAuthenticationProvider implements AuthenticationProvider {
 
     private static final int RESPONSE_SKEW = 1200;
@@ -73,7 +75,9 @@ public class SAMLProxyAuthenticationProvider implements AuthenticationProvider {
                     .filter(e -> e.getEndpointId().equals(endpointId)).findFirst();
 
                 if (endpointOpt.isPresent()) {
-                    return validateAuthentication(auth, decoded, endpointId, endpointOpt.get());
+                    Authentication validated = validateAuthentication(auth, decoded, endpointId, endpointOpt.get());
+                    log.debug("Successfully authenticate user with name: " + auth.getName());
+                    return validated;
                 } else {
                     throw new AuthenticationServiceException("Authentication error: unexpected external service");
                 }

--- a/api/src/main/java/com/epam/pipeline/security/saml/SAMLUserDetailsServiceImpl.java
+++ b/api/src/main/java/com/epam/pipeline/security/saml/SAMLUserDetailsServiceImpl.java
@@ -148,13 +148,13 @@ public class SAMLUserDetailsServiceImpl implements SAMLUserDetailsService {
                 .stream()
                 .noneMatch(GroupStatus::isBlocked);
         if (!isValidGroupList) {
-            LOGGER.debug("User {} is blocked due to one of his groups is blocked!", userName);
+            LOGGER.info("Authentication failed! User {} is blocked due to one of his groups is blocked!", userName);
             throw new LockedException("User is blocked!");
         }
     }
 
     private void throwUserIsBlocked(final String userName) {
-        LOGGER.debug("Authentication failed! User {} is blocked!", userName);
+        LOGGER.info("Authentication failed! User {} is blocked!", userName);
         throw new LockedException("User is blocked!");
     }
 

--- a/api/src/main/resources/log4j2-spring.xml
+++ b/api/src/main/resources/log4j2-spring.xml
@@ -144,6 +144,9 @@
         <Logger name="com.epam.pipeline.manager.user" level="info" additivity="true">
             <AppenderRef ref="JSONSecurityLogsAppender"/>
         </Logger>
+        <Logger name="org.springframework.security.saml" level="error" additivity="true">
+            <AppenderRef ref="JSONSecurityLogsAppender"/>
+        </Logger>
         <Logger name="org.springframework.security.saml" level="debug" additivity="false">
             <AppenderRef ref="Spring-Appender"/>
         </Logger>

--- a/api/src/main/resources/log4j2-spring.xml
+++ b/api/src/main/resources/log4j2-spring.xml
@@ -47,6 +47,26 @@
                 </pattern>
             </PatternLayout>
         </RollingFile >
+        <RollingFile  name="JSONSecurityLogsAppender" fileName="${log-path}/security.json"
+                      filePattern="${log-path}/security-%d{yyyyMMdd}.json">
+            <DefaultRolloverStrategy>
+                <Delete basePath="${log-path}" maxDepth="1">
+                    <IfFileName glob="security-*.json">
+                        <IfAny>
+                            <IfAccumulatedFileCount exceeds="20"/>
+                        </IfAny>
+                    </IfFileName>
+                </Delete>
+            </DefaultRolloverStrategy>
+            <Policies>
+                <TimeBasedTriggeringPolicy />
+            </Policies>
+            <JsonLayout complete="false" compact="false" eventEol="true" stacktraceAsString="true">
+                <KeyValuePair key="user" value="$${ctx:user:-NotAuthorized}" />
+                <KeyValuePair key="log_context" value="Security" />
+                <KeyValuePair key="timestamp" value="$${date:yyyy-MM-dd'T'HH:mm:ss.SSSZ}" />
+            </JsonLayout>
+        </RollingFile >
         <RollingFile  name="Spring-Appender" fileName="${log-path}/spring.log"
                       filePattern="${log-path}/spring-%d{yyyyMMdd}.log">
             <DefaultRolloverStrategy>
@@ -114,6 +134,12 @@
     <Loggers>
         <Logger name="com.epam.pipeline" level="debug" additivity="true">
             <AppenderRef ref="App-Appender"/>
+        </Logger>
+        <Logger name="com.epam.pipeline.security" level="info" additivity="true">
+            <AppenderRef ref="JSONSecurityLogsAppender"/>
+        </Logger>
+        <Logger name="com.epam.pipeline.manager.security" level="info" additivity="true">
+            <AppenderRef ref="JSONSecurityLogsAppender"/>
         </Logger>
         <Logger name="org.springframework.security.saml" level="debug" additivity="false">
             <AppenderRef ref="Spring-Appender"/>

--- a/api/src/main/resources/log4j2-spring.xml
+++ b/api/src/main/resources/log4j2-spring.xml
@@ -61,7 +61,7 @@
             <Policies>
                 <TimeBasedTriggeringPolicy />
             </Policies>
-            <JsonLayout complete="false" compact="false" eventEol="true" stacktraceAsString="true">
+            <JsonLayout complete="false" compact="true" eventEol="true" stacktraceAsString="true">
                 <KeyValuePair key="user" value="$${ctx:user:-NotAuthorized}" />
                 <KeyValuePair key="log_context" value="Security" />
                 <KeyValuePair key="timestamp" value="$${date:yyyy-MM-dd'T'HH:mm:ss.SSSZ}" />

--- a/api/src/main/resources/log4j2-spring.xml
+++ b/api/src/main/resources/log4j2-spring.xml
@@ -141,6 +141,9 @@
         <Logger name="com.epam.pipeline.manager.security" level="info" additivity="true">
             <AppenderRef ref="JSONSecurityLogsAppender"/>
         </Logger>
+        <Logger name="com.epam.pipeline.manager.user" level="info" additivity="true">
+            <AppenderRef ref="JSONSecurityLogsAppender"/>
+        </Logger>
         <Logger name="org.springframework.security.saml" level="debug" additivity="false">
             <AppenderRef ref="Spring-Appender"/>
         </Logger>

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -447,3 +447,7 @@ error.billing.invalid.paging='Paging parameters can't be negative!'
 
 #Other
 error.keep.alive.policy.not.supported=Unsupported node keep alive policy: {0}.
+
+#Security
+user.not.registered.explicitly="Authentication failed! Registration policy specified as EXPLICITLY. User {0} is not registered in the system."
+user.not.registered.group.explicitly="Authentication failed! Registration policy specified as GROUP_EXPLICITLY. Groups: {0} and User {1} is not registered in the system."

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -273,6 +273,14 @@ error.mutable.acl.return=MutableAcl should be been returned
 error.no.group.was.found=No groups were found for user ''{0}''
 group.status.exists=Group status for ''{0}'' already exists.
 error.user.not.authorized=Current user is not authorized.
+info.assign.role=Assing role. RoleId={0} UserIds={1}
+info.unassign.role=Unassing role. RoleId={0} UserIds={1}
+info.create.user=Create user with name: {0}
+info.delete.user=Delete user with name: {0} id: {1}
+info.update.user.roles=Update user roles. User id: {0} roles id: {1}
+info.update.user.datastorage=Update user datastorage. User id: {0} datastorage id: {1}
+info.update.user.block.status=Update user blocking status. User id={0}. Blocking status={1}
+info.update.user.saml.info=Update user SAML info. User: name={0} id={1}
 
 # Metadata
 error.metadata.not.found=Error: metadata for id ''{0}'' and class ''{1}'' not found.

--- a/deploy/docker/cp-edge/endpoints-config/route.template.loc.conf
+++ b/deploy/docker/cp-edge/endpoints-config/route.template.loc.conf
@@ -2,6 +2,7 @@ location {edge_route_location} {
     set $username "{edge_route_owner}";
     set $shared_with_users "{edge_route_shared_users}";
     set $shared_with_groups "{edge_route_shared_groups}";
+    set $route_location_root "{edge_route_location}";
     default_type text/html;
     access_by_lua_file /etc/nginx/validate_cookie.lua;
     proxy_pass http://{edge_route_target};

--- a/deploy/docker/cp-edge/endpoints-config/route.template.loc.conf
+++ b/deploy/docker/cp-edge/endpoints-config/route.template.loc.conf
@@ -3,6 +3,7 @@ location {edge_route_location} {
     set $shared_with_users "{edge_route_shared_users}";
     set $shared_with_groups "{edge_route_shared_groups}";
     set $route_location_root "{edge_route_location}";
+    set $run_id "{run_id}";
     default_type text/html;
     access_by_lua_file /etc/nginx/validate_cookie.lua;
     proxy_pass http://{edge_route_target};

--- a/deploy/docker/cp-edge/nginx.conf
+++ b/deploy/docker/cp-edge/nginx.conf
@@ -1,6 +1,6 @@
 user             root;
 worker_processes auto;
-error_log        /etc/nginx/logs/error.log;
+error_log        /etc/nginx/logs/error.log warn;
 pid              /usr/local/openresty/nginx/logs/nginx.pid;
 include          /usr/share/nginx/modules/*.conf;
 

--- a/deploy/docker/cp-edge/sync-routes.py
+++ b/deploy/docker/cp-edge/sync-routes.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -514,6 +514,7 @@ for added_route in routes_to_add:
                 .replace('{edge_route_location}', service_location)\
                 .replace('{edge_route_target}', service_spec["edge_target"])\
                 .replace('{edge_route_owner}', service_spec["pod_owner"]) \
+                 .replace('{run_id}', service_spec["run_id"]) \
                 .replace('{edge_route_shared_users}', service_spec["shared_users_sids"]) \
                 .replace('{edge_route_shared_groups}', service_spec["shared_groups_sids"]) \
                 .replace('{additional}', service_spec["additional"])

--- a/deploy/docker/cp-edge/validate_cookie.lua
+++ b/deploy/docker/cp-edge/validate_cookie.lua
@@ -24,7 +24,7 @@ local function arr_has_value (tab, val)
     return false
 end
 
-function arr_intersect(a, b)
+local function arr_intersect(a, b)
 	for index, value in ipairs(a) do
         if arr_has_value(b, value) then
             return true
@@ -34,17 +34,17 @@ function arr_intersect(a, b)
     return false
 end
 
-function arr_length(T)
+local function arr_length(T)
     local count = 0
     for _ in pairs(T) do count = count + 1 end
     return count
 end
 
-function split_str(inputstr, sep)
+local function split_str(inputstr, sep)
     if sep == nil then
         sep = "%s"
     end
-    local t={} ; i=1
+    local t={} ; local i=1
     for str in string.gmatch(inputstr, "([^"..sep.."]+)") do
         t[i] = str
         i = i + 1
@@ -75,7 +75,7 @@ if token then
     if not jwt_obj["verified"] then
         ngx.header['Set-Cookie'] = 'bearer=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
         ngx.status = ngx.HTTP_UNAUTHORIZED
-        ngx.log(ngx.WARN, jwt_obj.reason)
+        ngx.log(ngx.WARN, "Application: " .. ngx.var.route_location_root .. "; User: NotAuthorized; Status: Authentication failed; Message: " .. jwt_obj.reason)
         ngx.exit(ngx.HTTP_UNAUTHORIZED)
     end
     local username = jwt_obj["payload"]["sub"]
@@ -90,12 +90,15 @@ if token then
     if username ~= ngx.var.username and not arr_has_value(shared_with_users, username) and not arr_intersect(user_roles, shared_with_groups) then
         ngx.header['Set-Cookie'] = 'bearer=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
         ngx.status = ngx.HTTP_UNAUTHORIZED
-        ngx.log(ngx.WARN, jwt_obj.reason)
+        ngx.log(ngx.WARN, "Application: " .. ngx.var.route_location_root .. "; User: " .. username .. "; Status:  Authentication failed; Message: Not an owner and access isn't shared.")
         ngx.exit(ngx.HTTP_UNAUTHORIZED)
     end
 
     -- If "bearer" is fine - allow nginx to proceed
     -- Pass authenticated user to the proxied resource as a header
+    if ngx.var.route_location_root == ngx.var.request_uri then
+        ngx.log(ngx.WARN,"Application: " .. ngx.var.route_location_root .. "; User: " .. username .. "; Status: Successfully autentificated.")
+    end
     ngx.req.set_header('X-Auth-User', username)
     return
 end

--- a/deploy/docker/cp-edge/validate_cookie.lua
+++ b/deploy/docker/cp-edge/validate_cookie.lua
@@ -1,4 +1,4 @@
--- Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+-- Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -75,7 +75,7 @@ if token then
     if not jwt_obj["verified"] then
         ngx.header['Set-Cookie'] = 'bearer=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
         ngx.status = ngx.HTTP_UNAUTHORIZED
-        ngx.log(ngx.WARN, "[SECURITY] Application: " .. ngx.var.route_location_root .. "; User: NotAuthorized; Status: Authentication failed; Message: " .. jwt_obj.reason)
+        ngx.log(ngx.WARN, "[SECURITY] RunId: ".. ngx.var.run_id .. " Application: " .. ngx.var.route_location_root .. "; User: NotAuthorized; Status: Authentication failed; Message: " .. jwt_obj.reason)
         ngx.exit(ngx.HTTP_UNAUTHORIZED)
     end
     local username = jwt_obj["payload"]["sub"]
@@ -90,14 +90,14 @@ if token then
     if username ~= ngx.var.username and not arr_has_value(shared_with_users, username) and not arr_intersect(user_roles, shared_with_groups) then
         ngx.header['Set-Cookie'] = 'bearer=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
         ngx.status = ngx.HTTP_UNAUTHORIZED
-        ngx.log(ngx.WARN, "[SECURITY] Application: " .. ngx.var.route_location_root .. "; User: " .. username .. "; Status:  Authentication failed; Message: Not an owner and access isn't shared.")
+        ngx.log(ngx.WARN, "[SECURITY] RunId: ".. ngx.var.run_id .. " Application: " .. ngx.var.route_location_root .. "; User: " .. username .. "; Status:  Authentication failed; Message: Not an owner and access isn't shared.")
         ngx.exit(ngx.HTTP_UNAUTHORIZED)
     end
 
     -- If "bearer" is fine - allow nginx to proceed
     -- Pass authenticated user to the proxied resource as a header
     if ngx.var.route_location_root == ngx.var.request_uri then
-        ngx.log(ngx.WARN,"[SECURITY] Application: " .. ngx.var.route_location_root .. "; User: " .. username .. "; Status: Successfully autentificated.")
+        ngx.log(ngx.WARN,"[SECURITY] RunId: ".. ngx.var.run_id .. " Application: " .. ngx.var.route_location_root .. "; User: " .. username .. "; Status: Successfully autentificated.")
     end
     ngx.req.set_header('X-Auth-User', username)
     return

--- a/deploy/docker/cp-edge/validate_cookie.lua
+++ b/deploy/docker/cp-edge/validate_cookie.lua
@@ -97,7 +97,7 @@ if token then
     -- If "bearer" is fine - allow nginx to proceed
     -- Pass authenticated user to the proxied resource as a header
     if ngx.var.route_location_root == ngx.var.request_uri then
-        ngx.log(ngx.WARN,"Application: " .. ngx.var.route_location_root .. "; User: " .. username .. "; Status: Successfully autentificated.")
+        ngx.log(ngx.WARN,"[SECURITY] Application: " .. ngx.var.route_location_root .. "; User: " .. username .. "; Status: Successfully autentificated.")
     end
     ngx.req.set_header('X-Auth-User', username)
     return

--- a/deploy/docker/cp-edge/validate_cookie.lua
+++ b/deploy/docker/cp-edge/validate_cookie.lua
@@ -80,7 +80,7 @@ if token then
     if not jwt_obj["verified"] then
         ngx.header['Set-Cookie'] = 'bearer=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
         ngx.status = ngx.HTTP_UNAUTHORIZED
-        ngx.log(ngx.WARN, "[SECURITY] RunId: ".. ngx.var.run_id .. "; Application: " .. ngx.var.route_location_root ..
+        ngx.log(ngx.WARN, "[SECURITY] Application: " .. ngx.var.route_location_root ..
                 "; User: " .. username .. "; Status: Authentication failed; Message: " .. jwt_obj.reason)
         ngx.exit(ngx.HTTP_UNAUTHORIZED)
     end
@@ -95,7 +95,7 @@ if token then
     if username ~= ngx.var.username and not arr_has_value(shared_with_users, username) and not arr_intersect(user_roles, shared_with_groups) then
         ngx.header['Set-Cookie'] = 'bearer=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
         ngx.status = ngx.HTTP_UNAUTHORIZED
-        ngx.log(ngx.WARN, "[SECURITY] RunId: ".. ngx.var.run_id .. "; Application: " .. ngx.var.route_location_root ..
+        ngx.log(ngx.WARN, "[SECURITY] Application: " .. ngx.var.route_location_root ..
                 "; User: " .. username .. "; Status:  Authentication failed; Message: Not an owner and access isn't shared.")
         ngx.exit(ngx.HTTP_UNAUTHORIZED)
     end
@@ -103,7 +103,7 @@ if token then
     -- If "bearer" is fine - allow nginx to proceed
     -- Pass authenticated user to the proxied resource as a header
     if ngx.var.route_location_root == ngx.var.request_uri then
-        ngx.log(ngx.WARN,"[SECURITY] RunId: ".. ngx.var.run_id .. "; Application: " .. ngx.var.route_location_root ..
+        ngx.log(ngx.WARN,"[SECURITY] Application: " .. ngx.var.route_location_root ..
                 "; User: " .. username .. "; Status: Successfully autentificated.")
     end
     ngx.req.set_header('X-Auth-User', username)

--- a/deploy/docker/cp-edge/validate_cookie.lua
+++ b/deploy/docker/cp-edge/validate_cookie.lua
@@ -75,7 +75,7 @@ if token then
     if not jwt_obj["verified"] then
         ngx.header['Set-Cookie'] = 'bearer=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
         ngx.status = ngx.HTTP_UNAUTHORIZED
-        ngx.log(ngx.WARN, "Application: " .. ngx.var.route_location_root .. "; User: NotAuthorized; Status: Authentication failed; Message: " .. jwt_obj.reason)
+        ngx.log(ngx.WARN, "[SECURITY] Application: " .. ngx.var.route_location_root .. "; User: NotAuthorized; Status: Authentication failed; Message: " .. jwt_obj.reason)
         ngx.exit(ngx.HTTP_UNAUTHORIZED)
     end
     local username = jwt_obj["payload"]["sub"]
@@ -90,7 +90,7 @@ if token then
     if username ~= ngx.var.username and not arr_has_value(shared_with_users, username) and not arr_intersect(user_roles, shared_with_groups) then
         ngx.header['Set-Cookie'] = 'bearer=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
         ngx.status = ngx.HTTP_UNAUTHORIZED
-        ngx.log(ngx.WARN, "Application: " .. ngx.var.route_location_root .. "; User: " .. username .. "; Status:  Authentication failed; Message: Not an owner and access isn't shared.")
+        ngx.log(ngx.WARN, "[SECURITY] Application: " .. ngx.var.route_location_root .. "; User: " .. username .. "; Status:  Authentication failed; Message: Not an owner and access isn't shared.")
         ngx.exit(ngx.HTTP_UNAUTHORIZED)
     end
 
@@ -150,7 +150,3 @@ else
         ngx.say('<html><body><script>window.location.href = "' .. req_uri .. '"</script></body></html>')
         return
 end
-
--- No cookie, no POST param - 401
-ngx.status = ngx.HTTP_UNAUTHORIZED
-ngx.exit(ngx.HTTP_UNAUTHORIZED)

--- a/deploy/docker/cp-edge/validate_cookie_dav.lua
+++ b/deploy/docker/cp-edge/validate_cookie_dav.lua
@@ -24,17 +24,17 @@ local function arr_has_value (tab, val)
 end
 
 
-function arr_length(T)
+local function arr_length(T)
     local count = 0
     for _ in pairs(T) do count = count + 1 end
     return count
 end
 
-function split_str(inputstr, sep)
+local function split_str(inputstr, sep)
     if sep == nil then
         sep = "%s"
     end
-    local t={} ; i=1
+    local t={} ; local i=1
     for str in string.gmatch(inputstr, "([^"..sep.."]+)") do
         t[i] = str
         i = i + 1
@@ -42,11 +42,11 @@ function split_str(inputstr, sep)
     return t
 end
 
-function is_empty(str)
+local function is_empty(str)
     return str == nil or str == ''
 end
 
-function get_basic_token()
+local function get_basic_token()
     local authorization = ngx.var.http_authorization
     if is_empty(authorization) then
         return nil
@@ -110,11 +110,18 @@ if token then
 
         local jwt_obj = jwt:verify(cert, token, claim_spec)
 
+        local jwt_username = "NotAuthorized"
+        if jwt_obj["payload"] ~= nil and jwt_obj["payload"]["sub"] ~= nil then
+            jwt_username = jwt_obj["payload"]["sub"]
+        end
+
+
     -- If "bearer" token is not valid - return 401 and clear cookie
         if not jwt_obj["verified"] then
             ngx.header['Set-Cookie'] = 'bearer=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
             ngx.status = ngx.HTTP_UNAUTHORIZED
-            ngx.log(ngx.WARN, "[SECURITY] RunId: ".. ngx.var.run_id .. " Application: DAV; User: NotAuthorized; Status: Authentication failed; Message: " .. jwt_obj.reason)
+            ngx.log(ngx.WARN, "[SECURITY] Application: DAV-" .. ngx.var.request_uri .. "; User: " .. jwt_username ..
+                    "; Status: Authentication failed; Message: " .. jwt_obj.reason)
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
         end
 
@@ -133,7 +140,8 @@ if token then
         local restricted_root_methods = { "PUT", "POST", "DELETE", "PROPPATCH", "MKCOL", "COPY", "MOVE", "LOCK", "UNLOCK", "PATCH" }
         if (uri_parts_len <= 3 and arr_has_value(restricted_root_methods, request_method)) then
             ngx.status = ngx.HTTP_UNAUTHORIZED
-            ngx.log(ngx.WARN, "[SECURITY] RunId: ".. ngx.var.run_id .. " Application: DAV; User: NotAuthorized; Status: Authentication failed; Message: Restrict writing to the root")
+            ngx.log(ngx.WARN, "[SECURITY] Application: DAV-" .. ngx.var.request_uri .. "; User: " .. jwt_username ..
+                    "; Status: Authentication failed; Message: Restrict writing to the root")
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
         end
 
@@ -148,7 +156,8 @@ if token then
             uri_username = uri_parts[2]
         else
             ngx.status = ngx.HTTP_UNAUTHORIZED
-            ngx.log(ngx.WARN, "[SECURITY] RunId: ".. ngx.var.run_id .. " Application: DAV; User: NotAuthorized; Status: Authentication failed; Message: username is not provided")
+            ngx.log(ngx.WARN, "[SECURITY] Application: DAV-" .. ngx.var.request_uri ..
+                    "; User: " .. jwt_username .. "; Status: Authentication failed; Message: username is not provided")
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
         end
 
@@ -157,14 +166,18 @@ if token then
         if jwt_username ~= uri_username then
             ngx.header['Set-Cookie'] = 'bearer=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
             ngx.status = ngx.HTTP_UNAUTHORIZED
-            ngx.log(ngx.WARN, "[SECURITY] RunId: ".. ngx.var.run_id .. " Application: DAV; User: NotAuthorized; Status: Authentication failed; "
+            ngx.log(ngx.WARN, "[SECURITY] Application: FSBrowser-" .. ngx.var.request_uri ..
+                    "; User: " .. jwt_username .. "; Status: Authentication failed; "
                     .. "Message: JWT Subject is not equal to the uri_username - restrict connection")
             ngx.log(ngx.WARN, jwt_obj.reason)
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
         end
 
     -- If "bearer" is fine - allow nginx to proceed
-    ngx.log(ngx.WARN,"[SECURITY] RunId: ".. ngx.var.run_id .. " Application: DAV; User: " .. jwt_username .. "; Status: Successfully autentificated.")
+    if string.gmatch(ngx.var.request_uri, "^/webdav/[%w_-]+/$") then
+        ngx.log(ngx.WARN,"[SECURITY] Application: DAV-" .. ngx.var.request_uri ..
+                "; User: " .. jwt_username .. "; Status: Successfully autentificated.")
+    end
     return
 end
 

--- a/deploy/docker/cp-edge/validate_cookie_dav.lua
+++ b/deploy/docker/cp-edge/validate_cookie_dav.lua
@@ -114,7 +114,7 @@ if token then
         if not jwt_obj["verified"] then
             ngx.header['Set-Cookie'] = 'bearer=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
             ngx.status = ngx.HTTP_UNAUTHORIZED
-            ngx.log(ngx.WARN, "Application: DAV; User: NotAuthorized; Status: Authentication failed; Message: " .. jwt_obj.reason)
+            ngx.log(ngx.WARN, "[SECURITY] Application: DAV; User: NotAuthorized; Status: Authentication failed; Message: " .. jwt_obj.reason)
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
         end
 
@@ -133,7 +133,7 @@ if token then
         local restricted_root_methods = { "PUT", "POST", "DELETE", "PROPPATCH", "MKCOL", "COPY", "MOVE", "LOCK", "UNLOCK", "PATCH" }
         if (uri_parts_len <= 3 and arr_has_value(restricted_root_methods, request_method)) then
             ngx.status = ngx.HTTP_UNAUTHORIZED
-            ngx.log(ngx.WARN, "Application: DAV; User: NotAuthorized; Status: Authentication failed; Message: Restrict writing to the root")
+            ngx.log(ngx.WARN, "[SECURITY] Application: DAV; User: NotAuthorized; Status: Authentication failed; Message: Restrict writing to the root")
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
         end
 
@@ -148,7 +148,7 @@ if token then
             uri_username = uri_parts[2]
         else
             ngx.status = ngx.HTTP_UNAUTHORIZED
-            ngx.log(ngx.WARN, "Application: DAV; User: NotAuthorized; Status: Authentication failed; Message: username is not provided")
+            ngx.log(ngx.WARN, "[SECURITY] Application: DAV; User: NotAuthorized; Status: Authentication failed; Message: username is not provided")
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
         end
 
@@ -157,14 +157,14 @@ if token then
         if jwt_username ~= uri_username then
             ngx.header['Set-Cookie'] = 'bearer=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
             ngx.status = ngx.HTTP_UNAUTHORIZED
-            ngx.log(ngx.WARN, "Application: DAV; User: NotAuthorized; Status: Authentication failed; "
+            ngx.log(ngx.WARN, "[SECURITY] Application: DAV; User: NotAuthorized; Status: Authentication failed; "
                     .. "Message: JWT Subject is not equal to the uri_username - restrict connection")
             ngx.log(ngx.WARN, jwt_obj.reason)
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
         end
 
     -- If "bearer" is fine - allow nginx to proceed
-    ngx.log(ngx.WARN,"Application: DAV; User: " .. jwt_username .. "; Status: Successfully autentificated.")
+    ngx.log(ngx.WARN,"[SECURITY] Application: DAV; User: " .. jwt_username .. "; Status: Successfully autentificated.")
     return
 end
 
@@ -211,7 +211,3 @@ else
         ngx.say('<html><body><script>window.location.href = "' .. req_uri .. '"</script></body></html>')
         return
 end
-
--- No cookie, no POST param - 401
-ngx.status = ngx.HTTP_UNAUTHORIZED
-ngx.exit(ngx.HTTP_UNAUTHORIZED)

--- a/deploy/docker/cp-edge/validate_cookie_dav.lua
+++ b/deploy/docker/cp-edge/validate_cookie_dav.lua
@@ -1,4 +1,4 @@
--- Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+-- Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -114,7 +114,7 @@ if token then
         if not jwt_obj["verified"] then
             ngx.header['Set-Cookie'] = 'bearer=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
             ngx.status = ngx.HTTP_UNAUTHORIZED
-            ngx.log(ngx.WARN, "[SECURITY] Application: DAV; User: NotAuthorized; Status: Authentication failed; Message: " .. jwt_obj.reason)
+            ngx.log(ngx.WARN, "[SECURITY] RunId: ".. ngx.var.run_id .. " Application: DAV; User: NotAuthorized; Status: Authentication failed; Message: " .. jwt_obj.reason)
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
         end
 
@@ -133,7 +133,7 @@ if token then
         local restricted_root_methods = { "PUT", "POST", "DELETE", "PROPPATCH", "MKCOL", "COPY", "MOVE", "LOCK", "UNLOCK", "PATCH" }
         if (uri_parts_len <= 3 and arr_has_value(restricted_root_methods, request_method)) then
             ngx.status = ngx.HTTP_UNAUTHORIZED
-            ngx.log(ngx.WARN, "[SECURITY] Application: DAV; User: NotAuthorized; Status: Authentication failed; Message: Restrict writing to the root")
+            ngx.log(ngx.WARN, "[SECURITY] RunId: ".. ngx.var.run_id .. " Application: DAV; User: NotAuthorized; Status: Authentication failed; Message: Restrict writing to the root")
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
         end
 
@@ -148,7 +148,7 @@ if token then
             uri_username = uri_parts[2]
         else
             ngx.status = ngx.HTTP_UNAUTHORIZED
-            ngx.log(ngx.WARN, "[SECURITY] Application: DAV; User: NotAuthorized; Status: Authentication failed; Message: username is not provided")
+            ngx.log(ngx.WARN, "[SECURITY] RunId: ".. ngx.var.run_id .. " Application: DAV; User: NotAuthorized; Status: Authentication failed; Message: username is not provided")
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
         end
 
@@ -157,14 +157,14 @@ if token then
         if jwt_username ~= uri_username then
             ngx.header['Set-Cookie'] = 'bearer=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
             ngx.status = ngx.HTTP_UNAUTHORIZED
-            ngx.log(ngx.WARN, "[SECURITY] Application: DAV; User: NotAuthorized; Status: Authentication failed; "
+            ngx.log(ngx.WARN, "[SECURITY] RunId: ".. ngx.var.run_id .. " Application: DAV; User: NotAuthorized; Status: Authentication failed; "
                     .. "Message: JWT Subject is not equal to the uri_username - restrict connection")
             ngx.log(ngx.WARN, jwt_obj.reason)
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
         end
 
     -- If "bearer" is fine - allow nginx to proceed
-    ngx.log(ngx.WARN,"[SECURITY] Application: DAV; User: " .. jwt_username .. "; Status: Successfully autentificated.")
+    ngx.log(ngx.WARN,"[SECURITY] RunId: ".. ngx.var.run_id .. " Application: DAV; User: " .. jwt_username .. "; Status: Successfully autentificated.")
     return
 end
 

--- a/deploy/docker/cp-edge/validate_cookie_dav.lua
+++ b/deploy/docker/cp-edge/validate_cookie_dav.lua
@@ -114,7 +114,7 @@ if token then
         if not jwt_obj["verified"] then
             ngx.header['Set-Cookie'] = 'bearer=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
             ngx.status = ngx.HTTP_UNAUTHORIZED
-            ngx.log(ngx.WARN, jwt_obj.reason)
+            ngx.log(ngx.WARN, "Application: DAV; User: NotAuthorized; Status: Authentication failed; Message: " .. jwt_obj.reason)
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
         end
 
@@ -133,6 +133,7 @@ if token then
         local restricted_root_methods = { "PUT", "POST", "DELETE", "PROPPATCH", "MKCOL", "COPY", "MOVE", "LOCK", "UNLOCK", "PATCH" }
         if (uri_parts_len <= 3 and arr_has_value(restricted_root_methods, request_method)) then
             ngx.status = ngx.HTTP_UNAUTHORIZED
+            ngx.log(ngx.WARN, "Application: DAV; User: NotAuthorized; Status: Authentication failed; Message: Restrict writing to the root")
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
         end
 
@@ -147,6 +148,7 @@ if token then
             uri_username = uri_parts[2]
         else
             ngx.status = ngx.HTTP_UNAUTHORIZED
+            ngx.log(ngx.WARN, "Application: DAV; User: NotAuthorized; Status: Authentication failed; Message: username is not provided")
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
         end
 
@@ -155,11 +157,14 @@ if token then
         if jwt_username ~= uri_username then
             ngx.header['Set-Cookie'] = 'bearer=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
             ngx.status = ngx.HTTP_UNAUTHORIZED
+            ngx.log(ngx.WARN, "Application: DAV; User: NotAuthorized; Status: Authentication failed; "
+                    .. "Message: JWT Subject is not equal to the uri_username - restrict connection")
             ngx.log(ngx.WARN, jwt_obj.reason)
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
         end
 
     -- If "bearer" is fine - allow nginx to proceed
+    ngx.log(ngx.WARN,"Application: DAV; User: " .. jwt_username .. "; Status: Successfully autentificated.")
     return
 end
 

--- a/deploy/docker/cp-edge/validate_cookie_dav.lua
+++ b/deploy/docker/cp-edge/validate_cookie_dav.lua
@@ -166,7 +166,7 @@ if token then
         if jwt_username ~= uri_username then
             ngx.header['Set-Cookie'] = 'bearer=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
             ngx.status = ngx.HTTP_UNAUTHORIZED
-            ngx.log(ngx.WARN, "[SECURITY] Application: FSBrowser-" .. ngx.var.request_uri ..
+            ngx.log(ngx.WARN, "[SECURITY] Application: DAV-" .. ngx.var.request_uri ..
                     "; User: " .. jwt_username .. "; Status: Authentication failed; "
                     .. "Message: JWT Subject is not equal to the uri_username - restrict connection")
             ngx.log(ngx.WARN, jwt_obj.reason)

--- a/deploy/docker/cp-edge/validate_cookie_fsbrowser.lua
+++ b/deploy/docker/cp-edge/validate_cookie_fsbrowser.lua
@@ -12,11 +12,11 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-function is_int(n)
+local function is_int(n)
     return tonumber(n) ~= nil
 end
 
-function split_str(inputstr, sep)
+local function split_str(inputstr, sep)
     if sep == nil then
         sep = "%s"
     end
@@ -29,13 +29,13 @@ function split_str(inputstr, sep)
     return t
 end
 
-function arr_length(T)
+local function arr_length(T)
     local count = 0
     for _ in pairs(T) do count = count + 1 end
     return count
 end
 
-function arr_to_string(T, sep)
+local function arr_to_string(T, sep)
     if sep == nil then
         sep = ''
     end
@@ -46,7 +46,7 @@ function arr_to_string(T, sep)
     return r
 end
 
-function dict_contains(dict, key)
+local function dict_contains(dict, key)
     return dict[key] ~= nil
 end
 
@@ -76,15 +76,20 @@ if token then
 
     local jwt_obj = jwt:verify(cert, token, claim_spec)
 
+    local username = "NotAuthorized"
+    if jwt_obj["payload"] ~= nil and jwt_obj["payload"]["sub"] ~= nil then
+        username = jwt_obj["payload"]["sub"]
+    end
+
+
     -- If "bearer" token is not valid - return 401 and clear cookie
     if not jwt_obj["verified"] then
         ngx.header['Set-Cookie'] = 'bearer=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
         ngx.status = ngx.HTTP_UNAUTHORIZED
-        ngx.log(ngx.ERR, "[SECURITY] RunId: ".. ngx.var.run_id .. " Application: FSBrowser; User: NotAuthorized; Status: Authentication failed; Message: " .. jwt_obj.reason)
+        ngx.log(ngx.ERR, "[SECURITY] Application: FSBrowser-" .. ngx.var.request_uri .. "; User: " .. username ..
+                "; Status: Authentication failed; Message: " .. jwt_obj.reason)
         ngx.exit(ngx.HTTP_UNAUTHORIZED)
     end
-
-    local username = jwt_obj["payload"]["sub"]
 
     -- --------------------------------------------
     -- token is ok - proceed with forwarding setup
@@ -135,7 +140,8 @@ if token then
         local run_api_token = os.getenv("API_TOKEN")
         -- Fail if the API connection parameters cannot be retrieved from the environment
         if not run_api_url or not run_api_token then
-            ngx.log(ngx.ERR, "[SECURITY] RunId: ".. ngx.var.run_id .. " Application: FSBrowser; User: NotAuthorized; Status: Authentication failed; Message: Cannot get API or API_TOKEN environment variables")
+            ngx.log(ngx.ERR, "[SECURITY] Application: FSBrowser-" .. ngx.var.request_uri .. "; User: " .. username ..
+                    "; Status: Authentication failed; Message: Cannot get API or API_TOKEN environment variables")
             ngx.status = ngx.HTTP_UNAUTHORIZED
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
             return
@@ -155,7 +161,8 @@ if token then
 
         -- Fail if the request was not successful
         if not res then
-            ngx.log(ngx.ERR, "[SECURITY] RunId: ".. ngx.var.run_id .. " Application: FSBrowser; User: NotAuthorized; Status: Authentication failed; Message: " ..
+            ngx.log(ngx.ERR, "[SECURITY] Application: FSBrowser-" .. ngx.var.request_uri .. "; User: " .. username ..
+                    "; Status: Authentication failed; Message: " ..
                     'Failed to request API for the Pod IP and SSH Pass. API - ' .. run_api_url .. ', Error - ' .. err)
             ngx.status = ngx.HTTP_UNAUTHORIZED
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
@@ -168,7 +175,8 @@ if token then
         if not dict_contains(data, 'payload') or 
            not dict_contains(data['payload'], 'sshPassword') or 
            not dict_contains(data['payload'], 'podIP') then
-            ngx.log(ngx.ERR, "[SECURITY] RunId: ".. ngx.var.run_id .. " Application: FSBrowser; User: NotAuthorized; Status: Authentication failed; Message: " ..
+            ngx.log(ngx.ERR, "[SECURITY] Application: FSBrowser-" .. ngx.var.request_uri .. "; User: " .. username ..
+                    "; Status: Authentication failed; Message: " ..
                     'Cannot get podIP and sshPassword from the API response')
             ngx.status = ngx.HTTP_UNAUTHORIZED
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
@@ -187,7 +195,8 @@ if token then
         local pod_cookie_parts = split_str(pod_cookie_val, ':')
         local pod_cookie_parts_len = arr_length(pod_cookie_parts)
         if (pod_cookie_parts_len ~= 2) then
-            ngx.log(ngx.ERR, "[SECURITY] RunId: ".. ngx.var.run_id .. " Application: FSBrowser; User: NotAuthorized; Status: Authentication failed; Message: "
+            ngx.log(ngx.ERR, "[SECURITY] Application: FSBrowser-" .. ngx.var.request_uri .. "; User: " .. username ..
+                    "; Status: Authentication failed; Message: "
                     .. 'Cannot parse cookie ' .. pod_cookie_name .. ' value ' .. pod_cookie_val .. 'into IP and Pass')
             ngx.header['Set-Cookie'] = pod_cookie_name .. '=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
             ngx.status = ngx.HTTP_UNAUTHORIZED
@@ -209,7 +218,10 @@ if token then
 
     ngx.req.set_header('token', token)
     ngx.req.set_header('X-Auth-User', username)
-    ngx.log(ngx.WARN,"[SECURITY] RunId: ".. ngx.var.run_id .. " Application: FSBrowser; User: " .. username .. "; Status: Successfully autentificated.")
+    if string.match(ngx.var.request_uri, "^/fsbrowser/[%w_-]+/$") then
+      ngx.log(ngx.WARN,"[SECURITY] Application: FSBrowser-" .. ngx.var.request_uri .. "; User: " .. username ..
+              "; Status: Successfully autentificated.")
+    end
     return
     -- --------------------------------------------
 end

--- a/deploy/docker/cp-edge/validate_cookie_fsbrowser.lua
+++ b/deploy/docker/cp-edge/validate_cookie_fsbrowser.lua
@@ -187,7 +187,8 @@ if token then
         local pod_cookie_parts = split_str(pod_cookie_val, ':')
         local pod_cookie_parts_len = arr_length(pod_cookie_parts)
         if (pod_cookie_parts_len ~= 2) then
-            ngx.log(ngx.ERR, 'Cannot parse cookie ' .. pod_cookie_name .. ' value ' .. pod_cookie_val .. 'into IP and Pass')
+            ngx.log(ngx.ERR, "[SECURITY] Application: FSBrowser; User: NotAuthorized; Status: Authentication failed; Message: "
+                    .. 'Cannot parse cookie ' .. pod_cookie_name .. ' value ' .. pod_cookie_val .. 'into IP and Pass')
             ngx.header['Set-Cookie'] = pod_cookie_name .. '=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
             ngx.status = ngx.HTTP_UNAUTHORIZED
             ngx.exit(ngx.HTTP_UNAUTHORIZED)

--- a/deploy/docker/cp-edge/validate_cookie_fsbrowser.lua
+++ b/deploy/docker/cp-edge/validate_cookie_fsbrowser.lua
@@ -80,7 +80,7 @@ if token then
     if not jwt_obj["verified"] then
         ngx.header['Set-Cookie'] = 'bearer=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
         ngx.status = ngx.HTTP_UNAUTHORIZED
-        ngx.log(ngx.ERR, "Application: FSBrowser; User: NotAuthorized; Status: Authentication failed; Message: " .. jwt_obj.reason)
+        ngx.log(ngx.ERR, "[SECURITY] Application: FSBrowser; User: NotAuthorized; Status: Authentication failed; Message: " .. jwt_obj.reason)
         ngx.exit(ngx.HTTP_UNAUTHORIZED)
     end
 
@@ -135,7 +135,7 @@ if token then
         local run_api_token = os.getenv("API_TOKEN")
         -- Fail if the API connection parameters cannot be retrieved from the environment
         if not run_api_url or not run_api_token then
-            ngx.log(ngx.ERR, "Application: FSBrowser; User: NotAuthorized; Status: Authentication failed; Message: Cannot get API or API_TOKEN environment variables")
+            ngx.log(ngx.ERR, "[SECURITY] Application: FSBrowser; User: NotAuthorized; Status: Authentication failed; Message: Cannot get API or API_TOKEN environment variables")
             ngx.status = ngx.HTTP_UNAUTHORIZED
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
             return
@@ -155,7 +155,7 @@ if token then
 
         -- Fail if the request was not successful
         if not res then
-            ngx.log(ngx.ERR, "Application: FSBrowser; User: NotAuthorized; Status: Authentication failed; Message: " ..
+            ngx.log(ngx.ERR, "[SECURITY] Application: FSBrowser; User: NotAuthorized; Status: Authentication failed; Message: " ..
                     'Failed to request API for the Pod IP and SSH Pass. API - ' .. run_api_url .. ', Error - ' .. err)
             ngx.status = ngx.HTTP_UNAUTHORIZED
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
@@ -168,7 +168,7 @@ if token then
         if not dict_contains(data, 'payload') or 
            not dict_contains(data['payload'], 'sshPassword') or 
            not dict_contains(data['payload'], 'podIP') then
-            ngx.log(ngx.ERR, "Application: FSBrowser; User: NotAuthorized; Status: Authentication failed; Message: " ..
+            ngx.log(ngx.ERR, "[SECURITY] Application: FSBrowser; User: NotAuthorized; Status: Authentication failed; Message: " ..
                     'Cannot get podIP and sshPassword from the API response')
             ngx.status = ngx.HTTP_UNAUTHORIZED
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
@@ -208,7 +208,7 @@ if token then
 
     ngx.req.set_header('token', token)
     ngx.req.set_header('X-Auth-User', username)
-    ngx.log(ngx.WARN,"Application: FSBrowser; User: " .. username .. "; Status: Successfully autentificated.")
+    ngx.log(ngx.WARN,"[SECURITY] Application: FSBrowser; User: " .. username .. "; Status: Successfully autentificated.")
     return
     -- --------------------------------------------
 end
@@ -260,7 +260,3 @@ else
         ngx.say('<html><body><script>window.location.href = "' .. req_uri .. '"</script></body></html>')
         return
 end
-
--- No cookie, no POST param - 401
-ngx.status = ngx.HTTP_UNAUTHORIZED
-ngx.exit(ngx.HTTP_UNAUTHORIZED)

--- a/deploy/docker/cp-edge/validate_cookie_fsbrowser.lua
+++ b/deploy/docker/cp-edge/validate_cookie_fsbrowser.lua
@@ -1,4 +1,4 @@
--- Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+-- Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ if token then
     if not jwt_obj["verified"] then
         ngx.header['Set-Cookie'] = 'bearer=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
         ngx.status = ngx.HTTP_UNAUTHORIZED
-        ngx.log(ngx.ERR, "[SECURITY] Application: FSBrowser; User: NotAuthorized; Status: Authentication failed; Message: " .. jwt_obj.reason)
+        ngx.log(ngx.ERR, "[SECURITY] RunId: ".. ngx.var.run_id .. " Application: FSBrowser; User: NotAuthorized; Status: Authentication failed; Message: " .. jwt_obj.reason)
         ngx.exit(ngx.HTTP_UNAUTHORIZED)
     end
 
@@ -135,7 +135,7 @@ if token then
         local run_api_token = os.getenv("API_TOKEN")
         -- Fail if the API connection parameters cannot be retrieved from the environment
         if not run_api_url or not run_api_token then
-            ngx.log(ngx.ERR, "[SECURITY] Application: FSBrowser; User: NotAuthorized; Status: Authentication failed; Message: Cannot get API or API_TOKEN environment variables")
+            ngx.log(ngx.ERR, "[SECURITY] RunId: ".. ngx.var.run_id .. " Application: FSBrowser; User: NotAuthorized; Status: Authentication failed; Message: Cannot get API or API_TOKEN environment variables")
             ngx.status = ngx.HTTP_UNAUTHORIZED
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
             return
@@ -155,7 +155,7 @@ if token then
 
         -- Fail if the request was not successful
         if not res then
-            ngx.log(ngx.ERR, "[SECURITY] Application: FSBrowser; User: NotAuthorized; Status: Authentication failed; Message: " ..
+            ngx.log(ngx.ERR, "[SECURITY] RunId: ".. ngx.var.run_id .. " Application: FSBrowser; User: NotAuthorized; Status: Authentication failed; Message: " ..
                     'Failed to request API for the Pod IP and SSH Pass. API - ' .. run_api_url .. ', Error - ' .. err)
             ngx.status = ngx.HTTP_UNAUTHORIZED
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
@@ -168,7 +168,7 @@ if token then
         if not dict_contains(data, 'payload') or 
            not dict_contains(data['payload'], 'sshPassword') or 
            not dict_contains(data['payload'], 'podIP') then
-            ngx.log(ngx.ERR, "[SECURITY] Application: FSBrowser; User: NotAuthorized; Status: Authentication failed; Message: " ..
+            ngx.log(ngx.ERR, "[SECURITY] RunId: ".. ngx.var.run_id .. " Application: FSBrowser; User: NotAuthorized; Status: Authentication failed; Message: " ..
                     'Cannot get podIP and sshPassword from the API response')
             ngx.status = ngx.HTTP_UNAUTHORIZED
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
@@ -187,7 +187,7 @@ if token then
         local pod_cookie_parts = split_str(pod_cookie_val, ':')
         local pod_cookie_parts_len = arr_length(pod_cookie_parts)
         if (pod_cookie_parts_len ~= 2) then
-            ngx.log(ngx.ERR, "[SECURITY] Application: FSBrowser; User: NotAuthorized; Status: Authentication failed; Message: "
+            ngx.log(ngx.ERR, "[SECURITY] RunId: ".. ngx.var.run_id .. " Application: FSBrowser; User: NotAuthorized; Status: Authentication failed; Message: "
                     .. 'Cannot parse cookie ' .. pod_cookie_name .. ' value ' .. pod_cookie_val .. 'into IP and Pass')
             ngx.header['Set-Cookie'] = pod_cookie_name .. '=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
             ngx.status = ngx.HTTP_UNAUTHORIZED
@@ -209,7 +209,7 @@ if token then
 
     ngx.req.set_header('token', token)
     ngx.req.set_header('X-Auth-User', username)
-    ngx.log(ngx.WARN,"[SECURITY] Application: FSBrowser; User: " .. username .. "; Status: Successfully autentificated.")
+    ngx.log(ngx.WARN,"[SECURITY] RunId: ".. ngx.var.run_id .. " Application: FSBrowser; User: " .. username .. "; Status: Successfully autentificated.")
     return
     -- --------------------------------------------
 end

--- a/deploy/docker/cp-edge/validate_cookie_fsbrowser.lua
+++ b/deploy/docker/cp-edge/validate_cookie_fsbrowser.lua
@@ -80,9 +80,11 @@ if token then
     if not jwt_obj["verified"] then
         ngx.header['Set-Cookie'] = 'bearer=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
         ngx.status = ngx.HTTP_UNAUTHORIZED
-        ngx.log(ngx.ERR, 'Cannot verify a token: ' .. jwt_obj.reason)
+        ngx.log(ngx.ERR, "Application: FSBrowser; User: NotAuthorized; Status: Authentication failed; Message: " .. jwt_obj.reason)
         ngx.exit(ngx.HTTP_UNAUTHORIZED)
     end
+
+    local username = jwt_obj["payload"]["sub"]
 
     -- --------------------------------------------
     -- token is ok - proceed with forwarding setup
@@ -133,7 +135,7 @@ if token then
         local run_api_token = os.getenv("API_TOKEN")
         -- Fail if the API connection parameters cannot be retrieved from the environment
         if not run_api_url or not run_api_token then
-            ngx.log(ngx.ERR, 'Cannot get API or API_TOKEN environment variables')
+            ngx.log(ngx.ERR, "Application: FSBrowser; User: NotAuthorized; Status: Authentication failed; Message: Cannot get API or API_TOKEN environment variables")
             ngx.status = ngx.HTTP_UNAUTHORIZED
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
             return
@@ -153,7 +155,8 @@ if token then
 
         -- Fail if the request was not successful
         if not res then
-            ngx.log(ngx.ERR, 'Failed to request API for the Pod IP and SSH Pass. API: ' .. run_api_url .. ', Error: ' .. err)
+            ngx.log(ngx.ERR, "Application: FSBrowser; User: NotAuthorized; Status: Authentication failed; Message: " ..
+                    'Failed to request API for the Pod IP and SSH Pass. API - ' .. run_api_url .. ', Error - ' .. err)
             ngx.status = ngx.HTTP_UNAUTHORIZED
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
             return
@@ -165,7 +168,8 @@ if token then
         if not dict_contains(data, 'payload') or 
            not dict_contains(data['payload'], 'sshPassword') or 
            not dict_contains(data['payload'], 'podIP') then
-            ngx.log(ngx.ERR, 'Cannot get podIP and sshPassword from the API response')
+            ngx.log(ngx.ERR, "Application: FSBrowser; User: NotAuthorized; Status: Authentication failed; Message: " ..
+                    'Cannot get podIP and sshPassword from the API response')
             ngx.status = ngx.HTTP_UNAUTHORIZED
             ngx.exit(ngx.HTTP_UNAUTHORIZED)
             return
@@ -204,6 +208,7 @@ if token then
 
     ngx.req.set_header('token', token)
     ngx.req.set_header('X-Auth-User', username)
+    ngx.log(ngx.WARN,"Application: FSBrowser; User: " .. username .. "; Status: Successfully autentificated.")
     return
     -- --------------------------------------------
 end

--- a/deploy/docker/cp-edge/validate_cookie_ssh.lua
+++ b/deploy/docker/cp-edge/validate_cookie_ssh.lua
@@ -36,7 +36,7 @@ if token then
     if not jwt_obj["verified"] then
         ngx.header['Set-Cookie'] = 'bearer=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
         ngx.status = ngx.HTTP_UNAUTHORIZED
-        ngx.log(ngx.WARN, "Application: SSH; User: NotAuthorized; Status: Authentication failed; Message: " .. jwt_obj.reason)
+        ngx.log(ngx.WARN, "[SECURITY] Application: SSH; User: NotAuthorized; Status: Authentication failed; Message: " .. jwt_obj.reason)
         ngx.exit(ngx.HTTP_UNAUTHORIZED)
     end
 
@@ -44,8 +44,8 @@ if token then
 
     -- If "bearer" is fine - allow nginx to proceed
     -- Pass authenticated user to the proxied resource as a header
-    if string.match(ngx.var.route_location_root, "/ssh/pipeline") then
-        ngx.log(ngx.WARN,"Application: SSH; User: " .. username .. "; Status: Successfully autentificated.")
+    if string.match(ngx.var.request_uri, "ssh/pipeline") then
+        ngx.log(ngx.WARN,"[SECURITY] Application: SSH; User: " .. username .. "; Status: Successfully autentificated.")
     end
     ngx.req.set_header('token', token)
     return
@@ -98,7 +98,3 @@ else
         ngx.say('<html><body><script>window.location.href = "' .. req_uri .. '"</script></body></html>')
         return
 end
-
--- No cookie, no POST param - 401
-ngx.status = ngx.HTTP_UNAUTHORIZED
-ngx.exit(ngx.HTTP_UNAUTHORIZED)

--- a/deploy/docker/cp-edge/validate_cookie_ssh.lua
+++ b/deploy/docker/cp-edge/validate_cookie_ssh.lua
@@ -36,12 +36,15 @@ if token then
     if not jwt_obj["verified"] then
         ngx.header['Set-Cookie'] = 'bearer=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
         ngx.status = ngx.HTTP_UNAUTHORIZED
-        ngx.log(ngx.WARN, jwt_obj.reason)
+        ngx.log(ngx.WARN, "Application: SSH; User: NotAuthorized; Status: Authentication failed; Message: " .. jwt_obj.reason)
         ngx.exit(ngx.HTTP_UNAUTHORIZED)
     end
 
     -- If "bearer" is fine - allow nginx to proceed
     -- Pass authenticated user to the proxied resource as a header
+    if string.match(ngx.var.route_location_root, "/ssh/pipeline") then
+        ngx.log(ngx.WARN,"Application: SSH; User: " .. username .. "; Status: Successfully autentificated.")
+    end
     ngx.req.set_header('token', token)
     return
 end

--- a/deploy/docker/cp-edge/validate_cookie_ssh.lua
+++ b/deploy/docker/cp-edge/validate_cookie_ssh.lua
@@ -40,6 +40,8 @@ if token then
         ngx.exit(ngx.HTTP_UNAUTHORIZED)
     end
 
+    local username = jwt_obj["payload"]["sub"]
+
     -- If "bearer" is fine - allow nginx to proceed
     -- Pass authenticated user to the proxied resource as a header
     if string.match(ngx.var.route_location_root, "/ssh/pipeline") then

--- a/deploy/docker/cp-edge/validate_cookie_ssh.lua
+++ b/deploy/docker/cp-edge/validate_cookie_ssh.lua
@@ -1,4 +1,4 @@
--- Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+-- Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ if token then
     if not jwt_obj["verified"] then
         ngx.header['Set-Cookie'] = 'bearer=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
         ngx.status = ngx.HTTP_UNAUTHORIZED
-        ngx.log(ngx.WARN, "[SECURITY] Application: SSH; User: NotAuthorized; Status: Authentication failed; Message: " .. jwt_obj.reason)
+        ngx.log(ngx.WARN, "[SECURITY] RunId: ".. ngx.var.run_id .. " Application: SSH; User: NotAuthorized; Status: Authentication failed; Message: " .. jwt_obj.reason)
         ngx.exit(ngx.HTTP_UNAUTHORIZED)
     end
 
@@ -45,7 +45,7 @@ if token then
     -- If "bearer" is fine - allow nginx to proceed
     -- Pass authenticated user to the proxied resource as a header
     if string.match(ngx.var.request_uri, "ssh/pipeline") then
-        ngx.log(ngx.WARN,"[SECURITY] Application: SSH; User: " .. username .. "; Status: Successfully autentificated.")
+        ngx.log(ngx.WARN,"[SECURITY] RunId: ".. ngx.var.run_id .. " Application: SSH; User: " .. username .. "; Status: Successfully autentificated.")
     end
     ngx.req.set_header('token', token)
     return


### PR DESCRIPTION
This PR is part of #989 
It adds additional information for security logs (authentication, permission modification) such as user name.
Also this PR brings new log appender that appends logs to security.json file, this log file accumulates all security events from api server:
## API server logs
* Success/Failed of user authentication 
  *  SAML authentication 
  *  SAML Proxy authentication
  *  JWT authentication 
* Permission modification
  *  Entity permission granting/deleting
  *  Locking/Unlocking entity 
* User profile modification
  *  Creating/Deleting user
  *  Adding/Deleting groups for user

## EDGE server logs
Additional logs for edge server was added. Auth logs for ssh-session and application are printed to error.log of Nginx.
The next log structure are proposed:
```
[SECURITY] RunId: {run_id}; Application: {app}; User: {username}; Status: {status}; Message: {message}
``` 