### PR TITLE
(Issue #1011) Disable live migration

### DIFF
--- a/workflows/pipe-common/pipeline/autoscaling/gcpprovider.py
+++ b/workflows/pipe-common/pipeline/autoscaling/gcpprovider.py
@@ -74,6 +74,7 @@ class GCPInstanceProvider(AbstractInstanceProvider):
             'name': instance_name,
             'machineType': machine_type,
             'scheduling': {
+                'onHostMaintenance': 'terminate',
                 'preemptible': is_spot
             },
             'canIpForward': True,


### PR DESCRIPTION
This PR related to #1011. 
Live migration is disabled for all GCP instances.