### PR TITLE
Issue #1017 Allow to specify region specific tags for GCP instances

### DIFF
--- a/workflows/pipe-common/pipeline/autoscaling/gcpprovider.py
+++ b/workflows/pipe-common/pipeline/autoscaling/gcpprovider.py
@@ -72,7 +72,7 @@ class GCPInstanceProvider(AbstractInstanceProvider):
             'canIpForward': True,
             'disks': self.__get_disk_devices(ins_img, OS_DISK_SIZE, ins_hdd, swap_size),
             'networkInterfaces': network_interfaces,
-            'labels': GCPInstanceProvider.get_tags(run_id),
+            'labels': GCPInstanceProvider.get_tags(run_id, self.cloud_region),
             "metadata": {
                 "items": [
                     {
@@ -340,10 +340,15 @@ class GCPInstanceProvider(AbstractInstanceProvider):
         }
 
     @staticmethod
-    def get_tags(run_id):
+    def get_tags(run_id, cloud_region):
         tags = GCPInstanceProvider.run_id_tag(run_id)
-        res_tags = GCPInstanceProvider.resource_tags()
-        for key in res_tags:
-            tags[key.lower()] = res_tags[key].lower()
+        GCPInstanceProvider.append_tags(tags, GCPInstanceProvider.resource_tags())
+        GCPInstanceProvider.append_tags(tags, utils.get_region_tags(cloud_region))
         return tags
 
+    @staticmethod
+    def append_tags(tags, tags_to_add):
+        if tags_to_add is None:
+            return
+        for key in tags_to_add:
+            tags[key.lower()] = tags_to_add[key].lower()

--- a/workflows/pipe-common/pipeline/autoscaling/gcpprovider.py
+++ b/workflows/pipe-common/pipeline/autoscaling/gcpprovider.py
@@ -236,7 +236,7 @@ class GCPInstanceProvider(AbstractInstanceProvider):
         if len(project_and_family) != 2:
             # TODO: missing exception?
             print("node_image parameter doesn't match to Google image name convention: <project>/<imageFamily>")
-        image = self.client.images().get(project=project_and_family[0], image=project_and_family[1])
+        image = self.client.images().get(project=project_and_family[0], image=project_and_family[1]).execute()
         if image is None or 'diskSizeGb' not in image:
             utils.pipe_log('Failed to get image disk size info. Falling back to default size %d ' % disk_size)
             image_disk_size = disk_size

--- a/workflows/pipe-common/pipeline/autoscaling/utils.py
+++ b/workflows/pipe-common/pipeline/autoscaling/utils.py
@@ -133,6 +133,10 @@ def get_allowed_zones(cloud_region):
     return list(get_networks_config(cloud_region).keys())
 
 
+def get_region_tags(cloud_region):
+    return get_cloud_config_section(cloud_region, "tags")
+
+
 def get_security_groups(cloud_region):
     config = get_cloud_config_section(cloud_region, "security_group_ids")
     if not config:


### PR DESCRIPTION
 This PR is related to #1017 

### Implementation
Node up script for GCP now supports region-specific section `tags` in `cluster.networks.config` SystemPreference. Both upper-level tags and region-specific tags are applied to created instances, region-specific tags override upper-level tags for the same keys.