### PR TITLE
Issue #1018 Allow to specify network tags for GCP instances

### DIFF
--- a/workflows/pipe-common/pipeline/autoscaling/gcpprovider.py
+++ b/workflows/pipe-common/pipeline/autoscaling/gcpprovider.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -73,6 +73,9 @@ class GCPInstanceProvider(AbstractInstanceProvider):
             'disks': self.__get_disk_devices(ins_img, OS_DISK_SIZE, ins_hdd, swap_size),
             'networkInterfaces': network_interfaces,
             'labels': GCPInstanceProvider.get_tags(run_id, self.cloud_region),
+            'tags': {
+                'items': utils.get_network_tags(self.cloud_region)
+            },
             "metadata": {
                 "items": [
                     {

--- a/workflows/pipe-common/pipeline/autoscaling/utils.py
+++ b/workflows/pipe-common/pipeline/autoscaling/utils.py
@@ -125,8 +125,13 @@ def get_networks_config(cloud_region):
 def get_access_config(cloud_region):
     return get_cloud_config_section(cloud_region, "access_config")
 
+
 def get_instance_images_config(cloud_region):
     return get_cloud_config_section(cloud_region, "amis")
+
+
+def get_network_tags(cloud_region):
+    return get_cloud_config_section(cloud_region, "network_tags")
 
 
 def get_allowed_zones(cloud_region):


### PR DESCRIPTION
This PR is related to #1018 

### Implementation
SystemPreference `cluster.networks.config` now supports `network_tags` section:
```
"network_tags": [ "tag1", "tag2"]
```
These tags are be applied to GCP instances.