### PR TITLE
Add log level and custom option pipe mount arguments

### DIFF
--- a/pipe-cli/mount/pipe-fuse.py
+++ b/pipe-cli/mount/pipe-fuse.py
@@ -190,6 +190,7 @@ if __name__ == '__main__':
     recording = args.logging_level == _debug_logging_level
     logging.basicConfig(format='[%(levelname)s] %(asctime)s %(filename)s - %(message)s',
                         level=_allowed_logging_level_names[args.logging_level])
+    logging.getLogger('botocore').setLevel(logging.ERROR)
 
     if is_frozen:
         logging.info('Frozen installation found. Bundled libfuse will be used.')

--- a/pipe-cli/mount/pipe-fuse.py
+++ b/pipe-cli/mount/pipe-fuse.py
@@ -41,7 +41,7 @@ from pipefuse.trunc import CopyOnDownTruncateFileSystemClient, \
 from pipefuse.api import CloudPipelineClient
 from pipefuse.webdav import CPWebDavClient
 from pipefuse.s3 import S3Client
-from pipefuse.pipefs import PipeFS
+from pipefuse.pipefs import PipeFS, RecordingFS
 from pipefuse.fslock import get_lock
 import ctypes
 import fuse
@@ -51,11 +51,12 @@ from cachetools import TTLCache
 _allowed_logging_level_names = logging._levelNames
 _allowed_logging_levels = filter(lambda name: isinstance(name, str), _allowed_logging_level_names.keys())
 _allowed_logging_levels_string = ', '.join(_allowed_logging_levels)
-_default_logging_level = logging.ERROR
+_default_logging_level = _allowed_logging_level_names[logging.ERROR]
+_debug_logging_level = _allowed_logging_level_names[logging.DEBUG]
 
 
 def start(mountpoint, webdav, bucket, buffer_size, trunc_buffer_size, chunk_size, cache_ttl, cache_size, default_mode,
-          mount_options=None, threads=False, monitoring_delay=600):
+          mount_options=None, threads=False, monitoring_delay=600, recording=False):
     if mount_options is None:
         mount_options = {}
     try:
@@ -94,6 +95,8 @@ def start(mountpoint, webdav, bucket, buffer_size, trunc_buffer_size, chunk_size
     else:
         logging.info('Truncating support is disabled.')
     fs = PipeFS(client=client, lock=get_lock(threads, monitoring_delay=monitoring_delay), mode=int(default_mode, 8))
+    if recording:
+        fs = RecordingFS(fs)
 
     enable_fallocate_support()
     FUSE(fs, mountpoint, nothreads=not threads, foreground=True, ro=client.is_read_only(), **mount_options)
@@ -182,8 +185,9 @@ if __name__ == '__main__':
         parser.error('Either --webdav or --bucket parameter should be specified.')
     if args.bucket and (args.chunk_size < 5 * MB or args.chunk_size > 5 * GB):
         parser.error('Chunk size can vary from 5 MB to 5 GB due to AWS s3 multipart upload limitations.')
-    if args.logging_level not in _allowed_logging_level_names:
+    if args.logging_level not in _allowed_logging_levels:
         parser.error('Only the following logging level are allowed: %s.' % _allowed_logging_levels_string)
+    recording = args.logging_level == _debug_logging_level
     logging.basicConfig(format='[%(levelname)s] %(asctime)s %(filename)s - %(message)s',
                         level=_allowed_logging_level_names[args.logging_level])
 
@@ -196,7 +200,7 @@ if __name__ == '__main__':
         start(args.mountpoint, webdav=args.webdav, bucket=args.bucket, buffer_size=args.buffer_size,
               trunc_buffer_size=args.trunc_buffer_size, chunk_size=args.chunk_size, cache_ttl=args.cache_ttl,
               cache_size=args.cache_size, default_mode=args.mode, mount_options=parse_mount_options(args.options),
-              threads=args.threads, monitoring_delay=args.monitoring_delay)
+              threads=args.threads, monitoring_delay=args.monitoring_delay, recording=recording)
     except BaseException as e:
         logging.error('Unhandled error: %s' % e.message)
         sys.exit(1)

--- a/pipe-cli/mount/pipefuse/api.py
+++ b/pipe-cli/mount/pipefuse/api.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import logging
 
 import requests
 
@@ -71,12 +72,14 @@ class CloudPipelineClient:
                             'Authorization': 'Bearer {}'.format(self._token)}
 
     def get_storage(self, name):
+        logging.info('Getting data storage %s' % name)
         response_data = self._get('datastorage/find?id={}'.format(name))
         if 'payload' in response_data:
             return DataStorage.load(response_data['payload'])
         return None
 
     def get_temporary_credentials(self, bucket):
+        logging.info('Getting temporary credentials for data storage #%s' % bucket.id)
         operation = {
             'id': bucket.id,
             'read': bucket.is_read_allowed(),

--- a/pipe-cli/mount/pipefuse/buff.py
+++ b/pipe-cli/mount/pipefuse/buff.py
@@ -158,7 +158,6 @@ class BufferedFileSystemClient(FileSystemClientDecorator):
             return read_ahead_buf.getvalue()
 
     def upload_range(self, fh, buf, path, offset=0):
-        logging.debug('Uploading range %d-%d for %d:%s' % (offset, offset + len(buf), fh, path))
         file_buf = self._write_file_buffs.get(path)
         if not file_buf:
             file_buf = self._new_write_buf(self._capacity, offset)

--- a/pipe-cli/mount/pipefuse/cache.py
+++ b/pipe-cli/mount/pipefuse/cache.py
@@ -40,6 +40,7 @@ class CachingFileSystemClient(FileSystemClientDecorator):
         self._delimiter = '/'
 
     def attrs(self, path):
+        logging.info('Getting attributes for %s' % path)
         parent_path, file_name = fuseutils.split_path(path)
         if not file_name:
             return self._root()
@@ -50,7 +51,6 @@ class CachingFileSystemClient(FileSystemClientDecorator):
                 if file:
                     logging.info('Using cached attributes for %s' % path)
                     return file
-        logging.info('Getting attributes for %s' % path)
         return self._find_in_listing(self._ls_as_dict(parent_path), file_name)
 
     def _find_in_listing(self, listing, file_name):
@@ -104,6 +104,7 @@ class CachingFileSystemClient(FileSystemClientDecorator):
         self._invalidate_parent_cache(path)
 
     def _remove_from_parent_cache(self, path):
+        logging.info('Invalidating cache for %s' % path)
         parent_path, _ = fuseutils.split_path(path)
         parent_listing = self._cache.get(parent_path, None)
         if parent_listing:

--- a/pipe-cli/mount/pipefuse/pipefs.py
+++ b/pipe-cli/mount/pipefuse/pipefs.py
@@ -113,7 +113,7 @@ class PipeFS(Operations):
         try:
             props = self.client.attrs(path)
             if not props:
-                raise RuntimeError('Cannot read attributes for a path because it doesn\'t exist %s' % path)
+                raise FuseOSError(errno.ENOENT)
             if path == self.root or props.is_dir:
                 mode = stat.S_IFDIR
             else:
@@ -131,6 +131,8 @@ class PipeFS(Operations):
             if props.ctime:
                 attrs['st_ctime'] = props.ctime
             return attrs
+        except FuseOSError:
+            raise
         except Exception:
             if path not in self._system_files:
                 logging.exception('Error occurred while getting attributes for %s' % path)

--- a/pipe-cli/mount/pipefuse/pipefs.py
+++ b/pipe-cli/mount/pipefuse/pipefs.py
@@ -295,4 +295,4 @@ class RecordingFS:
         return ', '.join(str(k) + '=' + self._trimmed(v) for k, v in kwargs.items())
 
     def _trimmed(self, value):
-        return 'BYTES' if isinstance(value, str) else str(value)
+        return 'BYTES#' + str(len(value)) if isinstance(value, str) else str(value)

--- a/pipe-cli/mount/pipefuse/pipefs.py
+++ b/pipe-cli/mount/pipefuse/pipefs.py
@@ -272,8 +272,8 @@ class RecordingFS:
             attr = getattr(self._inner, name)
             if callable(attr):
                 def _wrapped_attr(method_name, *args, **kwargs):
-                    args_string = ', '.join(str(v) for v in args)
-                    kwargs_string = ', '.join(str(k) + '=' + str(v) for k, v in kwargs.items())
+                    args_string = self._args_string(args)
+                    kwargs_string = self._kwargs_string(kwargs)
                     if args_string and kwargs_string:
                         complete_args_string = args_string + ', ' + kwargs_string
                     elif args_string:
@@ -282,9 +282,17 @@ class RecordingFS:
                         complete_args_string = kwargs_string
                     logging.debug('[FSRecorder] %s (%s)' % (method_name, complete_args_string))
                     return attr(method_name, *args, **kwargs)
-
                 return _wrapped_attr
             else:
                 return attr
         else:
             return getattr(self._inner, name)
+
+    def _args_string(self, args):
+        return ', '.join(self._trimmed(v) for v in args)
+
+    def _kwargs_string(self, kwargs):
+        return ', '.join(str(k) + '=' + self._trimmed(v) for k, v in kwargs.items())
+
+    def _trimmed(self, value):
+        return 'BYTES' if isinstance(value, str) else str(value)

--- a/pipe-cli/mount/pipefuse/record.py
+++ b/pipe-cli/mount/pipefuse/record.py
@@ -1,0 +1,90 @@
+import io
+import logging
+
+
+def _merge_arguments(args, kwargs):
+    args_string = _args_string(args)
+    kwargs_string = _kwargs_string(kwargs)
+    if args_string and kwargs_string:
+        complete_args_string = args_string + ', ' + kwargs_string
+    elif args_string:
+        complete_args_string = args_string
+    else:
+        complete_args_string = kwargs_string
+    return complete_args_string
+
+
+def _args_string(args):
+    return ', '.join(_trimmed(v) for v in args)
+
+
+def _kwargs_string(kwargs):
+    return ', '.join(str(k) + '=' + _trimmed(v) for k, v in kwargs.items())
+
+
+def _trimmed(value):
+    if isinstance(value, io.BytesIO):
+        return 'BYTES'
+    elif isinstance(value, (bytearray, bytes, str)):
+        return 'BYTES#' + str(len(value))
+    else:
+        return str(value)
+
+
+class RecordingFS:
+
+    def __init__(self, inner):
+        """
+        Recording File System.
+
+        It records any call to the inner file system.
+
+        :param inner: Recording file system.
+        """
+        self._inner = inner
+        self._tag = type(inner).__name__ + ' Recorder'
+
+    def __getattr__(self, name):
+        if hasattr(self._inner, name):
+            attr = getattr(self._inner, name)
+            if callable(attr):
+                def _wrapped_attr(method_name, *args, **kwargs):
+                    complete_args_string = _merge_arguments(args, kwargs)
+                    if method_name in ['read', 'write']:
+                        logging.debug('[%s] %s (%s)' % (self._tag, method_name, complete_args_string))
+                    else:
+                        logging.info('[%s] %s (%s)' % (self._tag, method_name, complete_args_string))
+                    return attr(method_name, *args, **kwargs)
+                return _wrapped_attr
+            else:
+                return attr
+        else:
+            return getattr(self._inner, name)
+
+
+class RecordingFileSystemClient:
+
+    def __init__(self, inner):
+        """
+        Recording File System Client.
+
+        It records any call to the inner file system client.
+
+        :param inner: Recording file system client.
+        """
+        self._inner = inner
+        self._tag = type(inner).__name__ + ' Recorder'
+
+    def __getattr__(self, name):
+        if hasattr(self._inner, name):
+            attr = getattr(self._inner, name)
+            if callable(attr):
+                def _wrapped_attr(*args, **kwargs):
+                    complete_args_string = _merge_arguments(args, kwargs)
+                    logging.info('[%s] %s (%s)' % (self._tag, name, complete_args_string))
+                    return attr(*args, **kwargs)
+                return _wrapped_attr
+            else:
+                return attr
+        else:
+            return getattr(self._inner, name)

--- a/pipe-cli/mount/pipefuse/record.py
+++ b/pipe-cli/mount/pipefuse/record.py
@@ -50,7 +50,7 @@ class RecordingFS:
             if callable(attr):
                 def _wrapped_attr(method_name, *args, **kwargs):
                     complete_args_string = _merge_arguments(args, kwargs)
-                    if method_name in ['read', 'write']:
+                    if method_name in ['read', 'write', 'getxattr']:
                         logging.debug('[%s] %s (%s)' % (self._tag, method_name, complete_args_string))
                     else:
                         logging.info('[%s] %s (%s)' % (self._tag, method_name, complete_args_string))

--- a/pipe-cli/mount/pipefuse/trunc.py
+++ b/pipe-cli/mount/pipefuse/trunc.py
@@ -35,7 +35,7 @@ class CopyOnDownTruncateFileSystemClient(FileSystemClientDecorator):
         self._capacity = capacity
 
     def truncate(self, fh, path, length):
-        logging.info('Truncating %d:%s to %d' % (fh, path, length))
+        logging.info('Truncating %s to %d' % (path, length))
         file_size = self.attrs(path).size
         if not length:
             self._inner.upload(bytearray(), path)
@@ -83,7 +83,7 @@ class WriteNullsOnUpTruncateFileSystemClient(FileSystemClientDecorator):
         self._capacity = capacity
 
     def truncate(self, fh, path, length):
-        logging.info('Truncating %d:%s to %d' % (fh, path, length))
+        logging.info('Truncating %s to %d' % (path, length))
         file_size = self.attrs(path).size
         if not length:
             self._inner.upload(bytearray(), path)
@@ -116,7 +116,7 @@ class WriteLastNullOnUpTruncateFileSystemClient(FileSystemClientDecorator):
         self._inner = inner
 
     def truncate(self, fh, path, length):
-        logging.info('Truncating %d:%s to %d' % (fh, path, length))
+        logging.info('Truncating %s to %d' % (path, length))
         file_size = self.attrs(path).size
         if not length:
             self._inner.upload(bytearray(), path)

--- a/pipe-cli/mount/pipefuse/trunc.py
+++ b/pipe-cli/mount/pipefuse/trunc.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import io
+import logging
 
 from fsclient import FileSystemClientDecorator
 
@@ -34,6 +35,7 @@ class CopyOnDownTruncateFileSystemClient(FileSystemClientDecorator):
         self._capacity = capacity
 
     def truncate(self, fh, path, length):
+        logging.info('Truncating %d:%s to %d' % (fh, path, length))
         file_size = self.attrs(path).size
         if not length:
             self._inner.upload(bytearray(), path)
@@ -81,6 +83,7 @@ class WriteNullsOnUpTruncateFileSystemClient(FileSystemClientDecorator):
         self._capacity = capacity
 
     def truncate(self, fh, path, length):
+        logging.info('Truncating %d:%s to %d' % (fh, path, length))
         file_size = self.attrs(path).size
         if not length:
             self._inner.upload(bytearray(), path)
@@ -113,6 +116,7 @@ class WriteLastNullOnUpTruncateFileSystemClient(FileSystemClientDecorator):
         self._inner = inner
 
     def truncate(self, fh, path, length):
+        logging.info('Truncating %d:%s to %d' % (fh, path, length))
         file_size = self.attrs(path).size
         if not length:
             self._inner.upload(bytearray(), path)

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -977,30 +977,22 @@ def storage_delete_object_tags(path, tags, version):
 
 @storage.command('mount')
 @click.argument('mountpoint', required=True)
-@click.option('-f', '--file', required=False, help='File system mode', is_flag=True)
-@click.option('-b', '--bucket', required=False, help='Bucket name')
-@click.option('-o', '--options', required=False, help='Specify mount options')
-@click.option('-l', '--log-file', required=False, help='Specify log file for mount operation')
-@click.option('-v', '--log-level', required=False, help='Specify log level for mount')
-@click.option('-q', '--quiet', help='Quiet mode', is_flag=True)
+@click.option('-f', '--file', required=False, help='Enables file system mode', is_flag=True)
+@click.option('-b', '--bucket', required=False, help='Mounting bucket name')
+@click.option('-o', '--options', required=False, help='Any mount options supported by underlying FUSE implementation')
+@click.option('-c', '--custom-options', required=False, help='Mount options supported only by pipe fuse')
+@click.option('-l', '--log-file', required=False, help='Log file for mount')
+@click.option('-v', '--log-level', required=False, help='Log level for mount: '
+                                                        'CRITICAL, ERROR, WARNING, INFO or DEBUG')
+@click.option('-q', '--quiet', help='Enables quiet mode', is_flag=True)
 @click.option('-t', '--threads', help='Enables multithreading', is_flag=True)
 @click.option('-m', '--mode', required=False, help='Default file permissions',  default=700, type=int)
-@click.option('-c', '--custom-options', required=False, help='Specify pipe fuse specific mount options')
 @Config.validate_access_token
 def mount_storage(mountpoint, file, bucket, options, custom_options, log_file, log_level, quiet, threads, mode):
     """ Mounts either all available file systems or a single bucket into a local folder.
         Either -f\\--file flag or -b\\--bucket argument should be specified.
         Command is supported for Linux distributions and MacOS and requires
         FUSE installed.
-        - mountpoint - destination for mount.
-        - file - enables file system mount mode.
-        - bucket - name of the bucket to mount.
-        - options - any mount options supported by underlying FUSE implementation.
-        - custom_options - pipe fuse specific mount options.
-        - log-file - path to FUSE log file.
-        - log-level - FUSE log level.
-        - threads - start FUSE in a multithreaded mode.
-        - mode - file permissions mask
     """
     DataStorageOperations.mount_storage(mountpoint, file=file, log_file=log_file, log_level=log_level,
                                         bucket=bucket, options=options, custom_options=custom_options,

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -985,8 +985,9 @@ def storage_delete_object_tags(path, tags, version):
 @click.option('-q', '--quiet', help='Quiet mode', is_flag=True)
 @click.option('-t', '--threads', help='Enables multithreading', is_flag=True)
 @click.option('-m', '--mode', required=False, help='Default file permissions',  default=700, type=int)
+@click.option('-c', '--custom-options', required=False, help='Specify pipe fuse specific mount options')
 @Config.validate_access_token
-def mount_storage(mountpoint, file, bucket, options, log_file, log_level, quiet, threads, mode):
+def mount_storage(mountpoint, file, bucket, options, custom_options, log_file, log_level, quiet, threads, mode):
     """ Mounts either all available file systems or a single bucket into a local folder.
         Either -f\\--file flag or -b\\--bucket argument should be specified.
         Command is supported for Linux distributions and MacOS and requires
@@ -995,14 +996,15 @@ def mount_storage(mountpoint, file, bucket, options, log_file, log_level, quiet,
         - file - enables file system mount mode.
         - bucket - name of the bucket to mount.
         - options - any mount options supported by underlying FUSE implementation.
+        - custom_options - pipe fuse specific mount options.
         - log-file - path to FUSE log file.
         - log-level - FUSE log level.
         - threads - start FUSE in a multithreaded mode.
         - mode - file permissions mask
     """
     DataStorageOperations.mount_storage(mountpoint, file=file, log_file=log_file, log_level=log_level,
-                                        bucket=bucket, options=options, quiet=quiet,
-                                        threading=threads, mode=mode)
+                                        bucket=bucket, options=options, custom_options=custom_options,
+                                        quiet=quiet, threading=threads, mode=mode)
 
 
 @storage.command('umount')

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -981,11 +981,12 @@ def storage_delete_object_tags(path, tags, version):
 @click.option('-b', '--bucket', required=False, help='Bucket name')
 @click.option('-o', '--options', required=False, help='Specify mount options')
 @click.option('-l', '--log-file', required=False, help='Specify log file for mount operation')
+@click.option('-v', '--log-level', required=False, help='Specify log level for mount')
 @click.option('-q', '--quiet', help='Quiet mode', is_flag=True)
 @click.option('-t', '--threads', help='Enables multithreading', is_flag=True)
 @click.option('-m', '--mode', required=False, help='Default file permissions',  default=700, type=int)
 @Config.validate_access_token
-def mount_storage(mountpoint, file, bucket, options, log_file, quiet, threads, mode):
+def mount_storage(mountpoint, file, bucket, options, log_file, log_level, quiet, threads, mode):
     """ Mounts either all available file systems or a single bucket into a local folder.
         Either -f\\--file flag or -b\\--bucket argument should be specified.
         Command is supported for Linux distributions and MacOS and requires
@@ -995,10 +996,11 @@ def mount_storage(mountpoint, file, bucket, options, log_file, quiet, threads, m
         - bucket - name of the bucket to mount.
         - options - any mount options supported by underlying FUSE implementation.
         - log-file - path to FUSE log file.
+        - log-level - FUSE log level.
         - threads - start FUSE in a multithreaded mode.
         - mode - file permissions mask
     """
-    DataStorageOperations.mount_storage(mountpoint, file=file, log_file=log_file,
+    DataStorageOperations.mount_storage(mountpoint, file=file, log_file=log_file, log_level=log_level,
                                         bucket=bucket, options=options, quiet=quiet,
                                         threading=threads, mode=mode)
 

--- a/pipe-cli/src/utilities/datastorage_operations.py
+++ b/pipe-cli/src/utilities/datastorage_operations.py
@@ -493,16 +493,16 @@ class DataStorageOperations(object):
                 yield ('File', os.path.join(source_path, path), path, size)
 
     @classmethod
-    def mount_storage(cls, mountpoint, file=False, bucket=None, log_file=None, log_level=None, options=None, quiet=False,
-                      threading=False, mode=700):
+    def mount_storage(cls, mountpoint, file=False, bucket=None, log_file=None, log_level=None, options=None,
+                      custom_options=None, quiet=False, threading=False, mode=700):
         try:
             if not file and not bucket:
                 click.echo('Either file system mode should be enabled (-f/--file) '
                            'or bucket name should be specified (-b/--bucket BUCKET).', err=True)
                 sys.exit(1)
             cls.check_platform("mount")
-            Mount().mount_storages(mountpoint, file, bucket, options, quiet=quiet, log_file=log_file,
-                                   log_level=log_level,  threading=threading, mode=mode)
+            Mount().mount_storages(mountpoint, file, bucket, options, custom_options=custom_options, quiet=quiet,
+                                   log_file=log_file, log_level=log_level,  threading=threading, mode=mode)
         except ALL_ERRORS as error:
             click.echo('Error: %s' % str(error), err=True)
             sys.exit(1)

--- a/pipe-cli/src/utilities/datastorage_operations.py
+++ b/pipe-cli/src/utilities/datastorage_operations.py
@@ -493,7 +493,7 @@ class DataStorageOperations(object):
                 yield ('File', os.path.join(source_path, path), path, size)
 
     @classmethod
-    def mount_storage(cls, mountpoint, file=False, bucket=None, log_file=None, options=None, quiet=False,
+    def mount_storage(cls, mountpoint, file=False, bucket=None, log_file=None, log_level=None, options=None, quiet=False,
                       threading=False, mode=700):
         try:
             if not file and not bucket:
@@ -502,7 +502,7 @@ class DataStorageOperations(object):
                 sys.exit(1)
             cls.check_platform("mount")
             Mount().mount_storages(mountpoint, file, bucket, options, quiet=quiet, log_file=log_file,
-                                   threading=threading, mode=mode)
+                                   log_level=log_level,  threading=threading, mode=mode)
         except ALL_ERRORS as error:
             click.echo('Error: %s' % str(error), err=True)
             sys.exit(1)

--- a/pipe-cli/src/utilities/storage/mount.py
+++ b/pipe-cli/src/utilities/storage/mount.py
@@ -32,27 +32,27 @@ from src.config import Config, is_frozen
 class AbstractMount(object):
     __metaclass__ = ABCMeta
 
-    @abstractmethod
-    def get_mount_webdav_cmd(self, config, mountpoint, options, web_dav_url, mode, threading=False):
-        pass
+    def get_mount_webdav_cmd(self, config, mountpoint, options, web_dav_url, mode, threading=False, log_level=None):
+        additional_args = self._append_arguments(['--webdav', web_dav_url], threading, log_level)
+        return self._get_mount_cmd(config, mountpoint, options, additional_args, mode)
+
+    def get_mount_storage_cmd(self, config, mountpoint, options, bucket, mode, threading=False, log_level=None):
+        additional_args = self._append_arguments(['--bucket', bucket], threading, log_level)
+        return self._get_mount_cmd(config, mountpoint, options, additional_args, mode)
+
+    def _append_arguments(self, args, threading, log_level):
+        if threading:
+            args.append('--threads')
+        if log_level:
+            args.extend(['--logging-level', log_level])
+        return args
 
     @abstractmethod
-    def get_mount_storage_cmd(self, config, mountpoint, options, bucket, mode, threading=False):
+    def _get_mount_cmd(self, config, mountpoint, options, additional_arguments, mode):
         pass
 
 
 class FrozenMount(AbstractMount):
-
-    def get_mount_webdav_cmd(self, config, mountpoint, options, web_dav_url, mode, threading=False):
-        additional_args = self._append_threading('--webdav ' + web_dav_url, threading)
-        return self._get_mount_cmd(config, mountpoint, options, additional_args, mode)
-
-    def get_mount_storage_cmd(self, config, mountpoint, options, bucket, mode, threading=False):
-        additional_args = self._append_threading('--bucket ' + bucket, threading)
-        return self._get_mount_cmd(config, mountpoint, options, additional_args, mode)
-
-    def _append_threading(self, args, threading):
-        return args + ' --threads' if threading else args
 
     def _get_mount_cmd(self, config, mountpoint, options, additional_arguments, mode):
         mount_bin = self.get_mount_executable(config)
@@ -98,24 +98,11 @@ class FrozenMount(AbstractMount):
 
 class SourceMount(AbstractMount):
 
-    def get_mount_webdav_cmd(self, config, mountpoint, options, web_dav_url, mode, threading=False):
-        additional_args = self._append_threading(['--webdav', web_dav_url], threading)
-        return self._get_mount_cmd(config, mountpoint, options, additional_args, mode)
-
-    def get_mount_storage_cmd(self, config, mountpoint, options, bucket, mode, threading=False):
-        additional_args = self._append_threading(['--bucket', bucket], threading)
-        return self._get_mount_cmd(config, mountpoint, options, additional_args, mode)
-
-    def _append_threading(self, args, threading):
-        if threading:
-            args.append('--threads')
-        return args
-
     def _get_mount_cmd(self, config, mountpoint, options, additional_arguments, mode):
         python_exec = sys.executable
         script_folder = dirname(Config.get_base_source_dir())
         script_path = os.path.join(script_folder, 'mount/pipe-fuse.py')
-        mount_cmd = [python_exec, script_path, '--mountpoint', mountpoint, '--mode', mode]
+        mount_cmd = [python_exec, script_path, '--mountpoint', mountpoint, '--mode', str(mode)]
         mount_cmd.extend(additional_arguments)
         if options:
             mount_cmd.extend(['-o', options])
@@ -125,7 +112,7 @@ class SourceMount(AbstractMount):
 class Mount(object):
 
     def mount_storages(self, mountpoint, file=False, bucket=None, options=None, quiet=False, log_file=None,
-                       threading=False, mode=700):
+                       log_level=None, threading=False, mode=700):
         config = Config.instance()
         username = config.get_current_user()
         mount = FrozenMount() if is_frozen() else SourceMount()
@@ -133,17 +120,19 @@ class Mount(object):
             web_dav_url = PreferenceAPI.get_preference('base.dav.auth.url').value
             web_dav_url = web_dav_url.replace('auth-sso/', username + '/')
             self.mount_dav(mount, config, mountpoint, options, web_dav_url, mode, log_file=log_file,
-                           threading=threading)
+                           log_level=log_level, threading=threading)
         else:
             self.mount_storage(mount, config, mountpoint, options, bucket, mode, log_file=log_file,
-                               threading=threading)
+                               log_level=log_level, threading=threading)
 
-    def mount_dav(self, mount, config, mountpoint, options, web_dav_url, mode, log_file=None, threading=False):
-        mount_cmd = mount.get_mount_webdav_cmd(config, mountpoint, options, web_dav_url, mode, threading=threading)
+    def mount_dav(self, mount, config, mountpoint, options, web_dav_url, mode, log_file=None, log_level=None, threading=False):
+        mount_cmd = mount.get_mount_webdav_cmd(config, mountpoint, options, web_dav_url, mode,
+                                               log_level=log_level, threading=threading)
         self.run(config, mount_cmd, log_file=log_file)
 
-    def mount_storage(self, mount, config, mountpoint, options, bucket, mode, log_file=None, threading=False):
-        mount_cmd = mount.get_mount_storage_cmd(config, mountpoint, options, bucket, mode, threading=threading)
+    def mount_storage(self, mount, config, mountpoint, options, bucket, mode, log_file=None, log_level=None, threading=False):
+        mount_cmd = mount.get_mount_storage_cmd(config, mountpoint, options, bucket, mode,
+                                                log_level=log_level, threading=threading)
         self.run(config, mount_cmd, log_file=log_file)
 
     def run(self, config, mount_cmd, mount_timeout=5, log_file=None):

--- a/pipe-cli/src/utilities/storage/mount.py
+++ b/pipe-cli/src/utilities/storage/mount.py
@@ -74,7 +74,7 @@ class FrozenMount(AbstractMount):
         return ['bash', mount_script]
 
     def create_mount_script(self, config_folder, mount_bin, mountpoint, options, additional_arguments, mode):
-        mount_cmd = '%s --mountpoint %s %s --mode %d' % (mount_bin, mountpoint, additional_arguments, mode)
+        mount_cmd = '%s --mountpoint %s %s --mode %d' % (mount_bin, mountpoint, ' '.join(additional_arguments), mode)
         if options:
             mount_cmd += ' -o ' + options
         mount_script = os.path.join(config_folder, 'pipe-fuse-script' + str(uuid.uuid4()))


### PR DESCRIPTION
Relates to #1030.

The pull request improves pipe fuse integration in several ways in order to simplify troubleshooting.

## Logging level

The pull request brings support for an additional `pipe mount` argument `--log-level` which can be used to specify python [logging level](https://docs.python.org/2.7/howto/logging.html) which defaults to `ERROR`.

```bash
pipe storage mount --file \
                   --log-file log.txt \
                   --log-level INFO \
                   mountpoint
```

For the simplest cases `INFO` logging level should be enough. It registers all the file system events but `write` and `read` calls which are available only in `DEBUG` logging level mode. The `DEBUG` logging level collects all the available logs which can results in very large logs file especially if `threading` is enabled. Moreover pipe fuse performance is significantly worse in case of `DEBUG` logging level.

## Libfuse logging

There is a possibility to enable libfuse low level logging with fuse `debug` option. The pull request doesn't introduce the feature but it seems fine to point it out along other logging configurations.

```bash
pipe storage mount --file \
                   --options debug \
                   mountpoint
```

## Custom options

Moreover the pull request brings an additional `--custom-options` argument which can be used to fine tune pipe fuse behavior. All the custom options are transferred to pipe fuse command line arguments.

```bash
pipe storage mount --file \
                   --custom-options buffer-size=10000,cache-size=10 \
                   mountpoint
```
