### PR TITLE
Enforce tool cloud region restrictions

### DIFF
--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -85,6 +85,7 @@ public final class MessageConstants {
     public static final String ERROR_TOOL_ICON_TOO_LARGE = "error.tool.icon.too.large";
     public static final String ERROR_TOOL_INVALID_IMAGE = "error.tool.invalid.image";
     public static final String ERROR_TOOL_VERSION_INVALID_SIZE = "error.tool.version.invalid.size";
+    public static final String ERROR_TOOL_CLOUD_REGION_NOT_ALLOWED = "error.tool.cloud.region.not.allowed";
 
     // Registry messages
     public static final String DEBUG_DOCKER_REGISTRY_AUTO_ENABLE = "debug.docker.registry.auto.enable";

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineConfigurationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineConfigurationManager.java
@@ -392,4 +392,10 @@ public class PipelineConfigurationManager {
         }
         return defaultConfiguration;
     }
+
+    public PipelineConfiguration getConfigurationForTool(final Tool tool, final PipelineConfiguration configuration) {
+        return Optional.ofNullable(getConfigurationForToolVersion(tool.getId(), configuration.getDockerImage(), null))
+                .map(ConfigurationEntry::getConfiguration)
+                .orElseGet(PipelineConfiguration::new);
+    }
 }

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -131,6 +131,7 @@ error.number.of.tools.with.image.greater.then.one=There are several repository w
 error.tool.icon.not.found=Icon for tool with specified ID: {0} not found
 error.tool.icon.too.large=Icon uploaded is too large: {0}, {1} allowed
 error.tool.version.invalid.size=Size is not available for tool ''{0}''
+error.tool.cloud.region.not.allowed=Tool is allowed to be executed only in ''{0}'' cloud region. Required ''{1}'' cloud region is not allowed for the tool execution.
 
 # Tool groups
 error.tool.group.already.exists=Tool group ''{0}'' already exists in registry ''{1}''


### PR DESCRIPTION
Relates to #1035.

The pull request enforce tool version cloud region restrictions. From now on tool can be launched only in the allowed cloud region if one is configured. Otherwise tools can be launched in any region as it was before. 

The restrictions affect pipelines and detached configurations which use the restricted tools as well.

Tool cloud region can be configured via `POST /tool/{toolId}/settings` API method the same way it can be done for a pipeline.