### PR TITLE
Issue 1050 check digest when docker registry sends notification

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/scan/ToolOSVersionView.java
+++ b/api/src/main/java/com/epam/pipeline/entity/scan/ToolOSVersionView.java
@@ -19,7 +19,7 @@ package com.epam.pipeline.entity.scan;
 import lombok.Getter;
 
 @Getter
-public class ToolOSVersionView {
+public final class ToolOSVersionView {
 
     private final String distribution;
     private final String version;

--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerRegistryManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerRegistryManager.java
@@ -27,13 +27,13 @@ import com.epam.pipeline.entity.docker.DockerRegistryList;
 import com.epam.pipeline.entity.docker.DockerRegistrySecret;
 import com.epam.pipeline.entity.docker.ImageDescription;
 import com.epam.pipeline.entity.docker.ManifestV2;
-import com.epam.pipeline.entity.docker.ToolVersion;
 import com.epam.pipeline.entity.pipeline.DockerRegistry;
 import com.epam.pipeline.entity.pipeline.DockerRegistryEvent;
 import com.epam.pipeline.entity.pipeline.DockerRegistryEventEnvelope;
 import com.epam.pipeline.entity.pipeline.Tool;
 import com.epam.pipeline.entity.pipeline.ToolGroup;
 import com.epam.pipeline.entity.pipeline.ToolScanStatus;
+import com.epam.pipeline.entity.scan.ToolVersionScanResult;
 import com.epam.pipeline.entity.security.JwtRawToken;
 import com.epam.pipeline.entity.security.acl.AclClass;
 import com.epam.pipeline.entity.utils.DateUtils;
@@ -491,8 +491,9 @@ public class DockerRegistryManager implements SecuredEntityManager {
         if (toolInGroup.isPresent()) {
             LOGGER.warn(messageHelper.getMessage(MessageConstants.ERROR_TOOL_ALREADY_EXIST, tool.getImage(),
                     toolGroup.getName()));
-            final ToolVersion toolVersion = toolVersionManager.loadToolVersion(tool.getId(), pushTag);
-            if (!toolVersion.getDigest().equals(pushDigest)) {
+            final Optional<ToolVersionScanResult> scanResult = toolManager.loadToolVersionScan(
+                    toolInGroup.get().getId(), pushTag);
+            if (!scanResult.isPresent() || !scanResult.get().getDigest().equals(pushDigest)) {
                 toolManager.updateToolVersionScanStatus(toolInGroup.get().getId(),
                         ToolScanStatus.NOT_SCANNED, DateUtils.now(), pushTag,
                         null, pushDigest);

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/ToolApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/ToolApiService.java
@@ -131,7 +131,8 @@ public class ToolApiService {
         if (toolScanResult != null) {
             return new ToolScanResultView(toolScanResult.getToolId(),
                     toolScanResult.getToolVersionScanResults().values().stream().map(vsr ->
-                            ToolVersionScanResultView.from(vsr, toolManager.isToolOSVersionAllowed(vsr.getToolOSVersion()))
+                            ToolVersionScanResultView.from(vsr,
+                                    toolManager.isToolOSVersionAllowed(vsr.getToolOSVersion()))
                     ).collect(Collectors.toMap(ToolVersionScanResultView::getVersion, vsrv -> vsrv)));
         } else {
             return null;


### PR DESCRIPTION
This PR related to #1050 
currently we do not check a digest of new push event from docker registry and just update scan result and set status NOT_SCANNED. 
This PR adds additional checks in order to not to update scan result if push event doesn't change image