### PR TITLE
Issue #1040 : Storage path permissions 

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/datastorage/DatastoragePath.java
+++ b/api/src/main/java/com/epam/pipeline/entity/datastorage/DatastoragePath.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.datastorage;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class DatastoragePath {
+
+    private String root;
+    private String path;
+}

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/ProviderUtils.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/ProviderUtils.java
@@ -21,6 +21,7 @@ import com.epam.pipeline.entity.datastorage.DatastoragePath;
 import com.epam.pipeline.entity.datastorage.PathDescription;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.Arrays;
 import java.util.function.Function;
 
 public final class ProviderUtils {
@@ -38,13 +39,14 @@ public final class ProviderUtils {
     }
 
     public static String withoutLeadingDelimiter(final String path) {
-        return StringUtils.isNotBlank(path) && path.startsWith(ProviderUtils.DELIMITER) ? path.substring(1) : path;
+        return StringUtils.isNotBlank(path) && path.startsWith(DELIMITER) ? path.substring(1) : path;
     }
 
     public static DatastoragePath parsePath(final String fullPath) {
-        final String[] chunks = fullPath.split(ProviderUtils.DELIMITER);
+        final String[] chunks = fullPath.split(DELIMITER);
         final String root = chunks[0];
-        final String path = chunks.length > 1 ? chunks[1] : StringUtils.EMPTY;
+        final String path = chunks.length > 1 ?
+                StringUtils.join(Arrays.copyOfRange(chunks, 1, chunks.length), DELIMITER) : StringUtils.EMPTY;
         return new DatastoragePath(root, path);
     }
 
@@ -55,7 +57,7 @@ public final class ProviderUtils {
                 .toLowerCase()
                 .replaceAll("[^a-z0-9\\-]+", "-");
         return StringUtils.isBlank(datastoragePath.getPath()) ?
-                bucketName : bucketName + ProviderUtils.DELIMITER + datastoragePath.getPath();
+                bucketName : bucketName + DELIMITER + datastoragePath.getPath();
     }
 
     public static String withoutTrailingDelimiter(final String path) {

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/AbstractS3ObjectWrapper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/AbstractS3ObjectWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ public abstract class AbstractS3ObjectWrapper {
         return new S3FileWrapper(objectSummary);
     }
 
-    public DataStorageFile convertToStorageFile(String requestPath) {
+    public DataStorageFile convertToStorageFile(String requestPath, String prefix) {
         String relativePath = getKey();
         if ((relativePath.endsWith(ProviderUtils.DELIMITER) && relativePath.equals(requestPath))
                 || StringUtils.endsWithIgnoreCase(relativePath,
@@ -49,7 +49,7 @@ public abstract class AbstractS3ObjectWrapper {
         String fileName = relativePath.substring(requestPath.length());
         DataStorageFile file = new DataStorageFile();
         file.setName(fileName);
-        file.setPath(relativePath);
+        file.setPath(ProviderUtils.removePrefix(relativePath, prefix));
         file.setSize(getSize());
         file.setVersion(getVersion());
         file.setChanged(S3Constants.getAwsDateFormat().format(getChanged()));

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3Helper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3Helper.java
@@ -325,7 +325,7 @@ public class S3Helper {
     }
 
     public DataStorageListing getItems(String bucket, String path, Boolean showVersion,
-            Integer pageSize, String marker) {
+            Integer pageSize, String marker, String prefix) {
         String requestPath = Optional.ofNullable(path).orElse("");
         AmazonS3 client = getDefaultS3Client();
         if (!StringUtils.isNullOrEmpty(requestPath)) {
@@ -335,8 +335,8 @@ public class S3Helper {
             }
         }
         DataStorageListing result = showVersion ?
-                listVersions(client, bucket, requestPath, pageSize, marker) :
-                listFiles(client, bucket, requestPath, pageSize, marker);
+                listVersions(client, bucket, requestPath, pageSize, marker, prefix) :
+                listFiles(client, bucket, requestPath, pageSize, marker, prefix);
         result.getResults().sort(AbstractDataStorageItem.getStorageItemComparator());
         return result;
     }
@@ -634,7 +634,7 @@ public class S3Helper {
         final String requestPath = Optional.ofNullable(path).orElse("");
         final AmazonS3 client = getDefaultS3Client();
 
-        ObjectListing listing = client.listObjects(dataStorage.getPath(), requestPath);
+        ObjectListing listing = client.listObjects(dataStorage.getRoot(), requestPath);
         boolean hasNextPageMarker = true;
         while (hasNextPageMarker && !pathDescription.getCompleted()) {
             ProviderUtils.getSizeByPath(listing.getObjectSummaries(), requestPath,
@@ -702,7 +702,7 @@ public class S3Helper {
     }
 
     private DataStorageListing listFiles(AmazonS3 client, String bucket,
-            String requestPath, Integer pageSize, String marker) {
+            String requestPath, Integer pageSize, String marker, String prefix) {
         ListObjectsV2Request req = new ListObjectsV2Request();
         req.setBucketName(bucket);
         req.setPrefix(requestPath);
@@ -721,11 +721,12 @@ public class S3Helper {
 
             for (String name : listing.getCommonPrefixes()) {
                 previous = getPreviousKey(previous, name);
-                items.add(parseFolder(requestPath, name));
+                items.add(parseFolder(requestPath, name, prefix));
             }
             for (S3ObjectSummary s3ObjectSummary : listing.getObjectSummaries()) {
                 DataStorageFile file =
-                        AbstractS3ObjectWrapper.getWrapper(s3ObjectSummary).convertToStorageFile(requestPath);
+                        AbstractS3ObjectWrapper.getWrapper(s3ObjectSummary)
+                                .convertToStorageFile(requestPath, prefix);
                 if (file != null) {
                     previous = getPreviousKey(previous, s3ObjectSummary.getKey());
                     items.add(file);
@@ -744,7 +745,7 @@ public class S3Helper {
         return key.compareTo(previous) > 0 ? key : previous;
     }
 
-    private DataStorageFolder parseFolder(String requestPath, String name) {
+    private DataStorageFolder parseFolder(String requestPath, String name, String prefix) {
         String relativePath = name;
         if (relativePath.endsWith(ProviderUtils.DELIMITER)) {
             relativePath = relativePath.substring(0, relativePath.length() - 1);
@@ -752,12 +753,12 @@ public class S3Helper {
         String folderName = relativePath.substring(requestPath.length());
         DataStorageFolder folder = new DataStorageFolder();
         folder.setName(folderName);
-        folder.setPath(relativePath);
+        folder.setPath(ProviderUtils.removePrefix(relativePath, prefix));
         return folder;
     }
 
     private DataStorageListing listVersions(AmazonS3 client, String bucket,
-            String requestPath, Integer pageSize, String marker) {
+            String requestPath, Integer pageSize, String marker, String prefix) {
         ListVersionsRequest request = new ListVersionsRequest()
                 .withBucketName(bucket).withPrefix(requestPath).withDelimiter(ProviderUtils.DELIMITER);
         if (StringUtils.hasValue(marker)) {
@@ -778,7 +779,7 @@ public class S3Helper {
                     return new DataStorageListing(previous, items);
                 }
                 previous = getPreviousKey(previous, commonPrefix);
-                AbstractDataStorageItem folder = parseFolder(requestPath, commonPrefix);
+                AbstractDataStorageItem folder = parseFolder(requestPath, commonPrefix, prefix);
                 items.add(folder);
             }
             for (S3VersionSummary versionSummary : versionListing.getVersionSummaries()) {
@@ -786,7 +787,7 @@ public class S3Helper {
                     continue;
                 }
                 DataStorageFile file =
-                        AbstractS3ObjectWrapper.getWrapper(versionSummary).convertToStorageFile(requestPath);
+                        AbstractS3ObjectWrapper.getWrapper(versionSummary).convertToStorageFile(requestPath, prefix);
                 if (file == null) {
                     continue;
                 }
@@ -871,7 +872,7 @@ public class S3Helper {
     public Map<String, String> updateObjectTags(AbstractDataStorage dataStorage, String path, Map<String, String> tags,
                                  String version) {
         AmazonS3 client = getDefaultS3Client();
-        SetObjectTaggingRequest setTaggingRequest = new SetObjectTaggingRequest(dataStorage.getPath(), path,
+        SetObjectTaggingRequest setTaggingRequest = new SetObjectTaggingRequest(dataStorage.getRoot(), path,
                 new ObjectTagging(convertMapToAwsTags(tags)));
         if (!StringUtils.isNullOrEmpty(version)) {
             setTaggingRequest.withVersionId(version);
@@ -884,7 +885,7 @@ public class S3Helper {
         try {
             AmazonS3 client = getDefaultS3Client();
             GetObjectTaggingRequest getTaggingRequest =
-                    new GetObjectTaggingRequest(dataStorage.getPath(), path);
+                    new GetObjectTaggingRequest(dataStorage.getRoot(), path);
             if (!StringUtils.isNullOrEmpty(version)) {
                 getTaggingRequest.withVersionId(version);
             }
@@ -892,7 +893,7 @@ public class S3Helper {
         } catch (AmazonS3Exception e) {
             if (e.getStatusCode() == NOT_FOUND) {
                 throw new DataStorageException(messageHelper
-                        .getMessage(MessageConstants.ERROR_DATASTORAGE_PATH_NOT_FOUND, path, dataStorage.getPath()));
+                        .getMessage(MessageConstants.ERROR_DATASTORAGE_PATH_NOT_FOUND, path, dataStorage.getRoot()));
             } else {
                 throw new DataStorageException(e.getMessage(), e);
             }
@@ -914,13 +915,13 @@ public class S3Helper {
         try {
             AmazonS3 client = getDefaultS3Client();
             GetObjectRequest rangeObjectRequest =
-                    new GetObjectRequest(dataStorage.getPath(), path, version).withRange(0, maxDownloadSize - 1);
+                    new GetObjectRequest(dataStorage.getRoot(), path, version).withRange(0, maxDownloadSize - 1);
             S3Object objectPortion = client.getObject(rangeObjectRequest);
             return downloadContent(maxDownloadSize, objectPortion);
         } catch (AmazonS3Exception e) {
             if (e.getStatusCode() == NOT_FOUND) {
                 throw new DataStorageException(messageHelper
-                        .getMessage(MessageConstants.ERROR_DATASTORAGE_PATH_NOT_FOUND, path, dataStorage.getPath()));
+                        .getMessage(MessageConstants.ERROR_DATASTORAGE_PATH_NOT_FOUND, path, dataStorage.getRoot()));
             } else if (e.getStatusCode() == INVALID_RANGE) {
                 // is thrown in case of en empty file
                 LOGGER.debug(e.getMessage(), e);
@@ -937,13 +938,13 @@ public class S3Helper {
         try {
             AmazonS3 client = getDefaultS3Client();
             GetObjectRequest rangeObjectRequest =
-                new GetObjectRequest(dataStorage.getPath(), path, version);
+                new GetObjectRequest(dataStorage.getRoot(), path, version);
             S3Object object = client.getObject(rangeObjectRequest);
             return new DataStorageStreamingContent(object.getObjectContent(), object.getKey());
         } catch (AmazonS3Exception e) {
             if (e.getStatusCode() == NOT_FOUND) {
                 throw new DataStorageException(messageHelper
-                        .getMessage(MessageConstants.ERROR_DATASTORAGE_PATH_NOT_FOUND, path, dataStorage.getPath()));
+                        .getMessage(MessageConstants.ERROR_DATASTORAGE_PATH_NOT_FOUND, path, dataStorage.getRoot()));
             } else {
                 throw new DataStorageException(e.getMessage(), e);
             }

--- a/api/src/test/java/com/epam/pipeline/manager/datastorage/providers/S3StorageProviderTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/datastorage/providers/S3StorageProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.when;
 public class S3StorageProviderTest extends AbstractSpringTest {
 
     public static final long REGION_ID = 1L;
-    private final String bucketName = "bucketName";
+    private final String bucketName = "bucketname";
 
     @SpyBean
     private S3StorageProvider s3StorageProvider;

--- a/api/src/test/java/com/epam/pipeline/manager/issue/AttachmentFileManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/issue/AttachmentFileManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ public class AttachmentFileManagerTest {
 
     private AttachmentFileManager attachmentFileManager;
 
-    private S3bucketDataStorage testSystemDataStorage = new S3bucketDataStorage(1L, TEST_SYSTEM_DATA_STORAGE, "//");
+    private S3bucketDataStorage testSystemDataStorage = new S3bucketDataStorage(1L, TEST_SYSTEM_DATA_STORAGE, "test");
 
     @Before
     public void setUp() throws Exception {

--- a/api/src/test/java/com/epam/pipeline/manager/issue/IssueManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/issue/IssueManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,7 +105,7 @@ public class IssueManagerTest extends AbstractSpringTest {
     private DataStorageManager dataStorageManager;
 
     private Attachment testAttachment;
-    private S3bucketDataStorage testSystemDataStorage = new S3bucketDataStorage(1L, TEST_SYSTEM_DATA_STORAGE, "//");
+    private S3bucketDataStorage testSystemDataStorage = new S3bucketDataStorage(1L, TEST_SYSTEM_DATA_STORAGE, "test");
 
     @Before
     public void setUp() throws Exception {

--- a/core/src/main/java/com/epam/pipeline/entity/datastorage/AbstractDataStorage.java
+++ b/core/src/main/java/com/epam/pipeline/entity/datastorage/AbstractDataStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -109,4 +109,8 @@ public abstract class AbstractDataStorage extends AbstractSecuredEntity {
      * @return
      */
     public abstract boolean isPolicySupported();
+
+    public String getRoot() {
+        return getPath().split(getDelimiter())[0];
+    }
 }


### PR DESCRIPTION
This PR is related to #1040 

### Implementation
This PR allows to register S3 bucket path as a separate datastorage. E.g. user can register `s3://bucket/folder` as a storage and only content of `folder` will be available via GUI.