### PR TITLE
Allow anonymous access to run endpoints

### DIFF
--- a/api/profiles/dev/application.properties
+++ b/api/profiles/dev/application.properties
@@ -50,7 +50,8 @@ saml.user.attributes=Email=http://schemas.xmlsoap.org/ws/2005/05/identity/claims
 saml.user.blocked.attribute=
 saml.user.blocked.attribute.true.val=true
 # Create a user if it is not present in the database. Available strategies: AUTO, EXPLICIT, EXPLICIT_GROUP
-saml.user.auto.create=EXPLICIT
+saml.user.auto.create=${CP_SAML_USER_AUTO_CREATE:EXPLICIT}
+saml.user.allow.anonymous=${CP_SAML_USER_ALLOW_ANONYMOUS:false}
 saml.authn.max.authentication.age=93600
 
 #applicaion configuration

--- a/api/profiles/dev/application.properties
+++ b/api/profiles/dev/application.properties
@@ -10,6 +10,9 @@ spring.http.encoding.charset=UTF-8
 spring.http.encoding.force=true
 spring.http.encoding.force-response=true
 
+#Security
+api.security.anonymous.urls=${CP_API_SECURITY_ANONYMOUS_URLS:/restapi/route}
+
 #db configuration
 database.url=jdbc:postgresql://localhost:5432/pipeline
 database.username=pipeline

--- a/api/profiles/release/application.properties
+++ b/api/profiles/release/application.properties
@@ -9,6 +9,9 @@ spring.http.encoding.charset=UTF-8
 spring.http.encoding.force=true
 spring.http.encoding.force-response=true
 
+#Security
+api.security.anonymous.urls=${CP_API_SECURITY_ANONYMOUS_URLS:/restapi/route}
+
 #db configuration
 database.url=
 database.username=pipeline

--- a/api/profiles/release/application.properties
+++ b/api/profiles/release/application.properties
@@ -66,6 +66,8 @@ saml.authorities.attribute.names=
 saml.authn.request.binding=
 saml.sign.key=
 saml.user.attributes=
+saml.user.auto.create=
+saml.user.allow.anonymous=
 
 
 #cluster management

--- a/api/src/main/java/com/epam/pipeline/app/JWTSecurityConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/JWTSecurityConfiguration.java
@@ -17,7 +17,6 @@
 package com.epam.pipeline.app;
 
 import com.epam.pipeline.entity.user.DefaultRoles;
-import com.epam.pipeline.entity.user.Role;
 import com.epam.pipeline.security.jwt.JwtAuthenticationProvider;
 import com.epam.pipeline.security.jwt.JwtFilterAuthenticationFilter;
 import com.epam.pipeline.security.jwt.JwtTokenVerifier;

--- a/api/src/main/java/com/epam/pipeline/app/JWTSecurityConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/JWTSecurityConfiguration.java
@@ -95,10 +95,10 @@ public class JWTSecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .antMatchers(HttpMethod.OPTIONS).permitAll()
                 .antMatchers(getUnsecuredResources()).permitAll()
                 .antMatchers(getAnonymousResources())
-                    .hasAnyAuthority(roles(DefaultRoles.ROLE_ADMIN, DefaultRoles.ROLE_USER, 
-                            DefaultRoles.ROLE_ANONYMOUS_USER))
+                    .hasAnyAuthority(DefaultRoles.ROLE_ADMIN.getName(), DefaultRoles.ROLE_USER.getName(), 
+                            DefaultRoles.ROLE_ANONYMOUS_USER.getName())
                 .antMatchers(getSecuredResources())
-                    .hasAnyAuthority(roles(DefaultRoles.ROLE_ADMIN, DefaultRoles.ROLE_USER))
+                    .hasAnyAuthority(DefaultRoles.ROLE_ADMIN.getName(), DefaultRoles.ROLE_USER.getName())
                 .and()
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
                 .and()
@@ -145,13 +145,6 @@ public class JWTSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     public String[] getAnonymousResources() {
         return anonymousResources;
-    }
-
-    private String[] roles(final DefaultRoles... roles) {
-        return Arrays.stream(roles)
-                .map(DefaultRoles::getRole)
-                .map(Role::getName)
-                .toArray(String[]::new);
     }
 
     //List of urls under REST that should be redirected back after authorization

--- a/api/src/main/java/com/epam/pipeline/app/ProxySecurityConfig.java
+++ b/api/src/main/java/com/epam/pipeline/app/ProxySecurityConfig.java
@@ -31,6 +31,7 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import com.epam.pipeline.security.jwt.RestAuthenticationEntryPoint;
 import com.epam.pipeline.security.saml.SAMLProxyAuthenticationProvider;
 import com.epam.pipeline.security.saml.SAMLProxyFilter;
+import com.epam.pipeline.entity.user.DefaultRoles;
 
 @Configuration
 @Order(1)
@@ -51,7 +52,8 @@ public class ProxySecurityConfig extends WebSecurityConfigurerAdapter {
             .requestMatcher(new AntPathRequestMatcher(RESTAPI_PROXY))
             .authorizeRequests()
                 .antMatchers(HttpMethod.OPTIONS).permitAll()
-                .antMatchers(RESTAPI_PROXY).authenticated()
+                .antMatchers(RESTAPI_PROXY)
+                    .hasAnyAuthority(DefaultRoles.ROLE_ADMIN.getName(), DefaultRoles.ROLE_USER.getName())
                 .anyRequest().permitAll()
             .and()
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)

--- a/api/src/main/java/com/epam/pipeline/app/SAMLSecurityConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/SAMLSecurityConfiguration.java
@@ -160,10 +160,10 @@ public class SAMLSecurityConfiguration extends WebSecurityConfigurerAdapter {
         http.authorizeRequests()
                 .antMatchers(getUnsecuredResources()).permitAll()
                 .antMatchers(getAnonymousResources())
-                    .hasAnyAuthority(roles(DefaultRoles.ROLE_ADMIN, DefaultRoles.ROLE_USER, 
-                            DefaultRoles.ROLE_ANONYMOUS_USER))
+                    .hasAnyAuthority(DefaultRoles.ROLE_ADMIN.getName(), DefaultRoles.ROLE_USER.getName(), 
+                            DefaultRoles.ROLE_ANONYMOUS_USER.getName())
                 .antMatchers(getSecuredResourcesRoot())
-                    .hasAnyAuthority(roles(DefaultRoles.ROLE_ADMIN, DefaultRoles.ROLE_USER));
+                    .hasAnyAuthority(DefaultRoles.ROLE_ADMIN.getName(), DefaultRoles.ROLE_USER.getName());
         http.logout().logoutSuccessUrl("/");
     }
 
@@ -182,13 +182,6 @@ public class SAMLSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     public String[] getAnonymousResources() {
         return anonymousResources;
-    }
-
-    private String[] roles(final DefaultRoles... roles) {
-        return Arrays.stream(roles)
-                .map(DefaultRoles::getRole)
-                .map(Role::getName)
-                .toArray(String[]::new);
     }
 
     protected RequestMatcher getFullRequestMatcher() {

--- a/api/src/main/java/com/epam/pipeline/app/SAMLSecurityConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/SAMLSecurityConfiguration.java
@@ -17,7 +17,6 @@
 package com.epam.pipeline.app;
 
 import com.epam.pipeline.entity.user.DefaultRoles;
-import com.epam.pipeline.entity.user.Role;
 import com.epam.pipeline.security.saml.OptionalSAMLLogoutFilter;
 import com.epam.pipeline.security.saml.SAMLContexProviderCustomSingKey;
 import com.epam.pipeline.utils.URLUtils;

--- a/api/src/main/java/com/epam/pipeline/entity/user/DefaultRoles.java
+++ b/api/src/main/java/com/epam/pipeline/entity/user/DefaultRoles.java
@@ -27,7 +27,8 @@ import lombok.Getter;
 public enum DefaultRoles {
 
     ROLE_ADMIN(new Role(1L, "ROLE_ADMIN", true, false, null, null)),
-    ROLE_USER(new Role(2L, "ROLE_USER", true, true, null, null));
+    ROLE_USER(new Role(2L, "ROLE_USER", true, true, null, null)),
+    ROLE_ANONYMOUS_USER(new Role(null, "ROLE_ANONYMOUS_USER", true, false, null, null));
 
     private Role role;
 

--- a/api/src/main/java/com/epam/pipeline/security/UserContext.java
+++ b/api/src/main/java/com/epam/pipeline/security/UserContext.java
@@ -31,6 +31,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -78,7 +80,7 @@ public class UserContext implements UserDetails {
 
     public JwtTokenClaims toClaims() {
         return JwtTokenClaims.builder()
-                .userId(userId.toString())
+                .userId(Optional.ofNullable(userId).map(Objects::toString).orElse(null))
                 .userName(userName)
                 .orgUnitId(orgUnitId)
                 .roles(roles.stream().map(Role::getName)

--- a/api/src/main/java/com/epam/pipeline/security/UserContext.java
+++ b/api/src/main/java/com/epam/pipeline/security/UserContext.java
@@ -52,11 +52,8 @@ public class UserContext implements UserDetails {
 
     public UserContext(JwtRawToken jwtRawToken, JwtTokenClaims claims) {
         this.jwtRawToken = jwtRawToken;
-        if (NumberUtils.isDigits(claims.getUserId())) {
-            this.userId = Long.parseLong(claims.getUserId());
-        } else {
-            throw new IllegalArgumentException("Invalid user ID: " + claims.getUserId());
-        }
+        this.userId = Optional.ofNullable(claims.getUserId()).filter(NumberUtils::isDigits).map(Long::parseLong)
+                .orElse(null);
         this.userName = claims.getUserName().toUpperCase();
         this.orgUnitId = claims.getOrgUnitId();
         this.roles = claims.getRoles().stream().map(Role::new).collect(Collectors.toList());

--- a/api/src/main/java/com/epam/pipeline/security/jwt/JwtTokenVerifier.java
+++ b/api/src/main/java/com/epam/pipeline/security/jwt/JwtTokenVerifier.java
@@ -83,10 +83,6 @@ public class JwtTokenVerifier {
             throw new TokenVerificationException("Invalid token: token ID is empty");
         }
 
-        if (StringUtils.isEmpty(tokenClaims.getUserId())) {
-            throw new TokenVerificationException("Invalid token: user ID is empty");
-        }
-
         if (StringUtils.isEmpty(tokenClaims.getUserName())) {
             throw new TokenVerificationException("Invalid token: user name is empty");
         }

--- a/api/src/main/java/com/epam/pipeline/security/saml/SAMLUserDetailsServiceImpl.java
+++ b/api/src/main/java/com/epam/pipeline/security/saml/SAMLUserDetailsServiceImpl.java
@@ -18,6 +18,7 @@ package com.epam.pipeline.security.saml;
 
 import com.epam.pipeline.common.MessageConstants;
 import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.entity.user.DefaultRoles;
 import com.epam.pipeline.entity.user.GroupStatus;
 import com.epam.pipeline.entity.user.PipelineUser;
 import com.epam.pipeline.entity.user.Role;
@@ -72,6 +73,9 @@ public class SAMLUserDetailsServiceImpl implements SAMLUserDetailsService {
 
     @Value("${saml.user.blocked.attribute.true.val: true}")
     private String blockedAttributeTrueValue;
+    
+    @Value("${saml.user.allow.anonymous: false}")
+    private boolean allowAnonymous;
 
     @Autowired
     private UserManager userManager;
@@ -102,21 +106,6 @@ public class SAMLUserDetailsServiceImpl implements SAMLUserDetailsService {
         return userContext;
     }
 
-    private UserContext processNewUser(final String userName, final List<String> groups,
-                                       final Map<String, String> attributes) {
-        checkAbilityToCreate(userName, groups);
-        LOGGER.debug(messageHelper.getMessage(MessageConstants.ERROR_USER_NAME_NOT_FOUND, userName));
-        final List<Long> roles = roleManager.getDefaultRolesIds();
-        final PipelineUser createdUser = userManager.createUser(userName,
-                                                                roles, groups, attributes, null);
-        userManager.updateUserFirstLoginDate(createdUser.getId(), DateUtils.nowUTC());
-        LOGGER.debug("Created user {} with groups {}", userName, groups);
-        final UserContext userContext = new UserContext(createdUser.getId(), userName);
-        userContext.setGroups(createdUser.getGroups());
-        userContext.setRoles(createdUser.getRoles());
-        return userContext;
-    }
-
     private UserContext processRegisteredUser(final String userName, final List<String> groups,
                                               final Map<String, String> attributes, final PipelineUser loadedUser) {
         LOGGER.debug("Found user by name {}", userName);
@@ -136,6 +125,61 @@ public class SAMLUserDetailsServiceImpl implements SAMLUserDetailsService {
         } else {
             return new UserContext(loadedUser);
         }
+    }
+
+    private UserContext processNewUser(final String userName, final List<String> groups,
+                                       final Map<String, String> attributes) {
+        LOGGER.debug(messageHelper.getMessage(MessageConstants.ERROR_USER_NAME_NOT_FOUND, userName));
+        switch (autoCreateUsers) {
+            case EXPLICIT:
+                return userNotRegisteredExplicitlyError(userName);
+            case EXPLICIT_GROUP:
+                if (permissionManager.isGroupRegistered(groups)) {
+                    return createUser(userName, groups, attributes);
+                } else {
+                    if (allowAnonymous) {
+                        return createAnonymousUser(userName, groups);
+                    } else {
+                        return userNotRegisteredGroupExplicitlyError(userName, groups);
+                    }
+                }
+            default:
+                return createUser(userName, groups, attributes);
+        }
+    }
+
+    private UserContext userNotRegisteredGroupExplicitlyError(final String userName, final List<String> groups) {
+        log.error(messageHelper.getMessage(MessageConstants.ERROR_USER_NOT_REGISTERED_GROUP_EXPLICITLY, userName));
+        throw new UsernameNotFoundException(
+                messageHelper.getMessage(MessageConstants.ERROR_USER_NOT_REGISTERED_GROUP_EXPLICITLY,
+                        String.join(", ", groups), userName));
+    }
+
+    private UserContext userNotRegisteredExplicitlyError(final String userName) {
+        log.error(messageHelper.getMessage(MessageConstants.ERROR_USER_NOT_REGISTERED_EXPLICITLY, userName));
+        throw new UsernameNotFoundException(
+                messageHelper.getMessage(MessageConstants.ERROR_USER_NOT_REGISTERED_EXPLICITLY, userName));
+    }
+
+    private UserContext createUser(final String userName, final List<String> groups,
+                                   final Map<String, String> attributes) {
+        final List<Long> roles = roleManager.getDefaultRolesIds();
+        final PipelineUser createdUser = userManager.createUser(userName,
+                roles, groups, attributes, null);
+        userManager.updateUserFirstLoginDate(createdUser.getId(), DateUtils.nowUTC());
+        LOGGER.debug("Created user {} with groups {}", userName, groups);
+        final UserContext userContext = new UserContext(createdUser.getId(), userName);
+        userContext.setGroups(createdUser.getGroups());
+        userContext.setRoles(createdUser.getRoles());
+        return userContext;
+    }
+
+    private UserContext createAnonymousUser(final String userName, final List<String> groups) {
+        LOGGER.debug("Created anonymous user {} with groups {}", userName, groups);
+        final UserContext userContext = new UserContext(null, userName);
+        userContext.setGroups(groups);
+        userContext.setRoles(Collections.singletonList(DefaultRoles.ROLE_ANONYMOUS_USER.getRole()));
+        return userContext;
     }
 
     private void validateGroupsBlockingStatus(final List<GrantedAuthority> authorities, final String userName) {
@@ -208,23 +252,4 @@ public class SAMLUserDetailsServiceImpl implements SAMLUserDetailsService {
         return parsedAttributes;
     }
 
-    private void checkAbilityToCreate(final String userName, final List<String> groups) {
-        switch (autoCreateUsers) {
-            case EXPLICIT:
-                log.error(messageHelper.getMessage(MessageConstants.ERROR_USER_NOT_REGISTERED_EXPLICITLY, userName));
-                throw new UsernameNotFoundException(
-                        messageHelper.getMessage(MessageConstants.ERROR_USER_NOT_REGISTERED_EXPLICITLY, userName));
-            case EXPLICIT_GROUP:
-                if (!permissionManager.isGroupRegistered(groups)) {
-                    log.error(messageHelper.getMessage(MessageConstants.ERROR_USER_NOT_REGISTERED_GROUP_EXPLICITLY,
-                            userName));
-                    throw new UsernameNotFoundException(
-                            messageHelper.getMessage(MessageConstants.ERROR_USER_NOT_REGISTERED_GROUP_EXPLICITLY,
-                                    String.join(", ", groups), userName));
-                }
-                break;
-            default:
-                break;
-        }
-    }
 }

--- a/api/src/main/resources/db/migration/v2020.04.13_15.00__issue-1037_anonymous_user_role.sql
+++ b/api/src/main/resources/db/migration/v2020.04.13_15.00__issue-1037_anonymous_user_role.sql
@@ -1,0 +1,1 @@
+INSERT INTO pipeline.role (id, name, predefined, user_default) VALUES (nextval('pipeline.s_role'), 'ROLE_ANONYMOUS_USER', TRUE, FALSE);

--- a/api/src/test/java/com/epam/pipeline/dao/user/RoleDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/user/RoleDaoTest.java
@@ -41,7 +41,7 @@ import static org.junit.Assert.*;
 @Transactional
 public class RoleDaoTest extends AbstractSpringTest {
 
-    private static final int EXPECTED_DEFAULT_ROLES_NUMBER = 8;
+    private static final int EXPECTED_DEFAULT_ROLES_NUMBER = 9;
     private static final String TEST_USER1 = "test_user1";
     private static final String TEST_ROLE = "ROLE_TEST";
     private static final String TEST_ROLE_UPDATED = "NEW_ROLE";

--- a/api/src/test/java/com/epam/pipeline/dao/user/UserDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/user/UserDaoTest.java
@@ -53,7 +53,7 @@ public class UserDaoTest extends AbstractSpringTest {
     private static final String ATTRIBUTES_KEY = "email";
     private static final String ATTRIBUTES_VALUE = "test_email";
     private static final String ATTRIBUTES_VALUE2 = "Mail@epam.com";
-    private static final int EXPECTED_DEFAULT_ROLES_NUMBER = 8;
+    private static final int EXPECTED_DEFAULT_ROLES_NUMBER = 9;
 
     @Autowired
     private UserDao userDao;

--- a/api/src/test/resources/test-application.properties
+++ b/api/src/test/resources/test-application.properties
@@ -24,6 +24,9 @@ database.driverClass=org.postgresql.Driver
 database.max.pool.size=2
 database.initial.pool.size=2
 
+#Security
+api.security.anonymous.urls=/restapi/route
+
 #flyway configuration
 flyway.sql-migration-prefix=v
 flyway.locations=classpath:db/migration
@@ -77,6 +80,7 @@ saml.user.blocked.attribute=
 saml.user.blocked.attribute.true.val=true
 # Create a user if it is not present in the database. Available strategies: AUTO, EXPLICIT, EXPLICIT_GROUP
 saml.user.auto.create=AUTO
+saml.user.allow.anonymous=false
 
 #cluster management
 cluster.networks.config=


### PR DESCRIPTION
Resolves issue #1037.

The following pull request brings optional support for anonymous access to run endpoints. Notice that anonymous users will be allowed to access resources only if they've successfully been authenticated with a configured idp service.

By default anonymous access to run endpoints is disabled. To enable the access the following application properties has to be specified.

```
saml.user.auto.create=EXPLICIT_GROUP
saml.user.allow.anonymous=true
```

The same behavior can be configured via global config map using the following properties.

```
CP_API_SRV_SAML_AUTO_USER_CREATE: EXPLICIT_GROUP
CP_API_SRV_SAML_ALLOW_ANONYMOUS_USER: "true"
```

Anonymous user role grants access to specific api methods which can be controlled by the following application property. 

```
api.security.anonymous.urls=/restapi/route
```

The same behavior can be configured via global config map using the following property.

```
CP_API_SRV_ANONYMOUS_URLS: "/restapi/route"
```

Once anonymous access is enabled system-wide each run that requires to be accessible by anonymous users has to be configured to share endpoints with the following user group `ROLE_ANONYMOUS_USER`.