### PR TITLE
Restrict usage of cloud regions to only allowed ones

### DIFF
--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -145,6 +145,7 @@ public final class MessageConstants {
     public static final String ERROR_RUN_DISK_ATTACHING_WRONG_STATUS = "error.run.attaching.wrong.status";
     public static final String ERROR_RUN_DISK_SIZE_NOT_FOUND = "error.run.disk.size.not.found";
     public static final String ERROR_BAD_STATS_FILE_ENCODING = "error.run.stats.file.bad.encoding";
+    public static final String ERROR_RUN_CLOUD_REGION_NOT_ALLOWED = "error.run.cloud.region.not.allowed";
 
     //Run schedule
     public static final String CRON_EXPRESSION_IS_NOT_PROVIDED = "cron.expression.is.not.provided";

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -69,6 +69,7 @@ import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.manager.region.CloudRegionManager;
 import com.epam.pipeline.manager.security.AuthManager;
+import com.epam.pipeline.manager.security.CheckPermissionHelper;
 import com.epam.pipeline.manager.security.run.RunPermissionManager;
 import com.epam.pipeline.utils.PasswordGenerator;
 import org.apache.commons.collections4.CollectionUtils;
@@ -185,6 +186,9 @@ public class PipelineRunManager {
 
     @Autowired
     private NodesManager nodesManager;
+    
+    @Autowired
+    private CheckPermissionHelper permissionHelper;
 
     /**
      * Launches cmd command execution, uses Tool as ACL identity
@@ -372,6 +376,8 @@ public class PipelineRunManager {
                     messageHelper.getMessage(MessageConstants.ERROR_TOOL_CLOUD_REGION_NOT_ALLOWED,
                             cloudRegionManager.load(toolConfiguration.getCloudRegionId()).getName(), region.getName()));
         }
+        Assert.isTrue(permissionHelper.isAllowed("READ", region),
+                messageHelper.getMessage(MessageConstants.ERROR_RUN_CLOUD_REGION_NOT_ALLOWED, region.getName()));
     }
 
     private void validateInstanceAndPriceTypes(final PipelineConfiguration configuration,

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -109,6 +109,7 @@ info.instance.started=Instance ''{0}'' successfully started.
 error.run.attaching.wrong.status=Disks can be attached to running or paused runs. Given run ''{0}'' has ''{1}'' status.
 error.run.disk.size.not.found=Pipeline run disk size should be specified.
 error.run.stats.file.bad.encoding=Written csv stats file encoding differs from UTF-8.
+error.run.cloud.region.not.allowed=User doesn''t have sufficient permissions to run instance in ''{0}'' cloud region.
 
 #Run schedule
 cron.expression.is.not.provided=Cron expression for {0} id ''{1}'' is not provided.


### PR DESCRIPTION
Resolves #1042.

The following pull request enforces cloud region permissions to prevent users from executing runs in not allowed cloud regions.