### PR TITLE
(issue #262) Run custom data script via waagent

### DIFF
--- a/deploy/infra/az/install-common-node.sh
+++ b/deploy/infra/az/install-common-node.sh
@@ -85,9 +85,6 @@ yum install -y \
 sed -i 's/Environment="KUBELET_CADVISOR_ARGS=--cadvisor-port=0"/Environment="KUBELET_CADVISOR_ARGS=--cadvisor-port=4194"/g' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 sed -i 's/Environment="KUBELET_CGROUP_ARGS=--cgroup-driver=systemd"/Environment="KUBELET_CGROUP_ARGS=--cgroup-driver=cgroupfs"/g' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 
-# delete CustomData from the image
-rm -f /var/lib/waagent/CustomData
-
 sed -i 's|Provisioning.DecodeCustomData=n|Provisioning.DecodeCustomData=y|g' /etc/waagent.conf
 sed -i 's|Provisioning.ExecuteCustomData=n|Provisioning.ExecuteCustomData=y|g' /etc/waagent.conf
 

--- a/deploy/infra/az/install-gpu-node.sh
+++ b/deploy/infra/az/install-gpu-node.sh
@@ -109,49 +109,13 @@ yum install nvidia-docker2-2.0.3-1.docker18.03* \
     nvidia-container-runtime-2.0.0-1.docker18.03* -y
 
 
-# create a script that will parse and run user data every start up time
-CUSTOM_USER_ACTIONS_SCRIPT="/usr/local/user-data-execute"
-cat <<'EOF' >$CUSTOM_USER_ACTIONS_SCRIPT
-#!/bin/bash
+sed -i 's|Provisioning.DecodeCustomData=n|Provisioning.DecodeCustomData=y|g' /etc/waagent.conf
+sed -i 's|Provisioning.ExecuteCustomData=n|Provisioning.ExecuteCustomData=y|g' /etc/waagent.conf
 
-exec > /var/log/user_data_rc.log 2>&1
+# Upgrade to the latest mainline kernel (4.17+)
+rpm --import https://www.elrepo.org/RPM-GPG-KEY-elrepo.org && \
+rpm -Uvh http://www.elrepo.org/elrepo-release-7.0-4.el7.elrepo.noarch.rpm && \
+yum --enablerepo=elrepo-kernel install kernel-ml -y && \
+sed -i '/GRUB_DEFAULT=/c\GRUB_DEFAULT=0' /etc/default/grub && \
+grub2-mkconfig -o /boot/grub2/grub.cfg
 
-rdom () { local IFS=\> ; read -d \< E C ;}
-
-custom_data_file=/var/lib/waagent/CustomData
-waagent_file=/var/lib/waagent/ovf-env.xml
-
-wait_attempts=120
-while [ "$wait_attempts" -ne 0 ]; do
-  if [ -f "$custom_data_file" ]; then
-    echo "Custom data file found at $custom_data_file"
-    cat /var/lib/waagent/CustomData | base64 --decode | /bin/bash
-    echo "$custom_data_file executed"
-    exit 0
-  fi
-  if [ -f "$waagent_file" ]; then
-    echo "Custom data file found at $waagent_file"
-    while rdom; do
-      if [[ $E = *CustomData* ]]; then
-          echo $C | base64 --decode | /bin/bash
-          echo "$waagent_file executed"
-          exit 0
-      fi
-    done < $waagent_file
-
-    echo "$waagent_file WAS NOT executed, as <CustomData> tag was not found. Will proceed with waiting"
-  fi
-  wait_attempts=$((wait_attempts-1))
-  sleep 1
-done
-
-echo "None of the Custom Data files was found: $custom_data_file , $waagent_file in the $wait_attempts seconds"
-EOF
-
-chmod +x $CUSTOM_USER_ACTIONS_SCRIPT
-
-echo "bash $CUSTOM_USER_ACTIONS_SCRIPT" >> /etc/rc.d/rc.local
-chmod +x /etc/rc.d/rc.local
-
-# delete CustomData from the image
-rm -f /var/lib/waagent/CustomData


### PR DESCRIPTION
This PR related to #262 
It changes waagent config for node image to be able to run customData as one of the steps waagent initialization.
It also upgrades node image kernel version to be able to run docker with `overlay2` fs