### PR TITLE
Issue #1040 Data storage paths CLI and mount support

### DIFF
--- a/api/src/main/java/com/epam/pipeline/controller/datastorage/DataStorageController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/datastorage/DataStorageController.java
@@ -178,6 +178,19 @@ public class DataStorageController extends AbstractRestController {
         return Result.success(dataStorageApiService.loadByNameOrId(identifier));
     }
 
+    @RequestMapping(value = "/datastorage/findByPath", method = RequestMethod.GET)
+    @ResponseBody
+    @ApiOperation(
+            value = "Returns a datastorage, specified by ID, name or one of path prefixes.",
+            notes = "Returns a datastorage, specified by ID, name or one of path prefixes.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public Result<AbstractDataStorage> findDataStorageByPath(@RequestParam(value = ID) final String identifier) {
+        return Result.success(dataStorageApiService.loadByPathOrId(identifier));
+    }
+
     @RequestMapping(value = "/datastorage/{id}/list", method = RequestMethod.GET)
     @ResponseBody
     @ApiOperation(

--- a/api/src/main/java/com/epam/pipeline/dao/datastorage/DataStorageDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/datastorage/DataStorageDao.java
@@ -68,6 +68,7 @@ public class DataStorageDao extends NamedParameterJdbcDaoSupport {
     private String loadStorageCountQuery;
     private String loadAllStoragesWithParentsQuery;
     private String loadStorageWithParentsQuery;
+    private String loadDataStorageByPrefixesQuery;
 
     @Autowired
     private DaoHelper daoHelper;
@@ -131,6 +132,13 @@ public class DataStorageDao extends NamedParameterJdbcDaoSupport {
                 .query(loadDataStorageByNameAndParentIdQuery, params,
                         DataStorageParameters.getRowMapper());
         return !items.isEmpty() ? items.get(0) : null;
+    }
+
+    public List<AbstractDataStorage> loadDataStoragesByPrefixes(final Collection<String> prefixes) {
+        MapSqlParameterSource params = new MapSqlParameterSource();
+        params.addValue(DataStorageParameters.PATH.name(), prefixes);
+        return getNamedParameterJdbcTemplate().query(loadDataStorageByPrefixesQuery, params,
+                DataStorageParameters.getRowMapper());
     }
 
     public List<AbstractDataStorage> loadRootDataStorages() {
@@ -238,6 +246,11 @@ public class DataStorageDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setLoadStorageWithParentsQuery(String loadStorageWithParentsQuery) {
         this.loadStorageWithParentsQuery = loadStorageWithParentsQuery;
+    }
+
+    @Required
+    public void setLoadDataStorageByPrefixesQuery(String loadDataStorageByPrefixesQuery) {
+        this.loadDataStorageByPrefixesQuery = loadDataStorageByPrefixesQuery;
     }
 
     public enum DataStorageParameters {

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/TemporaryCredentialsManagerImpl.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/TemporaryCredentialsManagerImpl.java
@@ -66,7 +66,7 @@ public class TemporaryCredentialsManagerImpl implements TemporaryCredentialsMana
         actions.forEach(action -> {
             AbstractDataStorage loadedDataStorage =
                     action.getId().equals(dataStorage.getId()) ? dataStorage : dataStorageManager.load(action.getId());
-            action.setBucketName(loadedDataStorage.getPath());
+            action.setBucketName(loadedDataStorage.getRoot());
             AbstractCloudRegion loadedRegion = credentialsGenerator.getRegion(loadedDataStorage);
             Assert.isTrue(Objects.equals(region.getId(), loadedRegion.getId()),
                     "Actions shall be requested for buckets from the same region");

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageApiService.java
@@ -123,6 +123,12 @@ public class DataStorageApiService {
         return dataStorageManager.loadByNameOrId(identifier);
     }
 
+    @PostAuthorize("hasRole('ADMIN') OR hasPermission(returnObject, 'READ')")
+    @AclMask
+    public AbstractDataStorage loadByPathOrId(final String identifier) {
+        return dataStorageManager.loadByPathOrId(identifier);
+    }
+
     @PreAuthorize(STORAGE_ID_READ)
     public DataStorageListing getDataStorageItems(final Long id, final String path,
             Boolean showVersion, Integer pageSize, String marker) {

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
@@ -146,6 +146,9 @@ public class DataStorageManager implements SecuredEntityManager {
     @Autowired
     private SearchManager searchManager;
 
+    @Autowired
+    private DataStoragePathLoader pathLoader;
+
     private AbstractDataStorageFactory dataStorageFactory =
             AbstractDataStorageFactory.getDefaultDataStorageFactory();
 
@@ -186,6 +189,10 @@ public class DataStorageManager implements SecuredEntityManager {
 
     @Override public AclClass getSupportedClass() {
         return AclClass.DATA_STORAGE;
+    }
+
+    public AbstractDataStorage loadByPathOrId(final String identifier) {
+        return pathLoader.loadDataStorageByPathOrId(identifier);
     }
 
     public AbstractDataStorage loadByNameOrId(final String identifier) {

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStoragePathLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStoragePathLoader.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.datastorage;
+
+import com.epam.pipeline.common.MessageConstants;
+import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.dao.datastorage.DataStorageDao;
+import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
+import com.epam.pipeline.manager.datastorage.providers.ProviderUtils;
+import com.epam.pipeline.manager.security.CheckPermissionHelper;
+import com.epam.pipeline.utils.CommonUtils;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Service
+@RequiredArgsConstructor
+public class DataStoragePathLoader {
+
+    private final DataStorageDao dataStorageDao;
+    private final MessageHelper messageHelper;
+    private final CheckPermissionHelper permissionHelper;
+
+    @SuppressWarnings("unchecked")
+    public AbstractDataStorage loadDataStorageByPathOrId(final String pathOrId) {
+        return CommonUtils.first(
+            () -> loadById(pathOrId),
+            () -> loadByNameOrPath(pathOrId),
+            () -> loadByPrefixes(pathOrId))
+                .orElseThrow(() -> new IllegalArgumentException(
+                        messageHelper.getMessage(MessageConstants.ERROR_DATASTORAGE_NOT_FOUND, pathOrId)));
+    }
+
+    private Optional<AbstractDataStorage> loadById(final String id) {
+        if (NumberUtils.isDigits(id)) {
+            return Optional.ofNullable(dataStorageDao.loadDataStorage(Long.parseLong(id)));
+        }
+        return Optional.empty();
+    }
+
+    private Optional<AbstractDataStorage> loadByNameOrPath(final String path) {
+        return Optional.ofNullable(dataStorageDao.loadDataStorageByNameOrPath(path, path));
+    }
+
+    // returns allowed to read storage with the longest prefix
+    private Optional<AbstractDataStorage> loadByPrefixes(final String path) {
+        final Collection<String> prefixes = splitPathByPrefix(path);
+        final List<AbstractDataStorage> storages = dataStorageDao.loadDataStoragesByPrefixes(prefixes);
+        return ListUtils.emptyIfNull(storages)
+                .stream()
+                .filter(storage -> permissionHelper.isAllowed("READ", storage))
+                .max(Comparator.comparing(storage -> storage.getPath().length()));
+    }
+
+    private Collection<String> splitPathByPrefix(final String path) {
+        final Set<String> result = new HashSet<>();
+        result.add(path);
+        int currentIndex = path.indexOf(ProviderUtils.DELIMITER);
+        while (currentIndex != -1) {
+            result.add(path.substring(0, currentIndex));
+            currentIndex = path.indexOf(ProviderUtils.DELIMITER, currentIndex + 1);
+        }
+        //add all variants of prefixes to result - with and without trailing delimiter
+        return Stream.concat(result.stream(), result.stream()
+                .map(prefix -> prefix.endsWith(ProviderUtils.DELIMITER) ?
+                        ProviderUtils.withoutTrailingDelimiter(prefix) :
+                        ProviderUtils.withTrailingDelimiter(prefix)))
+                .collect(Collectors.toSet());
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/utils/CommonUtils.java
+++ b/api/src/main/java/com/epam/pipeline/utils/CommonUtils.java
@@ -22,10 +22,12 @@ import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.EnumUtils;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -62,5 +64,12 @@ public final class CommonUtils {
                     Map.Entry::getKey,
                     Map.Entry::getValue,
                     (value1, value2) -> value1));
+    }
+
+    public static <T> Optional<T> first(Supplier<Optional<T>>... suppliers) {
+        return Arrays.asList(suppliers).stream()
+                .map(Supplier::get)
+                .flatMap(o -> o.map(Stream::of).orElseGet(Stream::empty))
+                .findFirst();
     }
 }

--- a/api/src/main/resources/dao/datastorage-dao.xml
+++ b/api/src/main/resources/dao/datastorage-dao.xml
@@ -219,6 +219,37 @@
                 ]]>
             </value>
         </property>
+        <property name="loadDataStorageByPrefixesQuery">
+            <value>
+                <![CDATA[
+                    SELECT
+                        datastorage_id,
+                        datastorage_name,
+                        description,
+                        datastorage_type,
+                        path,
+                        sts_duration,
+                        lts_duration,
+                        incomplete_upload_cleanup_days,
+                        folder_id,
+                        created_date,
+                        owner,
+                        enable_versioning,
+                        backup_duration,
+                        locked as datastorage_locked,
+                        mount_point,
+                        mount_options,
+                        shared,
+                        allowed_cidrs,
+                        region_id as region_id,
+                        file_share_mount_id
+                    FROM
+                        pipeline.datastorage
+                    WHERE
+                        path IN (:PATH)
+                ]]>
+            </value>
+        </property>
         <property name="loadDataStorageByNameAndParentIdQuery">
             <value>
                 <![CDATA[

--- a/api/src/test/java/com/epam/pipeline/manager/datastorage/DataStorageManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/datastorage/DataStorageManagerTest.java
@@ -22,6 +22,7 @@ import com.epam.pipeline.dao.region.CloudRegionDao;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.DataStorageType;
 import com.epam.pipeline.entity.datastorage.StoragePolicy;
+import com.epam.pipeline.entity.datastorage.aws.S3bucketDataStorage;
 import com.epam.pipeline.entity.pipeline.Folder;
 import com.epam.pipeline.entity.preference.Preference;
 import com.epam.pipeline.entity.region.AwsRegion;
@@ -88,7 +89,7 @@ public class DataStorageManagerTest extends AbstractSpringTest {
 
     @Before
     public void setUp() {
-        doReturn(new MockS3Helper()).when(storageProviderManager).getS3Helper(any());
+        doReturn(new MockS3Helper()).when(storageProviderManager).getS3Helper(any(S3bucketDataStorage.class));
         doReturn(new AwsRegion()).when(regionManager).loadOrDefault(any());
         doReturn(new AwsRegion()).when(regionManager).getAwsRegion(any());
         Preference systemIndependentBlackList = SystemPreferences.DATA_STORAGE_NFS_MOUNT_BLACK_LIST.toPreference();

--- a/api/src/test/java/com/epam/pipeline/manager/datastorage/DataStoragePathLoaderTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/datastorage/DataStoragePathLoaderTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.datastorage;
+
+import com.epam.pipeline.AbstractSpringTest;
+import com.epam.pipeline.controller.vo.DataStorageVO;
+import com.epam.pipeline.dao.region.CloudRegionDao;
+import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
+import com.epam.pipeline.entity.datastorage.DataStorageType;
+import com.epam.pipeline.entity.datastorage.aws.S3bucketDataStorage;
+import com.epam.pipeline.entity.region.AwsRegion;
+import com.epam.pipeline.manager.MockS3Helper;
+import com.epam.pipeline.manager.ObjectCreatorUtils;
+import com.epam.pipeline.manager.datastorage.providers.aws.s3.S3StorageProvider;
+import com.epam.pipeline.manager.region.CloudRegionManager;
+import com.epam.pipeline.manager.security.CheckPermissionHelper;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+
+@Transactional
+public class DataStoragePathLoaderTest extends AbstractSpringTest {
+
+    private static final int STS_DURATION = 1;
+    private static final int LTS_DURATION = 11;
+    private static final Long WITHOUT_PARENT_ID = null;
+    private static final String PATH = "bucket";
+    private static final String NAME = "name";
+    private static final String DESCRIPTION = "description";
+    public static final String FOLDER = "/folder";
+
+    @SpyBean
+    private S3StorageProvider storageProviderManager;
+
+    @MockBean
+    private CloudRegionManager regionManager;
+
+    @Autowired
+    private CloudRegionDao cloudRegionDao;
+
+    @Autowired
+    private DataStorageManager storageManager;
+
+    @Autowired
+    private DataStoragePathLoader pathLoader;
+
+    @MockBean
+    private CheckPermissionHelper permissionHelper;
+
+    @Before
+    public void setUp() {
+        doReturn(new MockS3Helper()).when(storageProviderManager)
+                .getS3Helper(any(S3bucketDataStorage.class));
+        doReturn(new AwsRegion()).when(regionManager).loadOrDefault(any());
+        doReturn(new AwsRegion()).when(regionManager).getAwsRegion(any());
+        cloudRegionDao.create(ObjectCreatorUtils.getDefaultAwsRegion());
+    }
+
+    @Test
+    public void shouldLoadStorageById() {
+        final AbstractDataStorage storage = createStorage(PATH);
+        loadAndAssertStorage(storage, String.valueOf(storage.getId()));
+    }
+
+    @Test
+    public void shouldLoadStorageByName() {
+        loadAndAssertStorage(createStorage(PATH), NAME);
+    }
+
+    @Test
+    public void shouldLoadStorageByPath() {
+        loadAndAssertStorage(createStorage(PATH), PATH);
+    }
+
+    @Test
+    public void shouldLoadStorageByPrefixWithDelimiter() {
+        doReturn(true).when(permissionHelper).isAllowed(eq("READ"), any());
+        loadAndAssertStorage(createStorage(PATH), PATH + "/folder/");
+    }
+
+    @Test
+    public void shouldLoadStorageByPrefixWithoutDelimiter() {
+        doReturn(true).when(permissionHelper).isAllowed(eq("READ"), any());
+        loadAndAssertStorage(createStorage(PATH), PATH + "/folder/test");
+    }
+
+    @Test
+    public void shouldReturnLongestMatch() {
+        doReturn(true).when(permissionHelper).isAllowed(eq("READ"), any());
+        createStorage(PATH);
+        loadAndAssertStorage(createStorage(NAME + "1", PATH + FOLDER), PATH + FOLDER);
+    }
+
+    private AbstractDataStorage createStorage(final String path) {
+        return createStorage(NAME, path);
+    }
+
+    private AbstractDataStorage createStorage(final String name, final String path) {
+        final DataStorageVO storageVO = ObjectCreatorUtils.constructDataStorageVO(name, DESCRIPTION, DataStorageType.S3,
+                path, STS_DURATION, LTS_DURATION, WITHOUT_PARENT_ID, "", "");
+        return storageManager.create(storageVO, false, false, false).getEntity();
+    }
+
+    private void loadAndAssertStorage(final AbstractDataStorage expected, final String query) {
+        AbstractDataStorage loaded = pathLoader.loadDataStorageByPathOrId(query);
+        Assert.assertEquals(expected.getId(), loaded.getId());
+    }
+
+}

--- a/api/src/test/java/com/epam/pipeline/manager/datastorage/providers/S3StorageProviderTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/datastorage/providers/S3StorageProviderTest.java
@@ -85,7 +85,7 @@ public class S3StorageProviderTest extends AbstractSpringTest {
                 "  }" +
                 "]");
         when(cloudRegionManager.getAwsRegion(any())).thenReturn(region);
-        doReturn(s3Helper).when(s3StorageProvider).getS3Helper(any());
+        doReturn(s3Helper).when(s3StorageProvider).getS3Helper(any(S3bucketDataStorage.class));
     }
 
     @Test

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/FolderManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/FolderManagerTest.java
@@ -30,6 +30,7 @@ import com.epam.pipeline.entity.configuration.RunConfigurationEntry;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.DataStorageType;
 import com.epam.pipeline.entity.datastorage.StoragePolicy;
+import com.epam.pipeline.entity.datastorage.aws.S3bucketDataStorage;
 import com.epam.pipeline.entity.metadata.FolderWithMetadata;
 import com.epam.pipeline.entity.metadata.MetadataClass;
 import com.epam.pipeline.entity.metadata.MetadataEntity;
@@ -155,7 +156,7 @@ public class FolderManagerTest extends AbstractSpringTest {
         awsRegionDTO.setDefault(true);
         awsRegionDTO.setProvider(CloudProvider.AWS);
         cloudRegion = cloudRegionManager.create(awsRegionDTO);
-        doReturn(new MockS3Helper()).when(storageProviderManager).getS3Helper(any());
+        doReturn(new MockS3Helper()).when(storageProviderManager).getS3Helper(any(S3bucketDataStorage.class));
 
         folder = new Folder();
         folder.setName(TEST_NAME);

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/FolderTemplateManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/FolderTemplateManagerTest.java
@@ -25,6 +25,7 @@ import com.epam.pipeline.dao.region.CloudRegionDao;
 import com.epam.pipeline.dao.util.AclTestDao;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.DataStorageType;
+import com.epam.pipeline.entity.datastorage.aws.S3bucketDataStorage;
 import com.epam.pipeline.entity.metadata.PipeConfValue;
 import com.epam.pipeline.entity.pipeline.Folder;
 import com.epam.pipeline.entity.region.AwsRegion;
@@ -96,7 +97,7 @@ public class FolderTemplateManagerTest extends AbstractSpringTest {
 
     @Before
     public void setUp() {
-        doReturn(new MockS3Helper()).when(storageProviderManager).getS3Helper(any());
+        doReturn(new MockS3Helper()).when(storageProviderManager).getS3Helper(any(S3bucketDataStorage.class));
 
         awsRegion = new AwsRegion();
         awsRegion.setName("US");

--- a/pipe-cli/mount/pipefuse/api.py
+++ b/pipe-cli/mount/pipefuse/api.py
@@ -73,7 +73,7 @@ class CloudPipelineClient:
 
     def get_storage(self, name):
         logging.info('Getting data storage %s' % name)
-        response_data = self._get('datastorage/find?id={}'.format(name))
+        response_data = self._get('datastorage/findByPath?id={}'.format(name))
         if 'payload' in response_data:
             return DataStorage.load(response_data['payload'])
         return None

--- a/pipe-cli/src/api/data_storage.py
+++ b/pipe-cli/src/api/data_storage.py
@@ -36,11 +36,12 @@ class DataStorage(API):
     def load_from_uri(cls, path):
         url = urlparse(path)
         requested_scheme = url.scheme
+        full_path = path.replace(requested_scheme + "://", '')
         if requested_scheme not in WrapperType.cloud_schemes():
             raise RuntimeError('Supported schemes for datastorage are: {}. '
                                'Actual scheme is "{}".'
                                .format('"' + '", "'.join(WrapperType.cloud_schemes()) + '"', requested_scheme))
-        storage = DataStorage.get(url.netloc)
+        storage = DataStorage.get_by_path(full_path)
         expected_scheme = WrapperType.cloud_scheme(storage.type)
         if not WrapperType.is_dynamic_cloud_scheme(requested_scheme) and requested_scheme != expected_scheme:
             raise RuntimeError('Requested datastorage scheme differs with its type. '
@@ -77,6 +78,16 @@ class DataStorage(API):
             return None
         api = cls.instance()
         response_data = api.call('datastorage/find?id={}'.format(name), None)
+        if 'payload' in response_data:
+            return DataStorageModel.load(response_data['payload'])
+        return None
+
+    @classmethod
+    def get_by_path(cls, path):
+        if path is None:
+            return None
+        api = cls.instance()
+        response_data = api.call('datastorage/findByPath?id={}'.format(path), None)
         if 'payload' in response_data:
             return DataStorageModel.load(response_data['payload'])
         return None

--- a/pipe-cli/src/model/data_storage_wrapper.py
+++ b/pipe-cli/src/model/data_storage_wrapper.py
@@ -265,6 +265,8 @@ class S3BucketWrapper(CloudDataStorageWrapper):
 
     def __init__(self, bucket, path):
         super(S3BucketWrapper, self).__init__(bucket, path)
+        # parse root bucket from path
+        self.bucket.path = bucket.path.split(self.path_separator)[0]
         self.is_empty_flag = True
         self.session = None
 

--- a/workflows/pipe-common/scripts/mount_storage.py
+++ b/workflows/pipe-common/scripts/mount_storage.py
@@ -341,6 +341,9 @@ class S3Mounter(StorageMounter):
         stat_cache = os.getenv('CP_S3_FUSE_STAT_CACHE', '1m0s')
         type_cache = os.getenv('CP_S3_FUSE_TYPE_CACHE', '1m0s')
         aws_key_id, aws_secret, region_name, session_token = self._get_credentials(self.storage)
+        path_chunks = self.storage.path.split('/')
+        bucket = path_chunks[0]
+        relative_path = '/'.join(path_chunks[1:]) if len(path_chunks) > 1 else ''
         if not PermissionHelper.is_storage_writable(self.storage):
             mask = '0554'
             permissions = 'ro'
@@ -356,13 +359,16 @@ class S3Mounter(StorageMounter):
                 'aws_key_id': aws_key_id,
                 'aws_secret': aws_secret,
                 'aws_token': session_token,
-                'tmp_dir': self.fuse_tmp
+                'tmp_dir': self.fuse_tmp,
+                'bucket': bucket,
+                'relative_path': relative_path
                 }
 
     def build_mount_command(self, params):
         if params['aws_token'] is not None or params['fuse_type'] == FUSE_PIPE_ID:
             return 'pipe storage mount {mount} -b {path} -t --mode 775'.format(**params)
         elif params['fuse_type'] == FUSE_GOOFYS_ID:
+            params['path'] = '{bucket}:{relative_path}'.format(**params) if params['relative_path'] else params['path']
             return 'AWS_ACCESS_KEY_ID={aws_key_id} AWS_SECRET_ACCESS_KEY={aws_secret} nohup goofys ' \
                    '--dir-mode {mask} --file-mode {mask} -o {permissions} -o allow_other ' \
                     '--stat-cache-ttl {stat_cache} --type-cache-ttl {type_cache} ' \

--- a/workflows/pipe-common/scripts/mount_storage.py
+++ b/workflows/pipe-common/scripts/mount_storage.py
@@ -368,6 +368,7 @@ class S3Mounter(StorageMounter):
                     '--stat-cache-ttl {stat_cache} --type-cache-ttl {type_cache} ' \
                     '-f --gid 0 --region "{region_name}" {path} {mount} > /var/log/fuse_{storage_id}.log 2>&1 &'.format(**params)
         elif params['fuse_type'] == FUSE_S3FS_ID:
+            params['path'] = '{bucket}:/{relative_path}'.format(**params) if params['relative_path'] else params['path']
             return 'AWSACCESSKEYID={aws_key_id} AWSSECRETACCESSKEY={aws_secret} s3fs {path} {mount} -o use_cache={tmp_dir} ' \
                     '-o umask=0000 -o {permissions} -o allow_other -o enable_noobj_cache ' \
                     '-o endpoint="{region_name}" -o url="https://s3.{region_name}.amazonaws.com"'.format(**params)


### PR DESCRIPTION
This PR is related to #1040

### Implementation
This PR brings support of storages with prefixes (data storage paths) to pipe CLI and mount scripts.