### PR TITLE
Increase the API startup process performance

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,5 +1,14 @@
 buildscript {
-    repositories { jcenter() }
+    repositories {
+        jcenter()
+        mavenLocal()
+    }
+    ext {
+        thinVersion = '1.0.24.RELEASE'
+    }
+    dependencies {
+        classpath("org.springframework.boot.experimental:spring-boot-thin-gradle-plugin:${thinVersion}")
+    }
 }
 
 plugins {
@@ -24,6 +33,8 @@ apply from: "profiles.gradle"
 apply plugin: "idea"
 apply plugin: "java"
 apply plugin: "jacoco"
+apply plugin: "maven"
+apply plugin: "org.springframework.boot.experimental.thin-launcher"
 
 task copyLaunchScripts(type: Copy) {
     from "$rootDir/scripts/pipeline-launch"
@@ -75,15 +86,23 @@ ext {
 
 ext["elasticsearch.version"] = project.ext.versionElasticsearch
 
+thinResolve {
+    group = 'build'
+    dependsOn ':core:publishToMavenLocal', ':api:thinProperties'
+    mustRunAfter ":client:buildUI", ":core:build", ":buildPipe", ":pipe-cli:build", ":pipe-cli:buildLinux", ":pipe-cli:buildWin"
+}
+thinProperties.mustRunAfter ':core:publishToMavenLocal'
+
 build.mustRunAfter ":client:buildUI", ":core:build", ":buildPipe", ":pipe-cli:build", ":pipe-cli:buildLinux", ":pipe-cli:buildWin"
 bootRepackage.mustRunAfter ":client:buildUI", ":core:build", ":buildPipe", ":pipe-cli:build", ":pipe-cli:buildLinux", ":pipe-cli:buildWin"
+build.finalizedBy thinResolve
+compileJava.dependsOn thinProperties
 
 dependencies {
     // Spring Boot
     configurations {
         all*.exclude module : "spring-boot-starter-logging"
     }
-    compile("org.springframework.boot:spring-boot-starter-actuator")
     compile group: "org.springframework.boot", name: "spring-boot-starter-web", version: project.ext.versionSpringBoot
     compile("org.springframework.boot:spring-boot-starter-tomcat")
     compile("org.aspectj:aspectjweaver:1.8.8")

--- a/api/pipeline.sh
+++ b/api/pipeline.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,4 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-nohup $JAVA_HOME/bin/java -jar pipeline.jar 1>/dev/null 2>nohup.stderr.log &
+CP_API_SRV_JAVA_OPTS="-Dthin.root=. -Dspring.jmx.enabled=false -noverify -XX:TieredStopAtLevel=1 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+nohup $JAVA_HOME/bin/java $CP_API_SRV_JAVA_OPTS -jar pipeline.jar --thin.location=file:./config 1>/dev/null 2>nohup.stderr.log &

--- a/api/src/main/java/com/epam/pipeline/app/LazyBeansFactoryPostProcessor.java
+++ b/api/src/main/java/com/epam/pipeline/app/LazyBeansFactoryPostProcessor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.epam.pipeline.app;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+
+@Component
+public class LazyBeansFactoryPostProcessor implements BeanFactoryPostProcessor {
+
+    @Override
+    public void postProcessBeanFactory(final ConfigurableListableBeanFactory beanFactory) throws BeansException {
+        Arrays.stream(beanFactory.getBeanDefinitionNames())
+                .map(beanFactory::getBeanDefinition)
+                .forEach(beanDefinition -> beanDefinition.setLazyInit(true));
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/app/TestApplication.java
+++ b/api/src/test/java/com/epam/pipeline/app/TestApplication.java
@@ -27,7 +27,6 @@ import com.epam.pipeline.security.jwt.JwtTokenGenerator;
 import com.epam.pipeline.security.jwt.JwtTokenVerifier;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.SpringBootConfiguration;
-import org.springframework.boot.actuate.autoconfigure.ManagementWebSecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.SecurityFilterAutoConfiguration;
@@ -60,7 +59,6 @@ import java.util.concurrent.Executor;
         ContextualPreferenceConfiguration.class})
 @EnableAutoConfiguration(exclude = {
         SecurityAutoConfiguration.class,
-        ManagementWebSecurityAutoConfiguration.class,
         SecurityFilterAutoConfiguration.class})
 @ComponentScan(
         basePackages = {

--- a/api/src/test/java/com/epam/pipeline/app/TestApplicationWithAclSecurity.java
+++ b/api/src/test/java/com/epam/pipeline/app/TestApplicationWithAclSecurity.java
@@ -20,7 +20,6 @@ import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.manager.cluster.InstanceOfferScheduler;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.SpringBootConfiguration;
-import org.springframework.boot.actuate.autoconfigure.ManagementWebSecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.SecurityFilterAutoConfiguration;
@@ -45,7 +44,6 @@ import org.springframework.test.context.TestPropertySource;
     })
 @EnableAutoConfiguration(exclude = {
     SecurityAutoConfiguration.class,
-    ManagementWebSecurityAutoConfiguration.class,
     SecurityFilterAutoConfiguration.class})
 @ComponentScan(
     basePackages = {

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ task buildDoc(type: Tar) {
 
 task buildAllFast(dependsOn: [":core:build", "client:buildUI", buildPipe, buildDoc,
                           ":pipe-cli:build", ":pipe-cli:buildLinux", ":pipe-cli:buildWin", ":jwt-generator:shadowJar",
-                          ":api:bootRepackage", ":notifier:smtp:bootRepackage", ":docker-comp-scan:bootRepackage",
+                          ":api:thinResolve", ":notifier:smtp:bootRepackage", ":docker-comp-scan:bootRepackage",
                           ":elasticsearch-agent:bootJar", ":data-transfer-service:bootJar", ":vm-monitor:bootJar",
                           ":data-sharing-service:buildFast", ":fs-browser:build", ":billing-report-agent:bootJar"]) {
     group = 'build'
@@ -138,8 +138,13 @@ task installDist() {
             into "$distFolder/vm-monitor-templates"
         }
 
+        copy {
+            from "$rootDir/api/build/thin/root/repository"
+            into "$distFolder/repository"
+        }
+
         def distFiles = files(
-                "$rootDir/api/build/libs/pipeline.jar",
+                "$rootDir/api/build/thin/root/pipeline.jar",
                 "$rootDir/api/pipeline.sh",
                 "$rootDir/jwt-generator/build/libs/jwt-generator.jar",
                 "$rootDir/notifier/smtp/build/libs/notifier.jar",

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,5 +1,8 @@
 buildscript {
-    repositories { jcenter() }
+    repositories {
+        jcenter()
+        mavenLocal()
+    }
 }
 
 plugins {
@@ -10,7 +13,8 @@ plugins {
 ext { springBootVersion = '1.5.2.RELEASE' }
 
 apply plugin: 'java'
-apply plugin: "jacoco"
+apply plugin: 'jacoco'
+apply plugin: 'maven-publish'
 
 jar {
     archiveName "core.pipeline.jar"
@@ -23,6 +27,14 @@ jar {
 sourceCompatibility = 1.8
 
 repositories { jcenter() }
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+        }
+    }
+}
 
 dependencies {
     compile('org.springframework.boot:spring-boot-starter')

--- a/deploy/docker/cp-api-srv/init-api
+++ b/deploy/docker/cp-api-srv/init-api
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -254,7 +254,8 @@ API_RUN_TIME_LOG=$CP_API_HOME/logs/runtime.log
 mkdir -p $(dirname $API_RUN_TIME_LOG)
 touch $API_RUN_TIME_LOG
 
-nohup java $CP_API_SRV_JAVA_OPTS -jar pipeline.jar &> $API_RUN_TIME_LOG &
+CP_API_SRV_JAVA_ALL_OPTS="$CP_API_SRV_JAVA_OPTS -Dthin.root=. -Dspring.jmx.enabled=false -noverify -XX:TieredStopAtLevel=1 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+nohup java $CP_API_SRV_JAVA_ALL_OPTS -jar pipeline.jar --thin.location=file:./config &> $API_RUN_TIME_LOG &
 APP_PID="$!"
 
 sleep 5


### PR DESCRIPTION
Resolves issue #995.

The following pull request consists of modifications to increase the API startup performance by the following changes:
* `api` module
   * build a **thin** `pipeline.jar` instead of **fat** jar
   * get rid of `spring-boot-starter-actuator` dependency
   * add the lazy initialization to all beans
*  docker `init-api` script of `cp-api-srv`
   * add the additional java opts to jar launch command