### PR TITLE
Issue 1060 SMB support for web dav

### DIFF
--- a/api/src/main/java/com/epam/pipeline/event/StartupApplicationListener.java
+++ b/api/src/main/java/com/epam/pipeline/event/StartupApplicationListener.java
@@ -17,6 +17,7 @@
 package com.epam.pipeline.event;
 
 import com.epam.pipeline.manager.docker.DockerRegistryManager;
+import com.epam.pipeline.manager.region.CloudRegionManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.ContextRefreshedEvent;
@@ -31,12 +32,14 @@ import java.util.Objects;
 @SuppressWarnings("PMD.AvoidCatchingGenericException")
 public class StartupApplicationListener {
     private final DockerRegistryManager dockerRegistryManager;
+    private final CloudRegionManager cloudRegionManager;
 
     @EventListener
     public void onApplicationEvent(ContextRefreshedEvent event) {
         try {
             if (Objects.isNull(event.getApplicationContext().getParent())) {
                 dockerRegistryManager.checkDockerSecrets();
+                cloudRegionManager.refreshCloudRegionCredKubeSecret();
             }
         } catch (Exception e) {
             log.error(e.getMessage(), e);

--- a/api/src/main/java/com/epam/pipeline/event/StartupApplicationListener.java
+++ b/api/src/main/java/com/epam/pipeline/event/StartupApplicationListener.java
@@ -35,7 +35,7 @@ public class StartupApplicationListener {
     private final CloudRegionManager cloudRegionManager;
 
     @EventListener
-    public void onApplicationEvent(ContextRefreshedEvent event) {
+    public void onApplicationEvent(final ContextRefreshedEvent event) {
         try {
             if (Objects.isNull(event.getApplicationContext().getParent())) {
                 dockerRegistryManager.checkDockerSecrets();

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesManager.java
@@ -156,7 +156,7 @@ public class KubernetesManager {
 
     public String refreshSecret(final String secretName, final Map<String, String> data) {
         Secret secret;
-        try (final KubernetesClient client = getKubernetesClient()) {
+        try (KubernetesClient client = getKubernetesClient()) {
             secret = client.secrets()
                     .inNamespace(kubeNamespace)
                     .withName(secretName)
@@ -200,7 +200,7 @@ public class KubernetesManager {
     }
 
     public boolean doesSecretExist(final String name) {
-        try (final KubernetesClient client = getKubernetesClient()) {
+        try (KubernetesClient client = getKubernetesClient()) {
             return Objects.nonNull(client.secrets().inNamespace(kubeNamespace).withName(name).get());
         } catch (KubernetesClientException e) {
             LOGGER.error(e.getMessage(), e);

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesManager.java
@@ -156,7 +156,7 @@ public class KubernetesManager {
 
     public String refreshSecret(final String secretName, final Map<String, String> data) {
         Secret secret;
-        try (KubernetesClient client = getKubernetesClient()) {
+        try (final KubernetesClient client = getKubernetesClient()) {
             secret = client.secrets()
                     .inNamespace(kubeNamespace)
                     .withName(secretName)
@@ -199,8 +199,8 @@ public class KubernetesManager {
         }
     }
 
-    public boolean isSecretExist(final String name) {
-        try (KubernetesClient client = getKubernetesClient()) {
+    public boolean doesSecretExist(final String name) {
+        try (final KubernetesClient client = getKubernetesClient()) {
             return Objects.nonNull(client.secrets().inNamespace(kubeNamespace).withName(name).get());
         } catch (KubernetesClientException e) {
             LOGGER.error(e.getMessage(), e);
@@ -366,7 +366,7 @@ public class KubernetesManager {
             Thread.sleep(NODE_READY_TIMEOUT);
             if (attempts <= 0) {
                 throw new IllegalStateException(String.format(
-                        "Node %s doesn't match the ready status over than %d times.", nodeName, ATTEMPTS_STATUS_NODE));
+                        "Node %s doesn't match the ready status over than %d times.", nodeName, attempts));
             }
         }
         LOGGER.debug("Labeling node with run id {}", runId);

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesManager.java
@@ -154,6 +154,38 @@ public class KubernetesManager {
         return dockerRegistrySecret.getMetadata().getName();
     }
 
+    public String refreshSecret(final String secretName, final Map<String, String> data) {
+        Secret secret;
+        try (KubernetesClient client = getKubernetesClient()) {
+            secret = client.secrets()
+                    .inNamespace(kubeNamespace)
+                    .withName(secretName)
+                    .edit()
+                    .withData(data)
+                    .done();
+            secret.getMetadata().getName();
+        }
+        Assert.notNull(secret, "Failed to refresh a secret");
+        return secret.getMetadata().getName();
+    }
+
+    public String updateSecret(final String secretName, final Map<String, String> toAdd,
+                               final Map<String, String> toRemove) {
+        Secret secret;
+        try (KubernetesClient client = getKubernetesClient()) {
+            secret = client.secrets()
+                    .inNamespace(kubeNamespace)
+                    .withName(secretName)
+                    .edit()
+                    .addToData(toAdd)
+                    .removeFromData(toRemove)
+                    .done();
+            secret.getMetadata().getName();
+        }
+        Assert.notNull(secret, "Failed to update a secret");
+        return secret.getMetadata().getName();
+    }
+
     public Set<String> listAllSecrets() {
         try (KubernetesClient client = getKubernetesClient()) {
             final SecretList list = client.secrets().list();
@@ -165,6 +197,15 @@ public class KubernetesManager {
                     .map(secret -> secret.getMetadata().getName())
                     .collect(Collectors.toSet());
         }
+    }
+
+    public boolean isSecretExist(final String name) {
+        try (KubernetesClient client = getKubernetesClient()) {
+            return Objects.nonNull(client.secrets().inNamespace(kubeNamespace).withName(name).get());
+        } catch (KubernetesClientException e) {
+            LOGGER.error(e.getMessage(), e);
+        }
+        return false;
     }
 
     public void deleteSecret(String secretName) {

--- a/api/src/main/java/com/epam/pipeline/manager/region/AzureRegionHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/region/AzureRegionHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,9 @@ import com.epam.pipeline.entity.region.AzureRegion;
 import com.epam.pipeline.entity.region.AzureRegionCredentials;
 import com.epam.pipeline.entity.region.CloudProvider;
 import com.epam.pipeline.manager.datastorage.providers.azure.AzureHelper;
+import com.epam.pipeline.utils.Base64Utils;
 import com.epam.pipeline.utils.NetworkUtils;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.microsoft.aad.adal4j.AuthenticationException;
 import com.microsoft.azure.management.Azure;
 import com.microsoft.azure.management.resources.fluentcore.arm.Region;
@@ -41,6 +43,7 @@ import org.springframework.util.Assert;
 
 import java.net.URL;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -57,6 +60,8 @@ public class AzureRegionHelper implements CloudRegionHelper<AzureRegion, AzureRe
     private static final Integer MAX_TRIES_COUNT = 1;
     private static final Integer TRY_TIMEOUT = 2;
 
+    private static final String STORAGE_ACCOUNT = "storage_account";
+    private static final String STORAGE_KEY = "storage_key";
 
     @Override
     public CloudProvider getProvider() {
@@ -103,6 +108,18 @@ public class AzureRegionHelper implements CloudRegionHelper<AzureRegion, AzureRe
             oldCredentials.setStorageAccountKey(updatedCredentials.getStorageAccountKey());
         }
         return oldCredentials;
+    }
+
+    public String serializeCredentials(AzureRegion region, AzureRegionCredentials credentials) {
+        final HashMap<String, String> creds = new HashMap<>();
+        creds.put(STORAGE_ACCOUNT, region.getStorageAccount());
+        creds.put(STORAGE_KEY, credentials.getStorageAccountKey());
+        try {
+            return Base64Utils.encodeBase64Map(creds);
+        } catch (JsonProcessingException e) {
+            log.error(e.getMessage());
+            return Base64Utils.EMPTY_ENCODED_MAP;
+        }
     }
 
     private void validateStorageAccount(final String storageAccountName, final String storageAccountKey) {

--- a/api/src/main/java/com/epam/pipeline/manager/region/CloudRegionAspect.java
+++ b/api/src/main/java/com/epam/pipeline/manager/region/CloudRegionAspect.java
@@ -48,22 +48,22 @@ public class CloudRegionAspect {
     private final ObjectMapper mapper = new JsonMapper();
 
     @Autowired
-    public CloudRegionAspect(KubernetesManager kubernetesManager) {
+    public CloudRegionAspect(final KubernetesManager kubernetesManager) {
         this.kubernetesManager = kubernetesManager;
     }
 
     @After("execution(* com.epam.pipeline.dao.region.CloudRegionDao.create(..)) && args(region, credentials)")
-    public void updateCloudRegionCreds(JoinPoint joinPoint, AbstractCloudRegion region,
-                                       AbstractCloudRegionCredentials credentials) throws JsonProcessingException {
+    public void updateCloudRegionCreds(final JoinPoint joinPoint, final AbstractCloudRegion region,
+                                       final AbstractCloudRegionCredentials credentials) throws JsonProcessingException {
         if (!region.getProvider().equals(CloudProvider.AZURE)) {
             return;
         }
-        if (!kubernetesManager.isSecretExist(CP_REGION_CREDS_SECRET)) {
+        if (!kubernetesManager.doesSecretExist(CP_REGION_CREDS_SECRET)) {
             log.warn("Secret: " + CP_REGION_CREDS_SECRET + " doesn't exist!");
             return;
         }
-        AzureRegion azureRegion = (AzureRegion) region;
-        AzureRegionCredentials azureRegionCredentials = (AzureRegionCredentials) credentials;
+        final AzureRegion azureRegion = (AzureRegion) region;
+        final AzureRegionCredentials azureRegionCredentials = (AzureRegionCredentials) credentials;
         log.debug("Update Kube secret with new cred value for region with id: {}", region.getId());
         final HashMap<String, String> creds = new HashMap<>();
         creds.put(STORAGE_ACCOUNT, azureRegion.getStorageAccount());
@@ -77,9 +77,9 @@ public class CloudRegionAspect {
     }
 
     @After("execution(* com.epam.pipeline.dao.region.CloudRegionDao.delete(..)) && args(region)")
-    public void deleteCloudRegionCreds(JoinPoint joinPoint, Long region) throws JsonProcessingException {
+    public void deleteCloudRegionCreds(final JoinPoint joinPoint, final Long region) throws JsonProcessingException {
         log.debug("Delete cred value of a region from Kube secret. Region id: {}", region);
-        if (kubernetesManager.isSecretExist(CP_REGION_CREDS_SECRET)) {
+        if (kubernetesManager.doesSecretExist(CP_REGION_CREDS_SECRET)) {
             kubernetesManager.updateSecret(CP_REGION_CREDS_SECRET,
                     Collections.emptyMap(),
                     Collections.singletonMap(

--- a/api/src/main/java/com/epam/pipeline/manager/region/CloudRegionAspect.java
+++ b/api/src/main/java/com/epam/pipeline/manager/region/CloudRegionAspect.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.region;
+
+import com.epam.pipeline.config.JsonMapper;
+import com.epam.pipeline.entity.region.*;
+import com.epam.pipeline.manager.cluster.KubernetesManager;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.binary.Base64;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.After;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.HashMap;
+
+@Slf4j
+@Service
+@Aspect
+public class CloudRegionAspect {
+
+    public static final String CP_REGION_CREDS_SECRET = "cp-region-creds-secret";
+    public static final String STORAGE_ACCOUNT = "storage_account";
+    public static final String STORAGE_KEY = "storage_key";
+    private final KubernetesManager kubernetesManager;
+    private final ObjectMapper mapper = new JsonMapper();
+
+    @Autowired
+    public CloudRegionAspect(KubernetesManager kubernetesManager) {
+        this.kubernetesManager = kubernetesManager;
+    }
+
+    @After("execution(* com.epam.pipeline.dao.region.CloudRegionDao.create(..)) && args(region, credentials)")
+    public void updateCloudRegionCreds(JoinPoint joinPoint, AbstractCloudRegion region,
+                                       AbstractCloudRegionCredentials credentials) throws JsonProcessingException {
+        if (!region.getProvider().equals(CloudProvider.AZURE)) {
+            return;
+        }
+        if (!kubernetesManager.isSecretExist(CP_REGION_CREDS_SECRET)) {
+            log.warn("Secret: " + CP_REGION_CREDS_SECRET + " doesn't exist!");
+        }
+        AzureRegion azureRegion = (AzureRegion) region;
+        AzureRegionCredentials azureRegionCredentials = (AzureRegionCredentials) credentials;
+        log.debug("Update Kube secret with new cred value for region with id: {}", region.getId());
+        final HashMap<String, String> creds = new HashMap<>();
+        creds.put(STORAGE_ACCOUNT, azureRegion.getStorageAccount());
+        creds.put(STORAGE_KEY, azureRegionCredentials.getStorageAccountKey());
+        kubernetesManager.updateSecret(CP_REGION_CREDS_SECRET,
+                Collections.singletonMap(
+                        azureRegion.getId().toString(),
+                        Base64.encodeBase64String(mapper.writeValueAsString(creds).getBytes())),
+                Collections.emptyMap()
+        );
+    }
+
+    @After("execution(* com.epam.pipeline.dao.region.CloudRegionDao.delete(..)) && args(region)")
+    public void deleteCloudRegionCreds(JoinPoint joinPoint, Long region) throws JsonProcessingException {
+        log.debug("Delete cred value of a region from Kube secret. Region id: {}", region);
+        if (kubernetesManager.isSecretExist(CP_REGION_CREDS_SECRET)) {
+            kubernetesManager.updateSecret(CP_REGION_CREDS_SECRET,
+                    Collections.emptyMap(),
+                    Collections.singletonMap(
+                            region.toString(),
+                            Base64.encodeBase64String(mapper.writeValueAsString(Collections.emptyMap()).getBytes()))
+            );
+        }
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/region/CloudRegionAspect.java
+++ b/api/src/main/java/com/epam/pipeline/manager/region/CloudRegionAspect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,11 @@
 package com.epam.pipeline.manager.region;
 
 import com.epam.pipeline.config.JsonMapper;
-import com.epam.pipeline.entity.region.*;
+import com.epam.pipeline.entity.region.AbstractCloudRegion;
+import com.epam.pipeline.entity.region.AbstractCloudRegionCredentials;
+import com.epam.pipeline.entity.region.AzureRegion;
+import com.epam.pipeline.entity.region.AzureRegionCredentials;
+import com.epam.pipeline.entity.region.CloudProvider;
 import com.epam.pipeline.manager.cluster.KubernetesManager;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -56,6 +60,7 @@ public class CloudRegionAspect {
         }
         if (!kubernetesManager.isSecretExist(CP_REGION_CREDS_SECRET)) {
             log.warn("Secret: " + CP_REGION_CREDS_SECRET + " doesn't exist!");
+            return;
         }
         AzureRegion azureRegion = (AzureRegion) region;
         AzureRegionCredentials azureRegionCredentials = (AzureRegionCredentials) credentials;

--- a/api/src/main/java/com/epam/pipeline/manager/region/CloudRegionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/region/CloudRegionManager.java
@@ -53,7 +53,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @AclSync

--- a/api/src/main/java/com/epam/pipeline/manager/region/CloudRegionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/region/CloudRegionManager.java
@@ -240,7 +240,7 @@ public class CloudRegionManager implements SecuredEntityManager {
 
     public void refreshCloudRegionCredKubeSecret() {
         log.debug("Create Kube secret with cloud region creds if it does not exist.");
-        if (!kubernetesManager.isSecretExist(CP_REGION_CREDS_SECRET)) {
+        if (!kubernetesManager.doesSecretExist(CP_REGION_CREDS_SECRET)) {
             log.warn("Secret: " + CP_REGION_CREDS_SECRET + " doesn't exist!");
             return;
         }

--- a/api/src/main/java/com/epam/pipeline/manager/region/CloudRegionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/region/CloudRegionManager.java
@@ -49,7 +49,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;

--- a/api/src/main/java/com/epam/pipeline/utils/Base64Utils.java
+++ b/api/src/main/java/com/epam/pipeline/utils/Base64Utils.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.codec.binary.Base64;
+
+import java.util.Map;
+
+public final class Base64Utils {
+    public static final String EMPTY_ENCODED_MAP = Base64.encodeBase64String("{}".getBytes());
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+
+    private Base64Utils() {
+
+    }
+
+    public static String encodeBase64Map(Map<String, String> toEncode) throws JsonProcessingException {
+        return  Base64.encodeBase64String(MAPPER.writeValueAsString(toEncode).getBytes());
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/dao/region/CloudRegionDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/region/CloudRegionDaoTest.java
@@ -24,9 +24,11 @@ import com.epam.pipeline.entity.region.AzureRegion;
 import com.epam.pipeline.entity.region.AzureRegionCredentials;
 import com.epam.pipeline.entity.region.GCPCustomInstanceType;
 import com.epam.pipeline.entity.region.GCPRegion;
+import com.epam.pipeline.manager.region.CloudRegionAspect;
 import org.apache.commons.lang.math.RandomUtils;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -70,6 +72,9 @@ public class CloudRegionDaoTest extends AbstractSpringTest {
 
     @Autowired
     private CloudRegionDao cloudRegionDao;
+
+    @MockBean
+    CloudRegionAspect cloudRegionAspect;
 
     @Test
     public void loadAllShouldReturnEmptyListIfThereAreNoRegions() {

--- a/api/src/test/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProviderTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProviderTest.java
@@ -37,12 +37,10 @@ import com.epam.pipeline.entity.datastorage.DataStorageListing;
 import com.epam.pipeline.entity.datastorage.FileShareMount;
 import com.epam.pipeline.entity.datastorage.MountType;
 import com.epam.pipeline.entity.region.CloudProvider;
+import com.epam.pipeline.manager.cluster.KubernetesManager;
 import com.epam.pipeline.manager.datastorage.FileShareMountManager;
 import com.epam.pipeline.manager.preference.PreferenceManager;
-import com.epam.pipeline.manager.region.AwsRegionHelper;
-import com.epam.pipeline.manager.region.AzureRegionHelper;
-import com.epam.pipeline.manager.region.CloudRegionHelper;
-import com.epam.pipeline.manager.region.CloudRegionManager;
+import com.epam.pipeline.manager.region.*;
 import com.epam.pipeline.manager.security.AuthManager;
 import com.epam.pipeline.mapper.region.CloudRegionMapper;
 import org.apache.commons.io.FileUtils;
@@ -55,6 +53,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.internal.util.reflection.Whitebox;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -73,6 +72,9 @@ public class NFSStorageProviderTest extends AbstractSpringTest {
 
     @Mock
     private CmdExecutor mockCmdExecutor;
+
+    @Mock
+    private KubernetesManager kubernetesManager;
 
     @Autowired
     private DataStorageDao dataStorageDao;
@@ -97,6 +99,9 @@ public class NFSStorageProviderTest extends AbstractSpringTest {
 
     @Autowired
     private AuthManager authManager;
+
+    @MockBean
+    CloudRegionAspect cloudRegionAspect;
 
 
     private FileShareMount awsFileShareMount;

--- a/api/src/test/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProviderTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProviderTest.java
@@ -124,7 +124,7 @@ public class NFSStorageProviderTest extends AbstractSpringTest {
         when(mockCmdExecutor.executeCommand(anyString())).thenReturn("");
 
         CloudRegionManager regionManager = new CloudRegionManager(cloudRegionDao, cloudRegionMapper,
-                fileShareMountManager, messageHelper, preferenceManager, authManager, helpers());
+                fileShareMountManager, messageHelper, preferenceManager, authManager, kubernetesManager, helpers());
 
         AWSRegionDTO awsRegion = new AWSRegionDTO();
         awsRegion.setName("region");

--- a/api/src/test/java/com/epam/pipeline/manager/region/AbstractCloudRegionManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/region/AbstractCloudRegionManagerTest.java
@@ -23,6 +23,7 @@ import com.epam.pipeline.dao.region.CloudRegionDao;
 import com.epam.pipeline.entity.region.AbstractCloudRegion;
 import com.epam.pipeline.entity.region.AbstractCloudRegionCredentials;
 import com.epam.pipeline.entity.region.CloudProvider;
+import com.epam.pipeline.manager.cluster.KubernetesManager;
 import com.epam.pipeline.manager.datastorage.FileShareMountManager;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
@@ -59,6 +60,7 @@ public abstract class AbstractCloudRegionManagerTest {
     final PreferenceManager preferenceManager = mock(PreferenceManager.class);
     final AuthManager authManager = mock(AuthManager.class);
     final FileShareMountManager fileShareMountManager = mock(FileShareMountManager.class);
+    private KubernetesManager kubernetesManager = mock(KubernetesManager.class);
     final CloudRegionManager cloudRegionManager =
             new CloudRegionManager(cloudRegionDao, cloudRegionMapper, fileShareMountManager,
                     messageHelper, preferenceManager, authManager, kubernetesManager, helpers());

--- a/api/src/test/java/com/epam/pipeline/manager/region/AbstractCloudRegionManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/region/AbstractCloudRegionManagerTest.java
@@ -61,7 +61,7 @@ public abstract class AbstractCloudRegionManagerTest {
     final FileShareMountManager fileShareMountManager = mock(FileShareMountManager.class);
     final CloudRegionManager cloudRegionManager =
             new CloudRegionManager(cloudRegionDao, cloudRegionMapper, fileShareMountManager,
-                    messageHelper, preferenceManager, authManager, helpers());
+                    messageHelper, preferenceManager, authManager, kubernetesManager, helpers());
 
     @Before
     public void initJsonMapper() {

--- a/deploy/contents/install/app/install-utils.sh
+++ b/deploy/contents/install/app/install-utils.sh
@@ -427,6 +427,10 @@ function init_kube_secrets {
 
     rm -f $_ssh_key_name
     rm -f $_ssh_pub_name
+
+    # create empty kube secret to store region credentials for WebDav service
+    kubectl delete secret cp-region-cres-secret
+    kubectl create secret generic cp-region-cres-secret
 }
 
 function update_config_value {

--- a/deploy/contents/install/app/install-utils.sh
+++ b/deploy/contents/install/app/install-utils.sh
@@ -429,8 +429,8 @@ function init_kube_secrets {
     rm -f $_ssh_pub_name
 
     # create empty kube secret to store region credentials for WebDav service
-    kubectl delete secret cp-region-cres-secret
-    kubectl create secret generic cp-region-cres-secret
+    kubectl delete secret cp-region-creds-secret
+    kubectl create secret generic cp-region-creds-secret
 }
 
 function update_config_value {

--- a/deploy/contents/k8s/cp-dav/cp-dav-dpl.yaml
+++ b/deploy/contents/k8s/cp-dav/cp-dav-dpl.yaml
@@ -29,6 +29,9 @@ spec:
           volumeMounts:
             - mountPath: /var/log/dav
               name: dav-logs
+            - name: cp-region-creds
+              mountPath: "/root/.cloud/regioncreds"
+              readOnly: true
           readinessProbe:
             httpGet:
               path: /${CP_DAV_URL_PATH}
@@ -40,5 +43,8 @@ spec:
         - name: dav-logs
           hostPath:
             path: /opt/dav/logs
+        - name: cp-region-creds
+          secret:
+            secretName: cp-region-creds-secret
       imagePullSecrets:
-        - name: cp-distr-docker-registry-secret
+        - name: cp-region-creds-secret

--- a/deploy/docker/cp-dav/Dockerfile
+++ b/deploy/docker/cp-dav/Dockerfile
@@ -67,6 +67,7 @@ RUN modules_shared="$(echo $(cat ${APACHE_BUILD_DIR}/modules.shared))" && \
 # Setup nfs sync
 RUN yum install -y cronie \
                    nfs-utils \
+                   cifs-utils \
                    python
 RUN curl -s https://bootstrap.pypa.io/get-pip.py | python && \
     pip install -I requests==2.21.0 && \

--- a/scripts/nfs-roles-management/internal/api/storages_api.py
+++ b/scripts/nfs-roles-management/internal/api/storages_api.py
@@ -14,6 +14,7 @@
 
 from .base import API
 from ..model.storage_model import StorageModel
+from ..model.share_mount_model import ShareMountModel
 
 
 class Storages(API):
@@ -33,3 +34,16 @@ class Storages(API):
             if 'totalCount' in response_data['payload']:
                 total_count = int(response_data['payload']['totalCount'])
         return storages, total_count
+
+
+    def list_share_mounts(self):
+            response_data = self.call('cloud/region', None)
+            share_mounts = {}
+            total_count = 0
+            if 'payload' in response_data:
+                for region in response_data['payload']:
+                    for share_mount_json in region['fileShareMounts']:
+                        share_mount = ShareMountModel.load(share_mount_json)
+                        if share_mount is not None:
+                            share_mounts[share_mount.identifier] = share_mount
+            return share_mounts

--- a/scripts/nfs-roles-management/internal/model/share_mount_model.py
+++ b/scripts/nfs-roles-management/internal/model/share_mount_model.py
@@ -1,0 +1,33 @@
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class ShareMountModel(object):
+    def __init__(self):
+        self.identifier = None
+        self.region_id = None
+        self.mount_root = None
+        self.mount_type = None
+        self.mount_options = None
+
+    @classmethod
+    def load(cls, json):
+        instance = ShareMountModel()
+        if not json:
+            return None
+        instance.identifier = json['id']
+        instance.region_id = json['regionId']
+        instance.mount_root = json['mountRoot']
+        instance.mount_type = json['mountType']
+        instance.mount_options = json['mountOptions'] if 'mountOptions' in json else None
+        return instance

--- a/scripts/nfs-roles-management/internal/model/storage_model.py
+++ b/scripts/nfs-roles-management/internal/model/storage_model.py
@@ -22,6 +22,7 @@ class StorageModel(object):
         self.mask = None
         self.type = None
         self.path = None
+        self.share_mount_id = None
         self.mount_source = None
         self.users = []
 
@@ -36,6 +37,7 @@ class StorageModel(object):
         instance.name = entity_json['name']
         instance.mask = entity_json['mask']
         instance.type = entity_json['type']
+        instance.share_mount_id = entity_json['fileShareMountId'] if 'fileShareMountId' in entity_json else None
         instance.path = entity_json['pathMask'] if 'pathMask' in entity_json else None
         if 'owner' in entity_json and entity_json['owner'].lower() != 'unauthorized':
             user = UserModel()

--- a/scripts/nfs-roles-management/syncmounts.sh
+++ b/scripts/nfs-roles-management/syncmounts.sh
@@ -149,7 +149,7 @@ while IFS='|' read -r mount_id region_id mount_root mount_type mount_options; do
             mount_protocol="cifs"
             region_cred_file="/root/.cloud/regioncreds/${region_id}"
             if [ ! -f ${region_cred_file} ]; then
-                echo "[ERROR] Cred file for Azure region ${region_id}, not found! Bucket ${mount_root_srv}:${mount_root_path} won't be mounted."
+                echo "[ERROR] Cred file for Azure region ${region_id}, not found! CIFS storage ${mount_root_srv}:${mount_root_path} won't be mounted."
                 continue
             fi
             username=$(cat ${region_cred_file} | jq .storage_account)

--- a/scripts/nfs-roles-management/syncmounts.sh
+++ b/scripts/nfs-roles-management/syncmounts.sh
@@ -56,7 +56,7 @@ function clean_outdated {
                 echo "Unable to unmount ${item}, skipping"
                 continue
             fi
-            
+
             echo "$item is unmounted, deleting directory"
             timeout -s 9 $_MOUNT_TIMEOUT_SEC \rm -r "$item"
             if [ $? -ne 0 ]; then
@@ -110,7 +110,7 @@ if ! command -v "jq" >/dev/null 2>&1 ; then
 fi
 
 fs_mounts="$(curl -sfk -H "Authorization: Bearer ${_API_TOKEN}" ${_API_URL%/}/cloud/region | \
-    jq -r '.payload[] | .fileShareMounts | select(.!=null)[] | "\(.id)|\(.regionId)|\(.mountRoot)|\(.mountType)"')"
+    jq -r '.payload[] | .fileShareMounts | select(.!=null)[] | "\(.id)|\(.regionId)|\(.mountRoot)|\(.mountType)|\(.mountOptions)"')"
 
 if [ $? -ne 0 ]; then
     echo "[ERROR] Cannot get list of the file shares, exiting"
@@ -123,34 +123,58 @@ mkdir -p "$_MOUNT_ROOT"
 while IFS='|' read -r mount_id region_id mount_root mount_type mount_options; do
     echo
     echo "[INFO] Staring processing: $mount_root (id: ${mount_id}, region: ${region_id} type: ${mount_type}, options: ${mount_options})"
-    if [ "$mount_type" == "NFS" ]; then
-        mount_root_srv="$(echo "$mount_root" | cut -f1 -d":")"
+    if [ "$mount_type" == "NFS" ] || [ "$mount_type" == "SMB" ]; then
+
+        # In a SMB paths we have the next structure : {mount_root_srv}/{mount_root_path} without any ':',
+        # that is why we need to do such conditional processing
+        mount_root_srv="$( [ ${mount_type} == "NFS" ] && echo "$mount_root" | cut -f1 -d":" || echo "$mount_root" | cut -f1 -d"/")"
         mount_root_path="/"
         if [[ "$mount_root" == *":"* ]]; then
-            mount_root_path="$(echo "$mount_root" | cut -f2 -d":")"
+            mount_root_path="$( [ ${mount_type} == "NFS" ] && echo "$mount_root" | cut -f2 -d"/" || echo "$mount_root" | cut -f2 -d"/")"
         fi
-        
+
         mount_root_srv_dir="${_MOUNT_ROOT}/${mount_root_srv}/${mount_root_path}"
         if mountpoint -q "$mount_root_srv_dir"; then
             echo "[DONE] $mount_root_srv_dir is already mounted, skipping"
             mounted_dirs+=($(remove_trailing_slashes "$mount_root_srv_dir"))
             continue
         fi
-        
+
         mount_options_opt=
         if [ "$mount_options" ] && [ "$mount_options" != "null" ]; then
             mount_options_opt="-o $mount_options"
         fi
+        mount_protocol="nfs"
+        if [ "$mount_type" == "SMB" ]; then
+            mount_protocol="cifs"
+            region_cred_file="/root/.cloud/regioncreds/${region_id}"
+            if [ ! -f ${region_cred_file} ]; then
+                echo "[ERROR] Cred file for Azure region ${region_id}, not found! Bucket ${mount_root_srv}:${mount_root_path} won't be mounted."
+                continue
+            fi
+            username=$(cat ${region_cred_file} | jq .storage_account)
+            password=$(cat ${region_cred_file} | jq .storage_key)
+            if [ "$mount_options_opt" ] && [ ! -z "$mount_options_opt" ]; then
+              mount_options_opt="${mount_options_opt},username=${username:1:-1},password=${password:1:-1}"
+            else
+              mount_options_opt="-o username=${username:1:-1},password=${password:1:-1}"
+            fi
+        fi
+
+        remote_nfs_path="${mount_root_srv}:${mount_root_path}"
+        if [ "$mount_type" == "SMB" ]; then
+            remote_nfs_path="//${mount_root_srv}${mount_root_path}"
+        fi
 
         mkdir -p "$mount_root_srv_dir"
-        timeout -s 9 $_MOUNT_TIMEOUT_SEC mount -t nfs "${mount_root_srv}:${mount_root_path}" "$mount_root_srv_dir" $mount_options_opt
+        echo "mount -t ${mount_protocol} $remote_nfs_path $mount_root_srv_dir $mount_options_opt"
+        timeout -s 9 $_MOUNT_TIMEOUT_SEC mount -t ${mount_protocol} "$remote_nfs_path" "$mount_root_srv_dir" $mount_options_opt
         if [ $? -ne 0 ]; then
             echo "[ERROR] Unable to mount $mount_root to $mount_root_srv_dir (id: ${mount_id}, type: ${mount_type}), skipping"
             continue
         fi
         echo "[DONE] $mount_root is mounted to $mount_root_srv_dir (id: ${mount_id}, type: ${mount_type})"
         mounted_dirs+=($(remove_trailing_slashes "$mount_root_srv_dir"))
-    # FIXME: Add SMB type handling
     else
         echo "[ERROR] Unsupported mount type $mount_type is specified. $mount_root (id: $mount_id), skipping"
         continue


### PR DESCRIPTION
This PR adds new functionality for mounting SMB share storages to webDAV Service.

Because of specific mount prerequisites (like azure storage creds) for mounting, not only WebDAV scripts are changed, but additional changes on deployment process are needed.

To be able to pass storage creds to WebDAV additional kube secret 'cp-region-creds-secret' was added. This secret is used to store all azure region credentials for datastorage accounts.

Each time region is created, api adds storage creds for this region to this kube secret.
WebDAV service mounts this secret as folder and can access creds file for mounting purpose. 

NOTE.
While redeploy existing CP instance with this changes, please remember that you need to create  'cp-region-creds-secret' manually, (when CP instance is created from scratch it will create this secret automatically by pipectl) 