### PR TITLE
Issue #761 Implement storage price list loading mode [AWS]

### DIFF
--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/app/CommonSyncConfiguration.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/app/CommonSyncConfiguration.java
@@ -24,6 +24,7 @@ import com.epam.pipeline.billingreportagent.service.impl.ElasticIndexService;
 import com.epam.pipeline.billingreportagent.service.impl.converter.AwsStoragePriceListLoader;
 import com.epam.pipeline.billingreportagent.service.impl.converter.AzureStoragePriceListLoader;
 import com.epam.pipeline.billingreportagent.service.impl.converter.GcpStoragePriceListLoader;
+import com.epam.pipeline.billingreportagent.service.impl.converter.PriceLoadingMode;
 import com.epam.pipeline.billingreportagent.service.impl.converter.StoragePricingService;
 import com.epam.pipeline.billingreportagent.service.impl.synchronizer.PipelineRunSynchronizer;
 import com.epam.pipeline.billingreportagent.service.impl.synchronizer.StorageSynchronizer;
@@ -92,10 +93,16 @@ public class CommonSyncConfiguration {
     @ConditionalOnProperty(value = STORAGE_SYNC_DISABLE_PROP, matchIfMissing = true, havingValue = FALSE)
     public StorageSynchronizer s3Synchronizer(final StorageLoader loader,
                                               final ElasticIndexService indexService,
-                                              final ElasticsearchServiceClient elasticsearchClient) {
+                                              final ElasticsearchServiceClient elasticsearchClient,
+                                              final @Value("${sync.storage.price.load.mode:api}")
+                                                      String priceMode,
+                                              final @Value("${sync.aws.json.price.endpoint.template}")
+                                                      String endpointTemplate) {
         final StorageBillingMapper mapper = new StorageBillingMapper(SearchDocumentType.S3_STORAGE, billingCenterKey);
         final StoragePricingService pricingService =
-            new StoragePricingService(new AwsStoragePriceListLoader("AmazonS3"));
+            new StoragePricingService(new AwsStoragePriceListLoader("AmazonS3",
+                                                                    PriceLoadingMode.valueOf(priceMode.toUpperCase()),
+                                                                    endpointTemplate));
         return new StorageSynchronizer(storageMapping,
                                        commonIndexPrefix,
                                        storageIndexName,
@@ -114,10 +121,16 @@ public class CommonSyncConfiguration {
     @ConditionalOnProperty(value = STORAGE_SYNC_DISABLE_PROP, matchIfMissing = true, havingValue = FALSE)
     public StorageSynchronizer efsSynchronizer(final StorageLoader loader,
                                                final ElasticIndexService indexService,
-                                               final ElasticsearchServiceClient elasticsearchClient) {
+                                               final ElasticsearchServiceClient elasticsearchClient,
+                                               final @Value("${sync.storage.price.load.mode:api}")
+                                                       String priceMode,
+                                               final @Value("${sync.aws.json.price.endpoint.template}")
+                                                       String endpointTemplate) {
         final StorageBillingMapper mapper = new StorageBillingMapper(SearchDocumentType.NFS_STORAGE, billingCenterKey);
         final StoragePricingService pricingService =
-            new StoragePricingService(new AwsStoragePriceListLoader("AmazonEFS"));
+            new StoragePricingService(new AwsStoragePriceListLoader("AmazonEFS",
+                                                                    PriceLoadingMode.valueOf(priceMode.toUpperCase()),
+                                                                    endpointTemplate));
         return new StorageSynchronizer(storageMapping,
                                        commonIndexPrefix,
                                        storageIndexName,

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/pricing/AwsFullTerms.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/pricing/AwsFullTerms.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.billingreportagent.model.pricing;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.util.Map;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AwsFullTerms {
+
+    @JsonProperty(value = "OnDemand")
+    private Map<String, Map<String, AwsPriceDimensions>> onDemand;
+
+    @JsonProperty(value = "Spot")
+    private Map<String, Map<String, AwsPriceDimensions>> spot;
+}

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/pricing/AwsPriceList.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/pricing/AwsPriceList.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.billingreportagent.model.pricing;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.util.Map;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AwsPriceList extends AwsPricingCard {
+
+    private Map<String, AwsProduct> products;
+
+    private String offerCode;
+
+    @JsonProperty(value = "terms")
+    private AwsFullTerms fullTerms;
+}

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/AwsStoragePriceListLoader.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/AwsStoragePriceListLoader.java
@@ -24,18 +24,25 @@ import com.amazonaws.services.pricing.model.GetProductsRequest;
 import com.amazonaws.services.pricing.model.GetProductsResult;
 import com.epam.pipeline.billingreportagent.model.billing.StoragePricing;
 import com.epam.pipeline.billingreportagent.model.pricing.AwsPriceDimensions;
+import com.epam.pipeline.billingreportagent.model.pricing.AwsPriceList;
 import com.epam.pipeline.billingreportagent.model.pricing.AwsPriceRate;
 import com.epam.pipeline.billingreportagent.model.pricing.AwsPricingCard;
+import com.epam.pipeline.billingreportagent.model.pricing.AwsTerms;
 import com.epam.pipeline.entity.region.CloudProvider;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.math.BigDecimal;
 import java.math.MathContext;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -125,7 +132,7 @@ public class AwsStoragePriceListLoader implements StoragePriceListLoader {
             case API:
                 return getAwsPricingCardsViaApi(awsStorageServiceName);
             case JSON:
-                return getAwsPricingCardsFromJson(awsStorageServiceName);
+                return getAwsPricingCardsFromJson();
             default:
                 throw new IllegalArgumentException(
                     String.format("Chosen mode [%s] isn't supported by AwsPriceListLoader!", mode));
@@ -163,8 +170,37 @@ public class AwsStoragePriceListLoader implements StoragePriceListLoader {
         return allPrices;
     }
 
-    private List<AwsPricingCard> getAwsPricingCardsFromJson(final String awsStorageServiceName) {
-        throw new UnsupportedOperationException();
+    private List<AwsPricingCard> getAwsPricingCardsFromJson() {
+        try {
+            final String jsonPriceList = readStringFromURL(priceLoadingEndpoint);
+            final AwsPriceList fullPriceList = mapper.readValue(jsonPriceList, AwsPriceList.class);
+            return fullPriceList.getProducts().values().stream()
+                .filter(awsProduct -> STORAGE.equals(awsProduct.getProductFamily()))
+                .filter(awsProduct -> GENERAL_STORAGE.equals(awsProduct.getAttributes().get(STORAGE_CLASS_KEY)))
+                .map(awsProduct -> {
+                    final AwsPricingCard card = new AwsPricingCard();
+                    card.setProduct(awsProduct);
+                    card.setServiceCode(fullPriceList.getOfferCode());
+                    card.setVersion(fullPriceList.getVersion());
+                    card.setPublicationDate(fullPriceList.getPublicationDate());
+                    final AwsTerms awsTerms = new AwsTerms();
+                    awsTerms.setOnDemand(MapUtils.emptyIfNull(fullPriceList.getFullTerms().getOnDemand())
+                                             .get(awsProduct.getSku()));
+                    awsTerms.setSpot(MapUtils.emptyIfNull(fullPriceList.getFullTerms().getSpot())
+                                         .get(awsProduct.getSku()));
+                    card.setTerms(awsTerms);
+                    return card;
+                })
+                .collect(Collectors.toList());
+        } catch (IOException e) {
+            throw new IllegalStateException("Can't load AWS price list from given endpoint!", e);
+        }
+    }
+
+    public String readStringFromURL(String url) throws IOException {
+        try (InputStream inputStream = new URL(url).openStream()) {
+            return IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+        }
     }
 
     private AwsPricingCard parseAwsPricingCard(final String jsonStr) {

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/PriceLoadingMode.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/PriceLoadingMode.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.billingreportagent.service.impl.converter;
+
+public enum PriceLoadingMode {
+    API, JSON
+}

--- a/billing-report-agent/src/main/resources/application.properties
+++ b/billing-report-agent/src/main/resources/application.properties
@@ -39,8 +39,10 @@ sync.run.index.name=pipeline-run-
 
 #Storage Settings
 sync.storage.disable=true
+sync.storage.price.load.mode=api
 sync.storage.index.mapping=classpath:/templates/storage_billing.json
 sync.storage.index.name=storage-
 sync.storage.file.index.pattern=*cp-%s-file-%d
 sync.storage.azure.auth.file=
 sync.storage.azure.offer.id=
+sync.aws.json.price.endpoint.template=https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/%s/current/index.json


### PR DESCRIPTION
This PR is related to issue #761 

It brings the opportunity to choose a mode of storage price list loading, implemented for AWS.
1. API - load using `com.amazonaws.services.pricing` library
2. JSON - load JSON file of specific format from the endpoint, configured via `application.properties` (configured to work with [files](https://aws.amazon.com/ru/blogs/aws/new-aws-price-list-api/), custom file of corresponding structure could be used as well)
