### PR TITLE
Issue #1086 Generate launch command for Windows correctly

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilder.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilder.java
@@ -17,6 +17,7 @@
 package com.epam.pipeline.manager.pipeline.runner;
 
 import com.epam.pipeline.entity.configuration.PipeConfValueVO;
+import com.epam.pipeline.entity.pipeline.run.OsType;
 import com.epam.pipeline.entity.pipeline.run.PipeRunCmdStartVO;
 import com.epam.pipeline.entity.pipeline.run.PipelineStart;
 import org.apache.commons.collections.MapUtils;
@@ -38,12 +39,14 @@ public class PipeRunCmdBuilder {
     private final PipelineStart runVO;
     private final PipeRunCmdStartVO startVO;
     private final List<String> cmd;
+    private final OsType runCmdExecutionEnvironment;
 
     public PipeRunCmdBuilder(final PipeRunCmdStartVO startVO) {
         this.startVO = startVO;
         this.runVO = startVO.getPipelineStart();
         this.cmd = new ArrayList<>();
         this.cmd.add("pipe run");
+        this.runCmdExecutionEnvironment = startVO.getRunStartCmdExecutionEnvironment();
     }
 
     public String build() {
@@ -192,7 +195,23 @@ public class PipeRunCmdBuilder {
     }
 
     private String quoteStringArgument(final String value) {
-        return String.format("'%s'", value);
+        final Character quote = getQuotes();
+        return String.format("%c%s%c", quote, escapeDoubleQuotes(value), quote);
+    }
+
+    private Character getQuotes() {
+        switch (runCmdExecutionEnvironment) {
+            case WINDOWS:
+                return '"';
+            default:
+                return '\'';
+        }
+    }
+
+    private String escapeDoubleQuotes(final String value) {
+        return OsType.WINDOWS.equals(runCmdExecutionEnvironment)
+               ? value.replaceAll("\"", "\\\\\"")
+               : value;
     }
 
     private boolean isOnDemand() {

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilderTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilderTest.java
@@ -17,11 +17,13 @@
 package com.epam.pipeline.manager.pipeline.runner;
 
 import com.epam.pipeline.entity.configuration.PipeConfValueVO;
+import com.epam.pipeline.entity.pipeline.run.OsType;
 import com.epam.pipeline.entity.pipeline.run.PipeRunCmdStartVO;
 import com.epam.pipeline.entity.pipeline.run.PipelineStart;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,6 +37,7 @@ public class PipeRunCmdBuilderTest {
     private static final String INSTANCE_TYPE = "type";
     private static final String DOCKER_IMAGE = "image";
     private static final String CMD_TEMPLATE = "sleep 100";
+    private static final String CMD_TEMPLATE_WITH_DOUBLE_QUOTES = "do \"command\"";
 
     @Test
     public void shouldGenerateLaunchCommand() {
@@ -44,26 +47,7 @@ public class PipeRunCmdBuilderTest {
         final PipeConfValueVO pipeConfValue2 = new PipeConfValueVO(TEST_PARAM_VALUE_2, "int");
         runParameters.put(TEST_PARAM_NAME_2, pipeConfValue2);
 
-        final PipelineStart pipelineStart = new PipelineStart();
-        pipelineStart.setPipelineId(1L);
-        pipelineStart.setVersion(TEST_VERSION);
-        pipelineStart.setParams(runParameters);
-        pipelineStart.setInstanceType(INSTANCE_TYPE);
-        pipelineStart.setHddSize(10);
-        pipelineStart.setDockerImage(DOCKER_IMAGE);
-        pipelineStart.setCmdTemplate(CMD_TEMPLATE);
-        pipelineStart.setTimeout(10L);
-        pipelineStart.setNodeCount(5);
-        pipelineStart.setCloudRegionId(1L);
-        pipelineStart.setParentNodeId(1L);
-        pipelineStart.setParentRunId(1L);
-
-        final PipeRunCmdStartVO pipeRunCmdStartVO = new PipeRunCmdStartVO();
-        pipeRunCmdStartVO.setPipelineStart(pipelineStart);
-        pipeRunCmdStartVO.setYes(true);
-        pipeRunCmdStartVO.setSync(true);
-        pipeRunCmdStartVO.setQuite(true);
-        pipeRunCmdStartVO.setShowParams(true);
+        final PipeRunCmdStartVO pipeRunCmdStartVO = getPipeRunCmdStartVO(runParameters);
 
         final PipeRunCmdBuilder pipeRunCmdBuilder = new PipeRunCmdBuilder(pipeRunCmdStartVO);
         final String actualResult = buildCmd(pipeRunCmdBuilder);
@@ -71,6 +55,35 @@ public class PipeRunCmdBuilderTest {
                         "-it type -di image -cmd '%s' -t 10 -q -ic 5 -s -pt spot -r 1 -pn 1",
                 TEST_VERSION, TEST_PARAM_NAME_1, TEST_PARAM_VALUE_1, TEST_PARAM_NAME_2, TEST_PARAM_VALUE_2,
                 CMD_TEMPLATE);
+        Assert.assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void shouldGenerateWindowsLaunchCommand() {
+        final PipeRunCmdStartVO pipeRunCmdStartVO = getPipeRunCmdStartVO(Collections.emptyMap());
+        pipeRunCmdStartVO.setRunStartCmdExecutionEnvironment(OsType.WINDOWS);
+
+        final PipeRunCmdBuilder pipeRunCmdBuilder = new PipeRunCmdBuilder(pipeRunCmdStartVO);
+        final String actualResult = buildCmd(pipeRunCmdBuilder);
+        final String expectedResult = String.format("pipe run -n 1@%s parent-id 1 -p -y -id 10 " +
+                                                    "-it type -di image -cmd \"%s\" "
+                                                    + "-t 10 -q -ic 5 -s -pt spot -r 1 -pn 1",
+                                                    TEST_VERSION, CMD_TEMPLATE);
+        Assert.assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void shouldGenerateWindowsLaunchCommandWithInnerQuotes() {
+        final PipeRunCmdStartVO pipeRunCmdStartVO = getPipeRunCmdStartVO(Collections.emptyMap());
+        pipeRunCmdStartVO.getPipelineStart().setCmdTemplate(CMD_TEMPLATE_WITH_DOUBLE_QUOTES);
+        pipeRunCmdStartVO.setRunStartCmdExecutionEnvironment(OsType.WINDOWS);
+
+        final PipeRunCmdBuilder pipeRunCmdBuilder = new PipeRunCmdBuilder(pipeRunCmdStartVO);
+        final String actualResult = buildCmd(pipeRunCmdBuilder);
+        final String expectedResult = String.format("pipe run -n 1@%s parent-id 1 -p -y -id 10 " +
+                                                    "-it type -di image -cmd \"do \\\"command\\\"\" "
+                                                    + "-t 10 -q -ic 5 -s -pt spot -r 1 -pn 1",
+                                                    TEST_VERSION);
         Assert.assertEquals(expectedResult, actualResult);
     }
 
@@ -139,5 +152,29 @@ public class PipeRunCmdBuilderTest {
                 .parentNode()
                 .nonPause()
                 .build();
+    }
+
+    private PipeRunCmdStartVO getPipeRunCmdStartVO(final Map<String, PipeConfValueVO> runParameters) {
+        final PipelineStart pipelineStart = new PipelineStart();
+        pipelineStart.setPipelineId(1L);
+        pipelineStart.setVersion(TEST_VERSION);
+        pipelineStart.setParams(runParameters);
+        pipelineStart.setInstanceType(INSTANCE_TYPE);
+        pipelineStart.setHddSize(10);
+        pipelineStart.setDockerImage(DOCKER_IMAGE);
+        pipelineStart.setCmdTemplate(CMD_TEMPLATE);
+        pipelineStart.setTimeout(10L);
+        pipelineStart.setNodeCount(5);
+        pipelineStart.setCloudRegionId(1L);
+        pipelineStart.setParentNodeId(1L);
+        pipelineStart.setParentRunId(1L);
+
+        final PipeRunCmdStartVO pipeRunCmdStartVO = new PipeRunCmdStartVO();
+        pipeRunCmdStartVO.setPipelineStart(pipelineStart);
+        pipeRunCmdStartVO.setYes(true);
+        pipeRunCmdStartVO.setSync(true);
+        pipeRunCmdStartVO.setQuite(true);
+        pipeRunCmdStartVO.setShowParams(true);
+        return pipeRunCmdStartVO;
     }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/run/OsType.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/run/OsType.java
@@ -16,19 +16,6 @@
 
 package com.epam.pipeline.entity.pipeline.run;
 
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-/**
- * This class supplements {@link PipelineStart} to provide ability to specify additional CLI specific options
- */
-@Data
-@NoArgsConstructor
-public class PipeRunCmdStartVO {
-    private PipelineStart pipelineStart;
-    private boolean quite;
-    private boolean yes;
-    private boolean showParams;
-    private boolean sync;
-    private OsType runStartCmdExecutionEnvironment = OsType.LINUX;
+public enum OsType {
+    LINUX, WINDOWS
 }


### PR DESCRIPTION
This PR is related to issue #1086 

It allows specifying an execution environment for run start command: `WINDOWS` or `LINUX` (default).   For now, this option control only the type of the quotes (single/double), used to wrap the strings (command and parameters).
