### PR TITLE
Issue #1090 Wrap launch command parameter values

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilder.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilder.java
@@ -160,7 +160,6 @@ public class PipeRunCmdBuilder {
         if (MapUtils.isNotEmpty(runVO.getParams())) {
             final String parametersCommand = runVO.getParams().entrySet()
                     .stream()
-                    .sorted(Map.Entry.comparingByKey())
                     .map(this::prepareParams)
                     .collect(Collectors.joining(WHITESPACE));
             cmd.add(parametersCommand);

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilder.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilder.java
@@ -24,9 +24,12 @@ import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -35,6 +38,8 @@ import java.util.stream.Collectors;
 public class PipeRunCmdBuilder {
 
     private static final String WHITESPACE = " ";
+    private static final Set<String> QUOTABLE_PARAMETER_TYPES =
+        new HashSet<>(Arrays.asList("string", "input", "output", "path", "common"));
 
     private final PipelineStart runVO;
     private final PipeRunCmdStartVO startVO;
@@ -83,7 +88,7 @@ public class PipeRunCmdBuilder {
     public PipeRunCmdBuilder cmdTemplate() {
         if (StringUtils.isNotBlank(runVO.getCmdTemplate())) {
             cmd.add("-cmd");
-            cmd.add(quoteStringArgument(runVO.getCmdTemplate()));
+            cmd.add(quoteArgumentValue(runVO.getCmdTemplate()));
         }
         return this;
     }
@@ -155,6 +160,7 @@ public class PipeRunCmdBuilder {
         if (MapUtils.isNotEmpty(runVO.getParams())) {
             final String parametersCommand = runVO.getParams().entrySet()
                     .stream()
+                    .sorted(Map.Entry.comparingByKey())
                     .map(this::prepareParams)
                     .collect(Collectors.joining(WHITESPACE));
             cmd.add(parametersCommand);
@@ -173,11 +179,13 @@ public class PipeRunCmdBuilder {
     }
 
     private String prepareParams(final Map.Entry<String, PipeConfValueVO> entry) {
-        String value = entry.getValue().getValue();
-        if (entry.getValue().getType().equalsIgnoreCase("string")) {
-            value = quoteStringArgument(value);
-        }
-        return entry.getKey() + WHITESPACE + value;
+        final String value = entry.getValue().getValue();
+        final String proceededValue = QUOTABLE_PARAMETER_TYPES.stream()
+            .filter(entry.getValue().getType()::equalsIgnoreCase)
+            .findAny()
+            .map(type -> quoteArgumentValue(value))
+            .orElse(value);
+        return entry.getKey() + WHITESPACE + proceededValue;
     }
 
     private void buildObjectCmdArg(final String argumentName, final Object argumentValue) {
@@ -194,7 +202,7 @@ public class PipeRunCmdBuilder {
         }
     }
 
-    private String quoteStringArgument(final String value) {
+    private String quoteArgumentValue(final String value) {
         final Character quote = getQuotes();
         return String.format("%c%s%c", quote, escapeDoubleQuotes(value), quote);
     }

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilderTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilderTest.java
@@ -32,12 +32,20 @@ public class PipeRunCmdBuilderTest {
     private static final String TEST_VERSION = "draft";
     private static final String TEST_PARAM_NAME_1 = "--param1";
     private static final String TEST_PARAM_NAME_2 = "--param2";
+    private static final String TEST_PARAM_NAME_3 = "--param3";
+    private static final String TEST_PARAM_NAME_4 = "--param4";
+    private static final String TEST_PARAM_NAME_5 = "--param5";
+    private static final String TEST_PARAM_NAME_6 = "--param6";
+    private static final String TEST_PARAM_NAME_7 = "--param7";
     private static final String TEST_PARAM_VALUE_1 = "string value";
     private static final String TEST_PARAM_VALUE_2 = "1";
+    private static final String TEST_PARAM_VALUE_MULTIPLE_PATHS = "/bucket1/, /bucket2/";
     private static final String INSTANCE_TYPE = "type";
     private static final String DOCKER_IMAGE = "image";
     private static final String CMD_TEMPLATE = "sleep 100";
     private static final String CMD_TEMPLATE_WITH_DOUBLE_QUOTES = "do \"command\"";
+    private static final String QUOTED_PARAMETER = "%s '%s' ";
+    private static final String NON_QUOTED_PARAMETER = "%s %s ";
 
     @Test
     public void shouldGenerateLaunchCommand() {
@@ -46,15 +54,40 @@ public class PipeRunCmdBuilderTest {
         runParameters.put(TEST_PARAM_NAME_1, pipeConfValue1);
         final PipeConfValueVO pipeConfValue2 = new PipeConfValueVO(TEST_PARAM_VALUE_2, "int");
         runParameters.put(TEST_PARAM_NAME_2, pipeConfValue2);
+        final PipeConfValueVO pipeConfValue3 = new PipeConfValueVO(TEST_PARAM_VALUE_MULTIPLE_PATHS, "input");
+        runParameters.put(TEST_PARAM_NAME_3, pipeConfValue3);
+        final PipeConfValueVO pipeConfValue4 = new PipeConfValueVO(TEST_PARAM_VALUE_MULTIPLE_PATHS, "output");
+        runParameters.put(TEST_PARAM_NAME_4, pipeConfValue4);
+        final PipeConfValueVO pipeConfValue5 = new PipeConfValueVO(TEST_PARAM_VALUE_MULTIPLE_PATHS, "path");
+        runParameters.put(TEST_PARAM_NAME_5, pipeConfValue5);
+        final PipeConfValueVO pipeConfValue6 = new PipeConfValueVO(TEST_PARAM_VALUE_MULTIPLE_PATHS, "common");
+        runParameters.put(TEST_PARAM_NAME_6, pipeConfValue6);
+        final PipeConfValueVO pipeConfValue7 = new PipeConfValueVO(Boolean.TRUE.toString(), "boolean");
+        runParameters.put(TEST_PARAM_NAME_7, pipeConfValue7);
 
         final PipeRunCmdStartVO pipeRunCmdStartVO = getPipeRunCmdStartVO(runParameters);
 
         final PipeRunCmdBuilder pipeRunCmdBuilder = new PipeRunCmdBuilder(pipeRunCmdStartVO);
         final String actualResult = buildCmd(pipeRunCmdBuilder);
-        final String expectedResult = String.format("pipe run -n 1@%s %s '%s' %s %s parent-id 1 -p -y -id 10 " +
-                        "-it type -di image -cmd '%s' -t 10 -q -ic 5 -s -pt spot -r 1 -pn 1",
-                TEST_VERSION, TEST_PARAM_NAME_1, TEST_PARAM_VALUE_1, TEST_PARAM_NAME_2, TEST_PARAM_VALUE_2,
-                CMD_TEMPLATE);
+        final String expectedResult = String.format("pipe run -n 1@%s "
+                                                    + QUOTED_PARAMETER
+                                                    + NON_QUOTED_PARAMETER
+                                                    + QUOTED_PARAMETER
+                                                    + QUOTED_PARAMETER
+                                                    + QUOTED_PARAMETER
+                                                    + QUOTED_PARAMETER
+                                                    + NON_QUOTED_PARAMETER
+                                                    + "parent-id 1 -p -y -id 10 -it type -di image -cmd '%s' "
+                                                    + "-t 10 -q -ic 5 -s -pt spot -r 1 -pn 1",
+                                                    TEST_VERSION,
+                                                    TEST_PARAM_NAME_1, TEST_PARAM_VALUE_1,
+                                                    TEST_PARAM_NAME_2, TEST_PARAM_VALUE_2,
+                                                    TEST_PARAM_NAME_3, TEST_PARAM_VALUE_MULTIPLE_PATHS,
+                                                    TEST_PARAM_NAME_4, TEST_PARAM_VALUE_MULTIPLE_PATHS,
+                                                    TEST_PARAM_NAME_5, TEST_PARAM_VALUE_MULTIPLE_PATHS,
+                                                    TEST_PARAM_NAME_6, TEST_PARAM_VALUE_MULTIPLE_PATHS,
+                                                    TEST_PARAM_NAME_7, true,
+                                                    CMD_TEMPLATE);
         Assert.assertEquals(expectedResult, actualResult);
     }
 

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilderTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilderTest.java
@@ -25,7 +25,9 @@ import org.junit.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class PipeRunCmdBuilderTest {
 
@@ -64,8 +66,10 @@ public class PipeRunCmdBuilderTest {
         runParameters.put(TEST_PARAM_NAME_6, pipeConfValue6);
         final PipeConfValueVO pipeConfValue7 = new PipeConfValueVO(Boolean.TRUE.toString(), "boolean");
         runParameters.put(TEST_PARAM_NAME_7, pipeConfValue7);
-
-        final PipeRunCmdStartVO pipeRunCmdStartVO = getPipeRunCmdStartVO(runParameters);
+        final Map<String, PipeConfValueVO> sortedParameters = runParameters.entrySet().stream()
+            .sorted(Map.Entry.comparingByKey())
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e2, LinkedHashMap::new));
+        final PipeRunCmdStartVO pipeRunCmdStartVO = getPipeRunCmdStartVO(sortedParameters);
 
         final PipeRunCmdBuilder pipeRunCmdBuilder = new PipeRunCmdBuilder(pipeRunCmdStartVO);
         final String actualResult = buildCmd(pipeRunCmdBuilder);


### PR DESCRIPTION
This PR is related to the issue #1090 

It wraps the value of parameter with quotes if the parameter's type allows multiple selections for the values [`input`, `output`, `common`, `path`]. 