### PR TITLE
Change location of filebeat package to download for api and edge

### DIFF
--- a/deploy/docker/cp-api-srv/Dockerfile
+++ b/deploy/docker/cp-api-srv/Dockerfile
@@ -110,7 +110,7 @@ ADD update-trust /update-trust
 RUN chmod +x /init* && \
     chmod +x /update-trust
 
-RUN wget -q https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-6.8.3-x86_64.rpm \
+RUN wget -q https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/filebeat/filebeat-6.8.3-x86_64.rpm \
     && rpm -vi filebeat-6.8.3-x86_64.rpm && rm -rf filebeat-6.8.3-x86_64.rpm
 
 COPY filebeat-template.yml /etc/filebeat/

--- a/deploy/docker/cp-edge/Dockerfile
+++ b/deploy/docker/cp-edge/Dockerfile
@@ -116,7 +116,7 @@ RUN chmod +x /liveness.sh
 
 ADD ingress-config /etc/nginx/ingress
 
-RUN wget -q https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-6.8.3-x86_64.rpm \
+RUN wget -q https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/filebeat/filebeat-6.8.3-x86_64.rpm \
     && rpm -vi filebeat-6.8.3-x86_64.rpm && rm -rf filebeat-6.8.3-x86_64.rpm
 
 COPY filebeat-template.yml /etc/filebeat/


### PR DESCRIPTION
this PR changes location of filebeat package to be downloaded while Docker builds api and edge images