### PR TITLE
Add support for LFS logs collection

### DIFF
--- a/workflows/pipe-common/shell/cluster_setup_shared_fs_lfs_chunk
+++ b/workflows/pipe-common/shell/cluster_setup_shared_fs_lfs_chunk
@@ -114,12 +114,7 @@ fi
 # Start LFS Chunk server
 ######################################################
 
-if [[ "$IS_RPM_BASED" = 0 ]]; then
-    nohup mfschunkserver -d start > /var/log/mfschunkserver.out 2>&1 &
-else
-    sed -i "s/fals/tru/g" /etc/default/lizardfs-chunkserver
-    service lizardfs-chunkserver start
-fi
+nohup mfschunkserver -d start > /var/log/mfschunkserver.out 2>&1 &
 
 if [ $? -ne 0 ]
 then

--- a/workflows/pipe-common/shell/cluster_setup_shared_fs_lfs_master
+++ b/workflows/pipe-common/shell/cluster_setup_shared_fs_lfs_master
@@ -66,13 +66,7 @@ echo "1 1 : _" > /etc/mfs/mfsgoals.cfg
 # Start LFS Master
 ######################################################
 
-if [[ "$IS_RPM_BASED" = 0 ]]; then
-    nohup mfsmaster -d start > /var/log/mfsmaster.out 2>&1 &
-else
-    sed -i "s/fals/tru/g" /etc/default/lizardfs-master
-    service lizardfs-master start
-fi
-
+nohup mfsmaster -d start > /var/log/mfsmaster.out 2>&1 &
 
 if [ $? -ne 0 ]
 then

--- a/workflows/pipe-common/shell/cluster_wait_for_nfs
+++ b/workflows/pipe-common/shell/cluster_wait_for_nfs
@@ -103,9 +103,18 @@ elif [ "$CP_CAP_SHARE_FS_TYPE" == "lfs" ]; then
     if ! grep "lizardfs-master" /etc/hosts -q; then
         echo "$NFS_IP" lizardfs-master >> /etc/hosts
     fi
+    if [ "${CP_CAP_NFS_MOUNT_OPTIONS}" ]
+    then
+        MOUNT_OPTIONS="${CP_CAP_NFS_MOUNT_OPTIONS}"
+    else
+        MOUNT_OPTIONS="-o big_writes,nosuid,nodev,noatime -o cacheexpirationtime=5000 -o readaheadmaxwindowsize=4096"
+    fi
+    if [ "${CP_CAP_NFS_DEBUG}" == "true" ] || [ "${CP_CAP_NFS_DEBUG}" == "yes" ]; then
+        MOUNT_OPTIONS="${MOUNT_OPTIONS} -o debug"
+    fi
     mkdir -p ${SHARED_PATH} && \
     rm -rf ${SHARED_PATH}/* && \
-    mfsmount -H lizardfs-master -o big_writes,nosuid,nodev,noatime -o cacheexpirationtime=5000 -o readaheadmaxwindowsize=4096 ${SHARED_PATH}
+    nohup mfsmount -f -H lizardfs-master ${MOUNT_OPTIONS} ${SHARED_PATH} > /var/log/mfsmount.out 2>&1 &
     
     if [ $? -ne 0 ]
     then

--- a/workflows/pipe-common/shell/cluster_wait_for_nfs
+++ b/workflows/pipe-common/shell/cluster_wait_for_nfs
@@ -107,7 +107,7 @@ elif [ "$CP_CAP_SHARE_FS_TYPE" == "lfs" ]; then
     then
         MOUNT_OPTIONS="${CP_CAP_NFS_MOUNT_OPTIONS}"
     else
-        MOUNT_OPTIONS="-o big_writes,nosuid,nodev,noatime -o cacheexpirationtime=5000 -o readaheadmaxwindowsize=4096"
+        MOUNT_OPTIONS="-o big_writes,nosuid,nodev,noatime -o cacheexpirationtime=5000 -o readaheadmaxwindowsize=4096 -o mfsioretries=400"
     fi
     if [ "${CP_CAP_NFS_DEBUG}" == "true" ] || [ "${CP_CAP_NFS_DEBUG}" == "yes" ]; then
         MOUNT_OPTIONS="${MOUNT_OPTIONS} -o debug"


### PR DESCRIPTION
Resolves issue #1098.

The pull request unifies LFS logging collection approaches for rpm and non-rpm linux distributions. From now on LFS logs can be found in `/var/log` directory for all cluster runs.

Moreover the pull request introduces two optional run parameters that can be used to customize LFS mounting:
- `CP_CAP_NFS_MOUNT_OPTIONS` string parameter allows to override default LFS mount options.
- `CP_CAP_NFS_DEBUG` boolean parameter allows to enable debug LFS mount logging. Disabled by default.

**Additionally** the pull request increases the default number of mfsmount retries from 30 to 400.