### PR TITLE
Issue #1036 Sensitive storage data transfer

### DIFF
--- a/api/src/main/java/com/epam/pipeline/aspect/leakagepolicy/DataLeakagePolicyAspect.java
+++ b/api/src/main/java/com/epam/pipeline/aspect/leakagepolicy/DataLeakagePolicyAspect.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.manager.datastorage.leakagepolicy;
+package com.epam.pipeline.aspect.leakagepolicy;
 
 import com.epam.pipeline.common.MessageConstants;
 import com.epam.pipeline.common.MessageHelper;

--- a/api/src/main/java/com/epam/pipeline/aspect/leakagepolicy/DataLeakagePolicyAspect.java
+++ b/api/src/main/java/com/epam/pipeline/aspect/leakagepolicy/DataLeakagePolicyAspect.java
@@ -19,6 +19,7 @@ package com.epam.pipeline.aspect.leakagepolicy;
 import com.epam.pipeline.common.MessageConstants;
 import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
+import com.epam.pipeline.exception.StorageForbiddenOperationException;
 import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
@@ -48,9 +49,9 @@ public class DataLeakagePolicyAspect {
 
     public void assertStorageIsNotSensitive(final AbstractDataStorage storage) {
         if (storage.isSensitive()) {
-            throw new IllegalArgumentException(messageHelper
-                                                   .getMessage(MessageConstants.ERROR_SENSITIVE_DATASTORAGE_OPERATION,
-                                                               storage.getId(), storage.getType()));
+            throw new StorageForbiddenOperationException(messageHelper.getMessage(
+                MessageConstants.ERROR_SENSITIVE_DATASTORAGE_OPERATION,
+                storage.getId(), storage.getType()));
         }
     }
 }

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -217,7 +217,8 @@ public final class MessageConstants {
     public static final String ERROR_DATASTORAGE_PATH_INVALID_SCHEMA = "error.datastorage.path.invalid.schema";
     public static final String ERROR_DATASTORAGE_PATH_PROCCESSING = "error.datastorage.path.processing.error";
     public static final String ERROR_AZURE_STORAGE_CREDENTIAL_INVALID = "error.azure.storage.credentials.invalid";
-
+    public static final String ERROR_SENSITIVE_DATASTORAGE_OPERATION =
+        "error.sensitive.datastorage.forbidden.operation";
 
     // NFS
     public static final String ERROR_DATASTORAGE_NFS_MOUNT = "error.datastorage.nfs.mount";

--- a/api/src/main/java/com/epam/pipeline/controller/ExceptionHandlerAdvice.java
+++ b/api/src/main/java/com/epam/pipeline/controller/ExceptionHandlerAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package com.epam.pipeline.controller;
 
 import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.exception.StorageForbiddenOperationException;
 import com.epam.pipeline.exception.docker.DockerAuthorizationException;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -72,6 +73,8 @@ public class ExceptionHandlerAdvice {
             }
         } else if (exception instanceof DockerAuthorizationException) {
             return new ResponseEntity<>(Result.error(exception.getMessage()), HttpStatus.UNAUTHORIZED);
+        } else if (exception instanceof StorageForbiddenOperationException) {
+            return new ResponseEntity<>(Result.error(exception.getMessage()), HttpStatus.FORBIDDEN);
         } else {
             message = exception.getMessage();
         }

--- a/api/src/main/java/com/epam/pipeline/dao/datastorage/DataStorageDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/datastorage/DataStorageDao.java
@@ -280,7 +280,9 @@ public class DataStorageDao extends NamedParameterJdbcDaoSupport {
         FILE_SHARE_MOUNT_ID,
 
         // cloud specific fields
-        REGION_ID;
+        REGION_ID,
+
+        SENSITIVE;
 
         static MapSqlParameterSource getParameters(AbstractDataStorage dataStorage) {
             MapSqlParameterSource params = new MapSqlParameterSource();
@@ -298,6 +300,7 @@ public class DataStorageDao extends NamedParameterJdbcDaoSupport {
             params.addValue(SHARED.name(), dataStorage.isShared());
             params.addValue(MOUNT_OPTIONS.name(), dataStorage.getMountOptions());
             params.addValue(FILE_SHARE_MOUNT_ID.name(), dataStorage.getFileShareMountId());
+            params.addValue(SENSITIVE.name(), dataStorage.isSensitive());
 
             if (dataStorage instanceof S3bucketDataStorage) {
                 S3bucketDataStorage bucket = ((S3bucketDataStorage) dataStorage);
@@ -395,6 +398,7 @@ public class DataStorageDao extends NamedParameterJdbcDaoSupport {
             }
             StoragePolicy policy = getStoragePolicy(rs);
             dataStorage.setStoragePolicy(policy);
+            dataStorage.setSensitive(rs.getBoolean(SENSITIVE.name()));
             return dataStorage;
         }
 

--- a/api/src/main/java/com/epam/pipeline/exception/StorageForbiddenOperationException.java
+++ b/api/src/main/java/com/epam/pipeline/exception/StorageForbiddenOperationException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.exception;
+
+public class StorageForbiddenOperationException extends RuntimeException {
+
+    public StorageForbiddenOperationException(final String error) {
+        super(error);
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageProviderManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageProviderManager.java
@@ -30,6 +30,7 @@ import com.epam.pipeline.entity.datastorage.DataStorageListing;
 import com.epam.pipeline.entity.datastorage.DataStorageStreamingContent;
 import com.epam.pipeline.entity.datastorage.DataStorageType;
 import com.epam.pipeline.entity.datastorage.PathDescription;
+import com.epam.pipeline.manager.datastorage.leakagepolicy.SensitiveStorageOperation;
 import com.epam.pipeline.manager.datastorage.providers.StorageProvider;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
@@ -46,7 +47,7 @@ import java.util.Set;
 
 @Service
 @SuppressWarnings("unchecked")
-public final class StorageProviderManager {
+public class StorageProviderManager {
     @Autowired
     private PreferenceManager preferenceManager;
 
@@ -101,10 +102,10 @@ public final class StorageProviderManager {
         return getStorageProvider(dataStorage).getItems(dataStorage, path, showVersion, pageSize, marker);
     }
 
+    @SensitiveStorageOperation
     public DataStorageDownloadFileUrl generateDownloadURL(AbstractDataStorage dataStorage,
                                                           String path, String version,
                                                           ContentDisposition contentDisposition) {
-        assertStorageIsNotSensitive(dataStorage);
         return getStorageProvider(dataStorage).generateDownloadURL(dataStorage, path, version, contentDisposition);
     }
 
@@ -166,14 +167,14 @@ public final class StorageProviderManager {
         return getStorageProvider(dataStorage).deleteObjectTags(dataStorage, path, tags, version);
     }
 
+    @SensitiveStorageOperation
     public DataStorageItemContent getFile(AbstractDataStorage dataStorage, String path, String version) {
-        assertStorageIsNotSensitive(dataStorage);
         long maxDownloadSize = preferenceManager.getPreference(SystemPreferences.DATA_STORAGE_MAX_DOWNLOAD_SIZE);
         return getStorageProvider(dataStorage).getFile(dataStorage, path, version, maxDownloadSize);
     }
 
+    @SensitiveStorageOperation
     public DataStorageStreamingContent getFileStream(AbstractDataStorage dataStorage, String path, String version) {
-        assertStorageIsNotSensitive(dataStorage);
         return getStorageProvider(dataStorage).getStream(dataStorage, path, version);
     }
 
@@ -184,13 +185,5 @@ public final class StorageProviderManager {
     public PathDescription getDataSize(final AbstractDataStorage dataStorage, final String path,
                                        final PathDescription pathDescription) {
         return getStorageProvider(dataStorage).getDataSize(dataStorage, path, pathDescription);
-    }
-
-    public void assertStorageIsNotSensitive(final AbstractDataStorage storage) {
-        if (storage.isSensitive()) {
-            throw new IllegalArgumentException(messageHelper
-                                                   .getMessage(MessageConstants.ERROR_SENSITIVE_DATASTORAGE_OPERATION,
-                                                               storage.getName(), storage.getType()));
-        }
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageProviderManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageProviderManager.java
@@ -104,6 +104,7 @@ public final class StorageProviderManager {
     public DataStorageDownloadFileUrl generateDownloadURL(AbstractDataStorage dataStorage,
                                                           String path, String version,
                                                           ContentDisposition contentDisposition) {
+        assertStorageIsNotSensitive(dataStorage);
         return getStorageProvider(dataStorage).generateDownloadURL(dataStorage, path, version, contentDisposition);
     }
 
@@ -166,11 +167,13 @@ public final class StorageProviderManager {
     }
 
     public DataStorageItemContent getFile(AbstractDataStorage dataStorage, String path, String version) {
+        assertStorageIsNotSensitive(dataStorage);
         long maxDownloadSize = preferenceManager.getPreference(SystemPreferences.DATA_STORAGE_MAX_DOWNLOAD_SIZE);
         return getStorageProvider(dataStorage).getFile(dataStorage, path, version, maxDownloadSize);
     }
 
     public DataStorageStreamingContent getFileStream(AbstractDataStorage dataStorage, String path, String version) {
+        assertStorageIsNotSensitive(dataStorage);
         return getStorageProvider(dataStorage).getStream(dataStorage, path, version);
     }
 
@@ -181,5 +184,13 @@ public final class StorageProviderManager {
     public PathDescription getDataSize(final AbstractDataStorage dataStorage, final String path,
                                        final PathDescription pathDescription) {
         return getStorageProvider(dataStorage).getDataSize(dataStorage, path, pathDescription);
+    }
+
+    public void assertStorageIsNotSensitive(final AbstractDataStorage storage) {
+        if (storage.isSensitive()) {
+            throw new IllegalArgumentException(messageHelper
+                                                   .getMessage(MessageConstants.ERROR_SENSITIVE_DATASTORAGE_OPERATION,
+                                                               storage.getName(), storage.getType()));
+        }
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/leakagepolicy/DataLeakagePolicyAspect.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/leakagepolicy/DataLeakagePolicyAspect.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.datastorage.leakagepolicy;
+
+import com.epam.pipeline.common.MessageConstants;
+import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+import java.util.stream.Stream;
+
+/**
+ * This aspect controls 'data-leakage' policy
+ */
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class DataLeakagePolicyAspect {
+
+    private final MessageHelper messageHelper;
+
+    @Around("execution(@com.epam.pipeline.manager.datastorage.leakagepolicy.SensitiveStorageOperation * *(..))")
+    public void proceedSensitiveStorageOperation(final ProceedingJoinPoint joinPoint) throws Throwable {
+        Stream.of(joinPoint.getArgs())
+            .filter(AbstractDataStorage.class::isInstance)
+            .map(AbstractDataStorage.class::cast)
+            .forEach(this::assertStorageIsNotSensitive);
+        joinPoint.proceed();
+    }
+
+    public void assertStorageIsNotSensitive(final AbstractDataStorage storage) {
+        if (storage.isSensitive()) {
+            throw new IllegalArgumentException(messageHelper
+                                                   .getMessage(MessageConstants.ERROR_SENSITIVE_DATASTORAGE_OPERATION,
+                                                               storage.getId(), storage.getType()));
+        }
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/leakagepolicy/SensitiveStorageOperation.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/leakagepolicy/SensitiveStorageOperation.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.datastorage.leakagepolicy;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SensitiveStorageOperation {
+
+}

--- a/api/src/main/resources/dao/datastorage-dao.xml
+++ b/api/src/main/resources/dao/datastorage-dao.xml
@@ -43,7 +43,8 @@
                         shared,
                         allowed_cidrs,
                         region_id,
-                        file_share_mount_id
+                        file_share_mount_id,
+                        sensitive
                     ) VALUES (
                         :DATASTORAGE_ID,
                         :DATASTORAGE_NAME,
@@ -64,7 +65,8 @@
                         :SHARED,
                         :ALLOWED_CIDRS,
                         :REGION_ID,
-                        :FILE_SHARE_MOUNT_ID
+                        :FILE_SHARE_MOUNT_ID,
+                        :SENSITIVE
                     )
                 ]]>
             </value>
@@ -83,7 +85,8 @@
                         enable_versioning = :ENABLE_VERSIONING,
                         backup_duration = :BACKUP_DURATION,
                         mount_point = :MOUNT_POINT,
-                        mount_options = :MOUNT_OPTIONS
+                        mount_options = :MOUNT_OPTIONS,
+                        sensitive = :SENSITIVE
                     WHERE
                         datastorage_id = :DATASTORAGE_ID
                 ]]>
@@ -119,7 +122,8 @@
                         shared,
                         allowed_cidrs,
                         region_id as region_id,
-                        file_share_mount_id
+                        file_share_mount_id,
+                        sensitive
                     FROM
                         pipeline.datastorage
                     ORDER BY datastorage_id
@@ -149,7 +153,8 @@
                         shared,
                         allowed_cidrs,
                         region_id as region_id,
-                        file_share_mount_id
+                        file_share_mount_id,
+                        sensitive
                     FROM
                         pipeline.datastorage
                     WHERE
@@ -180,7 +185,8 @@
                         shared,
                         allowed_cidrs,
                         region_id as region_id,
-                        file_share_mount_id
+                        file_share_mount_id,
+                        sensitive
                     FROM
                         pipeline.datastorage
                     WHERE
@@ -211,7 +217,8 @@
                         shared,
                         allowed_cidrs,
                         region_id as region_id,
-                        file_share_mount_id
+                        file_share_mount_id,
+                        sensitive
                     FROM
                         pipeline.datastorage
                     WHERE
@@ -242,7 +249,8 @@
                         shared,
                         allowed_cidrs,
                         region_id as region_id,
-                        file_share_mount_id
+                        file_share_mount_id,
+                        sensitive
                     FROM
                         pipeline.datastorage
                     WHERE
@@ -273,7 +281,8 @@
                         shared,
                         allowed_cidrs,
                         region_id as region_id,
-                        file_share_mount_id
+                        file_share_mount_id,
+                        sensitive
                     FROM
                         pipeline.datastorage
                     WHERE
@@ -305,7 +314,8 @@
                         shared,
                         allowed_cidrs,
                         region_id as region_id,
-                        file_share_mount_id
+                        file_share_mount_id,
+                        sensitive
                     FROM
                         pipeline.datastorage
                     WHERE
@@ -354,6 +364,7 @@
                             d.allowed_cidrs,
                             d.region_id as region_id,
                             d.file_share_mount_id,
+                            d.sensitive,
                             c.folder_id,
                             c.parent_id AS parent_folder_id
 	                    FROM pipeline.datastorage d
@@ -384,6 +395,7 @@
                             null as allowed_cidrs,
                             null as region_id,
                             null as file_share_mount_id,
+                            null as sensitive,
 		                    m.folder_id,
                             m.parent_id AS parent_folder_id
 	                    FROM pipeline.folder m
@@ -416,6 +428,7 @@
                             d.allowed_cidrs,
                             d.region_id as region_id,
                             d.file_share_mount_id,
+                            d.sensitive,
                             c.folder_id,
                             c.parent_id AS parent_folder_id
 	                    FROM pipeline.datastorage d
@@ -442,6 +455,7 @@
                             null as allowed_cidrs,
                             null as region_id,
                             null as file_share_mount_id,
+                            null as sensitive,
 		                    m.folder_id,
                             m.parent_id AS parent_folder_id
 	                    FROM pipeline.folder m

--- a/api/src/main/resources/db/migration/v2020.05.13_14.00__issue_1036_sensitive_data_storage.sql
+++ b/api/src/main/resources/db/migration/v2020.05.13_14.00__issue_1036_sensitive_data_storage.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pipeline.datastorage ADD sensitive boolean DEFAULT false;

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -224,6 +224,7 @@ error.datastorage.is.used.default=Datastorage with id ''{0}'' is used as default
 
 error.datastorage.path.invalid.schema=The specified path ''{0}'' has incorrect scheme. Expected path schema: ''{1}''.
 error.datastorage.path.processing.error=An error occurred during processing path ''{0}'': ''{1}''.
+error.sensitive.datastorage.forbidden.operation=Error: requested operation is forbidden for sensitive data storage (id: ''{0}'', type: ''{1}'').
 
 # Git messages
 

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/datastorage/AbstractDataStorage.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/datastorage/AbstractDataStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,6 +66,11 @@ public abstract class AbstractDataStorage extends AbstractSecuredEntity {
      * Defines if that data storage can be shared though a proxy service
      */
     private boolean shared;
+
+    /**
+     * Defines if 'data-leak' rules applied
+     */
+    private boolean sensitive;
 
     public AbstractDataStorage(final Long id, final String name,
                                final String path, final DataStorageType type) {

--- a/core/src/main/java/com/epam/pipeline/entity/datastorage/AbstractDataStorage.java
+++ b/core/src/main/java/com/epam/pipeline/entity/datastorage/AbstractDataStorage.java
@@ -56,6 +56,11 @@ public abstract class AbstractDataStorage extends AbstractSecuredEntity {
      */
     private boolean shared;
 
+    /**
+     * Defines if 'data-leak' rules applied
+     */
+    private boolean sensitive;
+
     public AbstractDataStorage(final Long id, final String name,
             final String path, final DataStorageType type) {
         this(id, name, path, type, DEFAULT_POLICY, "");


### PR DESCRIPTION
This PR is related to issue #1036

It brings basic restrictions on secured storage:
- `sensitive` attribute added to `AbstractDataStorage`
- validation on required methods is performed with `SensitiveStorageOperation` annotation and `DataLeakagePolicyAspect`