### PR TITLE
Issue 1104 nomachine image is unusable after commit

### DIFF
--- a/deploy/docker/cp-tools/base/desktop/nomachine/centos/Dockerfile
+++ b/deploy/docker/cp-tools/base/desktop/nomachine/centos/Dockerfile
@@ -94,3 +94,4 @@ RUN wget -q "https://dl.google.com/linux/direct/google-chrome-stable_current_x86
 # Add Chrome desktop icon
 ADD create_chrome_launcher.sh /caps/create_chrome_launcher.sh
 RUN echo "bash /caps/create_chrome_launcher.sh" >> /caps.sh
+RUN cp /usr/NX/etc/server.cfg /usr/NX/etc/server.cfg.template

--- a/deploy/docker/cp-tools/base/desktop/nomachine/centos/Dockerfile
+++ b/deploy/docker/cp-tools/base/desktop/nomachine/centos/Dockerfile
@@ -43,6 +43,8 @@ RUN yum -y install epel-release && \
 RUN curl https://bootstrap.pypa.io/get-pip.py | python - && \
     pip install --upgrade pip flask
 
+RUN pip install -I setuptools
+
 # Install git from sources, as it conflicts with nvidia/cuda docker base image
 ADD centos/scripts/install_git.sh /opt/install_git.sh
 RUN chmod +x /opt/install_git.sh && \

--- a/deploy/docker/cp-tools/base/desktop/nomachine/nomachine_launcher.sh
+++ b/deploy/docker/cp-tools/base/desktop/nomachine/nomachine_launcher.sh
@@ -35,7 +35,7 @@ mkdir -p /home/${OWNER}/Desktop
 chown ${OWNER} /home/${OWNER}/Desktop
 chmod o+rwx /home/${OWNER}/Desktop
 
-cp /usr/NX/etc/server.cfg.template /usr/NX/etc/server.cfg
+\cp /usr/NX/etc/server.cfg.template /usr/NX/etc/server.cfg
 
 sed -i '/#CreateDisplay/c\CreateDisplay 1' /usr/NX/etc/server.cfg
 sed -i "/#DisplayOwner/c\DisplayOwner $OWNER" /usr/NX/etc/server.cfg

--- a/deploy/docker/cp-tools/base/desktop/nomachine/nomachine_launcher.sh
+++ b/deploy/docker/cp-tools/base/desktop/nomachine/nomachine_launcher.sh
@@ -35,6 +35,8 @@ mkdir -p /home/${OWNER}/Desktop
 chown ${OWNER} /home/${OWNER}/Desktop
 chmod o+rwx /home/${OWNER}/Desktop
 
+cp /usr/NX/etc/server.cfg.template /usr/NX/etc/server.cfg
+
 sed -i '/#CreateDisplay/c\CreateDisplay 1' /usr/NX/etc/server.cfg
 sed -i "/#DisplayOwner/c\DisplayOwner $OWNER" /usr/NX/etc/server.cfg
 

--- a/deploy/docker/cp-tools/base/desktop/nomachine/ubuntu/Dockerfile
+++ b/deploy/docker/cp-tools/base/desktop/nomachine/ubuntu/Dockerfile
@@ -48,6 +48,8 @@ RUN apt-get update -y && \
 RUN curl https://bootstrap.pypa.io/get-pip.py | python - && \
     pip install --upgrade pip flask
 
+RUN pip install -I setuptools
+
 ARG GUI_ENV="xfce4 xfce4-xkb-plugin"
 RUN apt-get update -y && \
     apt-get install -y ${GUI_ENV}              

--- a/deploy/docker/cp-tools/base/desktop/nomachine/ubuntu/Dockerfile
+++ b/deploy/docker/cp-tools/base/desktop/nomachine/ubuntu/Dockerfile
@@ -89,3 +89,4 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
 # Add Chrome desktop icon
 ADD create_chrome_launcher.sh /caps/create_chrome_launcher.sh
 RUN echo "bash /caps/create_chrome_launcher.sh" >> /caps.sh
+RUN cp /usr/NX/etc/server.cfg /usr/NX/etc/server.cfg.template


### PR DESCRIPTION
This PR is related to #1104 
It's fix NoMachine-based image buildings to be able to use this images after commit operation.

This situation was caused by bug in `nomachine_launcher.sh` script.
This script performs some pre-start actions (that actually change some config parameters by replacing strings) to run NX processes as user that start this `pipeline run`. But when we commit image NoMachine server config file is already changed and next time we will try to start this image pre-start action will not be applied.

This PR adds `server config template` file  that will be copied to `server config` file each time we run the image and all pre-start actions will be applied to the new and clear config file.