### PR TITLE
Allow to run "pipe" commands on behalf of the other user

### DIFF
--- a/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
@@ -62,16 +63,19 @@ public class UserController extends AbstractRestController {
     @RequestMapping(value = "/user/token", method = RequestMethod.GET)
     @ResponseBody
     @ApiOperation(
-            value = "Returns a new valid token for currently authenticated user.",
-            notes = "Returns a new valid token for currently authenticated user.",
+            value = "Returns a new valid token.",
+            notes = "Returns a new valid token. " +
+                    "If user is name not specified a new token will be generated for currently authenticated user.",
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiResponses(
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
             })
-    public Result<JwtRawToken> getSettings(@RequestParam(required = false) Long expiration) {
-        return Result.success(authManager.issueTokenForCurrentUser(expiration));
+    public Result<JwtRawToken> getSettings(@RequestParam(required = false) Long expiration,
+                                           @RequestParam(required = false) String name) {
+        return Result.success(StringUtils.isNotBlank(name)
+                ? userApiService.issueToken(name, expiration)
+                : authManager.issueTokenForCurrentUser(expiration));
     }
-
 
     @RequestMapping(value = "/whoami", method = RequestMethod.GET)
     @ResponseBody

--- a/api/src/main/java/com/epam/pipeline/manager/user/UserApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/UserApiService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.epam.pipeline.manager.user;
 
 import com.epam.pipeline.controller.vo.PipelineUserExportVO;
 import com.epam.pipeline.controller.vo.PipelineUserVO;
+import com.epam.pipeline.entity.security.JwtRawToken;
 import com.epam.pipeline.entity.user.CustomControl;
 import com.epam.pipeline.entity.user.GroupStatus;
 import com.epam.pipeline.entity.user.PipelineUser;
@@ -162,5 +163,16 @@ public class UserApiService {
     @PreAuthorize(ADMIN_ONLY)
     public byte[] exportUsers(final PipelineUserExportVO attr) {
         return userManager.exportUsers(attr);
+    }
+
+    /**
+     * Generates a JWT token for specified user
+     * @param userName the name of the user
+     * @param expiration token expiration time (seconds)
+     * @return generated token
+     */
+    @PreAuthorize(ADMIN_ONLY)
+    public JwtRawToken issueToken(final String userName, final Long expiration) {
+        return userManager.issueToken(userName, expiration);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/user/UserManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/UserManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import com.epam.pipeline.controller.vo.PipelineUserVO;
 import com.epam.pipeline.dao.user.GroupStatusDao;
 import com.epam.pipeline.dao.user.RoleDao;
 import com.epam.pipeline.dao.user.UserDao;
+import com.epam.pipeline.entity.security.JwtRawToken;
 import com.epam.pipeline.entity.user.CustomControl;
 import com.epam.pipeline.entity.user.DefaultRoles;
 import com.epam.pipeline.entity.user.GroupStatus;
@@ -122,6 +123,17 @@ public class UserManager {
         PipelineUser pipelineUser = userDao.loadUserByName(name);
         Assert.notNull(pipelineUser, messageHelper.getMessage(MessageConstants.ERROR_USER_NAME_NOT_FOUND, name));
         return new UserContext(pipelineUser);
+    }
+
+    /**
+     * Generates a JWT token for specified user
+     * @param userName the name of the user
+     * @param expiration token expiration time (seconds)
+     * @return generated token
+     */
+    public JwtRawToken issueToken(final String userName, final Long expiration) {
+        final UserContext userContext = loadUserContext(userName);
+        return authManager.issueToken(userContext, expiration);
     }
 
     public PipelineUser loadUserByName(String name) {

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -754,7 +754,7 @@ def storage():
 @click.option('-r', '--region_id', default='default', help='Cloud Region ID where the datastorage shall be created',
               prompt='Cloud Region ID where the datastorage shall be created')
 @click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False,
-              help=USER_OPTION_DESCRIPTION, prompt=USER_OPTION_DESCRIPTION)
+              help=USER_OPTION_DESCRIPTION, prompt=USER_OPTION_DESCRIPTION, default='')
 @Config.validate_access_token
 def create(name, description, short_term_storage, long_term_storage, versioning, backup_duration, type,
            parent_folder, on_cloud, path, region_id):

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -36,10 +36,12 @@ from src.utilities.permissions_operations import PermissionsOperations
 from src.utilities.pipeline_run_operations import PipelineRunOperations
 from src.utilities.ssh_operations import run_ssh
 from src.utilities.update_cli_version import UpdateCLIVersionManager
+from src.utilities.user_token_operations import UserTokenOperations
 from src.version import __version__
 
 MAX_INSTANCE_COUNT = 1000
 MAX_CORES_COUNT = 10000
+USER_OPTION_DESCRIPTION = 'The user name to perform operation from specified user. Available for admins only'
 
 
 def silent_print_api_version():
@@ -60,6 +62,11 @@ def print_version(ctx, param, value):
     click.echo('Cloud Pipeline CLI, version {}'.format(__version__))
     silent_print_config_info()
     ctx.exit()
+
+
+def set_user_token(ctx, param, value):
+    if value:
+        UserTokenOperations().set_user_token(value)
 
 
 @click.group()
@@ -141,6 +148,7 @@ def echo_title(title, line=True):
 @click.option('-p', '--parameters', help='List parameters of a pipeline', is_flag=True)
 @click.option('-s', '--storage-rules', help='List storage rules of a pipeline', is_flag=True)
 @click.option('-r', '--permissions', help='List user permissions for a pipeline', is_flag=True)
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token
 def view_pipes(pipeline, versions, parameters, storage_rules, permissions):
     """Lists pipelines definitions
@@ -275,6 +283,7 @@ def view_pipe(pipeline, versions, parameters, storage_rules, permissions):
 @click.option('-nd', '--node-details', help='Display node details of a specific run', is_flag=True)
 @click.option('-pd', '--parameters-details', help='Display parameters of a specific run', is_flag=True)
 @click.option('-td', '--tasks-details', help='Display tasks of a specific run', is_flag=True)
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token
 def view_runs(run_id,
               status,
@@ -466,6 +475,7 @@ def view_run(run_id, node_details, parameters_details, tasks_details):
 
 @cli.command(name='view-cluster')
 @click.argument('node-name', required=False)
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token
 def view_cluster(node_name):
     """Lists cluster nodes
@@ -637,6 +647,7 @@ def view_cluster_for_node(node_name):
 @click.option('-pn', '--parent-node', help='Parent instance Run ID. That allows to run a pipeline as a child job on the existing running instance', type=int, required=False)
 @click.option('-np', '--non-pause', help='Allow to switch off auto-pause option. Supported for on-demand runs only',
               is_flag=True)
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token(quiet_flag_property_name='quiet')
 def run(pipeline,
         config,
@@ -666,6 +677,7 @@ def run(pipeline,
 @cli.command(name='stop')
 @click.argument('run-id', required=True, type=int)
 @click.option('-y', '--yes', is_flag=True, help='Do not ask confirmation')
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token
 def stop(run_id, yes):
     """Stops a running pipeline
@@ -676,6 +688,7 @@ def stop(run_id, yes):
 @cli.command(name='terminate-node')
 @click.argument('node-name', required=True, type=str)
 @click.option('-y', '--yes', is_flag=True, help='Do not ask confirmation')
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token
 def terminate_node(node_name, yes):
     """Terminates a calculation node
@@ -740,6 +753,8 @@ def storage():
               prompt='Datastorage path')
 @click.option('-r', '--region_id', default='default', help='Cloud Region ID where the datastorage shall be created',
               prompt='Cloud Region ID where the datastorage shall be created')
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False,
+              help=USER_OPTION_DESCRIPTION, prompt=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token
 def create(name, description, short_term_storage, long_term_storage, versioning, backup_duration, type,
            parent_folder, on_cloud, path, region_id):
@@ -753,6 +768,7 @@ def create(name, description, short_term_storage, long_term_storage, versioning,
 @click.option('-n', '--name', required=True, help='Name of the storage to delete')
 @click.option('-c', '--on_cloud', help='Delete a datastorage from the Cloud', is_flag=True)
 @click.option('-y', '--yes', is_flag=True, help='Do not ask confirmation')
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token
 def delete(name, on_cloud, yes):
     """Deletes an object storage
@@ -772,6 +788,7 @@ def delete(name, on_cloud, yes):
               prompt='Do you want to enable versioning for this datastorage?',
               help='Enable versioning for this datastorage')
 @click.option('-b', '--backup_duration', default='', help='Number of days for storing backups of the datastorage')
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token
 def update_policy(name, short_term_storage, long_term_storage, versioning, backup_duration):
     """Updates the policy of the datastorage
@@ -786,6 +803,7 @@ def update_policy(name, short_term_storage, long_term_storage, versioning, backu
 @storage.command(name='mvtodir')
 @click.argument('name', required=True)
 @click.argument('directory', required=True)
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 def mvtodir(name, directory):
     """Moves an object storage to a new parent folder
     """
@@ -799,6 +817,7 @@ def mvtodir(name, directory):
 @click.option('-r', '--recursive', is_flag=True, help='Recursive listing')
 @click.option('-p', '--page', type=int, help='Maximum number of records to show')
 @click.option('-a', '--all', is_flag=True, help='Show all results at once ignoring page settings')
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token
 def storage_list(path, show_details, show_versions, recursive, page, all):
     """Lists storage contents
@@ -808,6 +827,7 @@ def storage_list(path, show_details, show_versions, recursive, page, all):
 
 @storage.command(name='mkdir')
 @click.argument('folders', required=True, nargs=-1)
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token
 def storage_mk_dir(folders):
     """ Creates a directory in a storage
@@ -825,6 +845,7 @@ def storage_mk_dir(folders):
               help='Exclude all files matching this pattern from processing')
 @click.option('-i', '--include', required=False, multiple=True,
               help='Include only files matching this pattern into processing')
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token
 def storage_remove_item(path, yes, version, hard_delete, recursive, exclude, include):
     """ Removes file or folder from a datastorage
@@ -857,6 +878,7 @@ def storage_remove_item(path, yes, version, hard_delete, recursive, exclude, inc
               "follow - follow symlinks (default); "
               "skip - do not follow symlinks; "
               "filter - follow symlinks but check for cyclic links")
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token(quiet_flag_property_name='quiet')
 def storage_move_item(source, destination, recursive, force, exclude, include, quiet, skip_existing, tags, file_list,
                       symlinks):
@@ -892,6 +914,7 @@ def storage_move_item(source, destination, recursive, force, exclude, include, q
               "follow - follow symlinks (default); "
               "skip - do not follow symlinks; "
               "filter - follow symlinks but check for cyclic links")
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token(quiet_flag_property_name='quiet')
 def storage_copy_item(source, destination, recursive, force, exclude, include, quiet, skip_existing, tags, file_list,
                       symlinks):
@@ -908,6 +931,8 @@ def storage_copy_item(source, destination, recursive, force, exclude, include, q
 @click.option('-f', '--format', help='Format for size [G/M/K]',
               type=click.Choice(DuFormatType.possible_types()), required=False, default='M')
 @click.option('-d', '--depth', help='Depth level', type=int, required=False)
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False,
+              help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token(quiet_flag_property_name='quiet')
 def du(name, relative_path, format, depth):
     DataStorageOperations.du(name, relative_path, format, depth)
@@ -921,6 +946,7 @@ def du(name, relative_path, format, depth):
               help='Exclude all files matching this pattern from processing')
 @click.option('-i', '--include', required=False, multiple=True,
               help='Include only files matching this pattern into processing')
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token
 def storage_restore_item(path, version, recursive, exclude, include):
     """ Restores file version in a datastorage.\n
@@ -934,6 +960,7 @@ def storage_restore_item(path, version, recursive, exclude, include):
 @click.argument('path', required=True)
 @click.argument('tags', required=True, nargs=-1)
 @click.option('-v', '--version', required=False, help='Set tags for a specified version')
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token
 def storage_set_object_tags(path, tags, version):
     """ Sets tags for a specified object.\n
@@ -950,6 +977,7 @@ def storage_set_object_tags(path, tags, version):
 @storage.command('get-object-tags')
 @click.argument('path', required=True)
 @click.option('-v', '--version', required=False, help='Get tags for a specified version')
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token
 def storage_get_object_tags(path, version):
     """ Gets tags for a specified object.\n
@@ -964,6 +992,7 @@ def storage_get_object_tags(path, version):
 @click.argument('path', required=True)
 @click.argument('tags', required=True, nargs=-1)
 @click.option('-v', '--version', required=False, help='Delete tags for a specified version')
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token
 def storage_delete_object_tags(path, tags, version):
     """ Deletes tags for a specified object.\n
@@ -987,6 +1016,7 @@ def storage_delete_object_tags(path, tags, version):
 @click.option('-q', '--quiet', help='Enables quiet mode', is_flag=True)
 @click.option('-t', '--threads', help='Enables multithreading', is_flag=True)
 @click.option('-m', '--mode', required=False, help='Default file permissions',  default=700, type=int)
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token
 def mount_storage(mountpoint, file, bucket, options, custom_options, log_file, log_level, quiet, threads, mode):
     """ Mounts either all available file systems or a single bucket into a local folder.
@@ -1020,6 +1050,7 @@ def umount_storage(mountpoint, quiet):
     required=True,
     type=click.Choice(ACLOperations.get_classes())
 )
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token
 def view_acl(identifier, object_type):
     """ View object permissions.\n
@@ -1041,6 +1072,7 @@ def view_acl(identifier, object_type):
 @click.option('-a', '--allow', help='Allow permissions')
 @click.option('-d', '--deny', help='Deny permissions')
 @click.option('-i', '--inherit', help='Inherit permissions')
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token
 def set_acl(identifier, object_type, sid, group, allow, deny, inherit):
     """ Set object permissions.\n
@@ -1086,6 +1118,7 @@ def tag():
 @click.argument('entity_class', required=True)
 @click.argument('entity_id', required=True)
 @click.argument('data', required=True, nargs=-1)
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token
 def set_tag(entity_class, entity_id, data):
     """ Sets tags for a specified object.\n
@@ -1103,6 +1136,7 @@ def set_tag(entity_class, entity_id, data):
 @tag.command(name='get')
 @click.argument('entity_class', required=True)
 @click.argument('entity_id', required=True)
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token
 def get_tag(entity_class, entity_id):
     """ Lists all tags for a specific object or list of objects.\n
@@ -1118,6 +1152,7 @@ def get_tag(entity_class, entity_id):
 @click.argument('entity_class', required=True)
 @click.argument('entity_id', required=True)
 @click.argument('keys', required=False, nargs=-1)
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token
 def delete_tag(entity_class, entity_id, keys):
     """ Deletes specified tags for a specified object.\n
@@ -1134,6 +1169,7 @@ def delete_tag(entity_class, entity_id, keys):
 @click.argument('user_name', required=True)
 @click.argument('entity_class', required=True)
 @click.argument('entity_name', required=True)
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token
 def chown(user_name, entity_class, entity_name):
     """ Changes current owner to specified.\n
@@ -1150,6 +1186,7 @@ def chown(user_name, entity_class, entity_name):
     ignore_unknown_options=True,
     allow_extra_args=True))
 @click.argument('run-id', required=True, type=int)
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @click.pass_context
 @Config.validate_access_token
 def ssh(ctx, run_id):
@@ -1167,6 +1204,7 @@ def ssh(ctx, run_id):
 
 @cli.command(name='update')
 @click.argument('path', required=False)
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token
 def update_cli_version(path):
     """
@@ -1188,6 +1226,7 @@ def update_cli_version(path):
 @click.option('-g', '--group', help='List group tools.')
 @click.option('-t', '--tool', help='List tool details.')
 @click.option('-v', '--version', help='List tool version details.')
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token
 def view_tools(tool_path,
                registry,
@@ -1273,6 +1312,14 @@ def split_tool_path(tool_path, registry, group, tool, version, strict=False):
                    'registry/group/tool:version', err=True)
         sys.exit(1)
     return registry, group, tool, version
+
+
+@cli.command(name='token')
+@click.argument('user-id', required=True)
+@click.option('-d', '--duration', required=False, help='Generates token according to specified duration [DAYS].')
+@Config.validate_access_token
+def token(user_id, duration):
+    UserTokenOperations().print_user_token(user_id, duration)
 
 
 # Used to run a PyInstaller "freezed" version

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1316,9 +1316,12 @@ def split_tool_path(tool_path, registry, group, tool, version, strict=False):
 
 @cli.command(name='token')
 @click.argument('user-id', required=True)
-@click.option('-d', '--duration', required=False, help='Generates token according to specified duration [DAYS].')
+@click.option('-d', '--duration', type=int, required=False, help='The number of days this token will be valid.')
 @Config.validate_access_token
 def token(user_id, duration):
+    """
+    Prints a JWT token for specified user
+    """
     UserTokenOperations().print_user_token(user_id, duration)
 
 

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1089,6 +1089,7 @@ def set_acl(identifier, object_type, sid, group, allow, deny, inherit):
     required=False,
     type=click.Choice(ACLOperations.get_classes())
 )
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token
 def view_user_objects(username, object_type):
     ACLOperations.print_sid_objects(username, True, object_type)
@@ -1102,6 +1103,7 @@ def view_user_objects(username, object_type):
     required=False,
     type=click.Choice(ACLOperations.get_classes())
 )
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token
 def view_group_objects(group_name, object_type):
     ACLOperations.print_sid_objects(group_name, False, object_type)

--- a/pipe-cli/src/api/base.py
+++ b/pipe-cli/src/api/base.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,11 +20,12 @@ from ..config import Config
 
 
 class API(object):
+
     def __init__(self):
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         self.__config__ = Config.instance()
         self.__headers__ = {'Content-Type': 'application/json',
-                            'Authorization': 'Bearer {}'.format(self.__config__.access_key)}
+                            'Authorization': 'Bearer {}'.format(self.__config__.get_token())}
         if self.__config__.proxy is not None:
             self.__proxies__ = self.__config__.resolve_proxy()
         else:

--- a/pipe-cli/src/api/user.py
+++ b/pipe-cli/src/api/user.py
@@ -67,4 +67,18 @@ class User(API):
         if 'message' in response_data:
             raise RuntimeError(response_data['message'])
         else:
-            raise RuntimeError("Failed to load metadata.")
+            raise RuntimeError("Failed to change owner.")
+
+    @classmethod
+    def generate_user_token(cls, user_name, duration):
+        api = cls.instance()
+        query = '/user/token?name=%s' % user_name
+        if duration:
+            query = '&expiration='.join([query, str(duration)])
+        response_data = api.call(query, None)
+        if 'payload' in response_data and 'token' in response_data['payload']:
+            return response_data['payload']['token']
+        if 'message' in response_data:
+            raise RuntimeError(response_data['message'])
+        else:
+            raise RuntimeError("Failed to generate user token.")

--- a/pipe-cli/src/config.py
+++ b/pipe-cli/src/config.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -58,6 +58,8 @@ class ProxyInvalidConfig(Exception):
 
 class Config(object):
     """Provides a wrapper for a pipe command configuration"""
+
+    __USER_TOKEN__ = None
 
     def __init__(self, raise_config_not_found_exception=True):
         self.initialized = False
@@ -231,9 +233,10 @@ class Config(object):
         return cls(raise_config_not_found_exception)
 
     def get_current_user(self):
-        if not self.access_key:
+        token = self.get_token()
+        if not token:
             raise RuntimeError('Access token is not specified. Cannot get user info.')
-        user_info = jwt.decode(self.access_key, verify=False)
+        user_info = jwt.decode(token, verify=False)
         if 'sub' in user_info:
             return user_info['sub']
         raise RuntimeError('User information is not specified to access token is invalid.')
@@ -242,3 +245,8 @@ class Config(object):
         if self.tz == 'utc':
             return pytz.utc
         return tzlocal.get_localzone()
+
+    def get_token(self):
+        if self.__USER_TOKEN__:
+            return self.__USER_TOKEN__
+        return self.access_key

--- a/pipe-cli/src/utilities/storage/common.py
+++ b/pipe-cli/src/utilities/storage/common.py
@@ -169,7 +169,7 @@ class StorageOperations:
     @classmethod
     def get_user(cls):
         config = Config.instance()
-        user_info = jwt.decode(config.access_key, verify=False)
+        user_info = jwt.decode(config.get_token(), verify=False)
         if 'sub' in user_info:
             return user_info['sub']
         raise RuntimeError('Cannot find user info.')

--- a/pipe-cli/src/utilities/storage/mount.py
+++ b/pipe-cli/src/utilities/storage/mount.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -155,7 +155,7 @@ class Mount(object):
         with open(output_file, 'w') as output:
             mount_environment = os.environ.copy()
             mount_environment['API'] = config.api
-            mount_environment['API_TOKEN'] = config.access_key
+            mount_environment['API_TOKEN'] = config.get_token()
             if config.proxy:
                 mount_environment['http_proxy'] = config.proxy
                 mount_environment['https_proxy'] = config.proxy

--- a/pipe-cli/src/utilities/user_token_operations.py
+++ b/pipe-cli/src/utilities/user_token_operations.py
@@ -1,0 +1,48 @@
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import sys
+import click
+
+from src.api.user import User
+from src.config import Config
+
+
+class UserTokenOperations(object):
+
+    def __init__(self):
+        pass
+
+    def print_user_token(self, user_name, duration=None):
+        click.echo(self.generate_user_token(user_name, duration))
+
+    def generate_user_token(self, user_name, duration=None):
+        try:
+            duration = self.convert_to_seconds(duration)
+            return User().generate_user_token(user_name, duration)
+        except Exception as error:
+            error_message = str(error)
+            if 'Access is denied' in error_message:
+                error_message = '%s. This operation available for admins only' % error_message
+            click.echo('Error: %s' % error_message, err=True)
+            sys.exit(1)
+
+    def set_user_token(self, user_name):
+        if user_name:
+            Config.__USER_TOKEN__ = self.generate_user_token(user_name)
+
+    @staticmethod
+    def convert_to_seconds(duration):
+        if duration:
+            return int(duration) * 24 * 60 * 60
+        return duration


### PR DESCRIPTION
This PR provides implementation for issue  #1085 

1. A new CLI option `--user (-u) `was added to all commands
2. A new CLI command `pipe token <user-id> (--duration)` was added. This command generates a JWT token for specified user name. The option `--duration (-d)` is optional and indicates the number of days this token will be valid.
3. API method `GET user/token` was updated by new request parameter `name`
