### PR TITLE
`pipe storage restore` command works incorrectly for not removed file

### DIFF
--- a/e2e/cli/buckets/versioning/test_data_storage_versioning.py
+++ b/e2e/cli/buckets/versioning/test_data_storage_versioning.py
@@ -195,7 +195,8 @@ class TestDataStorageVersioning(object):
                 f('{}/{}'.format(self.test_folder_1, self.test_file_1), 10, added=True)
             ]
             compare_listing(actual_output, expected_output, 2)
-            pipe_storage_restore('cp://{}/{}'.format(self.bucket, self.test_folder_1), expected_status=0)
+            pipe_storage_restore('cp://{}/{}'.format(self.bucket, self.test_folder_1), expected_status=0,
+                                 recursive=True)
             actual_output = get_pipe_listing(self.path_to_bucket)
             assert len(actual_output) == 1 and self.test_folder_1 in actual_output[0].name
             actual_output = assert_and_filter_first_versioned_listing_line(

--- a/e2e/cli/common_utils/pipe_cli.py
+++ b/e2e/cli/common_utils/pipe_cli.py
@@ -95,11 +95,13 @@ def create_data_storage(bucket_name, path=None, versioning=False, token=None, ex
     get_command_output(command, expected_status=expected_status, token=token)
 
 
-def pipe_storage_restore(path, version=None, expected_status=None, token=None):
+def pipe_storage_restore(path, version=None, expected_status=None, token=None, recursive=False):
     command = ['pipe', 'storage', 'restore', path]
     if version:
         command.append('-v')
         command.append(version)
+    if recursive:
+        command.append('-r')
     return get_command_output(command, expected_status=expected_status, token=token)
 
 

--- a/pipe-cli/src/utilities/datastorage_operations.py
+++ b/pipe-cli/src/utilities/datastorage_operations.py
@@ -236,6 +236,9 @@ class DataStorageOperations(object):
             if version and recursive:
                 click.echo('"version" argument should\'t be combined with "recursive" option', err=True)
                 sys.exit(1)
+            if not recursive and not source_wrapper.is_file():
+                click.echo('Flag --recursive (-r) is required to restore folders.', err=True)
+                sys.exit(1)
             manager = source_wrapper.get_restore_manager()
             manager.restore_version(version, exclude, include, recursive=recursive)
         except ALL_ERRORS as error:

--- a/pipe-cli/src/utilities/storage/s3.py
+++ b/pipe-cli/src/utilities/storage/s3.py
@@ -253,14 +253,20 @@ class RestoreManager(StorageItemManager, AbstractRestoreManager):
         client = self.session.client('s3', config=S3BucketOperations.get_proxy_config())
         bucket = self.bucket.bucket.path
 
-        if not recursive and version:
-            self.restore_file_version(version, bucket, client)
-        else:
-            item = self.load_delete_marker(bucket, self.bucket.path, client, quite=True)
-            if item:
-                self.restore_last_file_version(item, client, bucket)
-            else:
-                self.restore_folder(bucket, client, exclude, include, recursive)
+        if not recursive:
+            if version:
+                self.restore_file_version(version, bucket, client)
+                return
+            item = self.load_delete_marker(bucket, self.bucket.path, client)
+            if not item:
+                raise RuntimeError('Failed to receive deleted marker')
+            self.restore_last_file_version(item, client, bucket)
+            return
+        item = self.load_delete_marker(bucket, self.bucket.path, client, quite=True)
+        if item:
+            self.restore_last_file_version(item, client, bucket)
+            return
+        self.restore_folder(bucket, client, exclude, include, recursive)
 
     @staticmethod
     def restore_last_file_version(item, client, bucket):
@@ -271,7 +277,7 @@ class RestoreManager(StorageItemManager, AbstractRestoreManager):
     def restore_file_version(self, version, bucket, client):
         current_item = self.load_item(bucket, client)
         if current_item['VersionId'] == version:
-            click.echo('Version "{}" is already the latest version'.format(version), err=True)
+            raise RuntimeError('Version "{}" is already the latest version'.format(version))
         try:
             client.copy_object(Bucket=bucket, Key=self.bucket.path,
                                CopySource=dict(Bucket=bucket, Key=self.bucket.path, VersionId=version))


### PR DESCRIPTION
This PR provides fix for issue #1097 

The following changes were added:
1. `pipe storage restore` fails if user initiate **folder** restore without `--recursive (-r)` option
2. `pipe storage restore cp://{bucket_name}/{file_name}` fails with `exit code 1` and error message `Error: Latest version in the buckets is not a delete marker. Please specify "--version" parameter.` if latest file version was not deleted marker
3. `pipe storage restore cp://{bucket_name}/{file_name} -v {latest_version} ` fails with `exit code 1` and error message `Error: Version "{latest_version}" is already the latest version` if latest version was set to restore

Moreover, test were fixed according to `1` case