### PR TITLE
CLI test should support --user option for `pipe storage create` command

### DIFF
--- a/e2e/cli/common_utils/pipe_cli.py
+++ b/e2e/cli/common_utils/pipe_cli.py
@@ -85,7 +85,7 @@ def create_data_storage(bucket_name, path=None, versioning=False, token=None, ex
     path = path if path else bucket_name
     command = ['pipe', 'storage', 'create', '--name', bucket_name, '-c', '--path', path,
                "-d", "The test bucket for integration testing", "-sts", sts, "-lts", lts, "-t", provider,
-               "-b", backup_duration, "-r", region_id]
+               "-b", backup_duration, "-r", region_id, '-u', '']
     if folder:
         command.extend(["-f", str(folder)])
     else:


### PR DESCRIPTION
This PR provides fix for CLI storage tests according to PR #1108 