### PR TITLE
Notifications for long pause/resume operations

### DIFF
--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
@@ -418,10 +418,11 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     @Transactional(propagation = Propagation.SUPPORTS)
     public List<PipelineRun> loadRunsByStatuses(final List<TaskStatus> statuses) {
         final MapSqlParameterSource params = new MapSqlParameterSource();
-        params.addValue("list", statuses.stream().map(TaskStatus::getId));
-        return ListUtils.emptyIfNull(
-                getJdbcTemplate().query(loadAllRunsByStatusQuery,
-                        PipelineRunParameters.getExtendedRowMapper(), params));
+        params.addValue("list", statuses.stream()
+                .map(TaskStatus::getId)
+                .collect(Collectors.toList()));
+        return ListUtils.emptyIfNull(getNamedParameterJdbcTemplate()
+                .query(loadAllRunsByStatusQuery, params, PipelineRunParameters.getRowMapper()));
     }
 
     private MapSqlParameterSource getPagingParameters(PagingRunFilterVO filter) {

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
@@ -111,13 +111,12 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     private String updatePodStatusQuery;
     private String loadEnvVarsQuery;
     private String updateLastNotificationQuery;
-
     private String updateProlongedAtTimeAndLastIdleNotificationTimeQuery;
-
     private String updateRunQuery;
     private String loadRunByPrettyUrlQuery;
     private String updateTagsQuery;
     private String loadAllRunsPossiblyActiveInPeriodQuery;
+    private String loadAllRunsByStatusQuery;
 
     // We put Propagation.REQUIRED here because this method can be called from non-transaction context
     // (see PipelineRunManager, it performs internal call for launchPipeline)
@@ -414,6 +413,15 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     @Transactional(propagation = Propagation.MANDATORY)
     public void deleteRunSids(Long runId) {
         getJdbcTemplate().update(deleteRunSidsByRunIdQuery, runId);
+    }
+
+    @Transactional(propagation = Propagation.SUPPORTS)
+    public List<PipelineRun> loadRunsByStatuses(final List<TaskStatus> statuses) {
+        final MapSqlParameterSource params = new MapSqlParameterSource();
+        params.addValue("list", statuses.stream().map(TaskStatus::getId));
+        return ListUtils.emptyIfNull(
+                getJdbcTemplate().query(loadAllRunsByStatusQuery,
+                        PipelineRunParameters.getExtendedRowMapper(), params));
     }
 
     private MapSqlParameterSource getPagingParameters(PagingRunFilterVO filter) {
@@ -1136,5 +1144,10 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setLoadAllRunsPossiblyActiveInPeriodQuery(final String loadAllRunsPossiblyActiveInPeriodQuery) {
         this.loadAllRunsPossiblyActiveInPeriodQuery = loadAllRunsPossiblyActiveInPeriodQuery;
+    }
+
+    @Required
+    public void setLoadAllRunsByStatusQuery(final String loadAllRunsByStatusQuery) {
+        this.loadAllRunsByStatusQuery = loadAllRunsByStatusQuery;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/notification/NotificationAspect.java
+++ b/api/src/main/java/com/epam/pipeline/manager/notification/NotificationAspect.java
@@ -58,7 +58,7 @@ public class NotificationAspect {
         pointcut =
             "execution(* com.epam.pipeline.manager.pipeline.PipelineRunManager.runPipeline(..)) || " +
             "execution(* com.epam.pipeline.manager.pipeline.PipelineRunManager.runCmd(..)) ||" +
-            "execution(* com.epam.pipeline.manager.pipeline.PipelineRunManager.updatePipelineStatus(" +
+            "execution(* com.epam.pipeline.manager.pipeline.PipelineRunCRUDService.updateRunStatus(" +
             "com.epam.pipeline.entity.pipeline.PipelineRun)) || " +
             "execution(* com.epam.pipeline.manager.pipeline.PipelineRunManager.updatePipelineStatusIfNotFinal(..)) ||" +
             "execution(* com.epam.pipeline.manager.pipeline.PipelineRunManager"

--- a/api/src/main/java/com/epam/pipeline/manager/notification/NotificationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/notification/NotificationManager.java
@@ -19,9 +19,11 @@ package com.epam.pipeline.manager.notification;
 import static com.epam.pipeline.entity.notification.NotificationSettings.NotificationGroup;
 import static com.epam.pipeline.entity.notification.NotificationSettings.NotificationType;
 
+import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -32,6 +34,8 @@ import java.util.stream.Collectors;
 import com.epam.pipeline.entity.cluster.monitoring.ELKUsageMetric;
 import com.epam.pipeline.entity.notification.NotificationTimestamp;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
+import com.epam.pipeline.entity.pipeline.run.RunStatus;
+import com.epam.pipeline.entity.utils.DateUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -329,6 +333,64 @@ public class NotificationManager { // TODO: rewrite with Strategy pattern?
         monitoringNotificationDao.createMonitoringNotifications(messages);
         monitoringNotificationDao.updateNotificationTimestamp(runIds, notificationType);
     }
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void notifyStuckInStatusRuns(final List<PipelineRun> runs) {
+        final NotificationSettings settings = notificationSettingsManager.load(NotificationType.LONG_STATUS);
+
+        if (settings == null || !settings.isEnabled() || settings.getTemplateId() == 0) {
+            LOGGER.info("No template configured for stuck status notifications or it was disabled!");
+            return;
+        }
+
+        final LocalDateTime now = DateUtils.nowUTC();
+        final Long threshold = settings.getThreshold();
+        if (threshold == null || threshold <= 0) {
+            return;
+        }
+        runs.stream()
+                .filter(run -> isRunStuckInStatus(settings, now, threshold, run))
+                .forEach(run -> {
+                    LOGGER.debug("Sending stuck status {} notification for run {}.",
+                            run.getStatus(), run.getId());
+                    final NotificationMessage notificationMessage = new NotificationMessage();
+                    if (settings.isKeepInformedOwner()) {
+                        PipelineUser pipelineOwner = userManager.loadUserByName(run.getOwner());
+                        notificationMessage.setToUserId(pipelineOwner.getId());
+                    }
+                    notificationMessage.setCopyUserIds(getCCUsers(settings));
+                    notificationMessage.setTemplate(new NotificationTemplate(settings.getTemplateId()));
+                    notificationMessage.setTemplateParameters(PipelineRunMapper.map(run, settings.getThreshold()));
+                    monitoringNotificationDao.createMonitoringNotification(notificationMessage);
+                });
+    }
+
+    private boolean isRunStuckInStatus(final NotificationSettings settings,
+                                       final LocalDateTime now,
+                                       final Long threshold,
+                                       final PipelineRun run) {
+        final List<RunStatus> runStatuses = run.getRunStatuses();
+        if (CollectionUtils.isEmpty(runStatuses)) {
+            LOGGER.debug("Status timestamps are not available for run {}. " +
+                    "Skipping stuck status duration check.", run.getId());
+            return false;
+        }
+
+        final Optional<RunStatus> lastStatus = runStatuses.stream()
+                .filter(status -> run.getStatus().equals(status.getStatus()))
+                .max(Comparator.comparing(RunStatus::getTimestamp));
+
+        return lastStatus
+                .map(status -> {
+                    final long secondsFromStatusUpdate = status.getTimestamp().until(now, ChronoUnit.SECONDS);
+                    return secondsFromStatusUpdate >= threshold && shouldNotify(run.getId(), settings);
+                })
+                .orElseGet(() -> {
+                    LOGGER.debug("Failed to find status {} timestamp for run {}.", run.getStatus(), run.getId());
+                    return false;
+                });
+    }
+
 
     /**
      * Creates a custom notification.

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunCRUDService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunCRUDService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.pipeline;
+
+import com.epam.pipeline.dao.pipeline.PipelineRunDao;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+//TODO: Move all CRUD and DB persistence methods from PipelineRunManager to this class
+@Service
+@RequiredArgsConstructor
+public class PipelineRunCRUDService {
+
+    private final PipelineRunDao pipelineRunDao;
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public PipelineRun updateRunStatus(PipelineRun run) {
+        updatePrettyUrlForFinishedRun(run);
+        pipelineRunDao.updateRunStatus(run);
+        return run;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void updatePrettyUrlForFinishedRun(PipelineRun run) {
+        if (run.getStatus().isFinal() && StringUtils.hasText(run.getPrettyUrl())) {
+            run.setPrettyUrl(null);
+            pipelineRunDao.updateRun(run);
+        }
+    }
+}

--- a/api/src/main/resources/dao/pipeline-run-dao.xml
+++ b/api/src/main/resources/dao/pipeline-run-dao.xml
@@ -1428,5 +1428,61 @@
                 ]]>
             </value>
         </property>
+        <property name="loadAllRunsByStatusQuery">
+            <value>
+                <![CDATA[
+                    SELECT
+                        run_id,
+                        pipeline_id,
+                        version,
+                        start_date,
+                        end_date,
+                        parameters,
+                        status,
+                        terminating,
+                        pod_id,
+                        node_type,
+                        node_disk,
+                        node_ip,
+                        node_id,
+                        node_name,
+                        node_image,
+                        node_cloud_region,
+                        docker_image,
+                        cmd_template,
+                        actual_cmd,
+                        timeout,
+                        owner,
+                        service_url,
+                        pod_ip,
+                        commit_status,
+                        last_change_commit_time,
+                        config_name,
+                        node_count,
+                        parent_id,
+                        entities_ids,
+                        is_spot,
+                        configuration_id,
+                        pod_status,
+                        prolonged_at_time,
+                        last_notification_time,
+                        last_idle_notification_time,
+                        exec_preferences,
+                        pretty_url,
+                        price_per_hour,
+                        state_reason,
+                        non_pause,
+                        node_real_disk,
+                        node_cloud_provider,
+                        tags
+                    FROM
+                        pipeline.pipeline_run
+                    WHERE
+                        status IN (:list)
+                    ORDER BY
+                        start_date
+                ]]>
+            </value>
+        </property>
     </bean>
 </beans>

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
@@ -779,6 +779,25 @@ public class PipelineRunDaoTest extends AbstractSpringTest {
         validateLoadRunBooleanFieldValue(false, run, PipelineRun::getQueued);
     }
 
+    @Test
+    public void shouldLoadRunsByStatuses() {
+        final PipelineRun running = buildPipelineRun(null, null);
+        running.setStatus(TaskStatus.RUNNING);
+        pipelineRunDao.createPipelineRun(running);
+
+        final PipelineRun pausing = buildPipelineRun(null, null);
+        pausing.setStatus(TaskStatus.PAUSING);
+        pipelineRunDao.createPipelineRun(pausing);
+
+        final PipelineRun resuming = buildPipelineRun(null, null);
+        resuming.setStatus(TaskStatus.RESUMING);
+        pipelineRunDao.createPipelineRun(resuming);
+
+        final List<PipelineRun> runs = pipelineRunDao.loadRunsByStatuses(
+                Arrays.asList(TaskStatus.PAUSING, TaskStatus.RESUMING));
+        assertEquals(2, runs.size());
+    }
+
     private PipelineRun createTestPipelineRun() {
         return createTestPipelineRun(testPipeline.getId());
     }

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunManagerUnitTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunManagerUnitTest.java
@@ -56,6 +56,10 @@ public class PipelineRunManagerUnitTest {
     @SuppressWarnings("PMD.UnusedPrivateField")
     private MessageHelper messageHelper;
 
+    @Mock
+    @SuppressWarnings("PMD.UnusedPrivateField")
+    private PipelineRunCRUDService runCRUDService;
+
     @InjectMocks
     private PipelineRunManager pipelineRunManager;
 
@@ -91,7 +95,7 @@ public class PipelineRunManagerUnitTest {
 
         pipelineRunManager.terminateRun(RUN_ID);
 
-        verify(pipelineRunDao).updateRunStatus(argThat(matches(run -> run.getStatus() == TaskStatus.STOPPED)));
+        verify(runCRUDService).updateRunStatus(argThat(matches(run -> run.getStatus() == TaskStatus.STOPPED)));
     }
 
     @Test

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/notification/NotificationSettings.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/notification/NotificationSettings.java
@@ -80,7 +80,10 @@ public class NotificationSettings {
         PIPELINE_RUN_STATUS(5, MISSING_TIME_THRESHOLD, MISSING_TIME_THRESHOLD, NotificationGroup.PIPELINE_RUN_STATUS),
         IDLE_RUN(6, MISSING_TIME_THRESHOLD, MISSING_TIME_THRESHOLD, NotificationGroup.IDLE_RUN),
         IDLE_RUN_PAUSED(7, MISSING_TIME_THRESHOLD, MISSING_TIME_THRESHOLD, NotificationGroup.IDLE_RUN),
-        IDLE_RUN_STOPPED(8, MISSING_TIME_THRESHOLD, MISSING_TIME_THRESHOLD, NotificationGroup.IDLE_RUN);
+        IDLE_RUN_STOPPED(8, MISSING_TIME_THRESHOLD, MISSING_TIME_THRESHOLD, NotificationGroup.IDLE_RUN),
+        HIGH_CONSUMED_RESOURCES(9, MISSING_TIME_THRESHOLD, 600L,  NotificationGroup.RESOURCE_CONSUMING),
+        LONG_STATUS(10, 3600L, 600L, NotificationGroup.LONG_STATUS);
+
 
         private static final Map<Long, NotificationType> BY_ID;
 
@@ -124,6 +127,8 @@ public class NotificationSettings {
         LONG_RUNNING,
         ISSUE,
         PIPELINE_RUN_STATUS,
-        IDLE_RUN
+        IDLE_RUN,
+        RESOURCE_CONSUMING,
+        LONG_STATUS
     }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/notification/NotificationSettings.java
+++ b/core/src/main/java/com/epam/pipeline/entity/notification/NotificationSettings.java
@@ -95,7 +95,8 @@ public class NotificationSettings {
         IDLE_RUN(6, MISSING_TIME_THRESHOLD, MISSING_TIME_THRESHOLD, Collections.emptyList(), true, NotificationGroup.IDLE_RUN),
         IDLE_RUN_PAUSED(7, MISSING_TIME_THRESHOLD, MISSING_TIME_THRESHOLD, Collections.emptyList(), true, NotificationGroup.IDLE_RUN),
         IDLE_RUN_STOPPED(8, MISSING_TIME_THRESHOLD, MISSING_TIME_THRESHOLD, Collections.emptyList(), true, NotificationGroup.IDLE_RUN),
-        HIGH_CONSUMED_RESOURCES(9, MISSING_TIME_THRESHOLD, 600L, Collections.emptyList(), true, NotificationGroup.RESOURCE_CONSUMING);
+        HIGH_CONSUMED_RESOURCES(9, MISSING_TIME_THRESHOLD, 600L, Collections.emptyList(), true, NotificationGroup.RESOURCE_CONSUMING),
+        LONG_STATUS(10, 3600L, 600L, Collections.emptyList(), true, NotificationGroup.LONG_STATUS);
 
         private static final Map<Long, NotificationType> BY_ID;
 
@@ -155,6 +156,7 @@ public class NotificationSettings {
         ISSUE,
         PIPELINE_RUN_STATUS,
         IDLE_RUN,
-        RESOURCE_CONSUMING
+        RESOURCE_CONSUMING,
+        LONG_STATUS
     }
 }

--- a/deploy/contents/install/email-templates/configs/LONG_STATUS.json
+++ b/deploy/contents/install/email-templates/configs/LONG_STATUS.json
@@ -1,0 +1,8 @@
+{
+  "keepInformedAdmins":true,
+  "keepInformedOwner":true,
+  "enabled":true,
+  "resendDelay": 600,
+  "threshold": 1200,
+  "subject":"Job #$templateParameters[\"id\"] is in status $templateParameters[\"status\"] for a long time"
+}

--- a/deploy/contents/install/email-templates/contents/LONG_STATUS.html
+++ b/deploy/contents/install/email-templates/contents/LONG_STATUS.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <style>
+        table,
+        td {
+            border: 1px solid black;
+            border-collapse: collapse;
+            padding: 5px;
+        }
+    </style>
+</head>
+
+<body>
+<p>Dear user,</p>
+<p>*** This is a system generated email, do not reply to this email ***</p>
+<p>There is a job with ID ${CP_DOLLAR}templateParameters["id"], launched from ${CP_DOLLAR}templateParameters.get("owner") account, that has been waiting in status ${CP_DOLLAR}templateParameters.get("status") for more than ${CP_DOLLAR}templateParameters.get("timeThreshold") minutes</p>
+<br />
+<p>If you consider the waiting time normal, please ignore this email</p>
+<p>Otherwise, please log into the <a href="https://$CP_API_SRV_EXTERNAL_HOST:$CP_API_SRV_EXTERNAL_PORT/pipeline/#/run/${CP_DOLLAR}templateParameters.get("id")/plain">$CP_PREF_UI_PIPELINE_DEPLOYMENT_NAME Platform</a> and check the job's status</p>
+<p>If anything went wrong during status change for that job, please contact the support team.</p>
+<br />
+<p><b>Job details:</b></p>
+<table>
+    <tr>
+        <td>Run #</td>
+        <td><a href="https://$CP_API_SRV_EXTERNAL_HOST:$CP_API_SRV_EXTERNAL_PORT/pipeline/#/run/${CP_DOLLAR}templateParameters.get("id")/plain">${CP_DOLLAR}templateParameters.get("id")</a></td>
+    </tr>
+    <tr>
+        <td>Job/Tool</td>#if( ${CP_DOLLAR}templateParameters.get("pipelineName") && ${CP_DOLLAR}templateParameters.get("pipelineName") != "pipeline" )<td>${CP_DOLLAR}templateParameters.get("pipelineName")</td>#else<td>${CP_DOLLAR}templateParameters.get("dockerImage")</td>#end
+    </tr>
+    <tr>
+        <td>Running Time</td>
+        <td>${CP_DOLLAR}templateParameters.get("runningTime") minutes</td>
+    </tr>
+    <tr>
+        <td>Start Date</td>${CP_DOLLAR}calendar.setTime(${CP_DOLLAR}dateFormat.parse(${CP_DOLLAR}templateParameters.get("startDate")))<td>${CP_DOLLAR}calendar.getTime().toString()</td>
+    </tr>
+    <tr>
+        <td>Instance Type</td>
+        <td>${CP_DOLLAR}templateParameters.get("instance").get("nodeType")</td>
+    </tr>
+    <tr>
+        <td>Instance Disk</td>
+        <td>${CP_DOLLAR}templateParameters.get("instance").get("nodeDisk")</td>
+    </tr>
+</table>
+<br />
+<p>Best regards,</p>
+<p>$CP_PREF_UI_PIPELINE_DEPLOYMENT_NAME Platform</p>
+</body>
+
+</html>


### PR DESCRIPTION
Related to #1087 

### Implementation
This PR adds a new type of notifications `LONG_STATUS`. This notification is send when a run is stuck in a status for a long period (configured via notification `threshold`). Currently `PAUSING` and `RESUMING` runs are checked for such statuses.