### PR TITLE
`pipe` CLI shall allow to list the users/groups/objects permissions globally

### DIFF
--- a/pipe-cli/mount/pipefuse/fslock.py
+++ b/pipe-cli/mount/pipefuse/fslock.py
@@ -16,6 +16,7 @@ import logging
 import time
 from abc import ABCMeta, abstractmethod
 from threading import RLock, Thread
+from future.utils import iteritems
 
 from fuse import fuse_get_context
 
@@ -29,7 +30,7 @@ def monitor_locks(monitor_lock, locks, timeout):
         try:
             monitor_lock.acquire()
             logging.debug('Updating path lock status')
-            free_paths = [path for path, lock in locks.iteritems() if lock.acquire(blocking=False)]
+            free_paths = [path for path, lock in iteritems(locks) if lock.acquire(blocking=False)]
             logging.debug('Releasing %d locks' % len(free_paths))
             for path in free_paths:
                 del locks[path]

--- a/pipe-cli/src/utilities/acl_operations.py
+++ b/pipe-cli/src/utilities/acl_operations.py
@@ -160,9 +160,7 @@ class ACLOperations(object):
             entities_table = prettytable.PrettyTable()
             entities_table.field_names = ["Type", "Name"]
             entities_table.align = "r"
-            for item in iteritems(available_entities):
-                entity_type = item[0]
-                entities = item[1]
+            for entity_type, entities in iteritems(available_entities):
                 for entity in entities:
                     entity_name = cls.build_name_by_type(entity, entity_type)
                     if not entity_name:

--- a/pipe-cli/src/utilities/acl_operations.py
+++ b/pipe-cli/src/utilities/acl_operations.py
@@ -16,7 +16,7 @@ import sys
 import click
 import requests
 import prettytable
-
+from future.utils import iteritems
 
 from src.api.entity import Entity
 from src.api.user import User
@@ -160,7 +160,7 @@ class ACLOperations(object):
             entities_table = prettytable.PrettyTable()
             entities_table.field_names = ["Type", "Name"]
             entities_table.align = "r"
-            for item in available_entities.iteritems():
+            for item in iteritems(available_entities):
                 entity_type = item[0]
                 entities = item[1]
                 for entity in entities:

--- a/pipe-cli/src/utilities/storage/umount.py
+++ b/pipe-cli/src/utilities/storage/umount.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import subprocess
-
+from future.utils import iteritems
 
 class Umount(object):
 
@@ -27,7 +27,7 @@ class Umount(object):
                 return
             cmd_logs[cmd] = log
         error_message = 'All attempts to umount %s failed.' % mountpoint
-        for cmd, log in cmd_logs.iteritems():
+        for cmd, log in iteritems(cmd_logs):
             if log:
                 error_message += '\n%s: %s' % (cmd, log)
         raise RuntimeError(error_message)


### PR DESCRIPTION
This PR provides fix for https://github.com/epam/cloud-pipeline/issues/911#issuecomment-629133120

The problem arise due to python versions: python3 does not support 'iteritems' for dictionaries.