### PR TITLE
Issue #761 Fix explicit creation of missing run statuses

### DIFF
--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverter.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverter.java
@@ -39,6 +39,7 @@ import java.math.RoundingMode;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -103,12 +104,13 @@ public class RunToBillingRequestConverter implements EntityToBillingRequestConve
                         .map(DateUtils::toLocalDateTime)
                         .orElse(syncStart);
                 statuses
-                    .add(new RunStatus(null, null, lastTimestamp.toLocalDate().atStartOfDay()));
+                    .add(new RunStatus(null, null,
+                                       lastTimestamp.toLocalDate().minusDays(1).atTime(LocalTime.MAX)));
             }
         } else {
             return Arrays.asList(
                 new RunStatus(null, TaskStatus.RUNNING, previousSync.toLocalDate().atStartOfDay()),
-                new RunStatus(null, null, syncStart.toLocalDate().atStartOfDay()));
+                new RunStatus(null, null, syncStart.toLocalDate().minusDays(1).atTime(LocalTime.MAX)));
         }
         return statuses;
     }

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverterImplTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverterImplTest.java
@@ -173,7 +173,7 @@ public class RunToBillingRequestConverterImplTest {
         Assert.assertEquals(run.getDockerImage(), requestFieldsMap.get("tool"));
         Assert.assertEquals(run.getInstance().getNodeType(), requestFieldsMap.get("instance_type"));
         Assert.assertEquals(9600, requestFieldsMap.get("cost"));
-        Assert.assertEquals(1441, requestFieldsMap.get("usage_minutes"));
+        Assert.assertEquals(1440, requestFieldsMap.get("usage_minutes"));
         Assert.assertEquals(PRICE.unscaledValue().intValue(), requestFieldsMap.get("run_price"));
         Assert.assertEquals(run.getInstance().getCloudRegionId().intValue(), requestFieldsMap.get("cloudRegionId"));
         Assert.assertEquals(USER_NAME, requestFieldsMap.get("owner"));


### PR DESCRIPTION
This PR is related to the issue #761

Some of the `RunToBillingRequestConverterImplTest` were failing because, during explicit run statuses creation, we used the start of the billable period end date for the last status created. 

So we were receiving one extra document describing one second of usage during the billable period end date. I'm assuming we need to use the end of the day, which is previous to the billable period end, rather than the start of it to avoid it.