### PR TITLE
Increase run compute and disks prices precision

### DIFF
--- a/api/src/main/resources/dao/pipeline-run-dao.xml
+++ b/api/src/main/resources/dao/pipeline-run-dao.xml
@@ -446,7 +446,6 @@
                         owner = :OWNER,
                         service_url = :SERVICE_URL,
                         pod_ip = :POD_IP,
-                        ssh_password = :SSH_PASSWORD,
                         commit_status = :COMMIT_STATUS,
                         last_change_commit_time = :LAST_CHANGE_COMMIT_TIME,
                         config_name = :CONFIG_NAME,

--- a/api/src/main/resources/db/migration/v2020.05.22_12.00__issue_1096_increase_run_prices_precision.sql
+++ b/api/src/main/resources/db/migration/v2020.05.22_12.00__issue_1096_increase_run_prices_precision.sql
@@ -1,0 +1,2 @@
+ALTER TABLE pipeline.pipeline_run ALTER COLUMN compute_price_per_hour TYPE numeric(100, 5) USING compute_price_per_hour::numeric(100, 5);
+ALTER TABLE pipeline.pipeline_run ALTER COLUMN disk_price_per_hour TYPE numeric(100, 5) USING disk_price_per_hour::numeric(100, 5);

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
@@ -105,6 +105,8 @@ public class PipelineRunDaoTest extends AbstractSpringTest {
     private static final String TEST_SERVICE_URL = "service_url";
     private static final String GROUP_NAME = "group_1";
     private static final BigDecimal PRICE_PER_HOUR = new BigDecimal("0.08");
+    private static final BigDecimal COMPUTE_PRICE_PER_HOUR = new BigDecimal("0.04000");
+    private static final BigDecimal DISK_PRICE_PER_HOUR = new BigDecimal("0.00012");
     private static final String TEST_REPO = "///";
     private static final String TEST_REPO_SSH = "git@test";
 
@@ -749,10 +751,14 @@ public class PipelineRunDaoTest extends AbstractSpringTest {
     public void testLoadRunWithPricePerHour() {
         PipelineRun run = createTestPipelineRun(testPipeline.getId());
         run.setPricePerHour(PRICE_PER_HOUR);
+        run.setComputePricePerHour(COMPUTE_PRICE_PER_HOUR);
+        run.setDiskPricePerHour(DISK_PRICE_PER_HOUR);
         pipelineRunDao.updateRun(run);
         PipelineRun loaded = pipelineRunDao.loadPipelineRun(run.getId());
         assertEquals(run.getId(), loaded.getId());
         assertEquals(PRICE_PER_HOUR, loaded.getPricePerHour());
+        assertEquals(COMPUTE_PRICE_PER_HOUR, loaded.getComputePricePerHour());
+        assertEquals(DISK_PRICE_PER_HOUR, loaded.getDiskPricePerHour());
     }
 
     @Test


### PR DESCRIPTION
Relates to #1096.

From now on run compute and disk prices will be stored in database with a higher precision.

Also it fixes ssh password erasing on pipeline run price adjusting.