### PR TITLE
Consider run node disks in billing

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -76,7 +76,6 @@ import com.epam.pipeline.utils.PasswordGenerator;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.MapUtils;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -94,7 +94,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -944,79 +943,11 @@ public class PipelineRunManager {
             return Collections.emptyList();
         }
 
-        final Map<Long, List<RunStatus>> runStatuses = runStatusManager.loadRunStatus(runIds).entrySet().stream()
-            .collect(Collectors.toMap(Map.Entry::getKey, e -> adjustStatuses(e.getValue(), start, end)));
+        final Map<Long, List<RunStatus>> runStatuses = runStatusManager.loadRunStatus(runIds);
 
         return runs.stream()
-            .peek(run -> {
-                final List<RunStatus> loadedStatuses = runStatuses.get(run.getId());
-                if (CollectionUtils.isNotEmpty(loadedStatuses)) {
-                    run.setRunStatuses(loadedStatuses);
-                } else {
-                    createRunStatusesForRun(run, start, end);
-                }
-            })
-            .filter(run -> CollectionUtils.isNotEmpty(run.getRunStatuses()))
+            .peek(run -> run.setRunStatuses(runStatuses.get(run.getId())))
             .collect(Collectors.toList());
-    }
-
-    /**
-     * Create statuses for run based on its start/end date according to requested billing period
-     *
-     * @param run run to create status
-     * @param syncStart start of the billing calculation period
-     * @param syncEnd end of the billing calculation period
-     */
-    void createRunStatusesForRun(final PipelineRun run, final LocalDateTime syncStart, final LocalDateTime syncEnd) {
-        final LocalDateTime runStart = DateUtils.convertDateToLocalDateTime(run.getStartDate());
-        final Date runEnd = run.getEndDate();
-        if ((!Objects.isNull(runEnd) && syncStart.isAfter(DateUtils.convertDateToLocalDateTime(runEnd)))
-            || syncEnd.isBefore(runStart)) {
-            return;
-        } else {
-            final LocalDateTime runStatusStart = syncStart.isBefore(runStart)
-                                                 ? runStart
-                                                 : syncStart;
-            final LocalDateTime runStatusEnd = Objects.isNull(runEnd)
-                                               ? syncEnd
-                                               : ObjectUtils.min(DateUtils.convertDateToLocalDateTime(runEnd), syncEnd);
-            run.setRunStatuses(Arrays.asList(
-                new RunStatus(run.getId(), TaskStatus.RUNNING, EMPTY_STRING, runStatusStart),
-                new RunStatus(run.getId(), TaskStatus.PAUSED, EMPTY_STRING, runStatusEnd)
-            ));
-        }
-    }
-
-    /**
-     * Adjust statuses to the given period: all the statuses after the end of the period are removed,
-     * activity periods completed before start of the period are removed as well.
-     * If run was in {@link TaskStatus#RUNNING} state during {@code start} moment, its {@link RunStatus#getTimestamp()}
-     * will be adjusted to {@code start} time point.
-     *
-     * @param runStatuses statuses to be adjusted
-     * @param start beginning of period
-     * @param end ending of period
-     * @return list of adjusted statuses in natural date order
-     */
-    List<RunStatus> adjustStatuses(final List<RunStatus> runStatuses,
-                                   final LocalDateTime start,
-                                   final LocalDateTime end) {
-        runStatuses.removeIf(runStatus -> runStatus.getTimestamp().isAfter(end));
-        runStatuses.sort(Comparator.comparing(RunStatus::getTimestamp));
-        final int statusesCount = runStatuses.size();
-        for (int i = statusesCount - 1; i >= 0; i--) {
-            final RunStatus runStatus = runStatuses.get(i);
-            if (runStatus.getTimestamp().isBefore(start)) {
-                if (runStatus.getStatus() == TaskStatus.RUNNING) {
-                    runStatus.setTimestamp(start);
-                    runStatuses.set(i, runStatus);
-                    return runStatuses.subList(i, statusesCount);
-                } else {
-                    return runStatuses.subList(Math.min(i + 1, statusesCount), statusesCount);
-                }
-            }
-        }
-        return runStatuses;
     }
 
     @Transactional(propagation = Propagation.REQUIRED)

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunManagerTest.java
@@ -70,7 +70,6 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -589,84 +588,8 @@ public class PipelineRunManagerTest extends AbstractManagerTest {
         Assert.assertEquals(2, stats.get(run2.getId()).getRunStatuses().size());
         Assert.assertEquals(2, stats.get(run3.getId()).getRunStatuses().size());
         Assert.assertEquals(1, stats.get(run4.getId()).getRunStatuses().size());
-        Assert.assertEquals(1, stats.get(run5.getId()).getRunStatuses().size());
-    }
-
-    @Test
-    public void testAdjustStatuses() {
-        final List<RunStatus> statuses = new ArrayList<>();
-        statuses.add(new RunStatus(PARENT_RUN_ID, TaskStatus.RUNNING, null, SYNC_PERIOD_START.minusHours(HOURS_24)));
-        statuses.add(new RunStatus(PARENT_RUN_ID, TaskStatus.PAUSED, null, SYNC_PERIOD_START.minusHours(HOURS_18)));
-        statuses.add(new RunStatus(PARENT_RUN_ID, TaskStatus.RUNNING, null, SYNC_PERIOD_START.minusHours(HOURS_12)));
-        statuses.add(new RunStatus(PARENT_RUN_ID, TaskStatus.PAUSED, null, SYNC_PERIOD_START.plusHours(HOURS_12)));
-        statuses.add(new RunStatus(PARENT_RUN_ID, TaskStatus.RUNNING, null, SYNC_PERIOD_START.plusHours(HOURS_18)));
-        statuses.add(new RunStatus(PARENT_RUN_ID, TaskStatus.PAUSED, null, SYNC_PERIOD_END.plusHours(HOURS_12)));
-
-        final List<RunStatus> adjustedStatuses =
-            pipelineRunManager.adjustStatuses(statuses, SYNC_PERIOD_START, SYNC_PERIOD_END);
-
-        Assert.assertEquals(3, adjustedStatuses.size());
-
-        Assert.assertEquals(TaskStatus.RUNNING, adjustedStatuses.get(0).getStatus());
-        Assert.assertEquals(SYNC_PERIOD_START, adjustedStatuses.get(0).getTimestamp());
-
-        Assert.assertEquals(TaskStatus.PAUSED, adjustedStatuses.get(1).getStatus());
-        Assert.assertEquals(SYNC_PERIOD_START.plusHours(HOURS_12), adjustedStatuses.get(1).getTimestamp());
-
-        Assert.assertEquals(TaskStatus.RUNNING, adjustedStatuses.get(2).getStatus());
-        Assert.assertEquals(SYNC_PERIOD_START.plusHours(HOURS_18), adjustedStatuses.get(2).getTimestamp());
-    }
-
-    @Test
-    public void testCreateRunStatuses() {
-        final LocalDateTime syncStartMinus24 = SYNC_PERIOD_START.minusHours(HOURS_24);
-        final LocalDateTime syncStartMinus12 = SYNC_PERIOD_START.minusHours(HOURS_12);
-        final LocalDateTime syncStartPlus12 = SYNC_PERIOD_START.plusHours(HOURS_12);
-        final LocalDateTime syncStartPlus18 = SYNC_PERIOD_START.plusHours(HOURS_18);
-        final LocalDateTime syncEndPlus12 = SYNC_PERIOD_END.plusHours(HOURS_12);
-        final LocalDateTime syncEndPlus18 = SYNC_PERIOD_END.plusHours(HOURS_18);
-
-        final PipelineRun run1 = launchPipeline(configuration, INSTANCE_TYPE, null);
-        run1.setStartDate(Timestamp.valueOf(syncStartMinus12));
-        pipelineRunManager.createRunStatusesForRun(run1, SYNC_PERIOD_START, SYNC_PERIOD_END);
-        assertCreatedRunStatuses(run1, SYNC_PERIOD_START, SYNC_PERIOD_END);
-
-        final PipelineRun run2 = launchRunWithStartEndDate(syncStartMinus24, syncStartMinus12);
-        pipelineRunManager.createRunStatusesForRun(run2, SYNC_PERIOD_START, SYNC_PERIOD_END);
-        final List<RunStatus> runStatuses2 = run2.getRunStatuses();
-        Assert.assertNull(runStatuses2);
-
-        final PipelineRun run3 = launchRunWithStartEndDate(syncStartMinus24, syncStartPlus12);
-        pipelineRunManager.createRunStatusesForRun(run3, SYNC_PERIOD_START, SYNC_PERIOD_END);
-        assertCreatedRunStatuses(run3, SYNC_PERIOD_START, syncStartPlus12);
-
-        final PipelineRun run4 = launchRunWithStartEndDate(syncStartPlus12, syncStartPlus18);
-        pipelineRunManager.createRunStatusesForRun(run4, SYNC_PERIOD_START, SYNC_PERIOD_END);
-        assertCreatedRunStatuses(run4, syncStartPlus12, syncStartPlus18);
-
-        final PipelineRun run5 = launchRunWithStartEndDate(syncStartPlus12, syncEndPlus18);
-        pipelineRunManager.createRunStatusesForRun(run5, SYNC_PERIOD_START, SYNC_PERIOD_END);
-        assertCreatedRunStatuses(run5, syncStartPlus12, SYNC_PERIOD_END);
-
-        final PipelineRun run6 = launchRunWithStartEndDate(syncEndPlus12, syncEndPlus18);
-        pipelineRunManager.createRunStatusesForRun(run6, SYNC_PERIOD_START, SYNC_PERIOD_END);
-        Assert.assertNull(run6.getRunStatuses());
-    }
-
-    private PipelineRun launchRunWithStartEndDate(final LocalDateTime startDate, final LocalDateTime endDate) {
-        final PipelineRun run = launchPipeline(configuration, INSTANCE_TYPE, null);
-        run.setStartDate(Timestamp.valueOf(startDate));
-        run.setEndDate(Timestamp.valueOf(endDate));
-        return run;
-    }
-
-    private void assertCreatedRunStatuses(final PipelineRun run,
-                                          final LocalDateTime firstStatusTimestamp,
-                                          final LocalDateTime secondStatusTimestamp) {
-        final List<RunStatus> runStatuses = run.getRunStatuses();
-        Assert.assertEquals(2, runStatuses.size());
-        Assert.assertEquals(firstStatusTimestamp, runStatuses.get(0).getTimestamp());
-        Assert.assertEquals(secondStatusTimestamp, runStatuses.get(1).getTimestamp());
+        Assert.assertEquals(3, stats.get(run5.getId()).getRunStatuses().size());
+        Assert.assertEquals(2, stats.get(run6.getId()).getRunStatuses().size());
     }
 
     private PipelineRun launchPipelineRun(final LocalDateTime startDate, final LocalDateTime stopDate) {

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/PipelineRunWithType.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/PipelineRunWithType.java
@@ -16,12 +16,16 @@
 
 package com.epam.pipeline.billingreportagent.model;
 
+import com.epam.pipeline.entity.cluster.NodeDisk;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import lombok.Value;
+
+import java.util.List;
 
 @Value
 public class PipelineRunWithType {
 
-    private PipelineRun pipelineRun;
-    private ComputeType runType;
+    PipelineRun pipelineRun;
+    List<NodeDisk> disks;
+    ComputeType runType;
 }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/PipelineRunBillingInfo.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/PipelineRunBillingInfo.java
@@ -29,11 +29,13 @@ import java.time.LocalDate;
 public class PipelineRunBillingInfo extends AbstractBillingInfo<PipelineRunWithType> {
 
     private Long usageMinutes;
+    private Long pausedMinutes;
 
     @Builder
     public PipelineRunBillingInfo(final LocalDate date, final PipelineRunWithType run,
-                                  final Long cost, final Long usageMinutes) {
+                                  final Long cost, final Long usageMinutes, final Long pausedMinutes) {
         super(date, run, cost, ResourceType.COMPUTE);
         this.usageMinutes = usageMinutes;
+        this.pausedMinutes = pausedMinutes;
     }
 }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/CloudPipelineAPIClient.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/CloudPipelineAPIClient.java
@@ -19,6 +19,7 @@ package com.epam.pipeline.billingreportagent.service.impl;
 import com.epam.pipeline.client.pipeline.CloudPipelineAPI;
 import com.epam.pipeline.client.pipeline.CloudPipelineApiBuilder;
 import com.epam.pipeline.entity.cluster.InstanceType;
+import com.epam.pipeline.entity.cluster.NodeDisk;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.metadata.MetadataEntry;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
@@ -67,5 +68,9 @@ public class CloudPipelineAPIClient {
 
     public List<MetadataEntry> loadMetadataEntry(List<EntityVO> entities) {
         return QueryUtils.execute(cloudPipelineAPI.loadFolderMetadata(entities));
+    }
+
+    public List<NodeDisk> loadNodeDisks(final String nodeId) {
+        return QueryUtils.execute(cloudPipelineAPI.loadNodeDisks(nodeId));
     }
 }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunPrice.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunPrice.java
@@ -1,0 +1,20 @@
+package com.epam.pipeline.billingreportagent.service.impl.converter;
+
+import lombok.Value;
+
+import java.math.BigDecimal;
+
+@Value
+public class RunPrice {
+    BigDecimal oldFashionedPricePerHour;
+    BigDecimal computePricePerHour;
+    BigDecimal diskPricePerHour;
+
+    public boolean isOldFashioned() {
+        return computePricePerHour.compareTo(BigDecimal.ZERO) == 0 && diskPricePerHour.compareTo(BigDecimal.ZERO) == 0;
+    }
+    
+    public boolean isNewFashioned() {
+        return !isOldFashioned();
+    }
+}

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverter.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverter.java
@@ -105,14 +105,12 @@ public class RunToBillingRequestConverter implements EntityToBillingRequestConve
                 final LocalDateTime lastTimestamp = Optional.ofNullable(run.getEndDate())
                         .map(DateUtils::toLocalDateTime)
                         .orElse(syncStart);
-                statuses
-                    .add(new RunStatus(null, null,
-                                       lastTimestamp.toLocalDate().minusDays(1).atTime(LocalTime.MAX)));
+                statuses.add(new RunStatus(null, null, lastTimestamp.toLocalDate().atStartOfDay()));
             }
         } else {
             return Arrays.asList(
                 new RunStatus(null, TaskStatus.RUNNING, previousSync.toLocalDate().atStartOfDay()),
-                new RunStatus(null, null, syncStart.toLocalDate().minusDays(1).atTime(LocalTime.MAX)));
+                new RunStatus(null, null, syncStart.toLocalDate().atStartOfDay()));
         }
         return statuses;
     }
@@ -276,7 +274,11 @@ public class RunToBillingRequestConverter implements EntityToBillingRequestConve
     }
 
     private Long getUsageMinutes(final Duration duration, final boolean active) {
-        return active ? duration.plusMinutes(1).toMinutes() : 0L;
+        return active ? max(duration, Duration.ofMinutes(1)).toMinutes() : 0L;
+    }
+
+    private Duration max(final Duration duration1, final Duration duration2) {
+        return duration1.compareTo(duration2) > 0 ? duration1 : duration2;
     }
 
     private DocWriteRequest getDocWriteRequest(final String indexPrefix,

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverter.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverter.java
@@ -40,7 +40,6 @@ import java.math.RoundingMode;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -158,18 +157,15 @@ public class RunToBillingRequestConverter implements EntityToBillingRequestConve
                                                                  final RunPrice price,
                                                                  final List<RunStatus> statuses) {
         final List<PipelineRunBillingInfo> billings = new ArrayList<>();
-        boolean isPreviousActive = false;
-        LocalDateTime periodStart = null;
-        for (final RunStatus current : statuses) {
-            final boolean isCurrentActive = TaskStatus.RUNNING.equals(current.getStatus());
-            if (isCurrentActive && !isPreviousActive) {
-                periodStart = current.getTimestamp();
-                isPreviousActive = true;
-            } else if (!isCurrentActive && isPreviousActive) {
-                isPreviousActive = false;
-                billings.addAll(createRunBillingsForActivePeriod(periodStart, current.getTimestamp(), run, price));
+        for (int i = 0; i < statuses.size() - 1; i++) {
+            final RunStatus previous = statuses.get(i);
+            final RunStatus current = statuses.get(i + 1);
+            if (TaskStatus.RUNNING.equals(previous.getStatus())) {
+                billings.addAll(createRunBillingsForActivePeriod(previous.getTimestamp(), current.getTimestamp(), 
+                        run, price));
             } else {
-                billings.addAll(createRunBillingsForInactivePeriod(periodStart, current.getTimestamp(), run, price));
+                billings.addAll(createRunBillingsForInactivePeriod(previous.getTimestamp(), current.getTimestamp(),
+                        run, price));
             }
         }
         return billings;

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverter.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverter.java
@@ -251,7 +251,8 @@ public class RunToBillingRequestConverter implements EntityToBillingRequestConve
         return calculateCostsForPeriod(duration.getSeconds(), price.getOldFashionedPricePerHour());
     }
 
-    private long getNewFashionedCosts(final Duration duration, final Long disk, final RunPrice price, final boolean active) {
+    private long getNewFashionedCosts(final Duration duration, final Long disk, final RunPrice price, 
+                                      final boolean active) {
         return getDiskCosts(duration, disk, price) + (active ? getComputeCosts(duration, price) : 0L);
     }
 

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverter.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverter.java
@@ -44,6 +44,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
@@ -187,10 +188,15 @@ public class RunToBillingRequestConverter implements EntityToBillingRequestConve
         return second.isAfter(first) ? second : first;
     }
 
-    private List<RunStatus> getDefaultStatuses(final PipelineRun run, final LocalDateTime start, final LocalDateTime end) {
-        return Arrays.asList(
-                new RunStatus(run.getId(), TaskStatus.RUNNING, start),
-                new RunStatus(run.getId(), TaskStatus.STOPPED, end));
+    private List<RunStatus> getDefaultStatuses(final PipelineRun run, final LocalDateTime start, 
+                                               final LocalDateTime end) {
+        final LocalDateTime runStart = getStart(run);
+        final LocalDateTime runEnd = getEnd(run);
+        return runEnd.isBefore(start) || runStart.isAfter(end)
+                ? Collections.singletonList(new RunStatus(run.getId(), TaskStatus.STOPPED, start))
+                : Arrays.asList(
+                new RunStatus(run.getId(), TaskStatus.RUNNING, max(start, runStart)),
+                new RunStatus(run.getId(), TaskStatus.STOPPED, min(end, runEnd)));
     }
 
     private RunPrice getPrice(final EntityContainer<PipelineRunWithType> runContainer) {

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/loader/PipelineRunLoader.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/loader/PipelineRunLoader.java
@@ -27,15 +27,16 @@ import com.epam.pipeline.entity.cluster.NodeDisk;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.user.PipelineUser;
-import org.apache.commons.collections4.ListUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -76,7 +77,11 @@ public class PipelineRunLoader implements EntityLoader<PipelineRunWithType> {
     }
 
     private List<NodeDisk> loadDisks(final PipelineRun run) {
-        return ListUtils.emptyIfNull(apiClient.loadNodeDisks(run.getInstance().getNodeId()));
+        return Optional.of(run)
+                .map(PipelineRun::getInstance)
+                .map(RunInstance::getNodeId)
+                .map(apiClient::loadNodeDisks)
+                .orElseGet(Collections::emptyList);
     }
 
     private ComputeType getRunType(final PipelineRun run, final Map<Long, List<InstanceType>> regionOffers) {

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/loader/PipelineRunLoader.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/loader/PipelineRunLoader.java
@@ -23,9 +23,11 @@ import com.epam.pipeline.billingreportagent.model.PipelineRunWithType;
 import com.epam.pipeline.billingreportagent.service.EntityLoader;
 import com.epam.pipeline.billingreportagent.service.impl.CloudPipelineAPIClient;
 import com.epam.pipeline.entity.cluster.InstanceType;
+import com.epam.pipeline.entity.cluster.NodeDisk;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.user.PipelineUser;
+import org.apache.commons.collections4.ListUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -67,10 +69,14 @@ public class PipelineRunLoader implements EntityLoader<PipelineRunWithType> {
         return runs
                 .stream()
                 .map(run -> EntityContainer.<PipelineRunWithType>builder()
-                        .entity(new PipelineRunWithType(run, getRunType(run, regionOffers)))
+                        .entity(new PipelineRunWithType(run, loadDisks(run), getRunType(run, regionOffers)))
                         .owner(usersWithMetadata.get(run.getOwner()))
                         .build())
                 .collect(Collectors.toList());
+    }
+
+    private List<NodeDisk> loadDisks(final PipelineRun run) {
+        return ListUtils.emptyIfNull(apiClient.loadNodeDisks(run.getInstance().getNodeId()));
     }
 
     private ComputeType getRunType(final PipelineRun run, final Map<Long, List<InstanceType>> regionOffers) {

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverterImplTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverterImplTest.java
@@ -67,7 +67,7 @@ public class RunToBillingRequestConverterImplTest {
     private static final Long PIPELINE_ID = 1L;
     private static final String TOOL_IMAGE = "cp/tool:latest";
     private static final BigDecimal PRICE = BigDecimal.valueOf(4, 2);
-    private static final List<String> USER_GROUPS = java.util.Arrays.asList(GROUP_1, GROUP_2);
+    private static final List<String> USER_GROUPS = Arrays.asList(GROUP_1, GROUP_2);
     private static final String NODE_ID = "nodeId";
     private static final LocalDateTime NO_DATE = null;
 
@@ -663,7 +663,7 @@ public class RunToBillingRequestConverterImplTest {
     }
     
     private void assertRunsActivityStats(final List<RunStatus> adjustedStatuses, final RunStatus... statuses) {
-        assertThat(adjustedStatuses.size(), is (statuses.length));
+        assertThat(adjustedStatuses.size(), is(statuses.length));
         for (int i = 0; i < statuses.length; i++) {
             assertThat(adjustedStatuses.get(i).getStatus(), is(statuses[i].getStatus()));
             assertThat(adjustedStatuses.get(i).getTimestamp(), is(statuses[i].getTimestamp()));

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverterImplTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverterImplTest.java
@@ -89,7 +89,7 @@ public class RunToBillingRequestConverterImplTest {
         run.setRunStatuses(statuses);
 
         final EntityContainer<PipelineRunWithType> runContainer = EntityContainer.<PipelineRunWithType>builder()
-                .entity(new PipelineRunWithType(run, ComputeType.CPU)).build();
+                .entity(new PipelineRunWithType(run, Collections.emptyList(), ComputeType.CPU)).build();
         final Collection<PipelineRunBillingInfo> billings =
                 converter.convertRunToBillings(runContainer,
                         LocalDateTime.of(2019, 12, 4, 0, 0),
@@ -114,7 +114,7 @@ public class RunToBillingRequestConverterImplTest {
         run.setRunStatuses(statuses);
 
         final EntityContainer<PipelineRunWithType> runContainer = EntityContainer.<PipelineRunWithType>builder()
-            .entity(new PipelineRunWithType(run, ComputeType.CPU)).build();
+            .entity(new PipelineRunWithType(run, Collections.emptyList(), ComputeType.CPU)).build();
         final Collection<PipelineRunBillingInfo> billings =
             converter.convertRunToBillings(runContainer,
                                            LocalDateTime.of(2019, 12, 1, 0, 0),
@@ -133,7 +133,7 @@ public class RunToBillingRequestConverterImplTest {
         run.setId(RUN_ID);
         run.setPricePerHour(BigDecimal.valueOf(4, 2));
         final EntityContainer<PipelineRunWithType> runContainer = EntityContainer.<PipelineRunWithType>builder()
-            .entity(new PipelineRunWithType(run, ComputeType.CPU)).build();
+            .entity(new PipelineRunWithType(run, Collections.emptyList(), ComputeType.CPU)).build();
 
         final Collection<PipelineRunBillingInfo> billings =
             converter.convertRunToBillings(runContainer,
@@ -153,7 +153,7 @@ public class RunToBillingRequestConverterImplTest {
 
         final EntityContainer<PipelineRunWithType> runContainer =
             EntityContainer.<PipelineRunWithType>builder()
-                .entity(new PipelineRunWithType(run, ComputeType.CPU))
+                .entity(new PipelineRunWithType(run, Collections.emptyList(), ComputeType.CPU))
                 .owner(testUserWithMetadata)
                 .build();
 

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapperTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapperTest.java
@@ -71,7 +71,7 @@ public class RunBillingMapperTest {
             TestUtils.createTestPipelineRun(TEST_RUN_ID, TEST_PIPELINE_ID, TEST_TOOL_IMAGE, TEST_PRICE,
                                             TestUtils.createTestInstance(TEST_REGION_ID, TEST_NODE_TYPE));
         final PipelineRunBillingInfo billing = PipelineRunBillingInfo.builder()
-            .run(new PipelineRunWithType(run, ComputeType.CPU))
+            .run(new PipelineRunWithType(run, Collections.emptyList(), ComputeType.CPU))
             .date(TEST_DATE)
             .cost(TEST_COST)
             .usageMinutes(TEST_USAGE_MINUTES)

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
@@ -17,6 +17,7 @@
 package com.epam.pipeline.client.pipeline;
 
 import com.epam.pipeline.entity.cluster.InstanceType;
+import com.epam.pipeline.entity.cluster.NodeDisk;
 import com.epam.pipeline.entity.cluster.NodeInstance;
 import com.epam.pipeline.entity.configuration.RunConfiguration;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
@@ -212,4 +213,7 @@ public interface CloudPipelineAPI {
 
     @GET("cluster/instance/loadAll")
     Call<Result<List<InstanceType>>> loadAllInstanceTypesForRegion(@Query(REGION_ID) Long regionId);
+
+    @GET("cluster/node/{id}/disks")
+    Call<Result<List<NodeDisk>>> loadNodeDisks(@Path(ID) String nodeId);
 }

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/NodeDisk.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/NodeDisk.java
@@ -1,0 +1,12 @@
+package com.epam.pipeline.entity.cluster;
+
+import lombok.Value;
+
+import java.time.LocalDateTime;
+
+@Value
+public class NodeDisk {
+    Long size;
+    String nodeId;
+    LocalDateTime createdDate;
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
@@ -95,7 +95,18 @@ public class PipelineRun extends AbstractSecuredEntity {
     private LocalDateTime prolongedAtTime;
     private ExecutionPreferences executionPreferences = ExecutionPreferences.getDefault();
     private String prettyUrl;
+    /**
+     * Pipeline run overall instance price per hour. 
+     */
     private BigDecimal pricePerHour;
+    /**
+     * Pipeline instance virtual machine price per hour.
+     */
+    private BigDecimal computePricePerHour;
+    /**
+     * Pipeline run instance disk gigabyte price per hour. 
+     */
+    private BigDecimal diskPricePerHour;
     private String stateReasonMessage;
     private List<RestartRun> restartedRuns;
     private List<RunStatus> runStatuses;


### PR DESCRIPTION
Relates to #1096.

The pull request introduces support for enhanced node disks billing. From now on run billing reports include costs for all disks of run's node including os, data, swap and attached disks.