### PR TITLE
Issue #1126: `pipe run` custom parameters parsing issue

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -1133,6 +1133,7 @@ public class PipelineRunManager {
 
     /**
      * Generates launch command for 'pipe run' CLI method.
+     * Note: runParameters should be at the end of the command.
      *
      * @param runVO {@link PipeRunCmdStartVO} contains input arguments for launch command
      * @return launch command
@@ -1142,7 +1143,6 @@ public class PipelineRunManager {
         return new PipeRunCmdBuilder(runVO)
                 .name()
                 .config()
-                .runParameters()
                 .parameters()
                 .yes()
                 .instanceDisk()
@@ -1157,6 +1157,7 @@ public class PipelineRunManager {
                 .regionId()
                 .parentNode()
                 .nonPause()
+                .runParameters()
                 .build();
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilder.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilder.java
@@ -169,7 +169,11 @@ public class PipeRunCmdBuilder {
             cmd.add(parametersCommand);
         }
         if (Objects.nonNull(runVO.getParentRunId())) {
-            addCmd(String.format("parent-id %d", runVO.getParentRunId()));
+            cmd.add(getNewLineIndicator());
+            if (MapUtils.isEmpty(runVO.getParams())) {
+                cmd.add(CMD_OPTIONS_DELIMITER);
+            }
+            cmd.add(String.format("parent-id %d", runVO.getParentRunId()));
         }
         return this;
     }

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilder.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilder.java
@@ -40,6 +40,7 @@ public class PipeRunCmdBuilder {
     private static final String WHITESPACE = " ";
     private static final Set<String> QUOTABLE_PARAMETER_TYPES =
         new HashSet<>(Arrays.asList("string", "input", "output", "path", "common"));
+    private static final String CMD_OPTIONS_DELIMITER = "--";
 
     private final PipelineStart runVO;
     private final PipeRunCmdStartVO startVO;
@@ -63,9 +64,9 @@ public class PipeRunCmdBuilder {
             return this;
         }
         if (StringUtils.isNotBlank(runVO.getVersion())) {
-            cmd.add(String.format("-n %d@%s", runVO.getPipelineId(), runVO.getVersion()));
+            addCmd(String.format("-n %d@%s", runVO.getPipelineId(), runVO.getVersion()));
         } else {
-            cmd.add(String.format("-n %d", runVO.getPipelineId()));
+            addCmd(String.format("-n %d", runVO.getPipelineId()));
         }
         return this;
     }
@@ -87,6 +88,7 @@ public class PipeRunCmdBuilder {
 
     public PipeRunCmdBuilder cmdTemplate() {
         if (StringUtils.isNotBlank(runVO.getCmdTemplate())) {
+            cmd.add(getNewLineIndicator());
             cmd.add("-cmd");
             cmd.add(quoteArgumentValue(runVO.getCmdTemplate()));
         }
@@ -108,6 +110,7 @@ public class PipeRunCmdBuilder {
     }
 
     public PipeRunCmdBuilder priceType() {
+        cmd.add(getNewLineIndicator());
         cmd.add("-pt");
         cmd.add(isOnDemand() ? "on-demand" : "spot");
         return this;
@@ -130,49 +133,50 @@ public class PipeRunCmdBuilder {
 
     public PipeRunCmdBuilder yes() {
         if (startVO.isYes()) {
-            cmd.add("-y");
+            addCmd("-y");
         }
         return this;
     }
 
     public PipeRunCmdBuilder quite() {
         if (startVO.isQuite()) {
-            cmd.add("-q");
+            addCmd("-q");
         }
         return this;
     }
 
     public PipeRunCmdBuilder sync() {
         if (startVO.isSync()) {
-            cmd.add("-s");
+            addCmd("-s");
         }
         return this;
     }
 
     public PipeRunCmdBuilder parameters() {
         if (startVO.isShowParams()) {
-            cmd.add("-p");
+            addCmd("-p");
         }
         return this;
     }
 
     public PipeRunCmdBuilder runParameters() {
         if (MapUtils.isNotEmpty(runVO.getParams())) {
+            addCmd(CMD_OPTIONS_DELIMITER);
             final String parametersCommand = runVO.getParams().entrySet()
                     .stream()
                     .map(this::prepareParams)
-                    .collect(Collectors.joining(WHITESPACE));
+                    .collect(Collectors.joining(WHITESPACE + getNewLineIndicator() + WHITESPACE));
             cmd.add(parametersCommand);
         }
         if (Objects.nonNull(runVO.getParentRunId())) {
-            cmd.add(String.format("parent-id %d", runVO.getParentRunId()));
+            addCmd(String.format("parent-id %d", runVO.getParentRunId()));
         }
         return this;
     }
 
     public PipeRunCmdBuilder nonPause() {
         if (isOnDemand() && runVO.isNonPause()) {
-            cmd.add("-np");
+            addCmd("-np");
         }
         return this;
     }
@@ -189,6 +193,7 @@ public class PipeRunCmdBuilder {
 
     private void buildObjectCmdArg(final String argumentName, final Object argumentValue) {
         if (Objects.nonNull(argumentValue)) {
+            cmd.add(getNewLineIndicator());
             cmd.add(argumentName);
             cmd.add(String.valueOf(argumentValue));
         }
@@ -196,6 +201,7 @@ public class PipeRunCmdBuilder {
 
     private void buildStringCmdArg(final String argumentName, final String argumentValue) {
         if (StringUtils.isNotBlank(argumentValue)) {
+            cmd.add(getNewLineIndicator());
             cmd.add(argumentName);
             cmd.add(argumentValue);
         }
@@ -223,5 +229,16 @@ public class PipeRunCmdBuilder {
 
     private boolean isOnDemand() {
         return Objects.nonNull(runVO.getIsSpot()) && !runVO.getIsSpot();
+    }
+
+    private void addCmd(final String value) {
+        cmd.add(getNewLineIndicator());
+        cmd.add(value);
+    }
+
+    private String getNewLineIndicator() {
+        return OsType.WINDOWS.equals(runCmdExecutionEnvironment)
+                ? "^\n"
+                : "\\\n";
     }
 }

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilderTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilderTest.java
@@ -107,7 +107,7 @@ public class PipeRunCmdBuilderTest {
         final String actualResult = buildCmd(pipeRunCmdBuilder);
         final String expectedResult = String.format(buildExpectedForWindows("pipe run",
                 "-n 1@%s", "-p", "-y", "-id 10", "-it type", "-di image", "-cmd \"%s\"",
-                "-t 10", "-q", "-ic 5", "-s", "-pt spot", "-r 1", "-pn 1", "parent-id 1"),
+                "-t 10", "-q", "-ic 5", "-s", "-pt spot", "-r 1", "-pn 1", "-- parent-id 1"),
                 TEST_VERSION, CMD_TEMPLATE);
         Assert.assertEquals(expectedResult, actualResult);
     }
@@ -122,7 +122,7 @@ public class PipeRunCmdBuilderTest {
         final String actualResult = buildCmd(pipeRunCmdBuilder);
         final String expectedResult = String.format(buildExpectedForWindows("pipe run", "-n 1@%s",
                 "-p", "-y", "-id 10", "-it type", "-di image", "-cmd \"do \\\"command\\\"\"",
-                "-t 10", "-q", "-ic 5", "-s", "-pt spot", "-r 1", "-pn 1", "parent-id 1"), TEST_VERSION);
+                "-t 10", "-q", "-ic 5", "-s", "-pt spot", "-r 1", "-pn 1", "-- parent-id 1"), TEST_VERSION);
         Assert.assertEquals(expectedResult, actualResult);
     }
 

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilderTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/runner/PipeRunCmdBuilderTest.java
@@ -46,8 +46,11 @@ public class PipeRunCmdBuilderTest {
     private static final String DOCKER_IMAGE = "image";
     private static final String CMD_TEMPLATE = "sleep 100";
     private static final String CMD_TEMPLATE_WITH_DOUBLE_QUOTES = "do \"command\"";
-    private static final String QUOTED_PARAMETER = "%s '%s' ";
-    private static final String NON_QUOTED_PARAMETER = "%s %s ";
+    private static final String FIRST_PARAMETER = "-- %s '%s'";
+    private static final String QUOTED_PARAMETER = "%s '%s'";
+    private static final String NON_QUOTED_PARAMETER = "%s %s";
+    private static final String LINUX_NEW_LINE_INDICATOR = "\\\n";
+    private static final String WINDOWS_NEW_LINE_INDICATOR = "^\n";
 
     @Test
     public void shouldGenerateLaunchCommand() {
@@ -73,25 +76,25 @@ public class PipeRunCmdBuilderTest {
 
         final PipeRunCmdBuilder pipeRunCmdBuilder = new PipeRunCmdBuilder(pipeRunCmdStartVO);
         final String actualResult = buildCmd(pipeRunCmdBuilder);
-        final String expectedResult = String.format("pipe run -n 1@%s "
-                                                    + QUOTED_PARAMETER
-                                                    + NON_QUOTED_PARAMETER
-                                                    + QUOTED_PARAMETER
-                                                    + QUOTED_PARAMETER
-                                                    + QUOTED_PARAMETER
-                                                    + QUOTED_PARAMETER
-                                                    + NON_QUOTED_PARAMETER
-                                                    + "parent-id 1 -p -y -id 10 -it type -di image -cmd '%s' "
-                                                    + "-t 10 -q -ic 5 -s -pt spot -r 1 -pn 1",
-                                                    TEST_VERSION,
-                                                    TEST_PARAM_NAME_1, TEST_PARAM_VALUE_1,
-                                                    TEST_PARAM_NAME_2, TEST_PARAM_VALUE_2,
-                                                    TEST_PARAM_NAME_3, TEST_PARAM_VALUE_MULTIPLE_PATHS,
-                                                    TEST_PARAM_NAME_4, TEST_PARAM_VALUE_MULTIPLE_PATHS,
-                                                    TEST_PARAM_NAME_5, TEST_PARAM_VALUE_MULTIPLE_PATHS,
-                                                    TEST_PARAM_NAME_6, TEST_PARAM_VALUE_MULTIPLE_PATHS,
-                                                    TEST_PARAM_NAME_7, true,
-                                                    CMD_TEMPLATE);
+        final String expectedResult = String.format(buildExpectedForLinux("pipe run", "-n 1@%s", "-p", "-y",
+                "-id 10", "-it type", "-di image", "-cmd '%s'", "-t 10", "-q", "-ic 5", "-s", "-pt spot", "-r 1",
+                "-pn 1",
+                FIRST_PARAMETER,
+                NON_QUOTED_PARAMETER,
+                QUOTED_PARAMETER,
+                QUOTED_PARAMETER,
+                QUOTED_PARAMETER,
+                QUOTED_PARAMETER,
+                NON_QUOTED_PARAMETER,
+                "parent-id 1"),
+                TEST_VERSION, CMD_TEMPLATE,
+                TEST_PARAM_NAME_1, TEST_PARAM_VALUE_1,
+                TEST_PARAM_NAME_2, TEST_PARAM_VALUE_2,
+                TEST_PARAM_NAME_3, TEST_PARAM_VALUE_MULTIPLE_PATHS,
+                TEST_PARAM_NAME_4, TEST_PARAM_VALUE_MULTIPLE_PATHS,
+                TEST_PARAM_NAME_5, TEST_PARAM_VALUE_MULTIPLE_PATHS,
+                TEST_PARAM_NAME_6, TEST_PARAM_VALUE_MULTIPLE_PATHS,
+                TEST_PARAM_NAME_7, true);
         Assert.assertEquals(expectedResult, actualResult);
     }
 
@@ -102,10 +105,10 @@ public class PipeRunCmdBuilderTest {
 
         final PipeRunCmdBuilder pipeRunCmdBuilder = new PipeRunCmdBuilder(pipeRunCmdStartVO);
         final String actualResult = buildCmd(pipeRunCmdBuilder);
-        final String expectedResult = String.format("pipe run -n 1@%s parent-id 1 -p -y -id 10 " +
-                                                    "-it type -di image -cmd \"%s\" "
-                                                    + "-t 10 -q -ic 5 -s -pt spot -r 1 -pn 1",
-                                                    TEST_VERSION, CMD_TEMPLATE);
+        final String expectedResult = String.format(buildExpectedForWindows("pipe run",
+                "-n 1@%s", "-p", "-y", "-id 10", "-it type", "-di image", "-cmd \"%s\"",
+                "-t 10", "-q", "-ic 5", "-s", "-pt spot", "-r 1", "-pn 1", "parent-id 1"),
+                TEST_VERSION, CMD_TEMPLATE);
         Assert.assertEquals(expectedResult, actualResult);
     }
 
@@ -117,10 +120,9 @@ public class PipeRunCmdBuilderTest {
 
         final PipeRunCmdBuilder pipeRunCmdBuilder = new PipeRunCmdBuilder(pipeRunCmdStartVO);
         final String actualResult = buildCmd(pipeRunCmdBuilder);
-        final String expectedResult = String.format("pipe run -n 1@%s parent-id 1 -p -y -id 10 " +
-                                                    "-it type -di image -cmd \"do \\\"command\\\"\" "
-                                                    + "-t 10 -q -ic 5 -s -pt spot -r 1 -pn 1",
-                                                    TEST_VERSION);
+        final String expectedResult = String.format(buildExpectedForWindows("pipe run", "-n 1@%s",
+                "-p", "-y", "-id 10", "-it type", "-di image", "-cmd \"do \\\"command\\\"\"",
+                "-t 10", "-q", "-ic 5", "-s", "-pt spot", "-r 1", "-pn 1", "parent-id 1"), TEST_VERSION);
         Assert.assertEquals(expectedResult, actualResult);
     }
 
@@ -135,7 +137,8 @@ public class PipeRunCmdBuilderTest {
 
         final PipeRunCmdBuilder pipeRunCmdBuilder = new PipeRunCmdBuilder(pipeRunCmdStartVO);
         final String actualResult = buildCmd(pipeRunCmdBuilder);
-        Assert.assertEquals("pipe run -n 1 -pt spot", actualResult);
+        final String expected = buildExpectedForLinux("pipe run", "-n 1", "-pt spot");
+        Assert.assertEquals(expected, actualResult);
     }
 
     @Test
@@ -150,7 +153,8 @@ public class PipeRunCmdBuilderTest {
 
         final PipeRunCmdBuilder pipeRunCmdBuilder = new PipeRunCmdBuilder(pipeRunCmdStartVO);
         final String actualResult = buildCmd(pipeRunCmdBuilder);
-        Assert.assertEquals("pipe run -n 1 -pt on-demand -np", actualResult);
+        final String expected = buildExpectedForLinux("pipe run", "-n 1", "-pt on-demand", "-np");
+        Assert.assertEquals(expected, actualResult);
     }
 
     @Test
@@ -165,7 +169,8 @@ public class PipeRunCmdBuilderTest {
 
         final PipeRunCmdBuilder pipeRunCmdBuilder = new PipeRunCmdBuilder(pipeRunCmdStartVO);
         final String actualResult = buildCmd(pipeRunCmdBuilder);
-        Assert.assertEquals("pipe run -n 1 -pt spot", actualResult);
+        final String expected = buildExpectedForLinux("pipe run", "-n 1", "-pt spot");
+        Assert.assertEquals(expected, actualResult);
     }
 
 
@@ -173,7 +178,6 @@ public class PipeRunCmdBuilderTest {
         return pipeRunCmdBuilder
                 .name()
                 .config()
-                .runParameters()
                 .parameters()
                 .yes()
                 .instanceDisk()
@@ -188,6 +192,7 @@ public class PipeRunCmdBuilderTest {
                 .regionId()
                 .parentNode()
                 .nonPause()
+                .runParameters()
                 .build();
     }
 
@@ -213,5 +218,13 @@ public class PipeRunCmdBuilderTest {
         pipeRunCmdStartVO.setQuite(true);
         pipeRunCmdStartVO.setShowParams(true);
         return pipeRunCmdStartVO;
+    }
+
+    private String buildExpectedForLinux(final String... values) {
+        return String.join(" " + LINUX_NEW_LINE_INDICATOR + " ", values);
+    }
+
+    private String buildExpectedForWindows(final String... values) {
+        return String.join(" " + WINDOWS_NEW_LINE_INDICATOR  + " ", values);
     }
 }


### PR DESCRIPTION
This PR provides fix for issue #1126 
The issue was that some run parameters values were parsed incorrectly via pipe CLI. To fix it we should put all run parameters at the end of the command and specify `--` before them.
Also, this PR provide style fixes for launch cmd: each options group (option name and value) should be placed at the new line.