### PR TITLE
Normalize node disks creation time to run's one

### DIFF
--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -500,6 +500,7 @@ public final class MessageConstants {
 
     //Disks    
     public static final String ERROR_DISK_NODE_MISSING = "error.disk.node.missing";
+    public static final String ERROR_DISK_DATE_MISSING = "error.disk.date.missing";
     public static final String ERROR_DISK_SIZE_MISSING = "error.disk.size.missing";
     public static final String ERROR_DISK_SIZE_INVALID = "error.disk.size.invalid";
 

--- a/api/src/main/java/com/epam/pipeline/dao/cluster/NodeDiskDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/cluster/NodeDiskDao.java
@@ -22,17 +22,23 @@ public class NodeDiskDao extends NamedParameterJdbcDaoSupport {
 
     @Transactional
     public List<NodeDisk> insert(final String nodeId, final List<DiskRegistrationRequest> requests) {
-        final List<NodeDisk> disks = toDisks(nodeId, requests);
+        return insert(nodeId, DateUtils.nowUTC(), requests);
+    }
+
+    @Transactional
+    public List<NodeDisk> insert(final String nodeId, final LocalDateTime creationDate, 
+                                 final List<DiskRegistrationRequest> requests) {
+        final List<NodeDisk> disks = toDisks(nodeId, creationDate, requests);
         for (NodeDisk disk : disks) {
             getNamedParameterJdbcTemplate().update(insertNodeDiskQuery, getParameters(disk));
         }
         return disks;
     }
 
-    private List<NodeDisk> toDisks(final String nodeId, final List<DiskRegistrationRequest> requests) {
-        final LocalDateTime now = DateUtils.nowUTC();
+    private List<NodeDisk> toDisks(final String nodeId, final LocalDateTime creationDate,
+                                   final List<DiskRegistrationRequest> requests) {
         return requests.stream()
-                .map(disk -> new NodeDisk(disk.getSize(), nodeId, now))
+                .map(disk -> new NodeDisk(disk.getSize(), nodeId, creationDate))
                 .collect(Collectors.toList());
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/NodeDiskManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/NodeDiskManager.java
@@ -52,7 +52,7 @@ public class NodeDiskManager {
     }
 
     private void validateCreationDate(final LocalDateTime date) {
-        Assert.notNull(date, messageHelper.getMessage(MessageConstants.ERROR_DISK_NODE_MISSING));
+        Assert.notNull(date, messageHelper.getMessage(MessageConstants.ERROR_DISK_DATE_MISSING));
     }
 
     private void validateRequests(final List<DiskRegistrationRequest> requests) {

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/NodeDiskManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/NodeDiskManager.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
 import javax.transaction.Transactional;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 
@@ -27,19 +28,38 @@ public class NodeDiskManager {
 
     @Transactional
     public List<NodeDisk> register(final String nodeId, final List<DiskRegistrationRequest> requests) {
-        Assert.notNull(nodeId,
-                messageHelper.getMessage(MessageConstants.ERROR_DISK_NODE_MISSING));
-        for (final DiskRegistrationRequest request : requests) {
-            Assert.notNull(request.getSize(),
-                    messageHelper.getMessage(MessageConstants.ERROR_DISK_SIZE_MISSING));
-            Assert.isTrue(request.getSize() > 0,
-                    messageHelper.getMessage(MessageConstants.ERROR_DISK_SIZE_INVALID, request.getSize()));
-        }
+        validateNodeId(nodeId);
+        validateRequests(requests);
         return nodeDiskDao.insert(nodeId, requests);
     }
 
+    @Transactional
+    public List<NodeDisk> register(final String nodeId, final LocalDateTime creationDate,
+                                   final List<DiskRegistrationRequest> requests) {
+        validateNodeId(nodeId);
+        validateCreationDate(creationDate);
+        validateRequests(requests);
+        return nodeDiskDao.insert(nodeId, creationDate, requests);
+    }
+
     public List<NodeDisk> loadByNodeId(final String nodeId) {
-        Assert.notNull(nodeId, messageHelper.getMessage(MessageConstants.ERROR_DISK_NODE_MISSING));
+        validateNodeId(nodeId);
         return nodeDiskDao.loadByNodeId(nodeId);
+    }
+
+    private void validateNodeId(final String nodeId) {
+        Assert.notNull(nodeId, messageHelper.getMessage(MessageConstants.ERROR_DISK_NODE_MISSING));
+    }
+
+    private void validateCreationDate(final LocalDateTime date) {
+        Assert.notNull(date, messageHelper.getMessage(MessageConstants.ERROR_DISK_NODE_MISSING));
+    }
+
+    private void validateRequests(final List<DiskRegistrationRequest> requests) {
+        for (final DiskRegistrationRequest request : requests) {
+            Assert.notNull(request.getSize(), messageHelper.getMessage(MessageConstants.ERROR_DISK_SIZE_MISSING));
+            Assert.isTrue(request.getSize() > 0, messageHelper.getMessage(
+                    MessageConstants.ERROR_DISK_SIZE_INVALID, request.getSize()));
+        }
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -1169,14 +1169,13 @@ public class PipelineRunManager {
      * Adjusts run price per hour including provided node disks.
      * 
      * @param runId of {@link PipelineRun} to update price for.
-     * @param instance of {@link PipelineRun}.
      * @param disks of {@link PipelineRun} instance.
      * @return Updated pipeline run.
      */
     @Transactional(propagation = Propagation.REQUIRED)
-    public PipelineRun adjustRunPricePerHourToDisks(final Long runId, final RunInstance instance, 
-                                                    final List<InstanceDisk> disks) {
+    public PipelineRun adjustRunPricePerHourToDisks(final Long runId, final List<InstanceDisk> disks) {
         final PipelineRun run = loadPipelineRun(runId);
+        final RunInstance instance = run.getInstance();
         if (disks.isEmpty()) {
             LOGGER.warn("Run #{} price per hour won't be adjusted since no disks are provided.", runId);
             return run;

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -461,6 +461,7 @@ error.billing.invalid.paging='Paging parameters can't be negative!'
 
 #Disks
 error.disk.node.missing=Disk node id should be specified.
+error.disk.date.missing=Disk creation date should be specified.
 error.disk.size.missing=Disk size should be specified.
 error.disk.size.invalid=Disk size should be a positive integer. Actual value is ''{0}''.
 

--- a/api/src/test/java/com/epam/pipeline/dao/cluster/NodeDiskDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/cluster/NodeDiskDaoTest.java
@@ -57,6 +57,15 @@ public class NodeDiskDaoTest extends AbstractSpringTest {
         assertTrue(actualCreationDate.isAfter(lowerExpectedCreationDate)
                 && actualCreationDate.isBefore(upperExpectedCreationDate));
     }
+
+    @Test
+    public void insertShouldInheritCreationDateIfSpecified() {
+        final LocalDateTime creationDate = LocalDateTime.now();
+        final List<NodeDisk> disks = insert(NODE_ID, creationDate, diskRequestOf(SIZE), diskRequestOf(SIZE));
+        
+        assertThat(disks.size(), is(2));
+        disks.forEach(disk -> assertThat(disk.getCreatedDate(), is(creationDate)));
+    }
     
     @Test
     public void insertShouldSaveAllDisks() {
@@ -92,6 +101,11 @@ public class NodeDiskDaoTest extends AbstractSpringTest {
         final List<NodeDisk> disks = dao.loadByNodeId(ANOTHER_NODE_ID);
         
         assertThat(disks.size(), is(3));
+    }
+
+    private List<NodeDisk> insert(final String nodeId, final LocalDateTime creationDate, 
+                                  final DiskRegistrationRequest... requests) {
+        return dao.insert(nodeId, creationDate, Arrays.asList(requests));
     }
 
     private List<NodeDisk> insert(final String nodeId, final DiskRegistrationRequest... requests) {

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/NodeDiskManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/NodeDiskManagerTest.java
@@ -28,6 +28,8 @@ public class NodeDiskManagerTest {
     private static final Long ZERO_SIZE = 0L;
     private static final Long NEGATIVE_SIZE = -1L;
     private static final Long NULL_SIZE = null;
+    private static final LocalDateTime CREATION_DATE = LocalDateTime.now();
+    private static final LocalDateTime NULL_CREATION_DATE = null;
 
     private final NodeDiskDao nodeDiskDao = mock(NodeDiskDao.class);
     private final MessageHelper messageHelper = mock(MessageHelper.class);
@@ -36,6 +38,7 @@ public class NodeDiskManagerTest {
     @Before
     public void mockInsertingDisk() {
         doReturn(Collections.singletonList(disk())).when(nodeDiskDao).insert(any(), any());
+        doReturn(Collections.singletonList(disk())).when(nodeDiskDao).insert(any(), any(), any());
     }
 
     @Test
@@ -57,12 +60,24 @@ public class NodeDiskManagerTest {
     public void insertShouldFailOnMissingNodeId() {
         assertThrows(IllegalArgumentException.class, () -> register(NULL_NODE_ID, request(SIZE)));
     }
+    
+    @Test
+    public void insertShouldFailOnMissingCreationDateIfSpecified() {
+        assertThrows(IllegalArgumentException.class, () -> register(NULL_NODE_ID, NULL_CREATION_DATE, request(SIZE)));
+    }
 
     @Test
     public void insertShouldSaveDisk() {
         register(NODE_ID, request(SIZE));
         
         verify(nodeDiskDao).insert(eq(NODE_ID), eq(Collections.singletonList(request(SIZE))));
+    }
+
+    @Test
+    public void insertShouldSaveDiskIfCreationDateIsSpecified() {
+        register(NODE_ID, CREATION_DATE, request(SIZE));
+        
+        verify(nodeDiskDao).insert(eq(NODE_ID), eq(CREATION_DATE), eq(Collections.singletonList(request(SIZE))));
     }
 
     @Test
@@ -74,6 +89,11 @@ public class NodeDiskManagerTest {
 
     private NodeDisk register(final String nodeId, final DiskRegistrationRequest request) {
         return manager.register(nodeId, request);
+    }
+
+    private NodeDisk register(final String nodeId, final LocalDateTime creationDate, 
+                              final DiskRegistrationRequest request) {
+        return manager.register(nodeId, creationDate, Collections.singletonList(request)).get(0);
     }
 
     private NodeDisk disk() {


### PR DESCRIPTION
Relates to #1096.

The pull request unifies run and its node disks creation time. It helps to calculate more accurate costs during the billing reports creation and to divide initial and attached node disks.