### PR TITLE
Issue #1130: Command pipe set-acl doesn't work in pipe CLI for Windows

### DIFF
--- a/pipe-cli/mount/pipe-fuse.py
+++ b/pipe-cli/mount/pipe-fuse.py
@@ -17,7 +17,7 @@ import errno
 import logging
 import os
 import sys
-
+import future.utils
 
 is_frozen = getattr(sys, 'frozen', False)
 
@@ -51,7 +51,7 @@ from fuse import FUSE, fuse_operations, fuse_file_info
 from cachetools import TTLCache
 
 _allowed_logging_level_names = logging._levelNames
-_allowed_logging_levels = filter(lambda name: isinstance(name, str), _allowed_logging_level_names.keys())
+_allowed_logging_levels = future.utils.lfilter(lambda name: isinstance(name, str), _allowed_logging_level_names.keys())
 _allowed_logging_levels_string = ', '.join(_allowed_logging_levels)
 _default_logging_level = _allowed_logging_level_names[logging.ERROR]
 _debug_logging_level = _allowed_logging_level_names[logging.DEBUG]

--- a/pipe-cli/src/utilities/acl_operations.py
+++ b/pipe-cli/src/utilities/acl_operations.py
@@ -14,6 +14,7 @@
 import sys
 
 import click
+import future
 import requests
 import prettytable
 from future.utils import iteritems
@@ -38,11 +39,10 @@ class ACLOperations(object):
             entity = Entity.load_by_id_or_name(identifier, object_type)
             identifier = entity['id']
             all_permissions = User.permissions(identifier, entity['aclClass'])
-            user_permissions = filter(lambda permission:
-                                      permission.name.lower() == sid.lower() and permission.principal != group,
-                                      all_permissions)
+            user_permissions = future.utils.lfilter(
+                lambda permission: permission.name.lower() == sid.lower() and permission.principal != group,
+                all_permissions)
             user_mask = 0
-            # TODO 25.02.19: It fails using python 3 with the following error: "object of type 'filter' has no len()"
             if len(user_permissions) == 1:
                 user_mask = user_permissions[0].mask
 

--- a/pipe-cli/tests/test_utils/stdout_parsers.py
+++ b/pipe-cli/tests/test_utils/stdout_parsers.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 import sys
 from StringIO import StringIO
 from tests.test_utils.build_models import *
+import future.utils
 
 
 def parse_view_pipe_stdout(stdout):
@@ -32,7 +33,7 @@ def parse_view_pipe_stdout(stdout):
                 line = skip_header(it)
                 versions = []
                 while not line.startswith("+"):
-                    splitted_line = filter(None, line.split("|"))
+                    splitted_line = future.utils.lfilter(None, line.split("|"))
                     version_model = build_version(clean_up_line(splitted_line[0]), clean_up_line(splitted_line[1]),
                                                   draft=clean_up_line(splitted_line[2]))
                     versions.append(version_model)
@@ -43,7 +44,7 @@ def parse_view_pipe_stdout(stdout):
                 line = skip_header(it)
                 run_parameters = []
                 while not line.startswith("+"):
-                    splitted_line = filter(None, line.split("|"))
+                    splitted_line = future.utils.lfilter(None, line.split("|"))
                     parameter_model = build_run_parameter(name=clean_up_line(splitted_line[0]),
                                                           value=clean_up_line(splitted_line[3]),
                                                           parameter_type=clean_up_line(splitted_line[1]),
@@ -57,7 +58,7 @@ def parse_view_pipe_stdout(stdout):
                 line = skip_header(it)
                 storage_rules = []
                 while not line.startswith("+"):
-                    splitted_line = filter(None, line.split("|"))
+                    splitted_line = future.utils.lfilter(None, line.split("|"))
                     storage_rule_model = build_storage_rule(pipeline_id, clean_up_line(splitted_line[1]),
                                                             clean_up_line(splitted_line[0]),
                                                             move_to_sts=clean_up_line(splitted_line[2]))
@@ -68,7 +69,7 @@ def parse_view_pipe_stdout(stdout):
             if line.startswith("Permissions"):
                 line = skip_header(it)
                 while not line.startswith("+"):
-                    splitted_line = filter(None, line.split("|"))
+                    splitted_line = future.utils.lfilter(None, line.split("|"))
                     model = ObjectPermissionModel()
                     model.name = clean_up_line(splitted_line[0])
                     model.principal = clean_up_line(splitted_line[1])
@@ -77,35 +78,35 @@ def parse_view_pipe_stdout(stdout):
                     line = it.next()
                 continue
             if line.startswith("ID"):
-                splitted_line = filter(None, line.split(":"))
+                splitted_line = future.utils.lfilter(None, line.split(":"))
                 if len(splitted_line) > 1:
                     pipeline_id = clean_up_line(splitted_line[1])
                     pipeline_model.identifier = pipeline_id
                 continue
             if line.startswith("Name"):
-                splitted_line = filter(None, line.split(":"))
+                splitted_line = future.utils.lfilter(None, line.split(":"))
                 if len(splitted_line) > 1:
                     pipeline_model.name = clean_up_line(splitted_line[1])
                 continue
             if line.startswith("Latest version"):
-                splitted_line = filter(None, line.split(":"))
+                splitted_line = future.utils.lfilter(None, line.split(":"))
                 if len(splitted_line) > 1:
                     version_name = clean_up_line(splitted_line[1])
                     pipeline_model.current_version_name = version_name
                 continue
             if line.startswith("Created"):
-                splitted_line = filter(None, line.split(":"))
+                splitted_line = future.utils.lfilter(None, line.split(":"))
                 if len(splitted_line) > 1:
                     created_date = clean_up_line(splitted_line[1])
                     pipeline_model.created_date = created_date
                 continue
             if line.startswith("Source repo"):
-                splitted_line = filter(None, line.split(":"))
+                splitted_line = future.utils.lfilter(None, line.split(":"))
                 if len(splitted_line) > 1:
                     pipeline_model.repository = clean_up_line(splitted_line[1])
                 continue
             if line.startswith("Description"):
-                splitted_line = filter(None, line.split(":"))
+                splitted_line = future.utils.lfilter(None, line.split(":"))
                 if len(splitted_line) > 1:
                     pipeline_model.description = clean_up_line(splitted_line[1])
                 continue
@@ -140,7 +141,7 @@ def view_pipes_stdout(stdout):
         try:
             line = skip_header(it)
             while not line.startswith("+"):
-                splitted_line = filter(None, line.split("|"))
+                splitted_line = future.utils.lfilter(None, line.split("|"))
                 pipeline_model = build_pipeline_model(identifier=clean_up_line(splitted_line[0]),
                                                       name=clean_up_line(splitted_line[1]),
                                                       current_version_name=clean_up_line(splitted_line[2]),
@@ -161,52 +162,52 @@ def parse_view_run_stdout(stdout):
         try:
             line = it.next()
             if line.startswith("ID"):
-                splitted_line = filter(None, line.split(":"))
+                splitted_line = future.utils.lfilter(None, line.split(":"))
                 if len(splitted_line) > 1:
                     pipeline_id = clean_up_line(splitted_line[1])
                     pipeline_model.identifier = pipeline_id
                 continue
             if line.startswith("Pipeline"):
-                splitted_line = filter(None, line.split(":"))
+                splitted_line = future.utils.lfilter(None, line.split(":"))
                 if len(splitted_line) > 1:
                     pipeline_model.pipeline = clean_up_line(splitted_line[1])
                 continue
             if line.startswith("Version"):
-                splitted_line = filter(None, line.split(":"))
+                splitted_line = future.utils.lfilter(None, line.split(":"))
                 if len(splitted_line) > 1:
                     version_name = clean_up_line(splitted_line[1])
                     pipeline_model.version = version_name
                 continue
             if line.startswith("Scheduled"):
-                splitted_line = filter(None, line.split(" "))
+                splitted_line = future.utils.lfilter(None, line.split(" "))
                 if len(splitted_line) > 1:
                     pipeline_model.scheduled_date = "{} {}".format(clean_up_line(splitted_line[1]),
                                                                    clean_up_line(splitted_line[2]))
                 continue
             if line.startswith("Started"):
-                splitted_line = filter(None, line.split(" "))
+                splitted_line = future.utils.lfilter(None, line.split(" "))
                 if len(splitted_line) > 1:
                     pipeline_model.start_date = "{} {}".format(clean_up_line(splitted_line[1]),
                                                                clean_up_line(splitted_line[2]))
                 continue
             if line.startswith("Completed"):
-                splitted_line = filter(None, line.split(":"))
+                splitted_line = future.utils.lfilter(None, line.split(":"))
                 if len(splitted_line) > 1:
                     pipeline_model.end_date = "{} {}".format(clean_up_line(splitted_line[1]),
                                                              clean_up_line(splitted_line[2]))
                 continue
             if line.startswith("ParentID"):
-                splitted_line = filter(None, line.split(":"))
+                splitted_line = future.utils.lfilter(None, line.split(":"))
                 if len(splitted_line) > 1:
                     pipeline_model.repository = clean_up_line(splitted_line[1])
                 continue
             if line.startswith("Estimated price"):
-                splitted_line = filter(None, line.split(":"))
+                splitted_line = future.utils.lfilter(None, line.split(":"))
                 if len(splitted_line) > 1:
                     pipeline_model.description = clean_up_line(splitted_line[1]).strip("$")
                 continue
             if line.startswith("Status"):
-                splitted_line = filter(None, line.split(":"))
+                splitted_line = future.utils.lfilter(None, line.split(":"))
                 if len(splitted_line) > 1:
                     pipeline_model.status = clean_up_line(splitted_line[1])
                 continue
@@ -215,7 +216,7 @@ def parse_view_run_stdout(stdout):
                 it.next()
                 line = it.next()
                 while line != "":
-                    splitted_line = filter(None, line.split(" "))
+                    splitted_line = future.utils.lfilter(None, line.split(" "))
                     details.update({clean_up_line(splitted_line[0]): clean_up_line(splitted_line[1])})
                     line = it.next()
                 pipeline_model.instance = details.items()
@@ -225,7 +226,7 @@ def parse_view_run_stdout(stdout):
                 it.next()
                 line = it.next()
                 while line != "":
-                    splitted_line = filter(None, line.split("="))
+                    splitted_line = future.utils.lfilter(None, line.split("="))
                     parameter_model = build_run_parameter(name=clean_up_line(splitted_line[0]),
                                                           value=clean_up_line(splitted_line[1]))
                     parameters.append(parameter_model)
@@ -236,7 +237,7 @@ def parse_view_run_stdout(stdout):
                 line = skip_header(it)
                 tasks = []
                 while not line.startswith("+"):
-                    splitted_line = filter(None, line.split("|"))
+                    splitted_line = future.utils.lfilter(None, line.split("|"))
                     task = build_task_model(created=clean_up_line(splitted_line[2]),
                                             started=clean_up_line(splitted_line[3]),
                                             finished=clean_up_line(splitted_line[4]),
@@ -280,7 +281,7 @@ def parse_view_runs(stdout):
             it.next()  # results count info
             line = skip_header(it)
             while not line.startswith("+"):
-                splitted_line = filter(None, line.split("|"))
+                splitted_line = future.utils.lfilter(None, line.split("|"))
                 run = build_run_model(identifier=clean_up_line(splitted_line[0]),
                                       parent_id=clean_up_line(splitted_line[1]),
                                       pipeline=clean_up_line(splitted_line[2]),
@@ -311,7 +312,7 @@ def parse_view_cluster(stdout):
         try:
             line = skip_header(it)
             while not line.startswith("+"):
-                splitted_line = filter(None, line.split("|"))
+                splitted_line = future.utils.lfilter(None, line.split("|"))
                 addresses = []
                 name = None
                 pipeline = None
@@ -344,19 +345,19 @@ def parse_view_cluster_for_node(stdout):
         try:
             line = it.next()
             if line.startswith("Name"):
-                splitted_line = filter(None, line.split(":"))
+                splitted_line = future.utils.lfilter(None, line.split(":"))
                 if len(splitted_line) > 1:
                     name = clean_up_line(splitted_line[1])
                     cluster_model.name = name
                 continue
             if line.startswith("Pipeline"):
-                splitted_line = filter(None, line.split(":"))
+                splitted_line = future.utils.lfilter(None, line.split(":"))
                 if len(splitted_line) > 1:
                     cluster_model.run = build_run_model(pipeline=clean_up_line(splitted_line[1]))
                 continue
             if line.startswith("Addresses"):
                 addresses = []
-                splitted_line = filter(None, line.split(":"))
+                splitted_line = future.utils.lfilter(None, line.split(":"))
                 if len(splitted_line) > 1:
                     addresses_string = clean_up_line(splitted_line[1])
                     splitted_add = addresses_string.split(";")
@@ -365,7 +366,7 @@ def parse_view_cluster_for_node(stdout):
                     cluster_model.addresses = addresses
                 continue
             if line.startswith("Created"):
-                splitted_line = filter(None, line.split(" "))
+                splitted_line = future.utils.lfilter(None, line.split(" "))
                 if len(splitted_line) > 1:
                     cluster_model.created = "{} {}".format(clean_up_line(splitted_line[1]),
                                                            clean_up_line(splitted_line[2]))
@@ -375,7 +376,7 @@ def parse_view_cluster_for_node(stdout):
                 it.next()
                 line = it.next()
                 while line != "":
-                    splitted_line = filter(None, line.split(" "))
+                    splitted_line = future.utils.lfilter(None, line.split(" "))
                     system_info.update({clean_up_line(splitted_line[0]): clean_up_line(splitted_line[1])})
                     line = it.next()
                 cluster_model.system_info = system_info
@@ -385,7 +386,7 @@ def parse_view_cluster_for_node(stdout):
                 it.next()
                 line = it.next()
                 while line != "":
-                    splitted_line = filter(None, line.split(" "))
+                    splitted_line = future.utils.lfilter(None, line.split(" "))
                     labels.update({clean_up_line(splitted_line[0]): clean_up_line(splitted_line[1])})
                     line = it.next()
                 cluster_model.labels = labels
@@ -394,7 +395,7 @@ def parse_view_cluster_for_node(stdout):
                 line = skip_header(it)
                 pods = []
                 while not line.startswith("+"):
-                    splitted_line = filter(None, line.split("|"))
+                    splitted_line = future.utils.lfilter(None, line.split("|"))
                     pod = build_pod_model(name=clean_up_line(splitted_line[0]),
                                           namespace=clean_up_line(splitted_line[1]),
                                           phase=clean_up_line(splitted_line[2]))
@@ -424,25 +425,25 @@ def parse_run_stdout(stdout):
         try:
             line = it.next()
             if line.startswith("Price per hour"):
-                splitted_line = filter(None, line.split(" "))
+                splitted_line = future.utils.lfilter(None, line.split(" "))
                 model.price.instance_type = clean_up_line(splitted_line[3].strip("(,"))
                 model.price.instance_disk = int(splitted_line[5].strip(")"))
                 model.price.price_per_hour = float(clean_up_line(splitted_line[6]))
                 continue
             if line.startswith("Minimum price"):
-                splitted_line = filter(None, line.split(" "))
+                splitted_line = future.utils.lfilter(None, line.split(" "))
                 model.price.minimum_time_price = float(clean_up_line(splitted_line[2]))
                 continue
             if line.startswith("Average price"):
-                splitted_line = filter(None, line.split(" "))
+                splitted_line = future.utils.lfilter(None, line.split(" "))
                 model.price.average_time_price = float(clean_up_line(splitted_line[2]))
                 continue
             if line.startswith("Maximum price"):
-                splitted_line = filter(None, line.split(" "))
+                splitted_line = future.utils.lfilter(None, line.split(" "))
                 model.price.maximum_time_price = float(clean_up_line(splitted_line[2]))
                 continue
             if line.startswith('"'):
-                splitted_line = filter(None, line.split(" "))
+                splitted_line = future.utils.lfilter(None, line.split(" "))
                 pipeline = splitted_line[0].strip('"').split('@')
                 model.pipeline_name = pipeline[0]
                 model.version = pipeline[1]
@@ -463,16 +464,16 @@ def parse_parameters_info_stdout(stdout):
             line = it.next()
             if line.startswith("--"):
                 parameter = PipelineRunParameterModel(None, None, None, False)
-                splitted_line = filter(None, line.split(" "))
+                splitted_line = future.utils.lfilter(None, line.split(" "))
                 parameter.name = splitted_line[0].strip("-")
                 parameter.parameter_type = splitted_line[1].strip(")").strip("(")
                 line = it.next()
-                splitted_line = filter(None, line.split(" "))
+                splitted_line = future.utils.lfilter(None, line.split(" "))
                 parameter.value = splitted_line[1]
                 model.parameters.append(parameter)
                 continue
             if line.startswith('"'):
-                splitted_line = filter(None, line.split(" "))
+                splitted_line = future.utils.lfilter(None, line.split(" "))
                 pipeline = splitted_line[0].strip('"').split('@')
                 model.pipeline_name = pipeline[0]
                 model.version = pipeline[1]
@@ -483,7 +484,7 @@ def parse_parameters_info_stdout(stdout):
 
 
 def check_last_line(line):
-    splitted_line = filter(None, line.split("|"))
+    splitted_line = future.utils.lfilter(None, line.split("|"))
     if len(splitted_line) > 4 and splitted_line[3].strip() != "":
         return [splitted_line[3]]
 


### PR DESCRIPTION
This PR provides fix for issue #1130 
The issue was that function `filter` returns `list` object with python2 and `iterator` object with python3.
The idea is to use `future.utils.lfilter` to provide backwards compatibility (this function returns `list` for both cases).

Also, this PR provides the similar changes for `pipe_fuse` script and tests.