### PR TITLE
`pipe run` command shall support input of "friendly" URL for a run

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -647,6 +647,7 @@ def view_cluster_for_node(node_name):
 @click.option('-pn', '--parent-node', help='Parent instance Run ID. That allows to run a pipeline as a child job on the existing running instance', type=int, required=False)
 @click.option('-np', '--non-pause', help='Allow to switch off auto-pause option. Supported for on-demand runs only',
               is_flag=True)
+@click.option('-fu', '--friendly-url', help='A friendly URL', type=str, required=False)
 @click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token(quiet_flag_property_name='quiet')
 def run(pipeline,
@@ -666,12 +667,13 @@ def run(pipeline,
         price_type,
         region_id,
         parent_node,
-        non_pause):
+        non_pause,
+        friendly_url):
     """Schedules a pipeline execution
     """
     PipelineRunOperations.run(pipeline, config, parameters, yes, run_params, instance_disk, instance_type,
                               docker_image, cmd_template, timeout, quiet, instance_count, cores, sync, price_type,
-                              region_id, parent_node, non_pause)
+                              region_id, parent_node, non_pause, friendly_url)
 
 
 @cli.command(name='stop')

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -647,7 +647,8 @@ def view_cluster_for_node(node_name):
 @click.option('-pn', '--parent-node', help='Parent instance Run ID. That allows to run a pipeline as a child job on the existing running instance', type=int, required=False)
 @click.option('-np', '--non-pause', help='Allow to switch off auto-pause option. Supported for on-demand runs only',
               is_flag=True)
-@click.option('-fu', '--friendly-url', help='A friendly URL', type=str, required=False)
+@click.option('-fu', '--friendly-url', help='A friendly URL. The URL should have the following formats: '
+                                            '<domain>/<path> or <path>', type=str, required=False)
 @click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token(quiet_flag_property_name='quiet')
 def run(pipeline,

--- a/pipe-cli/src/api/pipeline.py
+++ b/pipe-cli/src/api/pipeline.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -104,7 +104,7 @@ class Pipeline(API):
                         instance_disk=None, instance_type=None,
                         docker_image=None, cmd_template=None,
                         timeout=None, config_name=None, instance_count=None,
-                        price_type=None, region_id=None, parent_node=None, non_pause=None):
+                        price_type=None, region_id=None, parent_node=None, non_pause=None, friendly_url=None):
         api = cls.instance()
         params = {}
         for parameter in parameters:
@@ -134,6 +134,8 @@ class Pipeline(API):
             cls.__add_parent_node_params(payload, parent_node)
         if non_pause is not None:
             payload['nonPause'] = non_pause
+        if friendly_url:
+            payload['prettyUrl'] = friendly_url
         data = json.dumps(payload)
         response_data = api.call('run', data)
         return PipelineRunModel.load(response_data['payload'])
@@ -142,7 +144,7 @@ class Pipeline(API):
     def launch_command(cls, instance_disk, instance_type,
                        docker_image, cmd_template, parameters,
                        timeout=None, instance_count=None, price_type=None,
-                       region_id=None, parent_node=None, non_pause=None):
+                       region_id=None, parent_node=None, non_pause=None, friendly_url=None):
         api = cls.instance()
         payload = {}
         if instance_disk is not None:
@@ -165,6 +167,8 @@ class Pipeline(API):
             cls.__add_parent_node_params(payload, parent_node)
         if non_pause is not None:
             payload['nonPause'] = non_pause
+        if friendly_url:
+            payload['prettyUrl'] = friendly_url
         if parameters is not None:
             params = {}
             for key in parameters.keys():
@@ -211,4 +215,3 @@ class Pipeline(API):
                 params['instanceType'] = ins_param[1]
         params['parentRunId'] = parent_node
         params['parentNodeId'] = parent_node
-

--- a/pipe-cli/src/utilities/pipeline_run_operations.py
+++ b/pipe-cli/src/utilities/pipeline_run_operations.py
@@ -364,7 +364,7 @@ class PipelineRunOperations(object):
         path = str(pretty_url).strip('/')
         parts = path.split('/')
         if len(parts) > 2:
-            click.echo("Pretty URL has an incorrect format. Expected format: <domain>/<path>.", err=True)
+            click.echo("Pretty URL has an incorrect format. Expected formats: <domain>/<path> or <path>.", err=True)
             exit(1)
         if len(parts) == 1:
             return '{"path":"%s"}' % parts[0]

--- a/pipe-cli/src/utilities/pipeline_run_operations.py
+++ b/pipe-cli/src/utilities/pipeline_run_operations.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ class PipelineRunOperations(object):
     @classmethod
     def run(cls, pipeline, config, parameters, yes, run_params, instance_disk, instance_type, docker_image,
             cmd_template, timeout, quiet, instance_count, cores, sync, price_type=None, region_id=None,
-            parent_node=None, non_pause=None):
+            parent_node=None, non_pause=None, friendly_url=None):
         # All pipeline run parameters can be specified as options, e.g. --read1 /path/to/reads.fastq
         # In this case - runs_params_dict will contain keys-values for each option, e.g. {'--read1': '/path/to/reads.fastq'}
         # So they can be addressed with run_params_dict['--read1']
@@ -88,6 +88,9 @@ class PipelineRunOperations(object):
             else:
                 instance_count = None
             instance_type = nodes_spec["name"]
+
+        if friendly_url:
+            friendly_url = cls._build_pretty_url(friendly_url)
 
         try:
             if not pipeline and docker_image and cls.required_args_missing(parent_node, instance_type, instance_disk,
@@ -190,7 +193,8 @@ class PipelineRunOperations(object):
                                                                       price_type=price_type,
                                                                       region_id=region_id,
                                                                       parent_node=parent_node,
-                                                                      non_pause=non_pause)
+                                                                      non_pause=non_pause,
+                                                                      friendly_url=friendly_url)
                         pipeline_run_id = pipeline_run_model.identifier
                         if not quiet:
                             click.echo('"{}@{}" pipeline run scheduled with RunId: {}'
@@ -242,7 +246,8 @@ class PipelineRunOperations(object):
                                                              price_type=price_type,
                                                              region_id=region_id,
                                                              parent_node=parent_node,
-                                                             non_pause=non_pause)
+                                                             non_pause=non_pause,
+                                                             friendly_url=friendly_url)
                 pipeline_run_id = pipeline_run_model.identifier
                 if not quiet:
                     click.echo('Pipeline run scheduled with RunId: {}'.format(pipeline_run_id))
@@ -353,3 +358,15 @@ class PipelineRunOperations(object):
     @staticmethod
     def required_args_missing(parent_node, instance_type, instance_disk, cmd_template):
         return parent_node is None and (instance_type is None or instance_disk is None or cmd_template is None)
+
+    @classmethod
+    def _build_pretty_url(cls, pretty_url):
+        path = str(pretty_url).strip('/')
+        parts = path.split('/')
+        if len(parts) > 2:
+            click.echo("Pretty URL has an incorrect format. Expected format: <domain>/<path>.", err=True)
+            exit(1)
+        if len(parts) == 1:
+            return '{"path":"%s"}' % parts[0]
+        return '{"domain":"%s","path":"%s"}' % (parts[0], parts[1])
+


### PR DESCRIPTION
This PR provides implementation for an issue #1153 

A new option `-fu (--friendly-url)` was added to the `pipe run` command. That option supports the following types of the input of "friendly" URL:
-  < "friendly" URL >
-  < custom host > / < "friendly" URL >