### PR TITLE
issue #1146 Increase Security logs readability

### DIFF
--- a/api/src/main/java/com/epam/pipeline/controller/MultiReadableHttpServletRequestWrapper.java
+++ b/api/src/main/java/com/epam/pipeline/controller/MultiReadableHttpServletRequestWrapper.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.controller;
+
+import org.apache.commons.io.IOUtils;
+
+import javax.servlet.ReadListener;
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class MultiReadableHttpServletRequestWrapper extends HttpServletRequestWrapper {
+
+    private byte[] body;
+
+    public MultiReadableHttpServletRequestWrapper(HttpServletRequest request) {
+        super(request);
+        try {
+            body = IOUtils.toByteArray(request.getInputStream());
+        } catch (IOException ex) {
+            body = new byte[0];
+        }
+    }
+
+    @Override
+    public ServletInputStream getInputStream() throws IOException {
+
+        return new DelegatingServletInputStream(new ByteArrayInputStream(body));
+
+
+    }
+    
+    public static class DelegatingServletInputStream extends ServletInputStream {
+    
+        private final InputStream sourceStream;
+        private boolean finished = false;
+    
+    
+        /**
+         * Create a DelegatingServletInputStream for the given source stream.
+         *
+         * @param sourceStream the source stream (never {@code null})
+         */
+        public DelegatingServletInputStream(InputStream sourceStream) {
+            this.sourceStream = sourceStream;
+        }
+    
+        /**
+         * Return the underlying source stream (never {@code null}).
+         */
+        public final InputStream getSourceStream() {
+            return this.sourceStream;
+        }
+    
+    
+        @Override
+        public int read() throws IOException {
+            int data = this.sourceStream.read();
+            if (data == -1) {
+                this.finished = true;
+            }
+            return data;
+        }
+    
+        @Override
+        public int available() throws IOException {
+            return this.sourceStream.available();
+        }
+    
+        @Override
+        public void close() throws IOException {
+            super.close();
+            this.sourceStream.close();
+        }
+    
+        @Override
+        public boolean isFinished() {
+            return this.finished;
+        }
+    
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+    
+        @Override
+        public void setReadListener(ReadListener readListener) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}
+

--- a/api/src/main/java/com/epam/pipeline/security/RequestDetails.java
+++ b/api/src/main/java/com/epam/pipeline/security/RequestDetails.java
@@ -26,12 +26,10 @@ import org.springframework.util.StringUtils;
 public class RequestDetails {
 
     private static final String H_CONTENT_TYPE_APPLICATION_JSON = "-H 'Content-Type: application/json'";
-    private static final String H_AUTHORIZATION = "-H 'Authorization: %s'";
     private static final String QUOTE = "'";
     private static final String PARAMS_MARK = "?";
     private static final String DATA = "--data";
 
-    private final String authorization;
     private final String httpMethod;
     private final StringBuffer path;
     private final String query;
@@ -41,9 +39,8 @@ public class RequestDetails {
     @Override
     public String toString() {
         StringBuilder curl = new StringBuilder(
-                String.format("curl -k %s %s -X%s '%s",
+                String.format("curl -k %s -X%s '%s",
                         H_CONTENT_TYPE_APPLICATION_JSON,
-                        String.format(H_AUTHORIZATION, authorization),
                         httpMethod,
                         path
                 )

--- a/api/src/main/java/com/epam/pipeline/security/RequestDetails.java
+++ b/api/src/main/java/com/epam/pipeline/security/RequestDetails.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.security;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.SneakyThrows;
+import org.springframework.util.StringUtils;
+
+@Builder
+@Data
+public class RequestDetails {
+
+    private static final String H_CONTENT_TYPE_APPLICATION_JSON = "-H 'Content-Type: application/json'";
+    private static final String H_AUTHORIZATION = "-H 'Authorization: %s'";
+    private static final String QUOTE = "'";
+    private static final String PARAMS_MARK = "?";
+    private static final String DATA = "--data";
+
+    private final String authorization;
+    private final String httpMethod;
+    private final StringBuffer path;
+    private final String query;
+    private final String body;
+
+    @SneakyThrows
+    @Override
+    public String toString() {
+        StringBuilder curl = new StringBuilder(
+                String.format("curl -k %s %s -X%s '%s",
+                        H_CONTENT_TYPE_APPLICATION_JSON,
+                        String.format(H_AUTHORIZATION, authorization),
+                        httpMethod,
+                        path
+                )
+        );
+        if (!StringUtils.isEmpty(query)) {
+            curl.append(PARAMS_MARK).append(query).append(QUOTE);
+        } else {
+            curl.append(QUOTE);
+        }
+
+        if (!StringUtils.isEmpty(body)) {
+            curl.append(" " + DATA + " " + QUOTE).append(body).append(QUOTE);
+        }
+
+        return curl.toString();
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/security/SecurityLogAspect.java
+++ b/api/src/main/java/com/epam/pipeline/security/SecurityLogAspect.java
@@ -19,7 +19,6 @@ package com.epam.pipeline.security;
 import com.auth0.jwt.JWT;
 import com.epam.pipeline.security.saml.SAMLProxyAuthentication;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.ThreadContext;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.After;
@@ -57,8 +56,8 @@ public class SecurityLogAspect {
     public static final String ANONYMOUS = "Anonymous";
     public static final String KEY_USER = "user";
     public static final String AUTH_TYPE = "auth_type";
-    public static final String JWT = "JWT";
-    public static final String SAML = "SAML";
+    public static final String JWT_AUTH_TYPE = "JWT";
+    public static final String SAML_AUTH_TYPE = "SAML";
     public static final String POST = "POST";
 
 
@@ -79,7 +78,7 @@ public class SecurityLogAspect {
             SAMLProxyAuthentication auth = (SAMLProxyAuthentication) authentication;
             ThreadContext.put(KEY_USER, auth.getName() != null ? auth.getName() : ANONYMOUS);
         }
-        ThreadContext.put(AUTH_TYPE, SAML);
+        ThreadContext.put(AUTH_TYPE, SAML_AUTH_TYPE);
     }
 
     @Before(value = "execution(* com.epam.pipeline.security.saml.SAMLUserDetailsServiceImpl.loadUserBySAML(..))" +
@@ -88,13 +87,13 @@ public class SecurityLogAspect {
         if (credential != null) {
             ThreadContext.put(KEY_USER, credential.getNameID().getValue().toUpperCase());
         }
-        ThreadContext.put(AUTH_TYPE, SAML);
+        ThreadContext.put(AUTH_TYPE, SAML_AUTH_TYPE);
     }
 
     @Before(value = "execution(* com.epam.pipeline.security.jwt.JwtTokenVerifier.readClaims(..)) && args(token,..)")
     public void addUserInfoWhileAuthByJWT(JoinPoint joinPoint, String token) {
-        JWT decode = com.auth0.jwt.JWT.decode(token);
-        ThreadContext.put(AUTH_TYPE, JWT);
+        JWT decode = JWT.decode(token);
+        ThreadContext.put(AUTH_TYPE, JWT_AUTH_TYPE);
         ThreadContext.put(KEY_USER, decode.getSubject() != null ? decode.getSubject() : ANONYMOUS);
     }
 

--- a/api/src/main/java/com/epam/pipeline/security/jwt/JwtFilterAuthenticationFilter.java
+++ b/api/src/main/java/com/epam/pipeline/security/jwt/JwtFilterAuthenticationFilter.java
@@ -57,7 +57,7 @@ public class JwtFilterAuthenticationFilter extends OncePerRequestFilter {
             FilterChain filterChain) throws ServletException, IOException {
         request = new MultiReadableHttpServletRequestWrapper(request);
         final JwtRawToken rawToken = fetchJwtRawToken(request);
-        putRequestDataToLogContext(request, rawToken);
+        putRequestDataToLogContext(request);
         try {
             if (!StringUtils.isEmpty(rawToken)) {
                 JwtTokenClaims claims = tokenVerifier.readClaims(rawToken.getToken());
@@ -113,19 +113,18 @@ public class JwtFilterAuthenticationFilter extends OncePerRequestFilter {
         ThreadContext.clearAll();
     }
 
-    private void putRequestDataToLogContext(HttpServletRequest request, JwtRawToken rawToken) {
+    private void putRequestDataToLogContext(HttpServletRequest request) {
         try {
-            ThreadContext.put(REQUEST_DETAILS, getRequestDetails(request, rawToken).toString());
+            ThreadContext.put(REQUEST_DETAILS, getRequestDetails(request).toString());
         } catch (IOException e) {
             throw new IllegalStateException(e);
         }
     }
 
-    private RequestDetails getRequestDetails(HttpServletRequest request, JwtRawToken rawToken) throws IOException {
+    private RequestDetails getRequestDetails(HttpServletRequest request) throws IOException {
         final RequestDetails.RequestDetailsBuilder builder = RequestDetails.builder();
         final String httpMethod = request.getMethod();
         builder.path(request.getRequestURL())
-                .authorization(rawToken.toHeader())
                 .httpMethod(httpMethod)
                 .query(request.getQueryString())
                 .body(readBody(request));

--- a/api/src/main/resources/log4j2-spring.xml
+++ b/api/src/main/resources/log4j2-spring.xml
@@ -63,6 +63,8 @@
             </Policies>
             <JsonLayout complete="false" compact="true" eventEol="true" stacktraceAsString="true">
                 <KeyValuePair key="user" value="$${ctx:user:-NotAuthorized}" />
+                <KeyValuePair key="auth_type" value="$${ctx:auth_type:-}" />
+                <KeyValuePair key="request_details" value="$${ctx:request_details:-}" />
                 <KeyValuePair key="log_context" value="Security" />
                 <KeyValuePair key="timestamp" value="$${date:yyyy-MM-dd'T'HH:mm:ss.SSSZ}" />
             </JsonLayout>

--- a/deploy/docker/cp-search-elk/init.sh
+++ b/deploy/docker/cp-search-elk/init.sh
@@ -142,6 +142,22 @@ INDEX_TEMPLATE="{
             }
           }
         },
+        \"auth_type\": {
+          \"type\": \"text\",
+          \"fields\": {
+            \"keyword\": {
+              \"type\": \"keyword\"
+            }
+          }
+        },
+        \"request_details\": {
+          \"type\": \"text\",
+          \"fields\": {
+            \"keyword\": {
+              \"type\": \"keyword\"
+            }
+          }
+        },
         \"thread\": {
           \"type\": \"text\",
           \"fields\": {


### PR DESCRIPTION
This PR adds new fields for Security Logs:
 - `auth_type` (JWT, SAML) 
 - `request_details` field for all JWT requests

`request_details` field stored in `curl` command format. f.e:
```
curl -k -H 'Content-Type: application/json' -H 'Authorization: Bearer <token>' -XPOST 'https://localhost:9999/pipeline/restapi/run/filter' --data '{"statuses": ["RUNNING"], "page": 1, "pageSize": 100}'
```