### PR TITLE
Issue #1166 NVIDIA container runtime installation

### DIFF
--- a/workflows/pipe-common/shell/dind_setup
+++ b/workflows/pipe-common/shell/dind_setup
@@ -84,27 +84,51 @@ nvidia-smi
 REQUIRES_GPU_DIND=$?
 if [ $REQUIRES_GPU_DIND -eq 0 ]; then
     pipe_log_info "Active CUDA environment detected, try to install NVIDIA Docker" "$DIND_SETUP_TASK"
+    export NVIDIA_CONTAINER_RUNTIME_VERSION_RPM="2.0.0-3.docker18.09.6"
+    export NVIDIA_CONTAINER_RUNTIME_VERSION_DEB="2.0.0+docker18.09.6-3"
     distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
+    mkdir nvidia-container-runtime
     if [ $IS_RPM_BASED -eq 0 ]; then
-        curl -s -L https://nvidia.github.io/nvidia-container-runtime/$distribution/nvidia-container-runtime.repo | \
-        tee /etc/yum.repos.d/nvidia-container-runtime.repo
-        yum install -y -q nvidia-container-runtime-2.0.0-3.docker18.09.6*
-        _DIND_NVIDIA_DEP_INSTALL_RESULT=$?
-        find /etc/yum.repos.d -type f \( -name "*nvidia*" -o -name "*docker*" \)  -exec rm -f {} \;
+      ncr_version=$NVIDIA_CONTAINER_RUNTIME_VERSION_RPM
     else
-        os=$(. /etc/os-release;echo $ID)
-        os_release=$(. /etc/os-release;echo $VERSION_CODENAME)
-        sources_list=/etc/apt/sources.list
-        curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | apt-key add -
-        curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list \
-        | tee /etc/apt/sources.list.d/nvidia-docker.list
-        apt-get update -yq && \
-        apt-get install -yq nvidia-container-runtime=2.0.0+docker18.09.6-3
-        _DIND_NVIDIA_DEP_INSTALL_RESULT=$?
-        rm /etc/apt/sources.list.d/nvidia-docker.list
+      ncr_version=$NVIDIA_CONTAINER_RUNTIME_VERSION_DEB
     fi
+    wget -q -O nvidia-container-runtime.tgz \
+          "https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/docker/nvidia/nvidia-container-runtime-$ncr_version-$distribution.tgz"
+    tar --extract --file nvidia-container-runtime.tgz \
+            --strip-components 1 \
+            --directory ./nvidia-container-runtime
+    if [ $IS_RPM_BASED -eq 0 ]; then
+        rpm -i nvidia-container-runtime/*.rpm
+    else
+        dpkg -i nvidia-container-runtime/*.deb
+    fi
+    _DIND_NVIDIA_DEP_INSTALL_RESULT=$?
+    rm -f nvidia-container-runtime.tgz
+    rm -rf nvidia-container-runtime
     if [ $_DIND_NVIDIA_DEP_INSTALL_RESULT -ne 0 ]; then
+        pipe_log_info "Unable to pull 'nvidia' runtime packages from public bucket, trying to download via package manager" "$DIND_SETUP_TASK"
+        if [ $IS_RPM_BASED -eq 0 ]; then
+            curl -s -L https://nvidia.github.io/nvidia-container-runtime/$distribution/nvidia-container-runtime.repo | \
+            tee /etc/yum.repos.d/nvidia-container-runtime.repo
+            yum install -y -q nvidia-container-runtime-$NVIDIA_CONTAINER_RUNTIME_VERSION_RPM*
+            _DIND_NVIDIA_DEP_INSTALL_RESULT=$?
+            find /etc/yum.repos.d -type f \( -name "*nvidia*" -o -name "*docker*" \)  -exec rm -f {} \;
+        else
+            os=$(. /etc/os-release;echo $ID)
+            os_release=$(. /etc/os-release;echo $VERSION_CODENAME)
+            sources_list=/etc/apt/sources.list
+            curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | apt-key add -
+            curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list \
+            | tee /etc/apt/sources.list.d/nvidia-docker.list
+            apt-get update -yq && \
+            apt-get install -yq nvidia-container-runtime=$NVIDIA_CONTAINER_RUNTIME_VERSION_DEB
+            _DIND_NVIDIA_DEP_INSTALL_RESULT=$?
+            rm /etc/apt/sources.list.d/nvidia-docker.list
+        fi
+        if [ $_DIND_NVIDIA_DEP_INSTALL_RESULT -ne 0 ]; then
         pipe_log_info "Unable to install NVIDIA DIND, 'nvidia' runtime will not be available" "$DIND_SETUP_TASK"
+        fi
     fi
 fi
 

--- a/workflows/pipe-common/shell/dind_setup
+++ b/workflows/pipe-common/shell/dind_setup
@@ -91,7 +91,7 @@ if [ $REQUIRES_GPU_DIND -eq 0 ]; then
     if [ $IS_RPM_BASED -eq 0 ]; then
       ncr_version=$NVIDIA_CONTAINER_RUNTIME_VERSION_RPM
     else
-      ncr_version=$NVIDIA_CONTAINER_RUNTIME_VERSION_DEB
+      ncr_version=$(echo "$NVIDIA_CONTAINER_RUNTIME_VERSION_DEB" | sed -s 's/+/-/g')
     fi
     wget -q -O nvidia-container-runtime.tgz \
           "https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/docker/nvidia/nvidia-container-runtime-$ncr_version-$distribution.tgz"


### PR DESCRIPTION
This PR is related to issue # 1166

Previously, the package manager was the only option for `nvidia-container-runtime` installation. From now the first option is to pull from a special public S3 bucket if it wasn't successful package manager is used.