### PR TITLE
Issue #1176: User shall be able to clone the pipelines

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/pipeline/PipelineApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/pipeline/PipelineApiService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -299,5 +299,12 @@ public class PipelineApiService {
     public List<GitRepositoryEntry> getPipelineRepositoryContents(Long id, String version, String path)
             throws GitClientException {
         return gitManager.getRepositoryContents(id, version, path);
+    }
+
+    @PreAuthorize("hasRole('ADMIN') OR hasPermission(#id, 'com.epam.pipeline.entity.pipeline.Pipeline', 'READ') AND "
+            + "(#parentFolderId != null AND hasRole('PIPELINE_MANAGER') AND "
+            + "hasPermission(#parentFolderId, 'com.epam.pipeline.entity.pipeline.Folder', 'WRITE'))")
+    public Pipeline copyPipeline(final Long id, final Long parentFolderId, final String newName) {
+        return pipelineManager.copyPipeline(id, parentFolderId, newName);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -671,5 +671,18 @@ public class PipelineController extends AbstractRestController {
             @RequestParam(value = VERSION) final String version,
             @RequestParam(value = PATH) final String path) throws GitClientException {
         return Result.success(pipelineApiService.getPipelineRepositoryContents(id, version, path));
+    }
+
+    @PostMapping(value = "/pipeline/{id}/copy")
+    @ResponseBody
+    @ApiOperation(
+            value = "Copies specified pipeline.",
+            notes = "Copies specified pipeline.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<Pipeline> copyPipeline(@PathVariable(ID) final Long id,
+                                         @RequestParam(value = "parentId", required = false) final Long parentId,
+                                         @RequestParam(value = "name", required = false) final String name) {
+        return Result.success(pipelineApiService.copyPipeline(id, parentId, name));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/entity/git/GitGroup.java
+++ b/api/src/main/java/com/epam/pipeline/entity/git/GitGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,11 +23,11 @@ import lombok.NoArgsConstructor;
 
 @Data
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
-public class GitProjectRequest {
+@NoArgsConstructor
+public class GitGroup {
+
+    private Long id;
     private String name;
     private String path;
-    private String description;
-    private String visibility;
 }

--- a/api/src/main/java/com/epam/pipeline/entity/git/GitGroupRequest.java
+++ b/api/src/main/java/com/epam/pipeline/entity/git/GitGroupRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,9 +25,8 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class GitProjectRequest {
+public class GitGroupRequest {
+
     private String name;
     private String path;
-    private String description;
-    private String visibility;
 }

--- a/api/src/main/java/com/epam/pipeline/manager/git/GitLabApi.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/GitLabApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package com.epam.pipeline.manager.git;
 
 import com.epam.pipeline.entity.git.GitCommitEntry;
 import com.epam.pipeline.entity.git.GitFile;
+import com.epam.pipeline.entity.git.GitGroup;
+import com.epam.pipeline.entity.git.GitGroupRequest;
 import com.epam.pipeline.entity.git.GitHookRequest;
 import com.epam.pipeline.entity.git.GitProject;
 import com.epam.pipeline.entity.git.GitProjectMember;
@@ -253,4 +255,29 @@ public interface GitLabApi {
     @PUT("api/v3/projects/{project}")
     Call<GitProject> updateProject(@Path(PROJECT) String project,
                                    @Body GitProjectRequest projectInfo);
+
+    /**
+     * Creates a new group
+     *
+     * @param groupInfo The new group info
+     */
+    @POST("api/v3/groups")
+    Call<GitGroup> createGroup(@Body GitGroupRequest groupInfo);
+
+    /**
+     * Deletes a group
+     *
+     * @param groupId The ID or URL-encoded path of the group
+     */
+    @DELETE("api/v3/groups/{groupId}")
+    Call<GitGroup> deleteGroup(@Path("groupId") String groupId);
+
+    /**
+     * Forks a project
+     *
+     * @param project The ID or URL-encoded path of the project
+     * @param namespace The ID or path of the namespace that the project will be forked to
+     */
+    @POST("api/v3/projects/{project}/fork")
+    Call<GitProject> forkProject(@Path(PROJECT) String project, @Query("namespace") String namespace);
 }

--- a/api/src/main/java/com/epam/pipeline/manager/git/GitManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/GitManager.java
@@ -879,6 +879,7 @@ public class GitManager {
         return forkedProject;
     }
 
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     private GitProject copyProject(final String projectName, final String newProjectName, final String tmpGroupName,
                                    final String defaultNamespace) {
         try {
@@ -891,8 +892,9 @@ public class GitManager {
             final GitProject resultProject = gitlabClient.forkProject(newProjectName, tmpGroupName, defaultNamespace);
             LOGGER.debug("The project '{}' was forked to default namespace '{}'", newProjectName, defaultNamespace);
             return resultProject;
-        } catch (GitClientException e) {
+        } catch (Exception e) {
             deleteGitGroup(tmpGroupName);
+            LOGGER.debug("The temporary git group '{}' was deleted due to unexpected error", tmpGroupName);
             throw new IllegalArgumentException(e.getMessage(), e);
         }
     }

--- a/api/src/main/java/com/epam/pipeline/manager/git/GitlabClient.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/GitlabClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ package com.epam.pipeline.manager.git;
 import com.epam.pipeline.entity.git.GitCommitEntry;
 import com.epam.pipeline.entity.git.GitCredentials;
 import com.epam.pipeline.entity.git.GitFile;
+import com.epam.pipeline.entity.git.GitGroup;
+import com.epam.pipeline.entity.git.GitGroupRequest;
 import com.epam.pipeline.entity.git.GitHookRequest;
 import com.epam.pipeline.entity.git.GitProject;
 import com.epam.pipeline.entity.git.GitProjectRequest;
@@ -375,12 +377,35 @@ public class GitlabClient {
     }
 
     public GitProject updateProjectName(final String currentName, final String newName) throws GitClientException {
+        return updateProjectName(currentName, newName, namespace);
+    }
+
+    public GitProject updateProjectName(final String currentName, final String newName, final String namespace)
+            throws GitClientException {
         final String normalizedNewName = GitUtils.convertPipeNameToProject(newName);
         return execute(gitLabApi.updateProject(makeProjectId(namespace, GitUtils.convertPipeNameToProject(currentName)),
                                                GitProjectRequest.builder()
                                                    .name(normalizedNewName)
                                                    .path(normalizedNewName)
                                                    .build()));
+    }
+
+    public GitGroup createGroup(final String newGroupName) throws GitClientException {
+        return execute(gitLabApi.createGroup(
+                GitGroupRequest.builder()
+                        .name(newGroupName)
+                        .path(newGroupName)
+                        .build()));
+    }
+
+    public GitGroup deleteGroup(final String groupName) throws GitClientException {
+        return execute(gitLabApi.deleteGroup(groupName));
+    }
+
+    public GitProject forkProject(final String projectName, final String namespaceFrom, final String namespaceTo)
+            throws GitClientException {
+        return execute(gitLabApi.forkProject(
+                makeProjectId(namespaceFrom, GitUtils.convertPipeNameToProject(projectName)), namespaceTo));
     }
 
     private <R> R execute(Call<R> call) throws GitClientException {

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineManager.java
@@ -365,8 +365,11 @@ public class PipelineManager implements SecuredEntityManager {
 
     private String buildCopyProjectName(final String sourceProjectName, final String uuid,
                                         final String newProjectName) {
-        return StringUtils.isNotBlank(newProjectName)
-                ? newProjectName
-                : String.format("%s_copy%s", sourceProjectName, uuid);
+        if (StringUtils.isNotBlank(newProjectName)) {
+            Assert.isTrue(!gitManager.checkProjectExists(newProjectName),
+                    messageHelper.getMessage(MessageConstants.ERROR_PIPELINE_REPO_EXISTS, newProjectName));
+            return newProjectName;
+        }
+        return String.format("%s_copy%s", sourceProjectName, uuid);
     }
 }


### PR DESCRIPTION
This PR provides implementation for issue #1176 

A new API method `POST /pipeline/{id}/copy` was added. This method accepts the following arguments:
- `id` (path variable) [required] - the ID of the pipeline that will be cloned
- `name` (parameter) [optional] - the name of the new pipeline copy. If not specified the following pattern will be used for name - `<source pipeline name>_copy<random string>`
- `parentId` (parameter) [optional] - the target parent folder ID. If not specified a root folder will be used.

It is impossible to fork git project to the same namespace. This way, the GitLab side operation is as follows:

1. Create a new temporary group with unique name
2. Fork the source project to the new namespace
3. Rename the project
4. Fork the project to the default namespace
5. Delete the temporary group

