### PR TITLE
Support google cloud storages in pipe mount

### DIFF
--- a/pipe-cli/build_linux.sh
+++ b/pipe-cli/build_linux.sh
@@ -65,7 +65,7 @@ cd $PIPE_MOUNT_SOURCES_DIR && \
 python2 $PYINSTALLER_PATH/pyinstaller/pyinstaller.py \
                                 --hidden-import=UserList \
                                 --hidden-import=UserString \
-                                --additional-hooks-dir="{$PIPE_MOUNT_SOURCES_DIR}/hooks" \
+                                --additional-hooks-dir="${PIPE_MOUNT_SOURCES_DIR}/hooks" \
                                 -y \
                                 --clean \
                                 --runtime-tmpdir $PIPE_CLI_RUNTIME_TMP_DIR \

--- a/pipe-cli/build_linux.sh
+++ b/pipe-cli/build_linux.sh
@@ -65,6 +65,7 @@ cd $PIPE_MOUNT_SOURCES_DIR && \
 python2 $PYINSTALLER_PATH/pyinstaller/pyinstaller.py \
                                 --hidden-import=UserList \
                                 --hidden-import=UserString \
+                                --additional-hooks-dir="{$PIPE_MOUNT_SOURCES_DIR}/hooks" \
                                 -y \
                                 --clean \
                                 --runtime-tmpdir $PIPE_CLI_RUNTIME_TMP_DIR \

--- a/pipe-cli/mount/build_mount.sh
+++ b/pipe-cli/mount/build_mount.sh
@@ -43,6 +43,7 @@ cd $PIPE_MOUNT_SOURCES_DIR && \
 python2 $PYINSTALLER_PATH/pyinstaller/pyinstaller.py \
                                 --hidden-import=UserList \
                                 --hidden-import=UserString \
+                                --additional-hooks-dir="{$PIPE_MOUNT_SOURCES_DIR}/hooks" \
                                 -y \
                                 --clean \
                                 --runtime-tmpdir $PIPE_CLI_RUNTIME_TMP_DIR \

--- a/pipe-cli/mount/build_mount.sh
+++ b/pipe-cli/mount/build_mount.sh
@@ -43,7 +43,7 @@ cd $PIPE_MOUNT_SOURCES_DIR && \
 python2 $PYINSTALLER_PATH/pyinstaller/pyinstaller.py \
                                 --hidden-import=UserList \
                                 --hidden-import=UserString \
-                                --additional-hooks-dir="{$PIPE_MOUNT_SOURCES_DIR}/hooks" \
+                                --additional-hooks-dir="${PIPE_MOUNT_SOURCES_DIR}/hooks" \
                                 -y \
                                 --clean \
                                 --runtime-tmpdir $PIPE_CLI_RUNTIME_TMP_DIR \

--- a/pipe-cli/mount/hooks/hook-google.resumable_media.requests.py
+++ b/pipe-cli/mount/hooks/hook-google.resumable_media.requests.py
@@ -1,0 +1,2 @@
+from PyInstaller.utils.hooks import copy_metadata
+datas = copy_metadata('requests')

--- a/pipe-cli/mount/pipe-fuse.py
+++ b/pipe-cli/mount/pipe-fuse.py
@@ -86,7 +86,7 @@ def start(mountpoint, webdav, bucket, buffer_size, trunc_buffer_size, chunk_size
         if bucket_object.type == CloudType.S3:
             client = S3Client(bucket, pipe=pipe, chunk_size=chunk_size)
         elif bucket_object.type == CloudType.GS:
-            client = GCPClient(bucket, pipe=pipe)
+            client = GCPClient(bucket, pipe=pipe, chunk_size=chunk_size)
         else:
             raise RuntimeError('Cloud storage type %s is not supported.' % bucket_object.type)
     if recording:
@@ -201,7 +201,7 @@ if __name__ == '__main__':
     if not args.webdav and not args.bucket:
         parser.error('Either --webdav or --bucket parameter should be specified.')
     if args.bucket and (args.chunk_size < 5 * MB or args.chunk_size > 5 * GB):
-        parser.error('Chunk size can vary from 5 MB to 5 GB due to AWS s3 multipart upload limitations.')
+        parser.error('Chunk size can vary from 5 MB to 5 GB due to AWS S3 multipart upload limitations.')
     if args.logging_level not in _allowed_logging_levels:
         parser.error('Only the following logging level are allowed: %s.' % _allowed_logging_levels_string)
     recording = args.logging_level in [_info_logging_level, _debug_logging_level]

--- a/pipe-cli/mount/pipefuse/api.py
+++ b/pipe-cli/mount/pipefuse/api.py
@@ -18,6 +18,15 @@ import logging
 import requests
 
 
+class CloudType:
+
+    S3 = 'S3'
+    GS = 'GS'
+
+    def __init__(self):
+        pass
+
+
 class TemporaryCredentials:
 
     def __init__(self):
@@ -47,6 +56,7 @@ class DataStorage:
         self.mask = None
         self.sensitive = False
         self.ro = False
+        self.type = None
 
     @classmethod
     def load(cls, json):
@@ -54,6 +64,7 @@ class DataStorage:
         instance.id = json['id']
         instance.mask = json['mask']
         instance.sensitive = json['sensitive']
+        instance.type = json['type']
         return instance
 
     def is_read_allowed(self):

--- a/pipe-cli/mount/pipefuse/buff.py
+++ b/pipe-cli/mount/pipefuse/buff.py
@@ -19,6 +19,9 @@ from fsclient import FileSystemClientDecorator
 from fuseutils import MB
 
 
+_ANY_ERROR = BaseException
+
+
 class _FileBuffer(object):
 
     def __init__(self, offset, capacity):
@@ -129,22 +132,28 @@ class BufferedFileSystemClient(FileSystemClientDecorator):
         return attrs
 
     def download_range(self, fh, buf, path, offset=0, length=0):
-        buf_key = fh, path
-        file_buf = self._read_file_buffs.get(buf_key)
-        if not file_buf:
-            file_size = self._inner.attrs(path).size
-            if not file_size or offset >= file_size:
-                return
-            file_buf = self._new_read_buf(fh, path, file_size, offset, length)
-            self._read_file_buffs[buf_key] = file_buf
-        if not file_buf.suits(offset, length):
-            if file_buf.offset < file_buf.capacity:
-                file_buf.append(self._read_ahead(fh, path, file_buf.offset, length))
-                file_buf.shrink()
-            if not file_buf.suits(offset, length) and offset < file_buf.capacity:
-                file_buf = self._new_read_buf(fh, path, file_buf.capacity, offset, length)
+        try:
+            buf_key = fh, path
+            file_buf = self._read_file_buffs.get(buf_key)
+            if not file_buf:
+                file_size = self._inner.attrs(path).size
+                if not file_size or offset >= file_size:
+                    return
+                file_buf = self._new_read_buf(fh, path, file_size, offset, length)
                 self._read_file_buffs[buf_key] = file_buf
-        buf.write(file_buf.view(offset, length))
+            if not file_buf.suits(offset, length):
+                if file_buf.offset < file_buf.capacity:
+                    file_buf.append(self._read_ahead(fh, path, file_buf.offset, length))
+                    file_buf.shrink()
+                if not file_buf.suits(offset, length) and offset < file_buf.capacity:
+                    file_buf = self._new_read_buf(fh, path, file_buf.capacity, offset, length)
+                    self._read_file_buffs[buf_key] = file_buf
+            buf.write(file_buf.view(offset, length))
+        except _ANY_ERROR:
+            logging.exception('Downloading has failed for %d:%s. '
+                              'Removing read buffer.' % (fh, path))
+            self._remove_read_buf(fh, path)
+            raise
 
     def _new_read_buf(self, fh, path, file_size, offset, length):
         file_buf = _ReadBuffer(offset, file_size)
@@ -159,24 +168,30 @@ class BufferedFileSystemClient(FileSystemClientDecorator):
             return read_ahead_buf.getvalue()
 
     def upload_range(self, fh, buf, path, offset=0):
-        file_buf = self._write_file_buffs.get(path)
-        if not file_buf:
-            file_buf = self._new_write_buf(self._capacity, offset)
-            self._write_file_buffs[path] = file_buf
-        if file_buf.suits(offset):
-            file_buf.append(buf)
-        else:
-            logging.info('Upload buffer is not sequential for %d:%s. Buffer will be cleared.' % (fh, path))
-            self._flush_write_buf(fh, path)
-            old_file_buf = self._remove_write_buf(fh, path)
-            file_buf = self._new_write_buf(self._capacity, offset, buf, old_file_buf)
-            self._write_file_buffs[path] = file_buf
-        if file_buf.is_full():
-            logging.info('Upload buffer is full for %d:%s. Buffer will be cleared.' % (fh, path))
-            self._flush_write_buf(fh, path)
+        try:
+            file_buf = self._write_file_buffs.get(path)
+            if not file_buf:
+                file_buf = self._new_write_buf(self._capacity, offset)
+                self._write_file_buffs[path] = file_buf
+            if file_buf.suits(offset):
+                file_buf.append(buf)
+            else:
+                logging.info('Upload buffer is not sequential for %d:%s. Buffer will be cleared.' % (fh, path))
+                self._flush_write_buf(fh, path)
+                old_file_buf = self._remove_write_buf(fh, path)
+                file_buf = self._new_write_buf(self._capacity, offset, buf, old_file_buf)
+                self._write_file_buffs[path] = file_buf
+            if file_buf.is_full():
+                logging.info('Upload buffer is full for %d:%s. Buffer will be cleared.' % (fh, path))
+                self._flush_write_buf(fh, path)
+                self._remove_write_buf(fh, path)
+                file_buf = self._new_write_buf(self._capacity, file_buf.offset, buf=None, old_write_buf=file_buf)
+                self._write_file_buffs[path] = file_buf
+        except _ANY_ERROR:
+            logging.exception('Uploading has failed for %d:%s. '
+                              'Removing write buffer.' % (fh, path))
             self._remove_write_buf(fh, path)
-            file_buf = self._new_write_buf(self._capacity, file_buf.offset, buf=None, old_write_buf=file_buf)
-            self._write_file_buffs[path] = file_buf
+            raise
 
     def _new_write_buf(self, capacity, offset, buf=None, old_write_buf=None):
         write_buf = _WriteBuffer(offset, capacity, inherited_size=old_write_buf.inherited_size if old_write_buf else 0)
@@ -185,11 +200,18 @@ class BufferedFileSystemClient(FileSystemClientDecorator):
         return write_buf
 
     def flush(self, fh, path):
-        logging.info('Flushing buffers for %d:%s' % (fh, path))
-        self._flush_write_buf(fh, path)
-        self._inner.flush(fh, path)
-        self._remove_read_buf(fh, path)
-        self._remove_write_buf(fh, path)
+        try:
+            logging.info('Flushing buffers for %d:%s' % (fh, path))
+            self._flush_write_buf(fh, path)
+            self._inner.flush(fh, path)
+            self._remove_read_buf(fh, path)
+            self._remove_write_buf(fh, path)
+        except _ANY_ERROR:
+            logging.exception('Flushing has failed for %d:%s. '
+                              'Removing read and write buffers.' % (fh, path))
+            self._remove_read_buf(fh, path)
+            self._remove_write_buf(fh, path)
+            raise
 
     def _remove_read_buf(self, fh, path):
         return self._read_file_buffs.pop((fh, path), None)

--- a/pipe-cli/mount/pipefuse/cache.py
+++ b/pipe-cli/mount/pipefuse/cache.py
@@ -39,7 +39,9 @@ class ListingCache:
         self._delimiter = '/'
 
     def get(self, path):
-        return self._cache.get(path, None)
+        listing = self._cache.get(path, None)
+        if listing:
+            return dict(listing)
 
     def set(self, path, listing):
         self._cache[path] = listing
@@ -53,14 +55,14 @@ class ListingCache:
     def _add_to_parent_cache(self, path, item):
         logging.info('Adding to parent cache for %s' % path)
         parent_path, _ = fuseutils.split_path(path)
-        parent_listing = self.get(parent_path)
+        parent_listing = self._cache.get(parent_path, None)
         if parent_listing:
             parent_listing[fuseutils.without_prefix(path, parent_path)] = item
 
     def _remove_from_parent_cache(self, path):
         logging.info('Removing from parent cache for %s' % path)
         parent_path, _ = fuseutils.split_path(path)
-        parent_listing = self.get(parent_path)
+        parent_listing = self._cache.get(parent_path, None)
         if parent_listing:
             return parent_listing.pop(fuseutils.without_prefix(path, parent_path), None)
 
@@ -81,7 +83,7 @@ class ListingCache:
         logging.info('Moving from parent cache %s to %s' % (old_path, path))
         cached_item = self._remove_from_parent_cache(old_path)
         parent_path, _ = fuseutils.split_path(path)
-        parent_listing = self.get(parent_path)
+        parent_listing = self._cache.get(parent_path, None)
         if cached_item and parent_listing:
             relative_name = fuseutils.without_prefix(path, parent_path)
             parent_listing[relative_name] = cached_item._replace(name=relative_name)

--- a/pipe-cli/mount/pipefuse/cache.py
+++ b/pipe-cli/mount/pipefuse/cache.py
@@ -57,7 +57,8 @@ class ListingCache:
         parent_path, _ = fuseutils.split_path(path)
         parent_listing = self._cache.get(parent_path, None)
         if parent_listing is not None:
-            parent_listing[fuseutils.without_prefix(path, parent_path)] = item
+            relative_name = fuseutils.without_prefix(path, parent_path)
+            parent_listing[relative_name] = item._replace(name=relative_name)
 
     def _remove_from_parent_cache(self, path):
         logging.info('Removing from parent cache for %s' % path)
@@ -82,11 +83,8 @@ class ListingCache:
     def move_from_parent_cache(self, old_path, path):
         logging.info('Moving from parent cache %s to %s' % (old_path, path))
         cached_item = self._remove_from_parent_cache(old_path)
-        parent_path, _ = fuseutils.split_path(path)
-        parent_listing = self._cache.get(parent_path, None)
-        if cached_item and parent_listing is not None:
-            relative_name = fuseutils.without_prefix(path, parent_path)
-            parent_listing[relative_name] = cached_item._replace(name=relative_name)
+        if cached_item:
+            self._add_to_parent_cache(path, cached_item)
         else:
             logging.info('Moving from parent cache %s to %s was not successful. '
                          'Invalidating both parent caches.' % (old_path, path))

--- a/pipe-cli/mount/pipefuse/cache.py
+++ b/pipe-cli/mount/pipefuse/cache.py
@@ -56,14 +56,14 @@ class ListingCache:
         logging.info('Adding to parent cache for %s' % path)
         parent_path, _ = fuseutils.split_path(path)
         parent_listing = self._cache.get(parent_path, None)
-        if parent_listing:
+        if parent_listing is not None:
             parent_listing[fuseutils.without_prefix(path, parent_path)] = item
 
     def _remove_from_parent_cache(self, path):
         logging.info('Removing from parent cache for %s' % path)
         parent_path, _ = fuseutils.split_path(path)
         parent_listing = self._cache.get(parent_path, None)
-        if parent_listing:
+        if parent_listing is not None:
             return parent_listing.pop(fuseutils.without_prefix(path, parent_path), None)
 
     def invalidate_parent_cache(self, path):
@@ -84,7 +84,7 @@ class ListingCache:
         cached_item = self._remove_from_parent_cache(old_path)
         parent_path, _ = fuseutils.split_path(path)
         parent_listing = self._cache.get(parent_path, None)
-        if cached_item and parent_listing:
+        if cached_item and parent_listing is not None:
             relative_name = fuseutils.without_prefix(path, parent_path)
             parent_listing[relative_name] = cached_item._replace(name=relative_name)
         else:

--- a/pipe-cli/mount/pipefuse/cache.py
+++ b/pipe-cli/mount/pipefuse/cache.py
@@ -179,9 +179,9 @@ class CachingFileSystemClient(FileSystemClientDecorator):
             if parent_listing:
                 file = self._find_in_listing(parent_listing, file_name)
                 if file:
-                    logging.info('Using cached attributes for %s' % path)
+                    logging.info('Attributes found for %s' % path)
                     return file
-        return self._find_in_listing(self._uncached_ls_as_dict(parent_path), file_name)
+            logging.info('Attributes not found for %s' % path)
 
     def _find_in_listing(self, listing, file_name):
         return listing.get(file_name, None)

--- a/pipe-cli/mount/pipefuse/cache.py
+++ b/pipe-cli/mount/pipefuse/cache.py
@@ -193,7 +193,7 @@ class CachingFileSystemClient(FileSystemClientDecorator):
         if listing:
             logging.info('Cached listing found for %s' % path)
         else:
-            logging.info('Cached listing not found for %s.' % path)
+            logging.info('Cached listing not found for %s' % path)
             listing = self._uncached_ls_as_dict(path, depth)
         return listing
 

--- a/pipe-cli/mount/pipefuse/cache.py
+++ b/pipe-cli/mount/pipefuse/cache.py
@@ -44,12 +44,25 @@ class ListingCache:
     def set(self, path, listing):
         self._cache[path] = listing
 
-    def remove_from_parent_cache(self, path):
-        logging.info('Invalidating parent cache partially for %s' % path)
+    def replace_in_parent_cache(self, path, item=None):
+        if item:
+            self._add_to_parent_cache(path, item)
+        else:
+            self._remove_from_parent_cache(path)
+
+    def _add_to_parent_cache(self, path, item):
+        logging.info('Adding to parent cache for %s' % path)
         parent_path, _ = fuseutils.split_path(path)
         parent_listing = self.get(parent_path)
         if parent_listing:
-            parent_listing.pop(fuseutils.without_prefix(path, parent_path), None)
+            parent_listing[fuseutils.without_prefix(path, parent_path)] = item
+
+    def _remove_from_parent_cache(self, path):
+        logging.info('Removing from parent cache for %s' % path)
+        parent_path, _ = fuseutils.split_path(path)
+        parent_listing = self.get(parent_path)
+        if parent_listing:
+            return parent_listing.pop(fuseutils.without_prefix(path, parent_path), None)
 
     def invalidate_parent_cache(self, path):
         parent_path, _ = fuseutils.split_path(path)
@@ -63,6 +76,20 @@ class ListingCache:
     def invalidate_cache(self, path):
         logging.info('Invalidating cache for %s' % path)
         self._cache.pop(path, None)
+
+    def move_from_parent_cache(self, old_path, path):
+        logging.info('Moving from parent cache %s to %s' % (old_path, path))
+        cached_item = self._remove_from_parent_cache(old_path)
+        parent_path, _ = fuseutils.split_path(path)
+        parent_listing = self.get(parent_path)
+        if cached_item and parent_listing:
+            relative_name = fuseutils.without_prefix(path, parent_path)
+            parent_listing[relative_name] = cached_item._replace(name=relative_name)
+        else:
+            logging.info('Moving from parent cache %s to %s was not successful. '
+                         'Invalidating both parent caches.' % (old_path, path))
+            self.invalidate_parent_cache(old_path)
+            self.invalidate_parent_cache(path)
 
     def _is_relative(self, cache_path, path):
         if cache_path.startswith(path):
@@ -103,8 +130,8 @@ class ThreadSafeListingCache:
         self._inner.set(path, listing)
 
     @synchronized
-    def remove_from_parent_cache(self, path):
-        self._inner.remove_from_parent_cache(path)
+    def replace_in_parent_cache(self, path, item=None):
+        return self._inner.replace_in_parent_cache(path, item)
 
     @synchronized
     def invalidate_parent_cache(self, path):
@@ -113,6 +140,10 @@ class ThreadSafeListingCache:
     @synchronized
     def invalidate_cache_recursively(self, path):
         self._inner.invalidate_cache_recursively(path)
+
+    @synchronized
+    def move_from_parent_cache(self, old_path, path):
+        self._inner.move_from_parent_cache(old_path, path)
 
     @synchronized
     def invalidate_cache(self, path):
@@ -158,8 +189,9 @@ class CachingFileSystemClient(FileSystemClientDecorator):
     def _ls_as_dict(self, path, depth=1):
         listing = self._cache.get(path)
         if listing:
-            logging.info('Using cached listing for %s' % path)
+            logging.info('Cached listing found for %s' % path)
         else:
+            logging.info('Cached listing not found for %s.' % path)
             listing = self._uncached_ls_as_dict(path, depth)
         return listing
 
@@ -183,51 +215,58 @@ class CachingFileSystemClient(FileSystemClientDecorator):
     def upload(self, buf, path):
         try:
             self._inner.upload(buf, path)
+            self._cache.replace_in_parent_cache(path, self._inner.attrs(path))
         except _ANY_ERROR:
+            logging.exception('Standalone uploading has failed for %s' % path)
             self._cache.invalidate_parent_cache(path)
-        else:
-            self._cache.invalidate_parent_cache(path)
+            raise
 
     def delete(self, path):
         try:
             self._inner.delete(path)
+            self._cache.replace_in_parent_cache(path)
         except _ANY_ERROR:
+            logging.exception('Deleting has failed for %s' % path)
             self._cache.invalidate_parent_cache(path)
-        else:
-            self._cache.remove_from_parent_cache(path)
+            raise
 
     def mv(self, old_path, path):
         try:
             self._inner.mv(old_path, path)
+            self._cache.move_from_parent_cache(old_path, path)
+            self._cache.invalidate_cache_recursively(old_path)
         except _ANY_ERROR:
+            logging.exception('Moving from %s to %s has failed' % (old_path, path))
             self._cache.invalidate_parent_cache(old_path)
+            self._cache.invalidate_cache_recursively(old_path)
             self._cache.invalidate_parent_cache(path)
-        else:
-            self._cache.remove_from_parent_cache(old_path)
-            self._cache.invalidate_parent_cache(path)
+            raise
 
     def mkdir(self, path):
         try:
             self._inner.mkdir(path)
+            self._cache.replace_in_parent_cache(path, self._inner.attrs(path))
         except _ANY_ERROR:
+            logging.exception('Mkdir has failed for %s' % path)
             self._cache.invalidate_parent_cache(path)
-        else:
-            self._cache.invalidate_parent_cache(path)
+            raise
 
     def rmdir(self, path):
         try:
             self._inner.rmdir(path)
+            self._cache.replace_in_parent_cache(path)
+            self._cache.invalidate_cache_recursively(path)
         except _ANY_ERROR:
+            logging.exception('Rmdir has failed for %s' % path)
             self._cache.invalidate_parent_cache(path)
             self._cache.invalidate_cache_recursively(path)
-        else:
-            self._cache.remove_from_parent_cache(path)
-            self._cache.invalidate_cache_recursively(path)
+            raise
 
     def flush(self, fh, path):
         try:
             self._inner.flush(fh, path)
+            self._cache.replace_in_parent_cache(path, self._inner.attrs(path))
         except _ANY_ERROR:
+            logging.exception('Flushing has failed for %s' % path)
             self._cache.invalidate_parent_cache(path)
-        else:
-            self._cache.invalidate_parent_cache(path)
+            raise

--- a/pipe-cli/mount/pipefuse/fsclient.py
+++ b/pipe-cli/mount/pipefuse/fsclient.py
@@ -125,6 +125,9 @@ class FileSystemClient:
         """
         pass
 
+    def stats(self):
+        return str(type(self).__name__)
+
 
 class FileSystemClientDecorator(FileSystemClient):
 
@@ -177,6 +180,9 @@ class FileSystemClientDecorator(FileSystemClient):
 
     def truncate(self, fh, path, length):
         self._inner.truncate(fh, path, length)
+
+    def stats(self):
+        return ' -> '.join([str(type(self).__name__), self._inner.stats()])
 
     def __getattr__(self, name):
         if hasattr(self._inner, name):

--- a/pipe-cli/mount/pipefuse/fuseutils.py
+++ b/pipe-cli/mount/pipefuse/fuseutils.py
@@ -18,6 +18,7 @@ DEFAULT_DELIMITER = '/'
 KB = 1024
 MB = KB * KB
 GB = MB * KB
+TB = GB * KB
 
 
 def join_path_with_delimiter(parent, child, delimiter=DEFAULT_DELIMITER):

--- a/pipe-cli/mount/pipefuse/fuseutils.py
+++ b/pipe-cli/mount/pipefuse/fuseutils.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 DEFAULT_DELIMITER = '/'
 KB = 1024
 MB = KB * KB
@@ -49,3 +51,20 @@ def lazy_range(start, end):
 def without_prefix(string, prefix):
     if string.startswith(prefix):
         return string[len(prefix):]
+
+
+def get_item_name(path, prefix, delimiter='/'):
+    possible_folder_name = prefix if prefix.endswith(delimiter) else \
+        prefix + delimiter
+    if prefix and path.startswith(prefix) and path != possible_folder_name and path != prefix:
+        if not path == prefix:
+            splitted = prefix.split(delimiter)
+            return splitted[len(splitted) - 1] + path[len(prefix):]
+        else:
+            return path[len(prefix):]
+    elif not path.endswith(delimiter) and path == prefix:
+        return os.path.basename(path)
+    elif path == possible_folder_name:
+        return os.path.basename(path.rstrip(delimiter)) + delimiter
+    else:
+        return path

--- a/pipe-cli/mount/pipefuse/gcp.py
+++ b/pipe-cli/mount/pipefuse/gcp.py
@@ -1,5 +1,6 @@
 import io
 import logging
+import sys
 import time
 from datetime import datetime
 
@@ -89,8 +90,7 @@ class _RefreshingCredentials(Credentials):
 
 
 class _RefreshingClient(Client):
-    # todo: Attempt limits should be removed
-    MAX_REFRESH_ATTEMPTS = 100
+    MAX_REFRESH_ATTEMPTS = sys.maxint
 
     def __init__(self, refresh):
         credentials = _RefreshingCredentials(refresh)
@@ -290,7 +290,3 @@ class GCPClient(FileSystemClient):
                 raise
             finally:
                 del self._mpus[source_path]
-
-    def truncate(self, fh, path, length):
-        # todo: Implement
-        pass

--- a/pipe-cli/mount/pipefuse/gcp.py
+++ b/pipe-cli/mount/pipefuse/gcp.py
@@ -186,6 +186,7 @@ class GoogleStorageLowLevelFileSystemClient(StorageLowLevelFileSystemClient):
         source_blob.delete()
 
     def download_range(self, fh, buf, path, offset=0, length=0):
+        logging.info('Downloading range %d-%d for %s' % (offset, offset + length, path))
         source_bucket = self._gcp.bucket(self.bucket)
         source_blob = source_bucket.blob(path)
         source_blob.download_to_file(buf, start=offset, end=offset + length - 1)

--- a/pipe-cli/mount/pipefuse/gcp.py
+++ b/pipe-cli/mount/pipefuse/gcp.py
@@ -11,13 +11,11 @@ from google.cloud.storage import Client
 from google.oauth2.credentials import Credentials
 
 import fuseutils
-from fsclient import FileSystemClient, File
+from fsclient import File
 from fuseutils import MB, TB
 from mpu import MultipartUpload, ChunkedMultipartUpload, SplittingMultipartCopyUpload, \
     CompositeMultipartUpload, AppendOptimizedCompositeMultipartCopyUpload
-from pipefuse.storage import StorageLowLevelFileSystemClient
-
-_ANY_ERROR = Exception
+from storage import StorageLowLevelFileSystemClient
 
 
 class GCPMultipartUpload(MultipartUpload):

--- a/pipe-cli/mount/pipefuse/gcp.py
+++ b/pipe-cli/mount/pipefuse/gcp.py
@@ -1,0 +1,164 @@
+import logging
+import time
+from datetime import datetime
+
+import pytz
+from google.auth import _helpers
+from google.auth.transport.requests import AuthorizedSession
+from google.cloud.storage import Client
+from google.oauth2.credentials import Credentials
+
+from fsclient import FileSystemClient, File
+from fuseutils import MB, GB
+from pipefuse import fuseutils
+
+
+class _RefreshingCredentials(Credentials):
+
+    def __init__(self, refresh):
+        self._refresh = refresh
+        self.temporary_credentials = self._refresh()
+        super(_RefreshingCredentials, self).__init__(self.temporary_credentials.session_token)
+
+    def refresh(self, request):
+        logging.info('Refreshing temporary credentials for data storage.')
+        self.temporary_credentials = self._refresh()
+
+    def apply(self, headers, token=None):
+        headers['authorization'] = 'Bearer {}'.format(_helpers.from_bytes(self.temporary_credentials.session_token))
+
+
+class _RefreshingClient(Client):
+    # todo: Attempt limits should be removed
+    MAX_REFRESH_ATTEMPTS = 100
+
+    def __init__(self, refresh):
+        credentials = _RefreshingCredentials(refresh)
+        session = AuthorizedSession(credentials, max_refresh_attempts=self.MAX_REFRESH_ATTEMPTS)
+        super(_RefreshingClient, self).__init__(project=credentials.temporary_credentials.secret_key, _http=session)
+
+
+class GCPClient(FileSystemClient):
+    _MIN_CHUNK = 1
+    _MAX_CHUNK = 10000
+    _MIN_PART_SIZE = 5 * MB
+    _MAX_PART_SIZE = 5 * GB
+    _SINGLE_UPLOAD_SIZE = 5 * MB
+
+    def __init__(self, bucket, pipe):
+        """
+        GCP API client for single bucket operations.
+
+        :param bucket: Name of the GCP bucket.
+        :param pipe: Cloud Pipeline API client.
+        """
+        super(GCPClient, self).__init__()
+        self._delimiter = '/'
+        self._is_read_only = False
+        path_chunks = bucket.rstrip(self._delimiter).split(self._delimiter)
+        self.bucket = path_chunks[0]
+        self.root_path = self._delimiter.join(path_chunks[1:]) if len(path_chunks) > 1 else ''
+        self._gcp = self._generate_gcp(pipe)
+
+    def _generate_gcp(self, pipe):
+        bucket_object = pipe.get_storage(self.bucket)
+        self._is_read_only = not bucket_object.is_write_allowed()
+        return _RefreshingClient(lambda: pipe.get_temporary_credentials(bucket_object))
+
+    def is_available(self):
+        # TODO 05.09.2019: Check GCP API for availability
+        return True
+
+    def is_read_only(self):
+        return self._is_read_only
+
+    def exists(self, path, expand_path=True):
+        return len(self.ls(path, expand_path=expand_path)) > 0
+
+    def ls(self, path, depth=1, expand_path=True):
+        prefix = self.build_full_path(path) if expand_path else path
+        recursive = depth < 0
+        bucket_object = self._gcp.bucket(self.bucket)
+        blobs_iterator = bucket_object.list_blobs(prefix=prefix,
+                                                  delimiter=self._delimiter if not recursive else None)
+        absolute_files = [self._get_file_object(blob, prefix, recursive) for blob in blobs_iterator]
+        absolute_folders = [self._get_folder_object(name) for name in blobs_iterator.prefixes]
+        absolute_items = absolute_folders + absolute_files
+        return absolute_items
+
+    def build_full_path(self, path):
+        full_path = None
+        if not self.root_path:
+            full_path = path
+        elif not path:
+            full_path = self.root_path
+        else:
+            full_path = self.root_path + self._delimiter + path.lstrip(self._delimiter)
+        if not full_path:
+            return ''
+        return full_path.lstrip(self._delimiter)
+
+    def _get_file_object(self, blob, prefix, recursive):
+        # todo: Extract the method to common utils
+        from s3 import S3Client
+        return File(name=blob.name if recursive else S3Client.get_item_name(blob.name, prefix=prefix),
+                    size=blob.size,
+                    mtime=time.mktime(blob.updated.astimezone(pytz.utc).timetuple()),
+                    ctime=None,
+                    contenttype='',
+                    is_dir=False)
+
+    def _get_folder_object(self, name):
+        return File(name=name,
+                    size=0,
+                    mtime=time.mktime(datetime.now(tz=pytz.utc).timetuple()),
+                    ctime=None,
+                    contenttype='',
+                    is_dir=True)
+
+    def upload(self, buf, path, expand_path=True):
+        destination_path = self.build_full_path(path) if expand_path else path
+        bucket_object = self._gcp.bucket(self.bucket)
+        blob = bucket_object.blob(destination_path)
+        blob.upload_from_string(str(buf))
+
+    def delete(self, path, expand_path=True):
+        prefix = self.build_full_path(path) if expand_path else path
+        bucket_object = self._gcp.bucket(self.bucket)
+        blob = bucket_object.blob(prefix)
+        blob.delete()
+
+    def mv(self, old_path, path):
+        source_path = self.build_full_path(old_path)
+        destination_path = self.build_full_path(path)
+        folder_source_path = fuseutils.append_delimiter(source_path)
+        if self.exists(folder_source_path, expand_path=False):
+            self._mvdir(folder_source_path, destination_path)
+        else:
+            self._mvfile(source_path, destination_path)
+
+    def _mvdir(self, folder_source_path, folder_destination_path):
+        for file in self.ls(fuseutils.append_delimiter(folder_source_path), depth=-1, expand_path=False):
+            relative_path = fuseutils.without_prefix(file.name, folder_source_path)
+            destination_path = fuseutils.join_path_with_delimiter(folder_destination_path, relative_path)
+            self._mvfile(file.name, destination_path)
+
+    def _mvfile(self, source_path, destination_path):
+        source_bucket = self._gcp.bucket(self.bucket)
+        source_blob = source_bucket.blob(source_path)
+        source_bucket.copy_blob(source_blob, source_bucket, destination_path)
+        source_blob.delete()
+
+    def mkdir(self, path):
+        synthetic_file_path = fuseutils.join_path_with_delimiter(path, '.DS_Store')
+        self.upload([], synthetic_file_path)
+
+    def rmdir(self, path):
+        for file in self.ls(fuseutils.append_delimiter(path), depth=-1):
+            self.delete(file.name, expand_path=False)
+
+    def download_range(self, fh, buf, path, offset, length):
+        pass
+
+    def upload_range(self, fh, buf, path, offset):
+        pass

--- a/pipe-cli/mount/pipefuse/gcp.py
+++ b/pipe-cli/mount/pipefuse/gcp.py
@@ -10,11 +10,11 @@ from google.auth.transport.requests import AuthorizedSession
 from google.cloud.storage import Client
 from google.oauth2.credentials import Credentials
 
+import fuseutils
 from fsclient import FileSystemClient, File
 from fuseutils import MB, TB
-import fuseutils
 from mpu import MultipartUpload, ChunkedMultipartUpload, SplittingMultipartCopyUpload, \
-    CompositeMultipartUpload, PrefixOptimizedCompositeMultipartCopyUpload
+    CompositeMultipartUpload, AppendOptimizedCompositeMultipartCopyUpload
 
 _ANY_ERROR = Exception
 
@@ -261,7 +261,7 @@ class GCPClient(FileSystemClient):
                                        new_mpu=lambda path: GCPMultipartUpload(self.bucket, path, self._gcp),
                                        mv=lambda old_path, path: self.mv(old_path, path),
                                        max_composite_parts=self._max_composite_parts)
-        mpu = PrefixOptimizedCompositeMultipartCopyUpload(mpu, original_size=file_size, chunk_size=self._chunk_size,
+        mpu = AppendOptimizedCompositeMultipartCopyUpload(mpu, original_size=file_size, chunk_size=self._chunk_size,
                                                           download=self._generate_region_download_function())
         mpu = SplittingMultipartCopyUpload(mpu, min_part_size=self._min_part_size, max_part_size=self._max_part_size)
         mpu = ChunkedMultipartUpload(mpu, original_size=file_size,

--- a/pipe-cli/mount/pipefuse/mpu.py
+++ b/pipe-cli/mount/pipefuse/mpu.py
@@ -560,13 +560,13 @@ class CompositeMultipartUpload(MultipartUpload):
         return self._part_path(self._mpu_number(part_number), part_number)
 
     def _mpu_path(self, mpu_number):
-        return '%s_%s_%d.tmp' % (self._path, self._hashed_path(), mpu_number)
+        return '%s_%s.tmp/%d' % (self._path, self._hashed_path(), mpu_number)
 
     def _part_path(self, mpu_number, part_number):
-        return '%s_%s_%d.%d.tmp' % (self._path, self._hashed_path(), mpu_number, part_number)
+        return '%s_%s.tmp/%d.%d' % (self._path, self._hashed_path(), mpu_number, part_number)
 
     def _merged_mpu_path(self, left_mpu_number, right_mpu_number):
-        return '%s_%s_%d:%d.tmp' % (self._path, self._hashed_path(), left_mpu_number, right_mpu_number)
+        return '%s_%s.tmp/%d:%d' % (self._path, self._hashed_path(), left_mpu_number, right_mpu_number)
 
     def _hashed_path(self):
         return str(abs(hash(self._path)))

--- a/pipe-cli/mount/pipefuse/mpu.py
+++ b/pipe-cli/mount/pipefuse/mpu.py
@@ -438,9 +438,13 @@ class AppendOptimizedCompositeMultipartCopyUpload(MultipartUploadDecorator):
     def _extract_prefix(self):
         if self._copy_parts:
             sorted_copy_parts = sorted(self._copy_parts, key=lambda copy_part: copy_part.offset)
-            if sorted_copy_parts[-1].end + self._chunk_size >= self._original_size:
-                return _CopyPart(0, self._original_size, offset=0, part_number=1,
-                                 part_path=self.path, keep=True)
+            prefix_end = 0
+            for copy_index, copy_part in enumerate(sorted_copy_parts):
+                if copy_part.offset != prefix_end:
+                    break
+                prefix_end += copy_part.end - copy_part.start
+            if prefix_end and prefix_end + self._chunk_size >= self._original_size:
+                return _CopyPart(0, self._original_size, offset=0, part_number=1, part_path=self.path, keep=True)
         return None
 
     def _adjust_first_uploaded_part(self, prefix_end):

--- a/pipe-cli/mount/pipefuse/mpu.py
+++ b/pipe-cli/mount/pipefuse/mpu.py
@@ -414,7 +414,6 @@ class AppendOptimizedCompositeMultipartCopyUpload(MultipartUploadDecorator):
         self._chunk_size = chunk_size
         self._download = download
         self._copy_parts = []
-        self._chunks = []
         self._first_chunk = sys.maxint
         self._first_chunk_offset = 0
 

--- a/pipe-cli/mount/pipefuse/path.py
+++ b/pipe-cli/mount/pipefuse/path.py
@@ -1,0 +1,73 @@
+import fuseutils
+from fsclient import FileSystemClientDecorator
+
+
+class PathExpandingStorageFileSystemClient(FileSystemClientDecorator):
+
+    def __init__(self, inner, root_path):
+        """
+        Path expanding storage file system client.
+
+        Neglects the difference between regular and prefixed data storages.
+
+        :param inner: Decorating file system client.
+        :param root_path: Root data storage path prefix.
+        """
+        super(PathExpandingStorageFileSystemClient, self).__init__(inner)
+        self._inner = inner
+        self._root_path = root_path
+        self._is_read_only = False
+        self._delimiter = '/'
+
+    def exists(self, path):
+        expanded_path = self._expand_path(path)
+        return self._inner.exists(expanded_path)
+
+    def attrs(self, path):
+        expanded_path = self._expand_path(path)
+        return self._inner.attrs(expanded_path)
+
+    def ls(self, path, depth=1):
+        expanded_path = self._expand_path(path)
+        return self._inner.ls(expanded_path, depth)
+
+    def upload(self, buf, path):
+        expanded_path = self._expand_path(path)
+        self._inner.upload(buf, expanded_path)
+
+    def delete(self, path):
+        expanded_path = self._expand_path(path)
+        self._inner.delete(expanded_path)
+
+    def mv(self, old_path, path):
+        expanded_old_path = self._expand_path(old_path)
+        expanded_path = self._expand_path(path)
+        self._inner.mv(expanded_old_path, expanded_path)
+
+    def mkdir(self, path):
+        expanded_path = self._expand_path(path)
+        self._inner.mkdir(expanded_path)
+
+    def rmdir(self, path):
+        expanded_path = self._expand_path(path)
+        self._inner.mkdir(expanded_path)
+
+    def download_range(self, fh, buf, path, offset=0, length=0):
+        expanded_path = self._expand_path(path)
+        self._inner.download_range(fh, buf, expanded_path, offset, length)
+
+    def upload_range(self, fh, buf, path, offset=0):
+        expanded_path = self._expand_path(path)
+        self._inner.upload_range(fh, buf, expanded_path, offset)
+
+    def flush(self, fh, path):
+        expanded_path = self._expand_path(path)
+        self._inner.flush(fh, expanded_path)
+
+    def truncate(self, fh, path, length):
+        expanded_path = self._expand_path(path)
+        self._inner.truncate(fh, expanded_path, length)
+
+    def _expand_path(self, path):
+        return fuseutils.join_path_with_delimiter(self._root_path, path) \
+            if self._root_path else path

--- a/pipe-cli/mount/pipefuse/path.py
+++ b/pipe-cli/mount/pipefuse/path.py
@@ -50,7 +50,7 @@ class PathExpandingStorageFileSystemClient(FileSystemClientDecorator):
 
     def rmdir(self, path):
         expanded_path = self._expand_path(path)
-        self._inner.mkdir(expanded_path)
+        self._inner.rmdir(expanded_path)
 
     def download_range(self, fh, buf, path, offset=0, length=0):
         expanded_path = self._expand_path(path)

--- a/pipe-cli/mount/pipefuse/s3.py
+++ b/pipe-cli/mount/pipefuse/s3.py
@@ -68,7 +68,7 @@ class S3MultipartUpload(MultipartUpload):
         )
         self._upload_id = response['UploadId']
 
-    def upload_part(self, buf, offset=None, part_number=None):
+    def upload_part(self, buf, offset=None, part_number=None, part_path=None):
         logging.info('Uploading multipart upload part %d range %d-%d for %s'
                      % (part_number, offset, offset + len(buf), self._path))
         with io.BytesIO(buf) as body:
@@ -81,7 +81,7 @@ class S3MultipartUpload(MultipartUpload):
             )
         self._parts[part_number] = response['ETag']
 
-    def upload_copy_part(self, start, end, offset=None, part_number=None):
+    def upload_copy_part(self, start, end, offset=None, part_number=None, part_path=None):
         logging.info('Uploading multipart upload part %d copy range %d-%d for %s'
                      % (part_number, start, end, self._path))
         response = self._s3.upload_part_copy(
@@ -359,7 +359,7 @@ class S3Client(FileSystemClient):
         mpu = OutOfBoundsSplittingMultipartCopyUpload(mpu, original_size=file_size,
                                                       min_part_size=self._MIN_PART_SIZE, max_part_size=self._chunk_size)
         mpu = ChunkedMultipartUpload(mpu, original_size=file_size,
-                                     download_func=self._generate_region_download_function(source_path),
+                                     download=self._generate_region_download_function(source_path),
                                      chunk_size=self._chunk_size, min_chunk=self._MIN_CHUNK, max_chunk=self._MAX_CHUNK)
         return mpu
 

--- a/pipe-cli/mount/pipefuse/s3.py
+++ b/pipe-cli/mount/pipefuse/s3.py
@@ -14,7 +14,6 @@
 
 import io
 import logging
-import os
 
 import time
 from datetime import datetime

--- a/pipe-cli/mount/pipefuse/storage.py
+++ b/pipe-cli/mount/pipefuse/storage.py
@@ -171,11 +171,13 @@ class StorageHighLevelFileSystemClient(FileSystemClientDecorator):
         if mpu:
             try:
                 mpu.complete()
+                del self._mpus[path]
             except _ANY_ERROR:
+                logging.exception('Multipart upload flushing has failed for %d:%s. '
+                                  'Attempting to abort the multipart upload.' % (fh, path))
+                del self._mpus[path]
                 mpu.abort()
                 raise
-            finally:
-                del self._mpus[path]
 
     def truncate(self, fh, path, length):
         source_path = path.lstrip(self._delimiter)

--- a/pipe-cli/mount/pipefuse/storage.py
+++ b/pipe-cli/mount/pipefuse/storage.py
@@ -1,0 +1,175 @@
+import io
+import logging
+from abc import abstractmethod, ABCMeta
+
+from pipefuse import fuseutils
+from pipefuse.fsclient import FileSystemClient, FileSystemClientDecorator
+from pipefuse.fuseutils import MB
+from pipefuse.mpu import UnmanageableMultipartUploadException
+
+_ANY_ERROR = Exception
+
+
+class StorageLowLevelFileSystemClient(FileSystemClient):
+    __metaclass__ = ABCMeta
+
+    def exists(self, path):
+        pass
+
+    def mkdir(self, path):
+        pass
+
+    def rmdir(self, path):
+        pass
+
+    def upload_range(self, fh, buf, path, offset):
+        pass
+
+    def flush(self, fh, path):
+        pass
+
+    @abstractmethod
+    def new_mpu(self, source_path, file_size, download):
+        pass
+
+
+class StorageHighLevelFileSystemClient(FileSystemClientDecorator):
+
+    def __init__(self, inner):
+        """
+        Cloud storage high level file system client.
+
+        It contains most of the common code between all cloud storage provider implementations.
+
+        :param inner: Decorating storage low level file system client.
+        """
+        super(StorageHighLevelFileSystemClient, self).__init__(inner)
+        self._inner = inner
+        self._delimiter = '/'
+        self._single_upload_size = 5 * MB
+        self._mpus = {}
+
+    def exists(self, path):
+        return len(self.ls(path)) > 0
+
+    def upload(self, buf, path):
+        destination_path = path.lstrip(self._delimiter)
+        self._inner.upload(buf, destination_path)
+
+    def delete(self, path):
+        source_path = path.lstrip(self._delimiter)
+        self._inner.delete(source_path)
+
+    def mv(self, old_path, path):
+        source_path = old_path.lstrip(self._delimiter)
+        destination_path = path.lstrip(self._delimiter)
+        folder_source_path = fuseutils.append_delimiter(source_path)
+        if self.exists(folder_source_path):
+            self._mvdir(folder_source_path, destination_path)
+        else:
+            self._mvfile(source_path, destination_path)
+
+    def _mvdir(self, old_path, path):
+        for file in self.ls(fuseutils.append_delimiter(old_path), depth=-1):
+            relative_path = fuseutils.without_prefix(file.name, old_path)
+            destination_path = fuseutils.join_path_with_delimiter(path, relative_path)
+            self._mvfile(file.name, destination_path)
+
+    def _mvfile(self, source_path, destination_path):
+        self._inner.mv(source_path, destination_path)
+
+    def mkdir(self, path):
+        synthetic_file_path = fuseutils.join_path_with_delimiter(path, '.DS_Store')
+        self.upload([], synthetic_file_path)
+
+    def rmdir(self, path):
+        for file in self.ls(fuseutils.append_delimiter(path), depth=-1):
+            self.delete(file.name)
+
+    def download_range(self, fh, buf, path, offset=0, length=0):
+        source_path = path.lstrip(self._delimiter)
+        self._inner.download_range(fh, buf, source_path, offset, length)
+
+    def upload_range(self, fh, buf, path, offset=0):
+        source_path = path.lstrip(self._delimiter)
+        mpu = self._mpus.get(source_path, None)
+        try:
+            if mpu:
+                mpu.upload_part(buf, offset)
+            else:
+                file_size = self.attrs(path).size
+                buf_size = len(buf)
+                if buf_size < self._single_upload_size \
+                        and file_size < self._single_upload_size \
+                        and offset < self._single_upload_size:
+                    logging.info('Using single range upload approach for %d:%s' % (fh, path))
+                    self._upload_single_range(fh, buf, source_path, offset, file_size)
+                else:
+                    logging.info('Using multipart upload approach for %d:%s' % (fh, path))
+                    mpu = self._new_mpu(source_path, file_size)
+                    self._mpus[path] = mpu
+                    mpu.initiate()
+                    mpu.upload_part(buf, offset)
+        except UnmanageableMultipartUploadException:
+            if mpu:
+                try:
+                    logging.exception('Unmanageable multipart upload detected for %d:%s. '
+                                      'Attempting to reinitialize the multipart upload.' % (fh, path))
+                    mpu.complete()
+                    file_size = self.attrs(path).size
+                    mpu = self._new_mpu(source_path, file_size, offset)
+                    self._mpus[source_path] = mpu
+                    mpu.initiate()
+                    mpu.upload_part(buf, offset)
+                except _ANY_ERROR:
+                    logging.exception('Reinitialized multipart upload has failed for %d:%s. '
+                                      'Attempting to abort the multipart upload.' % (fh, path))
+                    del self._mpus[source_path]
+                    mpu.abort()
+                    raise
+            else:
+                raise
+        except _ANY_ERROR:
+            if mpu:
+                logging.exception('Multipart upload has failed for %d:%s. '
+                                  'Attempting to abort the multipart upload.' % (fh, path))
+                del self._mpus[path]
+                mpu.abort()
+            raise
+
+    def _generate_region_download_function(self):
+        def download(path, region_offset, region_length):
+            with io.BytesIO() as buf:
+                self.download_range(None, buf, path, region_offset, region_length)
+                return buf.getvalue()
+        return download
+
+    def _upload_single_range(self, fh, buf, path, offset, file_size):
+        if file_size:
+            with io.BytesIO() as original_buf:
+                self.download_range(fh, original_buf, path, offset=0, length=file_size)
+                original_bytes = bytearray(original_buf.getvalue())
+        else:
+            original_bytes = bytearray()
+        modified_bytes = bytearray(max(offset + len(buf), len(original_bytes)))
+        modified_bytes[0: len(original_bytes)] = original_bytes
+        modified_bytes[offset: offset + len(buf)] = buf
+        with io.BytesIO(modified_bytes) as body:
+            logging.info('Uploading range %d-%d for %s' % (offset, offset + len(buf), path))
+            self._s3.put_object(Bucket=self.bucket, Key=path, Body=body,
+                                ACL='bucket-owner-full-control')
+
+    def flush(self, fh, path):
+        mpu = self._mpus.get(path, None)
+        if mpu:
+            try:
+                mpu.complete()
+            except _ANY_ERROR:
+                mpu.abort()
+                raise
+            finally:
+                del self._mpus[path]
+
+    def truncate(self, fh, path, length):
+        source_path = path.lstrip(self._delimiter)
+        self._inner.truncate(fh, source_path, length)

--- a/pipe-cli/mount/pipefuse/storage.py
+++ b/pipe-cli/mount/pipefuse/storage.py
@@ -92,7 +92,7 @@ class StorageHighLevelFileSystemClient(FileSystemClientDecorator):
 
     def upload_range(self, fh, buf, path, offset=0):
         source_path = path.lstrip(self._delimiter)
-        mpu = self._mpus.get(source_path, None)
+        mpu = self._mpus.get(path, None)
         try:
             if mpu:
                 mpu.upload_part(buf, offset)
@@ -122,13 +122,13 @@ class StorageHighLevelFileSystemClient(FileSystemClientDecorator):
                     mpu = self._inner.new_mpu(source_path, file_size,
                                               download=self._generate_region_download_function(),
                                               mv=self._generate_move_file_function())
-                    self._mpus[source_path] = mpu
+                    self._mpus[path] = mpu
                     mpu.initiate()
                     mpu.upload_part(buf, offset)
                 except _ANY_ERROR:
                     logging.exception('Reinitialized multipart upload has failed for %d:%s. '
                                       'Attempting to abort the multipart upload.' % (fh, path))
-                    del self._mpus[source_path]
+                    del self._mpus[path]
                     mpu.abort()
                     raise
             else:

--- a/pipe-cli/mount/requirements.txt
+++ b/pipe-cli/mount/requirements.txt
@@ -8,3 +8,4 @@ requests==2.20.0
 pytz==2018.3
 cachetools==3.1.1
 python-intervals==1.10.0
+google-cloud-storage==1.15.0

--- a/pipe-cli/mount/requirements.txt
+++ b/pipe-cli/mount/requirements.txt
@@ -8,4 +8,5 @@ requests==2.20.0
 pytz==2018.3
 cachetools==3.1.1
 python-intervals==1.10.0
+google-resumable-media==0.3.2
 google-cloud-storage==1.15.0


### PR DESCRIPTION
Resolves issue #1173.

The pull request brings support for Google Cloud to pipe mount tool. The implementation mostly reuses functionality from AWS  support resolved in #661. All of the provided independent features such as caching and buffering are supported for google provider as well. The single notable difference between the AWS and Google Cloud implementations is the usage of so-called [composite objects](https://cloud.google.com/storage/docs/composite-objects) in the second case.

# Details

Google Cloud has similar yet different approach for multipart uploading in compare with AWS. 

In AWS an uploading object can be constructed from parts of already uploaded object or from additionally uploaded parts. All the temporary parts are not visible to the user.

Google Cloud allows to merge several already uploaded objects to a single composite one. Using such mechanism pipe mount uploads all the parts as temporary files and then composes them. All the temporary files are visible to the user from moment they are uploaded to the storage till the moment the upload is completed.

_As a result Google Cloud allows to support sequential and non-sequential random writes without any uploading file size limitations._ Nevertheless default chunk size considerations is the same as for AWS.

## Benchmarks

| operation | gcsfuse | pipe |
| --- | --- | --- |
| list 1000 | 0m31.384s | 0m0.365s |
|           | 0m30.648s* | 0m0.012s |
| read 1G   | 0m7.136s | 0m18.125s |
|           | 0m7.377s | 0m18.663s |
| read 10G  | 1m56.705s | 2m52.147s |
|           | 1m55.685s | 2m55.278s |
| write 1G  | 0m10.926s | 0m37.361s |
|           | 0m15.681s | 0m35.497s |
| write 10G | 4m32.414s | 5m53.244s |
|           | 6m46.451s | 5m51.303s |

> \* Most subsequent attempts to list 1000 files using gcsfuse stuck for more than 4 minutes and was interrupted after.
