### PR TITLE
Issue #1038: "Serverless" Cloud Pipeline API

### DIFF
--- a/api/src/main/java/com/epam/pipeline/controller/configuration/ServerlessConfigurationController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/configuration/ServerlessConfigurationController.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.controller.configuration;
+
+import com.epam.pipeline.controller.AbstractRestController;
+import com.epam.pipeline.controller.Result;
+import com.epam.pipeline.manager.configuration.ServerlessConfigurationApiService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Controller
+@Api(value = "Serverless configuration methods")
+@RequiredArgsConstructor
+public class ServerlessConfigurationController extends AbstractRestController {
+
+    private final ServerlessConfigurationApiService serverlessConfigurationApiService;
+
+    @GetMapping(value = "/serverless/url/{id}")
+    @ResponseBody
+    @ApiOperation(
+            value = "Generates serverless url.",
+            notes = "Generates serverless url.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public Result<String> generateUrl(@PathVariable final Long id,
+                                      @RequestParam(required = false) final String config) {
+        return Result.success(serverlessConfigurationApiService.generateUrl(id, config));
+    }
+
+    @RequestMapping(value = "/serverless/{id}/{config}/**", method = {
+            RequestMethod.POST,
+            RequestMethod.GET,
+            RequestMethod.PUT,
+            RequestMethod.DELETE
+    })
+    @ResponseBody
+    @ApiOperation(
+            value = "Launches serverless configuration request",
+            notes = "Launches serverless configuration request",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public Result<String> run(@PathVariable("id") final Long id, @PathVariable("config") final String config,
+                              final HttpServletRequest request) {
+        return Result.success(serverlessConfigurationApiService.run(id, config, request));
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/controller/configuration/ServerlessConfigurationController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/configuration/ServerlessConfigurationController.java
@@ -60,8 +60,7 @@ public class ServerlessConfigurationController extends AbstractRestController {
             RequestMethod.POST,
             RequestMethod.GET,
             RequestMethod.PUT,
-            RequestMethod.DELETE
-    })
+            RequestMethod.DELETE})
     @ResponseBody
     @ApiOperation(
             value = "Launches serverless configuration request",

--- a/api/src/main/java/com/epam/pipeline/controller/configuration/ServerlessConfigurationController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/configuration/ServerlessConfigurationController.java
@@ -69,8 +69,8 @@ public class ServerlessConfigurationController extends AbstractRestController {
     @ApiResponses(
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
             })
-    public Result<String> run(@PathVariable("id") final Long id, @PathVariable("config") final String config,
-                              final HttpServletRequest request) {
-        return Result.success(serverlessConfigurationApiService.run(id, config, request));
+    public String run(@PathVariable("id") final Long id, @PathVariable("config") final String config,
+                      final HttpServletRequest request) {
+        return serverlessConfigurationApiService.run(id, config, request);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/vo/ServiceUrlVO.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/ServiceUrlVO.java
@@ -23,4 +23,5 @@ public class ServiceUrlVO {
 
     private final String name;
     private final String url;
+    private final boolean isDefault;
 }

--- a/api/src/main/java/com/epam/pipeline/controller/vo/ServiceUrlVO.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/ServiceUrlVO.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.controller.vo;
+
+import lombok.Data;
+
+@Data
+public class ServiceUrlVO {
+
+    private final String name;
+    private final String url;
+}

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -122,6 +122,7 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     private String loadAllRunsPossiblyActiveInPeriodQuery;
     private String loadAllRunsByStatusQuery;
     private String loadRunByPodIPQuery;
+    private String loadServerlessRunsToStopQuery;
 
     // We put Propagation.REQUIRED here because this method can be called from non-transaction context
     // (see PipelineRunManager, it performs internal call for launchPipeline)
@@ -446,6 +447,13 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
                 .query(loadRunByPodIPQuery, params, PipelineRunParameters.getRowMapper()))
                 .stream()
                 .findFirst();
+    }
+
+    public List<PipelineRun> loadServerlessRunsToStop(final LocalDateTime maxLastUpdate) {
+        final MapSqlParameterSource params = new MapSqlParameterSource();
+        params.addValue("MAX_LAST_UPDATE", maxLastUpdate);
+        return ListUtils.emptyIfNull(getNamedParameterJdbcTemplate()
+                .query(loadServerlessRunsToStopQuery, params, PipelineRunParameters.getRowMapper()));
     }
 
     private MapSqlParameterSource getPagingParameters(PagingRunFilterVO filter) {
@@ -1195,5 +1203,10 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setDeleteRunSidsByPipelineIdQuery(final String deleteRunSidsByPipelineIdQuery) {
         this.deleteRunSidsByPipelineIdQuery = deleteRunSidsByPipelineIdQuery;
+    }
+
+    @Required
+    public void setLoadServerlessRunsToStopQuery(final String loadServerlessRunsToStopQuery) {
+        this.loadServerlessRunsToStopQuery = loadServerlessRunsToStopQuery;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/StopServerlessRunDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/StopServerlessRunDao.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.dao.pipeline;
+
+import com.epam.pipeline.dao.DaoHelper;
+import com.epam.pipeline.entity.pipeline.StopServerlessRun;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Required;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcDaoSupport;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+public class StopServerlessRunDao extends NamedParameterJdbcDaoSupport {
+
+    @Autowired
+    private DaoHelper daoHelper;
+
+    private String serverlessRunSequenceQuery;
+    private String saveServerlessRunQuery;
+    private String updateServerlessRunQuery;
+    private String loadAllServerlessRunsQuery;
+    private String deleteByRunIdServerlessRunQuery;
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public Long createServerlessRunId() {
+        return daoHelper.createId(serverlessRunSequenceQuery);
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void createServerlessRun(final StopServerlessRun run) {
+        final Long id = createServerlessRunId();
+        run.setId(id);
+        getNamedParameterJdbcTemplate().update(saveServerlessRunQuery,
+                StopServerlessRunParameters.getParameters(run));
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void updateServerlessRun(final StopServerlessRun run) {
+        getNamedParameterJdbcTemplate().update(updateServerlessRunQuery,
+                StopServerlessRunParameters.getParameters(run));
+    }
+
+    public List<StopServerlessRun> loadAll() {
+        return getJdbcTemplate().query(loadAllServerlessRunsQuery, StopServerlessRunParameters.getRowMapper());
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void deleteByRunId(final Long runId) {
+        getJdbcTemplate().update(deleteByRunIdServerlessRunQuery, runId);
+    }
+
+    public enum StopServerlessRunParameters {
+        ID,
+        RUN_ID,
+        LAST_UPDATE;
+
+        static MapSqlParameterSource getParameters(final StopServerlessRun run) {
+            final MapSqlParameterSource params = new MapSqlParameterSource();
+            params.addValue(ID.name(), run.getId());
+            params.addValue(RUN_ID.name(), run.getRunId());
+            params.addValue(LAST_UPDATE.name(), run.getLastUpdate());
+            return params;
+        }
+
+        static RowMapper<StopServerlessRun> getRowMapper() {
+            return (rs, rowNum) -> {
+                final StopServerlessRun run = new StopServerlessRun();
+                run.setId(rs.getLong(ID.name()));
+                run.setRunId(rs.getLong(RUN_ID.name()));
+                run.setLastUpdate(rs.getTimestamp(LAST_UPDATE.name()).toLocalDateTime());
+                return run;
+            };
+        }
+    }
+
+    @Required
+    public void setServerlessRunSequenceQuery(final String serverlessRunSequenceQuery) {
+        this.serverlessRunSequenceQuery = serverlessRunSequenceQuery;
+    }
+
+    @Required
+    public void setLoadAllServerlessRunsQuery(final String loadAllServerlessRunsQuery) {
+        this.loadAllServerlessRunsQuery = loadAllServerlessRunsQuery;
+    }
+
+    @Required
+    public void setSaveServerlessRunQuery(final String saveServerlessRunQuery) {
+        this.saveServerlessRunQuery = saveServerlessRunQuery;
+    }
+
+    @Required
+    public void setUpdateServerlessRunQuery(final String updateServerlessRunQuery) {
+        this.updateServerlessRunQuery = updateServerlessRunQuery;
+    }
+
+    @Required
+    public void setDeleteByRunIdServerlessRunQuery(final String deleteByRunIdServerlessRunQuery) {
+        this.deleteByRunIdServerlessRunQuery = deleteByRunIdServerlessRunQuery;
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/entity/security/JwtRawToken.java
+++ b/api/src/main/java/com/epam/pipeline/entity/security/JwtRawToken.java
@@ -40,18 +40,7 @@ public class JwtRawToken implements Serializable {
             throw new AuthenticationServiceException("Authorization header is blank");
         }
 
-        if (authorizationHeader.startsWith(BEARER_PREFIX)) {
-            return new JwtRawToken(authorizationHeader.substring(BEARER_PREFIX.length()));
-        }
-
-        if (authorizationHeader.startsWith(AuthorizationUtils.BASIC_AUTH)) {
-            final String[] credentials = AuthorizationUtils.parseBasicAuth(authorizationHeader);
-            if (Objects.nonNull(credentials)) {
-                return new JwtRawToken(credentials[1]);
-            }
-        }
-
-        throw new AuthenticationServiceException("Authorization type Bearer or Basic Auth is missed");
+        return getJwtRawToken(authorizationHeader);
     }
 
     public static JwtRawToken fromCookie(Cookie authCookie) throws UnsupportedEncodingException {
@@ -59,13 +48,24 @@ public class JwtRawToken implements Serializable {
             throw new AuthenticationServiceException("Authorization cookie is blank");
         }
 
-        String authCookieValue = URLDecoder.decode(authCookie.getValue(), "UTF-8");
+        final String authCookieValue = URLDecoder.decode(authCookie.getValue(), "UTF-8");
 
-        if (!authCookieValue.startsWith(BEARER_PREFIX)) {
-            throw new AuthenticationServiceException("Authorization type Bearer is missed");
+        return getJwtRawToken(authCookieValue);
+    }
+
+    private static JwtRawToken getJwtRawToken(final String authorizationValue) {
+        if (authorizationValue.startsWith(BEARER_PREFIX)) {
+            return new JwtRawToken(authorizationValue.substring(BEARER_PREFIX.length()));
         }
 
-        return new JwtRawToken(authCookieValue.substring(BEARER_PREFIX.length(), authCookieValue.length()));
+        if (authorizationValue.startsWith(AuthorizationUtils.BASIC_AUTH)) {
+            final String[] credentials = AuthorizationUtils.parseBasicAuth(authorizationValue);
+            if (Objects.nonNull(credentials)) {
+                return new JwtRawToken(credentials[1]);
+            }
+        }
+
+        throw new AuthenticationServiceException("Authorization type Bearer or Basic Auth is missed");
     }
 
     public String toHeader() {

--- a/api/src/main/java/com/epam/pipeline/entity/security/JwtRawToken.java
+++ b/api/src/main/java/com/epam/pipeline/entity/security/JwtRawToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,11 @@ package com.epam.pipeline.entity.security;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.util.Objects;
 
 import javax.servlet.http.Cookie;
 
+import com.epam.pipeline.utils.AuthorizationUtils;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
@@ -30,7 +32,7 @@ import org.springframework.security.authentication.AuthenticationServiceExceptio
 @Getter
 @AllArgsConstructor
 public class JwtRawToken implements Serializable {
-    private static final String HEADER_PREFIX = "Bearer ";
+    private static final String BEARER_PREFIX = "Bearer ";
     private String token;
 
     public static JwtRawToken fromHeader(String authorizationHeader) {
@@ -38,11 +40,18 @@ public class JwtRawToken implements Serializable {
             throw new AuthenticationServiceException("Authorization header is blank");
         }
 
-        if (!authorizationHeader.startsWith(HEADER_PREFIX)) {
-            throw new AuthenticationServiceException("Authorization type Bearer is missed");
+        if (authorizationHeader.startsWith(BEARER_PREFIX)) {
+            return new JwtRawToken(authorizationHeader.substring(BEARER_PREFIX.length()));
         }
 
-        return new JwtRawToken(authorizationHeader.substring(HEADER_PREFIX.length(), authorizationHeader.length()));
+        if (authorizationHeader.startsWith(AuthorizationUtils.BASIC_AUTH)) {
+            final String[] credentials = AuthorizationUtils.parseBasicAuth(authorizationHeader);
+            if (Objects.nonNull(credentials)) {
+                return new JwtRawToken(credentials[1]);
+            }
+        }
+
+        throw new AuthenticationServiceException("Authorization type Bearer or Basic Auth is missed");
     }
 
     public static JwtRawToken fromCookie(Cookie authCookie) throws UnsupportedEncodingException {
@@ -52,14 +61,14 @@ public class JwtRawToken implements Serializable {
 
         String authCookieValue = URLDecoder.decode(authCookie.getValue(), "UTF-8");
 
-        if (!authCookieValue.startsWith(HEADER_PREFIX)) {
+        if (!authCookieValue.startsWith(BEARER_PREFIX)) {
             throw new AuthenticationServiceException("Authorization type Bearer is missed");
         }
 
-        return new JwtRawToken(authCookieValue.substring(HEADER_PREFIX.length(), authCookieValue.length()));
+        return new JwtRawToken(authCookieValue.substring(BEARER_PREFIX.length(), authCookieValue.length()));
     }
 
     public String toHeader() {
-        return HEADER_PREFIX + token;
+        return BEARER_PREFIX + token;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/configuration/ServerlessConfigurationApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/configuration/ServerlessConfigurationApiService.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.configuration;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Service
+@RequiredArgsConstructor
+public class ServerlessConfigurationApiService {
+
+    private final ServerlessConfigurationManager serverlessConfigurationManager;
+
+    @PreAuthorize("hasRole('ADMIN') OR hasPermission(#id, "
+            + "'com.epam.pipeline.entity.configuration.RunConfiguration', 'READ')")
+    public String generateUrl(final Long id, final String name) {
+        return serverlessConfigurationManager.generateUrl(id, name);
+    }
+
+    @PreAuthorize("hasRole('ADMIN') OR "
+            + "@grantPermissionManager.hasConfigurationUpdatePermission(#configuration, 'EXECUTE')")
+    public String run(final Long id, final String configName, final HttpServletRequest request) {
+        return serverlessConfigurationManager.run(id, configName, request);
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/configuration/ServerlessConfigurationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/configuration/ServerlessConfigurationManager.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.configuration;
+
+import com.epam.pipeline.config.JsonMapper;
+import com.epam.pipeline.controller.vo.PagingRunFilterVO;
+import com.epam.pipeline.controller.vo.ServiceUrlVO;
+import com.epam.pipeline.dao.pipeline.StopServerlessRunDao;
+import com.epam.pipeline.entity.configuration.AbstractRunConfigurationEntry;
+import com.epam.pipeline.entity.configuration.RunConfiguration;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.pipeline.StopServerlessRun;
+import com.epam.pipeline.entity.pipeline.TaskStatus;
+import com.epam.pipeline.manager.pipeline.PipelineRunManager;
+import com.epam.pipeline.manager.pipeline.runner.ConfigurationRunner;
+import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.epam.pipeline.manager.preference.SystemPreferences;
+import com.epam.pipeline.mapper.AbstractRunConfigurationMapper;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.ssl.TrustStrategy;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.Assert;
+import org.springframework.web.client.RestTemplate;
+
+import javax.net.ssl.SSLContext;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.X509Certificate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ServerlessConfigurationManager {
+
+    private static final int REQUEST_TIMEOUT = 30 * 1000;
+
+    private final RunConfigurationManager runConfigurationManager;
+    private final ConfigurationRunner configurationRunner;
+    private final AbstractRunConfigurationMapper runConfigurationMapper;
+    private final PipelineRunManager runManager;
+    private final PreferenceManager preferenceManager;
+    private final StopServerlessRunDao stopServerlessRunDao;
+    private final ObjectMapper objectMapper;
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public String run(final Long configurationId, final String configName, final HttpServletRequest request) {
+        final RunConfiguration configuration = runConfigurationManager.load(configurationId);
+        final AbstractRunConfigurationEntry configurationEntry = configuration.getEntries().stream()
+                .filter(config -> Objects.equals(config.getName(), configName))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(String
+                        .format("Cannot find configuration with name '%s'", configName)));
+        final PipelineRun pipelineRun = receivePipelineRun(configurationId, configuration);
+
+        final StopServerlessRun stopRunInfo = StopServerlessRun.builder()
+                .runId(pipelineRun.getId())
+                .lastUpdate(LocalDateTime.now())
+                .build();
+        if (configurationEntry.isStopAfter()) {
+            stopServerlessRunDao.createServerlessRun(stopRunInfo);
+        }
+
+        waitForRunInitialized(pipelineRun);
+        final String endPointName = getEndpointUrl(configuration, configurationEntry, pipelineRun);
+
+        final String appPath = buildApplicationUrl(request, endPointName);
+        log.debug("The request '{}' will be sent", appPath);
+
+        final String response = sendRequest(request, appPath);
+
+        if (configurationEntry.isStopAfter()) {
+            stopRunInfo.setLastUpdate(LocalDateTime.now());
+            stopServerlessRunDao.updateServerlessRun(stopRunInfo);
+        }
+
+        return response;
+    }
+
+    public String generateUrl(final Long configurationId, String configName) {
+        configName = getConfigurationName(configurationId, configName);
+        final String apiHost = preferenceManager.getPreference(SystemPreferences.BASE_API_HOST_EXTERNAL);
+        Assert.state(StringUtils.isNotBlank(apiHost), "API host is not specified");
+        return String.format("%s/serverless/%d/%s", StringUtils.stripEnd(apiHost, "/"),
+                configurationId, configName);
+    }
+
+    private String getConfigurationName(final Long configurationId, final String configName) {
+        return runConfigurationManager.load(configurationId).getEntries().stream()
+                .filter(entry -> StringUtils.isNotBlank(configName)
+                        ? Objects.equals(entry.getName(), configName)
+                        : entry.isDefaultConfiguration())
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Failed to determine config name"))
+                .getName();
+    }
+
+    private void waitForRunInitialized(final PipelineRun pipelineRun) {
+        final Integer maxRetryCount = preferenceManager.getPreference(SystemPreferences.LAUNCH_SERVERLESS_WAIT_COUNT);
+        final Integer waitTime = preferenceManager.getPreference(SystemPreferences.LAUNCH_TASK_STATUS_UPDATE_RATE);
+
+        for (int i = 0; i < maxRetryCount; i++) {
+            if (StringUtils.isNotBlank(runManager.loadPipelineRun(pipelineRun.getId()).getServiceUrl())) {
+                return;
+            }
+            try {
+                Thread.sleep(waitTime);
+            } catch (InterruptedException e) {
+                throw new IllegalArgumentException(e);
+            }
+        }
+        throw new IllegalArgumentException("Exceeded maximum waiting time for launching configuration");
+    }
+
+    private PipelineRun receivePipelineRun(final Long configurationId, final RunConfiguration configuration) {
+        final PagingRunFilterVO filter = new PagingRunFilterVO();
+        filter.setConfigurationIds(Collections.singletonList(configurationId));
+        filter.setStatuses(Collections.singletonList(TaskStatus.RUNNING));
+        List<PipelineRun> activeRunsForConfiguration = ListUtils.emptyIfNull(runManager
+                .searchPipelineRuns(filter, false)
+                .getElements());
+        if (CollectionUtils.isEmpty(activeRunsForConfiguration)) {
+            activeRunsForConfiguration = configurationRunner.runConfiguration(null,
+                    runConfigurationMapper.toRunConfigurationWithEntitiesVO(configuration), null);
+        }
+        return activeRunsForConfiguration.stream()
+                .max(Comparator.comparing(PipelineRun::getStartDate))
+                .orElseThrow(() -> new IllegalArgumentException("Failed to find pipeline run for configuration"));
+    }
+
+    private String getEndpointUrl(final RunConfiguration configuration,
+                                  final AbstractRunConfigurationEntry configurationEntry,
+                                  final PipelineRun pipelineRun) {
+        final String endpointName = configurationEntry.getEndpointName();
+        final List<ServiceUrlVO> serviceUrls = ListUtils.emptyIfNull(JsonMapper.parseData(pipelineRun.getServiceUrl(),
+                new TypeReference<List<ServiceUrlVO>>() {}, objectMapper));
+
+        if (StringUtils.isNotBlank(endpointName)) {
+            return serviceUrls.stream()
+                    .filter(serviceUrl -> Objects.equals(serviceUrl.getName(), endpointName))
+                    .findAny()
+                    .orElseThrow(() -> new IllegalArgumentException(String
+                            .format("Failed to find endpoint url for endpoint name '%s'", endpointName)))
+                    .getUrl();
+        }
+        Assert.state(serviceUrls.size() == 1,
+                "Only one service url is allowed when endpoint name is not specified");
+        return serviceUrls.get(0).getUrl();
+    }
+
+    String sendRequest(final HttpServletRequest request, final String appPath) {
+        try {
+            final HttpEntity<String> requestEntity = buildHttpEntity(request);
+            final ResponseEntity<String> resp = buildRestTemplate()
+                    .exchange(appPath, HttpMethod.valueOf(request.getMethod()), requestEntity, String.class);
+            return resp.getBody();
+        } catch (IOException | NoSuchAlgorithmException | KeyStoreException | KeyManagementException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    private String buildApplicationUrl(final HttpServletRequest request, final String endpointName) {
+        final String appPath = String.format("%s/%s",
+                StringUtils.stripEnd(endpointName, "/"), getApplicationPath(request));
+        return StringUtils.isNotBlank(request.getQueryString())
+                ? String.format("%s?%s", appPath, request.getQueryString())
+                : appPath;
+    }
+
+    private String getApplicationPath(final HttpServletRequest request) {
+        final Pattern pattern = Pattern.compile("/serverless/.*?/.*?/([^']*)");
+        final Matcher matcher = pattern.matcher(request.getPathInfo());
+        return matcher.matches() ? matcher.group(1) : "";
+    }
+
+    private HttpHeaders buildHttpHeaders(final HttpServletRequest request) {
+        final HttpHeaders headers = new HttpHeaders();
+        Collections.list(request.getHeaderNames())
+                .forEach(headerName -> headers.add(headerName, request.getHeader(headerName)));
+        return headers;
+    }
+
+    private RestTemplate buildRestTemplate() throws KeyStoreException, NoSuchAlgorithmException,
+            KeyManagementException {
+        final RestTemplateBuilder builder = new RestTemplateBuilder()
+                .additionalMessageConverters(new RestTemplate().getMessageConverters());
+        final TrustStrategy acceptingTrustStrategy = (X509Certificate[] chain, String authType) -> true;
+        final SSLContext sslContext = org.apache.http.ssl.SSLContexts.custom()
+                .loadTrustMaterial(null, acceptingTrustStrategy)
+                .build();
+        final SSLConnectionSocketFactory csf = new SSLConnectionSocketFactory(sslContext);
+        final CloseableHttpClient httpClient = HttpClients.custom()
+                .setSSLSocketFactory(csf)
+                .build();
+        final HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory();
+        requestFactory.setHttpClient(httpClient);
+        return builder
+                .requestFactory(requestFactory)
+                .setConnectTimeout(REQUEST_TIMEOUT)
+                .build();
+    }
+
+    private HttpEntity<String> buildHttpEntity(final HttpServletRequest request) throws IOException {
+        final String body = IOUtils.toString(request.getInputStream(),
+                Charset.forName(request.getCharacterEncoding()));
+        return new HttpEntity<>(body, buildHttpHeaders(request));
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/configuration/ServerlessConfigurationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/configuration/ServerlessConfigurationManager.java
@@ -104,7 +104,7 @@ public class ServerlessConfigurationManager {
         }
 
         waitForRunInitialized(pipelineRun);
-        final String endPointName = getEndpointUrl(configuration, configurationEntry, pipelineRun);
+        final String endPointName = getEndpointUrl(configurationEntry, pipelineRun);
 
         final String appPath = buildApplicationUrl(request, endPointName);
         log.debug("The request '{}' will be sent", appPath);
@@ -119,8 +119,8 @@ public class ServerlessConfigurationManager {
         return response;
     }
 
-    public String generateUrl(final Long configurationId, String configName) {
-        configName = getConfigurationName(configurationId, configName);
+    public String generateUrl(final Long configurationId, final String config) {
+        final String configName = getConfigurationName(configurationId, config);
         final String apiHost = preferenceManager.getPreference(SystemPreferences.BASE_API_HOST_EXTERNAL);
         Assert.state(StringUtils.isNotBlank(apiHost), "API host is not specified");
         return String.format("%s/serverless/%d/%s", StringUtils.stripEnd(apiHost, "/"),
@@ -170,8 +170,7 @@ public class ServerlessConfigurationManager {
                 .orElseThrow(() -> new IllegalArgumentException("Failed to find pipeline run for configuration"));
     }
 
-    private String getEndpointUrl(final RunConfiguration configuration,
-                                  final AbstractRunConfigurationEntry configurationEntry,
+    private String getEndpointUrl(final AbstractRunConfigurationEntry configurationEntry,
                                   final PipelineRun pipelineRun) {
         final String endpointName = configurationEntry.getEndpointName();
         final List<ServiceUrlVO> serviceUrls = ListUtils.emptyIfNull(JsonMapper.parseData(pipelineRun.getServiceUrl(),

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -24,6 +24,7 @@ import com.epam.pipeline.controller.vo.PipelineRunFilterVO;
 import com.epam.pipeline.controller.vo.PipelineRunServiceUrlVO;
 import com.epam.pipeline.controller.vo.TagsVO;
 import com.epam.pipeline.dao.pipeline.PipelineRunDao;
+import com.epam.pipeline.dao.pipeline.StopServerlessRunDao;
 import com.epam.pipeline.entity.AbstractSecuredEntity;
 import com.epam.pipeline.entity.BaseEntity;
 import com.epam.pipeline.entity.cluster.InstanceDisk;
@@ -197,6 +198,9 @@ public class PipelineRunManager {
 
     @Autowired
     private PipelineRunCRUDService runCRUDService;
+
+    @Autowired
+    private StopServerlessRunDao stopServerlessRunDao;
 
     /**
      * Launches cmd command execution, uses Tool as ACL identity
@@ -1153,6 +1157,16 @@ public class PipelineRunManager {
         return pipelineRunDao.loadRunByPodIP(ip, Arrays.stream(TaskStatus.values())
                 .filter(status -> !status.isFinal())
                 .collect(Collectors.toList()));
+    }
+
+    public List<PipelineRun> loadExpiredServerlessRuns(final LocalDateTime maxLastUpdate) {
+        return pipelineRunDao.loadServerlessRunsToStop(maxLastUpdate);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void stopServerlessRun(final Long runId) {
+        stop(runId);
+        stopServerlessRunDao.deleteByRunId(runId);
     }
 
     private int getTotalSize(final List<InstanceDisk> disks) {

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -388,6 +388,10 @@ public class SystemPreferences {
             "launch.serverless.wait.count", 20, LAUNCH_GROUP, isGreaterThan(0));
     public static final IntPreference LAUNCH_SERVERLESS_STOP_TIMEOUT = new IntPreference(
             "launch.serverless.stop.timeout", 60, LAUNCH_GROUP, isGreaterThan(0));
+    public static final IntPreference LAUNCH_SERVERLESS_ENDPOINT_WAIT_COUNT = new IntPreference(
+            "launch.serverless.endpoint.wait.count", 40, LAUNCH_GROUP, isGreaterThan(0));
+    public static final IntPreference LAUNCH_SERVERLESS_ENDPOINT_WAIT_TIME = new IntPreference(
+            "launch.serverless.endpoint.wait.time", 20000, LAUNCH_GROUP, isGreaterThan(0));
 
     //DTS submission
     public static final StringPreference DTS_LAUNCH_CMD_TEMPLATE = new StringPreference("dts.launch.cmd",

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -384,6 +384,10 @@ public class SystemPreferences {
             LAUNCH_GROUP, isValidEnum(ContainerMemoryResourcePolicy.class));
     public static final IntPreference LAUNCH_CONTAINER_MEMORY_RESOURCE_REQUEST = new IntPreference(
             "launch.container.memory.resource.request", 1, LAUNCH_GROUP, isGreaterThan(0));
+    public static final IntPreference LAUNCH_SERVERLESS_WAIT_COUNT = new IntPreference(
+            "launch.serverless.wait.count", 20, LAUNCH_GROUP, isGreaterThan(0));
+    public static final IntPreference LAUNCH_SERVERLESS_STOP_TIMEOUT = new IntPreference(
+            "launch.serverless.stop.timeout", 60, LAUNCH_GROUP, isGreaterThan(0));
 
     //DTS submission
     public static final StringPreference DTS_LAUNCH_CMD_TEMPLATE = new StringPreference("dts.launch.cmd",

--- a/api/src/main/java/com/epam/pipeline/mapper/AbstractRunConfigurationMapper.java
+++ b/api/src/main/java/com/epam/pipeline/mapper/AbstractRunConfigurationMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.List;
 
 import com.epam.pipeline.controller.vo.configuration.RunConfigurationVO;
+import com.epam.pipeline.controller.vo.configuration.RunConfigurationWithEntitiesVO;
 import com.epam.pipeline.entity.configuration.AbstractRunConfigurationEntry;
 import com.epam.pipeline.entity.configuration.RunConfiguration;
 import com.epam.pipeline.entity.pipeline.Folder;
@@ -32,6 +33,12 @@ public abstract class AbstractRunConfigurationMapper {
 
     @Mapping(target = "parentId", expression = "java(fillParentFolderId(runConfiguration))")
     public abstract RunConfigurationVO toRunConfigurationVO(RunConfiguration runConfiguration);
+
+    @Mapping(target = "parentId", expression = "java(fillParentFolderId(runConfiguration))")
+    @Mapping(target = "metadataClass", ignore = true)
+    @Mapping(target = "entitiesIds", ignore = true)
+    @Mapping(target = "folderId", ignore = true)
+    public abstract RunConfigurationWithEntitiesVO toRunConfigurationWithEntitiesVO(RunConfiguration runConfiguration);
 
     @Mapping(target = "entries", expression = "java(fillEntries(runConfigurationVO))")
     @Mapping(target = "parent", expression = "java(fillParentFolder(runConfigurationVO))")

--- a/api/src/main/java/com/epam/pipeline/utils/AuthorizationUtils.java
+++ b/api/src/main/java/com/epam/pipeline/utils/AuthorizationUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.utils;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+public interface AuthorizationUtils {
+
+    String BASIC_AUTH = "Basic";
+
+    static String[] parseBasicAuth(final String authorization) {
+        if (authorization != null && authorization.startsWith(BASIC_AUTH)) {
+            // Authorization: Basic base64credentials
+            final String base64Credentials = authorization.substring(BASIC_AUTH.length()).trim();
+            final String credentials = new String(Base64.getDecoder().decode(base64Credentials),
+                    StandardCharsets.UTF_8);
+            // credentials = username:password
+            final String[] values = credentials.split(":", 2);
+            if (values.length < 2 || StringUtils.isBlank(values[0]) || StringUtils.isBlank(values[1])) {
+                return null;
+            }
+            return values;
+        }
+        return null;
+    }
+}

--- a/api/src/main/resources/dao/pipeline-run-dao.xml
+++ b/api/src/main/resources/dao/pipeline-run-dao.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+  ~ Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -1637,6 +1637,67 @@
                     DELETE FROM pipeline.run_user ru
                     USING pipeline.pipeline_run pr, pipeline.pipeline p
                     WHERE pr.run_id = ru.run_id AND p.pipeline_id = pr.pipeline_id AND p.pipeline_id = ?
+                ]]>
+            </value>
+        </property>
+        <property name="loadServerlessRunsToStopQuery">
+            <value>
+                <![CDATA[
+                    SELECT
+                        r.run_id,
+                        r.pipeline_id,
+                        r.version,
+                        r.start_date,
+                        r.end_date,
+                        r.parameters,
+                        r.status,
+                        r.terminating,
+                        r.pod_id,
+                        r.node_type,
+                        r.node_disk,
+                        r.node_ip,
+                        r.node_id,
+                        r.node_name,
+                        r.node_image,
+                        r.node_cloud_region,
+                        r.docker_image,
+                        r.actual_docker_image,
+                        r.cmd_template,
+                        r.actual_cmd,
+                        r.timeout,
+                        r.owner,
+                        r.service_url,
+                        r.pod_ip,
+                        r.commit_status,
+                        r.last_change_commit_time,
+                        r.config_name,
+                        r.node_count,
+                        r.parent_id,
+                        r.entities_ids,
+                        r.is_spot,
+                        r.configuration_id,
+                        r.pod_status,
+                        r.prolonged_at_time,
+                        r.last_notification_time,
+                        r.last_idle_notification_time,
+                        r.exec_preferences,
+                        r.pretty_url,
+                        r.price_per_hour,
+                        r.compute_price_per_hour,
+                        r.disk_price_per_hour,
+                        r.state_reason,
+                        r.non_pause,
+                        r.node_real_disk,
+                        r.node_cloud_provider,
+                        r.tags,
+                        r.sensitive
+                    FROM
+                        pipeline.pipeline_run r
+                    LEFT JOIN pipeline.stop_serverless_run s ON (s.run_id = r.run_id)
+                    WHERE
+                        r.status = 2 and s.last_update < :MAX_LAST_UPDATE
+                    ORDER BY
+                        r.start_date
                 ]]>
             </value>
         </property>

--- a/api/src/main/resources/dao/stop-serverless-run-dao.xml
+++ b/api/src/main/resources/dao/stop-serverless-run-dao.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <bean class="com.epam.pipeline.dao.pipeline.StopServerlessRunDao" id="stopServerlessRunDao" autowire="byName">
+        <property name="serverlessRunSequenceQuery" value="pipeline.s_stop_serverless_run"/>
+        <property name="saveServerlessRunQuery">
+            <value>
+                <![CDATA[
+                    INSERT INTO pipeline.stop_serverless_run (
+                        id,
+                        run_id,
+                        last_update)
+                    VALUES (
+                        :ID,
+                        :RUN_ID,
+                        :LAST_UPDATE)
+                ]]>
+            </value>
+        </property>
+        <property name="updateServerlessRunQuery">
+            <value>
+                <![CDATA[
+                    UPDATE pipeline.stop_serverless_run SET
+                        last_update = :LAST_UPDATE
+                    WHERE id = :ID
+                ]]>
+            </value>
+        </property>
+        <property name="deleteByRunIdServerlessRunQuery">
+            <value>
+                <![CDATA[
+                    DELETE FROM pipeline.stop_serverless_run WHERE run_id = ?
+                ]]>
+            </value>
+        </property>
+        <property name="loadAllServerlessRunsQuery">
+            <value>
+                <![CDATA[
+                    SELECT
+                        id,
+                        run_id,
+                        last_update
+                    FROM
+                        pipeline.stop_serverless_run
+                ]]>
+            </value>
+        </property>
+    </bean>
+</beans>

--- a/api/src/main/resources/db/migration/v2020.07.01_12.00__issue_1038_serverless.sql
+++ b/api/src/main/resources/db/migration/v2020.07.01_12.00__issue_1038_serverless.sql
@@ -1,0 +1,6 @@
+CREATE SEQUENCE pipeline.s_stop_serverless_run START WITH 1 INCREMENT BY 1;
+CREATE TABLE IF NOT EXISTS pipeline.stop_serverless_run (
+    id BIGINT NOT NULL PRIMARY KEY,
+    run_id BIGINT NOT NULL REFERENCES pipeline.pipeline_run(run_id),
+    last_update TIMESTAMP WITH TIME ZONE NOT NULL
+);

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/StopServerlessRunDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/StopServerlessRunDaoTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.dao.pipeline;
+
+import com.epam.pipeline.AbstractSpringTest;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.pipeline.StopServerlessRun;
+import com.epam.pipeline.manager.ObjectCreatorUtils;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@Transactional
+public class StopServerlessRunDaoTest extends AbstractSpringTest {
+
+    @Autowired
+    private StopServerlessRunDao stopServerlessRunDao;
+    @Autowired
+    private PipelineRunDao pipelineRunDao;
+
+    @Test
+    public void crud() {
+        final PipelineRun pipelineRun = pipelineRun();
+        pipelineRunDao.createPipelineRun(pipelineRun);
+
+        final LocalDateTime firstUpdate = LocalDateTime.now();
+        final StopServerlessRun stopServerlessRun = StopServerlessRun.builder()
+                .runId(pipelineRun.getId())
+                .lastUpdate(firstUpdate)
+                .build();
+        stopServerlessRunDao.createServerlessRun(stopServerlessRun);
+        assertNotNull(stopServerlessRun.getId());
+
+        assertEquals(stopServerlessRunDao.loadAll().size(), 1);
+
+        final LocalDateTime newUpdate = firstUpdate.plusHours(1);
+        stopServerlessRun.setLastUpdate(newUpdate);
+        stopServerlessRunDao.updateServerlessRun(stopServerlessRun);
+
+        final List<StopServerlessRun> loaded = stopServerlessRunDao.loadAll();
+        assertEquals(loaded.size(), 1);
+        assertEquals(loaded.get(0).getLastUpdate(), newUpdate);
+
+        stopServerlessRunDao.deleteByRunId(pipelineRun.getId());
+
+        assertEquals(stopServerlessRunDao.loadAll().size(), 0);
+
+        pipelineRunDao.deleteRunsByPipeline(1L);
+    }
+
+    private PipelineRun pipelineRun() {
+        return ObjectCreatorUtils.createPipelineRun(null, null, null, 1L);
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/manager/ObjectCreatorUtils.java
+++ b/api/src/test/java/com/epam/pipeline/manager/ObjectCreatorUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package com.epam.pipeline.manager;
 import com.epam.pipeline.controller.vo.DataStorageVO;
 import com.epam.pipeline.controller.vo.PipelineVO;
 import com.epam.pipeline.controller.vo.configuration.RunConfigurationVO;
+import com.epam.pipeline.controller.vo.configuration.RunConfigurationWithEntitiesVO;
 import com.epam.pipeline.controller.vo.docker.DockerRegistryVO;
 import com.epam.pipeline.controller.vo.metadata.MetadataEntityVO;
 import com.epam.pipeline.entity.configuration.AbstractRunConfigurationEntry;
@@ -166,6 +167,16 @@ public final class ObjectCreatorUtils {
     public static RunConfigurationVO createRunConfigurationVO(String name, String description, Long parentFolderId,
                                                               List<AbstractRunConfigurationEntry> entries) {
         RunConfigurationVO runConfigurationVO = new RunConfigurationVO();
+        runConfigurationVO.setName(name);
+        runConfigurationVO.setDescription(description);
+        runConfigurationVO.setParentId(parentFolderId);
+        runConfigurationVO.setEntries(entries);
+        return runConfigurationVO;
+    }
+
+    public static RunConfigurationWithEntitiesVO createRunConfigurationWithEntitiesVO(
+            String name, String description, Long parentFolderId, List<AbstractRunConfigurationEntry> entries) {
+        RunConfigurationWithEntitiesVO runConfigurationVO = new RunConfigurationWithEntitiesVO();
         runConfigurationVO.setName(name);
         runConfigurationVO.setDescription(description);
         runConfigurationVO.setParentId(parentFolderId);

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManagerTest.java
@@ -67,8 +67,14 @@ import java.util.Map;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyMap;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+@SuppressWarnings("PMD.TooManyStaticImports")
 public class ResourceMonitoringManagerTest {
     private static final long TEST_OK_RUN_ID = 1;
     private static final double TEST_OK_RUN_CPU_LOAD = 800.0;
@@ -166,6 +172,9 @@ public class ResourceMonitoringManagerTest {
                 .thenReturn(TEST_HIGH_CONSUMING_RUN_LOAD);
         when(preferenceManager.getPreference(SystemPreferences.SYSTEM_IDLE_ACTION))
                 .thenReturn(IdleRunAction.NOTIFY.name());
+        when(preferenceManager.getPreference(SystemPreferences.LAUNCH_SERVERLESS_STOP_TIMEOUT))
+                .thenReturn(TEST_MAX_IDLE_MONITORING_TIMEOUT);
+        when(pipelineRunManager.loadExpiredServerlessRuns(any())).thenReturn(Collections.emptyList());
 
         SecurityContext context = SecurityContextHolder.createEmptyContext();
         UserContext userContext = new UserContext(1L, "admin");

--- a/api/src/test/java/com/epam/pipeline/manager/configuration/ServerlessConfigurationManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/configuration/ServerlessConfigurationManagerTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.configuration;
+
+import com.epam.pipeline.config.JsonMapper;
+import com.epam.pipeline.controller.PagedResult;
+import com.epam.pipeline.controller.vo.configuration.RunConfigurationWithEntitiesVO;
+import com.epam.pipeline.dao.pipeline.StopServerlessRunDao;
+import com.epam.pipeline.entity.configuration.RunConfiguration;
+import com.epam.pipeline.entity.configuration.RunConfigurationEntry;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.manager.ObjectCreatorUtils;
+import com.epam.pipeline.manager.pipeline.PipelineRunManager;
+import com.epam.pipeline.manager.pipeline.runner.ConfigurationRunner;
+import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.epam.pipeline.manager.preference.SystemPreferences;
+import com.epam.pipeline.mapper.AbstractRunConfigurationMapper;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("PMD.TooManyStaticImports")
+public class ServerlessConfigurationManagerTest {
+
+    private static final String TEST_NAME = "test";
+    private static final String ANOTHER_TEST_NAME = "another";
+    private static final String TEST_URL = "https://external.api/";
+    private static final String TEST_QUERY = "query=1";
+    private static final String TEST_APP_PATH = "app/path";
+    private static final Long PIPELINE_ID = 1L;
+    private static final Long RUN_ID = 2L;
+    private static final Long CONFIGURATION_ID = 3L;
+
+    private final RunConfigurationManager runConfigurationManager = mock(RunConfigurationManager.class);
+    private final ConfigurationRunner configurationRunner = mock(ConfigurationRunner.class);
+    private final AbstractRunConfigurationMapper runConfigurationMapper = mock(AbstractRunConfigurationMapper.class);
+    private final PipelineRunManager runManager = mock(PipelineRunManager.class);
+    private final PreferenceManager preferenceManager = mock(PreferenceManager.class);
+    private final StopServerlessRunDao stopServerlessRunDao = mock(StopServerlessRunDao.class);
+    private final ServerlessConfigurationManager serverlessConfigurationManager =
+            spy(new ServerlessConfigurationManager(
+                    runConfigurationManager,
+                    configurationRunner,
+                    runConfigurationMapper,
+                    runManager,
+                    preferenceManager,
+                    stopServerlessRunDao,
+                    new JsonMapper()));
+
+    @Test
+    public void shouldRunServerlessConfiguration() {
+        final RunConfigurationEntry entry = runConfigurationEntry(TEST_NAME, true);
+        final RunConfiguration configuration = runConfiguration(TEST_NAME, entry);
+        final RunConfigurationWithEntitiesVO runConfigurationVO = runConfigurationWithEntitiesVO(TEST_NAME, entry);
+        final PipelineRun pipelineRun = pipelineRun();
+        pipelineRun.setServiceUrl(String.format("[{\"url\": \"%s\"}]", TEST_URL));
+        final PagedResult<List<PipelineRun>> activeRuns = new PagedResult<>(Collections.emptyList(), 0);
+
+        when(runConfigurationManager.load(any())).thenReturn(configuration);
+        when(runConfigurationMapper.toRunConfigurationWithEntitiesVO(any())).thenReturn(runConfigurationVO);
+        when(configurationRunner.runConfiguration(any(), any(), any()))
+                .thenReturn(Collections.singletonList(pipelineRun));
+        when(runManager.searchPipelineRuns(any(), anyBoolean())).thenReturn(activeRuns);
+        when(preferenceManager.getPreference(SystemPreferences.LAUNCH_SERVERLESS_WAIT_COUNT)).thenReturn(1);
+        when(runManager.loadPipelineRun(any())).thenReturn(pipelineRun);
+        doReturn(StringUtils.EMPTY).when(serverlessConfigurationManager).sendRequest(any(), any());
+
+        serverlessConfigurationManager.run(CONFIGURATION_ID, TEST_NAME, mockRequest());
+        verifyEndpoint();
+        verify(configurationRunner).runConfiguration(any(), any(), any());
+    }
+
+    @Test
+    public void shouldRunServerlessConfigurationWithEndpointName() {
+        final RunConfigurationEntry entry = runConfigurationEntry(TEST_NAME, true);
+        entry.setEndpointName(TEST_NAME);
+        final RunConfiguration configuration = runConfiguration(TEST_NAME, entry);
+        final RunConfigurationWithEntitiesVO runConfigurationVO = runConfigurationWithEntitiesVO(TEST_NAME, entry);
+        final PipelineRun pipelineRun = pipelineRun();
+        pipelineRun.setServiceUrl(String.format("[{\"url\": \"%s\", \"name\": \"%s\"}]", TEST_URL, TEST_NAME));
+        final PagedResult<List<PipelineRun>> activeRuns = new PagedResult<>(Collections.emptyList(), 0);
+
+        when(runConfigurationManager.load(any())).thenReturn(configuration);
+        when(runConfigurationMapper.toRunConfigurationWithEntitiesVO(any())).thenReturn(runConfigurationVO);
+        when(configurationRunner.runConfiguration(any(), any(), any()))
+                .thenReturn(Collections.singletonList(pipelineRun));
+        when(runManager.searchPipelineRuns(any(), anyBoolean())).thenReturn(activeRuns);
+        when(preferenceManager.getPreference(SystemPreferences.LAUNCH_SERVERLESS_WAIT_COUNT)).thenReturn(1);
+        when(runManager.loadPipelineRun(any())).thenReturn(pipelineRun);
+        doReturn(StringUtils.EMPTY).when(serverlessConfigurationManager).sendRequest(any(), any());
+
+        serverlessConfigurationManager.run(CONFIGURATION_ID, TEST_NAME, mockRequest());
+        verifyEndpoint();
+        verify(configurationRunner).runConfiguration(any(), any(), any());
+    }
+
+    @Test
+    public void shouldSendRequestIfConfigurationAlreadyRun() {
+        final RunConfigurationEntry entry = runConfigurationEntry(TEST_NAME, true);
+        entry.setEndpointName(TEST_NAME);
+        final RunConfiguration configuration = runConfiguration(TEST_NAME, entry);
+        final PipelineRun pipelineRun = pipelineRun();
+        pipelineRun.setServiceUrl(String.format("[{\"url\": \"%s\", \"name\": \"%s\"}]", TEST_URL, TEST_NAME));
+        final PagedResult<List<PipelineRun>> activeRuns = new PagedResult<>(
+                Collections.singletonList(pipelineRun), 1);
+
+        when(runConfigurationManager.load(any())).thenReturn(configuration);
+        when(runManager.searchPipelineRuns(any(), anyBoolean())).thenReturn(activeRuns);
+        when(preferenceManager.getPreference(SystemPreferences.LAUNCH_SERVERLESS_WAIT_COUNT)).thenReturn(1);
+        when(runManager.loadPipelineRun(any())).thenReturn(pipelineRun);
+        doReturn(StringUtils.EMPTY).when(serverlessConfigurationManager).sendRequest(any(), any());
+
+        serverlessConfigurationManager.run(CONFIGURATION_ID, TEST_NAME, mockRequest());
+        verifyEndpoint();
+        verify(configurationRunner, times(0)).runConfiguration(any(), any(), any());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailIfConfigNameNotFound() {
+        final RunConfigurationEntry entry = runConfigurationEntry(TEST_NAME, true);
+        final RunConfiguration configuration = runConfiguration(TEST_NAME, entry);
+
+        when(runConfigurationManager.load(any())).thenReturn(configuration);
+
+        serverlessConfigurationManager.run(CONFIGURATION_ID, ANOTHER_TEST_NAME, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailIfInitializationTimeExceeded() {
+        final RunConfigurationEntry entry = runConfigurationEntry(TEST_NAME, true);
+        final RunConfiguration configuration = runConfiguration(TEST_NAME, entry);
+        final PipelineRun pipelineRun = pipelineRun();
+        final PagedResult<List<PipelineRun>> activeRuns = new PagedResult<>(
+                Collections.singletonList(pipelineRun), 1);
+
+        when(runConfigurationManager.load(any())).thenReturn(configuration);
+        when(preferenceManager.getPreference(SystemPreferences.LAUNCH_SERVERLESS_WAIT_COUNT)).thenReturn(1);
+        when(preferenceManager.getPreference(SystemPreferences.LAUNCH_TASK_STATUS_UPDATE_RATE)).thenReturn(1);
+        when(runManager.loadPipelineRun(any())).thenReturn(pipelineRun);
+        when(runManager.searchPipelineRuns(any(), anyBoolean())).thenReturn(activeRuns);
+
+        serverlessConfigurationManager.run(CONFIGURATION_ID, TEST_NAME, mockRequest());
+    }
+
+    @Test
+    public void shouldGenerateServerelessUrl() {
+        final RunConfigurationEntry defaultEntry = runConfigurationEntry(TEST_NAME, true);
+        final RunConfigurationEntry entry = runConfigurationEntry(ANOTHER_TEST_NAME, false);
+        final RunConfiguration configuration = ObjectCreatorUtils.createConfiguration(TEST_NAME, null, null,
+                null, Arrays.asList(entry, defaultEntry));
+
+        when(preferenceManager.getPreference(SystemPreferences.BASE_API_HOST_EXTERNAL)).thenReturn(TEST_URL);
+        when(runConfigurationManager.load(any())).thenReturn(configuration);
+
+        final String result = serverlessConfigurationManager.generateUrl(CONFIGURATION_ID, ANOTHER_TEST_NAME);
+        assertEquals(TEST_URL + "serverless/" + CONFIGURATION_ID + "/" + ANOTHER_TEST_NAME, result);
+    }
+
+    @Test
+    public void shouldGenerateServerelessUrlFromDefaultConfiguration() {
+        final RunConfigurationEntry defaultEntry = runConfigurationEntry(TEST_NAME, true);
+        final RunConfigurationEntry entry = runConfigurationEntry(ANOTHER_TEST_NAME, false);
+        final RunConfiguration configuration = ObjectCreatorUtils.createConfiguration(TEST_NAME, null, null,
+                null, Arrays.asList(entry, defaultEntry));
+
+        when(preferenceManager.getPreference(SystemPreferences.BASE_API_HOST_EXTERNAL)).thenReturn(TEST_URL);
+        when(runConfigurationManager.load(any())).thenReturn(configuration);
+
+        final String result = serverlessConfigurationManager.generateUrl(CONFIGURATION_ID, null);
+        assertEquals(TEST_URL + "serverless/" + CONFIGURATION_ID + "/" + TEST_NAME, result);
+    }
+
+    private RunConfigurationEntry runConfigurationEntry(final String name, final boolean isDefault) {
+        return ObjectCreatorUtils.createConfigEntry(name, isDefault, null);
+    }
+
+    private RunConfiguration runConfiguration(final String name, final RunConfigurationEntry entry) {
+        return ObjectCreatorUtils.createConfiguration(name, null, null,
+                null, Collections.singletonList(entry));
+    }
+
+    private RunConfigurationWithEntitiesVO runConfigurationWithEntitiesVO(final String name,
+                                                                          final RunConfigurationEntry entry) {
+        return ObjectCreatorUtils.createRunConfigurationWithEntitiesVO(name,
+                        null, null, Collections.singletonList(entry));
+    }
+
+    private PipelineRun pipelineRun() {
+        return ObjectCreatorUtils.createPipelineRun(RUN_ID, PIPELINE_ID, null, null);
+    }
+
+    private MockHttpServletRequest mockRequest() {
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setPathInfo(String.format("/serverless/%d/%s/%s", CONFIGURATION_ID, TEST_NAME, TEST_APP_PATH));
+        request.setQueryString(TEST_QUERY);
+        return request;
+    }
+
+    private void verifyEndpoint() {
+        final ArgumentCaptor<String> endpointCaptor = ArgumentCaptor.forClass(String.class);
+        verify(serverlessConfigurationManager).sendRequest(any(), endpointCaptor.capture());
+        assertEquals(String.format("%s%s?%s", TEST_URL, TEST_APP_PATH, TEST_QUERY), endpointCaptor.getValue());
+    }
+}

--- a/core/src/main/java/com/epam/pipeline/entity/configuration/AbstractRunConfigurationEntry.java
+++ b/core/src/main/java/com/epam/pipeline/entity/configuration/AbstractRunConfigurationEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,6 +49,8 @@ public abstract class AbstractRunConfigurationEntry {
     private String configName;
     @JsonProperty(value = "default")
     private boolean defaultConfiguration = false;
+    private String endpointName;
+    private boolean stopAfter = false;
 
     public abstract boolean checkConfigComplete();
     public abstract PipelineStart toPipelineStart();

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/StopServerlessRun.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/StopServerlessRun.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.pipeline;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StopServerlessRun {
+    private Long id;
+    private Long runId;
+    private LocalDateTime lastUpdate;
+}


### PR DESCRIPTION
This PR provide implementation for issue #1038 

A new API methods were added:
- GET `serverless/url/{id}?config={configName}` that generates a URL for clients for specified configuration ID. If config name is not specified the default will be used 
- GET/PUT/POST/DELETE `serverless/{id}/{configName}/**` that launches execution. Client can specify addition request query and request parameters if needed.

The following steps were implemented for `serverless/{id}/{configName}/**` method
- check if corresponding run exists, otherwise launch run
- wait for `serviceUrl` appearance for run. If `serviceUrl`  was not found after timeout an error will be occurred. This timeout is managed by `launch.serverless.wait.count` and `launch.serverless.wait.time` system preferences. If `AbstractRunConfigurationEntry#endpointName` was specified this name shall be present is `serviceUrl` string
- send the request to specified URL and wait for response
- if `AbstractRunConfigurationEntry#stopAfter` was true the `ResourceMonitoringManager` will stop this run after `launch.serverless.stop.timeout` minutes

Also, the basic auth is supported now.