### PR TITLE
`pipe` CLI shall allow to list the users/groups/objects permissions globally - owner added to listings

### DIFF
--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/FolderDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/FolderDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -255,6 +255,7 @@ public class FolderDao extends NamedParameterJdbcDaoSupport {
                                 new Date(rs.getTimestamp(PIPELINE_CREATED_DATE.name()).getTime()));
                         pipeline.setLocked(rs.getBoolean(PIPELINE_LOCKED.name()));
                         pipeline.setParentFolderId(folderId);
+                        pipeline.setOwner(rs.getString(OWNER.name()));
                         folder.getPipelines().add(pipeline);
                     }
                     Long dataStorageId = rs.getLong(DATASTORAGE_ID.name());
@@ -296,6 +297,7 @@ public class FolderDao extends NamedParameterJdbcDaoSupport {
                         dataStorage.setLocked(rs.getBoolean(DATASTORAGE_LOCKED.name()));
                         dataStorage.setShared(rs.getBoolean(DATASTORAGE_SHARED.name()));
                         dataStorage.setSensitive(rs.getBoolean(DATASTORAGE_SENSITIVE.name()));
+                        dataStorage.setOwner(rs.getString(OWNER.name()));
                         folder.getStorages().add(dataStorage);
                     }
                     rs.getLong(CONFIG_ID.name());

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/FolderDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/FolderDaoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -141,6 +141,7 @@ public class FolderDaoTest extends AbstractSpringTest {
         pipelineDao.createPipeline(pipeline);
         Folder loadedParent2 = folderDao.loadFolder(parent.getId());
         assertEquals(pipeline.getId(), loadedParent2.getPipelines().get(0).getId());
+        assertEquals(pipeline.getOwner(), loadedParent2.getPipelines().get(0).getOwner());
         assertEquals(0, loadedParent2.getChildFolders().get(0).getPipelines().size());
 
         //delete
@@ -241,6 +242,7 @@ public class FolderDaoTest extends AbstractSpringTest {
         assertEquals(1, loadedConfigs.size());
         assertEquals(configuration.getId(), loadedConfigs.get(0).getId());
         assertEquals(loaded.getId(), loadedConfigs.get(0).getParent().getId());
+        assertEquals(configuration.getOwner(), loadedConfigs.get(0).getOwner());
     }
 
     private void checkStorageIsPresent(AbstractDataStorage storage, Folder loaded) {
@@ -250,6 +252,7 @@ public class FolderDaoTest extends AbstractSpringTest {
         assertEquals(loaded.getId(), loadedStorages.get(0).getParentFolderId());
         assertEquals(storage.getMountPoint(), loadedStorages.get(0).getMountPoint());
         assertEquals(storage.getMountOptions(), loadedStorages.get(0).getMountOptions());
+        assertEquals(storage.getOwner(), loadedStorages.get(0).getOwner());
     }
 
     private RunConfiguration addConfiguration(Folder folder) {

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/ToolGroup.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/ToolGroup.java
@@ -98,6 +98,7 @@ public class ToolGroup extends AbstractHierarchicalEntity {
         result.setDescription(this.getDescription());
         result.setPrivateGroup(this.isPrivateGroup());
         result.setParent(this.getParent());
+        result.setOwner(this.getOwner());
         return result;
     }
 }

--- a/pipe-cli/src/api/user.py
+++ b/pipe-cli/src/api/user.py
@@ -24,7 +24,7 @@ class User(API):
     @classmethod
     def get_permissions(cls, identifier, acl_class):
         entity = Entity.load_by_id_or_name(identifier, acl_class)
-        return cls.permissions(entity['id'], entity['aclClass'])
+        return cls.permissions(entity['id'], entity['aclClass']), entity['owner']
 
     @classmethod
     def permissions(cls, id, acl_class):

--- a/pipe-cli/src/utilities/acl_operations.py
+++ b/pipe-cli/src/utilities/acl_operations.py
@@ -121,7 +121,8 @@ class ACLOperations(object):
         """
 
         try:
-            permissions_list = User.get_permissions(identifier, object_type)
+            permissions_list, owner = User.get_permissions(identifier, object_type)
+            click.echo("Owner: %s" % owner)
             if len(permissions_list) > 0:
                 permissions_table = prettytable.PrettyTable()
                 permissions_table.field_names = ["SID", "Principal", "Allow", "Deny"]

--- a/pipe-cli/src/utilities/acl_operations.py
+++ b/pipe-cli/src/utilities/acl_operations.py
@@ -159,14 +159,15 @@ class ACLOperations(object):
                 click.echo("No accessible objects available for '%s'" % sid_name)
                 sys.exit(0)
             entities_table = prettytable.PrettyTable()
-            entities_table.field_names = ["Type", "Name"]
+            entities_table.field_names = ["Type", "Name", "Owner"]
             entities_table.align = "r"
             for entity_type, entities in iteritems(available_entities):
                 for entity in entities:
                     entity_name = cls.build_name_by_type(entity, entity_type)
                     if not entity_name:
                         continue
-                    entities_table.add_row([entity_type, entity_name])
+                    owner = entity['owner'] if 'owner' in entity else ''
+                    entities_table.add_row([entity_type, entity_name, owner])
             click.echo(entities_table)
             click.echo()
         except ConfigNotFoundError as config_not_found_error:


### PR DESCRIPTION
This PR provides additional functionality for issue #911 

The following CLI commands were updated and show owner information now:
- `view-acl` contains a new string with owner user name:
```
$ pipe view-acl pipeline_1 -t pipeline
Owner: USER
+-----------+-----------+----------------------+------+
|       SID | Principal |                Allow | Deny |
+-----------+-----------+----------------------+------+
| ROLE_USER |     False | Read, Write, Execute |      |
+-----------+-----------+----------------------+------+
```
- `view-user-objects`/`view-group-objects` commands contain a new column with owner user name:
```
$ pipe view-user-objects <USER_NAME>
+--------------+------------+-------+
| Type         | Name       | Owner |
+--------------+------------+-------+
| DATA_STORAGE | storage_1  | USER  |
+--------------+------------+-------+
| PIPELINE     | pipeline_1 | USER  |
+--------------+------------+-------+
```