### PR TITLE
Issue #1208: Cannot delete pipeline due to SQL error

### DIFF
--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
@@ -111,6 +111,7 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     private String deleteRunSidsByRunIdQuery;
     private String loadRunSidsQuery;
     private String loadRunSidsQueryForList;
+    private String deleteRunSidsByPipelineIdQuery;
     private String updatePodStatusQuery;
     private String loadEnvVarsQuery;
     private String updateLastNotificationQuery;
@@ -417,6 +418,11 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     @Transactional(propagation = Propagation.MANDATORY)
     public void deleteRunSids(Long runId) {
         getJdbcTemplate().update(deleteRunSidsByRunIdQuery, runId);
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void deleteRunSidsByPipelineId(final Long pipelineId) {
+        getJdbcTemplate().update(deleteRunSidsByPipelineIdQuery, pipelineId);
     }
 
     @Transactional(propagation = Propagation.SUPPORTS)
@@ -1184,5 +1190,10 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setLoadRunByPodIPQuery(final String loadRunByPodIPQuery) {
         this.loadRunByPodIPQuery = loadRunByPodIPQuery;
+    }
+
+    @Required
+    public void setDeleteRunSidsByPipelineIdQuery(final String deleteRunSidsByPipelineIdQuery) {
+        this.deleteRunSidsByPipelineIdQuery = deleteRunSidsByPipelineIdQuery;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineManager.java
@@ -243,6 +243,7 @@ public class PipelineManager implements SecuredEntityManager {
         restartRunManager.deleteRestartedRunsForPipeline(id);
         runStatusManager.deleteRunStatusForPipeline(id);
         runScheduleManager.deleteSchedulesForRunByPipeline(id);
+        pipelineRunDao.deleteRunSidsByPipelineId(id);
         pipelineRunDao.deleteRunsByPipeline(id);
         dataStorageRuleDao.deleteRulesByPipeline(id);
         pipelineDao.deletePipeline(id);

--- a/api/src/main/resources/dao/pipeline-run-dao.xml
+++ b/api/src/main/resources/dao/pipeline-run-dao.xml
@@ -1631,5 +1631,14 @@
                 ]]>
             </value>
         </property>
+        <property name="deleteRunSidsByPipelineIdQuery">
+            <value>
+                <![CDATA[
+                    DELETE FROM pipeline.run_user ru
+                    USING pipeline.pipeline_run pr, pipeline.pipeline p
+                    WHERE pr.run_id = ru.run_id AND p.pipeline_id = pr.pipeline_id AND p.pipeline_id = ?
+                ]]>
+            </value>
+        </property>
     </bean>
 </beans>

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
@@ -45,6 +45,7 @@ import com.epam.pipeline.manager.filter.FilterExpressionType;
 import com.epam.pipeline.manager.filter.FilterOperandType;
 import com.epam.pipeline.manager.filter.WrongFilterException;
 import com.epam.pipeline.util.TestUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Test;
@@ -72,8 +73,8 @@ import java.util.stream.Stream;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 @Transactional
 public class PipelineRunDaoTest extends AbstractSpringTest {
@@ -817,6 +818,20 @@ public class PipelineRunDaoTest extends AbstractSpringTest {
         final List<PipelineRun> runs = pipelineRunDao.loadRunsByStatuses(
                 Arrays.asList(TaskStatus.PAUSING, TaskStatus.RESUMING));
         assertEquals(2, runs.size());
+    }
+
+    @Test
+    public void shouldDeleteSidsFromRunByPipelineId() {
+        final RunSid runSid = new RunSid();
+        runSid.setName(GROUP_NAME);
+        runSid.setIsPrincipal(false);
+        final Pipeline pipeline = getPipeline();
+        final PipelineRun run = createRunWithRunSids(pipeline.getId(), null, Collections.singletonList(runSid));
+
+        pipelineRunDao.deleteRunSidsByPipelineId(pipeline.getId());
+
+        final PipelineRun loadedRun = pipelineRunDao.loadPipelineRun(run.getId());
+        assertTrue(CollectionUtils.isEmpty(loadedRun.getRunSids()));
     }
 
     private PipelineRun createTestPipelineRun() {


### PR DESCRIPTION
This PR provides fix for issue #1208 : contains a new SQL query that deletes sids from `run_user` table before runs deletion