### PR TITLE
Redis cache support

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -100,6 +100,12 @@ dependencies {
     compile group: "org.springframework", name: "spring-context", version: "4.3.7.RELEASE"
     compile group: "org.springframework", name: "spring-context-support", version: "4.3.7.RELEASE"
 
+    compile("org.springframework.boot:spring-boot-starter-cache:2.3.1.RELEASE")
+    compile group: 'org.springframework.data', name: 'spring-data-redis', version: '1.8.23.RELEASE'
+//    compile group: 'io.lettuce', name: 'lettuce-core', version: '5.3.1.RELEASE'
+    compile group: 'biz.paluch.redis', name: 'lettuce', version: '4.2.0.Final'
+
+
     //GCP
     compile group: "com.google.auth", name: "google-auth-library-oauth2-http", version: "0.10.0"
     compile group: "com.google.api-client", name: "google-api-client", version: "1.23.0"

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -100,11 +100,10 @@ dependencies {
     compile group: "org.springframework", name: "spring-context", version: "4.3.7.RELEASE"
     compile group: "org.springframework", name: "spring-context-support", version: "4.3.7.RELEASE"
 
-    compile("org.springframework.boot:spring-boot-starter-cache:2.3.1.RELEASE")
+    //Cache
+    compile("org.springframework.boot:spring-boot-starter-cache")
     compile group: 'org.springframework.data', name: 'spring-data-redis', version: '1.8.23.RELEASE'
-//    compile group: 'io.lettuce', name: 'lettuce-core', version: '5.3.1.RELEASE'
-    compile group: 'biz.paluch.redis', name: 'lettuce', version: '4.2.0.Final'
-
+    compile group: 'redis.clients', name: 'jedis', version: '2.9.0'
 
     //GCP
     compile group: "com.google.auth", name: "google-auth-library-oauth2-http", version: "0.10.0"

--- a/api/profiles/dev/application.properties
+++ b/api/profiles/dev/application.properties
@@ -157,3 +157,6 @@ billing.center.key=${CP_BILLING_CENTER_KEY:billing-center}
 log.security.elastic.index.prefix=${CP_SECURITY_LOGS_ELASTIC_PREFIX:security_log}*
 
 migration.alias.file=${CP_API_MIGRATION_ALIAS_FILE:}
+
+#Cache
+cache.type=MEMORY

--- a/api/src/main/java/com/epam/pipeline/Application.java
+++ b/api/src/main/java/com/epam/pipeline/Application.java
@@ -26,11 +26,17 @@ import com.epam.pipeline.app.RestConfiguration;
 import com.epam.pipeline.app.SecurityConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 
-@SpringBootApplication
+@SpringBootApplication(
+        exclude = {
+                RedisAutoConfiguration.class,
+                RedisRepositoriesAutoConfiguration.class
+        })
 @Import({AppMVCConfiguration.class,
         AppConfiguration.class,
         DBConfiguration.class,

--- a/api/src/main/java/com/epam/pipeline/Application.java
+++ b/api/src/main/java/com/epam/pipeline/Application.java
@@ -18,6 +18,7 @@ package com.epam.pipeline;
 
 import com.epam.pipeline.app.AppConfiguration;
 import com.epam.pipeline.app.AppMVCConfiguration;
+import com.epam.pipeline.app.CacheConfiguration;
 import com.epam.pipeline.app.DBConfiguration;
 import com.epam.pipeline.app.ElasticsearchConfig;
 import com.epam.pipeline.app.MappersConfiguration;
@@ -35,7 +36,8 @@ import org.springframework.context.annotation.Import;
         DBConfiguration.class,
         ElasticsearchConfig.class,
         SecurityConfig.class,
-        MappersConfiguration.class})
+        MappersConfiguration.class,
+        CacheConfiguration.class})
 @ComponentScan(basePackages = {"com.epam.pipeline.app"},
         excludeFilters = {@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = RestConfiguration.class)})
 @SuppressWarnings("checkstyle:HideUtilityClassConstructor")

--- a/api/src/main/java/com/epam/pipeline/app/AclSecurityConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/AclSecurityConfiguration.java
@@ -18,14 +18,11 @@ package com.epam.pipeline.app;
 
 
 import com.epam.pipeline.entity.user.DefaultRoles;
-import com.epam.pipeline.security.acl.DisabledAclCache;
 import com.epam.pipeline.security.acl.JdbcMutableAclServiceImpl;
 import com.epam.pipeline.security.acl.LookupStrategyImpl;
 import com.epam.pipeline.security.acl.PermissionGrantingStrategyImpl;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cache.ehcache.EhCacheFactoryBean;
-import org.springframework.cache.ehcache.EhCacheManagerFactoryBean;
+import org.springframework.cache.CacheManager;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -40,9 +37,9 @@ import org.springframework.security.acls.domain.AclAuthorizationStrategy;
 import org.springframework.security.acls.domain.AclAuthorizationStrategyImpl;
 import org.springframework.security.acls.domain.AuditLogger;
 import org.springframework.security.acls.domain.ConsoleAuditLogger;
-import org.springframework.security.acls.domain.EhCacheBasedAclCache;
 import org.springframework.security.acls.domain.PermissionFactory;
 import org.springframework.security.acls.domain.SidRetrievalStrategyImpl;
+import org.springframework.security.acls.domain.SpringCacheBasedAclCache;
 import org.springframework.security.acls.jdbc.JdbcMutableAclService;
 import org.springframework.security.acls.jdbc.LookupStrategy;
 import org.springframework.security.acls.model.AclCache;
@@ -66,8 +63,8 @@ public class AclSecurityConfiguration extends GlobalMethodSecurityConfiguration 
     @Autowired
     private PermissionFactory permissionFactory;
 
-    @Value("${acl.disable.cache:false}")
-    private boolean disableCache;
+    @Autowired
+    private CacheManager cacheManager;
 
     @Override
     protected MethodSecurityExpressionHandler createExpressionHandler() {
@@ -123,31 +120,14 @@ public class AclSecurityConfiguration extends GlobalMethodSecurityConfiguration 
 
     @Bean
     public AclCache aclCache() {
-        if (disableCache) {
-            return new DisabledAclCache();
-        }
-        return new EhCacheBasedAclCache(ehCacheFactoryBean().getObject(),
+        return new SpringCacheBasedAclCache(
+                cacheManager.getCache(CacheConfiguration.ACL_CACHE),
                 permissionGrantingStrategy(), aclAuthorizationStrategy());
     }
 
     @Bean
     public PermissionGrantingStrategy permissionGrantingStrategy() {
         return new PermissionGrantingStrategyImpl(auditLogger());
-    }
-
-    @Bean
-    public EhCacheFactoryBean ehCacheFactoryBean() {
-        EhCacheFactoryBean factoryBean = new EhCacheFactoryBean();
-        factoryBean.setCacheManager(ehCacheManagerFactoryBean().getObject());
-        factoryBean.setCacheName("aclCache");
-        return factoryBean;
-    }
-
-    @Bean
-    public EhCacheManagerFactoryBean ehCacheManagerFactoryBean() {
-        EhCacheManagerFactoryBean factoryBean = new EhCacheManagerFactoryBean();
-        factoryBean.setCacheManagerName("aclCacheManager");
-        return factoryBean;
     }
 }
 

--- a/api/src/main/java/com/epam/pipeline/app/CacheConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/CacheConfiguration.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.app;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.cache.support.NoOpCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import javax.swing.text.html.Option;
+import java.util.Arrays;
+import java.util.Optional;
+
+@EnableCaching
+public class CacheConfiguration {
+
+    public static final String PREFERENCE_CACHE = "preferences";
+    public static final String ACL_CACHE = "aclCache";
+
+    @Value("${cache.type:}")
+    private String cacheType;
+
+    @Value("${redis.host:}")
+    private String redisHost;
+
+    @Value("${redis.port:0}")
+    private int redisPort;
+
+    @Bean
+    @Primary
+    public CacheManager cacheManager(final Optional<RedisCacheManager> redisCacheManager) {
+        switch (cacheType) {
+            case "MEMORY":
+                return new ConcurrentMapCacheManager(PREFERENCE_CACHE, ACL_CACHE);
+            case "REDIS":
+                return redisCacheManager
+                        .orElseThrow(IllegalArgumentException::new);
+            default:
+                return new NoOpCacheManager();
+        }
+    }
+
+    @Bean
+    @ConditionalOnProperty(value = "cache.type", havingValue = "REDIS")
+    public RedisCacheManager redisCacheManager(final RedisTemplate template) {
+        return new RedisCacheManager(template, Arrays.asList(PREFERENCE_CACHE, ACL_CACHE));
+    }
+
+    @Bean
+    @ConditionalOnProperty(value = "cache.type", havingValue = "REDIS")
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    @ConditionalOnProperty(value = "cache.type", havingValue = "REDIS")
+    public RedisTemplate<Object, Object> redisTemplate(final RedisConnectionFactory redisConnectionFactory) {
+        final RedisTemplate<Object, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        return redisTemplate;
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/app/DBConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/DBConfiguration.java
@@ -16,22 +16,16 @@
 
 package com.epam.pipeline.app;
 
-import java.beans.PropertyVetoException;
-import javax.sql.DataSource;
-
+import com.mchange.v2.c3p0.ComboPooledDataSource;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cache.CacheManager;
-import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
-import org.springframework.cache.support.NoOpCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
 
-import com.mchange.v2.c3p0.ComboPooledDataSource;
+import javax.sql.DataSource;
+import java.beans.PropertyVetoException;
 
 @Configuration
-@EnableCaching
 @ImportResource({"classpath*:dao/*.xml"})
 public class DBConfiguration {
 
@@ -53,9 +47,6 @@ public class DBConfiguration {
     @Value("${database.initial.pool.size}")
     private int initialPoolSize;
 
-    @Value("${database.disable.cache:false}")
-    private boolean disableCache;
-
     @Bean(destroyMethod = "close")
     public DataSource dataSource() throws PropertyVetoException {
         ComboPooledDataSource dataSource = new ComboPooledDataSource();
@@ -66,13 +57,5 @@ public class DBConfiguration {
         dataSource.setMaxPoolSize(maxPoolSize);
         dataSource.setInitialPoolSize(initialPoolSize);
         return dataSource;
-    }
-
-    @Bean
-    public CacheManager cacheManager() {
-        if (disableCache) {
-            return new NoOpCacheManager();
-        }
-        return new ConcurrentMapCacheManager("preferences");
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/preference/PreferenceDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/preference/PreferenceDao.java
@@ -19,6 +19,7 @@ package com.epam.pipeline.dao.preference;
 import com.epam.pipeline.entity.preference.Preference;
 import com.epam.pipeline.entity.preference.PreferenceType;
 import com.epam.pipeline.entity.utils.DateUtils;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Required;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
@@ -32,6 +33,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Date;
 import java.util.List;
 
+@Slf4j
 public class PreferenceDao extends NamedParameterJdbcDaoSupport {
 
     private static final String PREFERENCES_CACHE = "preferences";
@@ -63,6 +65,7 @@ public class PreferenceDao extends NamedParameterJdbcDaoSupport {
 
     @Cacheable(value = PREFERENCES_CACHE, key="#name")
     public Preference loadPreferenceByName(String name) {
+        log.debug("Loading preference {} from DB.", name);
         List<Preference> items = getJdbcTemplate().query(
                 loadPreferenceByNameQuery,
                 PreferenceParameters.getRowMapper(),

--- a/api/src/main/java/com/epam/pipeline/entity/preference/Preference.java
+++ b/api/src/main/java/com/epam/pipeline/entity/preference/Preference.java
@@ -16,6 +16,7 @@
 
 package com.epam.pipeline.entity.preference;
 
+import java.io.Serializable;
 import java.util.Date;
 import java.util.function.Function;
 
@@ -32,7 +33,7 @@ import org.apache.commons.lang.StringUtils;
 @Setter
 @NoArgsConstructor
 @EqualsAndHashCode
-public class Preference {
+public class Preference implements Serializable {
     private String name;
     private Date createdDate;
     private String value;

--- a/api/src/test/java/com/epam/pipeline/app/AclTestConfiguration.java
+++ b/api/src/test/java/com/epam/pipeline/app/AclTestConfiguration.java
@@ -68,7 +68,8 @@ import javax.sql.DataSource;
  * defined in this class.
  */
 @SpringBootConfiguration
-@Import({AclSecurityConfiguration.class, DBConfiguration.class, MappersConfiguration.class})
+@Import({AclSecurityConfiguration.class, DBConfiguration.class,
+        MappersConfiguration.class, CacheConfiguration.class})
 @ComponentScan(basePackages = {"com.epam.pipeline.manager.security"})
 @TestPropertySource(value={"classpath:test-application.properties"})
 @EnableGlobalMethodSecurity(securedEnabled = true, prePostEnabled = true)

--- a/api/src/test/java/com/epam/pipeline/app/TestApplication.java
+++ b/api/src/test/java/com/epam/pipeline/app/TestApplication.java
@@ -56,6 +56,7 @@ import java.util.concurrent.Executor;
 @SpringBootConfiguration
 @Import({AppMVCConfiguration.class,
         DBConfiguration.class,
+        CacheConfiguration.class,
         MappersConfiguration.class,
         ContextualPreferenceConfiguration.class})
 @EnableAutoConfiguration(exclude = {

--- a/api/src/test/java/com/epam/pipeline/app/TestApplicationWithAclSecurity.java
+++ b/api/src/test/java/com/epam/pipeline/app/TestApplicationWithAclSecurity.java
@@ -41,7 +41,8 @@ import org.springframework.test.context.TestPropertySource;
 @Import({
         AppMVCConfiguration.class,
         DBConfiguration.class,
-        TestAclSecurityConfig.class
+        TestAclSecurityConfig.class,
+        CacheConfiguration.class
     })
 @EnableAutoConfiguration(exclude = {
     SecurityAutoConfiguration.class,

--- a/deploy/contents/install/install-config
+++ b/deploy/contents/install/install-config
@@ -184,8 +184,8 @@ CP_TP_START_SERVERS=2
 CP_TP_MAX_REQ_PER_CHILD=0
 
 # cp-redis
-redis.host=cp-redis.default.svc.cluster.local
-redis.port=30097
+CP_REDIS_INTERNAL_HOST=cp-redis.default.svc.cluster.local
+CP_REDIS_INTERNAL_PORT=30097
 
 # Other params, specified on command line
 #

--- a/deploy/contents/install/install-config
+++ b/deploy/contents/install/install-config
@@ -183,5 +183,9 @@ CP_TP_MAX_SPARE_SERVERS=5
 CP_TP_START_SERVERS=2
 CP_TP_MAX_REQ_PER_CHILD=0
 
+# cp-redis
+redis.host=cp-redis.default.svc.cluster.local
+redis.port=30097
+
 # Other params, specified on command line
 #

--- a/deploy/contents/k8s/cp-redis/cp-redis-dpl.yaml
+++ b/deploy/contents/k8s/cp-redis/cp-redis-dpl.yaml
@@ -1,0 +1,25 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cp-redis
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    metadata:
+      namespace: default
+      labels:
+        cloud-pipeline/cp-redis: "true"
+    spec:
+      nodeSelector:
+        cloud-pipeline/cp-redis: "true"
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      containers:
+        - name: cp-redis
+          image: redis:6.0.5
+          imagePullPolicy: "IfNotPresent"
+          envFrom:
+            - configMapRef:
+                name: cp-config-global

--- a/deploy/contents/k8s/cp-redis/cp-redis-svc.yaml
+++ b/deploy/contents/k8s/cp-redis/cp-redis-svc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    cloud-pipeline/cp-redis: "true"
+  name: cp-redis
+  namespace: default
+spec:
+  ports:
+    - protocol: TCP
+      port: ${CP_REDIS_INTERNAL_PORT}
+      targetPort: 6379
+      name: cp-redis-port-http
+  selector:
+    cloud-pipeline/cp-redis: "true"

--- a/deploy/docker/cp-api-srv/config/application.properties
+++ b/deploy/docker/cp-api-srv/config/application.properties
@@ -136,3 +136,8 @@ billing.center.key=${CP_BILLING_CENTER_KEY:billing-center}
 log.security.elastic.index.prefix=${CP_SECURITY_LOGS_ELASTIC_PREFIX:security_log}*
 
 migration.alias.file=${CP_API_MIGRATION_ALIAS_FILE:}
+
+#Cache
+cache.type=${CP_API_CACHE_TYPE:MEMORY}
+redis.host=${CP_REDIS_INTERNAL_HOST:}
+redis.port=${CP_REDIS_INTERNAL_PORT:}


### PR DESCRIPTION
This PR is related to #1209 

### Implementation
This PR add an option `cache.type` to configure caching solution for API server. Three cache types are supported:
- **MEMORY** (default) - simple in memory cache
- **REDIS** - Redis-based cache, redis settings are configured via `CP_REDIS_INTERNAL_HOST` and `CP_REDIS_INTERNAL_HOST` variables
- **NO VALUE** - no cache