### PR TITLE
Support dynamic pipeline parameters on the API server

### DIFF
--- a/api/src/test/java/com/epam/pipeline/entity/PipelineConfigurationTest.java
+++ b/api/src/test/java/com/epam/pipeline/entity/PipelineConfigurationTest.java
@@ -35,12 +35,14 @@ public class PipelineConfigurationTest {
                     "\"main_file\" : {" +
                         "\"value\" : \"\"," +
                         "\"required\" : \"true\"," +
-                        "\"type\" : \"string\"" +
+                        "\"type\" : \"string\"," +
+                        "\"enum\" : [{\"name\": \"v1\"}, {\"name\": \"v2\"}]" +
                     "}," +
                     "\"main_class\" : {" +
                         "\"value\" : \"\"," +
                         "\"required\" : \"false\"," +
-                        "\"type\" : \"class\"" +
+                        "\"type\" : \"class\"," +
+                        "\"enum\" : [\"v1\", \"v2\"]" +
                     "}," +
                     "\"instance_size\" : {" +
                         "\"type\" : \"string\"" +

--- a/core/src/main/java/com/epam/pipeline/entity/configuration/PipeConfValueVO.java
+++ b/core/src/main/java/com/epam/pipeline/entity/configuration/PipeConfValueVO.java
@@ -43,7 +43,13 @@ public class PipeConfValueVO {
     private boolean required;
 
     @JsonProperty(value = "enum")
-    private List<String> availableValues;
+    private List<Object> availableValues;
+
+    /**
+     * String expression to determine visibility of a param
+     * User for GUI client only
+     */
+    private String visible;
 
     private String description;
 

--- a/core/src/main/java/com/epam/pipeline/entity/configuration/PipelineConfValuesMapDeserializer.java
+++ b/core/src/main/java/com/epam/pipeline/entity/configuration/PipelineConfValuesMapDeserializer.java
@@ -17,10 +17,15 @@
 package com.epam.pipeline.entity.configuration;
 
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.NullNode;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -29,6 +34,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+@Slf4j
 public class PipelineConfValuesMapDeserializer extends JsonDeserializer<Map<String, PipeConfValueVO>> {
 
     private static final String VALUE_FIELD = "value";
@@ -36,9 +42,15 @@ public class PipelineConfValuesMapDeserializer extends JsonDeserializer<Map<Stri
     private static final String REQUIRED_FIELD = "required";
     private static final String ENUM_FIELD = "enum";
     private static final String DESCRIPTION_FIELD = "description";
+    private static final String VISIBLE_FIELD = "visible";
     private static final  NullNode NULL_NODE = NullNode.getInstance();
+    private final ObjectMapper mapper;
 
-
+    public PipelineConfValuesMapDeserializer() {
+        mapper = new ObjectMapper();
+        mapper.configure(SerializationFeature.WRITE_NULL_MAP_VALUES, true);
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
 
     @Override
     public Map<String, PipeConfValueVO> deserialize(JsonParser p, DeserializationContext ctxt)
@@ -65,20 +77,39 @@ public class PipelineConfValuesMapDeserializer extends JsonDeserializer<Map<Stri
                 if (hasValue(required)) {
                     parameter.setRequired(required.asBoolean());
                 }
-                JsonNode availableValuesNode = child.get(ENUM_FIELD);
-                if (hasValue(availableValuesNode) && availableValuesNode.isArray()) {
-                    List<String> availableValues = new ArrayList<>();
-                    availableValuesNode.forEach(arrayItem -> availableValues.add(arrayItem.asText()));
-                    parameter.setAvailableValues(availableValues);
-                }
+                parseEnumValues(ctxt, child, parameter);
                 final JsonNode description = child.get(DESCRIPTION_FIELD);
                 if (hasValue(description)) {
                     parameter.setDescription(description.asText());
+                }
+                final JsonNode visible = child.get(VISIBLE_FIELD);
+                if (hasValue(visible)) {
+                    parameter.setVisible(visible.asText());
                 }
             }
             parameters.put(name, parameter);
         }
         return parameters;
+    }
+
+    public void parseEnumValues(DeserializationContext ctxt, JsonNode child, PipeConfValueVO parameter) {
+        JsonNode availableValuesNode = child.get(ENUM_FIELD);
+        if (hasValue(availableValuesNode) && availableValuesNode.isArray()) {
+            List<Object> availableValues = new ArrayList<>();
+            availableValuesNode.forEach(arrayItem -> {
+                if (arrayItem.isObject()) {
+                    try {
+                        availableValues.add(mapper.readValue(arrayItem.traverse(),
+                                new TypeReference<Map<String,String>>(){}));
+                    } catch (IOException e) {
+                        log.error(e.getMessage(), e);
+                    }
+                } else {
+                    availableValues.add(arrayItem.asText());
+                }
+            });
+            parameter.setAvailableValues(availableValues);
+        }
     }
 
     private boolean hasValue(final JsonNode required) {


### PR DESCRIPTION
This PR is related to #1215 

#### Approach

- new `visible` field with type `string` is supported for pipeline parameters
- `enum` field now supports two types: array of `string` (previous version) and array of `objects` (format of object `Map<String,String>`)