### PR TITLE
Issue #1038: "Serverless" Cloud Pipeline API - fixes

### DIFF
--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
@@ -25,6 +25,7 @@ import com.epam.pipeline.entity.pipeline.CommitStatus;
 import com.epam.pipeline.entity.pipeline.Pipeline;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.RunInstance;
+import com.epam.pipeline.entity.pipeline.StopServerlessRun;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.epam.pipeline.entity.pipeline.run.ExecutionPreferences;
 import com.epam.pipeline.entity.pipeline.run.parameter.RunAccessType;
@@ -449,11 +450,9 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
                 .findFirst();
     }
 
-    public List<PipelineRun> loadServerlessRunsToStop(final LocalDateTime maxLastUpdate) {
-        final MapSqlParameterSource params = new MapSqlParameterSource();
-        params.addValue("MAX_LAST_UPDATE", maxLastUpdate);
+    public List<StopServerlessRun> loadServerlessRunsToStop() {
         return ListUtils.emptyIfNull(getNamedParameterJdbcTemplate()
-                .query(loadServerlessRunsToStopQuery, params, PipelineRunParameters.getRowMapper()));
+                .query(loadServerlessRunsToStopQuery, StopServerlessRunDao.StopServerlessRunParameters.getRowMapper()));
     }
 
     private MapSqlParameterSource getPagingParameters(PagingRunFilterVO filter) {

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
@@ -25,7 +25,6 @@ import com.epam.pipeline.entity.pipeline.CommitStatus;
 import com.epam.pipeline.entity.pipeline.Pipeline;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.RunInstance;
-import com.epam.pipeline.entity.pipeline.StopServerlessRun;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.epam.pipeline.entity.pipeline.run.ExecutionPreferences;
 import com.epam.pipeline.entity.pipeline.run.parameter.RunAccessType;
@@ -123,7 +122,6 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     private String loadAllRunsPossiblyActiveInPeriodQuery;
     private String loadAllRunsByStatusQuery;
     private String loadRunByPodIPQuery;
-    private String loadServerlessRunsToStopQuery;
 
     // We put Propagation.REQUIRED here because this method can be called from non-transaction context
     // (see PipelineRunManager, it performs internal call for launchPipeline)
@@ -448,11 +446,6 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
                 .query(loadRunByPodIPQuery, params, PipelineRunParameters.getRowMapper()))
                 .stream()
                 .findFirst();
-    }
-
-    public List<StopServerlessRun> loadServerlessRunsToStop() {
-        return ListUtils.emptyIfNull(getNamedParameterJdbcTemplate()
-                .query(loadServerlessRunsToStopQuery, StopServerlessRunDao.StopServerlessRunParameters.getRowMapper()));
     }
 
     private MapSqlParameterSource getPagingParameters(PagingRunFilterVO filter) {
@@ -1202,10 +1195,5 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setDeleteRunSidsByPipelineIdQuery(final String deleteRunSidsByPipelineIdQuery) {
         this.deleteRunSidsByPipelineIdQuery = deleteRunSidsByPipelineIdQuery;
-    }
-
-    @Required
-    public void setLoadServerlessRunsToStopQuery(final String loadServerlessRunsToStopQuery) {
-        this.loadServerlessRunsToStopQuery = loadServerlessRunsToStopQuery;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/StopServerlessRunDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/StopServerlessRunDao.java
@@ -27,6 +27,7 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 public class StopServerlessRunDao extends NamedParameterJdbcDaoSupport {
 
@@ -38,6 +39,7 @@ public class StopServerlessRunDao extends NamedParameterJdbcDaoSupport {
     private String updateServerlessRunQuery;
     private String loadAllServerlessRunsQuery;
     private String deleteByRunIdServerlessRunQuery;
+    private String loadServerlessunByRunIdQuery;
 
     @Transactional(propagation = Propagation.MANDATORY)
     public Long createServerlessRunId() {
@@ -62,6 +64,12 @@ public class StopServerlessRunDao extends NamedParameterJdbcDaoSupport {
         return getJdbcTemplate().query(loadAllServerlessRunsQuery, StopServerlessRunParameters.getRowMapper());
     }
 
+    public Optional<StopServerlessRun> loadByRunId(final Long runId) {
+        return getJdbcTemplate().query(loadServerlessunByRunIdQuery, StopServerlessRunParameters.getRowMapper())
+                .stream()
+                .findFirst();
+    }
+
     @Transactional(propagation = Propagation.MANDATORY)
     public void deleteByRunId(final Long runId) {
         getJdbcTemplate().update(deleteByRunIdServerlessRunQuery, runId);
@@ -70,13 +78,15 @@ public class StopServerlessRunDao extends NamedParameterJdbcDaoSupport {
     public enum StopServerlessRunParameters {
         ID,
         RUN_ID,
-        LAST_UPDATE;
+        LAST_UPDATE,
+        STOP_AFTER;
 
         static MapSqlParameterSource getParameters(final StopServerlessRun run) {
             final MapSqlParameterSource params = new MapSqlParameterSource();
             params.addValue(ID.name(), run.getId());
             params.addValue(RUN_ID.name(), run.getRunId());
             params.addValue(LAST_UPDATE.name(), run.getLastUpdate());
+            params.addValue(STOP_AFTER.name(), run.getStopAfter());
             return params;
         }
 
@@ -86,6 +96,7 @@ public class StopServerlessRunDao extends NamedParameterJdbcDaoSupport {
                 run.setId(rs.getLong(ID.name()));
                 run.setRunId(rs.getLong(RUN_ID.name()));
                 run.setLastUpdate(rs.getTimestamp(LAST_UPDATE.name()).toLocalDateTime());
+                run.setStopAfter(rs.getLong(STOP_AFTER.name()));
                 return run;
             };
         }
@@ -114,5 +125,10 @@ public class StopServerlessRunDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setDeleteByRunIdServerlessRunQuery(final String deleteByRunIdServerlessRunQuery) {
         this.deleteByRunIdServerlessRunQuery = deleteByRunIdServerlessRunQuery;
+    }
+
+    @Required
+    public void setLoadServerlessunByRunIdQuery(final String loadServerlessunByRunIdQuery) {
+        this.loadServerlessunByRunIdQuery = loadServerlessunByRunIdQuery;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/StopServerlessRunDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/StopServerlessRunDao.java
@@ -18,6 +18,7 @@ package com.epam.pipeline.dao.pipeline;
 
 import com.epam.pipeline.dao.DaoHelper;
 import com.epam.pipeline.entity.pipeline.StopServerlessRun;
+import org.apache.commons.collections4.ListUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Required;
 import org.springframework.jdbc.core.RowMapper;
@@ -40,13 +41,14 @@ public class StopServerlessRunDao extends NamedParameterJdbcDaoSupport {
     private String loadAllServerlessRunsQuery;
     private String deleteByRunIdServerlessRunQuery;
     private String loadServerlessunByRunIdQuery;
+    private String loadServerlessByStatusRunningQuery;
 
     @Transactional(propagation = Propagation.MANDATORY)
     public Long createServerlessRunId() {
         return daoHelper.createId(serverlessRunSequenceQuery);
     }
 
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.MANDATORY)
     public void createServerlessRun(final StopServerlessRun run) {
         final Long id = createServerlessRunId();
         run.setId(id);
@@ -54,7 +56,7 @@ public class StopServerlessRunDao extends NamedParameterJdbcDaoSupport {
                 StopServerlessRunParameters.getParameters(run));
     }
 
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.MANDATORY)
     public void updateServerlessRun(final StopServerlessRun run) {
         getNamedParameterJdbcTemplate().update(updateServerlessRunQuery,
                 StopServerlessRunParameters.getParameters(run));
@@ -68,6 +70,11 @@ public class StopServerlessRunDao extends NamedParameterJdbcDaoSupport {
         return getJdbcTemplate().query(loadServerlessunByRunIdQuery, StopServerlessRunParameters.getRowMapper())
                 .stream()
                 .findFirst();
+    }
+
+    public List<StopServerlessRun> loadByStatusRunning() {
+        return ListUtils.emptyIfNull(getNamedParameterJdbcTemplate()
+                .query(loadServerlessByStatusRunningQuery, StopServerlessRunParameters.getRowMapper()));
     }
 
     @Transactional(propagation = Propagation.REQUIRED)
@@ -130,5 +137,10 @@ public class StopServerlessRunDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setLoadServerlessunByRunIdQuery(final String loadServerlessunByRunIdQuery) {
         this.loadServerlessunByRunIdQuery = loadServerlessunByRunIdQuery;
+    }
+
+    @Required
+    public void setLoadServerlessByStatusRunningQuery(final String loadServerlessByStatusRunningQuery) {
+        this.loadServerlessByStatusRunningQuery = loadServerlessByStatusRunningQuery;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/StopServerlessRunDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/StopServerlessRunDao.java
@@ -46,7 +46,7 @@ public class StopServerlessRunDao extends NamedParameterJdbcDaoSupport {
         return daoHelper.createId(serverlessRunSequenceQuery);
     }
 
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.REQUIRED)
     public void createServerlessRun(final StopServerlessRun run) {
         final Long id = createServerlessRunId();
         run.setId(id);
@@ -54,7 +54,7 @@ public class StopServerlessRunDao extends NamedParameterJdbcDaoSupport {
                 StopServerlessRunParameters.getParameters(run));
     }
 
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.REQUIRED)
     public void updateServerlessRun(final StopServerlessRun run) {
         getNamedParameterJdbcTemplate().update(updateServerlessRunQuery,
                 StopServerlessRunParameters.getParameters(run));
@@ -70,7 +70,7 @@ public class StopServerlessRunDao extends NamedParameterJdbcDaoSupport {
                 .findFirst();
     }
 
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.REQUIRED)
     public void deleteByRunId(final Long runId) {
         getJdbcTemplate().update(deleteByRunIdServerlessRunQuery, runId);
     }

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
@@ -34,6 +34,7 @@ import javax.annotation.PostConstruct;
 import com.epam.pipeline.entity.cluster.monitoring.ELKUsageMetric;
 import com.epam.pipeline.entity.pipeline.StopServerlessRun;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
+import com.epam.pipeline.manager.pipeline.StopServerlessRunManager;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import lombok.extern.slf4j.Slf4j;
@@ -119,6 +120,7 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
         private final MonitoringESDao monitoringDao;
         private final MessageHelper messageHelper;
         private final PreferenceManager preferenceManager;
+        private final StopServerlessRunManager stopServerlessRunManager;
         private Map<String, InstanceType> instanceTypeMap = new HashMap<>();
 
         @Autowired
@@ -126,12 +128,14 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
                                       final NotificationManager notificationManager,
                                       final MonitoringESDao monitoringDao,
                                       final MessageHelper messageHelper,
-                                      final PreferenceManager preferenceManager) {
+                                      final PreferenceManager preferenceManager,
+                                      final StopServerlessRunManager stopServerlessRunManager) {
             this.pipelineRunManager = pipelineRunManager;
             this.messageHelper = messageHelper;
             this.notificationManager = notificationManager;
             this.monitoringDao = monitoringDao;
             this.preferenceManager = preferenceManager;
+            this.stopServerlessRunManager = stopServerlessRunManager;
         }
 
         @Scheduled(cron = "0 0 0 ? * *")
@@ -410,14 +414,15 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
 
         private void processServerlessRuns() {
             final List<StopServerlessRun> activeServerlessRuns = ListUtils.emptyIfNull(
-                    pipelineRunManager.loadActiveServerlessRuns());
+                    stopServerlessRunManager.loadActiveServerlessRuns());
             activeServerlessRuns.stream()
                     .filter(this::serverlessRunIsExpired)
                     .forEach(run -> pipelineRunManager.stopServerlessRun(run.getId()));
         }
 
         private boolean serverlessRunIsExpired(final StopServerlessRun run) {
-            return run.getLastUpdate().isBefore(LocalDateTime.now().minusMinutes(getTimeoutMinutes(run)));
+            final Long timeout = getTimeoutMinutes(run);
+            return Objects.nonNull(timeout) && run.getLastUpdate().isBefore(LocalDateTime.now().minusMinutes(timeout));
         }
 
         private Long getTimeoutMinutes(final StopServerlessRun run) {

--- a/api/src/main/java/com/epam/pipeline/manager/configuration/ServerlessConfigurationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/configuration/ServerlessConfigurationManager.java
@@ -19,13 +19,13 @@ package com.epam.pipeline.manager.configuration;
 import com.epam.pipeline.config.JsonMapper;
 import com.epam.pipeline.controller.vo.PagingRunFilterVO;
 import com.epam.pipeline.controller.vo.ServiceUrlVO;
-import com.epam.pipeline.dao.pipeline.StopServerlessRunDao;
 import com.epam.pipeline.entity.configuration.AbstractRunConfigurationEntry;
 import com.epam.pipeline.entity.configuration.RunConfiguration;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.StopServerlessRun;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.epam.pipeline.manager.pipeline.PipelineRunManager;
+import com.epam.pipeline.manager.pipeline.StopServerlessRunManager;
 import com.epam.pipeline.manager.pipeline.runner.ConfigurationRunner;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
@@ -89,7 +89,7 @@ public class ServerlessConfigurationManager {
     private final AbstractRunConfigurationMapper runConfigurationMapper;
     private final PipelineRunManager runManager;
     private final PreferenceManager preferenceManager;
-    private final StopServerlessRunDao stopServerlessRunDao;
+    private final StopServerlessRunManager stopServerlessRunManager;
     private final ObjectMapper objectMapper;
     private final AuthManager authManager;
 
@@ -114,7 +114,7 @@ public class ServerlessConfigurationManager {
         final String response = sendRequest(request, appPath);
 
         stopRunInfo.setLastUpdate(LocalDateTime.now());
-        stopServerlessRunDao.updateServerlessRun(stopRunInfo);
+        stopServerlessRunManager.updateServerlessRun(stopRunInfo);
 
         return response;
     }
@@ -128,10 +128,10 @@ public class ServerlessConfigurationManager {
     }
 
     private StopServerlessRun getServerlessRun(final Long runId, final Long stopAfter) {
-        return stopServerlessRunDao.loadByRunId(runId)
+        return stopServerlessRunManager.loadByRunId(runId)
                 .map(run -> {
                     run.setLastUpdate(LocalDateTime.now());
-                    stopServerlessRunDao.updateServerlessRun(run);
+                    stopServerlessRunManager.updateServerlessRun(run);
                     return run;
                 }).orElseGet(() -> {
                     final StopServerlessRun run = StopServerlessRun.builder()
@@ -139,7 +139,7 @@ public class ServerlessConfigurationManager {
                             .stopAfter(stopAfter)
                             .lastUpdate(LocalDateTime.now())
                             .build();
-                    stopServerlessRunDao.createServerlessRun(run);
+                    stopServerlessRunManager.createServerlessRun(run);
                     return run;
                 });
     }

--- a/api/src/main/java/com/epam/pipeline/manager/configuration/ServerlessConfigurationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/configuration/ServerlessConfigurationManager.java
@@ -71,7 +71,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/api/src/main/java/com/epam/pipeline/manager/configuration/ServerlessConfigurationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/configuration/ServerlessConfigurationManager.java
@@ -129,20 +129,20 @@ public class ServerlessConfigurationManager {
     }
 
     private StopServerlessRun getServerlessRun(final Long runId, final Long stopAfter) {
-        final Optional<StopServerlessRun> stopServerlessRun = stopServerlessRunDao.loadByRunId(runId);
-        if (stopServerlessRun.isPresent()) {
-            final StopServerlessRun stopRunInfo = stopServerlessRun.get();
-            stopRunInfo.setLastUpdate(LocalDateTime.now());
-            stopServerlessRunDao.updateServerlessRun(stopRunInfo);
-            return stopRunInfo;
-        }
-        final StopServerlessRun stopRunInfo = StopServerlessRun.builder()
-                .runId(runId)
-                .stopAfter(stopAfter)
-                .lastUpdate(LocalDateTime.now())
-                .build();
-        stopServerlessRunDao.createServerlessRun(stopRunInfo);
-        return stopRunInfo;
+        return stopServerlessRunDao.loadByRunId(runId)
+                .map(run -> {
+                    run.setLastUpdate(LocalDateTime.now());
+                    stopServerlessRunDao.updateServerlessRun(run);
+                    return run;
+                }).orElseGet(() -> {
+                    final StopServerlessRun run = StopServerlessRun.builder()
+                            .runId(runId)
+                            .stopAfter(stopAfter)
+                            .lastUpdate(LocalDateTime.now())
+                            .build();
+                    stopServerlessRunDao.createServerlessRun(run);
+                    return run;
+                });
     }
 
     private String getConfigurationName(final Long configurationId, final String configName) {

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -24,7 +24,6 @@ import com.epam.pipeline.controller.vo.PipelineRunFilterVO;
 import com.epam.pipeline.controller.vo.PipelineRunServiceUrlVO;
 import com.epam.pipeline.controller.vo.TagsVO;
 import com.epam.pipeline.dao.pipeline.PipelineRunDao;
-import com.epam.pipeline.dao.pipeline.StopServerlessRunDao;
 import com.epam.pipeline.entity.AbstractSecuredEntity;
 import com.epam.pipeline.entity.BaseEntity;
 import com.epam.pipeline.entity.cluster.InstanceDisk;
@@ -43,7 +42,6 @@ import com.epam.pipeline.entity.pipeline.Folder;
 import com.epam.pipeline.entity.pipeline.Pipeline;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.RunInstance;
-import com.epam.pipeline.entity.pipeline.StopServerlessRun;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.epam.pipeline.entity.pipeline.Tool;
 import com.epam.pipeline.entity.pipeline.run.ExecutionPreferences;
@@ -201,7 +199,7 @@ public class PipelineRunManager {
     private PipelineRunCRUDService runCRUDService;
 
     @Autowired
-    private StopServerlessRunDao stopServerlessRunDao;
+    private StopServerlessRunManager stopServerlessRunManager;
 
     /**
      * Launches cmd command execution, uses Tool as ACL identity
@@ -1160,14 +1158,10 @@ public class PipelineRunManager {
                 .collect(Collectors.toList()));
     }
 
-    public List<StopServerlessRun> loadActiveServerlessRuns() {
-        return pipelineRunDao.loadServerlessRunsToStop();
-    }
-
     @Transactional(propagation = Propagation.REQUIRED)
     public void stopServerlessRun(final Long runId) {
         stop(runId);
-        stopServerlessRunDao.deleteByRunId(runId);
+        stopServerlessRunManager.deleteByRunId(runId);
     }
 
     private int getTotalSize(final List<InstanceDisk> disks) {

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -43,6 +43,7 @@ import com.epam.pipeline.entity.pipeline.Folder;
 import com.epam.pipeline.entity.pipeline.Pipeline;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.RunInstance;
+import com.epam.pipeline.entity.pipeline.StopServerlessRun;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.epam.pipeline.entity.pipeline.Tool;
 import com.epam.pipeline.entity.pipeline.run.ExecutionPreferences;
@@ -1159,8 +1160,8 @@ public class PipelineRunManager {
                 .collect(Collectors.toList()));
     }
 
-    public List<PipelineRun> loadExpiredServerlessRuns(final LocalDateTime maxLastUpdate) {
-        return pipelineRunDao.loadServerlessRunsToStop(maxLastUpdate);
+    public List<StopServerlessRun> loadActiveServerlessRuns() {
+        return pipelineRunDao.loadServerlessRunsToStop();
     }
 
     @Transactional(propagation = Propagation.REQUIRED)

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/StopServerlessRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/StopServerlessRunManager.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.pipeline;
+
+import com.epam.pipeline.dao.pipeline.StopServerlessRunDao;
+import com.epam.pipeline.entity.pipeline.StopServerlessRun;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class StopServerlessRunManager {
+
+    private final StopServerlessRunDao stopServerlessRunDao;
+
+    public List<StopServerlessRun> loadActiveServerlessRuns() {
+        return stopServerlessRunDao.loadByStatusRunning();
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void createServerlessRun(final StopServerlessRun run) {
+        stopServerlessRunDao.createServerlessRun(run);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void updateServerlessRun(final StopServerlessRun run) {
+        stopServerlessRunDao.updateServerlessRun(run);
+    }
+
+    public List<StopServerlessRun> loadAll() {
+        return stopServerlessRunDao.loadAll();
+    }
+
+    public Optional<StopServerlessRun> loadByRunId(final Long runId) {
+        return stopServerlessRunDao.loadByRunId(runId);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void deleteByRunId(final Long runId) {
+        stopServerlessRunDao.deleteByRunId(runId);
+    }
+}

--- a/api/src/main/resources/dao/pipeline-run-dao.xml
+++ b/api/src/main/resources/dao/pipeline-run-dao.xml
@@ -1644,58 +1644,15 @@
             <value>
                 <![CDATA[
                     SELECT
-                        r.run_id,
-                        r.pipeline_id,
-                        r.version,
-                        r.start_date,
-                        r.end_date,
-                        r.parameters,
-                        r.status,
-                        r.terminating,
-                        r.pod_id,
-                        r.node_type,
-                        r.node_disk,
-                        r.node_ip,
-                        r.node_id,
-                        r.node_name,
-                        r.node_image,
-                        r.node_cloud_region,
-                        r.docker_image,
-                        r.actual_docker_image,
-                        r.cmd_template,
-                        r.actual_cmd,
-                        r.timeout,
-                        r.owner,
-                        r.service_url,
-                        r.pod_ip,
-                        r.commit_status,
-                        r.last_change_commit_time,
-                        r.config_name,
-                        r.node_count,
-                        r.parent_id,
-                        r.entities_ids,
-                        r.is_spot,
-                        r.configuration_id,
-                        r.pod_status,
-                        r.prolonged_at_time,
-                        r.last_notification_time,
-                        r.last_idle_notification_time,
-                        r.exec_preferences,
-                        r.pretty_url,
-                        r.price_per_hour,
-                        r.compute_price_per_hour,
-                        r.disk_price_per_hour,
-                        r.state_reason,
-                        r.non_pause,
-                        r.node_real_disk,
-                        r.node_cloud_provider,
-                        r.tags,
-                        r.sensitive
+                        s.id,
+                        s.run_id,
+                        s.stop_after,
+                        s.last_update
                     FROM
-                        pipeline.pipeline_run r
-                    LEFT JOIN pipeline.stop_serverless_run s ON (s.run_id = r.run_id)
+                        pipeline.stop_serverless_run s
+                    LEFT JOIN pipeline.pipeline_run r ON (s.run_id = r.run_id)
                     WHERE
-                        r.status = 2 and s.last_update < :MAX_LAST_UPDATE
+                        r.status = 2
                     ORDER BY
                         r.start_date
                 ]]>

--- a/api/src/main/resources/dao/pipeline-run-dao.xml
+++ b/api/src/main/resources/dao/pipeline-run-dao.xml
@@ -1640,23 +1640,5 @@
                 ]]>
             </value>
         </property>
-        <property name="loadServerlessRunsToStopQuery">
-            <value>
-                <![CDATA[
-                    SELECT
-                        s.id,
-                        s.run_id,
-                        s.stop_after,
-                        s.last_update
-                    FROM
-                        pipeline.stop_serverless_run s
-                    LEFT JOIN pipeline.pipeline_run r ON (s.run_id = r.run_id)
-                    WHERE
-                        r.status = 2
-                    ORDER BY
-                        r.start_date
-                ]]>
-            </value>
-        </property>
     </bean>
 </beans>

--- a/api/src/main/resources/dao/stop-serverless-run-dao.xml
+++ b/api/src/main/resources/dao/stop-serverless-run-dao.xml
@@ -26,11 +26,13 @@
                     INSERT INTO pipeline.stop_serverless_run (
                         id,
                         run_id,
-                        last_update)
+                        last_update,
+                        stop_after)
                     VALUES (
                         :ID,
                         :RUN_ID,
-                        :LAST_UPDATE)
+                        :LAST_UPDATE,
+                        :STOP_AFTER)
                 ]]>
             </value>
         </property>
@@ -56,7 +58,21 @@
                     SELECT
                         id,
                         run_id,
-                        last_update
+                        last_update,
+                        stop_after
+                    FROM
+                        pipeline.stop_serverless_run
+                ]]>
+            </value>
+        </property>
+        <property name="loadServerlessunByRunIdQuery">
+            <value>
+                <![CDATA[
+                    SELECT
+                        id,
+                        run_id,
+                        last_update,
+                        stop_after
                     FROM
                         pipeline.stop_serverless_run
                 ]]>

--- a/api/src/main/resources/dao/stop-serverless-run-dao.xml
+++ b/api/src/main/resources/dao/stop-serverless-run-dao.xml
@@ -78,5 +78,23 @@
                 ]]>
             </value>
         </property>
+        <property name="loadServerlessByStatusRunningQuery">
+            <value>
+                <![CDATA[
+                    SELECT
+                        s.id,
+                        s.run_id,
+                        s.stop_after,
+                        s.last_update
+                    FROM
+                        pipeline.stop_serverless_run s
+                    LEFT JOIN pipeline.pipeline_run r ON (s.run_id = r.run_id)
+                    WHERE
+                        r.status = 2
+                    ORDER BY
+                        r.start_date
+                ]]>
+            </value>
+        </property>
     </bean>
 </beans>

--- a/api/src/main/resources/db/migration/v2020.07.15_14.00__issue_1038_fix_for_stop_after.sql
+++ b/api/src/main/resources/db/migration/v2020.07.15_14.00__issue_1038_fix_for_stop_after.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pipeline.stop_serverless_run ADD stop_after BIGINT;

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
@@ -28,7 +28,6 @@ import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.PipelineTask;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.RunLog;
-import com.epam.pipeline.entity.pipeline.StopServerlessRun;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.epam.pipeline.entity.pipeline.run.RunStatus;
 import com.epam.pipeline.entity.pipeline.run.parameter.RunAccessType;
@@ -137,9 +136,6 @@ public class PipelineRunDaoTest extends AbstractSpringTest {
 
     @Autowired
     private CloudRegionDao regionDao;
-
-    @Autowired
-    private StopServerlessRunDao stopServerlessRunDao;
 
     @Value("${run.pipeline.init.task.name?:InitializeEnvironment}")
     private String initTaskName;
@@ -836,33 +832,6 @@ public class PipelineRunDaoTest extends AbstractSpringTest {
 
         final PipelineRun loadedRun = pipelineRunDao.loadPipelineRun(run.getId());
         assertTrue(CollectionUtils.isEmpty(loadedRun.getRunSids()));
-    }
-
-    @Test
-    public void shouldLoadExpiredServerlessRuns() {
-        final LocalDateTime now = LocalDateTime.now();
-
-        final PipelineRun run1 = buildPipelineRun(null, null);
-        run1.setStatus(TaskStatus.RUNNING);
-        pipelineRunDao.createPipelineRun(run1);
-        final StopServerlessRun serverlessRun1 = StopServerlessRun.builder()
-                .lastUpdate(now)
-                .runId(run1.getId())
-                .build();
-        stopServerlessRunDao.createServerlessRun(serverlessRun1);
-
-        final PipelineRun run2 = buildPipelineRun(null, null);
-        run2.setStatus(TaskStatus.STOPPED);
-        pipelineRunDao.createPipelineRun(run2);
-        final StopServerlessRun serverlessRun2 = StopServerlessRun.builder()
-                .lastUpdate(now)
-                .runId(run2.getId())
-                .build();
-        stopServerlessRunDao.createServerlessRun(serverlessRun2);
-
-        final List<StopServerlessRun> pipelineRuns = pipelineRunDao.loadServerlessRunsToStop();
-        assertEquals(pipelineRuns.size(), 1);
-        assertEquals(pipelineRuns.get(0).getRunId(), run1.getId());
     }
 
     private PipelineRun createTestPipelineRun() {

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
@@ -841,7 +841,6 @@ public class PipelineRunDaoTest extends AbstractSpringTest {
     @Test
     public void shouldLoadExpiredServerlessRuns() {
         final LocalDateTime now = LocalDateTime.now();
-        final LocalDateTime maxLastUpdate = now.plusMinutes(30);
 
         final PipelineRun run1 = buildPipelineRun(null, null);
         run1.setStatus(TaskStatus.RUNNING);
@@ -853,18 +852,17 @@ public class PipelineRunDaoTest extends AbstractSpringTest {
         stopServerlessRunDao.createServerlessRun(serverlessRun1);
 
         final PipelineRun run2 = buildPipelineRun(null, null);
-        run2.setStatus(TaskStatus.RUNNING);
+        run2.setStatus(TaskStatus.STOPPED);
         pipelineRunDao.createPipelineRun(run2);
         final StopServerlessRun serverlessRun2 = StopServerlessRun.builder()
-                .lastUpdate(now.plusHours(1))
+                .lastUpdate(now)
                 .runId(run2.getId())
                 .build();
         stopServerlessRunDao.createServerlessRun(serverlessRun2);
 
-
-        final List<PipelineRun> pipelineRuns = pipelineRunDao.loadServerlessRunsToStop(maxLastUpdate);
+        final List<StopServerlessRun> pipelineRuns = pipelineRunDao.loadServerlessRunsToStop();
         assertEquals(pipelineRuns.size(), 1);
-        assertEquals(pipelineRuns.get(0).getId(), run1.getId());
+        assertEquals(pipelineRuns.get(0).getRunId(), run1.getId());
     }
 
     private PipelineRun createTestPipelineRun() {

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/StopServerlessRunDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/StopServerlessRunDaoTest.java
@@ -19,6 +19,7 @@ package com.epam.pipeline.dao.pipeline;
 import com.epam.pipeline.AbstractSpringTest;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.StopServerlessRun;
+import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.epam.pipeline.manager.ObjectCreatorUtils;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -76,6 +77,33 @@ public class StopServerlessRunDaoTest extends AbstractSpringTest {
         assertEquals(stopServerlessRunDao.loadAll().size(), 0);
 
         pipelineRunDao.deleteRunsByPipeline(1L);
+    }
+
+    @Test
+    public void shouldLoadRunningServerlessRuns() {
+        final LocalDateTime now = LocalDateTime.now();
+
+        final PipelineRun run1 = pipelineRun();
+        run1.setStatus(TaskStatus.RUNNING);
+        pipelineRunDao.createPipelineRun(run1);
+        final StopServerlessRun serverlessRun1 = StopServerlessRun.builder()
+                .lastUpdate(now)
+                .runId(run1.getId())
+                .build();
+        stopServerlessRunDao.createServerlessRun(serverlessRun1);
+
+        final PipelineRun run2 = pipelineRun();
+        run2.setStatus(TaskStatus.STOPPED);
+        pipelineRunDao.createPipelineRun(run2);
+        final StopServerlessRun serverlessRun2 = StopServerlessRun.builder()
+                .lastUpdate(now)
+                .runId(run2.getId())
+                .build();
+        stopServerlessRunDao.createServerlessRun(serverlessRun2);
+
+        final List<StopServerlessRun> pipelineRuns = stopServerlessRunDao.loadByStatusRunning();
+        assertEquals(pipelineRuns.size(), 1);
+        assertEquals(pipelineRuns.get(0).getRunId(), run1.getId());
     }
 
     private PipelineRun pipelineRun() {

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/StopServerlessRunDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/StopServerlessRunDaoTest.java
@@ -26,12 +26,16 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 @Transactional
 public class StopServerlessRunDaoTest extends AbstractSpringTest {
+
+    private static final Long TEST_STOP_AFTER = 60L;
 
     @Autowired
     private StopServerlessRunDao stopServerlessRunDao;
@@ -47,6 +51,7 @@ public class StopServerlessRunDaoTest extends AbstractSpringTest {
         final StopServerlessRun stopServerlessRun = StopServerlessRun.builder()
                 .runId(pipelineRun.getId())
                 .lastUpdate(firstUpdate)
+                .stopAfter(TEST_STOP_AFTER)
                 .build();
         stopServerlessRunDao.createServerlessRun(stopServerlessRun);
         assertNotNull(stopServerlessRun.getId());
@@ -60,6 +65,11 @@ public class StopServerlessRunDaoTest extends AbstractSpringTest {
         final List<StopServerlessRun> loaded = stopServerlessRunDao.loadAll();
         assertEquals(loaded.size(), 1);
         assertEquals(loaded.get(0).getLastUpdate(), newUpdate);
+
+        final Optional<StopServerlessRun> loadedRun = stopServerlessRunDao.loadByRunId(pipelineRun.getId());
+        assertTrue(loadedRun.isPresent());
+        assertEquals(loadedRun.get().getRunId(), stopServerlessRun.getRunId());
+        assertEquals(loadedRun.get().getStopAfter(), stopServerlessRun.getStopAfter());
 
         stopServerlessRunDao.deleteByRunId(pipelineRun.getId());
 

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManagerTest.java
@@ -174,7 +174,7 @@ public class ResourceMonitoringManagerTest {
                 .thenReturn(IdleRunAction.NOTIFY.name());
         when(preferenceManager.getPreference(SystemPreferences.LAUNCH_SERVERLESS_STOP_TIMEOUT))
                 .thenReturn(TEST_MAX_IDLE_MONITORING_TIMEOUT);
-        when(pipelineRunManager.loadExpiredServerlessRuns(any())).thenReturn(Collections.emptyList());
+        when(pipelineRunManager.loadActiveServerlessRuns()).thenReturn(Collections.emptyList());
 
         SecurityContext context = SecurityContextHolder.createEmptyContext();
         UserContext userContext = new UserContext(1L, "admin");

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManagerTest.java
@@ -29,6 +29,7 @@ import com.epam.pipeline.entity.utils.DateUtils;
 import com.epam.pipeline.manager.cluster.InstanceOfferManager;
 import com.epam.pipeline.manager.notification.NotificationManager;
 import com.epam.pipeline.manager.pipeline.PipelineRunManager;
+import com.epam.pipeline.manager.pipeline.StopServerlessRunManager;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.manager.security.AuthManager;
@@ -123,6 +124,8 @@ public class ResourceMonitoringManagerTest {
     private MessageHelper messageHelper;
     @Mock
     private AuthManager authManager;
+    @Mock
+    private StopServerlessRunManager stopServerlessRunManager;
 
     @Captor
     ArgumentCaptor<List<PipelineRun>> runsToUpdateCaptor;
@@ -150,7 +153,8 @@ public class ResourceMonitoringManagerTest {
                                                                         notificationManager,
                                                                         monitoringESDao,
                                                                         messageHelper,
-                                                                        preferenceManager);
+                                                                        preferenceManager,
+                                                                        stopServerlessRunManager);
         resourceMonitoringManager = new ResourceMonitoringManager(instanceOfferManager, core);
         Whitebox.setInternalState(resourceMonitoringManager, "authManager", authManager);
         Whitebox.setInternalState(resourceMonitoringManager, "preferenceManager", preferenceManager);
@@ -174,7 +178,7 @@ public class ResourceMonitoringManagerTest {
                 .thenReturn(IdleRunAction.NOTIFY.name());
         when(preferenceManager.getPreference(SystemPreferences.LAUNCH_SERVERLESS_STOP_TIMEOUT))
                 .thenReturn(TEST_MAX_IDLE_MONITORING_TIMEOUT);
-        when(pipelineRunManager.loadActiveServerlessRuns()).thenReturn(Collections.emptyList());
+        when(stopServerlessRunManager.loadActiveServerlessRuns()).thenReturn(Collections.emptyList());
 
         SecurityContext context = SecurityContextHolder.createEmptyContext();
         UserContext userContext = new UserContext(1L, "admin");

--- a/api/src/test/java/com/epam/pipeline/manager/configuration/ServerlessConfigurationManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/configuration/ServerlessConfigurationManagerTest.java
@@ -28,6 +28,7 @@ import com.epam.pipeline.manager.pipeline.PipelineRunManager;
 import com.epam.pipeline.manager.pipeline.runner.ConfigurationRunner;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
+import com.epam.pipeline.manager.security.AuthManager;
 import com.epam.pipeline.mapper.AbstractRunConfigurationMapper;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
@@ -68,6 +69,7 @@ public class ServerlessConfigurationManagerTest {
     private final PipelineRunManager runManager = mock(PipelineRunManager.class);
     private final PreferenceManager preferenceManager = mock(PreferenceManager.class);
     private final StopServerlessRunDao stopServerlessRunDao = mock(StopServerlessRunDao.class);
+    private final AuthManager authManager = mock(AuthManager.class);
     private final ServerlessConfigurationManager serverlessConfigurationManager =
             spy(new ServerlessConfigurationManager(
                     runConfigurationManager,
@@ -76,7 +78,8 @@ public class ServerlessConfigurationManagerTest {
                     runManager,
                     preferenceManager,
                     stopServerlessRunDao,
-                    new JsonMapper()));
+                    new JsonMapper(),
+                    authManager));
 
     @Test
     public void shouldRunServerlessConfiguration() {

--- a/api/src/test/java/com/epam/pipeline/manager/configuration/ServerlessConfigurationManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/configuration/ServerlessConfigurationManagerTest.java
@@ -19,13 +19,13 @@ package com.epam.pipeline.manager.configuration;
 import com.epam.pipeline.config.JsonMapper;
 import com.epam.pipeline.controller.PagedResult;
 import com.epam.pipeline.controller.vo.configuration.RunConfigurationWithEntitiesVO;
-import com.epam.pipeline.dao.pipeline.StopServerlessRunDao;
 import com.epam.pipeline.entity.configuration.RunConfiguration;
 import com.epam.pipeline.entity.configuration.RunConfigurationEntry;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.StopServerlessRun;
 import com.epam.pipeline.manager.ObjectCreatorUtils;
 import com.epam.pipeline.manager.pipeline.PipelineRunManager;
+import com.epam.pipeline.manager.pipeline.StopServerlessRunManager;
 import com.epam.pipeline.manager.pipeline.runner.ConfigurationRunner;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
@@ -69,7 +69,7 @@ public class ServerlessConfigurationManagerTest {
     private final AbstractRunConfigurationMapper runConfigurationMapper = mock(AbstractRunConfigurationMapper.class);
     private final PipelineRunManager runManager = mock(PipelineRunManager.class);
     private final PreferenceManager preferenceManager = mock(PreferenceManager.class);
-    private final StopServerlessRunDao stopServerlessRunDao = mock(StopServerlessRunDao.class);
+    private final StopServerlessRunManager stopServerlessRunManager = mock(StopServerlessRunManager.class);
     private final AuthManager authManager = mock(AuthManager.class);
     private final ServerlessConfigurationManager serverlessConfigurationManager =
             spy(new ServerlessConfigurationManager(
@@ -78,7 +78,7 @@ public class ServerlessConfigurationManagerTest {
                     runConfigurationMapper,
                     runManager,
                     preferenceManager,
-                    stopServerlessRunDao,
+                    stopServerlessRunManager,
                     new JsonMapper(),
                     authManager));
 
@@ -99,13 +99,13 @@ public class ServerlessConfigurationManagerTest {
         when(preferenceManager.getPreference(SystemPreferences.LAUNCH_SERVERLESS_WAIT_COUNT)).thenReturn(1);
         when(runManager.loadPipelineRun(any())).thenReturn(pipelineRun);
         doReturn(StringUtils.EMPTY).when(serverlessConfigurationManager).sendRequest(any(), any());
-        when(stopServerlessRunDao.loadByRunId(any())).thenReturn(Optional.empty());
+        when(stopServerlessRunManager.loadByRunId(any())).thenReturn(Optional.empty());
 
         serverlessConfigurationManager.run(CONFIGURATION_ID, TEST_NAME, mockRequest());
         verifyEndpoint();
         verify(configurationRunner).runConfiguration(any(), any(), any());
-        verify(stopServerlessRunDao).createServerlessRun(any());
-        verify(stopServerlessRunDao).updateServerlessRun(any());
+        verify(stopServerlessRunManager).createServerlessRun(any());
+        verify(stopServerlessRunManager).updateServerlessRun(any());
     }
 
     @Test
@@ -126,13 +126,13 @@ public class ServerlessConfigurationManagerTest {
         when(preferenceManager.getPreference(SystemPreferences.LAUNCH_SERVERLESS_WAIT_COUNT)).thenReturn(1);
         when(runManager.loadPipelineRun(any())).thenReturn(pipelineRun);
         doReturn(StringUtils.EMPTY).when(serverlessConfigurationManager).sendRequest(any(), any());
-        when(stopServerlessRunDao.loadByRunId(any())).thenReturn(Optional.empty());
+        when(stopServerlessRunManager.loadByRunId(any())).thenReturn(Optional.empty());
 
         serverlessConfigurationManager.run(CONFIGURATION_ID, TEST_NAME, mockRequest());
         verifyEndpoint();
         verify(configurationRunner).runConfiguration(any(), any(), any());
-        verify(stopServerlessRunDao).createServerlessRun(any());
-        verify(stopServerlessRunDao).updateServerlessRun(any());
+        verify(stopServerlessRunManager).createServerlessRun(any());
+        verify(stopServerlessRunManager).updateServerlessRun(any());
     }
 
     @Test
@@ -150,7 +150,7 @@ public class ServerlessConfigurationManagerTest {
         when(preferenceManager.getPreference(SystemPreferences.LAUNCH_SERVERLESS_WAIT_COUNT)).thenReturn(1);
         when(runManager.loadPipelineRun(any())).thenReturn(pipelineRun);
         doReturn(StringUtils.EMPTY).when(serverlessConfigurationManager).sendRequest(any(), any());
-        when(stopServerlessRunDao.loadByRunId(any())).thenReturn(Optional.of(
+        when(stopServerlessRunManager.loadByRunId(any())).thenReturn(Optional.of(
                 StopServerlessRun.builder()
                         .runId(pipelineRun.getId())
                         .lastUpdate(LocalDateTime.now())
@@ -159,8 +159,8 @@ public class ServerlessConfigurationManagerTest {
         serverlessConfigurationManager.run(CONFIGURATION_ID, TEST_NAME, mockRequest());
         verifyEndpoint();
         verify(configurationRunner, times(0)).runConfiguration(any(), any(), any());
-        verify(stopServerlessRunDao, times(0)).createServerlessRun(any());
-        verify(stopServerlessRunDao, times(2)).updateServerlessRun(any());
+        verify(stopServerlessRunManager, times(0)).createServerlessRun(any());
+        verify(stopServerlessRunManager, times(2)).updateServerlessRun(any());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -186,7 +186,7 @@ public class ServerlessConfigurationManagerTest {
         when(preferenceManager.getPreference(SystemPreferences.LAUNCH_TASK_STATUS_UPDATE_RATE)).thenReturn(1);
         when(runManager.loadPipelineRun(any())).thenReturn(pipelineRun);
         when(runManager.searchPipelineRuns(any(), anyBoolean())).thenReturn(activeRuns);
-        when(stopServerlessRunDao.loadByRunId(any())).thenReturn(Optional.empty());
+        when(stopServerlessRunManager.loadByRunId(any())).thenReturn(Optional.empty());
 
         serverlessConfigurationManager.run(CONFIGURATION_ID, TEST_NAME, mockRequest());
     }

--- a/api/src/test/java/com/epam/pipeline/manager/configuration/ServerlessConfigurationManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/configuration/ServerlessConfigurationManagerTest.java
@@ -37,10 +37,12 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -93,6 +95,8 @@ public class ServerlessConfigurationManagerTest {
         when(preferenceManager.getPreference(SystemPreferences.LAUNCH_SERVERLESS_WAIT_COUNT)).thenReturn(1);
         when(runManager.loadPipelineRun(any())).thenReturn(pipelineRun);
         doReturn(StringUtils.EMPTY).when(serverlessConfigurationManager).sendRequest(any(), any());
+        when(stopServerlessRunDao.loadByRunId(any())).thenReturn(Optional.empty());
+        doNothing().when(stopServerlessRunDao).createServerlessRun(any());
 
         serverlessConfigurationManager.run(CONFIGURATION_ID, TEST_NAME, mockRequest());
         verifyEndpoint();
@@ -117,6 +121,8 @@ public class ServerlessConfigurationManagerTest {
         when(preferenceManager.getPreference(SystemPreferences.LAUNCH_SERVERLESS_WAIT_COUNT)).thenReturn(1);
         when(runManager.loadPipelineRun(any())).thenReturn(pipelineRun);
         doReturn(StringUtils.EMPTY).when(serverlessConfigurationManager).sendRequest(any(), any());
+        when(stopServerlessRunDao.loadByRunId(any())).thenReturn(Optional.empty());
+        doNothing().when(stopServerlessRunDao).createServerlessRun(any());
 
         serverlessConfigurationManager.run(CONFIGURATION_ID, TEST_NAME, mockRequest());
         verifyEndpoint();
@@ -138,6 +144,8 @@ public class ServerlessConfigurationManagerTest {
         when(preferenceManager.getPreference(SystemPreferences.LAUNCH_SERVERLESS_WAIT_COUNT)).thenReturn(1);
         when(runManager.loadPipelineRun(any())).thenReturn(pipelineRun);
         doReturn(StringUtils.EMPTY).when(serverlessConfigurationManager).sendRequest(any(), any());
+        when(stopServerlessRunDao.loadByRunId(any())).thenReturn(Optional.empty());
+        doNothing().when(stopServerlessRunDao).createServerlessRun(any());
 
         serverlessConfigurationManager.run(CONFIGURATION_ID, TEST_NAME, mockRequest());
         verifyEndpoint();
@@ -167,6 +175,8 @@ public class ServerlessConfigurationManagerTest {
         when(preferenceManager.getPreference(SystemPreferences.LAUNCH_TASK_STATUS_UPDATE_RATE)).thenReturn(1);
         when(runManager.loadPipelineRun(any())).thenReturn(pipelineRun);
         when(runManager.searchPipelineRuns(any(), anyBoolean())).thenReturn(activeRuns);
+        when(stopServerlessRunDao.loadByRunId(any())).thenReturn(Optional.empty());
+        doNothing().when(stopServerlessRunDao).createServerlessRun(any());
 
         serverlessConfigurationManager.run(CONFIGURATION_ID, TEST_NAME, mockRequest());
     }

--- a/core/src/main/java/com/epam/pipeline/entity/configuration/AbstractRunConfigurationEntry.java
+++ b/core/src/main/java/com/epam/pipeline/entity/configuration/AbstractRunConfigurationEntry.java
@@ -50,7 +50,7 @@ public abstract class AbstractRunConfigurationEntry {
     @JsonProperty(value = "default")
     private boolean defaultConfiguration = false;
     private String endpointName;
-    private boolean stopAfter = false;
+    private Long stopAfter;
 
     public abstract boolean checkConfigComplete();
     public abstract PipelineStart toPipelineStart();

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/StopServerlessRun.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/StopServerlessRun.java
@@ -33,4 +33,5 @@ public class StopServerlessRun {
     private Long id;
     private Long runId;
     private LocalDateTime lastUpdate;
+    private Long stopAfter;
 }


### PR DESCRIPTION
This PR provides updates for current implementation for issue #1038 

The following changes were added:
- the field `RunConfiguration#stopAfter` is numeric value now and indicates how long corresponding run will be alive after the last request (in minutes). If this value is not specified the value `launch.serverless.stop.timeout` from system preferences will be used
- bearer token will be added to request cookies if not specified (required for `edge` auth) 