### PR TITLE
Issue #1230: Sensitive env vars

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/cluster/EnvVarsSettings.java
+++ b/api/src/main/java/com/epam/pipeline/entity/cluster/EnvVarsSettings.java
@@ -31,6 +31,8 @@ public class EnvVarsSettings {
 
     @JsonProperty("variables")
     private Map<String, Object> defaultEnvVars;
+    @JsonProperty("sensitive")
+    private Map<String, Object> sensitiveEnvVars;
     @JsonProperty("regions")
     private List<CloudRegionEnvVars> regionEnvVars;
 
@@ -42,6 +44,7 @@ public class EnvVarsSettings {
         private Long regionId;
         @JsonProperty("variables")
         private Map<String, Object> envVars;
-
+        @JsonProperty("sensitive")
+        private Map<String, Object> sensitiveEnvVars;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/execution/PipelineLauncher.java
+++ b/api/src/main/java/com/epam/pipeline/manager/execution/PipelineLauncher.java
@@ -101,12 +101,12 @@ public class PipelineLauncher {
     private final SimpleDateFormat timeFormat = new SimpleDateFormat(Constants.SIMPLE_TIME_FORMAT);
 
     public String launch(PipelineRun run, PipelineConfiguration configuration, List<String> endpoints,
-            String nodeIdLabel,  String clusterId) {
+                         String nodeIdLabel, String clusterId) {
         return launch(run, configuration, endpoints, nodeIdLabel, true, run.getPodId(), clusterId);
     }
 
     public String launch(PipelineRun run, PipelineConfiguration configuration,
-            List<String> endpoints, String nodeIdLabel, boolean useLaunch, String pipelineId, String clusterId) {
+                         List<String> endpoints, String nodeIdLabel, boolean useLaunch, String pipelineId, String clusterId) {
         return launch(run, configuration, endpoints, nodeIdLabel, useLaunch, pipelineId, clusterId, true);
     }
 
@@ -123,7 +123,7 @@ public class PipelineLauncher {
                 configuration, gitCredentials);
         checkRunOnParentNode(run, nodeIdLabel, systemParams);
         List<EnvVar> envVars = EnvVarsBuilder.buildEnvVars(run, configuration, systemParams,
-                buildRegionSpecificEnvVars(run.getInstance().getCloudRegionId()));
+                buildRegionSpecificEnvVars(run.getInstance().getCloudRegionId(), run.getSensitive()));
 
         Assert.isTrue(!StringUtils.isEmpty(configuration.getCmdTemplate()), messageHelper.getMessage(
                 MessageConstants.ERROR_CMD_TEMPLATE_NOT_RESOLVED));
@@ -139,13 +139,15 @@ public class PipelineLauncher {
         return pipelineCommand;
     }
 
-    private Map<String, String> buildRegionSpecificEnvVars(final Long cloudRegionId) {
-        final Map<String, String> externalProperties = getExternalProperties(cloudRegionId);
+    private Map<String, String> buildRegionSpecificEnvVars(final Long cloudRegionId,
+                                                           final boolean sensitiveRun) {
+        final Map<String, String> externalProperties = getExternalProperties(cloudRegionId, sensitiveRun);
         final Map<String, String> cloudEnvVars = cloudFacade.buildContainerCloudEnvVars(cloudRegionId);
         return CommonUtils.mergeMaps(externalProperties, cloudEnvVars);
     }
 
-    private Map<String, String> getExternalProperties(final Long regionId) {
+    private Map<String, String> getExternalProperties(final Long regionId,
+                                                      final boolean sensitiveRun) {
         final EnvVarsSettings podEnvVarsFileMap =
                 preferenceManager.getPreference(SystemPreferences.LAUNCH_ENV_PROPERTIES);
         if (podEnvVarsFileMap == null) {
@@ -153,16 +155,28 @@ public class PipelineLauncher {
         }
         final Map<String, Object> mergedEnvVars = new HashMap<>(
                 MapUtils.emptyIfNull(podEnvVarsFileMap.getDefaultEnvVars()));
-        ListUtils.emptyIfNull(podEnvVarsFileMap.getRegionEnvVars()).stream()
+        if (sensitiveRun) {
+            MapUtils.emptyIfNull(podEnvVarsFileMap.getSensitiveEnvVars())
+                    .putAll(mergedEnvVars);
+        }
+        ListUtils.emptyIfNull(podEnvVarsFileMap.getRegionEnvVars())
+                .stream()
                 .filter(region -> regionId.equals(region.getRegionId()))
                 .findFirst()
-                .map(region -> MapUtils.emptyIfNull(region.getEnvVars()))
-                .ifPresent(mergedEnvVars::putAll);
-        return new ObjectMapper().convertValue(mergedEnvVars, new TypeReference<Map<String, String>>() {});
+                .ifPresent(region -> {
+                    MapUtils.emptyIfNull(region.getEnvVars())
+                            .putAll(mergedEnvVars);
+                    if (sensitiveRun) {
+                        MapUtils.emptyIfNull(region.getSensitiveEnvVars())
+                                .putAll(mergedEnvVars);
+                    }
+                });
+        return new ObjectMapper().convertValue(mergedEnvVars, new TypeReference<Map<String, String>>() {
+        });
     }
 
     private void checkRunOnParentNode(PipelineRun run, String nodeIdLabel,
-            Map<SystemParams, String> systemParams) {
+                                      Map<SystemParams, String> systemParams) {
         if (!run.getId().toString().equals(nodeIdLabel)) {
             systemParams.put(SystemParams.RUN_ON_PARENT_NODE, EMPTY_PARAMETER);
         }
@@ -242,7 +256,7 @@ public class PipelineLauncher {
         systemParamsWithValue.put(SystemParams.OWNER, run.getOwner());
         if (gitCredentials != null) {
             putIfStringValuePresent(systemParamsWithValue,
-                    SystemParams.GIT_USER,  gitCredentials.getUserName());
+                    SystemParams.GIT_USER, gitCredentials.getUserName());
             putIfStringValuePresent(systemParamsWithValue,
                     SystemParams.GIT_TOKEN, gitCredentials.getToken());
         }
@@ -281,8 +295,8 @@ public class PipelineLauncher {
     }
 
     private void putIfStringValuePresent(EnumMap<SystemParams, String> params,
-                                        SystemParams parameter,
-                                        String value) {
+                                         SystemParams parameter,
+                                         String value) {
         if (StringUtils.hasText(value)) {
             params.put(parameter, value);
         }


### PR DESCRIPTION
This PR provides implementation for #1230 

### Approach
This PR adds new optional section `sensitive` to `launch.env.properties`. Properties from this section are applied to sensitive runs only and will override common environment variables.