### PR TITLE
Issue #1038: "Serverless" Cloud Pipeline API

### DIFF
--- a/api/profiles/dev/application.properties
+++ b/api/profiles/dev/application.properties
@@ -160,3 +160,7 @@ migration.alias.file=${CP_API_MIGRATION_ALIAS_FILE:}
 
 #Cache
 cache.type=MEMORY
+
+#edge
+edge.internal.host=${CP_EDGE_INTERNAL_HOST:cp-edge.default.svc.cluster.local}
+edge.internal.port=${CP_EDGE_INTERNAL_PORT:31081}

--- a/deploy/docker/cp-api-srv/config/application.properties
+++ b/deploy/docker/cp-api-srv/config/application.properties
@@ -143,3 +143,7 @@ redis.host=${CP_REDIS_INTERNAL_HOST:}
 redis.port=${CP_REDIS_INTERNAL_PORT:}
 redis.pool.timeout=${CP_REDIS_POOL_TIMEOUT:20000}
 redis.max.connections=${CP_REDIS_MAX_CONNECTIONS:20}
+
+#edge
+edge.internal.host=${CP_EDGE_INTERNAL_HOST:cp-edge.default.svc.cluster.local}
+edge.internal.port=${CP_EDGE_INTERNAL_PORT:31081}


### PR DESCRIPTION
This PR provides fixes for issue #1038 

The following changes were added:
- fix for actual pipeline run state retrieving
- fix for application endpoint: replace host and port if edge internal host and port were specified (a new application properties `edge.internal.host` and `edge.internal.port` were added) 