### PR TITLE
Pipe storage cp/mv commands shall support multithreaded execution

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -884,7 +884,7 @@ def storage_remove_item(path, yes, version, hard_delete, recursive, exclude, inc
               "filter - follow symlinks but check for cyclic links")
 @click.option('-n', '--threads', type=int, required=False,
               help='The number of threads that will work to perform operation. Allowed for folders only. '
-                   'Use to move a huge number of small files. Not supported for Windows OS')
+                   'Use to move a huge number of small files. Not supported for Windows OS. Progress bar is disabled')
 @click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token(quiet_flag_property_name='quiet')
 def storage_move_item(source, destination, recursive, force, exclude, include, quiet, skip_existing, tags, file_list,
@@ -923,7 +923,7 @@ def storage_move_item(source, destination, recursive, force, exclude, include, q
               "filter - follow symlinks but check for cyclic links")
 @click.option('-n', '--threads', type=int, required=False,
               help='The number of threads that will work to perform operation. Allowed for folders only. '
-                   'Use to copy a huge number of small files. Not supported for Windows OS')
+                   'Use to copy a huge number of small files. Not supported for Windows OS. Progress bar is disabled')
 @click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token(quiet_flag_property_name='quiet')
 def storage_copy_item(source, destination, recursive, force, exclude, include, quiet, skip_existing, tags, file_list,

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -884,7 +884,7 @@ def storage_remove_item(path, yes, version, hard_delete, recursive, exclude, inc
               "filter - follow symlinks but check for cyclic links")
 @click.option('-n', '--threads', type=int, required=False,
               help='The number of threads that will work to perform operation. Allowed for folders only. '
-                   'Use to move a huge number of small files')
+                   'Use to move a huge number of small files. Not supported for Windows OS')
 @click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token(quiet_flag_property_name='quiet')
 def storage_move_item(source, destination, recursive, force, exclude, include, quiet, skip_existing, tags, file_list,
@@ -923,7 +923,7 @@ def storage_move_item(source, destination, recursive, force, exclude, include, q
               "filter - follow symlinks but check for cyclic links")
 @click.option('-n', '--threads', type=int, required=False,
               help='The number of threads that will work to perform operation. Allowed for folders only. '
-                   'Use to copy a huge number of small files')
+                   'Use to copy a huge number of small files. Not supported for Windows OS')
 @click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token(quiet_flag_property_name='quiet')
 def storage_copy_item(source, destination, recursive, force, exclude, include, quiet, skip_existing, tags, file_list,

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -882,7 +882,9 @@ def storage_remove_item(path, yes, version, hard_delete, recursive, exclude, inc
               "follow - follow symlinks (default); "
               "skip - do not follow symlinks; "
               "filter - follow symlinks but check for cyclic links")
-@click.option('-n', '--threads', help='The number  of threads allowed for operation', type=int, required=False)
+@click.option('-n', '--threads', type=int, required=False,
+              help='The number of threads that will work to perform operation. Allowed for folders only. '
+                   'Use to move a huge number of small files')
 @click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token(quiet_flag_property_name='quiet')
 def storage_move_item(source, destination, recursive, force, exclude, include, quiet, skip_existing, tags, file_list,
@@ -919,7 +921,9 @@ def storage_move_item(source, destination, recursive, force, exclude, include, q
               "follow - follow symlinks (default); "
               "skip - do not follow symlinks; "
               "filter - follow symlinks but check for cyclic links")
-@click.option('-n', '--threads', help='The number  of threads allowed for operation', type=int, required=False)
+@click.option('-n', '--threads', type=int, required=False,
+              help='The number of threads that will work to perform operation. Allowed for folders only. '
+                   'Use to copy a huge number of small files')
 @click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token(quiet_flag_property_name='quiet')
 def storage_copy_item(source, destination, recursive, force, exclude, include, quiet, skip_existing, tags, file_list,

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -882,15 +882,16 @@ def storage_remove_item(path, yes, version, hard_delete, recursive, exclude, inc
               "follow - follow symlinks (default); "
               "skip - do not follow symlinks; "
               "filter - follow symlinks but check for cyclic links")
+@click.option('-n', '--threads', help='The number  of threads allowed for operation', type=int, required=False)
 @click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token(quiet_flag_property_name='quiet')
 def storage_move_item(source, destination, recursive, force, exclude, include, quiet, skip_existing, tags, file_list,
-                      symlinks):
+                      symlinks, threads):
     """ Moves a file or a folder from one datastorage to another one
     or between the local filesystem and a datastorage (in both directions)
     """
     DataStorageOperations.cp(source, destination, recursive, force, exclude, include, quiet, tags, file_list,
-                             symlinks, clean=True, skip_existing=skip_existing)
+                             symlinks, threads, clean=True, skip_existing=skip_existing)
 
 
 @storage.command('cp')
@@ -918,15 +919,16 @@ def storage_move_item(source, destination, recursive, force, exclude, include, q
               "follow - follow symlinks (default); "
               "skip - do not follow symlinks; "
               "filter - follow symlinks but check for cyclic links")
+@click.option('-n', '--threads', help='The number  of threads allowed for operation', type=int, required=False)
 @click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token(quiet_flag_property_name='quiet')
 def storage_copy_item(source, destination, recursive, force, exclude, include, quiet, skip_existing, tags, file_list,
-                      symlinks):
+                      symlinks, threads):
     """ Copies files from one datastorage to another one
     or between the local filesystem and a datastorage (in both directions)
     """
     DataStorageOperations.cp(source, destination, recursive, force,
-                             exclude, include, quiet, tags, file_list, symlinks, skip_existing=skip_existing)
+                             exclude, include, quiet, tags, file_list, symlinks, threads, skip_existing=skip_existing)
 
 
 @storage.command('du')

--- a/pipe-cli/src/utilities/datastorage_operations.py
+++ b/pipe-cli/src/utilities/datastorage_operations.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import datetime
+import multiprocessing
 import os
 import platform
 import sys
@@ -20,6 +21,7 @@ import sys
 import click
 import prettytable
 from future.utils import iteritems
+from operator import itemgetter
 
 from src.api.data_storage import DataStorage
 from src.api.folder import Folder
@@ -36,8 +38,8 @@ ALL_ERRORS = Exception
 
 class DataStorageOperations(object):
     @classmethod
-    def cp(cls, source, destination, recursive, force, exclude, include, quiet, tags, file_list, symlinks, clean=False,
-           skip_existing=False):
+    def cp(cls, source, destination, recursive, force, exclude, include, quiet, tags, file_list, symlinks, threads,
+           clean=False, skip_existing=False):
         try:
             source_wrapper = DataStorageWrapper.get_wrapper(source, symlinks)
             destination_wrapper = DataStorageWrapper.get_wrapper(destination)
@@ -63,6 +65,9 @@ class DataStorageOperations(object):
                     click.echo('Specified --file-list file does not exist.', err=True)
                     sys.exit(1)
                 files_to_copy = cls.__get_file_to_copy(file_list, source_wrapper.path)
+            if threads and not recursive:
+                click.echo('-n (--threads) is allowed for folders only.', err=True)
+                sys.exit(1)
             relative = os.path.basename(source) if source_wrapper.is_file() else None
             if not force and not destination_wrapper.is_empty(relative=relative):
                 click.echo('Flag --force (-f) is required to overwrite files in the destination data.', err=True)
@@ -85,6 +90,7 @@ class DataStorageOperations(object):
             permission_to_check = os.R_OK if command == 'cp' else os.W_OK
             manager = DataStorageWrapper.get_operation_manager(source_wrapper, destination_wrapper, command)
             items = files_to_copy if file_list else source_wrapper.get_items()
+            sorted_items = list()
             for item in items:
                 full_path = item[1]
                 relative_path = item[2]
@@ -109,9 +115,15 @@ class DataStorageOperations(object):
                         click.echo("Skipping file {} since it matches exclude patterns [{}]."
                                    .format(full_path, ",".join(exclude)))
                     continue
-                manager.transfer(source_wrapper, destination_wrapper, path=full_path,
-                                 relative_path=relative_path, clean=clean, quiet=quiet, size=size,
-                                 tags=tags, skip_existing=skip_existing)
+                if threads:
+                    sorted_items.append(item)
+                else:
+                    manager.transfer(source_wrapper, destination_wrapper, path=full_path,
+                                     relative_path=relative_path, clean=clean, quiet=quiet, size=size,
+                                     tags=tags, skip_existing=skip_existing)
+            if threads:
+                cls._multiprocess_transfer_items(sorted_items, threads, manager, source_wrapper, destination_wrapper,
+                                                 clean, quiet, tags, skip_existing)
         except ALL_ERRORS as error:
             click.echo('Error: %s' % str(error), err=True)
             sys.exit(1)
@@ -518,3 +530,44 @@ class DataStorageOperations(object):
         if platform.system() == 'Windows':
             click.echo('%s command is not supported for Windows OS.' % command, err=True)
             sys.exit(1)
+
+    @classmethod
+    def _split_items_by_process(cls, sorted_items, threads):
+        splitted_items = list()
+        for i in range(threads):
+            splitted_items.append(list())
+        for i in range(len(sorted_items)):
+            j = i % threads
+            splitted_items[j].append(sorted_items[i])
+        return splitted_items
+
+    @classmethod
+    def _transfer_items(cls, items, manager, source_wrapper, destination_wrapper, clean, quiet, tags, skip_existing,
+                        lock):
+        for item in items:
+            full_path = item[1]
+            relative_path = item[2]
+            size = item[3]
+            manager.transfer(source_wrapper, destination_wrapper, path=full_path,
+                             relative_path=relative_path, clean=clean, quiet=quiet, size=size,
+                             tags=tags, skip_existing=skip_existing, lock=lock)
+
+    @classmethod
+    def _multiprocess_transfer_items(cls, sorted_items, threads, manager, source_wrapper, destination_wrapper, clean,
+                                     quiet, tags, skip_existing):
+        size_index = 3
+        sorted_items.sort(key=itemgetter(size_index), reverse=True)
+        splitted_items = cls._split_items_by_process(sorted_items, threads)
+        lock = multiprocessing.Lock()
+        for i in range(threads):
+            multiprocessing.Process(target=cls._transfer_items,
+                                    args=(splitted_items[i],
+                                          manager,
+                                          source_wrapper,
+                                          destination_wrapper,
+                                          clean,
+                                          quiet,
+                                          tags,
+                                          skip_existing,
+                                          lock)) \
+                .start()

--- a/pipe-cli/src/utilities/datastorage_operations.py
+++ b/pipe-cli/src/utilities/datastorage_operations.py
@@ -68,6 +68,9 @@ class DataStorageOperations(object):
             if threads and not recursive:
                 click.echo('-n (--threads) is allowed for folders only.', err=True)
                 sys.exit(1)
+            if threads and platform.system() == 'Windows':
+                click.echo('-n (--threads) is not supported for Windows OS', err=True)
+                sys.exit(1)
             relative = os.path.basename(source) if source_wrapper.is_file() else None
             if not force and not destination_wrapper.is_empty(relative=relative):
                 click.echo('Flag --force (-f) is required to overwrite files in the destination data.', err=True)

--- a/pipe-cli/src/utilities/storage/common.py
+++ b/pipe-cli/src/utilities/storage/common.py
@@ -215,7 +215,7 @@ class AbstractTransferManager:
 
     @abstractmethod
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False,
-                 quiet=False, size=None, tags=(), skip_existing=False):
+                 quiet=False, size=None, tags=(), skip_existing=False, lock=None):
         """
         Transfers data from the source storage to the destination storage.
 
@@ -231,8 +231,20 @@ class AbstractTransferManager:
         :param tags: Additional tags that will be included to the transferring object.
         Tags CP_SOURCE and CP_OWNER will be included by default.
         :param skip_existing: Skips transfer objects that already exist in the destination storage.
+        :param lock: The lock object if multithreaded transfer is requested
+        :type lock: multiprocessing.Lock
         """
         pass
+
+    @staticmethod
+    def create_local_folder(destination_key, lock):
+        folder = os.path.dirname(destination_key)
+        if lock:
+            lock.acquire()
+        if folder and not os.path.exists(folder):
+            os.makedirs(folder)
+        if lock:
+            lock.release()
 
 
 class AbstractListingManager:

--- a/pipe-cli/src/utilities/storage/common.py
+++ b/pipe-cli/src/utilities/storage/common.py
@@ -115,8 +115,8 @@ class StorageOperations:
         return re.sub(delimiter + '+', delimiter, path)
 
     @classmethod
-    def show_progress(cls, quiet, size):
-        return not quiet and size is not None and size != 0
+    def show_progress(cls, quiet, size, lock=None):
+        return not quiet and size is not None and size != 0 and lock is None
 
     @classmethod
     def get_local_file_size(cls, path):
@@ -241,10 +241,12 @@ class AbstractTransferManager:
         folder = os.path.dirname(destination_key)
         if lock:
             lock.acquire()
-        if folder and not os.path.exists(folder):
-            os.makedirs(folder)
-        if lock:
-            lock.release()
+        try:
+            if folder and not os.path.exists(folder):
+                os.makedirs(folder)
+        finally:
+            if lock:
+                lock.release()
 
 
 class AbstractListingManager:

--- a/pipe-cli/src/utilities/storage/local.py
+++ b/pipe-cli/src/utilities/storage/local.py
@@ -71,7 +71,7 @@ class TransferFromHttpOrFtpToLocal(object):
                 return
         AbstractTransferManager.create_local_folder(destination_key, lock)
         file_stream = urlopen(source_key)
-        if StorageItemManager.show_progress(quiet, size):
+        if StorageItemManager.show_progress(quiet, size, lock):
             progress_bar = ProgressPercentage(relative_path, size)
         with open(destination_key, 'wb') as f:
             while True:
@@ -79,7 +79,7 @@ class TransferFromHttpOrFtpToLocal(object):
                 if not chunk:
                     break
                 f.write(chunk)
-                if StorageItemManager.show_progress(quiet, size):
+                if StorageItemManager.show_progress(quiet, size, lock):
                     progress_bar.__call__(len(chunk))
         file_stream.close()
 

--- a/pipe-cli/src/utilities/storage/local.py
+++ b/pipe-cli/src/utilities/storage/local.py
@@ -1,4 +1,21 @@
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
+
+from src.utilities.storage.common import AbstractTransferManager
+
 try:
     from urllib.request import urlopen  # Python 3
 except ImportError:
@@ -17,7 +34,7 @@ class TransferFromHttpOrFtpToLocal(object):
         pass
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False,
-                 quiet=False, size=None, tags=(), skip_existing=False):
+                 quiet=False, size=None, tags=(), skip_existing=False, lock=None):
         """
         Transfers data from remote resource (only ftp(s) or http(s) protocols supported) to local file system.
         :param source_wrapper: wrapper for ftp or http resource
@@ -31,6 +48,8 @@ class TransferFromHttpOrFtpToLocal(object):
         :param size: the size of the source file
         :param tags: not needed for this kind of transfer
         :param skip_existing: indicates --skip_existing option
+        :param lock: The lock object if multithreaded transfer is requested
+        :type lock: multiprocessing.Lock
         """
         if clean:
             raise AttributeError("Cannot perform 'mv' operation due to deletion remote files "
@@ -50,9 +69,7 @@ class TransferFromHttpOrFtpToLocal(object):
                 if not quiet:
                     click.echo('Skipping file %s since it exists in the destination %s' % (source_key, destination_key))
                 return
-        dir_path = os.path.dirname(destination_key)
-        if not os.path.exists(dir_path):
-            os.makedirs(dir_path)
+        AbstractTransferManager.create_local_folder(destination_key, lock)
         file_stream = urlopen(source_key)
         if StorageItemManager.show_progress(quiet, size):
             progress_bar = ProgressPercentage(relative_path, size)

--- a/pipe-cli/src/utilities/storage/s3.py
+++ b/pipe-cli/src/utilities/storage/s3.py
@@ -49,8 +49,8 @@ class StorageItemManager(object):
             self.bucket = self.s3.Bucket(bucket)
 
     @classmethod
-    def show_progress(cls, quiet, size):
-        return StorageOperations.show_progress(quiet, size)
+    def show_progress(cls, quiet, size, lock=None):
+        return StorageOperations.show_progress(quiet, size, lock)
 
     @classmethod
     def _get_user(cls):
@@ -104,7 +104,7 @@ class DownloadManager(StorageItemManager, AbstractTransferManager):
                     click.echo('Skipping file %s since it exists in the destination %s' % (source_key, destination_key))
                 return
         self.create_local_folder(destination_key, lock)
-        if StorageItemManager.show_progress(quiet, size):
+        if StorageItemManager.show_progress(quiet, size, lock):
             self.bucket.download_file(source_key, destination_key, Callback=ProgressPercentage(relative_path, size))
         else:
             self.bucket.download_file(source_key, destination_key)
@@ -137,7 +137,7 @@ class UploadManager(StorageItemManager, AbstractTransferManager):
             'Tagging': self._convert_tags_to_url_string(tags)
         }
         TransferManager.ALLOWED_UPLOAD_ARGS.append('Tagging')
-        if StorageItemManager.show_progress(quiet, size):
+        if StorageItemManager.show_progress(quiet, size, lock):
             self.bucket.upload_file(source_key, destination_key, Callback=ProgressPercentage(relative_path, size),
                                     ExtraArgs=extra_args)
         else:
@@ -178,7 +178,7 @@ class TransferFromHttpOrFtpToS3Manager(StorageItemManager, AbstractTransferManag
         }
         TransferManager.ALLOWED_UPLOAD_ARGS.append('Tagging')
         file_stream = urlopen(source_key)
-        if StorageItemManager.show_progress(quiet, size):
+        if StorageItemManager.show_progress(quiet, size, lock):
             self.bucket.upload_fileobj(file_stream, destination_key, Callback=ProgressPercentage(relative_path, size),
                                        ExtraArgs=extra_args)
         else:
@@ -217,7 +217,7 @@ class TransferBetweenBucketsManager(StorageItemManager, AbstractTransferManager)
         extra_args = {
             'Tagging': self._convert_tags_to_url_string(tags)
         }
-        if StorageItemManager.show_progress(quiet, size):
+        if StorageItemManager.show_progress(quiet, size, lock):
             self.bucket.copy(copy_source, destination_key, Callback=ProgressPercentage(relative_path, size),
                              ExtraArgs=extra_args)
         else:


### PR DESCRIPTION
This PR provides implementation for issue #1214 

A new CLI option `--threads (-n)` was added to `pipe storage cp/mv` operations. Available for folders only. This option indicates a multithreded files processing. The processing based on the following algorithm:
1. lists all files in folder recursively
2. sorts them by size descending
3. splits into N chunks where N is the `--threads (-n)` option value

This option is aimed at working with a huge number of small files.

The progress bar is disabled if  `--threads (-n)` is specified.

### Benchmarks

The benchmarks were taken for `AWS` provider only.

The following tests datasets were generated:
- 1000 files with 7 Mb size
- 100 files with 20 Mb size

Instance info: m5.large (2 CPU, 8 RAM)

1000 files with 7 Mb size:

|Operation	|n = 1		|n = 2		|n = 3		|n = 4		|n = 8|n = 16|
| --- | --- | --- | --- | --- | --- |--- |
|Upload		|4m42.889s	|2m8.634s	|1m37.565s	|1m13.003s	|1m1.270s|0m52.974s|
|Download	|4m47.033s	|2m25.133s	|1m38.428s	|1m11.698s	|0m52.849s|0m52.069s|

100 files with 20 Mb size:

|Operation|	n = 1|		n = 2|		n = 3|		n = 4|		n = 8|		n = 16|
| --- | --- | --- | --- | --- | --- | --- |		
|Upload|	0m48.492s|	0m22.963s|	0m18.422s|	0m15.642s|	0m13.278s|	0m13.423s|
|Download|	0m27.859s|	0m16.909s|	0m14.886s|	0m14.190s|	0m13.931s|	0m15.489s|

In case with 20 Mb size files a low performance gain is observed with n >= 3. This is due to the fact that `boto3` has its own parallel implementation by file. The parallel computation starts when the file size is greater than [multi-part threshold](https://docs.aws.amazon.com/cli/latest/topic/s3-config.html#multipart-threshold) (default : 8Mb). This way, threads start to competing for resource and affect the performance.
