### PR TITLE
Issue #441 Lustre AWS FSx [2]: mount to run

### DIFF
--- a/deploy/docker/cp-api-srv/Dockerfile
+++ b/deploy/docker/cp-api-srv/Dockerfile
@@ -37,13 +37,13 @@ RUN yum install -y \
                 cifs-utils \
                 gettext
 
-ARG AMAZON_FSX_PUBLIC_KEY_URL="https://fsx-lustre-client-repo-public-keys.s3.amazonaws.com/fsx-rpm-public-key.asc"
-ARG LUSTRE_CLIENT_REPO_URL="https://fsx-lustre-client-repo.s3.amazonaws.com/el/7/fsx-lustre-client.repo"
-RUN wget $AMAZON_FSX_PUBLIC_KEY_URL -O /tmp/fsx-rpm-public-key.asc && \
-    rpm --import /tmp/fsx-rpm-public-key.asc && \
-    wget $LUSTRE_CLIENT_REPO_URL -O /etc/yum.repos.d/aws-fsx.repo && \
-    yum install -y kmod-lustre-client lustre-client && \
-    rm -f /tmp/fsx-rpm-public-key.asc /etc/yum.repos.d/aws-fsx.repo
+ARG LUSTRE_VERSION="2.12.5-1.el7.x86_64"
+ARG LUSTRE_CLIENT_URL="https://cloud-pipeline-oss-builds.s3.amazonaws.com/tools/lustre/client/rpm/lustre-client-$LUSTRE_VERSION.rpm"
+ARG LUSTRE_KMOD_URL="https://cloud-pipeline-oss-builds.s3.amazonaws.com/tools/lustre/client/rpm/kmod-lustre-client-$LUSTRE_VERSION.rpm"
+RUN wget -q $LUSTRE_KMOD_URL -O kmod-lustre-client.rpm && \
+    wget -q $LUSTRE_CLIENT_URL -O lustre-client.rpm && \
+    yum install -y -q kmod-lustre-client.rpm lustre-client.rpm && \
+    rm -f *lustre-client.rpm
 
 # Prebuild version of openssl v1.1.x which is required by osslsigncode.
 # As long as its compatibility is proven for osslsigncode tool only

--- a/workflows/pipe-common/scripts/mount_storage.py
+++ b/workflows/pipe-common/scripts/mount_storage.py
@@ -518,6 +518,8 @@ class NFSMounter(StorageMounter):
             command = command.format(protocol="cifs")
             if not params['path'].startswith("//"):
                 params['path'] = '//' + params['path']
+        elif self.share_mount.mount_type == "LUSTRE":
+            command = command.format(protocol="lustre")
         else:
             command = command.format(protocol="nfs")
 

--- a/workflows/pipe-common/shell/install_nfs_client
+++ b/workflows/pipe-common/shell/install_nfs_client
@@ -26,15 +26,17 @@ then
     CHECK_NFS_SMB_CMD="rpm -qa | grep nfs-utils && rpm -qa | grep cifs-utils"
     INSTALL_NFS_SMB_CMD="yum install nfs-utils cifs-utils -y -q"
     CHECK_LUSTRE_CMD="rpm -qa | grep lustre-client"
-    AMAZON_FSX_PUBLIC_KEY_URL="https://fsx-lustre-client-repo-public-keys.s3.amazonaws.com/fsx-rpm-public-key.asc" &&
-    LUSTRE_CLIENT_REPO_URL="https://fsx-lustre-client-repo.s3.amazonaws.com/el/$(. /etc/os-release;echo $VERSION_ID)/fsx-lustre-client.repo" &&
+    OS_VERSION_ID=$(. /etc/os-release;echo $VERSION_ID)
+    LUSTRE_VERSION=$([ $OS_VERSION_ID -eq 6 ] && echo "2.10.8-1" || echo "2.12.5-1")
+    LUSTRE_VERSION="$LUSTRE_VERSION.el$OS_VERSION_ID.x86_64"
+    LUSTRE_CLIENT_URL="https://cloud-pipeline-oss-builds.s3.amazonaws.com/tools/lustre/client/rpm/lustre-client-$LUSTRE_VERSION.rpm"
+    LUSTRE_KMOD_URL="https://cloud-pipeline-oss-builds.s3.amazonaws.com/tools/lustre/client/rpm/kmod-lustre-client-$LUSTRE_VERSION.rpm"
     read -r -d '' INSTALL_LUSTRE_CMD <<- EOM
-      yum install nfs-utils cifs-utils wget -y -q &&
-      wget $AMAZON_FSX_PUBLIC_KEY_URL -qO /tmp/fsx-rpm-public-key.asc &&
-      rpm --import /tmp/fsx-rpm-public-key.asc &&
-      wget $LUSTRE_CLIENT_REPO_URL -qO /etc/yum.repos.d/aws-fsx.repo &&
-      yum install -y -q kmod-lustre-client lustre-client &&
-      rm -f /tmp/fsx-rpm-public-key.asc /etc/yum.repos.d/aws-fsx.repo
+      yum install -y -q wget && \
+      wget -q $LUSTRE_KMOD_URL -O kmod-lustre-client.rpm && \
+      wget -q $LUSTRE_CLIENT_URL -O lustre-client.rpm && \
+      yum install -y -q kmod-lustre-client.rpm lustre-client.rpm && \
+      rm -f *lustre-client.rpm
 EOM
 else
     CHECK_NFS_SMB_CMD="dpkg -l | grep nfs-common && dpkg -l | grep cifs-utils"

--- a/workflows/pipe-common/shell/install_nfs_client
+++ b/workflows/pipe-common/shell/install_nfs_client
@@ -32,24 +32,26 @@ then
     LUSTRE_CLIENT_URL="https://cloud-pipeline-oss-builds.s3.amazonaws.com/tools/lustre/client/rpm/lustre-client-$LUSTRE_VERSION.rpm"
     LUSTRE_KMOD_URL="https://cloud-pipeline-oss-builds.s3.amazonaws.com/tools/lustre/client/rpm/kmod-lustre-client-$LUSTRE_VERSION.rpm"
     read -r -d '' INSTALL_LUSTRE_CMD <<- EOM
-      yum install -y -q wget && \
-      wget -q $LUSTRE_KMOD_URL -O kmod-lustre-client.rpm && \
-      wget -q $LUSTRE_CLIENT_URL -O lustre-client.rpm && \
-      yum install -y -q kmod-lustre-client.rpm lustre-client.rpm && \
+      yum install -y -q wget &&
+      wget -q $LUSTRE_KMOD_URL -O kmod-lustre-client.rpm &&
+      wget -q $LUSTRE_CLIENT_URL -O lustre-client.rpm &&
+      yum install -y -q kmod-lustre-client.rpm lustre-client.rpm &&
       rm -f *lustre-client.rpm
 EOM
 else
     CHECK_NFS_SMB_CMD="dpkg -l | grep nfs-common && dpkg -l | grep cifs-utils"
     INSTALL_NFS_SMB_CMD='apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" nfs-common cifs-utils -y -qq'
     CHECK_LUSTRE_CMD="dpkg -l | grep lustre-client"
-    AMAZON_FSX_PUBLIC_KEY_URL="https://fsx-lustre-client-repo-public-keys.s3.amazonaws.com/fsx-ubuntu-public-key.asc"
-    LUSTRE_CLIENT_REPO_URL="https://fsx-lustre-client-repo.s3.amazonaws.com/$(. /etc/os-release;echo $ID $VERSION_CODENAME)"
+    LUSTRE_VERSION=$(. /etc/os-release;echo $ID-$VERSION_CODENAME)
+    LUSTRE_CLIENT_URL="https://cloud-pipeline-oss-builds.s3.amazonaws.com/tools/lustre/client/deb/lustre-client-$LUSTRE_VERSION.tar.gz"
     read -r -d '' INSTALL_LUSTRE_CMD <<- EOM
-      apt-get install wget apt-utils -y -qq  &&
-      wget -qO- $AMAZON_FSX_PUBLIC_KEY_URL | apt-key add - &&
-      echo "deb $LUSTRE_CLIENT_REPO_URL main" > /etc/apt/sources.list.d/fsxlustreclientrepo.list && apt-get update -qq &&
+      apt-get install wget -y -qq  &&
+      wget -q $LUSTRE_CLIENT_URL -O lustre-client.tar.gz &&
+      mkdir lustre-client-install/ &&
+      tar -C lustre-client-install/ -zxvf lustre-client.tar.gz &&
       mkdir -p /lib/modules/$(uname -r) &&
-      apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" nfs-common cifs-utils linux-aws lustre-client-modules-aws -y > /dev/null
+      dpkg -i lustre-client-install/* &&
+      rm -rf lustre-client-install/ lustre-client.tar.gz
 EOM
 fi
 

--- a/workflows/pipe-common/shell/install_nfs_client
+++ b/workflows/pipe-common/shell/install_nfs_client
@@ -23,11 +23,27 @@ IS_RPM_BASED=$?
 
 if [[ "$IS_RPM_BASED" = 0 ]]
 then
-    CHECK_CMD="rpm -qa | grep nfs-utils && rpm -qa | grep cifs-utils"
-    INSTALL_CMD="yum install nfs-utils cifs-utils -y -q"
+    CHECK_CMD="rpm -qa | grep nfs-utils && rpm -qa | grep cifs-utils && rpm -qa | grep lustre-client"
+    AMAZON_FSX_PUBLIC_KEY_URL="https://fsx-lustre-client-repo-public-keys.s3.amazonaws.com/fsx-rpm-public-key.asc" &&
+    LUSTRE_CLIENT_REPO_URL="https://fsx-lustre-client-repo.s3.amazonaws.com/el/$(. /etc/os-release;echo $VERSION_ID)/fsx-lustre-client.repo" &&
+    read -r -d '' INSTALL_CMD <<- EOM
+      yum install nfs-utils cifs-utils wget -y -q &&
+      wget $AMAZON_FSX_PUBLIC_KEY_URL -qO /tmp/fsx-rpm-public-key.asc &&
+      rpm --import /tmp/fsx-rpm-public-key.asc &&
+      wget $LUSTRE_CLIENT_REPO_URL -qO /etc/yum.repos.d/aws-fsx.repo &&
+      yum install -y -q kmod-lustre-client lustre-client &&
+      rm -f /tmp/fsx-rpm-public-key.asc /etc/yum.repos.d/aws-fsx.repo
+EOM
 else
-    CHECK_CMD="dpkg -l | grep nfs-common && dpkg -l | grep cifs-utils"
-    INSTALL_CMD='apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" nfs-common cifs-utils -y -qq'
+    CHECK_CMD="dpkg -l | grep nfs-common && dpkg -l | grep cifs-utils && dpkg -l | grep lustre-client"
+    AMAZON_FSX_PUBLIC_KEY_URL="https://fsx-lustre-client-repo-public-keys.s3.amazonaws.com/fsx-ubuntu-public-key.asc"
+    LUSTRE_CLIENT_REPO_URL="https://fsx-lustre-client-repo.s3.amazonaws.com/$(. /etc/os-release;echo $ID $VERSION_CODENAME)"
+    read -r -d '' INSTALL_CMD <<- EOM
+      apt-get install wget apt-utils -y -qq  &&
+      wget -qO- $AMAZON_FSX_PUBLIC_KEY_URL | apt-key add - &&
+      echo "deb $LUSTRE_CLIENT_REPO_URL main" > /etc/apt/sources.list.d/fsxlustreclientrepo.list && apt-get update -qq &&
+      apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" nfs-common cifs-utils linux-aws lustre-client-modules-aws -y > /dev/null
+EOM
 fi
 
 eval "$CHECK_CMD"

--- a/workflows/pipe-common/shell/install_nfs_client
+++ b/workflows/pipe-common/shell/install_nfs_client
@@ -87,7 +87,7 @@ else
     if [ $IS_LUSTRE_INSTALLED -ne 0 ]
     then
         pipe_log_info "--> Installing [lustre] client" "$NFS_INSTALL_TASK"
-        LUSTRE_INSTALLATION_LOG="/run/lustre_client_installation.log"
+        LUSTRE_INSTALLATION_LOG="/var/log/lustre_client_installation.log"
         eval "$INSTALL_LUSTRE_CMD" > $LUSTRE_INSTALLATION_LOG 2>&1
         if [ $? -ne 0 ]
         then
@@ -97,10 +97,6 @@ else
         fi
     else
         pipe_log_info "--> NFS client packages [lustre] installed already" "$NFS_INSTALL_TASK"
-    fi
-    eval "df -t lustre" > /dev/null 2>&1
-    if [[ -z $(cat /proc/filesystems | grep lustre) ]]; then
-        pipe_log_warn "--> [lustre] filesystem is not available. " "$NFS_INSTALL_TASK"
     fi
     pipe_log_info "--> NFS clients installation is finished" "$NFS_INSTALL_TASK"
 fi

--- a/workflows/pipe-common/shell/install_nfs_client
+++ b/workflows/pipe-common/shell/install_nfs_client
@@ -23,10 +23,12 @@ IS_RPM_BASED=$?
 
 if [[ "$IS_RPM_BASED" = 0 ]]
 then
-    CHECK_CMD="rpm -qa | grep nfs-utils && rpm -qa | grep cifs-utils && rpm -qa | grep lustre-client"
+    CHECK_NFS_SMB_CMD="rpm -qa | grep nfs-utils && rpm -qa | grep cifs-utils"
+    INSTALL_NFS_SMB_CMD="yum install nfs-utils cifs-utils -y -q"
+    CHECK_LUSTRE_CMD="rpm -qa | grep lustre-client"
     AMAZON_FSX_PUBLIC_KEY_URL="https://fsx-lustre-client-repo-public-keys.s3.amazonaws.com/fsx-rpm-public-key.asc" &&
     LUSTRE_CLIENT_REPO_URL="https://fsx-lustre-client-repo.s3.amazonaws.com/el/$(. /etc/os-release;echo $VERSION_ID)/fsx-lustre-client.repo" &&
-    read -r -d '' INSTALL_CMD <<- EOM
+    read -r -d '' INSTALL_LUSTRE_CMD <<- EOM
       yum install nfs-utils cifs-utils wget -y -q &&
       wget $AMAZON_FSX_PUBLIC_KEY_URL -qO /tmp/fsx-rpm-public-key.asc &&
       rpm --import /tmp/fsx-rpm-public-key.asc &&
@@ -35,10 +37,12 @@ then
       rm -f /tmp/fsx-rpm-public-key.asc /etc/yum.repos.d/aws-fsx.repo
 EOM
 else
-    CHECK_CMD="dpkg -l | grep nfs-common && dpkg -l | grep cifs-utils && dpkg -l | grep lustre-client"
+    CHECK_NFS_SMB_CMD="dpkg -l | grep nfs-common && dpkg -l | grep cifs-utils"
+    INSTALL_NFS_SMB_CMD='apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" nfs-common cifs-utils -y -qq'
+    CHECK_LUSTRE_CMD="dpkg -l | grep lustre-client"
     AMAZON_FSX_PUBLIC_KEY_URL="https://fsx-lustre-client-repo-public-keys.s3.amazonaws.com/fsx-ubuntu-public-key.asc"
     LUSTRE_CLIENT_REPO_URL="https://fsx-lustre-client-repo.s3.amazonaws.com/$(. /etc/os-release;echo $ID $VERSION_CODENAME)"
-    read -r -d '' INSTALL_CMD <<- EOM
+    read -r -d '' INSTALL_LUSTRE_CMD <<- EOM
       apt-get install wget apt-utils -y -qq  &&
       wget -qO- $AMAZON_FSX_PUBLIC_KEY_URL | apt-key add - &&
       echo "deb $LUSTRE_CLIENT_REPO_URL main" > /etc/apt/sources.list.d/fsxlustreclientrepo.list && apt-get update -qq &&
@@ -47,24 +51,54 @@ else
 EOM
 fi
 
-eval "$CHECK_CMD"
+eval "$CHECK_LUSTRE_CMD"
+IS_LUSTRE_INSTALLED=$?
+
+eval "$CHECK_NFS_SMB_CMD"
+IS_NFS_SMB_INSTALLED=$?
 
 ######################################################
 # If NFS client is already installed - skip installation, otherwise install
 ######################################################
-if [ $? -ne 0 ]
+if [ $IS_NFS_SMB_INSTALLED -eq 0 ] && [ $IS_LUSTRE_INSTALLED -eq 0 ]
 then
-    pipe_log_info "--> NFS client not found, proceeding with installation" "$NFS_INSTALL_TASK"
-    pipe_log_info "--> Installing NFS client" "$NFS_INSTALL_TASK"
-    eval "$INSTALL_CMD"
-    if [ $? -ne 0 ]
-    then
-        pipe_log_fail "Failed to install NFS client, process will not continue with shared FS initialization" "$NFS_INSTALL_TASK"
-        exit 1
-    fi
-    pipe_log_info "--> NFS client installed" "$NFS_INSTALL_TASK"
-else
     pipe_log_info "--> NFS client is already installed" "$NFS_INSTALL_TASK"
+else
+    pipe_log_info "--> NFS client not found, proceeding with installation" "$NFS_INSTALL_TASK"
+    pipe_log_info "--> Installing NFS clients" "$NFS_INSTALL_TASK"
+    if [ $IS_NFS_SMB_INSTALLED -ne 0 ]
+    then
+        pipe_log_info "--> Installing [nfs, smb] client" "$NFS_INSTALL_TASK"
+        eval "$INSTALL_NFS_SMB_CMD"
+        if [ $? -ne 0 ]
+        then
+            pipe_log_fail "Failed to install NFS client [nfs, smb], process will not continue with shared FS initialization" "$NFS_INSTALL_TASK"
+            exit 1
+        else
+            pipe_log_info "--> NFS client [nfs, smb] installed successfully" "$NFS_INSTALL_TASK"
+        fi
+    else
+        pipe_log_info "--> NFS client [nfs, smb] installed already" "$NFS_INSTALL_TASK"
+    fi
+    if [ $IS_LUSTRE_INSTALLED -ne 0 ]
+    then
+        pipe_log_info "--> Installing [lustre] client" "$NFS_INSTALL_TASK"
+        LUSTRE_INSTALLATION_LOG="/run/lustre_client_installation.log"
+        eval "$INSTALL_LUSTRE_CMD" > $LUSTRE_INSTALLATION_LOG 2>&1
+        if [ $? -ne 0 ]
+        then
+            pipe_log_fail "Errors occured during NFS client [lustre] installation, check $LUSTRE_INSTALLATION_LOG for more details" "$NFS_INSTALL_TASK"
+        else
+            pipe_log_info "--> NFS client packages [lustre] installed successfully" "$NFS_INSTALL_TASK"
+        fi
+    else
+        pipe_log_info "--> NFS client packages [lustre] installed already" "$NFS_INSTALL_TASK"
+    fi
+    eval "df -t lustre" > /dev/null 2>&1
+    if [[ -z $(cat /proc/filesystems | grep lustre) ]]; then
+        pipe_log_warn "--> [lustre] filesystem is not available. " "$NFS_INSTALL_TASK"
+    fi
+    pipe_log_info "--> NFS clients installation is finished" "$NFS_INSTALL_TASK"
 fi
 
 #####################################################

--- a/workflows/pipe-common/shell/install_nfs_client
+++ b/workflows/pipe-common/shell/install_nfs_client
@@ -42,6 +42,7 @@ else
       apt-get install wget apt-utils -y -qq  &&
       wget -qO- $AMAZON_FSX_PUBLIC_KEY_URL | apt-key add - &&
       echo "deb $LUSTRE_CLIENT_REPO_URL main" > /etc/apt/sources.list.d/fsxlustreclientrepo.list && apt-get update -qq &&
+      mkdir -p /lib/modules/$(uname -r) &&
       apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" nfs-common cifs-utils linux-aws lustre-client-modules-aws -y > /dev/null
 EOM
 fi


### PR DESCRIPTION
This PR is related to issue #441.
It brings the second part of the Lustre FS support:

- add Lustre modules installation to `install_nfs_client`
- modify `mount_storage.py` to support Lustre fstype