### PR TITLE
Use default owner full control acl for all s3 uploads

### DIFF
--- a/client/src/components/special/UploadButton.js
+++ b/client/src/components/special/UploadButton.js
@@ -189,6 +189,7 @@ export default class UploadButton extends React.Component {
     } else {
       const url = request.value.url;
       const tagValue = request.value.tagValue;
+      const cannedACLValue = request.value.cannedACLValue;
       return new Promise((resolve) => {
         const files = this.state.uploadingFiles;
         const [uploadingFile] = files.filter(f => f.uid === file.uid);
@@ -258,6 +259,9 @@ export default class UploadButton extends React.Component {
         request.open('PUT', url, true);
         if (tagValue) {
           request.setRequestHeader('x-amz-tagging', tagValue);
+        }
+        if (cannedACLValue) {
+          request.setRequestHeader('x-amz-acl', cannedACLValue);
         }
         request.send(file);
         uploadingFile.abortCallback = () => {

--- a/core/src/main/java/com/epam/pipeline/entity/datastorage/DataStorageDownloadFileUrl.java
+++ b/core/src/main/java/com/epam/pipeline/entity/datastorage/DataStorageDownloadFileUrl.java
@@ -27,4 +27,5 @@ public class DataStorageDownloadFileUrl {
     private String url;
     private Date expires;
     private String tagValue;
+    private String cannedACLValue;
 }

--- a/pipe-cli/mount/pipefuse/s3.py
+++ b/pipe-cli/mount/pipefuse/s3.py
@@ -64,7 +64,8 @@ class S3MultipartUpload(MultipartUpload):
         logging.info('Initializing multipart upload for %s' % self._path)
         response = self._s3.create_multipart_upload(
             Bucket=self._bucket,
-            Key=self._path
+            Key=self._path,
+            ACL='bucket-owner-full-control'
         )
         self._upload_id = response['UploadId']
 
@@ -264,7 +265,8 @@ class S3Client(FileSystemClient):
     def upload(self, buf, path, expand_path=True):
         destination_path = self.build_full_path(path) if expand_path else path
         with io.BytesIO(bytearray(buf)) as body:
-            self._s3.put_object(Bucket=self.bucket, Key=destination_path, Body=body)
+            self._s3.put_object(Bucket=self.bucket, Key=destination_path, Body=body,
+                                ExtraArgs={'ACL': 'bucket-owner-full-control'})
 
     def delete(self, path, expand_path=True):
         source_path = self.build_full_path(path) if expand_path else path
@@ -362,7 +364,8 @@ class S3Client(FileSystemClient):
         modified_bytes[offset: offset + len(buf)] = buf
         with io.BytesIO(modified_bytes) as body:
             logging.info('Uploading range %d-%d for %s' % (offset, offset + len(buf), path))
-            self._s3.put_object(Bucket=self.bucket, Key=path, Body=body)
+            self._s3.put_object(Bucket=self.bucket, Key=path, Body=body,
+                                ExtraArgs={'ACL': 'bucket-owner-full-control'})
 
     def flush(self, fh, path):
         source_path = self.build_full_path(path)

--- a/pipe-cli/src/utilities/storage/s3.py
+++ b/pipe-cli/src/utilities/storage/s3.py
@@ -134,7 +134,8 @@ class UploadManager(StorageItemManager, AbstractTransferManager):
         tags += ("CP_SOURCE={}".format(source_key),)
         tags += ("CP_OWNER={}".format(self._get_user()),)
         extra_args = {
-            'Tagging': self._convert_tags_to_url_string(tags)
+            'Tagging': self._convert_tags_to_url_string(tags),
+            'ACL': 'bucket-owner-full-control'
         }
         TransferManager.ALLOWED_UPLOAD_ARGS.append('Tagging')
         if StorageItemManager.show_progress(quiet, size, lock):
@@ -174,7 +175,8 @@ class TransferFromHttpOrFtpToS3Manager(StorageItemManager, AbstractTransferManag
         tags += ("CP_SOURCE={}".format(source_key),)
         tags += ("CP_OWNER={}".format(self._get_user()),)
         extra_args = {
-            'Tagging': self._convert_tags_to_url_string(tags)
+            'Tagging': self._convert_tags_to_url_string(tags),
+            'ACL': 'bucket-owner-full-control'
         }
         TransferManager.ALLOWED_UPLOAD_ARGS.append('Tagging')
         file_stream = urlopen(source_key)
@@ -215,7 +217,8 @@ class TransferBetweenBucketsManager(StorageItemManager, AbstractTransferManager)
             tags += ('CP_OWNER={}'.format(self._get_user()),)
         TransferManager.ALLOWED_COPY_ARGS.append('Tagging')
         extra_args = {
-            'Tagging': self._convert_tags_to_url_string(tags)
+            'Tagging': self._convert_tags_to_url_string(tags),
+            'ACL': 'bucket-owner-full-control'
         }
         if StorageItemManager.show_progress(quiet, size, lock):
             self.bucket.copy(copy_source, destination_key, Callback=ProgressPercentage(relative_path, size),

--- a/workflows/pipe-common/scripts/mount_storage.py
+++ b/workflows/pipe-common/scripts/mount_storage.py
@@ -385,6 +385,7 @@ class S3Mounter(StorageMounter):
             return 'AWS_ACCESS_KEY_ID={aws_key_id} AWS_SECRET_ACCESS_KEY={aws_secret} nohup goofys ' \
                    '--dir-mode {mask} --file-mode {mask} -o {permissions} -o allow_other ' \
                     '--stat-cache-ttl {stat_cache} --type-cache-ttl {type_cache} ' \
+                    '--acl "bucket-owner-full-control" ' \
                     '-f --gid 0 --region "{region_name}" {path} {mount} > /var/log/fuse_{storage_id}.log 2>&1 &'.format(**params)
         elif params['fuse_type'] == FUSE_S3FS_ID:
             params['path'] = '{bucket}:/{relative_path}'.format(**params) if params['relative_path'] else params['path']
@@ -393,6 +394,7 @@ class S3Mounter(StorageMounter):
             return 'AWSACCESSKEYID={aws_key_id} AWSSECRETACCESSKEY={aws_secret} s3fs {path} {mount} -o use_cache={tmp_dir} ' \
                     '-o umask=0000 -o {permissions} -o allow_other -o enable_noobj_cache ' \
                     '-o endpoint="{region_name}" -o url="https://s3.{region_name}.amazonaws.com" {ensure_diskfree_option} ' \
+                    '-o default_acl="bucket-owner-full-control" ' \
                     '-o dbglevel="info" -f > /var/log/fuse_{storage_id}.log 2>&1 &'.format(**params)
         else:
             return 'exit 1'


### PR DESCRIPTION
Resolves issue #1246.

The pull request brings support for default owner full controll acl upload rules to all services: pipe cli, pipe mount, api and gui.