### PR TITLE
Consider only running time for long running notifications

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/notification/NotificationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/notification/NotificationManager.java
@@ -104,10 +104,11 @@ public class NotificationManager { // TODO: rewrite with Strategy pattern?
      * Internal method for creating notification message that selecting appropriate email template from db,
      * serialize PipelineRun to key-value object and save it to notification_queue table.
      * @param run
+     * @param duration Running duration of a run in seconds.
      * @param settings defines, if a long initialization or long running message template should be used
      */
     @Transactional(propagation = Propagation.REQUIRED)
-    public void notifyLongRunningTask(PipelineRun run, NotificationSettings settings) {
+    public void notifyLongRunningTask(PipelineRun run, Long duration, NotificationSettings settings) {
         LOGGER.debug(messageHelper.getMessage(MessageConstants.INFO_NOTIFICATION_SUBMITTED, run.getPodId()));
 
         NotificationMessage notificationMessage = new NotificationMessage();
@@ -125,7 +126,7 @@ public class NotificationManager { // TODO: rewrite with Strategy pattern?
                     settings.getTemplateId()));
         }
 
-        notificationMessage.setTemplateParameters(PipelineRunMapper.map(run, settings.getThreshold()));
+        notificationMessage.setTemplateParameters(PipelineRunMapper.map(run, settings.getThreshold(), duration));
         monitoringNotificationDao.createMonitoringNotification(notificationMessage);
     }
 

--- a/api/src/main/java/com/epam/pipeline/mapper/PipelineRunMapper.java
+++ b/api/src/main/java/com/epam/pipeline/mapper/PipelineRunMapper.java
@@ -31,11 +31,12 @@ public final class PipelineRunMapper {
     /**
      * Mapping a {@code PipelineRun}
      * @param run {@code PipelineRun}
-     * @param threshold
+     * @param duration Pipeline run running duration in seconds.
+     * @param threshold Long running threshold in seconds.
      * @return a mapped {@code PipelineRun}, {@code Map} key - a field name of {@code PipelineRun},
      * {@code Map} value - a {@code PipelineRun} field value
      */
-    public static Map<String, Object> map(PipelineRun run, Long threshold) {
+    public static Map<String, Object> map(PipelineRun run, Long threshold, Long duration) {
         JsonMapper mapper = new JsonMapper();
         Map<String, Object> params = mapper.convertValue(run, mapper.getTypeFactory()
             .constructParametricType(Map.class, String.class, Object.class));
@@ -44,9 +45,16 @@ public final class PipelineRunMapper {
             params.put("timeThreshold", threshold / SECONDS_IN_MINUTE);
         }
 
-        params.put("runningTime", Duration.between(run.getStartDate().toInstant(), DateUtils.now()
-            .toInstant()).abs().getSeconds() / SECONDS_IN_MINUTE);
+        params.put("runningTime", duration / SECONDS_IN_MINUTE);
 
         return params;
+    }
+    
+    public static Map<String, Object> map(PipelineRun run, Long threshold) {
+        return map(run, threshold, overallDurationOf(run));
+    }
+
+    private static long overallDurationOf(PipelineRun run) {
+        return Duration.between(run.getStartDate().toInstant(), DateUtils.now().toInstant()).abs().getSeconds();
     }
 }

--- a/api/src/test/java/com/epam/pipeline/manager/notification/NotificationManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/notification/NotificationManagerTest.java
@@ -99,7 +99,8 @@ public class NotificationManagerTest extends AbstractManagerTest {
     private static final String BODY = "body";
     private static final String NON_EXISTING_USER = "not_existing_user";
     private static final Map<String, Object> PARAMETERS = Collections.singletonMap("key", "value");
-    public static final int LONG_STATUS_THRESHOLD = 100;
+    private static final int LONG_STATUS_THRESHOLD = 100;
+    private static final Duration LONG_RUNNING_DURATION = Duration.standardMinutes(6);
 
     @Autowired
     private NotificationManager notificationManager;
@@ -184,7 +185,7 @@ public class NotificationManagerTest extends AbstractManagerTest {
                 HIGH_CONSUMED_RESOURCES.getDefaultThreshold(), HIGH_CONSUMED_RESOURCES.getDefaultResendDelay());
 
         longRunnging = new PipelineRun();
-        DateTime date = DateTime.now(DateTimeZone.UTC).minus(Duration.standardMinutes(6));
+        DateTime date = DateTime.now(DateTimeZone.UTC).minus(LONG_RUNNING_DURATION);
         longRunnging.setStartDate(date.toDate());
         longRunnging.setStatus(TaskStatus.RUNNING);
         longRunnging.setOwner(admin.getUserName());
@@ -280,7 +281,7 @@ public class NotificationManagerTest extends AbstractManagerTest {
         NotificationSettings settings = notificationSettingsDao.loadNotificationSettings(1L);
         settings.setKeepInformedAdmins(false);
         notificationSettingsDao.updateNotificationSettings(settings);
-        notificationManager.notifyLongRunningTask(longRunnging, settings);
+        notificationManager.notifyLongRunningTask(longRunnging, LONG_RUNNING_DURATION.getStandardSeconds(), settings);
 
         List<NotificationMessage> messages = monitoringNotificationDao.loadAllNotifications();
         Assert.assertEquals(1, messages.size());
@@ -291,7 +292,7 @@ public class NotificationManagerTest extends AbstractManagerTest {
         settings.setKeepInformedAdmins(false);
         settings.setInformedUserIds(Collections.singletonList(userDao.loadUserByName("admin").getId()));
         notificationSettingsDao.updateNotificationSettings(settings);
-        notificationManager.notifyLongRunningTask(longRunnging, settings);
+        notificationManager.notifyLongRunningTask(longRunnging, LONG_RUNNING_DURATION.getStandardSeconds(), settings);
         messages = monitoringNotificationDao.loadAllNotifications();
         Assert.assertTrue(messages.get(messages.size() - 1).getCopyUserIds().contains(admin.getId()));
     }


### PR DESCRIPTION
Resolves issue #1244.

The pull request updates long running notification calculations to consider only running time and ignore paused as well as all intermediate run states.