### PR TITLE
Issue #441 Lustre path handling improvements

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/datastorage/nfs/NFSDataStorage.java
+++ b/api/src/main/java/com/epam/pipeline/entity/datastorage/nfs/NFSDataStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.DataStorageType;
 import com.epam.pipeline.entity.datastorage.StoragePolicy;
 import com.epam.pipeline.manager.datastorage.providers.ProviderUtils;
+import com.epam.pipeline.manager.datastorage.providers.nfs.NFSHelper;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -51,6 +52,11 @@ public class NFSDataStorage extends AbstractDataStorage {
     @Override
     public boolean isPolicySupported() {
         return false;
+    }
+
+    @Override
+    public String getRoot() {
+        return NFSHelper.getNfsRootPath(getPath());
     }
 
     private static String normalizeNfsPath(String path) {

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/FileShareMountManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/FileShareMountManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package com.epam.pipeline.manager.datastorage;
 
 import com.epam.pipeline.dao.datastorage.FileShareMountDao;
 import com.epam.pipeline.entity.datastorage.FileShareMount;
+import com.epam.pipeline.entity.datastorage.MountType;
+import com.epam.pipeline.manager.datastorage.providers.nfs.NFSHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,6 +52,10 @@ public class FileShareMountManager {
         LOGGER.debug("Create new FileShareMount: " + fileShareMount);
         Assert.notNull(fileShareMount.getRegionId(), "Region id cannot be null for File share mount!");
         Assert.notNull(fileShareMount.getMountType(), "Mount type cannot be null for File share mount!");
+        if (MountType.LUSTRE == fileShareMount.getMountType()) {
+            Assert.isTrue(NFSHelper.isValidLustrePath(fileShareMount.getMountRoot()),
+                          "Given path for the Lustre file share is invalid!");
+        }
         if (fileShareMount.getId() != null && fileShareMountDao.loadById(fileShareMount.getId()).isPresent()) {
             fileShareMountDao.update(fileShareMount);
             return fileShareMount;

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSHelper.java
@@ -24,7 +24,7 @@ import com.epam.pipeline.entity.region.AzureRegionCredentials;
 import com.epam.pipeline.entity.region.CloudProvider;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.ArrayUtils;
-import org.springframework.util.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -121,9 +121,12 @@ public final class NFSHelper {
         if (protocol.equalsIgnoreCase(MountType.SMB.getProtocol()) && !path.startsWith(SMB_SCHEME)) {
             path = SMB_SCHEME + path;
         }
-        if (protocol.equalsIgnoreCase(MountType.LUSTRE.getProtocol())
-            && !NFS_LUSTRE_ROOT_PATTERN.matcher(path).find()) {
-            throw new IllegalArgumentException("Invalid Lustre path format!");
+        if (protocol.equalsIgnoreCase(MountType.LUSTRE.getProtocol())) {
+            if (!NFS_LUSTRE_ROOT_PATTERN.matcher(path).find()) {
+                throw new IllegalArgumentException("Invalid Lustre path format!");
+            } else if (path.endsWith(PATH_SEPARATOR)) {
+                path = StringUtils.chop(path);
+            }
         }
         if (protocol.equalsIgnoreCase(MountType.NFS.getProtocol()) && !path.contains(NFS_HOST_DELIMITER)) {
             path = path + NFS_HOST_DELIMITER;

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSHelper.java
@@ -81,10 +81,13 @@ public final class NFSHelper {
 
     static String getNfsRootPath(String path) {
         path = path.endsWith(PATH_SEPARATOR) ? path.substring(0, path.length() - 1) : path;
-        Matcher matcher = NFS_ROOT_PATTERN.matcher(path);
-        Matcher matcherWithHomeDir = NFS_PATTERN_WITH_HOME_DIR.matcher(path);
-        Matcher azureNfsMatcher = NFS_AZURE_ROOT_PATTERN.matcher(path);
-        if (matcher.find()) {
+        final Matcher lustreMatcher = NFS_LUSTRE_ROOT_PATTERN.matcher(path);
+        final Matcher matcher = NFS_ROOT_PATTERN.matcher(path);
+        final Matcher matcherWithHomeDir = NFS_PATTERN_WITH_HOME_DIR.matcher(path);
+        final Matcher azureNfsMatcher = NFS_AZURE_ROOT_PATTERN.matcher(path);
+        if (lustreMatcher.find()) {
+            return lustreMatcher.group();
+        } else if (matcher.find()) {
             return matcher.group(1);
         } else if (matcherWithHomeDir.find()) {
             return matcherWithHomeDir.group(1);

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSHelper.java
@@ -79,12 +79,14 @@ public final class NFSHelper {
         return NFS_LUSTRE_ROOT_PATTERN.matcher(lustrePath).find();
     }
 
-    public static String getNfsRootPath(String path) {
-        path = path.endsWith(PATH_SEPARATOR) ? path.substring(0, path.length() - 1) : path;
-        final Matcher lustreMatcher = NFS_LUSTRE_ROOT_PATTERN.matcher(path);
-        final Matcher matcher = NFS_ROOT_PATTERN.matcher(path);
-        final Matcher matcherWithHomeDir = NFS_PATTERN_WITH_HOME_DIR.matcher(path);
-        final Matcher azureNfsMatcher = NFS_AZURE_ROOT_PATTERN.matcher(path);
+    public static String getNfsRootPath(final String path) {
+        final String pathToParse = path.endsWith(PATH_SEPARATOR)
+                                   ? path.substring(0, path.length() - 1)
+                                   : path;
+        final Matcher lustreMatcher = NFS_LUSTRE_ROOT_PATTERN.matcher(pathToParse);
+        final Matcher matcher = NFS_ROOT_PATTERN.matcher(pathToParse);
+        final Matcher matcherWithHomeDir = NFS_PATTERN_WITH_HOME_DIR.matcher(pathToParse);
+        final Matcher azureNfsMatcher = NFS_AZURE_ROOT_PATTERN.matcher(pathToParse);
         if (lustreMatcher.find()) {
             return lustreMatcher.group();
         } else if (matcher.find()) {
@@ -100,7 +102,7 @@ public final class NFSHelper {
 
     static String getNFSMountOption(final AbstractCloudRegion cloudRegion,
                                     final AbstractCloudRegionCredentials credentials,
-                                    final String defaultOptions, String protocol) {
+                                    final String defaultOptions, final String protocol) {
         String result = defaultOptions;
         if (cloudRegion != null && cloudRegion.getProvider() == CloudProvider.AZURE
                 && protocol.equalsIgnoreCase(MountType.SMB.getProtocol())) {
@@ -117,19 +119,19 @@ public final class NFSHelper {
         return StringUtils.isEmpty(result) ? "" : "-o " + result;
     }
 
-    static String formatNfsPath(String path, String protocol) {
+    static String formatNfsPath(final String path, final String protocol) {
         if (protocol.equalsIgnoreCase(MountType.SMB.getProtocol()) && !path.startsWith(SMB_SCHEME)) {
-            path = SMB_SCHEME + path;
+            return SMB_SCHEME + path;
         }
         if (protocol.equalsIgnoreCase(MountType.LUSTRE.getProtocol())) {
             if (!NFS_LUSTRE_ROOT_PATTERN.matcher(path).find()) {
                 throw new IllegalArgumentException("Invalid Lustre path format!");
             } else if (path.endsWith(PATH_SEPARATOR)) {
-                path = StringUtils.chop(path);
+                return StringUtils.chop(path);
             }
         }
         if (protocol.equalsIgnoreCase(MountType.NFS.getProtocol()) && !path.contains(NFS_HOST_DELIMITER)) {
-            path = path + NFS_HOST_DELIMITER;
+            return path + NFS_HOST_DELIMITER;
         }
         return path;
     }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSHelper.java
@@ -79,7 +79,7 @@ public final class NFSHelper {
         return NFS_LUSTRE_ROOT_PATTERN.matcher(lustrePath).find();
     }
 
-    static String getNfsRootPath(String path) {
+    public static String getNfsRootPath(String path) {
         path = path.endsWith(PATH_SEPARATOR) ? path.substring(0, path.length() - 1) : path;
         final Matcher lustreMatcher = NFS_LUSTRE_ROOT_PATTERN.matcher(path);
         final Matcher matcher = NFS_ROOT_PATTERN.matcher(path);

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -163,33 +163,26 @@ public class NFSStorageProvider implements StorageProvider<NFSDataStorage> {
         return ActionStatus.notSupported();
     }
 
-    private synchronized File mount(NFSDataStorage dataStorage) {
-        File mntDir = Paths.get(rootMountPoint, getMountDirName(dataStorage.getPath())).toFile();
+    private synchronized File mount(final NFSDataStorage dataStorage) {
         try {
-            FileShareMount fileShareMount = shareMountManager.load(dataStorage.getFileShareMountId());
-            final String mountPath;
-            if (MountType.LUSTRE == fileShareMount.getMountType()) {
-                mntDir = Paths.get(rootMountPoint, getLustreMountDirName(dataStorage.getPath())).toFile();
-                mountPath = normalizeLustrePath(fileShareMount.getMountRoot());
-            } else {
-                mountPath = normalizePath(fileShareMount.getMountRoot());
-            }
-            final File rootMount = Paths.get(rootMountPoint, mountPath).toFile();
+            final FileShareMount fileShareMount = shareMountManager.load(dataStorage.getFileShareMountId());
+            final File mntDir = getStorageMountRoot(dataStorage, fileShareMount);
+            final File rootMount = getShareRootMount(fileShareMount);
             if(!rootMount.exists()) {
                 Assert.isTrue(rootMount.mkdirs(), messageHelper.getMessage(
                         MessageConstants.ERROR_DATASTORAGE_NFS_MOUNT_DIRECTORY_NOT_CREATED));
 
-                AbstractCloudRegion cloudRegion = regionManager.load(fileShareMount.getRegionId());
-                String protocol = fileShareMount.getMountType().getProtocol();
-                AbstractCloudRegionCredentials credentials = cloudRegion.getProvider() == CloudProvider.AZURE ?
+                final AbstractCloudRegion cloudRegion = regionManager.load(fileShareMount.getRegionId());
+                final String protocol = fileShareMount.getMountType().getProtocol();
+                final AbstractCloudRegionCredentials credentials = cloudRegion.getProvider() == CloudProvider.AZURE ?
                          regionManager.loadCredentials(cloudRegion) : null;
 
-                String mountOptions = NFSHelper.getNFSMountOption(cloudRegion, credentials,
+                final String mountOptions = NFSHelper.getNFSMountOption(cloudRegion, credentials,
                         dataStorage.getMountOptions(), protocol);
 
-                String rootNfsPath = formatNfsPath(fileShareMount.getMountRoot(), protocol);
+                final String rootNfsPath = formatNfsPath(fileShareMount.getMountRoot(), protocol);
 
-                String mountCmd = String.format(NFS_MOUNT_CMD_PATTERN, protocol, mountOptions,
+                final String mountCmd = String.format(NFS_MOUNT_CMD_PATTERN, protocol, mountOptions,
                                                 rootNfsPath, rootMount.getAbsolutePath());
                 try {
                     cmdExecutor.executeCommand(mountCmd);
@@ -202,36 +195,46 @@ public class NFSStorageProvider implements StorageProvider<NFSDataStorage> {
                             dataStorage.getPath()), e);
                 }
             }
+            String storageName = getStorageName(dataStorage.getPath());
+            return new File(mntDir, storageName);
         } catch (IOException e) {
             throw new DataStorageException(messageHelper.getMessage(
                     messageHelper.getMessage(MessageConstants.ERROR_DATASTORAGE_NFS_MOUNT, dataStorage.getName(),
                                              dataStorage.getPath())), e);
         }
-
-        String storageName = getStorageName(dataStorage.getPath());
-        return new File(mntDir, storageName);
     }
 
     private synchronized void unmountNFSIfEmpty(AbstractDataStorage storage) {
-        FileShareMount fileShareMount = shareMountManager.load(storage.getFileShareMountId());
-        final String shareMountPath = MountType.LUSTRE == fileShareMount.getMountType()
-                                      ? normalizeLustrePath(fileShareMount.getMountRoot())
-                                      : normalizePath(fileShareMount.getMountRoot());
-        File rootMount = Paths.get(rootMountPoint, shareMountPath).toFile();
-        List<AbstractDataStorage> remaining = dataStorageDao.loadDataStoragesByFileShareMountID(
+        final FileShareMount fileShareMount = shareMountManager.load(storage.getFileShareMountId());
+        final File rootMount = getShareRootMount(fileShareMount);
+        final List<AbstractDataStorage> remaining = dataStorageDao.loadDataStoragesByFileShareMountID(
                 storage.getFileShareMountId());
         LOGGER.debug("Remaining NFS: " + remaining.stream().map(AbstractDataStorage::getPath)
                 .collect(Collectors.joining(";")) + " related with current file share mount");
 
         if (rootMount.exists() && isStorageOnlyOnNFS(storage, remaining)) {
             try {
-                String umountCmd = String.format(NFS_UNMOUNT_CMD_PATTERN, rootMount.getAbsolutePath());
+                final String umountCmd = String.format(NFS_UNMOUNT_CMD_PATTERN, rootMount.getAbsolutePath());
                 cmdExecutor.executeCommand(umountCmd);
                 FileUtils.deleteDirectory(rootMount);
             } catch (IOException e) {
                 throw new DataStorageException(e);
             }
         }
+    }
+
+    private File getStorageMountRoot(final NFSDataStorage dataStorage,  final FileShareMount fileShareMount) {
+        final String storageMountPath = MountType.LUSTRE == fileShareMount.getMountType()
+                                        ? normalizeLustrePath(getNfsRootPath(dataStorage.getPath()))
+                                        : normalizePath(getNfsRootPath(dataStorage.getPath()));
+        return Paths.get(rootMountPoint, storageMountPath).toFile();
+    }
+
+    private File getShareRootMount(final FileShareMount fileShareMount) {
+        final String shareMountPath = MountType.LUSTRE == fileShareMount.getMountType()
+                                      ? normalizeLustrePath(fileShareMount.getMountRoot())
+                                      : normalizePath(fileShareMount.getMountRoot());
+        return Paths.get(rootMountPoint, shareMountPath).toFile();
     }
 
     private boolean isStorageOnlyOnNFS(AbstractDataStorage storage, List<AbstractDataStorage> remaining) {
@@ -379,14 +382,6 @@ public class NFSStorageProvider implements StorageProvider<NFSDataStorage> {
 
     private String getStorageName(String path) {
         return  path.replace(getNfsRootPath(path), "");
-    }
-
-    private String getMountDirName(String nfsPath) {
-        return normalizePath(getNfsRootPath(nfsPath));
-    }
-
-    private String getLustreMountDirName(String nfsPath) {
-        return normalizeLustrePath(getNfsRootPath(nfsPath));
     }
 
     private String normalizePath(String nfsPath) {

--- a/api/src/test/java/com/epam/pipeline/manager/datastorage/FileShareMountManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/datastorage/FileShareMountManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,6 +75,14 @@ public class FileShareMountManagerTest extends AbstractSpringTest {
         shareMountManager.save(fileShareMount);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void saveThrowIfLustreMountRootIsInvalid() {
+        final FileShareMount fileShareMount = new FileShareMount();
+        fileShareMount.setRegionId(0L);
+        fileShareMount.setMountType(MountType.LUSTRE);
+        fileShareMount.setMountRoot("host");
+        shareMountManager.save(fileShareMount);
+    }
 
     private FileShareMount azureShareMount() {
         FileShareMount fileShareMount = new FileShareMount();

--- a/api/src/test/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSHelperTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSHelperTest.java
@@ -89,6 +89,8 @@ public class NFSHelperTest {
             Assert.assertEquals(TEST_PATH + ":/mnt/", nfsRootPath);
             nfsRootPath = NFSHelper.getNfsRootPath(TEST_PATH  + "/mnt/directory");
             Assert.assertEquals(TEST_PATH + "/mnt/", nfsRootPath);
+            String lustreRootPath = NFSHelper.getNfsRootPath("host@tcp:/lustre/directory");
+            Assert.assertEquals("host@tcp:/lustre", lustreRootPath);
         }
 
         @Test(expected = IllegalArgumentException.class)

--- a/api/src/test/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSHelperTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSHelperTest.java
@@ -23,72 +23,153 @@ import com.epam.pipeline.entity.region.AzureRegionCredentials;
 import com.epam.pipeline.manager.ObjectCreatorUtils;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Enclosed.class)
 public class NFSHelperTest {
 
-    private static final String TEST_PATH = "localhost";
-    private static final String EMPTY_STRING = "";
-    private static final String RESOURCE_GROUP = "rg";
+    public static class NonParametrizedTests {
+        private static final String TEST_PATH = "localhost";
+        private static final String EMPTY_STRING = "";
+        private static final String RESOURCE_GROUP = "rg";
 
-    @Test
-    public void getNFSMountOption() {
-        String protocol = MountType.NFS.getProtocol();
-        String result = NFSHelper.getNFSMountOption(new AwsRegion(), null, EMPTY_STRING, protocol);
-        Assert.assertEquals(EMPTY_STRING, result);
+        @Test
+        public void getNFSMountOption() {
+            String protocol = MountType.NFS.getProtocol();
+            String result = NFSHelper.getNFSMountOption(new AwsRegion(), null, EMPTY_STRING, protocol);
+            Assert.assertEquals(EMPTY_STRING, result);
 
-        protocol = MountType.SMB.getProtocol();
-        AzureRegion azureRegion = ObjectCreatorUtils.getDefaultAzureRegion(RESOURCE_GROUP, "account");
-        AzureRegionCredentials credentials = ObjectCreatorUtils.getAzureCredentials("key");
-        result = NFSHelper.getNFSMountOption(azureRegion, credentials, EMPTY_STRING, protocol);
-        Assert.assertEquals("-o ,username=account,password=key", result);
+            protocol = MountType.SMB.getProtocol();
+            AzureRegion azureRegion = ObjectCreatorUtils.getDefaultAzureRegion(RESOURCE_GROUP, "account");
+            AzureRegionCredentials credentials = ObjectCreatorUtils.getAzureCredentials("key");
+            result = NFSHelper.getNFSMountOption(azureRegion, credentials, EMPTY_STRING, protocol);
+            Assert.assertEquals("-o ,username=account,password=key", result);
 
-        result = NFSHelper.getNFSMountOption(azureRegion, credentials, "options", protocol);
-        Assert.assertEquals("-o options,username=account,password=key", result);
+            result = NFSHelper.getNFSMountOption(azureRegion, credentials, "options", protocol);
+            Assert.assertEquals("-o options,username=account,password=key", result);
 
-        azureRegion = ObjectCreatorUtils.getDefaultAzureRegion(RESOURCE_GROUP, null);
-        result = NFSHelper.getNFSMountOption(azureRegion, null, EMPTY_STRING, protocol);
-        Assert.assertEquals(EMPTY_STRING, result);
+            azureRegion = ObjectCreatorUtils.getDefaultAzureRegion(RESOURCE_GROUP, null);
+            result = NFSHelper.getNFSMountOption(azureRegion, null, EMPTY_STRING, protocol);
+            Assert.assertEquals(EMPTY_STRING, result);
 
+        }
+
+        @Test
+        public void formatNfsPath() {
+            final String rightPath = "//samba.share/path";
+            String result = NFSHelper.formatNfsPath(rightPath, "cifs");
+            Assert.assertEquals(rightPath, result);
+
+            final String unformattedPath = "samba.share/path";
+            result = NFSHelper.formatNfsPath(unformattedPath, "cifs");
+            //smb protocol -> should format with //
+            Assert.assertEquals("//" + unformattedPath, result);
+
+            //nfs protocol -> should add suffix
+            result = NFSHelper.formatNfsPath(TEST_PATH, "nfs");
+            Assert.assertEquals(TEST_PATH + ":/", result);
+        }
+
+        @Test
+        public void getNfsRootPathTest() {
+            String nfsRootPath = NFSHelper.getNfsRootPath(TEST_PATH + ":" + "directory");
+            Assert.assertEquals(TEST_PATH + ":", nfsRootPath);
+            nfsRootPath = NFSHelper.getNfsRootPath(TEST_PATH + ":" + "/directory");
+            Assert.assertEquals(TEST_PATH + ":/", nfsRootPath);
+            nfsRootPath = NFSHelper.getNfsRootPath(TEST_PATH + ":" + "/mnt/");
+            Assert.assertEquals(TEST_PATH + ":/", nfsRootPath);
+            nfsRootPath = NFSHelper.getNfsRootPath(TEST_PATH + ":" + "mnt/");
+            Assert.assertEquals(TEST_PATH + ":", nfsRootPath);
+            nfsRootPath = NFSHelper.getNfsRootPath(TEST_PATH + ":" + "/mnt/directory");
+            Assert.assertEquals(TEST_PATH + ":/mnt/", nfsRootPath);
+            nfsRootPath = NFSHelper.getNfsRootPath(TEST_PATH  + "/mnt/directory");
+            Assert.assertEquals(TEST_PATH + "/mnt/", nfsRootPath);
+        }
+
+        @Test(expected = IllegalArgumentException.class)
+        public void getNfsRootPathShouldFailIfPathInvalid() {
+            NFSHelper.getNfsRootPath(TEST_PATH + ":");
+        }
     }
 
-    @Test
-    public void formatNfsPath() {
-        final String rightPath = "//samba.share/path";
-        String result = NFSHelper.formatNfsPath(rightPath, "cifs");
-        Assert.assertEquals(rightPath, result);
+    @RunWith(Parameterized.class)
+    public static class InvalidLustrePathTests {
 
-        final String unformattedPath = "samba.share/path";
-        result = NFSHelper.formatNfsPath(unformattedPath, "cifs");
-        //smb protocol -> should format with //
-        Assert.assertEquals("//" + unformattedPath, result);
+        private final String caseName;
+        private final boolean isValid;
+        private final String lustrePath;
 
-        //lustre protocol -> should add suffix
-        result = NFSHelper.formatNfsPath(TEST_PATH, "lustre");
-        Assert.assertEquals(TEST_PATH + "@tcp:/", result);
+        public InvalidLustrePathTests(final String caseName, final boolean isValid, final String path) {
+            this.caseName = caseName;
+            this.isValid = isValid;
+            this.lustrePath = path;
+        }
 
-        //nfs protocol -> should add suffix
-        result = NFSHelper.formatNfsPath(TEST_PATH, "nfs");
-        Assert.assertEquals(TEST_PATH + ":/", result);
-    }
+        @Parameterized.Parameters
+        public static Collection<Object[]> data() {
+            return Arrays.asList(new Object[][] {
+                {
+                    "empty lnd, host delimiter, filesystem name",
+                    false,
+                    "host"
+                },
+                {
+                    "empty lnd, filesystem name",
+                    false,
+                    "host:/"
+                },
+                {
+                    "empty lnd",
+                    false,
+                    "host:/lustre"
+                },
+                {
+                    "invalid delimiter",
+                    false,
+                    "host@tcp/lustre"
+                },
+                {
+                    "empty filesystem name",
+                    false,
+                    "host@tcp:/"
+                },
+                {
+                    "valid path",
+                    true,
+                    "host@tcp:/lustre"
+                },
+                {
+                    "valid multi-mgs path",
+                    true,
+                    "host1@tcp:host2@tcp:/lustre"
+                },
+                {
+                    "valid path with port specification",
+                    true,
+                    "host:1234@tcp:/lustre"
+                },
+                {
+                    "valid multi-nid path with port specification for one",
+                    true,
+                    "host1@tcp:host2:1234@tcp:/lustre"
+                },
+                {
+                    "valid multi-nid path with port specification for one",
+                    true,
+                    "host1:1234@tcp:host2:1234@tcp:/lustre"
+                }
+            });
+        }
 
-    @Test
-    public void getNfsRootPathTest() {
-        String nfsRootPath = NFSHelper.getNfsRootPath(TEST_PATH + ":" + "directory");
-        Assert.assertEquals(TEST_PATH + ":", nfsRootPath);
-        nfsRootPath = NFSHelper.getNfsRootPath(TEST_PATH + ":" + "/directory");
-        Assert.assertEquals(TEST_PATH + ":/", nfsRootPath);
-        nfsRootPath = NFSHelper.getNfsRootPath(TEST_PATH + ":" + "/mnt/");
-        Assert.assertEquals(TEST_PATH + ":/", nfsRootPath);
-        nfsRootPath = NFSHelper.getNfsRootPath(TEST_PATH + ":" + "mnt/");
-        Assert.assertEquals(TEST_PATH + ":", nfsRootPath);
-        nfsRootPath = NFSHelper.getNfsRootPath(TEST_PATH + ":" + "/mnt/directory");
-        Assert.assertEquals(TEST_PATH + ":/mnt/", nfsRootPath);
-        nfsRootPath = NFSHelper.getNfsRootPath(TEST_PATH  + "/mnt/directory");
-        Assert.assertEquals(TEST_PATH + "/mnt/", nfsRootPath);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void getNfsRootPathShouldFailIfPathInvalid() {
-        NFSHelper.getNfsRootPath(TEST_PATH + ":");
+        @Test
+        public void shouldThrowException() {
+            final boolean lustrePathValidationResult = NFSHelper.isValidLustrePath(lustrePath);
+            Assert.assertEquals(isValid, lustrePathValidationResult);
+        }
     }
 }

--- a/api/src/test/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSHelperTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSHelperTest.java
@@ -35,6 +35,7 @@ public class NFSHelperTest {
 
     public static class NonParametrizedTests {
         private static final String TEST_PATH = "localhost";
+        private static final String TEST_LUSTRE_PATH = "localhost@tcp:/lustre";
         private static final String EMPTY_STRING = "";
         private static final String RESOURCE_GROUP = "rg";
 
@@ -69,6 +70,10 @@ public class NFSHelperTest {
             result = NFSHelper.formatNfsPath(unformattedPath, "cifs");
             //smb protocol -> should format with //
             Assert.assertEquals("//" + unformattedPath, result);
+
+            //lustre protocol -> remove path separator from the end
+            result = NFSHelper.formatNfsPath(TEST_LUSTRE_PATH+ "/", "lustre");
+            Assert.assertEquals(TEST_LUSTRE_PATH, result);
 
             //nfs protocol -> should add suffix
             result = NFSHelper.formatNfsPath(TEST_PATH, "nfs");

--- a/client/src/components/settings/AWSRegionsForm.js
+++ b/client/src/components/settings/AWSRegionsForm.js
@@ -1976,8 +1976,8 @@ const MountRootFormat = {
       format: 'server:port'
     },
     [MountOptions.LUSTRE]: {
-      mask: /^[^:]+(:[\d]+)?$/i,
-      format: 'server:port'
+      mask: /^([^:]+(:\d+)?@\w+)(:([^:]+(:\d+)?@\w+))*(:\/)[^/]+$/i,
+      format: 'host@LND-protocol(:/host@LND-protocol:/...):/root'
     }
   },
   AZURE: {
@@ -1990,8 +1990,8 @@ const MountRootFormat = {
       format: 'server:port'
     },
     [MountOptions.LUSTRE]: {
-      mask: /^[^:]+(:[\d]+)?$/i,
-      format: 'server:port'
+      mask: /^([^:]+(:\d+)?@\w+)(:([^:]+(:\d+)?@\w+))*(:\/)[^/]+$/i,
+      format: 'host@LND-protocol(:/host@LND-protocol:/...):/root'
     }
   },
   GCP: {
@@ -2004,8 +2004,8 @@ const MountRootFormat = {
       format: 'server:port:/root'
     },
     [MountOptions.LUSTRE]: {
-      mask: /^[^:]+(:[\d]+)?:\/.+$/i,
-      format: 'server:port:/root'
+      mask: /^([^:]+(:\d+)?@\w+)(:([^:]+(:\d+)?@\w+))*(:\/)[^/]+$/i,
+      format: 'host@LND-protocol(:/host@LND-protocol:/...):/root'
     }
   }
 };
@@ -2078,7 +2078,7 @@ class CloudRegionFileShareMountFormItem extends React.Component {
         mountOptions: undefined,
         mountRootError: null,
         mountTypeValid: true
-      });
+      }, this.validate);
     } else {
       this.setState({
         id: newValue.id,
@@ -2088,7 +2088,7 @@ class CloudRegionFileShareMountFormItem extends React.Component {
         mountOptions: newValue.mountOptions,
         mountRootError: this.mountRootValidationError(newValue.mountRoot, provider),
         mountTypeValid: !!newValue.mountType
-      });
+      }, this.validate);
     }
   };
 

--- a/workflows/pipe-common/scripts/mount_storage.py
+++ b/workflows/pipe-common/scripts/mount_storage.py
@@ -43,6 +43,7 @@ FUSE_PIPE_ID = 'pipefuse'
 FUSE_NA_ID = None
 AZURE_PROVIDER = 'AZURE'
 S3_PROVIDER = 'S3'
+READ_ONLY_MOUNT_OPT = 'ro'
 
 class PermissionHelper:
 
@@ -531,29 +532,37 @@ class NFSMounter(StorageMounter):
             permission = 'g+rx'
             mask = '0554'
             if not mount_options:
-                mount_options = 'ro'
+                mount_options = READ_ONLY_MOUNT_OPT
             else:
                 options = mount_options.split(',')
-                if 'ro' not in options:
-                    mount_options += ',ro'
+                if READ_ONLY_MOUNT_OPT not in options:
+                    mount_options += ',{0}'.format(READ_ONLY_MOUNT_OPT)
         if self.share_mount.mount_type == "SMB":
             file_mode_options = 'file_mode={mode},dir_mode={mode}'.format(mode=mask)
             if not mount_options:
                 mount_options = file_mode_options
             else:
                 mount_options += ',' + file_mode_options
-        if mount_options:
-            command += ' -o {}'.format(mount_options)
+
         transition_mount = False
         if self.share_mount.mount_type == "LUSTRE" and params['path'] != self.share_mount.mount_root:
             lustre_root = self.share_mount.mount_root
             hidden_lustre_root_mount = '/mnt/.{}'.format(os.path.basename(lustre_root))
             if self.create_directory(hidden_lustre_root_mount, 'Hidden lustre root [{0}] creation'.format(lustre_root)):
                 transition_mount = True
-                command += ' {0} {1}'.format(lustre_root, hidden_lustre_root_mount)
+                root_mount_options = mount_options.split(',')
+                bind_mount_options = ''
+                if READ_ONLY_MOUNT_OPT in root_mount_options:
+                    root_mount_options.remove(READ_ONLY_MOUNT_OPT)
+                    bind_mount_options = '-o ' + READ_ONLY_MOUNT_OPT
+                root_mount_options = ' -o {}'.format(','.join(root_mount_options))
                 path_in_hidden_root = params['path'].replace(lustre_root, hidden_lustre_root_mount)
-                command += ' && mount --bind {0} {1}'.format(path_in_hidden_root, params['mount'])
+                command += ' {0} {1} {2} && mount --bind {3} {4} {5}'\
+                    .format(root_mount_options, lustre_root, hidden_lustre_root_mount,
+                            bind_mount_options, path_in_hidden_root, params['mount'])
         if not transition_mount:
+            if mount_options:
+                command += ' -o {}'.format(mount_options)
             command += ' {path} {mount}'.format(**params)
         if PermissionHelper.is_storage_writable(self.storage):
             command += ' && chmod {permission} {mount}'.format(permission=permission, **params)

--- a/workflows/pipe-common/scripts/mount_storage.py
+++ b/workflows/pipe-common/scripts/mount_storage.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -522,6 +522,8 @@ class NFSMounter(StorageMounter):
                 params['path'] = '//' + params['path']
         elif self.share_mount.mount_type == "LUSTRE":
             command = command.format(protocol="lustre")
+            if params['path'].count('/') > 1 and params['path'].endswith('/'):
+                params['path'] = params['path'][:-1]
         else:
             command = command.format(protocol="nfs")
 

--- a/workflows/pipe-common/shell/install_nfs_client
+++ b/workflows/pipe-common/shell/install_nfs_client
@@ -50,7 +50,7 @@ else
       mkdir lustre-client-install/ &&
       tar -C lustre-client-install/ -zxvf lustre-client.tar.gz &&
       mkdir -p /lib/modules/$(uname -r) &&
-      dpkg -i lustre-client-install/* &&
+      (dpkg -i lustre-client-install/* || apt-get --fix-broken install -y ) &&
       rm -rf lustre-client-install/ lustre-client.tar.gz
 EOM
 fi


### PR DESCRIPTION
This PR is related to issue #441.
It updates the handling of Lustre paths. 
Lustre allows specifying complicated ("multi-host") mount roots [[1]](http://wiki.lustre.org/Lustre_Networking_(LNET)_Overview) [[2]](http://wiki.lustre.org/Mounting_a_Lustre_File_System_on_Client_Nodes). As the same char ':' is used for many purposes:
- split port from a server in host specification
- split LNet Network Identifiers (NID) in host specification
- part of sequence splitting host from the other part of mount path (':/')
user input is verified against the specific regex, describing valid Lustre path.
The format is checking during `NFSStorageProvider.mount` operation, as well, and operation is being aborted if the format is invalid.
Also, Lustre mount fails, if path ends with a separator (even if valid), so additional operation is applied if necessary.