### PR TITLE
Issue 1251 run pipe mounts logging parameters

### DIFF
--- a/pipe-cli/mount/pipe-fuse.py
+++ b/pipe-cli/mount/pipe-fuse.py
@@ -190,11 +190,12 @@ if __name__ == '__main__':
         parser.error('Either --webdav or --bucket parameter should be specified.')
     if args.bucket and (args.chunk_size < 5 * MB or args.chunk_size > 5 * GB):
         parser.error('Chunk size can vary from 5 MB to 5 GB due to AWS s3 multipart upload limitations.')
-    if args.logging_level not in _allowed_logging_levels:
+    logging_level = os.environ.get('CP_PIPE_FUSE_LOGGING_LEVEL', args.logging_level)
+    if logging_level not in _allowed_logging_levels:
         parser.error('Only the following logging level are allowed: %s.' % _allowed_logging_levels_string)
-    recording = args.logging_level in [_info_logging_level, _debug_logging_level]
+    recording = logging_level in [_info_logging_level, _debug_logging_level]
     logging.basicConfig(format='[%(levelname)s] %(asctime)s %(filename)s - %(message)s',
-                        level=_allowed_logging_level_names[args.logging_level])
+                        level=_allowed_logging_level_names[logging_level])
     logging.getLogger('botocore').setLevel(logging.ERROR)
 
     if is_frozen:

--- a/pipe-cli/mount/pipe-fuse.py
+++ b/pipe-cli/mount/pipe-fuse.py
@@ -190,12 +190,11 @@ if __name__ == '__main__':
         parser.error('Either --webdav or --bucket parameter should be specified.')
     if args.bucket and (args.chunk_size < 5 * MB or args.chunk_size > 5 * GB):
         parser.error('Chunk size can vary from 5 MB to 5 GB due to AWS s3 multipart upload limitations.')
-    logging_level = os.environ.get('CP_PIPE_FUSE_LOGGING_LEVEL', args.logging_level)
-    if logging_level not in _allowed_logging_levels:
+    if args.logging_level not in _allowed_logging_levels:
         parser.error('Only the following logging level are allowed: %s.' % _allowed_logging_levels_string)
-    recording = logging_level in [_info_logging_level, _debug_logging_level]
+    recording = args.logging_level in [_info_logging_level, _debug_logging_level]
     logging.basicConfig(format='[%(levelname)s] %(asctime)s %(filename)s - %(message)s',
-                        level=_allowed_logging_level_names[logging_level])
+                        level=_allowed_logging_level_names[args.logging_level])
     logging.getLogger('botocore').setLevel(logging.ERROR)
 
     if is_frozen:

--- a/workflows/pipe-common/scripts/mount_storage.py
+++ b/workflows/pipe-common/scripts/mount_storage.py
@@ -380,14 +380,14 @@ class S3Mounter(StorageMounter):
     def build_mount_command(self, params):
         if params['aws_token'] is not None or params['fuse_type'] == FUSE_PIPE_ID:
             persist_logs = os.getenv('CP_PIPE_FUSE_PERSIST_LOGS', 'false').lower() == 'true'
-            debug_fuselib = os.getenv('CP_PIPE_FUSE_DEBUG_FUSELIB', 'false').lower() == 'true'
+            debug_libfuse = os.getenv('CP_PIPE_FUSE_DEBUG_LIBFUSE', 'false').lower() == 'true'
             logging_level = os.getenv('CP_PIPE_FUSE_LOGGING_LEVEL')
             if logging_level:
                 params['logging_level'] = logging_level
             return ('pipe storage mount {mount} -b {path} -t --mode 775 -w {mount_timeout} '
                     + ('-l /var/log/fuse_{storage_id}.log ' if persist_logs else '')
                     + ('-v {logging_level} ' if logging_level else '')
-                    + ('-o allow_other,debug ' if debug_fuselib else '-o allow_other ')
+                    + ('-o allow_other,debug ' if debug_libfuse else '-o allow_other ')
                     ).format(**params)
         elif params['fuse_type'] == FUSE_GOOFYS_ID:
             params['path'] = '{bucket}:{relative_path}'.format(**params) if params['relative_path'] else params['path']

--- a/workflows/pipe-common/scripts/mount_storage.py
+++ b/workflows/pipe-common/scripts/mount_storage.py
@@ -379,7 +379,12 @@ class S3Mounter(StorageMounter):
 
     def build_mount_command(self, params):
         if params['aws_token'] is not None or params['fuse_type'] == FUSE_PIPE_ID:
-            return 'pipe storage mount {mount} -b {path} -t --mode 775 -w {mount_timeout} -o allow_other'.format(**params)
+            persist_logs = os.getenv('CP_PIPE_FUSE_PERSIST_LOGS', 'false').lower() == 'true'
+            debug_fuselib = os.getenv('CP_PIPE_FUSE_DEBUG_FUSELIB', 'false').lower() == 'true'
+            params['logging_options'] = '-l /var/log/fuse_{storage_id}.log'.format(**params) if persist_logs else ''
+            params['fuselib_options'] = '-o allow_other,debug' if debug_fuselib else '-o allow_other'
+            return 'pipe storage mount {mount} -b {path} -t --mode 775 -w {mount_timeout} ' \
+                   '{logging_options} {fuselib_options}'.format(**params)
         elif params['fuse_type'] == FUSE_GOOFYS_ID:
             params['path'] = '{bucket}:{relative_path}'.format(**params) if params['relative_path'] else params['path']
             return 'AWS_ACCESS_KEY_ID={aws_key_id} AWS_SECRET_ACCESS_KEY={aws_secret} nohup goofys ' \


### PR DESCRIPTION
Resolves #1251.

The pull request brings several run parameters that allow to control pipe fuse storage mounts logging.

| Parameter | Description |
| --- | ---|
| CP_PIPE_FUSE_PERSIST_LOGS | Enables pipe fuse logs persistence to `/var/log` directory. Disabled by default. |
| CP_PIPE_FUSE_DEBUG_LIBFUSE | Enables pipe fuse libfuse debug logging. Disabled by default. |
| CP_PIPE_FUSE_LOGGING_LEVEL | Specifies logging level (CRITICAL, ERROR, WARN, WARNING, INFO, DEBUG) for pipe fuse. Defaults to ERROR. |

**Notice** that verbose logging levels and especially libfuse logging significantly affect pipe fuse performance! More about pipe fuse logging can be found in #1032.