### PR TITLE
Handle listing caches in thread safe manner in pipe fuse

### DIFF
--- a/pipe-cli/mount/pipe-fuse.py
+++ b/pipe-cli/mount/pipe-fuse.py
@@ -34,7 +34,7 @@ if os.path.exists(libfuse_path):
 
 
 from pipefuse.fuseutils import MB, GB
-from pipefuse.cache import CachingFileSystemClient
+from pipefuse.cache import CachingFileSystemClient, ListingCache, ThreadSafeListingCache
 from pipefuse.buff import BufferedFileSystemClient
 from pipefuse.trunc import CopyOnDownTruncateFileSystemClient, \
     WriteNullsOnUpTruncateFileSystemClient, \
@@ -83,7 +83,10 @@ def start(mountpoint, webdav, bucket, buffer_size, trunc_buffer_size, chunk_size
     if recording:
         client = RecordingFileSystemClient(client)
     if cache_ttl > 0 and cache_size > 0:
-        cache = TTLCache(maxsize=cache_size, ttl=cache_ttl)
+        cache_implementation = TTLCache(maxsize=cache_size, ttl=cache_ttl)
+        cache = ListingCache(cache_implementation)
+        if threads:
+            cache = ThreadSafeListingCache(cache)
         client = CachingFileSystemClient(client, cache)
     else:
         logging.info('Caching is disabled.')


### PR DESCRIPTION
The pull request introduces thread safe listing caches in pipe fuse. Previously pipe fuse plainly used [cache implementation](https://cachetools.readthedocs.io/en/latest/#cache-implementations) that is not thread safe which probably was the cause of some issues in the past. From now on all interactions with the cache implementation are synchronized.