### PR TITLE
Issue #1254 Upgrade RStudio image

### DIFF
--- a/deploy/docker/build-dockers.sh
+++ b/deploy/docker/build-dockers.sh
@@ -265,7 +265,9 @@ build_and_push_tool $BASE_TOOLS_DOCKERS_SOURCES_PATH/ubuntu/cuda "$CP_DIST_REPO_
 build_and_push_tool $BASE_TOOLS_DOCKERS_SOURCES_PATH/ubuntu/cuda "$CP_DIST_REPO_NAME:tools-base-ubuntu-18.04-cuda-${DOCKERS_VERSION}" "library/ubuntu-cuda:latest" --build-arg BASE_IMAGE="nvidia/cuda:10.0-cudnn7-runtime-ubuntu18.04"
 
 # RStudio
-build_and_push_tool $BASE_TOOLS_DOCKERS_SOURCES_PATH/rstudio "$CP_DIST_REPO_NAME:tools-base-rstudio-${DOCKERS_VERSION}" "library/rstudio:latest"
+build_and_push_tool $BASE_TOOLS_DOCKERS_SOURCES_PATH/rstudio "$CP_DIST_REPO_NAME:tools-base-rstudio-${DOCKERS_VERSION}" "library/rstudio:3.5.1"
+build_and_push_tool $BASE_TOOLS_DOCKERS_SOURCES_PATH/rstudio "$CP_DIST_REPO_NAME:tools-base-rstudio-${DOCKERS_VERSION}" "library/rstudio:4.0.0" --file "Dockerfile.el7"
+build_and_push_tool $BASE_TOOLS_DOCKERS_SOURCES_PATH/rstudio "$CP_DIST_REPO_NAME:tools-base-rstudio-${DOCKERS_VERSION}" "library/rstudio:latest" --file "Dockerfile.el7"
 
 # Cromwell
 build_and_push_tool $BASE_TOOLS_DOCKERS_SOURCES_PATH/cromwell "$CP_DIST_REPO_NAME:tools-base-cromwell-${DOCKERS_VERSION}" "library/cromwell:latest"

--- a/deploy/docker/cp-tools/base/rstudio/Dockerfile.el7
+++ b/deploy/docker/cp-tools/base/rstudio/Dockerfile.el7
@@ -82,4 +82,6 @@ RUN chmod +x /root/post_commit.sh
 ADD start.sh /start.sh
 RUN chmod 777 /start.sh
 
+RUN yum install -y initscripts
+
 CMD ["/start.sh"]

--- a/deploy/docker/cp-tools/base/rstudio/Dockerfile.el7
+++ b/deploy/docker/cp-tools/base/rstudio/Dockerfile.el7
@@ -15,8 +15,22 @@
 ARG BASE_IMAGE=centos:7
 FROM ${BASE_IMAGE}
 
-RUN yum install -y wget \
-        https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN yum install -y \
+            centos-release-scl \
+            epel-release
+RUN yum install -y \
+            cmake \
+            devtoolset-7 \
+            java-1.8.0-openjdk-devel \
+            libcurl-openssl-devel \
+            libffi-devel \
+            libpng-devel \
+            libssh2-devel \
+            libxml2-devel \
+            openssl-devel \
+            python-devel \
+            wget && \
+        curl https://bootstrap.pypa.io/get-pip.py | python -
 RUN yum-config-manager --enable "rhel-*-optional-rpms"
 
 ARG R_VERSION=4.0.0
@@ -27,6 +41,21 @@ RUN wget -q $R_PACKAGE_URL -O rpackage.rpm && \
         ln -s /opt/R/${R_VERSION}/bin/R /usr/local/bin/R && \
         ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/local/bin/Rscript
 
+RUN wget -q https://github.com/libgit2/libgit2/archive/v0.28.1.tar.gz && \
+         tar xzf v0.28.1.tar.gz && \
+         cd libgit2-0.28.1/ && \
+         cmake . && \
+         make && make install && cd .. && \
+         ldconfig && \
+         pip install 'pygit2==0.28.1'
+RUN wget -q https://codeload.github.com/PressLabs/gitfs/zip/0.5.2 && \
+        unzip 0.5.2 && \
+        cd gitfs-0.5.2 && \
+        python setup.py install && cd .. && \
+        mkdir -p /var/lib/gitfs
+SHELL [ "/usr/bin/scl", "enable", "devtoolset-7"]
+RUN R -e "install.packages(c('sparklyr', 'tidyverse', 'magrittr'), repos='http://cran.rstudio.com/')"
+
 ARG R_STUDIO_VERSION="el7-1.3.1056"
 ARG R_STUDIO_URL="https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/r/rstudio-server-${R_STUDIO_VERSION}-x86_64.rpm"
 RUN wget -q $R_STUDIO_URL -O rstudio-server.rpm && \
@@ -35,7 +64,8 @@ RUN wget -q $R_STUDIO_URL -O rstudio-server.rpm && \
 
 ARG SHINY_SERVER_VERSION="1.5.14.948"
 ARG SHINY_SERVER_URL="https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/r/shiny-server-${SHINY_SERVER_VERSION}.x86_64.rpm"
-RUN R -e "install.packages(c('shiny', 'rmarkdown', 'devtools', 'RJDBC'), repos='http://cran.rstudio.com/')" && \
+RUN R CMD javareconf -e && \
+        R -e "install.packages(c('shiny', 'rmarkdown', 'devtools', 'RJDBC'), repos='http://cran.rstudio.com/')" && \
         wget -q $SHINY_SERVER_URL -O shiny-server.rpm && \
         yum install -y shiny-server.rpm && \
         rm -f shiny-server.rpm

--- a/deploy/docker/cp-tools/base/rstudio/Dockerfile.el7
+++ b/deploy/docker/cp-tools/base/rstudio/Dockerfile.el7
@@ -1,0 +1,55 @@
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG BASE_IMAGE=centos:7
+FROM ${BASE_IMAGE}
+
+RUN yum install -y wget \
+        https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN yum-config-manager --enable "rhel-*-optional-rpms"
+
+ARG R_VERSION=4.0.0
+ARG R_PACKAGE_URL="https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/r/R-${R_VERSION}-1-1.el7.x86_64.rpm"
+RUN wget -q $R_PACKAGE_URL -O rpackage.rpm && \
+        yum install -y rpackage.rpm && \
+        rm -f rpackage.rpm && \
+        ln -s /opt/R/${R_VERSION}/bin/R /usr/local/bin/R && \
+        ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/local/bin/Rscript
+
+ARG R_STUDIO_VERSION="el7-1.3.1056"
+ARG R_STUDIO_URL="https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/r/rstudio-server-${R_STUDIO_VERSION}-x86_64.rpm"
+RUN wget -q $R_STUDIO_URL -O rstudio-server.rpm && \
+        yum install -y rstudio-server.rpm && \
+        rm -f rstudio-server.rpm
+
+ARG SHINY_SERVER_VERSION="1.5.14.948"
+ARG SHINY_SERVER_URL="https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/r/shiny-server-${SHINY_SERVER_VERSION}.x86_64.rpm"
+RUN R -e "install.packages(c('shiny', 'rmarkdown', 'devtools', 'RJDBC'), repos='http://cran.rstudio.com/')" && \
+        wget -q $SHINY_SERVER_URL -O shiny-server.rpm && \
+        yum install -y shiny-server.rpm && \
+        rm -f shiny-server.rpm
+
+# Configure nginx
+RUN yum install -y nginx gettext
+RUN mkdir -p /etc/nginx/sites-enabled/
+ADD auto-fill-form-template.conf /auto-fill-form-template.conf
+ADD nginx.conf /etc/nginx/nginx.conf
+
+ADD post_commit.sh /root/post_commit.sh
+RUN chmod +x /root/post_commit.sh
+
+ADD start.sh /start.sh
+RUN chmod 777 /start.sh
+
+CMD ["/start.sh"]

--- a/deploy/docker/cp-tools/base/rstudio/start.sh
+++ b/deploy/docker/cp-tools/base/rstudio/start.sh
@@ -56,6 +56,8 @@ fi
 
 sed -i "s|run_as shiny;|run_as ${OWNER};|g" /etc/shiny-server/shiny-server.conf
 
+ln -s /srv/shiny-server /home/${OWNER}
+
 # Configure nginx for SSO
 envsubst '${OWNER}' < /auto-fill-form-template.conf > /etc/nginx/sites-enabled/auto-fill-form.conf
 rstudio-server start

--- a/deploy/docker/cp-tools/base/rstudio/start.sh
+++ b/deploy/docker/cp-tools/base/rstudio/start.sh
@@ -19,16 +19,17 @@ then
     exit 1
 fi
 
+R_HOME=$(R RHOME)
 # Add rstudio permissions to the OWNER and create a home dir for this account
 groupadd rstudio
 groupadd staff
 usermod -a -G rstudio "$OWNER"
 usermod -a -G staff "$OWNER"
 usermod -a -G wheel "$OWNER"
-chmod g+wx /usr/local/lib/R/site-library
+chmod g+wx $R_HOME/library
 
 # Configure env variables for R Session
-R_ENV_FILE=$(R RHOME)/etc/Renviron
+R_ENV_FILE=$R_HOME/etc/Renviron
 cat $CP_ENV_FILE_TO_SOURCE | sed '/^export/s/export//' >> $R_ENV_FILE
 
 # Configure R executable

--- a/deploy/docker/cp-tools/base/rstudio/start.sh
+++ b/deploy/docker/cp-tools/base/rstudio/start.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,10 +20,11 @@ then
 fi
 
 # Add rstudio permissions to the OWNER and create a home dir for this account
-addgroup rstudio staff
-adduser $OWNER rstudio
-adduser $OWNER staff
-adduser $OWNER sudo
+groupadd rstudio
+groupadd staff
+usermod -a -G rstudio "$OWNER"
+usermod -a -G staff "$OWNER"
+usermod -a -G wheel "$OWNER"
 chmod g+wx /usr/local/lib/R/site-library
 
 # Configure env variables for R Session
@@ -57,4 +58,6 @@ sed -i "s|run_as shiny;|run_as ${OWNER};|g" /etc/shiny-server/shiny-server.conf
 
 # Configure nginx for SSO
 envsubst '${OWNER}' < /auto-fill-form-template.conf > /etc/nginx/sites-enabled/auto-fill-form.conf
-/init & nginx -g 'daemon off;'
+rstudio-server start
+/usr/bin/shiny-server &> /var/log/shiny-server.log &
+nginx -g 'daemon off;'


### PR DESCRIPTION
This PR is related to issue #1254

It changes the way of building `RStudio` image. Previously it used to be based on `rocker/rstudio`, but it might contain certain issues, so a more stable CentOS 7 image is used. Also, the main packages are updated to the latest versions.
Following packages are installed:
- R v4.0.0
- RStudio v1.3.1056
- Shiny Server v1.5.14.948

A new image can be built from `Dockerfile.el7`, `start.sh` is updated according to the new base OS.