### PR TITLE
Add support for data storage directory temporary urls in Azure

### DIFF
--- a/api/src/main/java/com/epam/pipeline/controller/datastorage/DataStorageController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/datastorage/DataStorageController.java
@@ -443,7 +443,9 @@ public class DataStorageController extends AbstractRestController {
             @PathVariable(value = ID) final Long id,
             @RequestBody final GenerateDownloadUrlVO generateDownloadUrlVO) {
         return Result.success(dataStorageApiService
-                .generateDataStorageItemUrl(id, generateDownloadUrlVO.getPaths()));
+                .generateDataStorageItemUrl(id, generateDownloadUrlVO.getPaths(), 
+                        generateDownloadUrlVO.getPermissions(),
+                        generateDownloadUrlVO.getHours()));
     }
 
     @PostMapping("/datastorage/{id}/generateUploadUrl")

--- a/api/src/main/java/com/epam/pipeline/controller/vo/GenerateDownloadUrlVO.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/GenerateDownloadUrlVO.java
@@ -25,4 +25,6 @@ import java.util.List;
 @Setter
 public class GenerateDownloadUrlVO {
     private List<String> paths;
+    private List<String> permissions;
+    private long hours;
 }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageApiService.java
@@ -63,6 +63,7 @@ import static com.epam.pipeline.security.acl.AclExpressions.ADMIN_ONLY;
 import static com.epam.pipeline.security.acl.AclExpressions.PIPELINE_ID_READ;
 import static com.epam.pipeline.security.acl.AclExpressions.PIPELINE_ID_WRITE;
 import static com.epam.pipeline.security.acl.AclExpressions.STORAGE_ID_OWNER;
+import static com.epam.pipeline.security.acl.AclExpressions.STORAGE_ID_PERMISSIONS;
 import static com.epam.pipeline.security.acl.AclExpressions.STORAGE_ID_READ;
 import static com.epam.pipeline.security.acl.AclExpressions.STORAGE_ID_WRITE;
 
@@ -191,10 +192,12 @@ public class DataStorageApiService {
         return dataStorageManager.generateDataStorageItemUrl(id, path, version, contentDisposition);
     }
 
-    @PreAuthorize(STORAGE_ID_READ)
+    @PreAuthorize(STORAGE_ID_PERMISSIONS)
     public List<DataStorageDownloadFileUrl> generateDataStorageItemUrl(final Long id,
-            final List<String> paths) {
-        return dataStorageManager.generateDataStorageItemUrl(id, paths);
+                                                                       final List<String> paths,
+                                                                       final List<String> permissions,
+                                                                       final long hours) {
+        return dataStorageManager.generateDataStorageItemUrl(id, paths, permissions, hours);
     }
 
     @PreAuthorize(STORAGE_ID_WRITE)

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageProviderManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageProviderManager.java
@@ -41,6 +41,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.io.InputStream;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -112,6 +113,14 @@ public class StorageProviderManager {
     public DataStorageDownloadFileUrl generateDataStorageItemUploadUrl(AbstractDataStorage dataStorage,
                                                                        String path) {
         return getStorageProvider(dataStorage).generateDataStorageItemUploadUrl(dataStorage, path);
+    }
+
+    @SensitiveStorageOperation
+    public DataStorageDownloadFileUrl generateUrl(AbstractDataStorage dataStorage,
+                                                  String path,
+                                                  List<String> permissions,
+                                                  Duration duration) {
+        return getStorageProvider(dataStorage).generateUrl(dataStorage, path, permissions, duration);
     }
 
     public DataStorageFile createFile(AbstractDataStorage dataStorage, String path, byte[] contents)

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/StorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/StorageProvider.java
@@ -17,6 +17,8 @@
 package com.epam.pipeline.manager.datastorage.providers;
 
 import java.io.InputStream;
+import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -56,6 +58,8 @@ public interface StorageProvider<T extends AbstractDataStorage> {
                                                    ContentDisposition contentDisposition);
 
     DataStorageDownloadFileUrl generateDataStorageItemUploadUrl(T dataStorage, String path);
+
+    DataStorageDownloadFileUrl generateUrl(T dataStorage, String path, List<String> permissions, Duration duration);
 
     DataStorageFile createFile(T dataStorage, String path, byte[] contents)
             throws DataStorageException;

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3StorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3StorageProvider.java
@@ -55,6 +55,7 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 import java.io.InputStream;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -187,6 +188,14 @@ public class S3StorageProvider implements StorageProvider<S3bucketDataStorage> {
         final TemporaryCredentials credentials = getStsCredentials(dataStorage, null, true);
         return getS3Helper(credentials).generateDataStorageItemUploadUrl(
                 dataStorage.getRoot(), ProviderUtils.buildPath(dataStorage, path), authManager.getAuthorizedUser());
+    }
+
+    @Override
+    public DataStorageDownloadFileUrl generateUrl(final S3bucketDataStorage dataStorage,
+                                                  final String path,
+                                                  final List<String> permissions,
+                                                  final Duration duration) {
+        return generateDownloadURL(dataStorage, path, null, null);
     }
 
     @Override public DataStorageFile createFile(S3bucketDataStorage dataStorage, String path,

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageProvider.java
@@ -40,6 +40,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.io.InputStream;
+import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -102,6 +104,14 @@ public class GSBucketStorageProvider implements StorageProvider<GSBucketStorage>
     public DataStorageDownloadFileUrl generateDataStorageItemUploadUrl(final GSBucketStorage dataStorage,
                                                                        final String path) {
         return null;
+    }
+
+    @Override
+    public DataStorageDownloadFileUrl generateUrl(final GSBucketStorage dataStorage,
+                                                  final String path,
+                                                  final List<String> permissions,
+                                                  final Duration duration) {
+        return generateDownloadURL(dataStorage, path, null, null);
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProvider.java
@@ -69,6 +69,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermission;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
@@ -339,6 +340,14 @@ public class NFSStorageProvider implements StorageProvider<NFSDataStorage> {
     @Override
     public DataStorageDownloadFileUrl generateDataStorageItemUploadUrl(NFSDataStorage dataStorage, String path) {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DataStorageDownloadFileUrl generateUrl(final NFSDataStorage dataStorage,
+                                                  final String path,
+                                                  final List<String> permissions,
+                                                  final Duration duration) {
+        return generateDownloadURL(dataStorage, path, null, null);
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionManager.java
@@ -111,6 +111,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -430,6 +431,14 @@ public class GrantPermissionManager {
         } else {
             return permissionsHelper.isAllowed(permissionName, storage);
         }
+    }
+
+    public boolean storagePermissions(Long storageId, List<String> permissionNames) {
+        return Optional.ofNullable(permissionNames)
+                .filter(org.apache.commons.collections4.CollectionUtils::isNotEmpty)
+                .orElseGet(() -> Collections.singletonList("READ"))
+                .stream()
+                .allMatch(permissionName -> storagePermission(storageId, permissionName));
     }
 
     public boolean storagePermissionByName(final String identifier, final String permissionName) {

--- a/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
+++ b/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
@@ -65,6 +65,16 @@ public final class AclExpressions {
             "(hasRole('ADMIN') OR @grantPermissionManager.storagePermission(#id, 'OWNER')) "
             + "AND @grantPermissionManager.checkStorageShared(#id)";
 
+    public static final String STORAGE_ID_PERMISSIONS =
+            "(" 
+                + "hasRole('ADMIN') "
+                    + "OR (" 
+                        + "@grantPermissionManager.storagePermission(#id, 'READ') "
+                        + "AND @grantPermissionManager.storagePermissions(#id, #permissions) "
+                    + ") "
+            + ") "
+            + "AND @grantPermissionManager.checkStorageShared(#id)";
+
     public static final String STORAGE_PATHS_READ = ADMIN_ONLY + OR +
             "@grantPermissionManager.hasDataStoragePathsPermission(returnObject, 'READ')";
 


### PR DESCRIPTION
The pull request brings support for data storage directories temporary urls generation. *Currently only Azure cloud provider is supported.*

From now on `POST datastorage/{id}/generateUrl` endpoint accepts the following request object.
```
{
    "paths": [ "", "/", "file", "folder/", "folder/file", "folder/folder/" ],
    "permissions": [ "READ", "WRITE" ],
    "hours": 1
}
```

Notice that directory paths should have trailing slash in path. Both empty string and slash can be used to generate url for data storage root. Request fields `permissions` and `hours` are optional and urls are generated with read-only permissions for one hour by default.

# Testing

Generating urls were tested using azure cli and azure storage explorer (only data storage root urls are supported). The following commands were use to test out the urls.

```
mkdir local
az storage copy -s "generated folder url" -d local/ --recursive
az storage copy -s local/folder -d "generated folder url" --recursive
```