### PR TITLE
Issue #1245 Enable NoMachine at run startup

### DIFF
--- a/scripts/pipeline-launch/launch.sh
+++ b/scripts/pipeline-launch/launch.sh
@@ -1620,7 +1620,20 @@ fi
 
 ######################################################
 
+######################################################
+# Setup NoMachine
+######################################################
 
+echo "Setup NoMachine environment"
+echo "-"
+
+if [ "$CP_CAP_DESKTOP_NM" == "true" ]; then
+      nomachine_setup
+else
+    echo "NoMachine support is not requested"
+fi
+
+######################################################
 
 ######################################################
 # Setup "Singularity" support

--- a/workflows/pipe-common/shell/nomachine_setup
+++ b/workflows/pipe-common/shell/nomachine_setup
@@ -53,9 +53,7 @@ EOM
     read -r -d '' NOMACHINE_INSTALL_CMD <<- EOM
     yum -y install epel-release && \
     yum update -y && \
-    yum install -y  gcc \
-                    gcc-c++ \
-                    lsof \
+    yum install -y  lsof \
                     python \
                     wget && \
     yum --enablerepo=epel -y -x gnome-keyring --skip-broken install @xfce-desktop && \
@@ -104,8 +102,7 @@ EOM
     locale-gen en_US && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=$LANG && \
-    apt-get install -y  g++ \
-                        lsof \
+    apt-get install -y  lsof \
                         python \
                         wget \
                         xfce4 \
@@ -138,8 +135,7 @@ fi
     mkdir -p nomachine-common/ /etc/nomachine/ && \
     tar -C nomachine-common/ -zxvf nomachine-common.tar.gz && \
     mv nomachine-common/create_chrome_launcher.sh /tmp/ && \
-    g++ nomachine-common/scramble_alg.cpp -o /usr/local/bin/scramble && \
-    rm -f nomachine-common/scramble.cpp && \
+    mv nomachine-common/scramble /usr/local/bin/ && \
     cp -r nomachine-common/* /etc/nomachine/ && \
     rm -f /etc/nomachine/xfce/.config/xfce4/panel/xkb-plugin-${XKB_PLUGIN_ID}.rc && \
     mv /etc/nomachine/xfce/.config/xfce4/panel/xkb-plugin.rc /etc/nomachine/xfce/.config/xfce4/panel/xkb-plugin-${XKB_PLUGIN_ID}.rc && \

--- a/workflows/pipe-common/shell/nomachine_setup
+++ b/workflows/pipe-common/shell/nomachine_setup
@@ -13,6 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Check if required proxy settings are correct
+export CP_NM_PROXY_HOST="${CP_CAP_NM_PROXY_HOST:-$(echo $CP_NM_PROXY_HOST)}"
+if [ -z $CP_NM_PROXY_HOST ]; then
+    pipe_log_fail "NoMachine proxy host is not set (CP_NM_PROXY_HOST). Exiting..."
+    exit 1
+fi
+
+export CP_NM_PROXY_PORT="${CP_CAP_NM_PROXY_PORT:-$(echo CP_NM_PROXY_PORT)}"
+if [ -z $CP_NM_PROXY_PORT ]; then
+    pipe_log_fail "NoMachine proxy port is not set (CP_NM_PROXY_PORT). Exiting..."
+    exit 1
+fi
+
 NOMACHINE_INSTALL_TASK="NoMachineInitialization"
 NOMACHINE_VERSION="${CP_CAP_NM_DEFAULT_VERSION:-6.5.6_9}"
 
@@ -22,8 +35,7 @@ IS_RPM_BASED=$?
 export LANG="en_US.UTF-8"
 export LANGUAGE=en_US
 
-if [[ "$IS_RPM_BASED" = 0 ]]
-then
+if [[ "$IS_RPM_BASED" = 0 ]]; then
     CHECK_NOMACHINE_INSTALLATION="rpm -qa | grep nomachine"
     GET_INSTALLED_NOMACHINE_VERSION="rpm -qa nomachine | sed 's/^\(nomachine-\)*//' | sed 's/.x86_64$//'"
 
@@ -43,6 +55,7 @@ EOM
     yum update -y && \
     yum install -y  gcc \
                     gcc-c++ \
+                    lsof \
                     python \
                     wget && \
     yum --enablerepo=epel install  @^graphical-server-environment -y && \
@@ -59,11 +72,11 @@ EOM
     sed -i '/DefaultDesktopCommand/c\DefaultDesktopCommand "/usr/bin/startxfce4"' /usr/NX/etc/node.cfg
 EOM
 
+    XKB_PLUGIN_ID=6
     read -r -d '' NOMACHINE_CONFIG_CMD <<- EOM
     sed -i 's@_XKB_PLUGIN_NAME_@xkb-plugin@g' /etc/nomachine/xfce/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml && \
-    sed -i 's@_XKB_PLUGIN_ID_@6@g' /etc/nomachine/xfce/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
+    sed -i 's@_XKB_PLUGIN_ID_@'"$XKB_PLUGIN_ID"'@g' /etc/nomachine/xfce/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
 EOM
-    XKB_PLUGIN_ID=6
 else
     export DEBIAN_FRONTEND=noninteractive
     CHECK_NOMACHINE_INSTALLATION="dpkg -l | grep nomachine"
@@ -87,6 +100,7 @@ EOM
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=$LANG && \
     apt-get install -y  g++ \
+                        lsof \
                         python \
                         wget \
                         xfce4 \
@@ -95,16 +109,15 @@ EOM
     dpkg -i nomachine.deb && \
     rm -f nomachine.deb
 EOM
-
+    XKB_PLUGIN_ID=9
     read -r -d '' NOMACHINE_CONFIG_CMD <<- EOM
     if [[ "$(. /etc/os-release;echo $VERSION_ID)" == *"18."* ]]; then
         sed -i 's@_XKB_PLUGIN_NAME_@xkb@g' /etc/nomachine/xfce/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml ;
     else
         sed -i 's@_XKB_PLUGIN_NAME_@xkb-plugin@g' /etc/nomachine/xfce/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml ;
     fi
-    sed -i 's@_XKB_PLUGIN_ID_@9@g' /etc/nomachine/xfce/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
+    sed -i 's@_XKB_PLUGIN_ID_@'"$XKB_PLUGIN_ID"'@g' /etc/nomachine/xfce/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
 EOM
-    XKB_PLUGIN_ID=9
 fi
 
     read -r -d '' NOMACHINE_COMMON_CONFIG_CMD <<- EOM
@@ -123,8 +136,7 @@ EOM
 NOMACHINE_INSTALLATION_LOG="/var/log/nomachine_installation.log"
 eval "$CHECK_NOMACHINE_INSTALLATION"
 IS_NM_INSTALLED=$?
-if [ $IS_NM_INSTALLED -eq 0 ]
-then
+if [ $IS_NM_INSTALLED -eq 0 ]; then
     NM_CURRENT_VERSION=$(eval "$GET_INSTALLED_NOMACHINE_VERSION")
     if [ NM_CURRENT_VERSION == NOMACHINE_VERSION ]; then
         pipe_log_info "--> NoMachine installed already" "$NOMACHINE_INSTALL_TASK"
@@ -132,12 +144,10 @@ then
         pipe_log_info "--> NoMachine installed, but version found [$NM_CURRENT_VERSION] differs from the target one [$NOMACHINE_VERSION]" "$NOMACHINE_INSTALL_TASK"
         pipe_log_info "--> Trying to configure required version" "$NOMACHINE_INSTALL_TASK"
         eval "$NOMACHINE_UPDATE_CMD" > $NOMACHINE_INSTALLATION_LOG 2>&1
-        if [ $? -ne 0 ]
-        then
+        if [ $? -ne 0 ]; then
             pipe_log_warn "Failed to repair NoMachine version, try removing it" "$NOMACHINE_INSTALL_TASK"
             eval "$NOMACHINE_REMOVE_CMD"
-            if [ $? -ne 0 ]
-            then
+            if [ $? -ne 0 ]; then
                 pipe_log_fail "Failed to remove installed NoMachine" "$NOMACHINE_INSTALL_TASK"
                 exit 1
             else
@@ -150,12 +160,10 @@ then
     fi
 fi
 
-if [ $IS_NM_INSTALLED -ne 0 ]
-then
+if [ $IS_NM_INSTALLED -ne 0 ]; then
     pipe_log_info "--> NoMachine is not detected, proceeding with the full installation" "$NOMACHINE_INSTALL_TASK"
     eval "$NOMACHINE_INSTALL_CMD" > $NOMACHINE_INSTALLATION_LOG 2>&1
-    if [ $? -ne 0 ]
-    then
+    if [ $? -ne 0 ]; then
         pipe_log_fail "Failed to install NoMachine" "$NOMACHINE_INSTALL_TASK"
         exit 1
     else
@@ -165,8 +173,7 @@ fi
 
 NOMACHINE_CONFIGURATION_LOG="/var/log/nomachine_configuration.log"
 eval "$NOMACHINE_COMMON_CONFIG_CMD && $NOMACHINE_CONFIG_CMD" > $NOMACHINE_CONFIGURATION_LOG 2>&1
-if [ $? -ne 0 ]
-then
+if [ $? -ne 0 ]; then
     pipe_log_fail "Failed to configure NoMachine" "$NOMACHINE_INSTALL_TASK"
     exit 1
 else
@@ -175,4 +182,21 @@ fi
 
 NOMACHINE_EXECUTION_LOG="/var/log/nomachine_execution.log"
 bash /etc/nomachine/nomachine_launcher.sh > $NOMACHINE_EXECUTION_LOG 2>&1 &
+if [ $? -ne 0 ]; then
+    pipe_log_fail "Failed to start NoMachine" "$NOMACHINE_INSTALL_TASK"
+    exit 1
+else
+    sleep 5
+    lsof -i:${CP_NM_NOMACHINE_PORT:-4000} | grep LISTEN > /dev/null
+    if [ $? -ne 0 ]; then
+        pipe_log_fail "NM service is not active" "$NOMACHINE_INSTALL_TASK"
+        exit 1
+    fi
+    lsof -i:${CP_NM_LOCAL_PORT:-8888} | grep LISTEN > /dev/null
+    if [ $? -ne 0 ]; then
+        pipe_log_fail "NM service is not available via selected $CP_NM_LOCAL_PORT " "$NOMACHINE_INSTALL_TASK"
+        exit 1
+    fi
+    pipe_log_info "--> NoMachine enabled" "$NOMACHINE_INSTALL_TASK"
+fi
 pipe_log_success "Finished NoMachine initialization" "$NOMACHINE_INSTALL_TASK"

--- a/workflows/pipe-common/shell/nomachine_setup
+++ b/workflows/pipe-common/shell/nomachine_setup
@@ -77,6 +77,12 @@ EOM
     sed -i 's@_XKB_PLUGIN_NAME_@xkb-plugin@g' /etc/nomachine/xfce/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml && \
     sed -i 's@_XKB_PLUGIN_ID_@'"$XKB_PLUGIN_ID"'@g' /etc/nomachine/xfce/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
 EOM
+
+    read -r -d '' EXTRA_PACKAGES_INSTALLATION_CMD <<- EOM
+    wget -q "https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm" -O /opt/google-chrome-stable_current_x86_64.rpm && \
+    yum install -y /opt/google-chrome-stable_current_*.rpm && \
+    rm -f /opt/google-chrome-stable_current_*.rpm
+EOM
 else
     export DEBIAN_FRONTEND=noninteractive
     CHECK_NOMACHINE_INSTALLATION="dpkg -l | grep nomachine"
@@ -118,6 +124,13 @@ EOM
     fi
     sed -i 's@_XKB_PLUGIN_ID_@'"$XKB_PLUGIN_ID"'@g' /etc/nomachine/xfce/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
 EOM
+
+    read -r -d '' EXTRA_PACKAGES_INSTALLATION_CMD <<- EOM
+    wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+    echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list && \
+    apt-get update && \
+    apt-get install -y google-chrome-stable
+EOM
 fi
 
     read -r -d '' NOMACHINE_COMMON_CONFIG_CMD <<- EOM
@@ -125,12 +138,14 @@ fi
     wget -q "https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/nomachine/nomachine-common.tar.gz" -O nomachine-common.tar.gz && \
     mkdir -p nomachine-common/ /etc/nomachine/ && \
     tar -C nomachine-common/ -zxvf nomachine-common.tar.gz && \
+    mv nomachine-common/create_chrome_launcher.sh /tmp/ && \
     g++ nomachine-common/scramble_alg.cpp -o /usr/local/bin/scramble && \
     rm -f nomachine-common/scramble.cpp && \
     cp -r nomachine-common/* /etc/nomachine/ && \
     rm -f /etc/nomachine/xfce/.config/xfce4/panel/xkb-plugin-${XKB_PLUGIN_ID}.rc && \
     mv /etc/nomachine/xfce/.config/xfce4/panel/xkb-plugin.rc /etc/nomachine/xfce/.config/xfce4/panel/xkb-plugin-${XKB_PLUGIN_ID}.rc && \
-    rm -rf nomachine-common*
+    rm -rf nomachine-common* && \
+    cp /usr/NX/etc/server.cfg /usr/NX/etc/server.cfg.template
 EOM
 
 NOMACHINE_INSTALLATION_LOG="/var/log/nomachine_installation.log"
@@ -178,6 +193,17 @@ if [ $? -ne 0 ]; then
     exit 1
 else
     pipe_log_info "--> NoMachine configured successfully" "$NOMACHINE_INSTALL_TASK"
+fi
+
+NOMACHINE_EXTRAS_CONFIGURATION_LOG="/var/log/nomachine_extras_configuration.log"
+eval "$EXTRA_PACKAGES_INSTALLATION_CMD &&
+      mkdir -p /home/${OWNER}/Desktop/ &&
+      bash /tmp/create_chrome_launcher.sh &&
+      rm -f /tmp/create_chrome_launcher.sh" > $NOMACHINE_EXTRAS_CONFIGURATION_LOG 2>&1
+if [ $? -ne 0 ]; then
+    pipe_log_warn "Error during NoMachine extras configuration" "$NOMACHINE_INSTALL_TASK"
+else
+    pipe_log_info "--> NoMachine extras configured successfully" "$NOMACHINE_INSTALL_TASK"
 fi
 
 NOMACHINE_EXECUTION_LOG="/var/log/nomachine_execution.log"

--- a/workflows/pipe-common/shell/nomachine_setup
+++ b/workflows/pipe-common/shell/nomachine_setup
@@ -94,14 +94,13 @@ EOM
 EOM
 
     read -r -d '' NOMACHINE_INSTALL_CMD <<- EOM
-    apt-get update -y && \
-    apt-get install -y locales && \
+    apt-get install -y --no-upgrade locales && \
     locale-gen en_US.UTF-8 && \
     locale-gen en_US && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=$LANG && \
-    apt-get install -y  lsof \
-                        python \
+    apt-get install -y --no-upgrade \
+                        lsof \
                         wget \
                         xfce4 \
                         xfce4-xkb-plugin && \

--- a/workflows/pipe-common/shell/nomachine_setup
+++ b/workflows/pipe-common/shell/nomachine_setup
@@ -13,21 +13,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+NOMACHINE_INSTALL_TASK="NoMachineInitialization"
+NOMACHINE_VERSION="${CP_CAP_NM_DEFAULT_VERSION:-6.5.6_9}"
+
 # Check if required proxy settings are correct
 export CP_NM_PROXY_HOST="${CP_NM_PROXY_HOST:-$(echo $CP_CAP_NM_PROXY_HOST)}"
 if [ -z $CP_NM_PROXY_HOST ]; then
-    pipe_log_fail "NoMachine proxy host is not set (CP_NM_PROXY_HOST). Exiting..."
+    pipe_log_fail "NoMachine proxy host is not set (CP_NM_PROXY_HOST). Exiting..." "$NOMACHINE_INSTALL_TASK"
     exit 1
 fi
 
 export CP_NM_PROXY_PORT="${CP_NM_PROXY_PORT:-$(echo $CP_CAP_NM_PROXY_PORT)}"
 if [ -z $CP_NM_PROXY_PORT ]; then
-    pipe_log_fail "NoMachine proxy port is not set (CP_NM_PROXY_PORT). Exiting..."
+    pipe_log_fail "NoMachine proxy port is not set (CP_NM_PROXY_PORT). Exiting..." "$NOMACHINE_INSTALL_TASK"
     exit 1
 fi
-
-NOMACHINE_INSTALL_TASK="NoMachineInitialization"
-NOMACHINE_VERSION="${CP_CAP_NM_DEFAULT_VERSION:-6.5.6_9}"
 
 /usr/bin/rpm -q -f /usr/bin/rpm >/dev/null 2>&1
 IS_RPM_BASED=$?
@@ -58,7 +58,6 @@ EOM
                     lsof \
                     python \
                     wget && \
-    yum --enablerepo=epel install  @^graphical-server-environment -y && \
     yum --enablerepo=epel -y -x gnome-keyring --skip-broken install @xfce-desktop && \
     yum -y groups install "Fonts" && \
     yum erase -y *power* *screensaver* && \

--- a/workflows/pipe-common/shell/nomachine_setup
+++ b/workflows/pipe-common/shell/nomachine_setup
@@ -14,7 +14,8 @@
 # limitations under the License.
 
 NOMACHINE_INSTALL_TASK="NoMachineInitialization"
-NOMACHINE_VERSION="6.5.6_9"
+NOMACHINE_VERSION="${CP_CAP_NM_DEFAULT_VERSION:-6.5.6_9}"
+
 /usr/bin/rpm -q -f /usr/bin/rpm >/dev/null 2>&1
 IS_RPM_BASED=$?
 
@@ -24,6 +25,19 @@ export LANGUAGE=en_US
 if [[ "$IS_RPM_BASED" = 0 ]]
 then
     CHECK_NOMACHINE_INSTALLATION="rpm -qa | grep nomachine"
+    GET_INSTALLED_NOMACHINE_VERSION="rpm -qa nomachine | sed 's/^\(nomachine-\)*//' | sed 's/.x86_64$//'"
+
+    read -r -d '' NOMACHINE_UPDATE_CMD <<- EOM
+    wget -q "https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/nomachine/nomachine_${NOMACHINE_VERSION}_x86_64.rpm" -O nomachine.rpm && \
+    yum downgrade -y nomachine.rpm && \
+    yum install -y nomachine.rpm && \
+    rm -f nomachine.rpm
+EOM
+
+    read -r -d '' NOMACHINE_REMOVE_CMD <<- EOM
+    yum remove -y nomachine
+EOM
+
     read -r -d '' NOMACHINE_INSTALL_CMD <<- EOM
     yum -y install epel-release && \
     yum update -y && \
@@ -53,6 +67,18 @@ EOM
 else
     export DEBIAN_FRONTEND=noninteractive
     CHECK_NOMACHINE_INSTALLATION="dpkg -l | grep nomachine"
+    GET_INSTALLED_NOMACHINE_VERSION="apt-cache show nomachine | grep ^Version | sed 's/^\(Version: \)*//' | sed 's/-/_/'"
+
+    read -r -d '' NOMACHINE_UPDATE_CMD <<- EOM
+    wget -q "https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/nomachine/nomachine_${NOMACHINE_VERSION}_amd64.deb" -O nomachine.deb && \
+    dpkg -i nomachine.deb && \
+    rm -f nomachine.deb
+EOM
+
+    read -r -d '' NOMACHINE_REMOVE_CMD <<- EOM
+    apt-get remove -y nomachine
+EOM
+
     read -r -d '' NOMACHINE_INSTALL_CMD <<- EOM
     apt-get update -y && \
     apt-get install -y locales && \
@@ -94,12 +120,40 @@ fi
     rm -rf nomachine-common*
 EOM
 
+NOMACHINE_INSTALLATION_LOG="/var/log/nomachine_installation.log"
 eval "$CHECK_NOMACHINE_INSTALLATION"
-if [ $? -ne 0 ]
+IS_NM_INSTALLED=$?
+if [ $IS_NM_INSTALLED -eq 0 ]
 then
-    pipe_log_info "--> NoMachine not found, proceeding with installation" "$NOMACHINE_INSTALL_TASK"
-    NOMACHINE_INSTALLATION_LOG="/var/log/nomachine_installation.log"
-    eval "$NOMACHINE_INSTALL_CMD" >> $NOMACHINE_INSTALLATION_LOG
+    NM_CURRENT_VERSION=$(eval "$GET_INSTALLED_NOMACHINE_VERSION")
+    if [ NM_CURRENT_VERSION == NOMACHINE_VERSION ]; then
+        pipe_log_info "--> NoMachine installed already" "$NOMACHINE_INSTALL_TASK"
+    else
+        pipe_log_info "--> NoMachine installed, but version found [$NM_CURRENT_VERSION] differs from the target one [$NOMACHINE_VERSION]" "$NOMACHINE_INSTALL_TASK"
+        pipe_log_info "--> Trying to configure required version" "$NOMACHINE_INSTALL_TASK"
+        eval "$NOMACHINE_UPDATE_CMD" > $NOMACHINE_INSTALLATION_LOG 2>&1
+        if [ $? -ne 0 ]
+        then
+            pipe_log_warn "Failed to repair NoMachine version, try removing it" "$NOMACHINE_INSTALL_TASK"
+            eval "$NOMACHINE_REMOVE_CMD"
+            if [ $? -ne 0 ]
+            then
+                pipe_log_fail "Failed to remove installed NoMachine" "$NOMACHINE_INSTALL_TASK"
+                exit 1
+            else
+                pipe_log_info "--> NoMachine removed successfully" "$NOMACHINE_INSTALL_TASK"
+            fi
+            IS_NM_INSTALLED=1
+        else
+            pipe_log_info "--> NoMachine version changed successfully" "$NOMACHINE_INSTALL_TASK"
+        fi
+    fi
+fi
+
+if [ $IS_NM_INSTALLED -ne 0 ]
+then
+    pipe_log_info "--> NoMachine is not detected, proceeding with the full installation" "$NOMACHINE_INSTALL_TASK"
+    eval "$NOMACHINE_INSTALL_CMD" > $NOMACHINE_INSTALLATION_LOG 2>&1
     if [ $? -ne 0 ]
     then
         pipe_log_fail "Failed to install NoMachine" "$NOMACHINE_INSTALL_TASK"
@@ -107,18 +161,18 @@ then
     else
         pipe_log_info "--> NoMachine installed successfully" "$NOMACHINE_INSTALL_TASK"
     fi
-    NOMACHINE_CONFIGURATION_LOG="/var/log/nomachine_configuration.log"
-    eval "$NOMACHINE_COMMON_CONFIG_CMD && $NOMACHINE_CONFIG_CMD" >> $NOMACHINE_CONFIGURATION_LOG
-    if [ $? -ne 0 ]
-    then
-        pipe_log_fail "Failed to configure NoMachine" "$NOMACHINE_INSTALL_TASK"
-        exit 1
-    else
-        pipe_log_info "--> NoMachine configured successfully" "$NOMACHINE_INSTALL_TASK"
-    fi
-else
-    pipe_log_info "--> NoMachine installed already" "$NOMACHINE_INSTALL_TASK"
 fi
 
-bash /etc/nomachine/nomachine_launcher.sh &
+NOMACHINE_CONFIGURATION_LOG="/var/log/nomachine_configuration.log"
+eval "$NOMACHINE_COMMON_CONFIG_CMD && $NOMACHINE_CONFIG_CMD" > $NOMACHINE_CONFIGURATION_LOG 2>&1
+if [ $? -ne 0 ]
+then
+    pipe_log_fail "Failed to configure NoMachine" "$NOMACHINE_INSTALL_TASK"
+    exit 1
+else
+    pipe_log_info "--> NoMachine configured successfully" "$NOMACHINE_INSTALL_TASK"
+fi
+
+NOMACHINE_EXECUTION_LOG="/var/log/nomachine_execution.log"
+bash /etc/nomachine/nomachine_launcher.sh > $NOMACHINE_EXECUTION_LOG 2>&1 &
 pipe_log_success "Finished NoMachine initialization" "$NOMACHINE_INSTALL_TASK"

--- a/workflows/pipe-common/shell/nomachine_setup
+++ b/workflows/pipe-common/shell/nomachine_setup
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+NOMACHINE_INSTALL_TASK="NoMachineInitialization"
+NOMACHINE_VERSION="6.5.6_9"
+/usr/bin/rpm -q -f /usr/bin/rpm >/dev/null 2>&1
+IS_RPM_BASED=$?
+
+export LANG="en_US.UTF-8"
+export LANGUAGE=en_US
+
+if [[ "$IS_RPM_BASED" = 0 ]]
+then
+    CHECK_NOMACHINE_INSTALLATION="rpm -qa | grep nomachine"
+    read -r -d '' NOMACHINE_INSTALL_CMD <<- EOM
+    yum -y install epel-release && \
+    yum update -y && \
+    yum install -y  gcc \
+                    gcc-c++ \
+                    python \
+                    wget && \
+    yum --enablerepo=epel install  @^graphical-server-environment -y && \
+    yum --enablerepo=epel -y -x gnome-keyring --skip-broken install @xfce-desktop && \
+    yum -y groups install "Fonts" && \
+    yum erase -y *power* *screensaver* && \
+    yum clean all && \
+    rm -f /etc/xdg/autostart/xfce-polkit* && \
+    /bin/dbus-uuidgen > /etc/machine-id && \
+    yum install -y xfce4-xkb-plugin && \
+    wget -q "https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/nomachine/nomachine_${NOMACHINE_VERSION}_x86_64.rpm" -O nomachine.rpm && \
+    yum install -y nomachine.rpm && \
+    rm -f nomachine.rpm && \
+    sed -i '/DefaultDesktopCommand/c\DefaultDesktopCommand "/usr/bin/startxfce4"' /usr/NX/etc/node.cfg
+EOM
+
+    read -r -d '' NOMACHINE_CONFIG_CMD <<- EOM
+    sed -i 's@_XKB_PLUGIN_NAME_@xkb-plugin@g' /etc/nomachine/xfce/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml && \
+    sed -i 's@_XKB_PLUGIN_ID_@6@g' /etc/nomachine/xfce/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
+EOM
+    XKB_PLUGIN_ID=6
+else
+    export DEBIAN_FRONTEND=noninteractive
+    CHECK_NOMACHINE_INSTALLATION="dpkg -l | grep nomachine"
+    read -r -d '' NOMACHINE_INSTALL_CMD <<- EOM
+    apt-get update -y && \
+    apt-get install -y locales && \
+    locale-gen en_US.UTF-8 && \
+    locale-gen en_US && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=$LANG && \
+    apt-get install -y  g++ \
+                        python \
+                        wget \
+                        xfce4 \
+                        xfce4-xkb-plugin && \
+    wget -q "https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/nomachine/nomachine_${NOMACHINE_VERSION}_amd64.deb" -O nomachine.deb && \
+    dpkg -i nomachine.deb && \
+    rm -f nomachine.deb
+EOM
+
+    read -r -d '' NOMACHINE_CONFIG_CMD <<- EOM
+    if [[ "$(. /etc/os-release;echo $VERSION_ID)" == *"18."* ]]; then
+        sed -i 's@_XKB_PLUGIN_NAME_@xkb@g' /etc/nomachine/xfce/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml ;
+    else
+        sed -i 's@_XKB_PLUGIN_NAME_@xkb-plugin@g' /etc/nomachine/xfce/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml ;
+    fi
+    sed -i 's@_XKB_PLUGIN_ID_@9@g' /etc/nomachine/xfce/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
+EOM
+    XKB_PLUGIN_ID=9
+fi
+
+    read -r -d '' NOMACHINE_COMMON_CONFIG_CMD <<- EOM
+    curl https://bootstrap.pypa.io/get-pip.py | python - && \
+    wget -q "https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/nomachine/nomachine-common.tar.gz" -O nomachine-common.tar.gz && \
+    mkdir -p nomachine-common/ /etc/nomachine/ && \
+    tar -C nomachine-common/ -zxvf nomachine-common.tar.gz && \
+    g++ nomachine-common/scramble_alg.cpp -o /usr/local/bin/scramble && \
+    rm -f nomachine-common/scramble.cpp && \
+    cp -r nomachine-common/* /etc/nomachine/ && \
+    rm -f /etc/nomachine/xfce/.config/xfce4/panel/xkb-plugin-${XKB_PLUGIN_ID}.rc && \
+    mv /etc/nomachine/xfce/.config/xfce4/panel/xkb-plugin.rc /etc/nomachine/xfce/.config/xfce4/panel/xkb-plugin-${XKB_PLUGIN_ID}.rc && \
+    rm -rf nomachine-common*
+EOM
+
+eval "$CHECK_NOMACHINE_INSTALLATION"
+if [ $? -ne 0 ]
+then
+    pipe_log_info "--> NoMachine not found, proceeding with installation" "$NOMACHINE_INSTALL_TASK"
+    NOMACHINE_INSTALLATION_LOG="/var/log/nomachine_installation.log"
+    eval "$NOMACHINE_INSTALL_CMD" >> $NOMACHINE_INSTALLATION_LOG
+    if [ $? -ne 0 ]
+    then
+        pipe_log_fail "Failed to install NoMachine" "$NOMACHINE_INSTALL_TASK"
+        exit 1
+    else
+        pipe_log_info "--> NoMachine installed successfully" "$NOMACHINE_INSTALL_TASK"
+    fi
+    NOMACHINE_CONFIGURATION_LOG="/var/log/nomachine_configuration.log"
+    eval "$NOMACHINE_COMMON_CONFIG_CMD && $NOMACHINE_CONFIG_CMD" >> $NOMACHINE_CONFIGURATION_LOG
+    if [ $? -ne 0 ]
+    then
+        pipe_log_fail "Failed to configure NoMachine" "$NOMACHINE_INSTALL_TASK"
+        exit 1
+    else
+        pipe_log_info "--> NoMachine configured successfully" "$NOMACHINE_INSTALL_TASK"
+    fi
+else
+    pipe_log_info "--> NoMachine installed already" "$NOMACHINE_INSTALL_TASK"
+fi
+
+bash /etc/nomachine/nomachine_launcher.sh &
+pipe_log_success "Finished NoMachine initialization" "$NOMACHINE_INSTALL_TASK"

--- a/workflows/pipe-common/shell/nomachine_setup
+++ b/workflows/pipe-common/shell/nomachine_setup
@@ -15,6 +15,7 @@
 
 NOMACHINE_INSTALL_TASK="NoMachineInitialization"
 NOMACHINE_VERSION="${CP_CAP_NM_DEFAULT_VERSION:-6.5.6_9}"
+OS_VERSION=$(. /etc/os-release;echo $ID-${VERSION_ID//.})
 
 # Check if required proxy settings are correct
 export CP_NM_PROXY_HOST="${CP_NM_PROXY_HOST:-$(echo $CP_CAP_NM_PROXY_HOST)}"
@@ -51,18 +52,15 @@ EOM
 EOM
 
     read -r -d '' NOMACHINE_INSTALL_CMD <<- EOM
-    yum -y install epel-release && \
-    yum update -y && \
     yum install -y  lsof \
-                    python \
                     wget && \
-    yum --enablerepo=epel -y -x gnome-keyring --skip-broken install @xfce-desktop && \
-    yum -y groups install "Fonts" && \
-    yum erase -y *power* *screensaver* && \
-    yum clean all && \
+    wget -q "https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/nomachine/xfce4-$OS_VERSION.tar.gz" -O xfcedesktop.tar.gz && \
+    mkdir -p xfcedesktop && \
+    tar -xzvf xfcedesktop.tar.gz -C xfcedesktop && \
+    yum install -y --nogpgcheck xfcedesktop/*.rpm && \
+    rm -rf xfcedesktop* && \
     rm -f /etc/xdg/autostart/xfce-polkit* && \
     /bin/dbus-uuidgen > /etc/machine-id && \
-    yum install -y xfce4-xkb-plugin && \
     wget -q "https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/nomachine/nomachine_${NOMACHINE_VERSION}_x86_64.rpm" -O nomachine.rpm && \
     yum install -y nomachine.rpm && \
     rm -f nomachine.rpm && \

--- a/workflows/pipe-common/shell/nomachine_setup
+++ b/workflows/pipe-common/shell/nomachine_setup
@@ -14,8 +14,7 @@
 # limitations under the License.
 
 NOMACHINE_INSTALL_TASK="NoMachineInitialization"
-NOMACHINE_VERSION="${CP_CAP_NM_DEFAULT_VERSION:-6.5.6_9}"
-OS_VERSION=$(. /etc/os-release;echo $ID-${VERSION_ID//.})
+NM_TARGET_VERSION="${CP_CAP_DESKTOP_NM_VERSION:-6.5.6-9}"
 
 # Check if required proxy settings are correct
 export CP_NM_PROXY_HOST="${CP_NM_PROXY_HOST:-$(echo $CP_CAP_NM_PROXY_HOST)}"
@@ -30,130 +29,162 @@ if [ -z $CP_NM_PROXY_PORT ]; then
     exit 1
 fi
 
-/usr/bin/rpm -q -f /usr/bin/rpm >/dev/null 2>&1
-IS_RPM_BASED=$?
+function install_prerequisites {
+  if [[ "$IS_RPM_BASED" = 0 ]]; then
+    yum install -y -q lsof wget
+  else
+    apt-get install -yq --no-upgrade lsof wget
+  fi
+}
 
-export LANG="en_US.UTF-8"
-export LANGUAGE=en_US
+function check_nm_installation {
+  if [[ "$IS_RPM_BASED" = 0 ]]; then
+    rpm -qa | grep nomachine
+  else
+    dpkg -l | grep nomachine
+  fi
+}
 
-if [[ "$IS_RPM_BASED" = 0 ]]; then
-    CHECK_NOMACHINE_INSTALLATION="rpm -qa | grep nomachine"
-    GET_INSTALLED_NOMACHINE_VERSION="rpm -qa nomachine | sed 's/^\(nomachine-\)*//' | sed 's/.x86_64$//'"
+function get_installed_nm_version {
+  if [[ "$IS_RPM_BASED" = 0 ]]; then
+    echo $(rpm -qa nomachine | sed 's/^\(nomachine-\)*//' | sed 's/.x86_64$//')
+  else
+    echo $(apt-cache show nomachine | grep ^Version | sed 's/^\(Version: \)*//')
+  fi
+}
 
-    read -r -d '' NOMACHINE_UPDATE_CMD <<- EOM
-    wget -q "https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/nomachine/nomachine_${NOMACHINE_VERSION}_x86_64.rpm" -O nomachine.rpm && \
+function update_nm {
+  nm_version=$1
+  if [[ "$IS_RPM_BASED" = 0 ]]; then
+    wget -q "https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/nomachine/nomachine_${nm_version}_x86_64.rpm" -O nomachine.rpm && \
     yum downgrade -y nomachine.rpm && \
     yum install -y nomachine.rpm && \
     rm -f nomachine.rpm
-EOM
+  else
+    wget -q "https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/nomachine/nomachine_${nm_version}_amd64.deb" -O nomachine.deb && \
+    dpkg -i nomachine.deb && \
+    rm -f nomachine.deb
+  fi
+}
 
-    read -r -d '' NOMACHINE_REMOVE_CMD <<- EOM
+function remove_nm {
+  is_rpm=$1
+  if [[ "$IS_RPM_BASED" = 0 ]]; then
     yum remove -y nomachine
-EOM
+  else
+    apt-get remove -y nomachine
+  fi
+}
 
-    read -r -d '' NOMACHINE_INSTALL_CMD <<- EOM
-    yum install -y  lsof \
-                    wget && \
-    wget -q "https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/nomachine/xfce4-$OS_VERSION.tar.gz" -O xfcedesktop.tar.gz && \
+function install_nm {
+  nm_version=$1
+  if [[ "$IS_RPM_BASED" = 0 ]]; then
+    os_ver=$(. /etc/os-release;echo $ID-${VERSION_ID//.})
+    wget -q "https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/nomachine/xfce4-$os_ver.tar.gz" -O xfcedesktop.tar.gz && \
     mkdir -p xfcedesktop && \
     tar -xzvf xfcedesktop.tar.gz -C xfcedesktop && \
     yum install -y --nogpgcheck xfcedesktop/*.rpm && \
     rm -rf xfcedesktop* && \
     rm -f /etc/xdg/autostart/xfce-polkit* && \
     /bin/dbus-uuidgen > /etc/machine-id && \
-    wget -q "https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/nomachine/nomachine_${NOMACHINE_VERSION}_x86_64.rpm" -O nomachine.rpm && \
+    wget -q "https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/nomachine/nomachine_${nm_version}_x86_64.rpm" -O nomachine.rpm && \
     yum install -y nomachine.rpm && \
     rm -f nomachine.rpm && \
     sed -i '/DefaultDesktopCommand/c\DefaultDesktopCommand "/usr/bin/startxfce4"' /usr/NX/etc/node.cfg
-EOM
-
-    XKB_PLUGIN_ID=6
-    read -r -d '' NOMACHINE_CONFIG_CMD <<- EOM
-    sed -i 's@_XKB_PLUGIN_NAME_@xkb-plugin@g' /etc/nomachine/xfce/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml && \
-    sed -i 's@_XKB_PLUGIN_ID_@'"$XKB_PLUGIN_ID"'@g' /etc/nomachine/xfce/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
-EOM
-
-    read -r -d '' EXTRA_PACKAGES_INSTALLATION_CMD <<- EOM
-    wget -q "https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm" -O /opt/google-chrome-stable_current_x86_64.rpm && \
-    yum install -y /opt/google-chrome-stable_current_*.rpm && \
-    rm -f /opt/google-chrome-stable_current_*.rpm
-EOM
-else
-    export DEBIAN_FRONTEND=noninteractive
-    CHECK_NOMACHINE_INSTALLATION="dpkg -l | grep nomachine"
-    GET_INSTALLED_NOMACHINE_VERSION="apt-cache show nomachine | grep ^Version | sed 's/^\(Version: \)*//' | sed 's/-/_/'"
-
-    read -r -d '' NOMACHINE_UPDATE_CMD <<- EOM
-    wget -q "https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/nomachine/nomachine_${NOMACHINE_VERSION}_amd64.deb" -O nomachine.deb && \
-    dpkg -i nomachine.deb && \
-    rm -f nomachine.deb
-EOM
-
-    read -r -d '' NOMACHINE_REMOVE_CMD <<- EOM
-    apt-get remove -y nomachine
-EOM
-
-    read -r -d '' NOMACHINE_INSTALL_CMD <<- EOM
+  else
     apt-get install -y --no-upgrade locales && \
     locale-gen en_US.UTF-8 && \
     locale-gen en_US && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=$LANG && \
-    apt-get install -y --no-upgrade \
-                        lsof \
-                        wget \
+    apt-get install -yq --no-upgrade \
                         xfce4 \
                         xfce4-xkb-plugin && \
-    wget -q "https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/nomachine/nomachine_${NOMACHINE_VERSION}_amd64.deb" -O nomachine.deb && \
+    wget -q "https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/nomachine/nomachine_${nm_version}_amd64.deb" -O nomachine.deb && \
     dpkg -i nomachine.deb && \
     rm -f nomachine.deb
-EOM
+  fi
+}
+
+function config_nm {
+  curl https://bootstrap.pypa.io/get-pip.py | python - && \
+  wget -q "https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/nomachine/nomachine-common.tar.gz" -O nomachine-common.tar.gz && \
+  mkdir -p nomachine-common/ /etc/nomachine/ && \
+  tar -C nomachine-common/ -zxvf nomachine-common.tar.gz && \
+  mv nomachine-common/create_chrome_launcher.sh /tmp/ && \
+  mv nomachine-common/scramble /usr/local/bin/ && \
+  cp -r nomachine-common/* /etc/nomachine/ && \
+  rm -f /etc/nomachine/xfce/.config/xfce4/panel/xkb-plugin-${XKB_PLUGIN_ID}.rc && \
+  mv /etc/nomachine/xfce/.config/xfce4/panel/xkb-plugin.rc /etc/nomachine/xfce/.config/xfce4/panel/xkb-plugin-${XKB_PLUGIN_ID}.rc && \
+  rm -rf nomachine-common* && \
+  cp /usr/NX/etc/server.cfg /usr/NX/etc/server.cfg.template
+  if [[ $? -ne 0 ]]; then
+    exit 1
+  fi
+
+  if [[ "$IS_RPM_BASED" = 0 ]]; then
+    XKB_PLUGIN_ID=6
+    sed -i 's@_XKB_PLUGIN_NAME_@xkb-plugin@g' /etc/nomachine/xfce/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml && \
+    sed -i 's@_XKB_PLUGIN_ID_@'"$XKB_PLUGIN_ID"'@g' /etc/nomachine/xfce/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
+  else
     XKB_PLUGIN_ID=9
-    read -r -d '' NOMACHINE_CONFIG_CMD <<- EOM
     if [[ "$(. /etc/os-release;echo $VERSION_ID)" == *"18."* ]]; then
         sed -i 's@_XKB_PLUGIN_NAME_@xkb@g' /etc/nomachine/xfce/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml ;
     else
-        sed -i 's@_XKB_PLUGIN_NAME_@xkb-plugin@g' /etc/nomachine/xfce/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml ;
+        sed -i 's@_XKB_PLUGIN_NAME_@xkb-plugin@g' /etc/nomachine/xfce/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml;
     fi
     sed -i 's@_XKB_PLUGIN_ID_@'"$XKB_PLUGIN_ID"'@g' /etc/nomachine/xfce/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
-EOM
+  fi
+}
 
-    read -r -d '' EXTRA_PACKAGES_INSTALLATION_CMD <<- EOM
+function install_nm_extras {
+  if [[ "$IS_RPM_BASED" = 0 ]]; then
+    wget -q "https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm" -O /opt/google-chrome-stable_current_x86_64.rpm && \
+    yum install -y /opt/google-chrome-stable_current_*.rpm && \
+    rm -f /opt/google-chrome-stable_current_*.rpm
+  else
     wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
     echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list && \
-    apt-get update && \
-    apt-get install -y google-chrome-stable
-EOM
+    apt-get update -y && \
+    apt-get install --no-upgrade -y google-chrome-stable
+  fi
+  if [[ $? -ne 0 ]]; then
+    exit 1
+  fi
+  mkdir -p /home/${OWNER}/Desktop/ && \
+  bash /tmp/create_chrome_launcher.sh && \
+  rm -f /tmp/create_chrome_launcher.sh
+}
+
+/usr/bin/rpm -q -f /usr/bin/rpm >/dev/null 2>&1
+IS_RPM_BASED=$?
+
+export LANG="en_US.UTF-8"
+export LANGUAGE=en_US
+if [[ "$IS_RPM_BASED" -ne 0 ]]; then
+    export DEBIAN_FRONTEND=noninteractive
 fi
 
-    read -r -d '' NOMACHINE_COMMON_CONFIG_CMD <<- EOM
-    curl https://bootstrap.pypa.io/get-pip.py | python - && \
-    wget -q "https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/nomachine/nomachine-common.tar.gz" -O nomachine-common.tar.gz && \
-    mkdir -p nomachine-common/ /etc/nomachine/ && \
-    tar -C nomachine-common/ -zxvf nomachine-common.tar.gz && \
-    mv nomachine-common/create_chrome_launcher.sh /tmp/ && \
-    mv nomachine-common/scramble /usr/local/bin/ && \
-    cp -r nomachine-common/* /etc/nomachine/ && \
-    rm -f /etc/nomachine/xfce/.config/xfce4/panel/xkb-plugin-${XKB_PLUGIN_ID}.rc && \
-    mv /etc/nomachine/xfce/.config/xfce4/panel/xkb-plugin.rc /etc/nomachine/xfce/.config/xfce4/panel/xkb-plugin-${XKB_PLUGIN_ID}.rc && \
-    rm -rf nomachine-common* && \
-    cp /usr/NX/etc/server.cfg /usr/NX/etc/server.cfg.template
-EOM
+install_prerequisites >/dev/null 2>&1
+if [[ $? -ne 0 ]]; then
+    pipe_log_fail "Unable to install prerequisites" "$NOMACHINE_INSTALL_TASK"
+    exit 1
+fi
 
-eval "$CHECK_NOMACHINE_INSTALLATION"
+check_nm_installation
 IS_NM_INSTALLED=$?
 if [ $IS_NM_INSTALLED -eq 0 ]; then
     NOMACHINE_REPAIR_LOG="/var/log/nomachine_repair.log"
-    NM_CURRENT_VERSION=$(eval "$GET_INSTALLED_NOMACHINE_VERSION")
-    if [ NM_CURRENT_VERSION == NOMACHINE_VERSION ]; then
+    NM_CURRENT_VERSION=$(get_installed_nm_version)
+    if [ "$NM_CURRENT_VERSION" == "$NM_TARGET_VERSION" ]; then
         pipe_log_info "--> NoMachine installed already" "$NOMACHINE_INSTALL_TASK"
     else
-        pipe_log_info "--> NoMachine installed, but version found [$NM_CURRENT_VERSION] differs from the target one [$NOMACHINE_VERSION]" "$NOMACHINE_INSTALL_TASK"
+        pipe_log_info "--> NoMachine installed, but version found [$NM_CURRENT_VERSION] differs from the target one [$NM_TARGET_VERSION]" "$NOMACHINE_INSTALL_TASK"
         pipe_log_info "--> Trying to configure required version" "$NOMACHINE_INSTALL_TASK"
-        eval "$NOMACHINE_UPDATE_CMD" > $NOMACHINE_REPAIR_LOG 2>&1
+        update_nm $NM_TARGET_VERSION > $NOMACHINE_REPAIR_LOG 2>&1
         if [ $? -ne 0 ]; then
             pipe_log_warn "Failed to repair NoMachine version, details are available in $NOMACHINE_REPAIR_LOG, try removing current NM version" "$NOMACHINE_INSTALL_TASK"
-            eval "$NOMACHINE_REMOVE_CMD" >> $NOMACHINE_REPAIR_LOG 2>&1
+            remove_nm >> $NOMACHINE_REPAIR_LOG 2>&1
             if [ $? -ne 0 ]; then
                 pipe_log_fail "Failed to remove installed NoMachine, details are available in $NOMACHINE_REPAIR_LOG" "$NOMACHINE_INSTALL_TASK"
                 exit 1
@@ -170,7 +201,7 @@ fi
 NOMACHINE_INSTALLATION_LOG="/var/log/nomachine_installation.log"
 if [ $IS_NM_INSTALLED -ne 0 ]; then
     pipe_log_info "--> NoMachine is not detected, proceeding with the full installation" "$NOMACHINE_INSTALL_TASK"
-    eval "$NOMACHINE_INSTALL_CMD" > $NOMACHINE_INSTALLATION_LOG 2>&1
+    install_nm $NM_TARGET_VERSION > $NOMACHINE_INSTALLATION_LOG 2>&1
     if [ $? -ne 0 ]; then
         pipe_log_fail "Failed to install NoMachine, details are available in $NOMACHINE_INSTALLATION_LOG" "$NOMACHINE_INSTALL_TASK"
         exit 1
@@ -180,7 +211,7 @@ if [ $IS_NM_INSTALLED -ne 0 ]; then
 fi
 
 NOMACHINE_CONFIGURATION_LOG="/var/log/nomachine_configuration.log"
-eval "$NOMACHINE_COMMON_CONFIG_CMD && $NOMACHINE_CONFIG_CMD" > $NOMACHINE_CONFIGURATION_LOG 2>&1
+config_nm > $NOMACHINE_CONFIGURATION_LOG 2>&1
 if [ $? -ne 0 ]; then
     pipe_log_fail "Failed to configure NoMachine, details are available in $NOMACHINE_CONFIGURATION_LOG" "$NOMACHINE_INSTALL_TASK"
     exit 1
@@ -189,10 +220,7 @@ else
 fi
 
 NOMACHINE_EXTRAS_CONFIGURATION_LOG="/var/log/nomachine_extras_configuration.log"
-eval "$EXTRA_PACKAGES_INSTALLATION_CMD &&
-      mkdir -p /home/${OWNER}/Desktop/ &&
-      bash /tmp/create_chrome_launcher.sh &&
-      rm -f /tmp/create_chrome_launcher.sh" > $NOMACHINE_EXTRAS_CONFIGURATION_LOG 2>&1
+install_nm_extras > $NOMACHINE_EXTRAS_CONFIGURATION_LOG 2>&1
 if [ $? -ne 0 ]; then
     pipe_log_warn "Error during NoMachine extras configuration, details are available in $NOMACHINE_EXTRAS_CONFIGURATION_LOG" "$NOMACHINE_INSTALL_TASK"
 else

--- a/workflows/pipe-common/shell/nomachine_setup
+++ b/workflows/pipe-common/shell/nomachine_setup
@@ -14,13 +14,13 @@
 # limitations under the License.
 
 # Check if required proxy settings are correct
-export CP_NM_PROXY_HOST="${CP_CAP_NM_PROXY_HOST:-$(echo $CP_NM_PROXY_HOST)}"
+export CP_NM_PROXY_HOST="${CP_NM_PROXY_HOST:-$(echo $CP_CAP_NM_PROXY_HOST)}"
 if [ -z $CP_NM_PROXY_HOST ]; then
     pipe_log_fail "NoMachine proxy host is not set (CP_NM_PROXY_HOST). Exiting..."
     exit 1
 fi
 
-export CP_NM_PROXY_PORT="${CP_CAP_NM_PROXY_PORT:-$(echo CP_NM_PROXY_PORT)}"
+export CP_NM_PROXY_PORT="${CP_NM_PROXY_PORT:-$(echo $CP_CAP_NM_PROXY_PORT)}"
 if [ -z $CP_NM_PROXY_PORT ]; then
     pipe_log_fail "NoMachine proxy port is not set (CP_NM_PROXY_PORT). Exiting..."
     exit 1
@@ -148,22 +148,22 @@ fi
     cp /usr/NX/etc/server.cfg /usr/NX/etc/server.cfg.template
 EOM
 
-NOMACHINE_INSTALLATION_LOG="/var/log/nomachine_installation.log"
 eval "$CHECK_NOMACHINE_INSTALLATION"
 IS_NM_INSTALLED=$?
 if [ $IS_NM_INSTALLED -eq 0 ]; then
+    NOMACHINE_REPAIR_LOG="/var/log/nomachine_repair.log"
     NM_CURRENT_VERSION=$(eval "$GET_INSTALLED_NOMACHINE_VERSION")
     if [ NM_CURRENT_VERSION == NOMACHINE_VERSION ]; then
         pipe_log_info "--> NoMachine installed already" "$NOMACHINE_INSTALL_TASK"
     else
         pipe_log_info "--> NoMachine installed, but version found [$NM_CURRENT_VERSION] differs from the target one [$NOMACHINE_VERSION]" "$NOMACHINE_INSTALL_TASK"
         pipe_log_info "--> Trying to configure required version" "$NOMACHINE_INSTALL_TASK"
-        eval "$NOMACHINE_UPDATE_CMD" > $NOMACHINE_INSTALLATION_LOG 2>&1
+        eval "$NOMACHINE_UPDATE_CMD" > $NOMACHINE_REPAIR_LOG 2>&1
         if [ $? -ne 0 ]; then
-            pipe_log_warn "Failed to repair NoMachine version, try removing it" "$NOMACHINE_INSTALL_TASK"
-            eval "$NOMACHINE_REMOVE_CMD"
+            pipe_log_warn "Failed to repair NoMachine version, details are available in $NOMACHINE_REPAIR_LOG, try removing current NM version" "$NOMACHINE_INSTALL_TASK"
+            eval "$NOMACHINE_REMOVE_CMD" >> $NOMACHINE_REPAIR_LOG 2>&1
             if [ $? -ne 0 ]; then
-                pipe_log_fail "Failed to remove installed NoMachine" "$NOMACHINE_INSTALL_TASK"
+                pipe_log_fail "Failed to remove installed NoMachine, details are available in $NOMACHINE_REPAIR_LOG" "$NOMACHINE_INSTALL_TASK"
                 exit 1
             else
                 pipe_log_info "--> NoMachine removed successfully" "$NOMACHINE_INSTALL_TASK"
@@ -175,11 +175,12 @@ if [ $IS_NM_INSTALLED -eq 0 ]; then
     fi
 fi
 
+NOMACHINE_INSTALLATION_LOG="/var/log/nomachine_installation.log"
 if [ $IS_NM_INSTALLED -ne 0 ]; then
     pipe_log_info "--> NoMachine is not detected, proceeding with the full installation" "$NOMACHINE_INSTALL_TASK"
     eval "$NOMACHINE_INSTALL_CMD" > $NOMACHINE_INSTALLATION_LOG 2>&1
     if [ $? -ne 0 ]; then
-        pipe_log_fail "Failed to install NoMachine" "$NOMACHINE_INSTALL_TASK"
+        pipe_log_fail "Failed to install NoMachine, details are available in $NOMACHINE_INSTALLATION_LOG" "$NOMACHINE_INSTALL_TASK"
         exit 1
     else
         pipe_log_info "--> NoMachine installed successfully" "$NOMACHINE_INSTALL_TASK"
@@ -189,7 +190,7 @@ fi
 NOMACHINE_CONFIGURATION_LOG="/var/log/nomachine_configuration.log"
 eval "$NOMACHINE_COMMON_CONFIG_CMD && $NOMACHINE_CONFIG_CMD" > $NOMACHINE_CONFIGURATION_LOG 2>&1
 if [ $? -ne 0 ]; then
-    pipe_log_fail "Failed to configure NoMachine" "$NOMACHINE_INSTALL_TASK"
+    pipe_log_fail "Failed to configure NoMachine, details are available in $NOMACHINE_CONFIGURATION_LOG" "$NOMACHINE_INSTALL_TASK"
     exit 1
 else
     pipe_log_info "--> NoMachine configured successfully" "$NOMACHINE_INSTALL_TASK"
@@ -201,7 +202,7 @@ eval "$EXTRA_PACKAGES_INSTALLATION_CMD &&
       bash /tmp/create_chrome_launcher.sh &&
       rm -f /tmp/create_chrome_launcher.sh" > $NOMACHINE_EXTRAS_CONFIGURATION_LOG 2>&1
 if [ $? -ne 0 ]; then
-    pipe_log_warn "Error during NoMachine extras configuration" "$NOMACHINE_INSTALL_TASK"
+    pipe_log_warn "Error during NoMachine extras configuration, details are available in $NOMACHINE_EXTRAS_CONFIGURATION_LOG" "$NOMACHINE_INSTALL_TASK"
 else
     pipe_log_info "--> NoMachine extras configured successfully" "$NOMACHINE_INSTALL_TASK"
 fi
@@ -209,7 +210,7 @@ fi
 NOMACHINE_EXECUTION_LOG="/var/log/nomachine_execution.log"
 bash /etc/nomachine/nomachine_launcher.sh > $NOMACHINE_EXECUTION_LOG 2>&1 &
 if [ $? -ne 0 ]; then
-    pipe_log_fail "Failed to start NoMachine" "$NOMACHINE_INSTALL_TASK"
+    pipe_log_fail "Failed to start NoMachine, details are available in $NOMACHINE_EXECUTION_LOG" "$NOMACHINE_INSTALL_TASK"
     exit 1
 else
     sleep 5


### PR DESCRIPTION
This PR is related to issue #1245

It brings changes to `launch.sh` and allows enabling NoMachine to run via `CP_CAP_DESKTOP_NM` system parameter

- NoMachine section is added to `launch.sh`
- All of the operations regarding NoMachine handling are stored in `nomachine_setup` file