### PR TITLE
Issue #1259 Acces to billing for a general user 

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
@@ -213,7 +213,6 @@ public class BillingManager {
         final PipelineUser authorizedUser = authManager.getCurrentUser();
         if (!hasFullBillingAccess(authorizedUser)) {
             filters.put("owner", Collections.singletonList(authorizedUser.getUserName()));
-            filters.put("groups", authorizedUser.getGroups());
         }
     }
 


### PR DESCRIPTION
This PR is related to issue #1259

It changes the way of processing billing requests of regular users (not an admin, no `ROLE_BILLING_MANAGER` assigned: only his/her own spending is shown.