### PR TITLE
issue 1289 install lustre only for AWS runs

### DIFF
--- a/workflows/pipe-common/shell/install_nfs_client
+++ b/workflows/pipe-common/shell/install_nfs_client
@@ -84,7 +84,7 @@ else
     else
         pipe_log_info "--> NFS client [nfs, smb] installed already" "$NFS_INSTALL_TASK"
     fi
-    if [ $IS_LUSTRE_INSTALLED -ne 0 ]
+    if [ $IS_LUSTRE_INSTALLED -ne 0 ] && [ "${CLOUD_PROVIDER}" == "AWS" ]
     then
         pipe_log_info "--> Installing [lustre] client" "$NFS_INSTALL_TASK"
         LUSTRE_INSTALLATION_LOG="/var/log/lustre_client_installation.log"


### PR DESCRIPTION
This PR change behavior of install_nfs_client script and installs lustre cluent only if run is AWS run
related to #1289 