### PR TITLE
issue 1290 check that power state exists for azure vm

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzureVMService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzureVMService.java
@@ -96,7 +96,7 @@ public class AzureVMService {
     public AzureVirtualMachineStats getRunningVMByRunId(final AzureRegion region, final String tagValue) {
         final AzureVirtualMachineStats virtualMachine = getVMStatsByTag(region, tagValue);
         final PowerState powerState = virtualMachine.getPowerState();
-        if (powerState != null && !powerState.equals(PowerState.RUNNING) && !powerState.equals(PowerState.STARTING)) {
+        if (powerState == null || (!powerState.equals(PowerState.RUNNING) && !powerState.equals(PowerState.STARTING))) {
             throw new AzureException(messageHelper.getMessage(
                     MessageConstants.ERROR_AZURE_INSTANCE_NOT_RUNNING, tagValue, powerState));
         }

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzureVMService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzureVMService.java
@@ -96,7 +96,7 @@ public class AzureVMService {
     public AzureVirtualMachineStats getRunningVMByRunId(final AzureRegion region, final String tagValue) {
         final AzureVirtualMachineStats virtualMachine = getVMStatsByTag(region, tagValue);
         final PowerState powerState = virtualMachine.getPowerState();
-        if (!powerState.equals(PowerState.RUNNING) && !powerState.equals(PowerState.STARTING)) {
+        if (powerState != null && !powerState.equals(PowerState.RUNNING) && !powerState.equals(PowerState.STARTING)) {
             throw new AzureException(messageHelper.getMessage(
                     MessageConstants.ERROR_AZURE_INSTANCE_NOT_RUNNING, tagValue, powerState));
         }


### PR DESCRIPTION
This PR check that powerstate for an AZ VM view exists before using it.
In case if this state doesn't exist it will behave like this VM has wrong state