### PR TITLE
Issue #1276 Add "max" data series to the resource monitoring 

### DIFF
--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/AbstractMetricRequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/AbstractMetricRequester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/CPURequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/CPURequester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/CPURequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/CPURequester.java
@@ -65,12 +65,15 @@ public class CPURequester extends AbstractMetricRequester {
                         .aggregation(AggregationBuilders.terms(AGGREGATION_NODE_NAME)
                                 .field(path(FIELD_METRICS_TAGS, FIELD_NODENAME_RAW))
                                 .size(resourceIds.size())
+                                .subAggregation(max(MAX_AGGREGATION + USAGE_RATE, USAGE_RATE))
                                 .subAggregation(average(AVG_AGGREGATION + USAGE_RATE, USAGE_RATE))));
     }
 
     @Override
     public Map<String, Double> parseResponse(final SearchResponse response) {
-        return collectAggregation(response, AGGREGATION_NODE_NAME, AVG_AGGREGATION + USAGE_RATE);
+        return collectAggregation(response, AGGREGATION_NODE_NAME,
+                                  AVG_AGGREGATION + USAGE_RATE,
+                                  MAX_AGGREGATION + USAGE_RATE);
     }
 
     @Override
@@ -82,6 +85,7 @@ public class CPURequester extends AbstractMetricRequester {
                         .size(0)
                         .aggregation(dateHistogram(CPU_HISTOGRAM, interval)
                                 .subAggregation(average(AVG_AGGREGATION + CPU_UTILIZATION, NODE_UTILIZATION))
+                                .subAggregation(max(MAX_AGGREGATION + CPU_UTILIZATION, NODE_UTILIZATION))
                                 .subAggregation(average(AVG_AGGREGATION + CPU_CAPACITY, NODE_CAPACITY))));
     }
 
@@ -111,15 +115,23 @@ public class CPURequester extends AbstractMetricRequester {
                 // Elastic CPU capacity is a number of cores times 1000. Therefore last three digits can be omitted.
                 .map(it -> it.substring(0, it.length() - 3))
                 .map(Integer::valueOf);
-        final Optional<Double> utilization = doubleValue(aggregations, AVG_AGGREGATION + CPU_UTILIZATION)
-                // Elastic CPU utilization is a share. Therefore it should be multiplied by number of cores.
-                .flatMap(u -> capacity.map(c -> Math.min(u * c, c)));
+        final Optional<Double> avgUtilization = getCpuUtilization(AVG_AGGREGATION, aggregations, capacity);
+        final Optional<Double> maxUtilization = getCpuUtilization(MAX_AGGREGATION, aggregations, capacity);
         final MonitoringStats.CPUUsage cpuUsage = new MonitoringStats.CPUUsage();
-        utilization.ifPresent(cpuUsage::setLoad);
+        avgUtilization.ifPresent(cpuUsage::setLoad);
+        maxUtilization.ifPresent(cpuUsage::setMax);
         monitoringStats.setCpuUsage(cpuUsage);
         final MonitoringStats.ContainerSpec containerSpec = new MonitoringStats.ContainerSpec();
         capacity.ifPresent(containerSpec::setNumberOfCores);
         monitoringStats.setContainerSpec(containerSpec);
         return monitoringStats;
+    }
+
+    private Optional<Double> getCpuUtilization(final String aggregationPrefix,
+                                               final List<Aggregation> aggregations,
+                                               final Optional<Integer> capacity) {
+        return doubleValue(aggregations, aggregationPrefix + CPU_UTILIZATION)
+                // Elastic CPU utilization is a share. Therefore it should be multiplied by number of cores.
+                .flatMap(u -> capacity.map(c -> Math.min(u * c, c)));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/MemoryRequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/MemoryRequester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/com/epam/pipeline/entity/cluster/monitoring/MonitoringStats.java
+++ b/api/src/main/java/com/epam/pipeline/entity/cluster/monitoring/MonitoringStats.java
@@ -42,6 +42,7 @@ public class MonitoringStats {
     @Getter
     public static class CPUUsage {
         private double load;
+        private double max;
     }
 
 
@@ -50,6 +51,7 @@ public class MonitoringStats {
     public static class MemoryUsage {
         private long capacity;
         private long usage;
+        private long max;
     }
 
     @Setter

--- a/api/src/main/java/com/epam/pipeline/entity/cluster/monitoring/MonitoringStats.java
+++ b/api/src/main/java/com/epam/pipeline/entity/cluster/monitoring/MonitoringStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/writer/MonitoringStatsWriter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/writer/MonitoringStatsWriter.java
@@ -36,7 +36,8 @@ import java.util.stream.IntStream;
 public class MonitoringStatsWriter {
 
     private static final List<String> COMMON_STATS_HEADER =
-        Arrays.asList("Timestamp", "CPU_cores", "CPU_usage[%]", "MEM_capacity[bytes]", "MEM_usage[%]");
+        Arrays.asList("Timestamp", "CPU_cores", "CPU_usage_avg[%]", "CPU_usage_max[%]",
+                      "MEM_capacity[bytes]", "MEM_usage_avg[%]", "MEM_usage_max[%]");
     private static final String DISK_TOTAL_HEADER_TEMPLATE = "%s_total[bytes]";
     private static final String DISK_USAGE_HEADER_TEMPLATE = "%s_usage[%%]";
     private static final String NETWORK_USAGE_IN_HEADER_TEMPLATE = "%s_in[bytes]";
@@ -106,9 +107,11 @@ public class MonitoringStatsWriter {
         newLine.add(stat.getEndTime());
         newLine.add(Integer.toString(stat.getContainerSpec().getNumberOfCores()));
         newLine.add(Double.toString(HUNDRED_PERCENTS * stat.getCpuUsage().getLoad()));
+        newLine.add(Double.toString(HUNDRED_PERCENTS * stat.getCpuUsage().getMax()));
         final long memCapacity = stat.getMemoryUsage().getCapacity();
         newLine.add(Long.toString(memCapacity));
         newLine.add(Double.toString(HUNDRED_PERCENTS * stat.getMemoryUsage().getUsage() / memCapacity));
+        newLine.add(Double.toString(HUNDRED_PERCENTS * stat.getMemoryUsage().getMax() / memCapacity));
     }
 
     private void fillDisksColumns(final MonitoringStats stat, final MonitoringStatsHeader header,


### PR DESCRIPTION
This PR is related to issue #1276

Utilization stats are expanded with the new `max` data-series, which is representing the highest value of CPU and memory consumption. 