### PR TITLE
Issue #1278 Expand details for storage billing response

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/billing/UserBillingDetailsLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/UserBillingDetailsLoader.java
@@ -60,14 +60,7 @@ public class UserBillingDetailsLoader implements EntityBillingDetailsLoader {
         final Map<String, String> details = new HashMap<>();
         final PipelineUser user = userManager.loadUserByName(entityIdentifier);
         if (user != null) {
-            final String billingCenter = Optional.ofNullable(
-                    metadataManager.loadMetadataItem(user.getId(), AclClass.PIPELINE_USER))
-                    .map(MetadataEntry::getData)
-                    .filter(MapUtils::isNotEmpty)
-                    .flatMap(attributes -> Optional.ofNullable(attributes.get(billingCenterKey)))
-                    .flatMap(value -> Optional.ofNullable(value.getValue()))
-                    .orElse(emptyValue);
-            details.put(BillingGrouping.BILLING_CENTER.getCorrespondingField(), billingCenter);
+            details.put(BillingGrouping.BILLING_CENTER.getCorrespondingField(), getUserBillingCenter(user));
         } else {
             details.putAll(getEmptyDetails());
         }
@@ -77,5 +70,20 @@ public class UserBillingDetailsLoader implements EntityBillingDetailsLoader {
     @Override
     public Map<String, String> getEmptyDetails() {
         return Collections.singletonMap(BillingGrouping.BILLING_CENTER.getCorrespondingField(), emptyValue);
+    }
+
+    String getUserBillingCenter(final String username) {
+        return Optional.ofNullable(userManager.loadUserByName(username))
+            .map(this::getUserBillingCenter)
+            .orElse(emptyValue);
+    }
+
+    private String getUserBillingCenter(final PipelineUser user) {
+        return Optional.ofNullable(metadataManager.loadMetadataItem(user.getId(), AclClass.PIPELINE_USER))
+            .map(MetadataEntry::getData)
+            .filter(MapUtils::isNotEmpty)
+            .flatMap(attributes -> Optional.ofNullable(attributes.get(billingCenterKey)))
+            .flatMap(value -> Optional.ofNullable(value.getValue()))
+            .orElse(emptyValue);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/FileShareMountManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/FileShareMountManager.java
@@ -29,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class FileShareMountManager {
@@ -39,8 +40,11 @@ public class FileShareMountManager {
     private FileShareMountDao fileShareMountDao;
 
     public FileShareMount load(final Long id) {
-        return fileShareMountDao.loadById(id)
-                .orElseThrow(() -> new IllegalArgumentException("There is no FileShare mount with id:" + id));
+        return find(id).orElseThrow(() -> new IllegalArgumentException("There is no FileShare mount with id:" + id));
+    }
+
+    public Optional<FileShareMount> find(final Long id) {
+        return fileShareMountDao.loadById(id);
     }
 
     public List<FileShareMount> loadByRegionId(final Long regionId) {


### PR DESCRIPTION
This PR is related to issue #1278

It extends detailed response for storages: `billing_center` and `storage_type` are returned.