### PR TITLE
Use btrfs docker storage driver

### DIFF
--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/MonitoringESDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/MonitoringESDao.java
@@ -63,7 +63,6 @@ public class MonitoringESDao {
 
     public Map<String, Double> loadMetrics(final ELKUsageMetric metric, final Collection<String> resourceIds,
                                            final LocalDateTime from, final LocalDateTime to) {
-
         if (CollectionUtils.isEmpty(resourceIds)) {
             return Collections.emptyMap();
         }

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/AbstractMetricRequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/AbstractMetricRequester.java
@@ -106,6 +106,7 @@ public abstract class AbstractMetricRequester implements MetricRequester, Monito
     protected static final String AGGREGATION_DISK_NAME = "disk_name";
 
     protected static final String SYNTHETIC_NETWORK_INTERFACE = "summary";
+    protected static final String SWAP_FILESYSTEM = "tmpfs";
 
     private RestHighLevelClient client;
 

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/CPURequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/CPURequester.java
@@ -55,24 +55,22 @@ public class CPURequester extends AbstractMetricRequester {
         return request(from, to,
                 new SearchSourceBuilder()
                         .query(QueryBuilders.boolQuery()
-                                .filter(QueryBuilders.termsQuery(path(FIELD_METRICS_TAGS, FIELD_POD_NAME_RAW),
+                                .filter(QueryBuilders.termsQuery(path(FIELD_METRICS_TAGS, FIELD_NODENAME_RAW),
                                         resourceIds))
-                                .filter(QueryBuilders.termQuery(path(FIELD_METRICS_TAGS, FIELD_NAMESPACE_NAME),
-                                        DEFAULT))
-                                .filter(QueryBuilders.termQuery(path(FIELD_METRICS_TAGS, FIELD_TYPE), POD_CONTAINER))
+                                .filter(QueryBuilders.termQuery(path(FIELD_METRICS_TAGS, FIELD_TYPE), NODE))
                                 .filter(QueryBuilders.rangeQuery(metric().getTimestamp())
                                         .from(from.toInstant(ZoneOffset.UTC).toEpochMilli())
                                         .to(to.toInstant(ZoneOffset.UTC).toEpochMilli())))
                         .size(0)
-                        .aggregation(AggregationBuilders.terms(AGGREGATION_POD_NAME)
-                                .field(path(FIELD_METRICS_TAGS, FIELD_POD_NAME_RAW))
+                        .aggregation(AggregationBuilders.terms(AGGREGATION_NODE_NAME)
+                                .field(path(FIELD_METRICS_TAGS, FIELD_NODENAME_RAW))
                                 .size(resourceIds.size())
                                 .subAggregation(average(AVG_AGGREGATION + USAGE_RATE, USAGE_RATE))));
     }
 
     @Override
     public Map<String, Double> parseResponse(final SearchResponse response) {
-        return collectAggregation(response, AGGREGATION_POD_NAME, AVG_AGGREGATION + USAGE_RATE);
+        return collectAggregation(response, AGGREGATION_NODE_NAME, AVG_AGGREGATION + USAGE_RATE);
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/FSRequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/FSRequester.java
@@ -78,12 +78,12 @@ public class FSRequester extends AbstractMetricRequester {
     public Map<String, Double> parseResponse(final SearchResponse response) {
         return ((Terms) response.getAggregations().get(AGGREGATION_NODE_NAME)).getBuckets().stream().collect(
                 Collectors.toMap(MultiBucketsAggregation.Bucket::getKeyAsString,
-                        b -> ((Terms) b.getAggregations().get(AGGREGATION_DISK_NAME)).getBuckets().stream()
-                                .filter(diskBucket -> !SWAP_FILESYSTEM.equalsIgnoreCase(diskBucket.getKeyAsString()))
-                                .map(this::toUsageAndLimit)
-                                .collect(Collectors.collectingAndThen(
-                                        Collectors.reducing(Pair.of(0d, 0d), this::toMergedUsageAndLimit),
-                                        this::toUsageRate))));
+                    b -> ((Terms) b.getAggregations().get(AGGREGATION_DISK_NAME)).getBuckets().stream()
+                            .filter(diskBucket -> !SWAP_FILESYSTEM.equalsIgnoreCase(diskBucket.getKeyAsString()))
+                            .map(this::toUsageAndLimit)
+                            .collect(Collectors.collectingAndThen(
+                                    Collectors.reducing(Pair.of(0d, 0d), this::toMergedUsageAndLimit),
+                                    this::toUsageRate))));
     }
 
     private Pair<Double, Double> toUsageAndLimit(final Terms.Bucket diskBucket) {

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/PodFSRequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/PodFSRequester.java
@@ -37,6 +37,11 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/**
+ * Pod file system requester.
+ * 
+ * Doesn't work with btrfs file system docker driver because cAdvisor stops reporting pod container file system stats.
+ */
 public class PodFSRequester extends FSRequester {
 
     public static final String FILESYSTEM = "filesystem";
@@ -61,7 +66,6 @@ public class PodFSRequester extends FSRequester {
                                       final LocalDateTime from,
                                       final LocalDateTime to,
                                       final Map <String, String> additional) {
-
         throw new UnsupportedOperationException();
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/CAdvisorMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/CAdvisorMonitoringManager.java
@@ -123,9 +123,9 @@ public class CAdvisorMonitoringManager implements UsageMonitoringManager {
     }
 
     @Override
-    public long getPodDiskSpaceAvailable(final String nodeName,
-                                         final String podId,
-                                         final String dockerImage) {
+    public long getDiskSpaceAvailable(final String nodeName,
+                                      final String podId,
+                                      final String dockerImage) {
         final String dockerDiskName = getDockerDiskName(nodeName, podId, dockerImage);
         final MonitoringStats monitoringStats = getLastMonitoringStat(getStatsForNode(nodeName), nodeName);
         final MonitoringStats.DisksUsage.DiskStats diskStats = monitoringStats.getDisksUsage()

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ESMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ESMonitoringManager.java
@@ -226,11 +226,6 @@ public class ESMonitoringManager implements UsageMonitoringManager {
         return LocalDateTime.parse(dateTimeString, MonitoringConstants.FORMATTER);
     }
 
-    private LocalDateTime asDateTime(final String dateTimeString) {
-        return LocalDateTime.parse(dateTimeString, MonitoringConstants.DATE_TIME_FORMATTER);
-    }
-
-
     private Optional<MonitoringStats> statsWithinRegion(final MonitoringStats stats, final LocalDateTime regionStart,
                                               final LocalDateTime regionEnd, final Duration interval) {
         final LocalDateTime intervalStart = asMonitoringDateTime(stats.getStartTime());

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ESMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ESMonitoringManager.java
@@ -42,6 +42,7 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -56,7 +57,8 @@ public class ESMonitoringManager implements UsageMonitoringManager {
     private static final Duration FALLBACK_MONITORING_PERIOD = Duration.ofHours(1);
     private static final Duration FALLBACK_MINIMAL_INTERVAL = Duration.ofMinutes(1);
     private static final int FALLBACK_INTERVALS_NUMBER = 10;
-    public static final int TWO = 2;
+    private static final int TWO = 2;
+    private static final String SWAP_FILESYSTEM = "tmpfs";
 
     private final RestHighLevelClient client;
     private final MonitoringESDao monitoringDao;
@@ -101,27 +103,31 @@ public class ESMonitoringManager implements UsageMonitoringManager {
     }
 
     @Override
-    public long getPodDiskSpaceAvailable(final String nodeName, final String podId, final String dockerImage) {
+    public long getDiskSpaceAvailable(final String nodeName, final String podId, final String dockerImage) {
         final Duration duration = minimalDuration();
         final MonitoringStats.DisksUsage.DiskStats diskStats =
-                AbstractMetricRequester.getStatsRequester(ELKUsageMetric.POD_FS, client)
+                AbstractMetricRequester.getStatsRequester(ELKUsageMetric.FS, client)
                         .requestStats(nodeName,
                                 DateUtils.nowUTC().minus(duration.multipliedBy(Math.max(numberOfIntervals(), TWO))),
                                 DateUtils.nowUTC(),
                                 duration
                         )
                         .stream()
+                        .collect(Collectors.groupingBy(MonitoringStats::getStartTime,
+                                Collectors.reducing(this::mergeStats)))
+                        .values()
+                        .stream()
+                        .filter(Optional::isPresent)
+                        .map(Optional::get)
                         .max(Comparator.comparing(MonitoringStats::getStartTime,
-                                Comparator.comparing(this::asDateTime)))
+                                Comparator.comparing(this::asMonitoringDateTime)))
                         .map(MonitoringStats::getDisksUsage)
                         .map(MonitoringStats.DisksUsage::getStatsByDevices)
-                        //get disks stats (in fact here only one stats for one disk)
                         .orElse(Collections.emptyMap())
-                        .values().stream()
-                        //get stats for the only Pod disk
-                        .findFirst()
-                        .orElseThrow(() -> new IllegalArgumentException(messageHelper.getMessage(
-                                MessageConstants.ERROR_GET_NODE_STAT, nodeName)));
+                        .entrySet().stream()
+                        .filter(it -> !SWAP_FILESYSTEM.equalsIgnoreCase(it.getKey()))
+                        .map(Map.Entry::getValue)
+                        .reduce(new MonitoringStats.DisksUsage.DiskStats(), this::merged);
         return diskStats.getCapacity() - diskStats.getUsableSpace();
     }
 
@@ -239,5 +245,13 @@ public class ESMonitoringManager implements UsageMonitoringManager {
         stats.setEndTime(MonitoringConstants.FORMATTER.format(end));
         stats.setMillsInPeriod(actualInterval.toMillis());
         return Optional.of(stats);
+    }
+
+    private MonitoringStats.DisksUsage.DiskStats merged(final MonitoringStats.DisksUsage.DiskStats s1,
+                                                        final MonitoringStats.DisksUsage.DiskStats s2) {
+        final MonitoringStats.DisksUsage.DiskStats s3 = new MonitoringStats.DisksUsage.DiskStats();
+        s3.setCapacity(s1.getCapacity() + s2.getCapacity());
+        s3.setUsableSpace(s1.getUsableSpace() + s2.getUsableSpace());
+        return s3;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/UsageMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/UsageMonitoringManager.java
@@ -66,15 +66,15 @@ public interface UsageMonitoringManager {
                                              Duration interval);
 
     /**
-     * Retrieves number of bytes that available on a pod disk .
+     * Retrieves number of bytes that available on a pod or node disk.
      *
      * @param nodeName Cluster node name.
      * @param podId
      * @param dockerImage of the container of the pod.
      * @return available bytes amount.
      */
-    long getPodDiskSpaceAvailable(String nodeName,
-                                  String podId,
-                                  String dockerImage);
+    long getDiskSpaceAvailable(String nodeName,
+                               String podId,
+                               String dockerImage);
 
 }

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -1031,7 +1031,7 @@ public class PipelineRunManager {
         final PipelineRun pipelineRun = pipelineRunDao.loadPipelineRun(runId);
         Assert.notNull(pipelineRun,
                 messageHelper.getMessage(MessageConstants.ERROR_RUN_PIPELINES_NOT_FOUND, runId));
-        final long availableDisk = usageMonitoringManager.getPodDiskSpaceAvailable(
+        final long availableDisk = usageMonitoringManager.getDiskSpaceAvailable(
                 pipelineRun.getInstance().getNodeName(), pipelineRun.getPodId(), pipelineRun.getDockerImage());
         final long requiredImageSize = (long)Math.ceil(
                 (double)toolManager.getCurrentImageSize(pipelineRun.getDockerImage())

--- a/api/src/test/java/com/epam/pipeline/dao/monitoring/MonitoringESDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/monitoring/MonitoringESDaoTest.java
@@ -47,8 +47,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class MonitoringESDaoTest {
     private static Node node = null;
-    private static final String POD1_NAME = "pod1";
-    private static final String POD2_NAME = "pod2";
+    private static final String NODE1_NAME = "node1";
+    private static final String NODE2_NAME = "node2";
     private static final String HEAPSTER_TOKEN = "heapster-";
     private static final String CPU_TYPE = "cpu";
     private static final int HALF_AN_HOUR = 30;
@@ -101,9 +101,8 @@ public class MonitoringESDaoTest {
         record1.put("Metrics", metrics);
 
         Map<String, Object> metricsTags = new HashMap<>();
-        metricsTags.put("pod_name", POD1_NAME);
-        metricsTags.put("type", "pod_container");
-        metricsTags.put("namespace_name", "default");
+        metricsTags.put("nodename", NODE1_NAME);
+        metricsTags.put("type", "node");
         record1.put("MetricsTags", metricsTags);
 
         client.prepareIndex(indexName, CPU_TYPE).setSource(record1).get();
@@ -115,11 +114,11 @@ public class MonitoringESDaoTest {
         client.prepareIndex(indexName, CPU_TYPE).setSource(record2).get();
 
         Map<String, Object> record3 = new HashMap<>(record1);
-        ((Map<String, Object>) record3.get("MetricsTags")).put("pod_name", POD2_NAME);
+        ((Map<String, Object>) record3.get("MetricsTags")).put("nodename", NODE2_NAME);
         client.prepareIndex(indexName, CPU_TYPE).setSource(record3).get();
 
         Map<String, Object> record4 = new HashMap<>(record2);
-        ((Map<String, Object>) record4.get("MetricsTags")).put("pod_name", POD2_NAME);
+        ((Map<String, Object>) record4.get("MetricsTags")).put("nodename", NODE2_NAME);
         ((Map<String, Object>) record4.get("Metrics")).put("cpu/usage_rate", Collections.singletonMap("value", 4));
         client.prepareIndex(indexName, CPU_TYPE).setSource(record4).get();
 
@@ -162,11 +161,11 @@ public class MonitoringESDaoTest {
     @Test
     public void testLoadCpuUsageRateMetrics() {
         Map<String, Double> stats = monitoringESDao.loadMetrics(ELKUsageMetric.CPU,
-                Arrays.asList(POD1_NAME, POD2_NAME), NOW.minusMinutes(HALF_AN_HOUR), NOW);
+                Arrays.asList(NODE1_NAME, NODE2_NAME), NOW.minusMinutes(HALF_AN_HOUR), NOW);
 
         Assert.assertEquals(2, stats.size());
-        Assert.assertEquals(3, stats.get(POD1_NAME), TEST_DELTA);
-        Assert.assertEquals(3, stats.get(POD2_NAME), TEST_DELTA);
+        Assert.assertEquals(3, stats.get(NODE1_NAME), TEST_DELTA);
+        Assert.assertEquals(3, stats.get(NODE2_NAME), TEST_DELTA);
     }
 
     @Test

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManagerTest.java
@@ -266,11 +266,11 @@ public class ResourceMonitoringManagerTest {
         highConsumingRun.setTags(stubTagMap);
 
         mockStats = new HashMap<>();
-        mockStats.put(okayRun.getPodId(), TEST_OK_RUN_CPU_LOAD); // in milicores, equals 80% of core load, per 2 cores,
+        mockStats.put(okayRun.getInstance().getNodeName(), TEST_OK_RUN_CPU_LOAD); // in milicores, equals 80% of core load, per 2 cores,
                                                                     // should be = 40% load
-        mockStats.put(idleSpotRun.getPodId(), TEST_IDLE_SPOT_RUN_CPU_LOAD);
-        mockStats.put(idleOnDemandRun.getPodId(), TEST_IDLE_ON_DEMAND_RUN_CPU_LOAD);
-        mockStats.put(autoscaleMasterRun.getPodId(), TEST_IDLE_ON_DEMAND_RUN_CPU_LOAD);
+        mockStats.put(idleSpotRun.getInstance().getNodeName(), TEST_IDLE_SPOT_RUN_CPU_LOAD);
+        mockStats.put(idleOnDemandRun.getInstance().getNodeName(), TEST_IDLE_ON_DEMAND_RUN_CPU_LOAD);
+        mockStats.put(autoscaleMasterRun.getInstance().getNodeName(), TEST_IDLE_ON_DEMAND_RUN_CPU_LOAD);
 
         when(monitoringESDao.loadMetrics(eq(ELKUsageMetric.CPU), any(), any(LocalDateTime.class),
                 any(LocalDateTime.class))).thenReturn(mockStats);
@@ -308,7 +308,7 @@ public class ResourceMonitoringManagerTest {
         Assert.assertEquals(2, runsToNotify.size());
         Assert.assertTrue(runsToNotify.stream().anyMatch(r -> r.getLeft().getPodId().equals(idleSpotRun.getPodId())));
         Assert.assertEquals(
-            mockStats.get(idleSpotRun.getPodId()) / MILICORES_TO_CORES / testType.getVCPU(),
+            mockStats.get(idleSpotRun.getInstance().getNodeName()) / MILICORES_TO_CORES / testType.getVCPU(),
             runsToNotify.stream()
                 .filter(r -> r.getLeft().getPodId().equals(idleSpotRun.getPodId()))
                 .findFirst().get().getRight(),
@@ -317,7 +317,7 @@ public class ResourceMonitoringManagerTest {
         Assert.assertTrue(runsToNotify.stream()
                 .anyMatch(r -> r.getLeft().getPodId().equals(idleOnDemandRun.getPodId())));
         Assert.assertEquals(
-            mockStats.get(idleOnDemandRun.getPodId()) / MILICORES_TO_CORES / testType.getVCPU(),
+            mockStats.get(idleOnDemandRun.getInstance().getNodeName()) / MILICORES_TO_CORES / testType.getVCPU(),
             runsToNotify.stream()
                 .filter(r -> r.getLeft().getPodId().equals(idleOnDemandRun.getPodId()))
                 .findFirst().get().getRight(),
@@ -332,7 +332,8 @@ public class ResourceMonitoringManagerTest {
         when(pipelineRunManager.loadPipelineRun(idleRunToProlong.getId())).thenReturn(idleRunToProlong);
         when(monitoringESDao.loadMetrics(eq(ELKUsageMetric.CPU), any(), any(LocalDateTime.class),
                 any(LocalDateTime.class)))
-                .thenReturn(Collections.singletonMap(idleRunToProlong.getPodId(), TEST_IDLE_ON_DEMAND_RUN_CPU_LOAD));
+                .thenReturn(Collections.singletonMap(idleRunToProlong.getInstance().getNodeName(), 
+                        TEST_IDLE_ON_DEMAND_RUN_CPU_LOAD));
         when(preferenceManager.getPreference(SystemPreferences.SYSTEM_IDLE_ACTION))
                 .thenReturn(IdleRunAction.NOTIFY.name());
 
@@ -543,7 +544,7 @@ public class ResourceMonitoringManagerTest {
             .thenReturn(IdleRunAction.STOP.name());
 
         mockAlreadyNotifiedRuns();
-        mockStats.put(idleSpotRun.getPodId(), NON_IDLE_CPU_LOAD); // mock not idle anymore
+        mockStats.put(idleSpotRun.getInstance().getNodeName(), NON_IDLE_CPU_LOAD); // mock not idle anymore
 
         Thread.sleep(10);
         idleSpotRun.setTags(new HashMap<>());

--- a/scripts/autoscaling/init_multicloud.sh
+++ b/scripts/autoscaling/init_multicloud.sh
@@ -125,7 +125,7 @@ if check_installed "nvidia-smi"; then
 cat <<EOT > /etc/docker/daemon.json
 {
   "data-root": "/ebs/docker",
-  "storage-driver": "overlay2",
+  "storage-driver": "btrfs",
   "max-concurrent-uploads": 1,
   "default-runtime": "nvidia",
    "runtimes": {
@@ -140,7 +140,7 @@ else
 cat <<EOT > /etc/docker/daemon.json
 {
   "data-root": "/ebs/docker",
-  "storage-driver": "overlay2",
+  "storage-driver": "btrfs",
   "max-concurrent-uploads": 1
 }
 EOT

--- a/scripts/autoscaling/init_multicloud_v1.15.4.sh
+++ b/scripts/autoscaling/init_multicloud_v1.15.4.sh
@@ -145,7 +145,7 @@ cat <<EOT > /etc/docker/daemon.json
 {
   "exec-opts": ["native.cgroupdriver=systemd"],
   "data-root": "/ebs/docker",
-  "storage-driver": "overlay2",
+  "storage-driver": "btrfs",
   "max-concurrent-uploads": 1,
   "default-runtime": "nvidia",
    "runtimes": {
@@ -161,7 +161,7 @@ cat <<EOT > /etc/docker/daemon.json
 {
   "exec-opts": ["native.cgroupdriver=systemd"],
   "data-root": "/ebs/docker",
-  "storage-driver": "overlay2",
+  "storage-driver": "btrfs",
   "max-concurrent-uploads": 1
 }
 EOT

--- a/workflows/pipe-common/shell/dind_setup
+++ b/workflows/pipe-common/shell/dind_setup
@@ -136,10 +136,7 @@ mkdir -p "/etc/docker"
 cat <<EOT > /etc/docker/daemon.json
 {
   "data-root": "$DIND_DATA_ROOT",
-  "storage-driver": "overlay2",
-  "storage-opts": [
-    "overlay2.override_kernel_check=true"
-  ]
+  "storage-driver": "btrfs"
 }
 EOT
 if [ $REQUIRES_GPU_DIND -eq 0 ] && [ $_DIND_NVIDIA_DEP_INSTALL_RESULT -eq 0 ]; then


### PR DESCRIPTION
Resolves issue #1275.

The pull request replaces previously used overlay2 docker storage driver with btrfs one.

It also updated file system metrics calculation in order to workaround cadvisor issue that prevents it from reporting container-level stats if btrfs docker storage driver is used. From now on run free disk space is calculated as a sum of all the node disks. It affects pause/commit free disk space checks as well as overloaded runs notifications triggering. Also cpu stats for monitoring are now aggregated for node rather then for a container.
