### PR TITLE
Issue #1276 Do not request `max` utilization stats for ResourceMonitoringManager

### DIFF
--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/AbstractMetricRequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/AbstractMetricRequester.java
@@ -164,12 +164,11 @@ public abstract class AbstractMetricRequester implements MetricRequester, Monito
     }
 
     public Map<String, Double> collectAggregation(final SearchResponse response,
-                                                  final String aggName, final String ... subAggNames) {
+                                                  final String aggName, final String subAggName) {
         return ((Terms)response.getAggregations().get(aggName)).getBuckets()
                 .stream()
-                .flatMap(b -> Stream.of(subAggNames)
-                    .map(subAggName -> Pair.of(b.getKey().toString(),
-                                               doubleValue(aggregations(b), subAggName)))
+                .map(b -> Pair.of(b.getKey().toString(),
+                        doubleValue(aggregations(b), subAggName))
                 )
                 .filter(pair -> pair.getRight().isPresent())
                 .collect(Collectors.toMap(Pair::getLeft, p -> p.getRight().get()));

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/CPURequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/CPURequester.java
@@ -65,15 +65,12 @@ public class CPURequester extends AbstractMetricRequester {
                         .aggregation(AggregationBuilders.terms(AGGREGATION_NODE_NAME)
                                 .field(path(FIELD_METRICS_TAGS, FIELD_NODENAME_RAW))
                                 .size(resourceIds.size())
-                                .subAggregation(max(MAX_AGGREGATION + USAGE_RATE, USAGE_RATE))
                                 .subAggregation(average(AVG_AGGREGATION + USAGE_RATE, USAGE_RATE))));
     }
 
     @Override
     public Map<String, Double> parseResponse(final SearchResponse response) {
-        return collectAggregation(response, AGGREGATION_NODE_NAME,
-                                  AVG_AGGREGATION + USAGE_RATE,
-                                  MAX_AGGREGATION + USAGE_RATE);
+        return collectAggregation(response, AGGREGATION_NODE_NAME, AVG_AGGREGATION + USAGE_RATE);
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/MemoryRequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/MemoryRequester.java
@@ -67,21 +67,14 @@ public class MemoryRequester extends AbstractMetricRequester {
                                 .size(resourceIds.size())
                                 .subAggregation(average(AVG_AGGREGATION + MEMORY_CAPACITY, NODE_CAPACITY))
                                 .subAggregation(average(AVG_AGGREGATION + MEMORY_UTILIZATION, WORKING_SET))
-                                .subAggregation(max(MAX_AGGREGATION + MEMORY_UTILIZATION, WORKING_SET))
-                                .subAggregation(division(AVG_AGGREGATION + DIVISION_AGGREGATION + NODE_UTILIZATION,
+                                .subAggregation(division(DIVISION_AGGREGATION + NODE_UTILIZATION,
                                         AVG_AGGREGATION + MEMORY_UTILIZATION,
-                                        AVG_AGGREGATION + MEMORY_CAPACITY))
-                                .subAggregation(division(MAX_AGGREGATION + DIVISION_AGGREGATION + NODE_UTILIZATION,
-                                        MAX_AGGREGATION + MEMORY_UTILIZATION,
-                                        AVG_AGGREGATION + MEMORY_CAPACITY))
-                        ));
+                                        AVG_AGGREGATION + MEMORY_CAPACITY))));
     }
 
     @Override
     public Map<String, Double> parseResponse(final SearchResponse response) {
-        return collectAggregation(response, AGGREGATION_NODE_NAME,
-                                  AVG_AGGREGATION + DIVISION_AGGREGATION + NODE_UTILIZATION,
-                                  MAX_AGGREGATION + DIVISION_AGGREGATION + NODE_UTILIZATION);
+        return collectAggregation(response, AGGREGATION_NODE_NAME, DIVISION_AGGREGATION + NODE_UTILIZATION);
     }
 
     @Override


### PR DESCRIPTION
This PR is related to issue #1276 

It reverts excess changes in `CPU` and `Memory` requesters, which were causing exception during metrics merging, and, besides that, the results of `parseResponse` and `buildResponse` methods' calls are used to determine  `IDLE`/`PRESSURE` state, which should be resolved based on average utilization only.