### PR TITLE
Admins added to storage permissions listing

### DIFF
--- a/api/src/main/java/com/epam/pipeline/controller/datastorage/DataStorageController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/datastorage/DataStorageController.java
@@ -687,8 +687,9 @@ public class DataStorageController extends AbstractRestController {
     public Result<EntityWithPermissionVO> getStoragePermissions(
             @RequestParam final Integer page,
             @RequestParam final Integer pageSize,
-            @RequestParam(required = false) final Integer filterMask) {
-        return Result.success(dataStorageApiService.getStoragePermission(page, pageSize, filterMask));
+            @RequestParam(required = false) final Integer filterMask,
+            @RequestParam(defaultValue = FALSE) final boolean includeAdmins) {
+        return Result.success(dataStorageApiService.getStoragePermission(page, pageSize, filterMask, includeAdmins));
     }
 
     @PostMapping(value = "/datastorage/path/size")

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageApiService.java
@@ -67,6 +67,7 @@ import static com.epam.pipeline.security.acl.AclExpressions.STORAGE_ID_PERMISSIO
 import static com.epam.pipeline.security.acl.AclExpressions.STORAGE_ID_READ;
 import static com.epam.pipeline.security.acl.AclExpressions.STORAGE_ID_WRITE;
 
+@SuppressWarnings("PMD.TooManyStaticImports")
 @Service
 public class DataStorageApiService {
 
@@ -329,11 +330,12 @@ public class DataStorageApiService {
     }
 
     @PreAuthorize(ADMIN_ONLY)
-    public EntityWithPermissionVO getStoragePermission(Integer page, Integer pageSize, Integer filterMask) {
+    public EntityWithPermissionVO getStoragePermission(Integer page, Integer pageSize, Integer filterMask,
+                                                       boolean includeAdmins) {
         Integer mask = Optional.ofNullable(filterMask)
                 .orElse(AclPermission.WRITE.getMask() | AclPermission.READ.getMask());
         return grantPermissionManager
-                .loadAllEntitiesPermissions(AclClass.DATA_STORAGE, page, pageSize, true, mask);
+                .loadAllEntitiesPermissions(AclClass.DATA_STORAGE, page, pageSize, true, mask, includeAdmins);
     }
 
     @PostAuthorize(AclExpressions.STORAGE_PATHS_READ)

--- a/api/src/test/java/com/epam/pipeline/app/AclTestConfiguration.java
+++ b/api/src/test/java/com/epam/pipeline/app/AclTestConfiguration.java
@@ -43,6 +43,7 @@ import com.epam.pipeline.manager.pipeline.ToolGroupManager;
 import com.epam.pipeline.manager.pipeline.ToolManager;
 import com.epam.pipeline.manager.pipeline.runner.ConfigurationProviderManager;
 import com.epam.pipeline.manager.pipeline.runner.ConfigurationRunner;
+import com.epam.pipeline.manager.user.RoleManager;
 import com.epam.pipeline.manager.user.UserManager;
 import com.epam.pipeline.manager.utils.UtilsManager;
 import com.epam.pipeline.security.acl.AclPermissionFactory;
@@ -165,6 +166,9 @@ public class AclTestConfiguration {
 
     @MockBean
     public BillingManager billingManager;
+
+    @MockBean
+    public RoleManager roleManager;
 
     @Bean
     public PermissionFactory permissionFactory() {

--- a/scripts/nfs-roles-management/internal/api/storages_api.py
+++ b/scripts/nfs-roles-management/internal/api/storages_api.py
@@ -21,8 +21,9 @@ class Storages(API):
     def __init__(self, config=None):
         super(Storages, self).__init__(config)
 
-    def list(self, page, page_size):
-        response_data = self.call('datastorage/permission?page={}&pageSize={}'.format(page, page_size), None)
+    def list(self, page, page_size, include_admins=True):
+        response_data = self.call('datastorage/permission?page={}&pageSize={}&includeAdmins={}'
+                                  .format(page, page_size, include_admins), None)
         storages = []
         total_count = 0
         if 'payload' in response_data:


### PR DESCRIPTION
## Background

The `GET datastorage/permission` method doesn't return admins. This way `scripts/nfs-roles-management/syncnfs.py` doesn't sync storages for admins.

## Approach

A new boolean request parameter `includeAdmins` was added to `GET datastorage/permission` method. This parameter indicates include admins into listing or not. The default value is `false`.