### PR TITLE
Issue #1320 Modify Lustre client installation for Debian support

### DIFF
--- a/workflows/pipe-common/shell/install_nfs_client
+++ b/workflows/pipe-common/shell/install_nfs_client
@@ -42,7 +42,7 @@ else
     CHECK_NFS_SMB_CMD="dpkg -l | grep nfs-common && dpkg -l | grep cifs-utils"
     INSTALL_NFS_SMB_CMD='apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" nfs-common cifs-utils -y -qq'
     CHECK_LUSTRE_CMD="dpkg -l | grep lustre-client"
-    LUSTRE_VERSION=$(. /etc/os-release;echo $ID-$VERSION_CODENAME)
+    LUSTRE_VERSION=$(. /etc/os-release;echo $ID-${VERSION_ID//.})
     LUSTRE_CLIENT_URL="https://cloud-pipeline-oss-builds.s3.amazonaws.com/tools/lustre/client/deb/lustre-client-$LUSTRE_VERSION.tar.gz"
     read -r -d '' INSTALL_LUSTRE_CMD <<- EOM
       apt-get install wget -y -qq  &&


### PR DESCRIPTION
This PR is related to issue #1320

It brings support of FSx for Lustre to `Debian`-based  images

- Lustre client installation script is modified for deb-based OS: previously **VERSION_CODENAME** from `/etc/os-release` was used to assemble required client version, but since `Debian` images might have no such information, more robust **VERSION_ID** is used.
- Archive with Lustre-client packages for `Debian 9` is uploaded to `cloud-pipeline` bucket