### PR TITLE
Issue #1277 Change billing mapping for storage

### DIFF
--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/app/CommonSyncConfiguration.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/app/CommonSyncConfiguration.java
@@ -23,6 +23,7 @@ import com.epam.pipeline.billingreportagent.service.impl.BulkRequestSender;
 import com.epam.pipeline.billingreportagent.service.impl.ElasticIndexService;
 import com.epam.pipeline.billingreportagent.service.impl.converter.AwsStoragePriceListLoader;
 import com.epam.pipeline.billingreportagent.service.impl.converter.AzureStoragePriceListLoader;
+import com.epam.pipeline.billingreportagent.service.impl.converter.FileShareMountsService;
 import com.epam.pipeline.billingreportagent.service.impl.converter.GcpStoragePriceListLoader;
 import com.epam.pipeline.billingreportagent.service.impl.converter.PriceLoadingMode;
 import com.epam.pipeline.billingreportagent.service.impl.converter.StoragePricingService;
@@ -129,7 +130,8 @@ public class CommonSyncConfiguration {
                                                final @Value("${sync.storage.price.load.mode:api}")
                                                        String priceMode,
                                                final @Value("${sync.aws.json.price.endpoint.template}")
-                                                       String endpointTemplate) {
+                                                       String endpointTemplate,
+                                               final FileShareMountsService fileShareMountsService) {
         final StorageBillingMapper mapper = new StorageBillingMapper(SearchDocumentType.NFS_STORAGE, billingCenterKey);
         final StoragePricingService pricingService =
                 new StoragePricingService(new AwsStoragePriceListLoader("AmazonEFS",
@@ -146,7 +148,8 @@ public class CommonSyncConfiguration {
                 new StorageToBillingRequestConverter(mapper, elasticsearchClient,
                         StorageType.FILE_STORAGE,
                         pricingService,
-                        fileIndexPattern),
+                        fileIndexPattern,
+                        fileShareMountsService),
                 DataStorageType.NFS);
     }
 

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/StorageBillingInfo.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/StorageBillingInfo.java
@@ -31,14 +31,14 @@ public class StorageBillingInfo extends AbstractBillingInfo<AbstractDataStorage>
 
     private Long usageBytes;
     private StorageType storageType;
-    private String regionName;
+    private Long regionId;
 
     @Builder
     public StorageBillingInfo(final LocalDate date, final AbstractDataStorage storage, final Long cost,
-                              final Long usageBytes, final StorageType storageType, final String regionName) {
+                              final Long usageBytes, final StorageType storageType, final Long regionId) {
         super(date, storage, cost, ResourceType.STORAGE);
         this.usageBytes = usageBytes;
         this.storageType = storageType;
-        this.regionName = regionName;
+        this.regionId = regionId;
     }
 }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/CloudPipelineAPIClient.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/CloudPipelineAPIClient.java
@@ -24,6 +24,7 @@ import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.metadata.MetadataEntry;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 
+import com.epam.pipeline.entity.region.AbstractCloudRegion;
 import com.epam.pipeline.entity.user.PipelineUser;
 import com.epam.pipeline.exception.PipelineResponseException;
 import com.epam.pipeline.utils.QueryUtils;
@@ -72,5 +73,9 @@ public class CloudPipelineAPIClient {
 
     public List<NodeDisk> loadNodeDisks(final String nodeId) {
         return QueryUtils.execute(cloudPipelineAPI.loadNodeDisks(nodeId));
+    }
+
+    public List<AbstractCloudRegion> loadAllCloudRegions() {
+        return QueryUtils.execute(cloudPipelineAPI.loadAllRegions());
     }
 }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/FileShareMountsService.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/FileShareMountsService.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.billingreportagent.service.impl.converter;
+
+import com.epam.pipeline.billingreportagent.model.EntityContainer;
+import com.epam.pipeline.billingreportagent.service.impl.loader.CloudRegionLoader;
+import com.epam.pipeline.entity.datastorage.FileShareMount;
+import com.epam.pipeline.entity.region.AbstractCloudRegion;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class FileShareMountsService {
+
+    private final Map<Long, Long> sharesWithRegions = new HashMap<>();
+    private final CloudRegionLoader regionLoader;
+
+    public FileShareMountsService(final CloudRegionLoader regionLoader) {
+        this.regionLoader = regionLoader;
+    }
+
+    public void updateSharesRegions() {
+        final Map<Long, Long> updatedSharesRegions = regionLoader.loadAllEntities().stream()
+            .map(EntityContainer::getEntity)
+            .map(AbstractCloudRegion::getFileShareMounts)
+            .flatMap(Collection::stream)
+            .collect(Collectors.toMap(FileShareMount::getId, FileShareMount::getRegionId));
+        sharesWithRegions.putAll(updatedSharesRegions);
+    }
+
+    public Long getRegionIdForShare(final Long fileShareId) {
+        return sharesWithRegions.get(fileShareId);
+    }
+}

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/loader/CloudRegionLoader.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/loader/CloudRegionLoader.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.billingreportagent.service.impl.loader;
+
+import com.epam.pipeline.billingreportagent.model.EntityContainer;
+import com.epam.pipeline.billingreportagent.service.EntityLoader;
+import com.epam.pipeline.billingreportagent.service.impl.CloudPipelineAPIClient;
+import com.epam.pipeline.entity.region.AbstractCloudRegion;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class CloudRegionLoader implements EntityLoader<AbstractCloudRegion> {
+
+    private final CloudPipelineAPIClient apiClient;
+
+    public CloudRegionLoader(final CloudPipelineAPIClient apiClient) {
+        this.apiClient = apiClient;
+    }
+
+    @Override
+    public List<EntityContainer<AbstractCloudRegion>> loadAllEntities() {
+        return apiClient.loadAllCloudRegions().stream()
+            .map(region -> EntityContainer.<AbstractCloudRegion>builder()
+                .entity(region)
+                .build())
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<EntityContainer<AbstractCloudRegion>> loadAllEntitiesActiveInPeriod(final LocalDateTime from,
+                                                                                    final LocalDateTime to) {
+        return loadAllEntities();
+    }
+}

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapper.java
@@ -47,7 +47,7 @@ public class StorageBillingMapper extends AbstractEntityMapper<StorageBillingInf
                 .field(DOC_TYPE_FIELD, documentType.name())
                 .field("storage_id", storage.getId())
                 .field("resource_type", billingInfo.getResourceType())
-                .field("region", billingInfo.getRegionName())
+                .field("cloudRegionId", billingInfo.getRegionId())
                 .field("provider", storage.getType())
                 .field("storage_type", billingInfo.getStorageType())
                 .field("usage_bytes", billingInfo.getUsageBytes())

--- a/billing-report-agent/src/main/resources/templates/storage_billing.json
+++ b/billing-report-agent/src/main/resources/templates/storage_billing.json
@@ -5,7 +5,7 @@
         "doc_type": { "type": "keyword", "store": true },
         "storage_id": { "type": "keyword", "store": true },
         "resource_type": { "type": "keyword" },
-        "region": { "type": "keyword" },
+        "cloudRegionId": { "type": "keyword" },
         "provider": { "type": "keyword" },
         "storage_type": { "type": "keyword" },
         "owner": { "type": "keyword" },

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapperTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapperTest.java
@@ -45,7 +45,7 @@ public class StorageBillingMapperTest {
     private static final String TEST_USER_NAME = "User";
     private static final String TEST_GROUP_1 = "TestGroup1";
     private static final String TEST_GROUP_2 = "TestGroup2";
-    private static final String TEST_REGION = "region-1";
+    private static final long TEST_REGION_ID = 1L;
     private static final long TEST_COST = 10;
     private static final long TEST_USAGE_BYTES = 600;
     private static final List<String> TEST_GROUPS = Arrays.asList(TEST_GROUP_1, TEST_GROUP_2);
@@ -72,7 +72,7 @@ public class StorageBillingMapperTest {
         final StorageBillingInfo billing = StorageBillingInfo.builder()
             .storage(s3Storage)
             .storageType(StorageType.OBJECT_STORAGE)
-            .regionName(TEST_REGION)
+            .regionId(TEST_REGION_ID)
             .usageBytes(TEST_USAGE_BYTES)
             .cost(TEST_COST)
             .date(TEST_DATE)
@@ -91,7 +91,7 @@ public class StorageBillingMapperTest {
                             mappedFields.get(ElasticsearchSynchronizer.DOC_TYPE_FIELD));
         Assert.assertEquals(s3Storage.getId(), mappedFields.get("storage_id"));
         Assert.assertEquals(ResourceType.STORAGE.toString(), mappedFields.get("resource_type"));
-        Assert.assertEquals(TEST_REGION, mappedFields.get("region"));
+        Assert.assertEquals((int) TEST_REGION_ID, mappedFields.get("cloudRegionId"));
         Assert.assertEquals(s3Storage.getType().toString(), mappedFields.get("provider"));
         Assert.assertEquals(StorageType.OBJECT_STORAGE.toString(), mappedFields.get("storage_type"));
         Assert.assertEquals(TEST_USER_NAME, mappedFields.get("owner"));
@@ -108,7 +108,7 @@ public class StorageBillingMapperTest {
         final StorageBillingInfo billing = StorageBillingInfo.builder()
             .storage(efsStorage)
             .storageType(StorageType.FILE_STORAGE)
-            .regionName(TEST_REGION)
+            .regionId(TEST_REGION_ID)
             .usageBytes(TEST_USAGE_BYTES)
             .cost(TEST_COST)
             .build();
@@ -126,7 +126,7 @@ public class StorageBillingMapperTest {
                             mappedFields.get(ElasticsearchSynchronizer.DOC_TYPE_FIELD));
         Assert.assertEquals(efsStorage.getId(), mappedFields.get("storage_id"));
         Assert.assertEquals(ResourceType.STORAGE.toString(), mappedFields.get("resource_type"));
-        Assert.assertEquals(billing.getRegionName(), mappedFields.get("region"));
+        Assert.assertEquals(billing.getRegionId().intValue(), mappedFields.get("cloudRegionId"));
         Assert.assertEquals(efsStorage.getType().toString(), mappedFields.get("provider"));
         Assert.assertEquals(StorageType.FILE_STORAGE.toString(), mappedFields.get("storage_type"));
         Assert.assertEquals(testUser.getUserName(), mappedFields.get("owner"));


### PR DESCRIPTION
This PR is related to issue #1277 

Previously, information about the storage region was stored as its name in `region` field of ES mapping. It led to the situation, that storages were unsearchable, via requests with an active filter on the cloud region.

- storage mapping is updated: `region` is replaced with `cloudRegionId` 
-  file storage's region is pulled from file share mount info