### PR TITLE
Issue #1270 Minimize Lustre installation space consuming

### DIFF
--- a/workflows/pipe-common/shell/install_nfs_client
+++ b/workflows/pipe-common/shell/install_nfs_client
@@ -50,7 +50,7 @@ else
       mkdir lustre-client-install/ &&
       tar -C lustre-client-install/ -zxvf lustre-client.tar.gz &&
       mkdir -p /lib/modules/$(uname -r) &&
-      (dpkg -i lustre-client-install/* || apt-get --fix-broken install -y ) &&
+      (dpkg --unpack lustre-client-install/* && rm -rf /var/lib/dpkg/info/lustre* || apt-get --fix-broken install -y) &&
       rm -rf lustre-client-install/ lustre-client.tar.gz
 EOM
 fi

--- a/workflows/pipe-common/shell/install_nfs_client
+++ b/workflows/pipe-common/shell/install_nfs_client
@@ -35,7 +35,7 @@ then
       yum install -y -q wget &&
       wget -q $LUSTRE_KMOD_URL -O kmod-lustre-client.rpm &&
       wget -q $LUSTRE_CLIENT_URL -O lustre-client.rpm &&
-      yum install -y -q kmod-lustre-client.rpm lustre-client.rpm &&
+      rpm -i --nodeps --quiet kmod-lustre-client.rpm lustre-client.rpm &&
       rm -f *lustre-client.rpm
 EOM
 else


### PR DESCRIPTION
This PR is related to issue #1270.

We encountered that Lustre installation adding ~ [250(rpm)/150(deb)] Mb to tool image size. The cause is, that all the dependencies (necessary and recommended) are installed/updated during installation. So the setup procedure is modified:
- for `Debian`-based OS: a slim version of Lustre tars (only required packages) is used from now, post-installation scripts are skipped to omit dependencies check
- for `RPM`-based OS: installation using `rpm` with no dependencies check