### PR TITLE
Support atomic hosts modifications

### DIFF
--- a/workflows/pipe-common/shell/add_to_hosts
+++ b/workflows/pipe-common/shell/add_to_hosts
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Adds a new record to /etc/hosts file as well as default hostfile using file system locking.
+# It prevents possible race condition during host files modification.
+# 
+# Usage examples:
+#
+# add_to_hosts "pipeline-12345" \
+#              "127.0.0.2"
+
+# Required args
+WORKER_HOST="$1"
+WORKER_IP="$2"
+
+LOCK_FILE="/var/run/hosts-modification.lock"
+DEFAULT_HOSTFILE="${DEFAULT_HOSTFILE:-/common/hostfile}"
+
+COMMAND="echo -e '$WORKER_IP\t$WORKER_HOST' >> '/etc/hosts';
+         echo -e '$WORKER_HOST' >> '$DEFAULT_HOSTFILE'"
+
+flock -w 10 "$LOCK_FILE" bash -c "$COMMAND"

--- a/workflows/pipe-common/shell/remove_from_hosts
+++ b/workflows/pipe-common/shell/remove_from_hosts
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Removes host record from /etc/hosts file as well as default hostfile using file system locking.
+# It prevents possible race condition during host files modification.
+#
+# Usage examples:
+#
+# remove_from_hosts "pipeline-12345"
+
+# Required args
+WORKER_HOST="$1"
+
+LOCK_FILE="/var/run/hosts-modification.lock"
+DEFAULT_HOSTFILE="${DEFAULT_HOSTFILE:-/common/hostfile}"
+
+COMMAND="sed '/\t$WORKER_HOST$/d' /etc/hosts > /etc/hosts_modified; cp /etc/hosts_modified /etc/hosts; rm /etc/hosts_modified;
+         sed '/^$WORKER_HOST$/d' '$DEFAULT_HOSTFILE' > '${DEFAULT_HOSTFILE}_modified'; cp '${DEFAULT_HOSTFILE}_modified' '$DEFAULT_HOSTFILE'; rm '${DEFAULT_HOSTFILE}_modified'"
+
+flock -w 10 "$LOCK_FILE" bash -c "$COMMAND"


### PR DESCRIPTION
Resolves #1332.

The pull request introduces two scripts which performs file system locking during host files modification. For each host a single record is added to `/etc/hosts` file as well as `$DEFAULT_HOSTFILE` which is usually `/common/hostfile`.

```bash
add_to_hosts "pipeline-12345" "127.0.0.2"
remove_from_hosts "pipeline-12345"
```

Also pull request introduces related changes to SGE autoscaler to support newly added scripts.