### PR TITLE
Codec error using the pipe tool

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -116,7 +116,7 @@ def cli():
               help='Password of the user, specified by the "--proxy-ntlm-user"',
               default=None)
 @click.option('-c', '--codec',
-              help='',
+              help='Encoding that shall be used',
               default=None)
 def configure(auth_token, api, timezone, proxy, proxy_ntlm, proxy_ntlm_user, proxy_ntlm_domain, proxy_ntlm_pass, codec):
     """Configures CLI parameters

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -115,7 +115,10 @@ def cli():
 @click.option('-np', '--proxy-ntlm-pass',
               help='Password of the user, specified by the "--proxy-ntlm-user"',
               default=None)
-def configure(auth_token, api, timezone, proxy, proxy_ntlm, proxy_ntlm_user, proxy_ntlm_domain, proxy_ntlm_pass):
+@click.option('-c', '--codec',
+              help='',
+              default=None)
+def configure(auth_token, api, timezone, proxy, proxy_ntlm, proxy_ntlm_user, proxy_ntlm_domain, proxy_ntlm_pass, codec):
     """Configures CLI parameters
     """
     if proxy_ntlm and not proxy_ntlm_user:
@@ -132,7 +135,8 @@ def configure(auth_token, api, timezone, proxy, proxy_ntlm, proxy_ntlm_user, pro
                  proxy_ntlm,
                  proxy_ntlm_user,
                  proxy_ntlm_domain,
-                 proxy_ntlm_pass)
+                 proxy_ntlm_pass,
+                 codec)
 
 
 def echo_title(title, line=True):

--- a/pipe-cli/src/config.py
+++ b/pipe-cli/src/config.py
@@ -102,6 +102,8 @@ class Config(object):
                         self.proxy_ntlm_pass = None
                 if self.api and self.access_key:
                     self.initialized = True
+                if 'codec' in data:
+                    self.change_encoding(data['codec'])
         elif raise_config_not_found_exception:
             raise ConfigNotFoundError()
         self.validate_pac_proxy(self.proxy)
@@ -180,7 +182,7 @@ class Config(object):
 
     @classmethod
     def store(cls, access_key, api, timezone, proxy,
-              proxy_ntlm, proxy_ntlm_user, proxy_ntlm_domain, proxy_ntlm_pass):
+              proxy_ntlm, proxy_ntlm_user, proxy_ntlm_domain, proxy_ntlm_pass, codec):
         check_token(access_key, timezone)
         if proxy == PROXY_TYPE_PAC and proxy_ntlm:
             raise ProxyInvalidConfig('NTLM proxy authentication cannot be used for the PAC proxy type'
@@ -197,7 +199,8 @@ class Config(object):
                   'proxy_ntlm': proxy_ntlm,
                   'proxy_ntlm_user': proxy_ntlm_user,
                   'proxy_ntlm_domain': proxy_ntlm_domain,
-                  'proxy_ntlm_pass': cls.encode_password(proxy_ntlm_pass)
+                  'proxy_ntlm_pass': cls.encode_password(proxy_ntlm_pass),
+                  'codec': codec
                   }
         config_file = cls.config_path()
         # create file
@@ -208,6 +211,15 @@ class Config(object):
         # save
         with open(config_file, 'w+') as config_file_stream:
             json.dump(config, config_file_stream)
+
+    @classmethod
+    def change_encoding(cls, codec):
+        if codec:
+            try:
+                reload(sys)
+                sys.setdefaultencoding(codec)
+            except NameError:
+                pass
 
     @classmethod
     def config_path(cls):

--- a/pipe-cli/src/config.py
+++ b/pipe-cli/src/config.py
@@ -191,6 +191,9 @@ class Config(object):
             raise ProxyInvalidConfig('NTLM proxy authentication is supported only for prebuilt CLI binaries.')
         if proxy_ntlm_pass:
             click.secho('Warning: NTLM proxy user password will be stored unencrypted.', fg='yellow')
+        if codec and sys.version_info[0] >= 3:
+            click.echo('Encoding can not be configured with current environment.', err=True)
+            exit(1)
         cls.validate_pac_proxy(proxy)
         config = {'api': api,
                   'access_key': access_key,


### PR DESCRIPTION
This PR provides fix for issue #1292 

A new option `--codec (-c)` was implemented for `configure` command. The default value is the system default (e.g for python 2 this value is `ascii`, for python 3 - `utf-8`). This option is available for python 2 only.