### PR TITLE
Issue 1258 1276 Update tests

### DIFF
--- a/api/src/test/java/com/epam/pipeline/dao/user/RoleDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/user/RoleDaoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ import static org.junit.Assert.*;
 @Transactional
 public class RoleDaoTest extends AbstractSpringTest {
 
-    private static final int EXPECTED_DEFAULT_ROLES_NUMBER = 9;
+    private static final int EXPECTED_DEFAULT_ROLES_NUMBER = 10;
     private static final String TEST_USER1 = "test_user1";
     private static final String TEST_ROLE = "ROLE_TEST";
     private static final String TEST_ROLE_UPDATED = "NEW_ROLE";

--- a/api/src/test/java/com/epam/pipeline/dao/user/UserDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/user/UserDaoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ public class UserDaoTest extends AbstractSpringTest {
     private static final String ATTRIBUTES_KEY = "email";
     private static final String ATTRIBUTES_VALUE = "test_email";
     private static final String ATTRIBUTES_VALUE2 = "Mail@epam.com";
-    private static final int EXPECTED_DEFAULT_ROLES_NUMBER = 9;
+    private static final int EXPECTED_DEFAULT_ROLES_NUMBER = 10;
 
     @Autowired
     private UserDao userDao;

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/writer/MonitoringStatsWriterTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/writer/MonitoringStatsWriterTest.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-@SuppressWarnings("checkstyle:MagicNumber")
 public class MonitoringStatsWriterTest {
 
     private static final int NUM_CORES = 2;
@@ -45,7 +44,7 @@ public class MonitoringStatsWriterTest {
     private static final List<Long> NETWORK_INTERFACES_RX = Arrays.asList(101L, 201L);
     private static final List<Long> NETWORK_INTERFACES_TX = Arrays.asList(102L, 202L);
     private static final double HUNDRED_PERCENTS = 100.0;
-    private static final int COMMON_INFO_SIZE = 5;
+    private static final int COMMON_INFO_SIZE = 7;
 
     @Test
     public void testMonitoringStatsToCsvConversion() {
@@ -66,34 +65,34 @@ public class MonitoringStatsWriterTest {
         final String[] firstStatEntry = table.get(1);
         final long totalSpace1 = DISK_INFOS.get(0).totalSpace;
         final long usedSpace1 = DISK_INFOS.get(0).usedSpace;
-        Assert.assertEquals(totalSpace1, Long.parseLong(firstStatEntry[5]));
+        Assert.assertEquals(totalSpace1, Long.parseLong(firstStatEntry[COMMON_INFO_SIZE]));
         Assert.assertEquals(0,
                             Double.compare(HUNDRED_PERCENTS * usedSpace1 / totalSpace1,
-                                           Double.parseDouble(firstStatEntry[6])));
-        Assert.assertEquals(StringUtils.EMPTY, firstStatEntry[7]);
-        Assert.assertEquals(StringUtils.EMPTY, firstStatEntry[8]);
+                                           Double.parseDouble(firstStatEntry[COMMON_INFO_SIZE + 1])));
+        Assert.assertEquals(StringUtils.EMPTY, firstStatEntry[COMMON_INFO_SIZE + 2]);
+        Assert.assertEquals(StringUtils.EMPTY, firstStatEntry[COMMON_INFO_SIZE + 3]);
         final long inBytes1 = NETWORK_INTERFACES_RX.get(0);
         final long outBytes1 = NETWORK_INTERFACES_TX.get(0);
-        Assert.assertEquals(inBytes1, Long.parseLong(firstStatEntry[9]));
-        Assert.assertEquals(outBytes1, Long.parseLong(firstStatEntry[10]));
-        Assert.assertEquals(StringUtils.EMPTY, firstStatEntry[11]);
-        Assert.assertEquals(StringUtils.EMPTY, firstStatEntry[12]);
+        Assert.assertEquals(inBytes1, Long.parseLong(firstStatEntry[COMMON_INFO_SIZE + 4]));
+        Assert.assertEquals(outBytes1, Long.parseLong(firstStatEntry[COMMON_INFO_SIZE + 5]));
+        Assert.assertEquals(StringUtils.EMPTY, firstStatEntry[COMMON_INFO_SIZE + 6]);
+        Assert.assertEquals(StringUtils.EMPTY, firstStatEntry[COMMON_INFO_SIZE + 7]);
 
         final String[] secondStatEntry = table.get(2);
-        Assert.assertEquals(StringUtils.EMPTY, secondStatEntry[5]);
-        Assert.assertEquals(StringUtils.EMPTY, secondStatEntry[6]);
+        Assert.assertEquals(StringUtils.EMPTY, secondStatEntry[COMMON_INFO_SIZE]);
+        Assert.assertEquals(StringUtils.EMPTY, secondStatEntry[COMMON_INFO_SIZE + 1]);
         final long totalSpace2 = DISK_INFOS.get(1).totalSpace;
         final long usedSpace2 = DISK_INFOS.get(1).usedSpace;
-        Assert.assertEquals(totalSpace2, Long.parseLong(secondStatEntry[7]));
+        Assert.assertEquals(totalSpace2, Long.parseLong(secondStatEntry[COMMON_INFO_SIZE + 2]));
         Assert.assertEquals(0,
                             Double.compare(HUNDRED_PERCENTS * usedSpace2 / totalSpace2,
-                                           Double.parseDouble(secondStatEntry[8])));
-        Assert.assertEquals(StringUtils.EMPTY, secondStatEntry[9]);
-        Assert.assertEquals(StringUtils.EMPTY, secondStatEntry[10]);
+                                           Double.parseDouble(secondStatEntry[COMMON_INFO_SIZE + 3])));
+        Assert.assertEquals(StringUtils.EMPTY, secondStatEntry[COMMON_INFO_SIZE + 4]);
+        Assert.assertEquals(StringUtils.EMPTY, secondStatEntry[COMMON_INFO_SIZE + 5]);
         final long inBytes2 = NETWORK_INTERFACES_RX.get(1);
         final long outBytes2 = NETWORK_INTERFACES_TX.get(1);
-        Assert.assertEquals(inBytes2, Long.parseLong(secondStatEntry[11]));
-        Assert.assertEquals(outBytes2, Long.parseLong(secondStatEntry[12]));
+        Assert.assertEquals(inBytes2, Long.parseLong(secondStatEntry[COMMON_INFO_SIZE + 6]));
+        Assert.assertEquals(outBytes2, Long.parseLong(secondStatEntry[COMMON_INFO_SIZE + 7]));
     }
 
     @Test


### PR DESCRIPTION
This PR is related to issues #1258 #1276

It fixes tests:
Issue 1258: `RoleDaoTest` `UserDaoTest` - default roles count is changed
Issue 1276: `MonitoringStatsWriterTest` - additional columns in monitoring stats table