### PR TITLE
Issue #1337: The cloned pipeline is not available

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineManager.java
@@ -327,7 +327,8 @@ public class PipelineManager implements SecuredEntityManager {
 
         final String sourceProjectName = GitUtils.convertPipeNameToProject(loadedPipeline.getName());
         final String uuid = PasswordGenerator.generateRandomString(20);
-        final String newProjectName = buildCopyProjectName(sourceProjectName, uuid, newName);
+        final String newProjectName = GitUtils.convertPipeNameToProject(
+                buildCopyProjectName(sourceProjectName, uuid, newName));
         final String newRepository =
                 GitUtils.replaceGitProjectNameInUrl(loadedPipeline.getRepository(), newProjectName);
         final String newRepositorySsh =

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineManagerTest.java
@@ -173,14 +173,15 @@ public class PipelineManagerTest {
 
     @Test
     public void shouldCopyPipeline() {
-        final String newName = REPOSITORY_NAME + "_copy";
-        final String newRepository = "https://example.com:repository/repository_copy.git";
-        final String newRepositorySsh = "git@example.com:repository/repository_copy.git";
+        final String sourceRepositoryName = "repository-clone";
+        final String newName = sourceRepositoryName + "_copy";
+        final String newRepository = "https://example.com:repository/repositoryclone_copy.git";
+        final String newRepositorySsh = "git@example.com:repository/repositoryclone_copy.git";
         final String storageRuleMask = "*.test";
 
         final PipelineVO pipelineVO = new PipelineVO();
         pipelineVO.setId(ID);
-        pipelineVO.setName(REPOSITORY_NAME);
+        pipelineVO.setName(sourceRepositoryName);
         pipelineVO.setRepository(REPOSITORY_HTTPS);
         pipelineVO.setRepositoryToken(REPOSITORY_TOKEN);
         pipelineVO.setRepositorySsh(REPOSITORY_SSH);
@@ -193,7 +194,8 @@ public class PipelineManagerTest {
 
         final Pipeline copiedPipeline = pipelineManager.copyPipeline(ID, null, newName);
 
-        assertThat(copiedPipeline.getName(), is(newName));
+        final String expectedNewRepositoryName = "repositoryclone_copy";
+        assertThat(copiedPipeline.getName(), is(expectedNewRepositoryName));
         assertThat(copiedPipeline.getRepository(), is(newRepository));
         assertThat(copiedPipeline.getRepositorySsh(), is(newRepositorySsh));
         assertThat(copiedPipeline.getDescription(), is(pipelineVO.getDescription()));


### PR DESCRIPTION
This PR provides fix for issue #1337 

The error was in incorrect conversion of the repository name (e.g. names with dash symbol)