### PR TITLE
ES billing modifications for aggregation performance

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/billing/EntityBillingDetailsLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/EntityBillingDetailsLoader.java
@@ -23,14 +23,16 @@ import java.util.Map;
 public interface EntityBillingDetailsLoader {
 
     String OWNER = "owner";
+    String NAME = "name";
 
     BillingGrouping getGrouping();
 
-    default String loadName(final String entityIdentifier) {
-        return entityIdentifier;
-    }
-
-    Map<String, String> loadDetails(String entityIdentifier);
+    /**
+     * Build a map of details for given entity. Always contains a value for {@linkplain #NAME} property
+     * @param entityIdentifier id of entity to build information
+     * @return entity's details
+     */
+    Map<String, String> loadInformation(String entityIdentifier, boolean loadDetails);
 
     Map<String, String> getEmptyDetails();
 

--- a/api/src/main/java/com/epam/pipeline/manager/billing/StorageBillingDetailsLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/StorageBillingDetailsLoader.java
@@ -16,6 +16,8 @@
 
 package com.epam.pipeline.manager.billing;
 
+import com.epam.pipeline.common.MessageConstants;
+import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.entity.billing.BillingGrouping;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.DataStorageType;
@@ -43,6 +45,7 @@ import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
+@SuppressWarnings("PMD.AvoidCatchingGenericException")
 @Slf4j
 public class StorageBillingDetailsLoader implements EntityBillingDetailsLoader {
 
@@ -65,35 +68,44 @@ public class StorageBillingDetailsLoader implements EntityBillingDetailsLoader {
     @Autowired
     private final UserBillingDetailsLoader userBillingDetailsLoader;
 
+    @Autowired
+    private final MessageHelper messageHelper;
+
     @Override
     public BillingGrouping getGrouping() {
         return BillingGrouping.STORAGE;
     }
 
     @Override
-    public String loadName(final String entityIdentifier) {
+    public Map<String, String> loadInformation(final String entityIdentifier, final boolean loadDetails) {
+        final Map<String, String> details = new HashMap<>();
         try {
             final AbstractDataStorage storage = dataStorageManager.loadByNameOrId(entityIdentifier);
-            return DataStorageType.NFS.equals(storage.getType())
-                   ? storage.getName()
-                   : storage.getPath();
-        } catch (IllegalArgumentException e) {
-            return entityIdentifier;
-        }
-    }
+            final String storageName = DataStorageType.NFS.equals(storage.getType())
+                             ? storage.getName()
+                             : storage.getPath();
+            details.put(NAME, storageName);
+            if (loadDetails) {
+                details.putAll(getRegionDetails(storage));
+                details.put(OWNER, storage.getOwner());
+                details.put(CREATED, DateTimeFormatter.ISO_DATE_TIME.format(storage.getCreatedDate()
+                                                                                .toInstant()
+                                                                                .atZone(ZoneId.systemDefault())
+                                                                                .toLocalDateTime()));
+                details.put(BillingGrouping.BILLING_CENTER.getCorrespondingField(),
+                            userBillingDetailsLoader.getUserBillingCenter(storage.getOwner()));
+                details.put(BillingGrouping.STORAGE_TYPE.getCorrespondingField(), getExplicitStorageType(storage));
 
-    @Override
-    public Map<String, String> loadDetails(final String entityIdentifier) {
-        final AbstractDataStorage storage = dataStorageManager.loadByNameOrId(entityIdentifier);
-        final Map<String, String> details = getRegionDetails(storage);
-        details.put(OWNER, storage.getOwner());
-        details.put(CREATED, DateTimeFormatter.ISO_DATE_TIME.format(storage.getCreatedDate()
-                                                                        .toInstant()
-                                                                        .atZone(ZoneId.systemDefault())
-                                                                        .toLocalDateTime()));
-        details.put(BillingGrouping.BILLING_CENTER.getCorrespondingField(),
-                    userBillingDetailsLoader.getUserBillingCenter(storage.getOwner()));
-        details.put(BillingGrouping.STORAGE_TYPE.getCorrespondingField(), getExplicitStorageType(storage));
+
+            }
+        } catch (RuntimeException e) {
+            log.info(messageHelper.getMessage(MessageConstants.INFO_BILLING_ENTITY_FOR_DETAILS_NOT_FOUND,
+                                              entityIdentifier, getGrouping()));
+            details.putIfAbsent(NAME, entityIdentifier);
+            if (loadDetails) {
+                details.putAll(getEmptyDetails());
+            }
+        }
         return details;
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/billing/UserBillingDetailsLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/UserBillingDetailsLoader.java
@@ -16,12 +16,15 @@
 
 package com.epam.pipeline.manager.billing;
 
+import com.epam.pipeline.common.MessageConstants;
+import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.entity.billing.BillingGrouping;
 import com.epam.pipeline.entity.metadata.MetadataEntry;
 import com.epam.pipeline.entity.security.acl.AclClass;
 import com.epam.pipeline.entity.user.PipelineUser;
 import com.epam.pipeline.manager.metadata.MetadataManager;
 import com.epam.pipeline.manager.user.UserManager;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.MapUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -32,22 +35,26 @@ import java.util.Map;
 import java.util.Optional;
 
 @Service
+@Slf4j
 public class UserBillingDetailsLoader implements EntityBillingDetailsLoader {
 
     private final String emptyValue;
     private final String billingCenterKey;
     private final UserManager userManager;
     private final MetadataManager metadataManager;
+    private final MessageHelper messageHelper;
 
     public UserBillingDetailsLoader(
             @Value("${billing.empty.report.value:unknown}") final String emptyValue,
             @Value("${billing.center.key}") final String billingCenterKey,
             final UserManager userManager,
-            final MetadataManager metadataManager) {
+            final MetadataManager metadataManager,
+            final MessageHelper messageHelper) {
         this.emptyValue = emptyValue;
         this.billingCenterKey = billingCenterKey;
         this.userManager = userManager;
         this.metadataManager = metadataManager;
+        this.messageHelper = messageHelper;
     }
 
     @Override
@@ -56,13 +63,18 @@ public class UserBillingDetailsLoader implements EntityBillingDetailsLoader {
     }
 
     @Override
-    public Map<String, String> loadDetails(final String entityIdentifier) {
+    public Map<String, String> loadInformation(final String entityIdentifier, final boolean loadDetails) {
         final Map<String, String> details = new HashMap<>();
-        final PipelineUser user = userManager.loadUserByName(entityIdentifier);
-        if (user != null) {
-            details.put(BillingGrouping.BILLING_CENTER.getCorrespondingField(), getUserBillingCenter(user));
-        } else {
-            details.putAll(getEmptyDetails());
+        details.put(NAME, entityIdentifier);
+        if (loadDetails) {
+            final PipelineUser user = userManager.loadUserByName(entityIdentifier);
+            if (user != null) {
+                details.put(BillingGrouping.BILLING_CENTER.getCorrespondingField(), getUserBillingCenter(user));
+            } else {
+                log.info(messageHelper.getMessage(MessageConstants.INFO_BILLING_ENTITY_FOR_DETAILS_NOT_FOUND,
+                                                  entityIdentifier, getGrouping()));
+                details.putAll(getEmptyDetails());
+            }
         }
         return details;
     }


### PR DESCRIPTION
This PR brings changes to `BillingManager`, which allows receiving aggregation results faster.

- Count unique runs with `ValueCount` aggregation instead of` Terms`
- Use `filter_path` param for grouping requests to reduce the size of JSON response from ES (only aggregation results are received without search details)