### PR TITLE
Wrap billing search response aggregations in optional to avoid NPE for expenses histogram

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
@@ -266,8 +266,11 @@ public class BillingManager {
 
         try {
             final SearchResponse searchResponse = elasticsearchClient.search(searchRequest);
-            final ParsedDateHistogram histogram = searchResponse.getAggregations().get(HISTOGRAM_AGGREGATION_NAME);
-            return parseHistogram(interval, histogram);
+            return Optional.ofNullable(searchResponse.getAggregations())
+                .map(aggs -> aggs.get(HISTOGRAM_AGGREGATION_NAME))
+                .map(ParsedDateHistogram.class::cast)
+                .map(histogram -> parseHistogram(interval, histogram))
+                .orElse(Collections.emptyList());
         } catch (IOException e) {
             log.error(e.getMessage(), e);
             throw new SearchException(e.getMessage(), e);


### PR DESCRIPTION

This PR is related to billing stability improvements.

When we executed the search in ES to build expenses histogram and target indices do not exist, we used to receive NPE, because `aggregations` field of `SearchResponse` is null. From now it is wrapped in `Optional` and an empty list is returned in such cases.