### PR TITLE
Add an option to validate user block status for JWT token

### DIFF
--- a/api/src/main/java/com/epam/pipeline/app/JWTSecurityConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/JWTSecurityConfiguration.java
@@ -17,6 +17,7 @@
 package com.epam.pipeline.app;
 
 import com.epam.pipeline.entity.user.DefaultRoles;
+import com.epam.pipeline.security.UserAccessService;
 import com.epam.pipeline.security.jwt.JwtAuthenticationProvider;
 import com.epam.pipeline.security.jwt.JwtFilterAuthenticationFilter;
 import com.epam.pipeline.security.jwt.JwtTokenVerifier;
@@ -70,6 +71,9 @@ public class JWTSecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Autowired
     private SAMLEntryPoint samlEntryPoint;
 
+    @Autowired
+    private UserAccessService userAccessService;
+
     protected String getPublicKey() {
         return publicKey;
     }
@@ -112,11 +116,11 @@ public class JWTSecurityConfiguration extends WebSecurityConfigurerAdapter {
     }
 
     @Bean protected JwtAuthenticationProvider jwtAuthenticationProvider() {
-        return new JwtAuthenticationProvider(jwtTokenVerifier());
+        return new JwtAuthenticationProvider(jwtTokenVerifier(), userAccessService);
     }
 
     protected JwtFilterAuthenticationFilter getJwtAuthenticationFilter() {
-        return new JwtFilterAuthenticationFilter(jwtTokenVerifier());
+        return new JwtFilterAuthenticationFilter(jwtTokenVerifier(), userAccessService);
     }
 
     protected RequestMatcher getFullRequestMatcher() {

--- a/api/src/main/java/com/epam/pipeline/security/UserAccessService.java
+++ b/api/src/main/java/com/epam/pipeline/security/UserAccessService.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.security;
+
+
+import com.epam.pipeline.entity.user.GroupStatus;
+import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.manager.user.UserManager;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.ListUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.LockedException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+public class UserAccessService {
+
+    private final UserManager userManager;
+    private final boolean validateUser;
+
+    public UserAccessService(final UserManager userManager,
+                             final @Value("${jwt.validate.token.user:false}") boolean validateUser) {
+        this.userManager = userManager;
+        this.validateUser = validateUser;
+    }
+
+    public void validateUserBlockStatus(final String userName) {
+        if (!validateUser) {
+            return;
+        }
+        final PipelineUser user = userManager.loadUserByName(userName);
+        if (user == null) {
+            log.info("Failed to find user by name {}. Access is still allowed.", userName);
+            return;
+        }
+        validateUserBlockStatus(user);
+        validateUserGroupsBlockStatus(user);
+    }
+
+    public void validateUserBlockStatus(final PipelineUser user) {
+        if (user.isBlocked()) {
+            throwUserIsBlocked(user.getUserName());
+        }
+    }
+
+    public void throwUserIsBlocked(final String userName) {
+        log.info("Authentication failed! User {} is blocked!", userName);
+        throw new LockedException("User is blocked!");
+    }
+
+    public void validateUserGroupsBlockStatus(final PipelineUser user) {
+        List<GrantedAuthority> authorities = new UserContext(user).getAuthorities();
+        final List<String> groups = ListUtils.emptyIfNull(authorities)
+                .stream()
+                .map(GrantedAuthority::getAuthority)
+                .distinct()
+                .collect(Collectors.toList());
+        final boolean isValidGroupList = ListUtils.emptyIfNull(userManager.loadGroupBlockingStatus(groups))
+                .stream()
+                .noneMatch(GroupStatus::isBlocked);
+        if (!isValidGroupList) {
+            log.info("Authentication failed! User {} is blocked due to one of his groups is blocked!",
+                    user.getUserName());
+            throw new LockedException("User is blocked!");
+        }
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/security/jwt/JwtAuthenticationProvider.java
+++ b/api/src/main/java/com/epam/pipeline/security/jwt/JwtAuthenticationProvider.java
@@ -18,17 +18,17 @@ package com.epam.pipeline.security.jwt;
 
 import com.epam.pipeline.entity.security.JwtRawToken;
 import com.epam.pipeline.entity.security.JwtTokenClaims;
+import com.epam.pipeline.security.UserAccessService;
 import com.epam.pipeline.security.UserContext;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.core.Authentication;
 
+@RequiredArgsConstructor
 public class JwtAuthenticationProvider implements AuthenticationProvider {
-    private JwtTokenVerifier tokenVerifier;
-
-    public JwtAuthenticationProvider(JwtTokenVerifier tokenVerifier) {
-        this.tokenVerifier = tokenVerifier;
-    }
+    private final JwtTokenVerifier tokenVerifier;
+    private final UserAccessService accessService;
 
     @Override
     public Authentication authenticate(Authentication authentication) {
@@ -44,7 +44,7 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
         }
 
         UserContext context = new UserContext(jwtRawToken, claims);
-
+        accessService.validateUserBlockStatus(context.getUsername());
         return new JwtAuthenticationToken(context, context.getAuthorities());
     }
 

--- a/api/src/main/java/com/epam/pipeline/security/jwt/JwtFilterAuthenticationFilter.java
+++ b/api/src/main/java/com/epam/pipeline/security/jwt/JwtFilterAuthenticationFilter.java
@@ -27,57 +27,58 @@ import javax.servlet.http.HttpServletResponse;
 
 import com.epam.pipeline.entity.security.JwtRawToken;
 import com.epam.pipeline.entity.security.JwtTokenClaims;
+import com.epam.pipeline.security.UserAccessService;
 import com.epam.pipeline.security.UserContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+@RequiredArgsConstructor
+@Slf4j
 public class JwtFilterAuthenticationFilter extends OncePerRequestFilter {
-    private static final Logger LOGGER = LoggerFactory.getLogger(JwtFilterAuthenticationFilter.class);
 
-    private JwtTokenVerifier tokenVerifier;
-
-    public JwtFilterAuthenticationFilter(JwtTokenVerifier tokenVerifier) {
-        this.tokenVerifier = tokenVerifier;
-    }
+    private final JwtTokenVerifier tokenVerifier;
+    private final UserAccessService accessService;
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
-            FilterChain filterChain) throws ServletException, IOException {
+    protected void doFilterInternal(final HttpServletRequest request,
+                                    final HttpServletResponse response,
+                                    final FilterChain filterChain) throws ServletException, IOException {
         final JwtRawToken rawToken = fetchJwtRawToken(request);
         try {
             if (!StringUtils.isEmpty(rawToken)) {
                 JwtTokenClaims claims = tokenVerifier.readClaims(rawToken.getToken());
                 UserContext context = new UserContext(rawToken, claims);
+                accessService.validateUserBlockStatus(context.getUsername());
                 JwtAuthenticationToken token = new JwtAuthenticationToken(context, context.getAuthorities());
                 token.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 SecurityContextHolder.getContext().setAuthentication(token);
-                LOGGER.info("Successfully authenticate user with name: " + context.getUsername());
+                log.info("Successfully authenticate user with name: " + context.getUsername());
             }
         } catch (TokenVerificationException e) {
-            LOGGER.info("JWT authentication failed!", e);
+            log.info("JWT authentication failed!", e);
         }
         filterChain.doFilter(request, response);
     }
 
-    private JwtRawToken fetchJwtRawToken(HttpServletRequest request) throws UnsupportedEncodingException {
+    private JwtRawToken fetchJwtRawToken(final HttpServletRequest request) throws UnsupportedEncodingException {
         JwtRawToken rawToken = null;
         String authorizationHeader = extractAuthHeader(request);
         Cookie authCookie = extractAuthCookie(request);
         try {
             if (!StringUtils.isEmpty(authorizationHeader)) { // attempt obtain JWT token from HTTP header
                 rawToken = JwtRawToken.fromHeader(authorizationHeader);
-                LOGGER.trace("Extracted JWT token from authorization HTTP header");
+                log.trace("Extracted JWT token from authorization HTTP header");
             } else if (!StringUtils.isEmpty(authCookie)) {   // else try to get token from cookies
                 rawToken = JwtRawToken.fromCookie(authCookie);
-                LOGGER.trace("Extracted JWT token from authorization cookie");
+                log.trace("Extracted JWT token from authorization cookie");
             }
         } catch (AuthenticationServiceException e) {
-            LOGGER.trace(e.getMessage(), e);
+            log.trace(e.getMessage(), e);
         }
         return rawToken;
     }

--- a/deploy/docker/cp-api-srv/config/application.properties
+++ b/deploy/docker/cp-api-srv/config/application.properties
@@ -54,6 +54,7 @@ pause.pool.size=10
 # JWT configuration
 jwt.key.public=${CP_API_JWT_KEY_PUBLIC}
 jwt.key.private=${CP_API_JWT_KEY_PRIVATE}
+jwt.validate.token.user=${CP_API_JWT_VALIDATE_USER:false}
 
 jwt.use.for.all.requests=${CP_API_USE_ONLY_JWT_AUTH:false}
 acl.disable.cache=${CP_API_DISABLE_ACL_CACHE:false}


### PR DESCRIPTION
This PR adds an option `jwt.validate.token.user` (`CP_API_JWT_VALIDATE_USER`) to enable user block status for JWT authorization. 