### PR TITLE
Issue #1282 Load all groups' available blocking statuses

### DIFF
--- a/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
@@ -353,4 +353,18 @@ public class UserController extends AbstractRestController {
     public Result<GroupStatus> deleteGroupBlockingStatus(@PathVariable final String groupName) {
         return Result.success(userApiService.deleteGroupBlockingStatus(groupName));
     }
+
+    @GetMapping(value = "/groups/block")
+    @ResponseBody
+    @ApiOperation(
+        value = "Load all available blocking statuses all over the groups.",
+        notes = "Load all available blocking statuses all over the groups. "
+                + "Returns all statuses presented in the corresponding DB table",
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+        value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+        })
+    public Result<List<GroupStatus>> loadGroupsBlockingStatuses() {
+        return Result.success(userApiService.loadAllGroupsBlockingStatuses());
+    }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/user/GroupStatusDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/user/GroupStatusDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ public class GroupStatusDao extends NamedParameterJdbcDaoSupport {
     private String upsertGroupStatusQuery;
     private String loadGroupsBlockedStatusQuery;
     private String deleteGroupStatusQuery;
+    private String loadAllGroupsStatusesQuery;
 
     @Transactional(propagation = Propagation.MANDATORY)
     public GroupStatus upsertGroupBlockingStatusQuery(final GroupStatus groupStatus) {
@@ -50,6 +51,9 @@ public class GroupStatusDao extends NamedParameterJdbcDaoSupport {
         getJdbcTemplate().update(deleteGroupStatusQuery, groupName);
     }
 
+    public List<GroupStatus> loadAllGroupsBlockingStatuses() {
+        return getJdbcTemplate().query(loadAllGroupsStatusesQuery, GroupParameters.getRowMapper());
+    }
 
     enum GroupParameters {
         GROUP_NAME,
@@ -88,5 +92,10 @@ public class GroupStatusDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setDeleteGroupStatusQuery(final String deleteGroupStatusQuery) {
         this.deleteGroupStatusQuery = deleteGroupStatusQuery;
+    }
+
+    @Required
+    public void setLoadAllGroupsStatusesQuery(final String loadAllGroupsStatusesQuery) {
+        this.loadAllGroupsStatusesQuery = loadAllGroupsStatusesQuery;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/user/UserApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/UserApiService.java
@@ -88,6 +88,11 @@ public class UserApiService {
     }
 
     @PreAuthorize(ADMIN_ONLY)
+    public List<GroupStatus> loadAllGroupsBlockingStatuses() {
+        return userManager.loadAllGroupsBlockingStatuses();
+    }
+
+    @PreAuthorize(ADMIN_ONLY)
     public PipelineUser loadUser(Long id) {
         return userManager.loadUserById(id);
     }

--- a/api/src/main/java/com/epam/pipeline/manager/user/UserManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/UserManager.java
@@ -228,6 +228,10 @@ public class UserManager {
         return groupStatus;
     }
 
+    public List<GroupStatus> loadAllGroupsBlockingStatuses() {
+        return groupStatusDao.loadAllGroupsBlockingStatuses();
+    }
+
     private GroupStatus loadGroupBlockingStatus(final String groupName) {
         return loadGroupBlockingStatus(Collections.singletonList(groupName)).stream()
                 .findFirst()

--- a/api/src/main/resources/dao/group-status-dao.xml
+++ b/api/src/main/resources/dao/group-status-dao.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+  ~ Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -50,6 +50,16 @@
                 <![CDATA[
                     DELETE FROM pipeline.group_status
                     WHERE group_name = ?
+                ]]>
+            </value>
+        </property>
+        <property name="loadAllGroupsStatusesQuery">
+            <value>
+                <![CDATA[
+                    SELECT
+                        group_name,
+                        blocked as group_blocked_status
+                    FROM  pipeline.group_status
                 ]]>
             </value>
         </property>

--- a/api/src/test/java/com/epam/pipeline/dao/user/GroupStatusDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/user/GroupStatusDaoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,11 +24,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Transactional
 public class GroupStatusDaoTest extends AbstractSpringTest {
 
     private static final String TEST_GROUP_1 = "test_group_1";
+    private static final String TEST_GROUP_2 = "test_group_2";
 
     @Autowired
     private GroupStatusDao groupStatusDao;
@@ -51,6 +54,21 @@ public class GroupStatusDaoTest extends AbstractSpringTest {
 
         groupStatusDao.deleteGroupBlockingStatus(TEST_GROUP_1);
         Assert.assertNull(loadGroupStatus(TEST_GROUP_1));
+    }
+
+    @Test
+    public void testGroupStatusLoadAll() {
+        final GroupStatus groupStatus1 = new GroupStatus(TEST_GROUP_1, false);
+        final GroupStatus groupStatus2 = new GroupStatus(TEST_GROUP_2, false);
+        groupStatusDao.upsertGroupBlockingStatusQuery(groupStatus1);
+        groupStatusDao.upsertGroupBlockingStatusQuery(groupStatus2);
+        final Map<String, Boolean> loadedStatuses = groupStatusDao.loadAllGroupsBlockingStatuses()
+            .stream()
+            .collect(Collectors.toMap(GroupStatus::getGroupName, GroupStatus::isBlocked));
+        Assert.assertEquals(2, loadedStatuses.size());
+        Assert.assertEquals(groupStatus1.isBlocked(), loadedStatuses.get(groupStatus1.getGroupName()));
+        Assert.assertEquals(groupStatus2.isBlocked(), loadedStatuses.get(groupStatus2.getGroupName()));
+
     }
 
     private GroupStatus loadGroupStatus(final String groupName) {

--- a/api/src/test/java/com/epam/pipeline/manager/user/UserManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/user/UserManagerTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *  * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *  *
  *  * Licensed under the Apache License, Version 2.0 (the "License");
  *  * you may not use this file except in compliance with the License.
@@ -56,6 +56,7 @@ public class UserManagerTest extends AbstractSpringTest {
     private static final String BODY = "Body";
     private static final List<Long> DEFAULT_USER_ROLES = Collections.singletonList(2L);
     private static final String TEST_GROUP_NAME_1 = "test_group_1";
+    private static final String TEST_GROUP_NAME_2 = "test_group_2";
     private static final List<String> DEFAULT_USER_GROUPS = Collections.singletonList(TEST_GROUP_NAME_1);
     private static final Map<String, String> DEFAULT_USER_ATTRIBUTE = Collections.emptyMap();
     private static final String ROLE_USER = "ROLE_USER";
@@ -232,6 +233,19 @@ public class UserManagerTest extends AbstractSpringTest {
         Assert.assertFalse(getGroupStatus(TEST_GROUP_NAME_1).isBlocked());
         userManager.deleteGroupBlockingStatus(TEST_GROUP_NAME_1);
         Assert.assertNull(getGroupStatus(TEST_GROUP_NAME_1));
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void loadAllGroupsStatuses() {
+        userManager.upsertGroupBlockingStatus(TEST_GROUP_NAME_1, false);
+        userManager.upsertGroupBlockingStatus(TEST_GROUP_NAME_2, true);
+        final Map<String, Boolean> groupsStatuses = userManager.loadAllGroupsBlockingStatuses()
+            .stream()
+            .collect(Collectors.toMap(GroupStatus::getGroupName, GroupStatus::isBlocked));
+        Assert.assertEquals(2, groupsStatuses.size());
+        Assert.assertFalse(groupsStatuses.get(TEST_GROUP_NAME_1));
+        Assert.assertTrue(groupsStatuses.get(TEST_GROUP_NAME_2));
     }
 
     @Test


### PR DESCRIPTION
This PR is related to issue #1282

It brings new endpoint `/groups/block`, that allows us to load all group statuses presented in the database, so we will be able to easily sync groups statuses between 2 environments.