### PR TITLE
Issue 1387 Role `USER_READER`

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/user/RoleApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/RoleApiService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.List;
 
 import static com.epam.pipeline.security.acl.AclExpressions.ADMIN_ONLY;
+import static com.epam.pipeline.security.acl.AclExpressions.OR_USER_READER;
 
 @Service
 public class RoleApiService {
@@ -34,7 +35,7 @@ public class RoleApiService {
     @Autowired
     private RoleManager roleManager;
 
-    @PreAuthorize(ADMIN_ONLY)
+    @PreAuthorize(ADMIN_ONLY + OR_USER_READER)
     public Collection<Role> loadRolesWithUsers() {
         return roleManager.loadAllRoles(true);
     }
@@ -43,7 +44,7 @@ public class RoleApiService {
         return roleManager.loadAllRoles(false);
     }
 
-    @PreAuthorize(ADMIN_ONLY)
+    @PreAuthorize(ADMIN_ONLY + OR_USER_READER)
     public Role loadRole(Long id) {
         return roleManager.loadRoleWithUsers(id);
     }

--- a/api/src/main/java/com/epam/pipeline/manager/user/UserApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/UserApiService.java
@@ -32,6 +32,7 @@ import java.util.List;
 
 import static com.epam.pipeline.security.acl.AclExpressions.ADMIN_ONLY;
 import static com.epam.pipeline.security.acl.AclExpressions.ADMIN_OR_GENERAL_USER;
+import static com.epam.pipeline.security.acl.AclExpressions.OR_USER_READER;
 
 @Service
 public class UserApiService {
@@ -87,17 +88,17 @@ public class UserApiService {
         return userManager.deleteGroupBlockingStatus(groupName);
     }
 
-    @PreAuthorize(ADMIN_ONLY)
+    @PreAuthorize(ADMIN_ONLY + OR_USER_READER)
     public List<GroupStatus> loadAllGroupsBlockingStatuses() {
         return userManager.loadAllGroupsBlockingStatuses();
     }
 
-    @PreAuthorize(ADMIN_ONLY)
+    @PreAuthorize(ADMIN_ONLY + OR_USER_READER)
     public PipelineUser loadUser(Long id) {
         return userManager.loadUserById(id);
     }
 
-    @PreAuthorize(ADMIN_ONLY)
+    @PreAuthorize(ADMIN_ONLY + OR_USER_READER)
     public PipelineUser loadUserByName(final String name) {
         return userManager.loadUserByName(name);
     }
@@ -112,12 +113,12 @@ public class UserApiService {
         return userManager.updateUser(id, roles);
     }
 
-    @PreAuthorize(ADMIN_ONLY)
+    @PreAuthorize(ADMIN_ONLY + OR_USER_READER)
     public List<PipelineUser> loadUsers() {
         return new ArrayList<>(userManager.loadAllUsers());
     }
 
-    @PreAuthorize(ADMIN_OR_GENERAL_USER)
+    @PreAuthorize(ADMIN_OR_GENERAL_USER + OR_USER_READER)
     public List<UserInfo> loadUsersInfo() {
         return userManager.loadUsersInfo();
     }
@@ -172,7 +173,7 @@ public class UserApiService {
         return userManager.findUsers(prefix);
     }
 
-    @PreAuthorize(ADMIN_ONLY)
+    @PreAuthorize(ADMIN_ONLY + OR_USER_READER)
     public byte[] exportUsers(final PipelineUserExportVO attr) {
         return userManager.exportUsers(attr);
     }

--- a/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
+++ b/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
@@ -22,7 +22,9 @@ public final class AclExpressions {
 
     public static final String ADMIN_ONLY = "hasRole('ADMIN')";
 
-    public static final String OR_USER_READER = OR + "hasRole('ROLE_USER_READER')";
+    public static final String USER_READER = "hasRole('ROLE_USER_READER')";
+
+    public static final String OR_USER_READER = OR + USER_READER;
 
     public static final String PIPELINE_ID_READ =
             "hasRole('ADMIN') OR hasPermission(#id, 'com.epam.pipeline.entity.pipeline.Pipeline', 'READ')";

--- a/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
+++ b/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
@@ -22,6 +22,8 @@ public final class AclExpressions {
 
     public static final String ADMIN_ONLY = "hasRole('ADMIN')";
 
+    public static final String OR_USER_READER = OR + "hasRole('ROLE_USER_READER')";
+
     public static final String PIPELINE_ID_READ =
             "hasRole('ADMIN') OR hasPermission(#id, 'com.epam.pipeline.entity.pipeline.Pipeline', 'READ')";
 

--- a/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
+++ b/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
@@ -22,9 +22,7 @@ public final class AclExpressions {
 
     public static final String ADMIN_ONLY = "hasRole('ADMIN')";
 
-    public static final String USER_READER = "hasRole('ROLE_USER_READER')";
-
-    public static final String OR_USER_READER = OR + USER_READER;
+    public static final String OR_USER_READER = OR + "hasRole('USER_READER')";
 
     public static final String PIPELINE_ID_READ =
             "hasRole('ADMIN') OR hasPermission(#id, 'com.epam.pipeline.entity.pipeline.Pipeline', 'READ')";

--- a/api/src/main/resources/db/migration/v2020.09.10_13.00__issue_1387_role_user_reader.sql
+++ b/api/src/main/resources/db/migration/v2020.09.10_13.00__issue_1387_role_user_reader.sql
@@ -1,0 +1,1 @@
+INSERT INTO pipeline.role (id, name, predefined, user_default)  VALUES (nextval('pipeline.s_role'), 'ROLE_USER_READER', TRUE, FALSE);

--- a/api/src/test/java/com/epam/pipeline/dao/user/RoleDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/user/RoleDaoTest.java
@@ -41,7 +41,7 @@ import static org.junit.Assert.*;
 @Transactional
 public class RoleDaoTest extends AbstractSpringTest {
 
-    private static final int EXPECTED_DEFAULT_ROLES_NUMBER = 10;
+    private static final int EXPECTED_DEFAULT_ROLES_NUMBER = 11;
     private static final String TEST_USER1 = "test_user1";
     private static final String TEST_ROLE = "ROLE_TEST";
     private static final String TEST_ROLE_UPDATED = "NEW_ROLE";

--- a/api/src/test/java/com/epam/pipeline/dao/user/UserDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/user/UserDaoTest.java
@@ -53,7 +53,7 @@ public class UserDaoTest extends AbstractSpringTest {
     private static final String ATTRIBUTES_KEY = "email";
     private static final String ATTRIBUTES_VALUE = "test_email";
     private static final String ATTRIBUTES_VALUE2 = "Mail@epam.com";
-    private static final int EXPECTED_DEFAULT_ROLES_NUMBER = 10;
+    private static final int EXPECTED_DEFAULT_ROLES_NUMBER = 11;
 
     @Autowired
     private UserDao userDao;


### PR DESCRIPTION
This PR is related to issue #1387

It brings a new predefined role `ROLE_USER_READER`, that grants read-only access to information regarding users, groups, roles.