### PR TITLE
issue 1388 introduce new lauch system param CP_TZ

### DIFF
--- a/deploy/contents/install/preferences/launch.system.parameters.json
+++ b/deploy/contents/install/preferences/launch.system.parameters.json
@@ -235,5 +235,12 @@
         "description": "Enable singularity for a current run",
         "defaultValue": "true",
         "passToWorkers": true
+    },
+    {
+        "name": "CP_TZ",
+        "type": "string",
+        "description": "Overwrites standard UTC timezone on pipeline run node",
+        "defaultValue": "/usr/share/zoneinfo/UTC",
+        "passToWorkers": true
     }
 ]

--- a/scripts/pipeline-launch/launch.sh
+++ b/scripts/pipeline-launch/launch.sh
@@ -625,6 +625,20 @@ fi
 
 
 ######################################################
+# Change Time Zone if configured
+######################################################
+
+echo "Cheking if timezone should be overwritten."
+if [ ! -z "$CP_TZ" ] && [ -f "$CP_TZ" ]; then
+  echo "CP_TZ variable set, and file exists, time zone will be changed to: $CP_TZ"
+  unlink /etc/localtime
+  ln -s "$CP_TZ" /etc/localtime
+else
+  echo "CP_TZ variable is not set, or that file doesn't exist, time zone will not be changed."
+fi
+
+
+######################################################
 # Install runtime dependencies
 ######################################################
 


### PR DESCRIPTION
Relates to #1388.
This PR introduces new launch system parameter that is handled in launch.sh to be able to overwrite local time zone by linking $CP_TZ file to /etc/localtime