### PR TITLE
Advanced configuration of notifications/automatic actions for "idle" runs

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/monitoring/LongPausedRunAction.java
+++ b/api/src/main/java/com/epam/pipeline/entity/monitoring/LongPausedRunAction.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.monitoring;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public enum LongPausedRunAction {
+    NOTIFY, STOP;
+
+    public static boolean contains(String value) {
+        return VALUE_SET.contains(value);
+    }
+
+    private static final Set<String> VALUE_SET = Arrays.stream(LongPausedRunAction.values())
+            .map(Enum::name)
+            .collect(Collectors.toSet());
+}

--- a/api/src/main/java/com/epam/pipeline/entity/monitoring/LongPausedRunAction.java
+++ b/api/src/main/java/com/epam/pipeline/entity/monitoring/LongPausedRunAction.java
@@ -20,14 +20,25 @@ import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/**
+ * Describes actions, that can be taken if a run is paused for a long time. This action type is controlled by
+ * {@code SystemPreferences.SYSTEM_LONG_PAUSED_ACTION}
+ */
 public enum LongPausedRunAction {
-    NOTIFY, STOP;
-
-    public static boolean contains(String value) {
-        return VALUE_SET.contains(value);
-    }
+    /**
+     * Notify users periodically
+     */
+    NOTIFY,
+    /**
+     * Notify users once and stop the run
+     */
+    STOP;
 
     private static final Set<String> VALUE_SET = Arrays.stream(LongPausedRunAction.values())
             .map(Enum::name)
             .collect(Collectors.toSet());
+
+    public static boolean contains(final String value) {
+        return VALUE_SET.contains(value);
+    }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
@@ -32,6 +32,7 @@ import java.util.stream.Stream;
 import javax.annotation.PostConstruct;
 
 import com.epam.pipeline.entity.cluster.monitoring.ELKUsageMetric;
+import com.epam.pipeline.entity.monitoring.LongPausedRunAction;
 import com.epam.pipeline.entity.pipeline.StopServerlessRun;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.epam.pipeline.manager.pipeline.StopServerlessRunManager;
@@ -152,6 +153,7 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
             processOverloadedRuns(runs);
             processPausingResumingRuns();
             processServerlessRuns();
+            processLongPausedRuns();
         }
 
         private void processPausingResumingRuns() {
@@ -433,6 +435,31 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
         public void updateInstanceMap(Map<String, InstanceType> types) {
             instanceTypeMap.clear();
             instanceTypeMap.putAll(types);
+        }
+
+        private void processLongPausedRuns() {
+            final LongPausedRunAction action = LongPausedRunAction.valueOf(preferenceManager.getPreference(
+                    SystemPreferences.SYSTEM_LONG_PAUSED_ACTION));
+
+            final List<PipelineRun> pausedRuns = pipelineRunManager
+                    .loadRunsByStatuses(Collections.singletonList(TaskStatus.PAUSED)).stream()
+                    .map(run -> pipelineRunManager.loadPipelineRunWithStatuses(run.getId()))
+                    .collect(Collectors.toList());
+
+            processLongPausedRuns(pausedRuns, action);
+        }
+
+        private void processLongPausedRuns(final List<PipelineRun> pausedRuns, final LongPausedRunAction action) {
+            if (CollectionUtils.isEmpty(pausedRuns)) {
+                return;
+            }
+
+            if (LongPausedRunAction.STOP.equals(action)) {
+                ListUtils.emptyIfNull(notificationManager.notifyLongPausedRunsBeforeStop(pausedRuns))
+                        .forEach(run -> pipelineRunManager.stop(run.getId()));
+            } else {
+                notificationManager.notifyLongPausedRuns(pausedRuns);
+            }
         }
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
@@ -456,7 +456,7 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
 
             if (LongPausedRunAction.STOP.equals(action)) {
                 ListUtils.emptyIfNull(notificationManager.notifyLongPausedRunsBeforeStop(pausedRuns))
-                        .forEach(run -> pipelineRunManager.stop(run.getId()));
+                        .forEach(run -> pipelineRunManager.terminateRun(run.getId()));
             } else {
                 notificationManager.notifyLongPausedRuns(pausedRuns);
             }

--- a/api/src/main/java/com/epam/pipeline/manager/notification/NotificationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/notification/NotificationManager.java
@@ -488,7 +488,6 @@ public class NotificationManager { // TODO: rewrite with Strategy pattern?
                         .collect(Collectors.toList())
                 ).stream()
                 .collect(Collectors.toMap(PipelineUser::getUserName, Function.identity()));
-
     }
 
     private List<Long> getCCUsers(final NotificationSettings idleRunSettings) {

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -613,6 +613,13 @@ public class PipelineRunManager {
         return run;
     }
 
+    @Transactional(propagation = Propagation.REQUIRED)
+    public PipelineRun loadPipelineRunWithStatuses(final Long id) {
+        final PipelineRun run = loadPipelineRun(id);
+        run.setRunStatuses(runStatusManager.loadRunStatus(id));
+        return run;
+    }
+
     /**
      * Method that will return all active runs for which current users is owner or is listed in run sids - a list of
      * identities (user names or groups) that have access to run

--- a/api/src/main/java/com/epam/pipeline/manager/preference/PreferenceValidators.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/PreferenceValidators.java
@@ -25,6 +25,7 @@ import com.amazonaws.services.kms.AWSKMSClientBuilder;
 import com.amazonaws.services.kms.model.KeyListEntry;
 import com.epam.pipeline.config.JsonMapper;
 import com.epam.pipeline.entity.monitoring.IdleRunAction;
+import com.epam.pipeline.entity.monitoring.LongPausedRunAction;
 import com.epam.pipeline.entity.preference.Preference;
 import com.epam.pipeline.security.ExternalServiceEndpoint;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -250,6 +251,9 @@ public final class PreferenceValidators {
 
     public static final BiPredicate<String, Map<String, Preference>> isValidIdleAction =
         (pref, ignored) -> IdleRunAction.contains(pref);
+
+    public static final BiPredicate<String, Map<String, Preference>> isValidLongPauseRunAction =
+            (pref, ignored) -> LongPausedRunAction.contains(pref);
 
     private PreferenceValidators() {
         // No-op

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -26,6 +26,7 @@ import com.epam.pipeline.entity.cluster.PriceType;
 import com.epam.pipeline.entity.cluster.container.ContainerMemoryResourcePolicy;
 import com.epam.pipeline.entity.git.GitlabVersion;
 import com.epam.pipeline.entity.monitoring.IdleRunAction;
+import com.epam.pipeline.entity.monitoring.LongPausedRunAction;
 import com.epam.pipeline.entity.preference.Preference;
 import com.epam.pipeline.entity.region.CloudProvider;
 import com.epam.pipeline.entity.search.SearchDocumentType;
@@ -530,6 +531,12 @@ public class SystemPreferences {
     // TODO: rewrite to an EnumPreference?
     public static final StringPreference SYSTEM_IDLE_ACTION = new StringPreference("system.idle.action",
                                    IdleRunAction.NOTIFY.name(), SYSTEM_GROUP, PreferenceValidators.isValidIdleAction);
+    /**
+     * Controls which action will be performed after action threshold for long paused runs.
+     * Can take values from {@link LongPausedRunAction} only.
+     */
+    public static final StringPreference SYSTEM_LONG_PAUSED_ACTION = new StringPreference("system.long.paused.action",
+            LongPausedRunAction.NOTIFY.name(), SYSTEM_GROUP, PreferenceValidators.isValidLongPauseRunAction);
     /**
      * Controls how long resource monitoring stats are being kept, in days
      */

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManagerTest.java
@@ -21,6 +21,7 @@ import com.epam.pipeline.dao.monitoring.MonitoringESDao;
 import com.epam.pipeline.entity.cluster.InstanceType;
 import com.epam.pipeline.entity.cluster.monitoring.ELKUsageMetric;
 import com.epam.pipeline.entity.monitoring.IdleRunAction;
+import com.epam.pipeline.entity.monitoring.LongPausedRunAction;
 import com.epam.pipeline.entity.notification.NotificationSettings.NotificationType;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.RunInstance;
@@ -178,6 +179,8 @@ public class ResourceMonitoringManagerTest {
                 .thenReturn(IdleRunAction.NOTIFY.name());
         when(preferenceManager.getPreference(SystemPreferences.LAUNCH_SERVERLESS_STOP_TIMEOUT))
                 .thenReturn(TEST_MAX_IDLE_MONITORING_TIMEOUT);
+        when(preferenceManager.getPreference(SystemPreferences.SYSTEM_LONG_PAUSED_ACTION))
+                .thenReturn(LongPausedRunAction.NOTIFY.name());
         when(stopServerlessRunManager.loadActiveServerlessRuns()).thenReturn(Collections.emptyList());
 
         SecurityContext context = SecurityContextHolder.createEmptyContext();
@@ -266,8 +269,8 @@ public class ResourceMonitoringManagerTest {
         highConsumingRun.setTags(stubTagMap);
 
         mockStats = new HashMap<>();
-        mockStats.put(okayRun.getInstance().getNodeName(), TEST_OK_RUN_CPU_LOAD); // in milicores, equals 80% of core load, per 2 cores,
-                                                                    // should be = 40% load
+        // in milicores, equals 80% of core load, per 2 cores, should be = 40% load
+        mockStats.put(okayRun.getInstance().getNodeName(), TEST_OK_RUN_CPU_LOAD);
         mockStats.put(idleSpotRun.getInstance().getNodeName(), TEST_IDLE_SPOT_RUN_CPU_LOAD);
         mockStats.put(idleOnDemandRun.getInstance().getNodeName(), TEST_IDLE_ON_DEMAND_RUN_CPU_LOAD);
         mockStats.put(autoscaleMasterRun.getInstance().getNodeName(), TEST_IDLE_ON_DEMAND_RUN_CPU_LOAD);

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/notification/NotificationSettings.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/notification/NotificationSettings.java
@@ -82,7 +82,8 @@ public class NotificationSettings {
         IDLE_RUN_PAUSED(7, MISSING_TIME_THRESHOLD, MISSING_TIME_THRESHOLD, NotificationGroup.IDLE_RUN),
         IDLE_RUN_STOPPED(8, MISSING_TIME_THRESHOLD, MISSING_TIME_THRESHOLD, NotificationGroup.IDLE_RUN),
         HIGH_CONSUMED_RESOURCES(9, MISSING_TIME_THRESHOLD, 600L,  NotificationGroup.RESOURCE_CONSUMING),
-        LONG_STATUS(10, 3600L, 600L, NotificationGroup.LONG_STATUS);
+        LONG_STATUS(10, 3600L, 600L, NotificationGroup.LONG_STATUS),
+        LONG_PAUSED(11, 3600L, 600L, NotificationGroup.LONG_PAUSED);
 
 
         private static final Map<Long, NotificationType> BY_ID;
@@ -129,6 +130,7 @@ public class NotificationSettings {
         PIPELINE_RUN_STATUS,
         IDLE_RUN,
         RESOURCE_CONSUMING,
-        LONG_STATUS
+        LONG_STATUS,
+        LONG_PAUSED
     }
 }

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/notification/NotificationSettings.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/notification/NotificationSettings.java
@@ -83,7 +83,8 @@ public class NotificationSettings {
         IDLE_RUN_STOPPED(8, MISSING_TIME_THRESHOLD, MISSING_TIME_THRESHOLD, NotificationGroup.IDLE_RUN),
         HIGH_CONSUMED_RESOURCES(9, MISSING_TIME_THRESHOLD, 600L,  NotificationGroup.RESOURCE_CONSUMING),
         LONG_STATUS(10, 3600L, 600L, NotificationGroup.LONG_STATUS),
-        LONG_PAUSED(11, 3600L, 600L, NotificationGroup.LONG_PAUSED);
+        LONG_PAUSED(11, MISSING_TIME_THRESHOLD, MISSING_TIME_THRESHOLD, NotificationGroup.LONG_PAUSED),
+        LONG_PAUSED_STOPPED(12, MISSING_TIME_THRESHOLD, MISSING_TIME_THRESHOLD, NotificationGroup.LONG_PAUSED);
 
 
         private static final Map<Long, NotificationType> BY_ID;

--- a/core/src/main/java/com/epam/pipeline/entity/notification/NotificationSettings.java
+++ b/core/src/main/java/com/epam/pipeline/entity/notification/NotificationSettings.java
@@ -96,7 +96,11 @@ public class NotificationSettings {
         IDLE_RUN_PAUSED(7, MISSING_TIME_THRESHOLD, MISSING_TIME_THRESHOLD, Collections.emptyList(), true, NotificationGroup.IDLE_RUN),
         IDLE_RUN_STOPPED(8, MISSING_TIME_THRESHOLD, MISSING_TIME_THRESHOLD, Collections.emptyList(), true, NotificationGroup.IDLE_RUN),
         HIGH_CONSUMED_RESOURCES(9, MISSING_TIME_THRESHOLD, 600L, Collections.emptyList(), true, NotificationGroup.RESOURCE_CONSUMING),
-        LONG_STATUS(10, 3600L, 600L, Collections.emptyList(), true, NotificationGroup.LONG_STATUS);
+        LONG_STATUS(10, 3600L, 600L, Collections.emptyList(), true, NotificationGroup.LONG_STATUS),
+        LONG_PAUSED(11, MISSING_TIME_THRESHOLD, MISSING_TIME_THRESHOLD, Collections.emptyList(), true,
+                NotificationGroup.LONG_PAUSED),
+        LONG_PAUSED_STOPPED(12, MISSING_TIME_THRESHOLD, MISSING_TIME_THRESHOLD, Collections.emptyList(), true,
+                NotificationGroup.LONG_PAUSED);
 
         private static final Map<Long, NotificationType> BY_ID;
 
@@ -157,6 +161,7 @@ public class NotificationSettings {
         PIPELINE_RUN_STATUS,
         IDLE_RUN,
         RESOURCE_CONSUMING,
-        LONG_STATUS
+        LONG_STATUS,
+        LONG_PAUSED
     }
 }

--- a/deploy/contents/install/email-templates/contents/LONG_PAUSED.html
+++ b/deploy/contents/install/email-templates/contents/LONG_PAUSED.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <style>
+        table,
+        td {
+            border: 1px solid black;
+            border-collapse: collapse;
+            padding: 5px;
+        }
+    </style>
+</head>
+
+<body>
+<p>Dear user,</p>
+<p>*** This is a system generated email, do not reply to this email ***</p>
+<p>There is a job with ID ${CP_DOLLAR}templateParameters["id"], launched from ${CP_DOLLAR}templateParameters.get("owner") account, that has been in paused state for more than ${CP_DOLLAR}templateParameters.get("timeThreshold") minutes</p>
+<br />
+<p>If you consider the waiting time normal, please ignore this email</p>
+<p>Otherwise, please log into the <a href="https://$CP_API_SRV_EXTERNAL_HOST:$CP_API_SRV_EXTERNAL_PORT/pipeline/#/run/${CP_DOLLAR}templateParameters.get("id")/plain">$CP_PREF_UI_PIPELINE_DEPLOYMENT_NAME Platform</a> and check the job's status</p>
+<p>If anything went wrong during status change for that job, please contact the support team.</p>
+<br />
+<p><b>Job details:</b></p>
+<table>
+    <tr>
+        <td>Run #</td>
+        <td><a href="https://$CP_API_SRV_EXTERNAL_HOST:$CP_API_SRV_EXTERNAL_PORT/pipeline/#/run/${CP_DOLLAR}templateParameters.get("id")/plain">${CP_DOLLAR}templateParameters.get("id")</a></td>
+    </tr>
+    <tr>
+        <td>Job/Tool</td>#if( ${CP_DOLLAR}templateParameters.get("pipelineName") && ${CP_DOLLAR}templateParameters.get("pipelineName") != "pipeline" )<td>${CP_DOLLAR}templateParameters.get("pipelineName")</td>#else<td>${CP_DOLLAR}templateParameters.get("dockerImage")</td>#end
+    </tr>
+    <tr>
+        <td>Running Time</td>
+        <td>${CP_DOLLAR}templateParameters.get("runningTime") minutes</td>
+    </tr>
+    <tr>
+        <td>Start Date</td>${CP_DOLLAR}calendar.setTime(${CP_DOLLAR}dateFormat.parse(${CP_DOLLAR}templateParameters.get("startDate")))<td>${CP_DOLLAR}calendar.getTime().toString()</td>
+    </tr>
+    <tr>
+        <td>Instance Type</td>
+        <td>${CP_DOLLAR}templateParameters.get("instance").get("nodeType")</td>
+    </tr>
+    <tr>
+        <td>Instance Disk</td>
+        <td>${CP_DOLLAR}templateParameters.get("instance").get("nodeDisk")</td>
+    </tr>
+</table>
+<br />
+<p>Best regards,</p>
+<p>$CP_PREF_UI_PIPELINE_DEPLOYMENT_NAME Platform</p>
+</body>
+
+</html>

--- a/deploy/contents/install/email-templates/contents/LONG_PAUSED_STOPPED.html
+++ b/deploy/contents/install/email-templates/contents/LONG_PAUSED_STOPPED.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <style>
+        table,
+        td {
+            border: 1px solid black;
+            border-collapse: collapse;
+            padding: 5px;
+        }
+    </style>
+</head>
+
+<body>
+<p>Dear user,</p>
+<p>*** This is a system generated email, do not reply to this email ***</p>
+<p>There is a job with ID ${CP_DOLLAR}templateParameters["id"], launched from ${CP_DOLLAR}templateParameters.get("owner") account, that has been in paused state for more than ${CP_DOLLAR}templateParameters.get("timeThreshold") minutes. This job will be stopped in a short stopped</p>
+<br />
+<p><b>Job details:</b></p>
+<table>
+    <tr>
+        <td>Run #</td>
+        <td><a href="https://$CP_API_SRV_EXTERNAL_HOST:$CP_API_SRV_EXTERNAL_PORT/pipeline/#/run/${CP_DOLLAR}templateParameters.get("id")/plain">${CP_DOLLAR}templateParameters.get("id")</a></td>
+    </tr>
+    <tr>
+        <td>Job/Tool</td>#if( ${CP_DOLLAR}templateParameters.get("pipelineName") && ${CP_DOLLAR}templateParameters.get("pipelineName") != "pipeline" )<td>${CP_DOLLAR}templateParameters.get("pipelineName")</td>#else<td>${CP_DOLLAR}templateParameters.get("dockerImage")</td>#end
+    </tr>
+    <tr>
+        <td>Running Time</td>
+        <td>${CP_DOLLAR}templateParameters.get("runningTime") minutes</td>
+    </tr>
+    <tr>
+        <td>Start Date</td>${CP_DOLLAR}calendar.setTime(${CP_DOLLAR}dateFormat.parse(${CP_DOLLAR}templateParameters.get("startDate")))<td>${CP_DOLLAR}calendar.getTime().toString()</td>
+    </tr>
+    <tr>
+        <td>Instance Type</td>
+        <td>${CP_DOLLAR}templateParameters.get("instance").get("nodeType")</td>
+    </tr>
+    <tr>
+        <td>Instance Disk</td>
+        <td>${CP_DOLLAR}templateParameters.get("instance").get("nodeDisk")</td>
+    </tr>
+</table>
+<br />
+<p>Best regards,</p>
+<p>$CP_PREF_UI_PIPELINE_DEPLOYMENT_NAME Platform</p>
+</body>
+
+</html>


### PR DESCRIPTION
This PR provides implementation for issue #1385 

The current PR contains the following changes:
- a new notification type `LONG_PAUSED` - indicates that run has been paused for a long time and notification shell be sent to users periodically with a certain time interval.
-  a new notification type `LONG_PAUSED_STOPPED` - indicates that run has been paused for a long time and shell be stopped after timeout.
- a new system property `system.long.paused.action` - indicated long paused runs action strategy: notify or stop
- a new email template files for a new notification types