### PR TITLE
fix addNewGroup method for tool registry permissions

### DIFF
--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/PermissionTabAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/PermissionTabAO.java
@@ -105,6 +105,7 @@ public class PermissionTabAO implements ClosableAO, AccessObject<PermissionTabAO
     public PermissionTabAO addNewGroup(String usersGroup) {
         return clickAddNewGroup()
                 .typeInField(usersGroup)
+                .selectGroup(usersGroup)
                 .ok();
     }
 
@@ -216,6 +217,11 @@ public class PermissionTabAO implements ClosableAO, AccessObject<PermissionTabAO
         public GroupAdditionPopupAO typeInField(String value) {
             Utils.getPopupByTitle("Select group")
                     .find(tagName("input")).shouldBe(visible).setValue(value);
+            return this;
+        }
+
+        private GroupAdditionPopupAO selectGroup(String name) {
+            $(byClassName("ant-select-dropdown-menu-root")).$(byText(name)).shouldBe(visible).click();
             return this;
         }
     }


### PR DESCRIPTION
This PR provides implementation for updating addNewGroup method for tool registry permissions.
The current PR contains the following changes: add selection of required value from drop-down list that fix issue for list with more then one values.