### PR TITLE
Advanced configuration of notifications/automatic actions for "idle" runs - improvements

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
@@ -455,7 +455,9 @@ public class ResourceMonitoringManager extends AbstractSchedulingManager {
             }
 
             if (LongPausedRunAction.STOP.equals(action)) {
-                ListUtils.emptyIfNull(notificationManager.notifyLongPausedRunsBeforeStop(pausedRuns))
+                ListUtils.emptyIfNull(notificationManager.notifyLongPausedRunsBeforeStop(pausedRuns.stream()
+                        .filter(run -> !run.isNonPause())
+                        .collect(Collectors.toList())))
                         .forEach(run -> pipelineRunManager.terminateRun(run.getId()));
             } else {
                 notificationManager.notifyLongPausedRuns(pausedRuns);

--- a/deploy/contents/install/email-templates/configs/LONG_PAUSED.json
+++ b/deploy/contents/install/email-templates/configs/LONG_PAUSED.json
@@ -1,0 +1,8 @@
+{
+  "keepInformedAdmins":true,
+  "keepInformedOwner":true,
+  "enabled":true,
+  "resendDelay": -1,
+  "threshold": -1,
+  "subject":"Job #$templateParameters[\"id\"] has been paused for a long time"
+}

--- a/deploy/contents/install/email-templates/configs/LONG_PAUSED_STOPPED.json
+++ b/deploy/contents/install/email-templates/configs/LONG_PAUSED_STOPPED.json
@@ -1,0 +1,8 @@
+{
+  "keepInformedAdmins":true,
+  "keepInformedOwner":true,
+  "enabled":true,
+  "resendDelay": -1,
+  "threshold": -1,
+  "subject":"Job #$templateParameters[\"id\"] has been paused for a long time and will be terminated"
+}


### PR DESCRIPTION
The PR provides additional implementations for issue #1385 

The current PR contains the following changes:
- added config files for `LONG_PAUSED` and `LONG_PAUSED_STOPPED`
- do not stop runs with disabled `auto pause`