### PR TITLE
Issue #1415 Load and validate JWT user from DB

### DIFF
--- a/api/src/main/java/com/epam/pipeline/security/jwt/JwtAuthenticationProvider.java
+++ b/api/src/main/java/com/epam/pipeline/security/jwt/JwtAuthenticationProvider.java
@@ -43,8 +43,7 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
             throw new AuthenticationServiceException("Authentication error", e);
         }
 
-        UserContext context = new UserContext(jwtRawToken, claims);
-        accessService.validateUserBlockStatus(context.getUsername());
+        UserContext context = accessService.getJwtUser(jwtRawToken, claims);
         return new JwtAuthenticationToken(context, context.getAuthorities());
     }
 

--- a/api/src/main/java/com/epam/pipeline/security/jwt/JwtFilterAuthenticationFilter.java
+++ b/api/src/main/java/com/epam/pipeline/security/jwt/JwtFilterAuthenticationFilter.java
@@ -52,8 +52,7 @@ public class JwtFilterAuthenticationFilter extends OncePerRequestFilter {
         try {
             if (!StringUtils.isEmpty(rawToken)) {
                 JwtTokenClaims claims = tokenVerifier.readClaims(rawToken.getToken());
-                UserContext context = new UserContext(rawToken, claims);
-                accessService.validateUserBlockStatus(context.getUsername());
+                UserContext context = accessService.getJwtUser(rawToken, claims);
                 JwtAuthenticationToken token = new JwtAuthenticationToken(context, context.getAuthorities());
                 token.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 SecurityContextHolder.getContext().setAuthentication(token);


### PR DESCRIPTION
This PR provides implementation for #1415 

### Implementation details
Online validation of JWT user is enabled via application property `jwt.validate.token.user` or environment variable `CP_API_JWT_VALIDATE_USER` and is disabled by default. If this feature is enabled, the following changes to JWT authentication/authorization are applied:
- During token validation user is loaded from DB by `username` and `user id` is checked. If ids don't match access is denied
- Blocked status is checked for user and his/her groups
- Groups and roles are taken from DB user and user for further authorization (e.g. access to objects)