### PR TITLE
Issue #1408: Pipe storage du ignores folders

### DIFF
--- a/pipe-cli/src/utilities/storage/s3.py
+++ b/pipe-cli/src/utilities/storage/s3.py
@@ -498,9 +498,9 @@ class ListingManager(StorageItemManager, AbstractListingManager):
         key = page_file['Key']
         if key == relative_path:
             return True
-        if relative_path.endswith("/"):
+        if relative_path.endswith(S3BucketOperations.S3_PATH_SEPARATOR):
             return True
-        if key.startswith("%s/" % relative_path):
+        if key.startswith("%s%s" % (relative_path, S3BucketOperations.S3_PATH_SEPARATOR)):
             return True
         return False
 


### PR DESCRIPTION
This PR provides implementation for issue #1408 

Previously, `pipe storage du` files listing took into consideration files as the `pipe storage ls`. This way, `pipe storage du` was calculated all files with common prefixes. 

The current PR provides additional check, that filters those paths that have not exact match with existing files/folders.