### PR TITLE
Fix Lustre deps installation

### DIFF
--- a/workflows/pipe-common/shell/install_nfs_client
+++ b/workflows/pipe-common/shell/install_nfs_client
@@ -35,8 +35,8 @@ then
       wget -q $LUSTRE_CLIENT_URL -O lustre-client.tar.gz &&
       mkdir -p lustre-client &&
       tar -xzvf lustre-client.tar.gz -C lustre-client/ &&
-      rpm -i --justdb --quiet --force lustre-client/dependencies/*.rpm &&
-      rpm -i --nodeps --quiet lustre-client/*.rpm &&
+      rpm -i --justdb --quiet --nodeps --force lustre-client/dependencies/*.rpm &&
+      yum install -y -q lustre-client/*.rpm &&
       package-cleanup --cleandupes -y &&
       rm -rf lustre-client*
 EOM


### PR DESCRIPTION
This PR fixes Lustre installation process: only hardware dependencies are passed straight to rpmdb, yum is used to install Lustre itself 