### PR TITLE
Issue #1426 Change dictionary POST endpoint behaviour

### DIFF
--- a/api/src/main/java/com/epam/pipeline/controller/metadata/CategoricalAttributeController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/metadata/CategoricalAttributeController.java
@@ -47,14 +47,14 @@ public class CategoricalAttributeController extends AbstractRestController {
 
     @PostMapping
     @ApiOperation(
-        value = "Add categorical attributes values.",
-        notes = "Add categorical attributes values",
+        value = "Update categorical attributes values.",
+        notes = "Update categorical attributes values",
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiResponses(
         value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
         })
-    public Result<Boolean> insertCategoricalAttributes(@RequestBody final List<CategoricalAttribute> dict) {
-        return Result.success(categoricalAttributeApiService.insertAttributesValues(dict));
+    public Result<Boolean> updateCategoricalAttributes(@RequestBody final List<CategoricalAttribute> dict) {
+        return Result.success(categoricalAttributeApiService.updateCategoricalAttributes(dict));
     }
 
     @GetMapping

--- a/api/src/main/java/com/epam/pipeline/manager/metadata/CategoricalAttributeApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/metadata/CategoricalAttributeApiService.java
@@ -31,8 +31,8 @@ public class CategoricalAttributeApiService {
     private final CategoricalAttributeManager categoricalAttributesManager;
 
     @PreAuthorize(AclExpressions.ADMIN_ONLY)
-    public boolean insertAttributesValues(final List<CategoricalAttribute> dict) {
-        return categoricalAttributesManager.insertAttributesValues(dict);
+    public boolean updateCategoricalAttributes(final List<CategoricalAttribute> dict) {
+        return categoricalAttributesManager.updateCategoricalAttributes(dict);
     }
 
     @PreAuthorize(AclExpressions.ADMIN_ONLY)

--- a/api/src/main/java/com/epam/pipeline/manager/metadata/CategoricalAttributeManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/metadata/CategoricalAttributeManager.java
@@ -36,6 +36,12 @@ public class CategoricalAttributeManager {
     private final MetadataManager metadataManager;
     private final MessageHelper messageHelper;
 
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public boolean updateCategoricalAttributes(final List<CategoricalAttribute> dict) {
+        return categoricalAttributesDao.updateCategoricalAttributes(dict);
+    }
+
     @Transactional(propagation = Propagation.REQUIRED)
     public boolean insertAttributesValues(final List<CategoricalAttribute> dict) {
         return categoricalAttributesDao.insertAttributesValues(dict);

--- a/api/src/main/resources/dao/categorical-attribute-dao.xml
+++ b/api/src/main/resources/dao/categorical-attribute-dao.xml
@@ -49,7 +49,7 @@
         <property name="deleteAttributeValuesQuery">
             <value>
                 <![CDATA[
-                    DELETE FROM pipeline.categorical_attributes WHERE key=:KEY
+                    DELETE FROM pipeline.categorical_attributes WHERE key IN (:list)
                 ]]>
             </value>
         </property>

--- a/api/src/test/java/com/epam/pipeline/dao/metadata/CategoricalAttributeDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/metadata/CategoricalAttributeDaoTest.java
@@ -76,6 +76,24 @@ public class CategoricalAttributeDaoTest extends AbstractSpringTest {
 
     @Test
     @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void testUpdateAttributesValues() {
+        final List<CategoricalAttribute> values = new ArrayList<>();
+        values.add(new CategoricalAttribute(ATTRIBUTE_KEY_1, Arrays.asList(ATTRIBUTE_VALUE_1, ATTRIBUTE_VALUE_2)));
+        Assert.assertTrue(categoricalAttributeDao.insertAttributesValues(values));
+        final List<CategoricalAttribute> attributes = categoricalAttributeDao.loadAll();
+        Assert.assertEquals(1, attributes.size());
+        assertAttribute(attributes.get(0), ATTRIBUTE_KEY_1, ATTRIBUTE_VALUE_1, ATTRIBUTE_VALUE_2);
+
+        final List<CategoricalAttribute> valuesToReplace = new ArrayList<>();
+        valuesToReplace.add(new CategoricalAttribute(ATTRIBUTE_KEY_1, Collections.singletonList(ATTRIBUTE_VALUE_3)));
+        Assert.assertTrue(categoricalAttributeDao.updateCategoricalAttributes(valuesToReplace));
+        final List<CategoricalAttribute> attributesAfter = categoricalAttributeDao.loadAll();
+        Assert.assertEquals(1, attributesAfter.size());
+        assertAttribute(attributesAfter.get(0), ATTRIBUTE_KEY_1, ATTRIBUTE_VALUE_3);
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void testLoadAll() {
         final List<CategoricalAttribute> values = Arrays.asList(
             new CategoricalAttribute(ATTRIBUTE_KEY_1, Arrays.asList(ATTRIBUTE_VALUE_1, ATTRIBUTE_VALUE_2)),
@@ -136,6 +154,12 @@ public class CategoricalAttributeDaoTest extends AbstractSpringTest {
         Assert.assertEquals(2, attributesWithValues.size());
         assertValuesPresentedForKeyInMap(attributesWithValues, ATTRIBUTE_KEY_1, ATTRIBUTE_VALUE_2);
         assertValuesPresentedForKeyInMap(attributesWithValues, ATTRIBUTE_KEY_2, ATTRIBUTE_VALUE_3);
+    }
+
+    private void assertAttribute(final CategoricalAttribute attributeAfter, final String key,
+                                 final String ... values) {
+        Assert.assertEquals(key, attributeAfter.getKey());
+        Assert.assertThat(attributeAfter.getValues(), CoreMatchers.is(Arrays.asList(values)));
     }
 
     private Map<String, List<String>> convertToMap(final List<CategoricalAttribute> attributes) {


### PR DESCRIPTION
This PR is relatred to issue #1426 

It changes the way POST `/categorical_attribute` endpoint behaves: from now it replaces the whole dictionary instead of appending values to it