### PR TITLE
Support parallel transfers in pipe cli for gcs

### DIFF
--- a/pipe-cli/requirements.txt
+++ b/pipe-cli/requirements.txt
@@ -11,6 +11,7 @@ pytest==3.2.5
 pytest-cov==2.5.1
 boto3==1.6.9
 botocore==1.9.9
+s3transfer==0.1.13
 future
 PyJWT==1.6.1
 tld==0.10

--- a/pipe-cli/src/utilities/progress_bar.py
+++ b/pipe-cli/src/utilities/progress_bar.py
@@ -76,6 +76,8 @@ class ProgressPercentage(object):
 
     def __call__(self, bytes_amount):
         with self._lock:
+            if int(bytes_amount) <= 0:
+                return
             self._seen_so_far += float(bytes_amount) / self.unit_divider
             if self._size == 0:
                 percentage = 100.00

--- a/pipe-cli/src/utilities/storage/gs.py
+++ b/pipe-cli/src/utilities/storage/gs.py
@@ -666,7 +666,12 @@ class GsUploadManager(GsManager, AbstractTransferManager):
         bucket = self.client.bucket(destination_wrapper.bucket.path)
         blob = self._progress_blob(bucket, destination_key, progress_callback, size)
         blob.metadata = StorageOperations.generate_tags(tags, source_key)
-        transfer_config = TransferConfig()
+        multipart_threshold = int(os.getenv('CP_CLI_GCP_MULTIPART_THRESHOLD') or 8 * MB)
+        multipart_chunksize = int(os.getenv('CP_CLI_GCP_MULTIPART_CHUNKSIZE') or 8 * MB)
+        max_concurrency = int(os.getenv('CP_CLI_GCP_MAX_CONCURRENCY') or 10)
+        transfer_config = TransferConfig(multipart_threshold=multipart_threshold,
+                                         multipart_chunksize=multipart_chunksize,
+                                         max_concurrency=max_concurrency)
         if size > transfer_config.multipart_threshold:
             # For big files uploading in google cloud storages composite uploads are used
             # in conjunction with s3transfer library which originally manages parallel uploading

--- a/pipe-cli/src/utilities/storage/gs.py
+++ b/pipe-cli/src/utilities/storage/gs.py
@@ -679,7 +679,7 @@ class GsUploadManager(GsManager, AbstractTransferManager):
             progress_callback = ProgressPercentage(relative_path, size) if progress_callback else None
             upload_client = GCPCompositeUploadClient(destination_wrapper.bucket.path, destination_key, self.client,
                                                      progress_callback)
-            uploader = MultipartUploader(client=upload_client, config=TransferConfig(), osutil=OSUtils())
+            uploader = MultipartUploader(client=upload_client, config=transfer_config, osutil=OSUtils())
             uploader.upload_file(filename=source_key, bucket=destination_wrapper.bucket.path, key=destination_key,
                                  callback=None, extra_args={})
             blob.patch()

--- a/pipe-cli/src/utilities/storage/gs.py
+++ b/pipe-cli/src/utilities/storage/gs.py
@@ -276,10 +276,6 @@ class _ResumableIterReader:
                                        'You can alter the number of allowed resumes using %s environment variable. '
                                        'Original error: %s.'
                                        % (self._total_attempts, CP_CLI_RESUMABLE_DOWNLOAD_ATTEMPTS, str(e)))
-                # todo: Remove before merging
-                else:
-                    print('Resumable download from %s to %s failed on %s because of %s. It will be resumed.'
-                          % (self._start, self._end, self._bytes_transferred, str(e)))
         return self._null
 
 

--- a/pipe-cli/src/utilities/storage/gs.py
+++ b/pipe-cli/src/utilities/storage/gs.py
@@ -260,7 +260,13 @@ class _ResumableDownloadProgressMixin(Blob):
             download._write_to_stream = lambda x: x
             response = download.consume(transport)
             body_iter = response.iter_content(chunk_size=1024 * 1024, decode_unicode=False)
-            return io.BufferedReader(IterStream(body_iter), buffer_size=1024 * 1024)
+
+            class ReadBuffer:
+
+                def read(self, *args, **kwargs):
+                    return body_iter.next()
+
+            return ReadBuffer()
         except resumable_media.InvalidResponse as exc:
             _raise_from_invalid_response(exc)
 
@@ -284,25 +290,6 @@ class _ResumableDownloadProgressMixin(Blob):
                                        'Original error: %s.'
                                        % (self._attempts, CP_CLI_RESUMABLE_DOWNLOAD_ATTEMPTS, str(e)))
         self.reload()
-
-
-class IterStream(io.RawIOBase):
-
-    def __init__(self, iterable):
-        self._leftover = None
-        self._iterable = iterable
-
-    def readable(self):
-        return True
-
-    def readinto(self, b):
-        try:
-            chunk = self._leftover or next(self._iterable)
-            output, self._leftover = chunk[:len(b)], chunk[len(b):]
-            b[:len(output)] = output
-            return len(output)
-        except StopIteration:
-            return 0
 
 
 class _UploadProgressMixin(Blob):


### PR DESCRIPTION
Resolves issue #1374.

The pull request brings support for parallel google cloud storages uploading / downloading functionality in pipe cli.

Current implementation uses s3transfer library which manages chunking and parallelization. The library is also used by boto3 to perform transferring for s3 data storages. 

The following heuristics based on gsutil ones are used in order to implement efficient parallel upload and download operations.
- Only files bigger than 200 MB (see CP_CLI_GCP_MULTIPART_THRESHOLD) are downloaded in parallel by 200 MB (see CP_CLI_GCP_MULTIPART_CHUNKSIZE) chunks.
- Only files bigger than 150 MB (see CP_CLI_GCP_MULTIPART_THRESHOLD) are uploaded in parallel in 32 chunks at most based on file size and minimum chunk size of 150 MB (see CP_CLI_GCP_MULTIPART_CHUNKSIZE).
- Number of upload / download threads are 10 at most.

All the default parallel uploading heuristics can be overriden via the following environment variables:
- `CP_CLI_GCP_MULTIPART_THRESHOLD` specifies fie size threshold for parallel upload / download.
- `CP_CLI_GCP_MULTIPART_CHUNKSIZE` specifies parallel upload / download chunk size.
- `CP_CLI_GCP_MAX_CONCURRENCY` specifies number of threads to be used for upload / download.

See benchmarks in #1374.