### PR TITLE
Repair parallel transfer in pipe cli for gcs on windows

### DIFF
--- a/pipe-cli/src/utilities/storage/gs.py
+++ b/pipe-cli/src/utilities/storage/gs.py
@@ -250,7 +250,7 @@ class _ResumableIterReader:
                     self._iter = self._get_iter(self._start + self._bytes_transferred, self._end)
                     self._need_resume = False
                 try:
-                    chunk = self._iter.next()
+                    chunk = next(self._iter)
                     self._bytes_transferred += len(chunk)
                     return chunk
                 except StopIteration:


### PR DESCRIPTION
Relates to #1374.

The pull request brings two fixes for gcs parallel transfer implementation:
- First one replaces python 2 `iterator.next()` call with python 2 and 3 `next(iterator)` call. It previously broke pipe cli win build where python target is 3 rather than 2 that is used for pipe cli linux build.
- Second one simplifies proxies resolving mechanism for gcs in order to avoid `pypac` library calls in multithreading mode which tends to fail on windows.
