### PR TITLE
Export user metadata

### DIFF
--- a/api/src/main/java/com/epam/pipeline/controller/metadata/MetadataController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/metadata/MetadataController.java
@@ -43,6 +43,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.List;
+import java.util.Set;
 
 @Controller
 @Api(value = "Metadata")
@@ -112,7 +113,7 @@ public class MetadataController extends AbstractRestController {
     @ApiResponses(
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
             })
-    public Result<List<String>> getMetadataKeys(@RequestParam final AclClass entityClass) {
+    public Result<Set<String>> getMetadataKeys(@RequestParam final AclClass entityClass) {
         return Result.success(metadataApiService.getMetadataKeys(entityClass));
     }
 

--- a/api/src/main/java/com/epam/pipeline/controller/metadata/MetadataController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/metadata/MetadataController.java
@@ -103,6 +103,19 @@ public class MetadataController extends AbstractRestController {
         return Result.success(metadataApiService.listMetadataItems(entities));
     }
 
+    @RequestMapping(value = "/metadata/keys", method = RequestMethod.GET)
+    @ResponseBody
+    @ApiOperation(
+            value = "Get list of metadata keys for a class.",
+            notes = "Get list of metadata keys for a class.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public Result<List<String>> getMetadataKeys(@RequestParam final AclClass entityClass) {
+        return Result.success(metadataApiService.getMetadataKeys(entityClass));
+    }
+
     @RequestMapping(value = "/metadata/find", method = RequestMethod.GET)
     @ResponseBody
     @ApiOperation(

--- a/api/src/main/java/com/epam/pipeline/controller/vo/PipelineUserExportVO.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/PipelineUserExportVO.java
@@ -18,6 +18,8 @@ package com.epam.pipeline.controller.vo;
 
 import lombok.Data;
 
+import java.util.List;
+
 
 @Data
 public class PipelineUserExportVO {
@@ -32,4 +34,5 @@ public class PipelineUserExportVO {
     private boolean includeFirstLoginDate;
     private boolean includeHeader;
     private boolean includeAttributes;
+    private List<String> metadataColumns;
 }

--- a/api/src/main/java/com/epam/pipeline/dao/metadata/MetadataDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/metadata/MetadataDao.java
@@ -24,6 +24,7 @@ import com.epam.pipeline.entity.metadata.MetadataEntryWithIssuesCount;
 import com.epam.pipeline.entity.metadata.PipeConfValue;
 import com.epam.pipeline.entity.security.acl.AclClass;
 import com.fasterxml.jackson.core.type.TypeReference;
+import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.annotation.Required;
 import org.springframework.beans.factory.annotation.Value;
@@ -37,6 +38,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -63,6 +65,7 @@ public class MetadataDao extends NamedParameterJdbcDaoSupport {
     private String searchMetadataByClassAndKeyValueQuery;
     private String loadUniqueValuesFromEntitiesAttributes;
     private String createMetadataDictionary;
+    private String loadMetadataKeysQuery;
 
     @Value("#{'${metadata.sensitive.keys}'.split(',')}")
     private List<String> sensitiveMetadataKeys;
@@ -160,6 +163,13 @@ public class MetadataDao extends NamedParameterJdbcDaoSupport {
         return JsonMapper.convertDataToJsonStringForQuery(data);
     }
 
+    public Set<String> loadMetadataKeys(final AclClass entityClass) {
+        final List<String> result = ListUtils.emptyIfNull(
+                getJdbcTemplate()
+                        .queryForList(loadMetadataKeysQuery, String.class, entityClass.name()));
+        return new HashSet<>(result);
+    }
+
     private String convertEntitiesToString(String query, List<EntityVO> entities) {
         return entitiesValuePattern.matcher(query)
                 .replaceAll(entities.stream()
@@ -220,6 +230,11 @@ public class MetadataDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setCreateMetadataDictionary(final String createMetadataDictionary) {
         this.createMetadataDictionary = createMetadataDictionary;
+    }
+
+    @Required
+    public void setLoadMetadataKeysQuery(final String loadMetadataKeysQuery) {
+        this.loadMetadataKeysQuery = loadMetadataKeysQuery;
     }
 
     public enum MetadataParameters {

--- a/api/src/main/java/com/epam/pipeline/entity/user/PipelineUserWithStoragePath.java
+++ b/api/src/main/java/com/epam/pipeline/entity/user/PipelineUserWithStoragePath.java
@@ -1,11 +1,10 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
- *
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,10 +15,13 @@
 
 package com.epam.pipeline.entity.user;
 
+import com.epam.pipeline.entity.metadata.PipeConfValue;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Delegate;
+
+import java.util.Map;
 
 @Getter
 @Setter
@@ -29,6 +31,7 @@ public class PipelineUserWithStoragePath {
     @Delegate
     private PipelineUser pipelineUser;
     private String defaultStoragePath;
+    private Map<String, PipeConfValue> metadata;
 
     @Getter
     public enum PipelineUserFields {

--- a/api/src/main/java/com/epam/pipeline/manager/metadata/MetadataApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/metadata/MetadataApiService.java
@@ -96,4 +96,9 @@ public class MetadataApiService {
                                                            final String value) {
         return metadataManager.searchMetadataByClassAndKeyValue(entityClass, key, value);
     }
+
+    @PreAuthorize(AclExpressions.ADMIN_OR_GENERAL_USER)
+    public List<String> getMetadataKeys(final AclClass entityClass) {
+        return metadataManager.getMetadataKeys(entityClass);
+    }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/metadata/MetadataApiService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/metadata/MetadataApiService.java
@@ -30,6 +30,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Set;
 
 @Service
 public class MetadataApiService {
@@ -98,7 +99,7 @@ public class MetadataApiService {
     }
 
     @PreAuthorize(AclExpressions.ADMIN_OR_GENERAL_USER)
-    public List<String> getMetadataKeys(final AclClass entityClass) {
+    public Set<String> getMetadataKeys(final AclClass entityClass) {
         return metadataManager.getMetadataKeys(entityClass);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/metadata/MetadataManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/metadata/MetadataManager.java
@@ -279,6 +279,10 @@ public class MetadataManager {
         return metadataDao.buildFullMetadataDict();
     }
 
+    public List<String> getMetadataKeys(final AclClass entityClass) {
+        return Collections.emptyList();
+    }
+
     Map<String, PipeConfValue> convertFileContentToMetadata(MultipartFile file) {
         String delimiter = MetadataParsingUtils.getDelimiterFromFileExtension(file.getOriginalFilename());
         try (InputStream content = file.getInputStream()) {

--- a/api/src/main/java/com/epam/pipeline/manager/metadata/MetadataManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/metadata/MetadataManager.java
@@ -279,8 +279,8 @@ public class MetadataManager {
         return metadataDao.buildFullMetadataDict();
     }
 
-    public List<String> getMetadataKeys(final AclClass entityClass) {
-        return Collections.emptyList();
+    public Set<String> getMetadataKeys(final AclClass entityClass) {
+        return metadataDao.loadMetadataKeys(entityClass);
     }
 
     Map<String, PipeConfValue> convertFileContentToMetadata(MultipartFile file) {

--- a/api/src/main/java/com/epam/pipeline/manager/user/UserManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/UserManager.java
@@ -18,13 +18,16 @@ package com.epam.pipeline.manager.user;
 
 import com.epam.pipeline.common.MessageConstants;
 import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.controller.vo.EntityVO;
 import com.epam.pipeline.controller.vo.PipelineUserExportVO;
 import com.epam.pipeline.controller.vo.PipelineUserVO;
 import com.epam.pipeline.dao.user.GroupStatusDao;
 import com.epam.pipeline.dao.user.RoleDao;
 import com.epam.pipeline.dao.user.UserDao;
 import com.epam.pipeline.entity.info.UserInfo;
+import com.epam.pipeline.entity.metadata.PipeConfValue;
 import com.epam.pipeline.entity.security.JwtRawToken;
+import com.epam.pipeline.entity.security.acl.AclClass;
 import com.epam.pipeline.entity.user.CustomControl;
 import com.epam.pipeline.entity.user.DefaultRoles;
 import com.epam.pipeline.entity.user.GroupStatus;
@@ -33,6 +36,7 @@ import com.epam.pipeline.entity.user.PipelineUserWithStoragePath;
 import com.epam.pipeline.entity.user.Role;
 import com.epam.pipeline.entity.utils.ControlEntry;
 import com.epam.pipeline.manager.datastorage.DataStorageValidator;
+import com.epam.pipeline.manager.metadata.MetadataManager;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.manager.security.AuthManager;
@@ -54,6 +58,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -86,6 +91,9 @@ public class UserManager {
 
     @Autowired
     private DataStorageValidator storageValidator;
+
+    @Autowired
+    private MetadataManager metadataManager;
 
     @Transactional(propagation = Propagation.REQUIRED)
     public PipelineUser createUser(String name, List<Long> roles,
@@ -167,7 +175,17 @@ public class UserManager {
     }
 
     public Collection<PipelineUserWithStoragePath> loadAllUsersWithDataStoragePath() {
-        return userDao.loadAllUsersWithDataStoragePath();
+        final Collection<PipelineUserWithStoragePath> users = userDao.loadAllUsersWithDataStoragePath();
+        final Map<Long, Map<String, PipeConfValue>> metadata = ListUtils.emptyIfNull(
+                metadataManager.listMetadataItems(users.stream()
+                        .map(user -> new EntityVO(user.getId(), AclClass.PIPELINE_USER))
+                        .collect(Collectors.toList())))
+                .stream()
+                .collect(HashMap::new,
+                    (map, entry) -> map.put(entry.getEntity().getEntityId(), entry.getData()),
+                    HashMap::putAll);
+        users.forEach(user -> user.setMetadata(metadata.get(user.getId())));
+        return users;
     }
 
     @Transactional(propagation = Propagation.REQUIRED)

--- a/api/src/main/resources/dao/metadata-dao.xml
+++ b/api/src/main/resources/dao/metadata-dao.xml
@@ -84,6 +84,15 @@
                 ]]>
             </value>
         </property>
+        <property name="loadMetadataKeysQuery">
+            <value>
+                <![CDATA[
+                    SELECT DISTINCT jsonb_object_keys(data) as key
+                    FROM pipeline.metadata as m
+                    WHERE m.entity_class = ?
+                ]]>
+            </value>
+        </property>
         <property name="loadMetadataItemsQuery">
             <value>
                 <![CDATA[

--- a/api/src/test/java/com/epam/pipeline/dao/metadata/MetadataDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/metadata/MetadataDaoTest.java
@@ -32,7 +32,6 @@ import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
@@ -47,6 +46,10 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertThat;
+
+@Transactional
 public class MetadataDaoTest extends AbstractSpringTest {
 
     private static final String AUTHOR = "Author";
@@ -73,7 +76,6 @@ public class MetadataDaoTest extends AbstractSpringTest {
     private MetadataDao metadataDao;
 
     @Test
-    @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
     public void testOneMetadata() {
         EntityVO entityVO = new EntityVO(ID_1, CLASS_1);
         Map<String, PipeConfValue> data = new HashMap<>();
@@ -139,7 +141,6 @@ public class MetadataDaoTest extends AbstractSpringTest {
     }
 
     @Test
-    @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
     public void testListMetadata() {
         EntityVO entity1 = new EntityVO(ID_1, CLASS_1);
         Map<String, PipeConfValue> data1 = new HashMap<>();
@@ -171,18 +172,7 @@ public class MetadataDaoTest extends AbstractSpringTest {
         Assert.assertNull(createdMetadata);
     }
 
-    private static MetadataEntryWithIssuesCount convertMetadataWithIssues(EntityVO entityVO,
-                                                                          Map<String, PipeConfValue> data,
-                                                                          long issuesCount) {
-        MetadataEntryWithIssuesCount metadataEntryWithIssuesCount = new MetadataEntryWithIssuesCount();
-        metadataEntryWithIssuesCount.setIssuesCount(issuesCount);
-        metadataEntryWithIssuesCount.setData(data);
-        metadataEntryWithIssuesCount.setEntity(entityVO);
-        return metadataEntryWithIssuesCount;
-    }
-
     @Test
-    @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
     public void testMetadataWithIssues() {
         Pair<EntityVO, MetadataEntry> pipelinePair = createItems("pipeline", AclClass.PIPELINE, true);
         Pair<EntityVO, MetadataEntry> folderPair = createItems("folder", AclClass.FOLDER, true);
@@ -202,7 +192,6 @@ public class MetadataDaoTest extends AbstractSpringTest {
     }
 
     @Test
-    @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
     public void testShouldSearchMetadataByClassAndKeyValuePair() {
         EntityVO entityVO = new EntityVO(ID_1, CLASS_1);
         Map<String, PipeConfValue> data = new HashMap<>();
@@ -225,7 +214,6 @@ public class MetadataDaoTest extends AbstractSpringTest {
     }
 
     @Test
-    @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
     public void testLoadUniqueAttributes() {
         createMetadataForEntity(ID_1, CLASS_1, DATA_KEY_1, DATA_TYPE_1, DATA_VALUE_1);
         createMetadataForEntity(ID_2, CLASS_1, DATA_KEY_1, DATA_TYPE_1, DATA_VALUE_1);
@@ -234,14 +222,13 @@ public class MetadataDaoTest extends AbstractSpringTest {
         final List<String> uniqueAttributeValues =
             metadataDao.loadUniqueValuesFromEntitiesAttribute(CLASS_1, DATA_KEY_1);
         Assert.assertEquals(2, uniqueAttributeValues.size());
-        Assert.assertThat(uniqueAttributeValues, CoreMatchers.hasItems(DATA_VALUE_1, DATA_VALUE_2));
+        assertThat(uniqueAttributeValues, CoreMatchers.hasItems(DATA_VALUE_1, DATA_VALUE_2));
         final List<String> emptyValues =
             metadataDao.loadUniqueValuesFromEntitiesAttribute(CLASS_1, NON_EXISTING_DATA_KEY);
         Assert.assertEquals(0, emptyValues.size());
     }
 
     @Test
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void testBuildFullMetadataDict() {
         createMetadataForEntity(ID_1, CLASS_1, DATA_KEY_1, DATA_TYPE_1, DATA_VALUE_1);
         createMetadataForEntity(ID_2, CLASS_1, DATA_KEY_1, DATA_TYPE_1, DATA_VALUE_2);
@@ -252,14 +239,22 @@ public class MetadataDaoTest extends AbstractSpringTest {
                                           .map(CategoricalAttributeValue::getValue)
                                           .collect(Collectors.toList())));
         Assert.assertEquals(2, metadataDict.size());
-        Assert.assertThat(metadataDict.get(DATA_KEY_1), CoreMatchers.is(Arrays.asList(DATA_VALUE_1, DATA_VALUE_2)));
-        Assert.assertThat(metadataDict.get(DATA_KEY_2), CoreMatchers.is(Collections.singletonList(DATA_VALUE_1)));
+        assertThat(metadataDict.get(DATA_KEY_1), CoreMatchers.is(Arrays.asList(DATA_VALUE_1, DATA_VALUE_2)));
+        assertThat(metadataDict.get(DATA_KEY_2), CoreMatchers.is(Collections.singletonList(DATA_VALUE_1)));
         Assert.assertFalse(metadataDict.containsKey(SENSITIVE_DATA_KEY));
         final MetadataEntry metadataEntryWithSensitiveField = metadataDao.loadMetadataItem(new EntityVO(ID_3, CLASS_1));
         final Map<String, PipeConfValue> sensitiveEntryData = metadataEntryWithSensitiveField.getData();
         Assert.assertEquals(2, sensitiveEntryData.size());
         assertMetadataValue(sensitiveEntryData.get(DATA_KEY_2), DATA_TYPE_1, DATA_VALUE_1);
         assertMetadataValue(sensitiveEntryData.get(SENSITIVE_DATA_KEY), DATA_TYPE_1, DATA_VALUE_2);
+    }
+
+    @Test
+    public void shouldReturnMetadataKeysForClass() {
+        createMetadataForEntity(ID_1, CLASS_1, DATA_KEY_1, DATA_TYPE_1, DATA_VALUE_1);
+        createMetadataForEntity(ID_2, CLASS_1, DATA_KEY_2, DATA_TYPE_1, DATA_VALUE_2);
+        final Set<String> metadataKeys = metadataDao.loadMetadataKeys(CLASS_1);
+        assertThat(metadataKeys, containsInAnyOrder(DATA_KEY_1, DATA_KEY_2));
     }
 
     private void assertMetadataValue(final PipeConfValue sensitivePipeConfValue, final String dataType,
@@ -308,5 +303,15 @@ public class MetadataDaoTest extends AbstractSpringTest {
             metadataDao.registerMetadataItem(metadataEntry);
         }
         return new ImmutablePair<>(entity, metadataEntry);
+    }
+
+    private static MetadataEntryWithIssuesCount convertMetadataWithIssues(EntityVO entityVO,
+                                                                          Map<String, PipeConfValue> data,
+                                                                          long issuesCount) {
+        MetadataEntryWithIssuesCount metadataEntryWithIssuesCount = new MetadataEntryWithIssuesCount();
+        metadataEntryWithIssuesCount.setIssuesCount(issuesCount);
+        metadataEntryWithIssuesCount.setData(data);
+        metadataEntryWithIssuesCount.setEntity(entityVO);
+        return metadataEntryWithIssuesCount;
     }
 }


### PR DESCRIPTION
This PR is related to #1462 

### Implementation
- new API method `GET /metadata/keys` allows to get all availables metadata keys for a class (`PIPELINE_USER` for users)
- a new field `metadataColumns` is added to request `POST /user/export`, columns specified in these field will be added to the exported csv