### PR TITLE
GUI Checkboxes label

### DIFF
--- a/client/src/components/pipelines/launch/form/BooleanParameterInput.js
+++ b/client/src/components/pipelines/launch/form/BooleanParameterInput.js
@@ -44,8 +44,9 @@ export default class BooleanParameterInput extends React.Component {
         className={this.props.className}
         disabled={this.props.disabled}
         checked={this.checked}
-        onChange={this.onChange}>
-        {this.checked ? 'Enabled' : 'Disabled'}
+        onChange={this.onChange}
+      >
+        Enabled
       </Checkbox>
     );
   };

--- a/client/src/components/pipelines/launch/form/LaunchPipelineForm.js
+++ b/client/src/components/pipelines/launch/form/LaunchPipelineForm.js
@@ -3827,7 +3827,7 @@ class LaunchPipelineForm extends localization.LocalizedReactComponent {
               <Row type="flex" align="middle">
                 <Col span={10}>
                   <Checkbox checked={this.state.autoPause} onChange={onChange}>
-                    {this.state.autoPause ? 'Enabled' : 'Disabled'}
+                    Enabled
                   </Checkbox>
                 </Col>
                 <Col span={1} style={{marginLeft: 7, marginTop: 3}}>

--- a/client/src/components/settings/forms/PreferenceGroup.js
+++ b/client/src/components/settings/forms/PreferenceGroup.js
@@ -248,10 +248,9 @@ class PreferenceInput extends React.Component {
           style={{lineHeight: 1, marginLeft: 2}}
           checked={`${this.state.value}` === 'true'}
           onChange={e => this.onValueChange(e.target.checked.toString())}
-          disabled={this.props.disabled}>
-          {
-            `${this.state.value}` === 'true' ? 'Enabled' : 'Disabled'
-          }
+          disabled={this.props.disabled}
+        >
+          Enabled
         </Checkbox>
       );
     } else if (this.props.value.type === 'OBJECT') {

--- a/client/src/components/tools/forms/EditToolFormParameters.js
+++ b/client/src/components/tools/forms/EditToolFormParameters.js
@@ -177,8 +177,9 @@ export default class EditToolFormParameters extends React.Component {
         disabled={this.props.readOnly}
         checked={`${parameter.value}` === 'true'}
         style={Object.assign({marginLeft: 5, marginTop: 4}, isError ? {color: 'red'} : {})}
-        onChange={onChange}>
-        {parameter.value ? 'Enabled' : 'Disabled'}
+        onChange={onChange}
+      >
+        Enabled
       </Checkbox>
     );
   };


### PR DESCRIPTION
This PR fixes #1474 issue. Checkboxes now always have `Enabled` label:
* Launch Form: for `boolean` parameters and `Auto-pause` setting;
* Tool Settings: for `boolean` parameters;
* Preferences: for `boolean` preferences.