### PR TITLE
Issue #1445 Change categorical attribute values update

### DIFF
--- a/api/src/main/resources/dao/categorical-attribute-dao.xml
+++ b/api/src/main/resources/dao/categorical-attribute-dao.xml
@@ -56,7 +56,7 @@
                 ]]>
             </value>
         </property>
-        <property name="loadAttributesValuesQuery">
+        <property name="loadAttributeValuesQuery">
             <value>
                 <![CDATA[
                     SELECT
@@ -71,6 +71,24 @@
                     LEFT OUTER JOIN pipeline.categorical_attributes_links links on attributes.id=links.parent_id
                     LEFT JOIN pipeline.categorical_attributes links_values on links_values.id = links.child_id
                     WHERE attributes.key=:KEY
+                ]]>
+            </value>
+        </property>
+        <property name="loadAttributesValuesQuery">
+            <value>
+                <![CDATA[
+                    SELECT
+                        attributes.key,
+                        attributes.value,
+                        attributes.id,
+                        links.child_id,
+                        links.autofill,
+                        links_values.key child_key,
+                        links_values.value as child_value
+                    FROM pipeline.categorical_attributes attributes
+                    LEFT OUTER JOIN pipeline.categorical_attributes_links links on attributes.id=links.parent_id
+                    LEFT JOIN pipeline.categorical_attributes links_values on links_values.id = links.child_id
+                    WHERE attributes.key IN (:list)
                 ]]>
             </value>
         </property>

--- a/api/src/test/java/com/epam/pipeline/manager/metadata/CategoricalAttributeManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/metadata/CategoricalAttributeManagerTest.java
@@ -16,6 +16,9 @@
 
 package com.epam.pipeline.manager.metadata;
 
+import static com.epam.pipeline.util.CategoricalAttributeTestUtils.assertAttribute;
+import static com.epam.pipeline.util.CategoricalAttributeTestUtils.fromStrings;
+
 import com.epam.pipeline.AbstractSpringTest;
 import com.epam.pipeline.controller.vo.EntityVO;
 import com.epam.pipeline.controller.vo.MetadataVO;
@@ -25,12 +28,17 @@ import com.epam.pipeline.entity.metadata.PipeConfValue;
 import com.epam.pipeline.entity.security.acl.AclClass;
 import com.epam.pipeline.entity.user.PipelineUser;
 import com.epam.pipeline.manager.user.UserManager;
+import org.apache.commons.collections4.CollectionUtils;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -46,6 +54,7 @@ public class CategoricalAttributeManagerTest extends AbstractSpringTest {
     private static final String SENSITIVE_KEY = "sensitive_metadata_key";
     private static final String VALUE_1 = "valueA";
     private static final String VALUE_2 = "valueB";
+    private static final String VALUE_3 = "valueC";
     private static final String TYPE = "string";
     private static final String TEST_USER = "TEST_USER";
 
@@ -90,8 +99,83 @@ public class CategoricalAttributeManagerTest extends AbstractSpringTest {
         Assert.assertFalse(categoricalAttributesAfterSync.containsKey(SENSITIVE_KEY));
     }
 
+    @Test
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void testLinkCreationAndCleanup() {
+        final List<CategoricalAttributeValue> valuesWithoutLinks =
+            fromStrings(KEY_1, Arrays.asList(VALUE_1, VALUE_2));
+        final CategoricalAttributeValue valueWithLink = new CategoricalAttributeValue(KEY_2, VALUE_3);
+        valueWithLink.setLinks(Collections.singletonList(new CategoricalAttributeValue(KEY_1, VALUE_1)));
+        final List<CategoricalAttribute> attributes =
+            Arrays.asList(new CategoricalAttribute(KEY_1, valuesWithoutLinks),
+                          new CategoricalAttribute(KEY_2, Collections.singletonList(valueWithLink)));
+
+        categoricalAttributeManager.updateCategoricalAttributes(attributes);
+
+        final Map<String, List<CategoricalAttributeValue>> attributeMap = categoricalAttributeManager.loadAll().stream()
+            .collect(Collectors.toMap(CategoricalAttribute::getKey, CategoricalAttribute::getValues));
+        Assert.assertTrue(attributeMap.get(KEY_1).stream()
+                              .map(CategoricalAttributeValue::getLinks)
+                              .allMatch(CollectionUtils::isEmpty));
+        final List<CategoricalAttributeValue> valuesForKey2 = attributeMap.get(KEY_2);
+        Assert.assertEquals(1, valuesForKey2.size());
+        final CategoricalAttributeValue value1ForKey2 = valuesForKey2.get(0);
+        Assert.assertEquals(KEY_2, value1ForKey2.getKey());
+        Assert.assertEquals(VALUE_3, value1ForKey2.getValue());
+        final List<CategoricalAttributeValue> links = value1ForKey2.getLinks();
+        Assert.assertEquals(1, links.size());
+        final CategoricalAttributeValue linkToKey1Value1 = links.get(0);
+        Assert.assertEquals(KEY_1, linkToKey1Value1.getKey());
+        Assert.assertEquals(VALUE_1, linkToKey1Value1.getValue());
+        Assert.assertFalse(linkToKey1Value1.getAutofill());
+        Assert.assertEquals(attributeMap.get(KEY_1).stream()
+                                .filter(value -> value.getKey().equals(KEY_1) && value.getValue().equals(VALUE_1))
+                                .map(CategoricalAttributeValue::getId)
+                                .findAny()
+                                .get(),
+                            linkToKey1Value1.getId());
+
+        categoricalAttributeManager.deleteAttributeValue(KEY_1, VALUE_1);
+        final Map<String, List<CategoricalAttributeValue>> attributeMapAfterDelete =
+            categoricalAttributeManager.loadAll().stream()
+                .collect(Collectors.toMap(CategoricalAttribute::getKey, CategoricalAttribute::getValues));
+        Assert.assertTrue(attributeMapAfterDelete.values().stream()
+                              .flatMap(Collection::stream)
+                              .map(CategoricalAttributeValue::getLinks)
+                              .allMatch(CollectionUtils::isEmpty));
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void loadValuesForNonExistentKey() {
         categoricalAttributeManager.loadAllValuesForKey(INVALID_KEY);
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void testUpdateAttributesValues() {
+        final List<CategoricalAttribute> values = new ArrayList<>();
+        values.add(new CategoricalAttribute(KEY_1, fromStrings(KEY_1, Arrays.asList(VALUE_1, VALUE_2))));
+        Assert.assertTrue(categoricalAttributeManager.updateCategoricalAttributes(values));
+        final List<CategoricalAttribute> attributes = categoricalAttributeManager.loadAll();
+        Assert.assertEquals(1, attributes.size());
+        assertAttribute(attributes.get(0), KEY_1, VALUE_1, VALUE_2);
+
+        final List<CategoricalAttribute> valuesToReplace = new ArrayList<>();
+        valuesToReplace.add(new CategoricalAttribute(KEY_1, fromStrings(KEY_1, Collections.singletonList(VALUE_3))));
+        Assert.assertTrue(categoricalAttributeManager.updateCategoricalAttributes(valuesToReplace));
+        final List<CategoricalAttribute> attributesAfter = categoricalAttributeManager.loadAll();
+        Assert.assertEquals(1, attributesAfter.size());
+        assertAttribute(attributesAfter.get(0), KEY_1, VALUE_3);
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void testCreateLinkOnNonExistentAttributeValue() {
+        final CategoricalAttributeValue valueWithLink = new CategoricalAttributeValue(KEY_2, VALUE_3);
+        valueWithLink.setLinks(Collections.singletonList(new CategoricalAttributeValue(KEY_1, VALUE_1)));
+        final List<CategoricalAttribute> attributes = Collections
+            .singletonList(new CategoricalAttribute(KEY_2, Collections.singletonList(valueWithLink)));
+        categoricalAttributeManager.updateCategoricalAttributes(attributes);
     }
 }

--- a/api/src/test/java/com/epam/pipeline/util/CategoricalAttributeTestUtils.java
+++ b/api/src/test/java/com/epam/pipeline/util/CategoricalAttributeTestUtils.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.util;
+
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+
+import com.epam.pipeline.entity.metadata.CategoricalAttribute;
+import com.epam.pipeline.entity.metadata.CategoricalAttributeValue;
+import org.apache.commons.collections4.CollectionUtils;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public final class CategoricalAttributeTestUtils {
+
+    private CategoricalAttributeTestUtils() {
+    }
+
+    public static void assertAttribute(final CategoricalAttribute attributeAfter, final String key,
+                                       final String... values) {
+        Assert.assertEquals(key, attributeAfter.getKey());
+        final List<CategoricalAttributeValue> attributeValues = Stream.of(values)
+            .map(v -> new CategoricalAttributeValue(key, v))
+            .collect(Collectors.toList());
+        Assert.assertThat(attributeAfter.getValues(), CoreMatchers.is(attributeValues));
+    }
+
+    public static Map<String, List<String>> convertToMap(final Collection<CategoricalAttribute> attributes) {
+        return attributes.stream()
+            .collect(Collectors.toMap(CategoricalAttribute::getKey,
+                attribute -> CollectionUtils.emptyIfNull(attribute.getValues()).stream()
+                    .map(CategoricalAttributeValue::getValue)
+                    .collect(Collectors.toList())));
+    }
+
+    public static void assertValuesPresentedForKeyInMap(final Map<String, List<String>> attributesWithValues,
+                                                        final String key,
+                                                        final String... values) {
+        final List<String> valuesForKey = attributesWithValues.get(key);
+        Assert.assertEquals(values.length, valuesForKey.size());
+        Assert.assertThat(valuesForKey, contains(values));
+    }
+
+    public static List<CategoricalAttributeValue> fromStrings(final String key, final List<String> strings) {
+        return strings.stream()
+            .map(s -> new CategoricalAttributeValue(key, s))
+            .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
This PR is related to issue #1445

It changes the way of categorical attribute values proceeding. Previously, all received for insert values were deleted from the DB before the update and it led to the removal of the corresponding links, so to keep the right structure user need to send all of the dictionaries every time. From now values are analyzed during insert and only values, that differ, are being removed.