### PR TITLE
Allow to transfer objects between AWS regions using pipe cp/mv commands

### DIFF
--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -235,6 +235,8 @@ public final class MessageConstants {
     public static final String ERROR_SENSITIVE_WRITE_FORBIDDEN = "error.sensitive.datastorage.write.forbidden";
     public static final String ERROR_SENSITIVE_RUN_NOT_ALLOWED_FOR_TOOL = "error.sensitive.tool.forbidden";
     public static final String ERROR_SHARED_STORAGE_IS_NOT_CONFIGURED = "error.share.storage.not.configured";
+    public static final String ERROR_DATASTORAGES_TYPES_NOT_SAME = "error.datastorages.types.not.same";
+    public static final String ERROR_DATASTORAGES_NOT_FOUND = "error.datastorages.not.found";
 
     // NFS
     public static final String ERROR_DATASTORAGE_NFS_MOUNT = "error.datastorage.nfs.mount";
@@ -504,6 +506,10 @@ public final class MessageConstants {
 
     public static final String ERROR_GCP_INSTANCE_NOT_RUNNING = "error.gcp.instance.not.running";
     public static final String ERROR_GCP_INSTANCE_NOT_FOUND = "error.gcp.instance.not.found";
+
+    //AWS
+    public static final String ERROR_AWS_PROFILE_UNIQUENESS = "error.aws.profile.uniqueness";
+    public static final String ERROR_AWS_S3_ROLE_UNIQUENESS = "error.aws.s3.role.uniqueness";
 
     //Billing
     public static final String ERROR_BILLING_FIELD_DATE_GROUPING_NOT_SUPPORTED =

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/TemporaryCredentialsGenerator.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/TemporaryCredentialsGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import java.util.TimeZone;
 
 public interface TemporaryCredentialsGenerator<T extends AbstractDataStorage> {
     DataStorageType getStorageType();
-    TemporaryCredentials generate(List<DataStorageAction> actions, T dataStorage);
+    TemporaryCredentials generate(List<DataStorageAction> actions, List<T> storages);
     AbstractCloudRegion getRegion(T dataStorage);
 
     static String expirationTimeWithUTC(final Date expiration) {

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/TemporaryCredentialsManagerImpl.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/TemporaryCredentialsManagerImpl.java
@@ -65,7 +65,8 @@ public class TemporaryCredentialsManagerImpl implements TemporaryCredentialsMana
                 .distinct()
                 .map(dataStorageManager::load)
                 .collect(Collectors.toList());
-        Assert.state(CollectionUtils.isNotEmpty(storages), "No storages were specified");
+        Assert.state(CollectionUtils.isNotEmpty(storages),
+                messageHelper.getMessage(MessageConstants.ERROR_DATASTORAGES_NOT_FOUND));
         final TemporaryCredentialsGenerator credentialsGenerator = getCredentialsGenerator(storages);
 
         final Map<Long, AbstractDataStorage> storagesById = storages.stream()
@@ -93,7 +94,7 @@ public class TemporaryCredentialsManagerImpl implements TemporaryCredentialsMana
         Assert.state(storages.stream()
                 .map(AbstractDataStorage::getType)
                 .distinct()
-                .count() <= 1, "Storage types shall be the same");
+                .count() <= 1, messageHelper.getMessage(MessageConstants.ERROR_DATASTORAGES_TYPES_NOT_SAME));
         return storages.get(0);
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSInstanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSInstanceService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -200,7 +200,7 @@ public class AWSInstanceService implements CloudInstanceService<AwsRegion> {
     public Map<String, String> buildContainerCloudEnvVars(final AwsRegion region) {
         final Map<String, String> envVars = new HashMap<>();
         envVars.put(SystemParams.CLOUD_REGION_PREFIX + region.getId(), region.getRegionCode());
-        final AWSCredentials credentials = AWSUtils.getCredentialsProvider(region).getCredentials();
+        final AWSCredentials credentials = AWSUtils.getCredentialsProvider(region.getProfile()).getCredentials();
         envVars.put(SystemParams.CLOUD_ACCOUNT_PREFIX + region.getId(), credentials.getAWSAccessKeyId());
         envVars.put(SystemParams.CLOUD_ACCOUNT_KEY_PREFIX + region.getId(), credentials.getAWSSecretKey());
         envVars.put(SystemParams.CLOUD_PROVIDER_PREFIX + region.getId(), region.getProvider().name());

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSUtils.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import com.epam.pipeline.entity.datastorage.aws.S3bucketDataStorage;
 import com.epam.pipeline.entity.region.AwsRegion;
 import org.apache.commons.lang3.StringUtils;
 
-
 public final class AWSUtils {
 
     private static final String EMPTY_KEY_ARN = "NONE";
@@ -32,11 +31,11 @@ public final class AWSUtils {
         //no op
     }
 
-    public static AWSCredentialsProvider getCredentialsProvider(final AwsRegion region) {
-        if (StringUtils.isEmpty(region.getProfile())) {
+    public static AWSCredentialsProvider getCredentialsProvider(final String profile) {
+        if (StringUtils.isEmpty(profile)) {
             return DefaultAWSCredentialsProviderChain.getInstance();
         }
-        return new ProfileCredentialsProvider(region.getProfile());
+        return new ProfileCredentialsProvider(profile);
     }
 
     /**
@@ -50,5 +49,15 @@ public final class AWSUtils {
             return null;
         }
         return storage.getKmsKeyArn();
+    }
+
+    /**
+     * @return Role from storage if it is specified, otherwise returns role from region
+     */
+    public static String getRoleValue(final S3bucketDataStorage storage, final AwsRegion region) {
+        if (StringUtils.isBlank(storage.getTempCredentialsRole())) {
+            return region.getTempCredentialsRole();
+        }
+        return storage.getTempCredentialsRole();
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/aws/S3TemporaryCredentialsGenerator.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/aws/S3TemporaryCredentialsGenerator.java
@@ -86,8 +86,8 @@ public class S3TemporaryCredentialsGenerator implements TemporaryCredentialsGene
     @Override
     public TemporaryCredentials generate(final List<DataStorageAction> actions,
                                          final List<S3bucketDataStorage> storages) {
-        final Integer duration =
-                preferenceManager.getPreference(SystemPreferences.DATA_STORAGE_TEMP_CREDENTIALS_DURATION);
+        final Integer duration = preferenceManager.getPreference(
+                SystemPreferences.DATA_STORAGE_TEMP_CREDENTIALS_DURATION);
         final List<Pair<S3bucketDataStorage, AwsRegion>> storagesWithRegions = storages.stream()
                 .map(storage -> new ImmutablePair<>(storage, cloudRegionManager.getAwsRegion(storage)))
                 .collect(Collectors.toList());
@@ -221,7 +221,7 @@ public class S3TemporaryCredentialsGenerator implements TemporaryCredentialsGene
                 .map(pair -> AWSUtils.getRoleValue(pair.getLeft(), pair.getRight()))
                 .distinct()
                 .collect(Collectors.toList());
-        Assert.state(roles.size() <= 1, "Multiple roles is not supported to assume for AWS provider");
+        Assert.state(roles.size() == 1, "Exactly one role is supported to assume for AWS provider");
         return roles.get(0);
     }
 
@@ -231,8 +231,8 @@ public class S3TemporaryCredentialsGenerator implements TemporaryCredentialsGene
                 .map(AwsRegion::getProfile)
                 .distinct()
                 .collect(Collectors.toList());
-        Assert.state(profiles.size() <= 1,
-                "Multiple account profiles is not supported to assume for AWS provider");
+        Assert.state(profiles.size() == 1,
+                "Exactly one account profile is supported for AWS provider");
         return profiles.get(0);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/aws/S3TemporaryCredentialsGenerator.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/aws/S3TemporaryCredentialsGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,11 +35,15 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
 
 import java.util.List;
-import java.util.Optional;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -80,17 +84,19 @@ public class S3TemporaryCredentialsGenerator implements TemporaryCredentialsGene
     }
 
     @Override
-    public TemporaryCredentials generate(final List<DataStorageAction> actions, final S3bucketDataStorage dataStorage) {
-        final AwsRegion awsRegion = cloudRegionManager.getAwsRegion(dataStorage);
-
+    public TemporaryCredentials generate(final List<DataStorageAction> actions,
+                                         final List<S3bucketDataStorage> storages) {
         final Integer duration =
                 preferenceManager.getPreference(SystemPreferences.DATA_STORAGE_TEMP_CREDENTIALS_DURATION);
-        final String role = Optional.ofNullable(dataStorage.getTempCredentialsRole())
-                .orElse(awsRegion.getTempCredentialsRole());
-        final String sessionName = "SessionID-" + PasswordGenerator.generateRandomString(10);
+        final List<Pair<S3bucketDataStorage, AwsRegion>> storagesWithRegions = storages.stream()
+                .map(storage -> new ImmutablePair<>(storage, cloudRegionManager.getAwsRegion(storage)))
+                .collect(Collectors.toList());
 
-        //TODO: handle situation when we have actions for different storages with different KMS keys
-        final String policy = createPolicyWithPermissions(actions, AWSUtils.getKeyArnValue(dataStorage, awsRegion));
+        final String role = buildRole(storagesWithRegions);
+        final String sessionName = "SessionID-" + PasswordGenerator.generateRandomString(10);
+        final String profile = buildProfile(storagesWithRegions);
+        final String policy = createPolicyWithPermissions(actions, buildKmsArns(storagesWithRegions));
+
         final AssumeRoleRequest assumeRoleRequest = new AssumeRoleRequest()
                 .withDurationSeconds(duration)
                 .withPolicy(policy)
@@ -98,8 +104,7 @@ public class S3TemporaryCredentialsGenerator implements TemporaryCredentialsGene
                 .withRoleArn(role);
 
         final AssumeRoleResult assumeRoleResult = AWSSecurityTokenServiceClientBuilder.standard()
-                .withRegion(awsRegion.getRegionCode())
-                .withCredentials(AWSUtils.getCredentialsProvider(awsRegion))
+                .withCredentials(AWSUtils.getCredentialsProvider(profile))
                 .build()
                 .assumeRole(assumeRoleRequest);
         final Credentials resultingCredentials = assumeRoleResult.getCredentials();
@@ -110,7 +115,6 @@ public class S3TemporaryCredentialsGenerator implements TemporaryCredentialsGene
                 .token(resultingCredentials.getSessionToken())
                 .expirationTime(TemporaryCredentialsGenerator
                         .expirationTimeWithUTC(resultingCredentials.getExpiration()))
-                .region(awsRegion.getRegionCode())
                 .build();
     }
 
@@ -119,22 +123,24 @@ public class S3TemporaryCredentialsGenerator implements TemporaryCredentialsGene
         return cloudRegionManager.getAwsRegion(dataStorage);
     }
 
-    private String createPolicyWithPermissions(final List<DataStorageAction> actions, final String kmsArn) {
+    private String createPolicyWithPermissions(final List<DataStorageAction> actions, final List<String> kmsArns) {
         final ObjectNode resultPolicy = JsonNodeFactory.instance.objectNode();
         resultPolicy.put("Version", "2012-10-17");
         final ArrayNode statements = resultPolicy.putArray("Statement");
-        if (StringUtils.isNotBlank(kmsArn)) {
-            addKmsActionToStatement(kmsArn, statements);
-        }
-        for (DataStorageAction action : actions) {
-            if (action.isList() || action.isRead() || action.isWrite()) {
-                addListingPermissions(action, statements);
-            }
-            if (action.isRead() || action.isWrite()) {
-                addActionToStatement(action, statements);
-            }
-        }
+        ListUtils.emptyIfNull(kmsArns)
+                .forEach(kmsArn -> addKmsActionToStatement(kmsArn, statements));
+        ListUtils.emptyIfNull(actions)
+                .forEach(action -> addActionsToStatement(action, statements));
         return resultPolicy.toString();
+    }
+
+    private void addActionsToStatement(final DataStorageAction action, final ArrayNode statements) {
+        if (action.isList() || action.isRead() || action.isWrite()) {
+            addListingPermissions(action, statements);
+        }
+        if (action.isRead() || action.isWrite()) {
+            addActionToStatement(action, statements);
+        }
     }
 
     private void addListingPermissions(final DataStorageAction action, final ArrayNode statements) {
@@ -201,5 +207,32 @@ public class S3TemporaryCredentialsGenerator implements TemporaryCredentialsGene
         actions.add(KMS_DESCRIBE_KEY_ACTION);
         statement.put(RESOURCE, kmsArn);
         statements.add(statement);
+    }
+
+    private List<String> buildKmsArns(final List<Pair<S3bucketDataStorage, AwsRegion>> storagesWithRegions) {
+        return storagesWithRegions.stream()
+                .map(pair -> AWSUtils.getKeyArnValue(pair.getLeft(), pair.getRight()))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    private String buildRole(final List<Pair<S3bucketDataStorage, AwsRegion>> storagesWithRegions) {
+        final List<String> roles = storagesWithRegions.stream()
+                .map(pair -> AWSUtils.getRoleValue(pair.getLeft(), pair.getRight()))
+                .distinct()
+                .collect(Collectors.toList());
+        Assert.state(roles.size() <= 1, "Multiple roles is not supported to assume for AWS provider");
+        return roles.get(0);
+    }
+
+    private String buildProfile(final List<Pair<S3bucketDataStorage, AwsRegion>> storagesWithRegions) {
+        final List<String> profiles = storagesWithRegions.stream()
+                .map(Pair::getRight)
+                .map(AwsRegion::getProfile)
+                .distinct()
+                .collect(Collectors.toList());
+        Assert.state(profiles.size() <= 1,
+                "Multiple account profiles is not supported to assume for AWS provider");
+        return profiles.get(0);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/aws/S3TemporaryCredentialsGenerator.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/aws/S3TemporaryCredentialsGenerator.java
@@ -20,6 +20,8 @@ import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder
 import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
 import com.amazonaws.services.securitytoken.model.AssumeRoleResult;
 import com.amazonaws.services.securitytoken.model.Credentials;
+import com.epam.pipeline.common.MessageConstants;
+import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.entity.datastorage.DataStorageAction;
 import com.epam.pipeline.entity.datastorage.DataStorageType;
 import com.epam.pipeline.entity.datastorage.TemporaryCredentials;
@@ -77,6 +79,7 @@ public class S3TemporaryCredentialsGenerator implements TemporaryCredentialsGene
 
     private final CloudRegionManager cloudRegionManager;
     private final PreferenceManager preferenceManager;
+    private final MessageHelper messageHelper;
 
     @Override
     public DataStorageType getStorageType() {
@@ -221,7 +224,8 @@ public class S3TemporaryCredentialsGenerator implements TemporaryCredentialsGene
                 .map(pair -> AWSUtils.getRoleValue(pair.getLeft(), pair.getRight()))
                 .distinct()
                 .collect(Collectors.toList());
-        Assert.state(roles.size() == 1, "Exactly one role is supported to assume for AWS provider");
+        Assert.state(roles.size() == 1,
+                messageHelper.getMessage(MessageConstants.ERROR_AWS_S3_ROLE_UNIQUENESS));
         return roles.get(0);
     }
 
@@ -232,7 +236,7 @@ public class S3TemporaryCredentialsGenerator implements TemporaryCredentialsGene
                 .distinct()
                 .collect(Collectors.toList());
         Assert.state(profiles.size() == 1,
-                "Exactly one account profile is supported for AWS provider");
+                messageHelper.getMessage(MessageConstants.ERROR_AWS_PROFILE_UNIQUENESS));
         return profiles.get(0);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzureTemporaryCredentialsGenerator.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzureTemporaryCredentialsGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,12 @@ public class AzureTemporaryCredentialsGenerator implements TemporaryCredentialsG
     }
 
     @Override
-    public TemporaryCredentials generate(final List<DataStorageAction> actions, final AzureBlobStorage dataStorage) {
+    public TemporaryCredentials generate(final List<DataStorageAction> actions, final List<AzureBlobStorage> storages) {
+        Assert.isTrue(storages.size() == 1, "Multiple regions are not supported for AZURE provider");
+        return generate(actions, storages.get(0));
+    }
+
+    private TemporaryCredentials generate(final List<DataStorageAction> actions, final AzureBlobStorage dataStorage) {
         final AzureRegion region = cloudRegionManager.getAzureRegion(dataStorage);
         final AzureRegionCredentials credentials = cloudRegionManager.loadCredentials(region);
 

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPTemporaryCredentialGenerator.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPTemporaryCredentialGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,6 +56,11 @@ public class GCPTemporaryCredentialGenerator implements TemporaryCredentialsGene
         return DataStorageType.GS;
     }
 
+    @Override
+    public TemporaryCredentials generate(final List<DataStorageAction> actions, final List<GSBucketStorage> storages) {
+        return generate(actions, storages.get(0));
+    }
+
     /**
      * Generates temporary access credentials. Returns full read access to all data storages if all actions require
      * only read access. If at least one action requires write access returns full write access to all data storages.
@@ -63,8 +68,7 @@ public class GCPTemporaryCredentialGenerator implements TemporaryCredentialsGene
      * @param dataStorage to get additional info
      * @return access token, project ID and expiration time
      */
-    @Override
-    public TemporaryCredentials generate(final List<DataStorageAction> actions, final GSBucketStorage dataStorage) {
+    private TemporaryCredentials generate(final List<DataStorageAction> actions, final GSBucketStorage dataStorage) {
         try {
             final GCPRegion region = getRegion(dataStorage);
             final IAMCredentials credentials = gcpClient.buildIAMCredentialsClient(region);

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPTemporaryCredentialGenerator.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPTemporaryCredentialGenerator.java
@@ -58,6 +58,10 @@ public class GCPTemporaryCredentialGenerator implements TemporaryCredentialsGene
 
     @Override
     public TemporaryCredentials generate(final List<DataStorageAction> actions, final List<GSBucketStorage> storages) {
+        Assert.state(storages.stream()
+                .map(GSBucketStorage::getRegionId)
+                .distinct()
+                .count() == 1, "Multi-region actions are not supported for GS data type");
         return generate(actions, storages.get(0));
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/RegionAwareS3Helper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/RegionAwareS3Helper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ public class RegionAwareS3Helper extends S3Helper {
     public AmazonS3 getDefaultS3Client() {
         return AmazonS3ClientBuilder.standard()
                 .withRegion(region.getRegionCode())
-                .withCredentials(AWSUtils.getCredentialsProvider(region))
+                .withCredentials(AWSUtils.getCredentialsProvider(region.getProfile()))
                 .build();
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3StorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3StorageProvider.java
@@ -346,6 +346,6 @@ public class S3StorageProvider implements StorageProvider<S3bucketDataStorage> {
         action.setWrite(write);
         action.setWriteVersion(useVersion);
         return stsCredentialsGenerator
-                .generate(Collections.singletonList(action), dataStorage);
+                .generate(Collections.singletonList(action), Collections.singletonList(dataStorage));
     }
 }

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -239,6 +239,8 @@ error.sensitive.request.wrong.context=Sensitive data is requested outside of sen
 
 error.sensitive.tool.forbidden=Tool ''{0}'' is not approved for sensitive data processing.
 error.share.storage.not.configured=Storage for run shared FS is not configured.
+error.datastorages.types.not.same=Storage types shall be the same
+error.datastorages.not.found=No storages were specified
 
 # Git messages
 
@@ -466,6 +468,11 @@ error.gcp.impersonate.account=Impersonated account for temporary credentials mus
 error.gcp.instance.not.running=GCP instance ''{0}'' is not in active state. Current state: ''{1}''
 error.gcp.instance.not.found=Instance with label ''{0}'' not found!
 
+#AWS
+error.aws.profile.uniqueness=Exactly one account profile is supported for AWS provider
+error.aws.s3.role.uniqueness=Exactly one role is supported to assume for AWS provider
+
+#Builling
 error.billing.date.field.grouping.not.supported="Currently field and date grouping at the same time isn't supporting!"
 error.billing.details.not.supported="Details are supported for grouping requests only!"
 error.billing.interval.not.supported="Given interval is not supported!"

--- a/api/src/test/java/com/epam/pipeline/manager/cloud/TemporaryCredentialsManagerImplTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cloud/TemporaryCredentialsManagerImplTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cloud;
+
+import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.entity.datastorage.DataStorageAction;
+import com.epam.pipeline.entity.datastorage.DataStorageType;
+import com.epam.pipeline.entity.datastorage.TemporaryCredentials;
+import com.epam.pipeline.entity.datastorage.aws.S3bucketDataStorage;
+import com.epam.pipeline.entity.datastorage.azure.AzureBlobStorage;
+import com.epam.pipeline.manager.datastorage.DataStorageManager;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static com.epam.pipeline.manager.ObjectCreatorUtils.createS3Bucket;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TemporaryCredentialsManagerImplTest {
+
+    private static final Long ID_1 = 1L;
+    private static final Long ID_2 = 2L;
+    private static final String TEST_PATH_1 = "path1";
+    private static final String TEST_PATH_2 = "path2";
+
+    private final TemporaryCredentialsGenerator generator = buildAWSCredentialsGeneratorMock();
+    private final List<TemporaryCredentialsGenerator> credentialsGenerators = Collections.singletonList(generator);
+    private final MessageHelper messageHelper = mock(MessageHelper.class);
+    private final DataStorageManager dataStorageManager = mock(DataStorageManager.class);
+
+    private final TemporaryCredentialsManagerImpl manager = new TemporaryCredentialsManagerImpl(credentialsGenerators,
+            messageHelper,  dataStorageManager);
+
+    @Before
+    public void setUp() {
+        when(generator.generate(any(), any())).thenReturn(TemporaryCredentials.builder().build());
+    }
+
+    @Test
+    public void shouldGenerateCredentialsForMultipleRegions() {
+        final List<DataStorageAction> actions = Arrays.asList(
+                dataStorageAction(ID_1, true),
+                dataStorageAction(ID_1, false),
+                dataStorageAction(ID_2, true));
+        final S3bucketDataStorage storage1 = s3DataStorage(ID_1, TEST_PATH_1);
+        final S3bucketDataStorage storage2 = s3DataStorage(ID_2, TEST_PATH_2);
+        when(dataStorageManager.load(ID_1)).thenReturn(storage1);
+        when(dataStorageManager.load(ID_2)).thenReturn(storage2);
+
+        manager.generate(actions);
+
+        final Pair<List<DataStorageAction>, List<S3bucketDataStorage>> captured = capture();
+
+        assertThat(captured.getRight())
+                .hasSize(2)
+                .contains(storage1, storage2);
+        assertThat(captured.getLeft()).hasSize(3);
+        captured.getLeft().forEach(actualAction -> {
+            if (actualAction.getId().equals(ID_1)) {
+                assertThat(actualAction.getBucketName()).isEqualTo(TEST_PATH_1);
+                assertThat(actualAction.getPath()).isEqualTo(TEST_PATH_1);
+            } else if (actualAction.getId().equals(ID_2)) {
+                assertThat(actualAction.getBucketName()).isEqualTo(TEST_PATH_2);
+                assertThat(actualAction.getPath()).isEqualTo(TEST_PATH_2);
+            }
+        });
+    }
+
+    @Test
+    public void shouldGenerateCredentialsForOneRegion() {
+        final List<DataStorageAction> actions = Arrays.asList(
+                dataStorageAction(ID_1, true),
+                dataStorageAction(ID_1, false));
+        final S3bucketDataStorage storage1 = s3DataStorage(ID_1, TEST_PATH_1);
+        when(dataStorageManager.load(ID_1)).thenReturn(storage1);
+
+        manager.generate(actions);
+
+        final Pair<List<DataStorageAction>, List<S3bucketDataStorage>> captured = capture();
+
+        assertThat(captured.getRight())
+                .hasSize(1)
+                .contains(storage1);
+        assertThat(captured.getLeft()).hasSize(2);
+        captured.getLeft().forEach(actualAction -> {
+            assertThat(actualAction.getId()).isEqualTo(ID_1);
+            assertThat(actualAction.getBucketName()).isEqualTo(TEST_PATH_1);
+            assertThat(actualAction.getPath()).isEqualTo(TEST_PATH_1);
+        });
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void shouldFailIfStorageIdWasNotSpecified() {
+        manager.generate(Collections.singletonList(dataStorageAction(null, true)));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void shouldFailIfStorageTypesNotSame() {
+        final List<DataStorageAction> actions = Arrays.asList(
+                dataStorageAction(ID_2, true),
+                dataStorageAction(ID_1, false));
+        when(dataStorageManager.load(ID_1)).thenReturn(s3DataStorage(ID_1, TEST_PATH_1));
+        when(dataStorageManager.load(ID_2)).thenReturn(azureDataStorage(ID_2, TEST_PATH_2));
+
+        manager.generate(actions);
+    }
+
+    private DataStorageAction dataStorageAction(final Long storageId, final boolean read) {
+        final DataStorageAction action = new DataStorageAction();
+        action.setId(storageId);
+        action.setRead(read);
+        return action;
+    }
+
+    private TemporaryCredentialsGenerator buildAWSCredentialsGeneratorMock() {
+        final TemporaryCredentialsGenerator generator = mock(TemporaryCredentialsGenerator.class);
+        when(generator.getStorageType()).thenReturn(DataStorageType.S3);
+        return generator;
+    }
+
+    private S3bucketDataStorage s3DataStorage(final Long id, final String name) {
+        return createS3Bucket(id, name, name, "OWNER");
+    }
+
+    private AzureBlobStorage azureDataStorage(final Long id, final String name) {
+        return new AzureBlobStorage(id, name, name, null, null);
+    }
+
+    private ArgumentCaptor argumentCaptor() {
+        return ArgumentCaptor.forClass((Class) List.class);
+    }
+
+    private Pair<List<DataStorageAction>, List<S3bucketDataStorage>> capture() {
+        final ArgumentCaptor<List<DataStorageAction>> actionsCaptor = argumentCaptor();
+        final ArgumentCaptor<List<S3bucketDataStorage>> storagesCaptor = argumentCaptor();
+        verify(generator).generate(actionsCaptor.capture(), storagesCaptor.capture());
+        final List<DataStorageAction> actualActions = actionsCaptor.getValue();
+        final List<S3bucketDataStorage> actualStorages = storagesCaptor.getValue();
+        return new ImmutablePair<>(actualActions, actualStorages);
+    }
+}

--- a/pipe-cli/src/utilities/storage/s3.py
+++ b/pipe-cli/src/utilities/storage/s3.py
@@ -827,8 +827,7 @@ class S3BucketOperations(object):
                 access_key=credentials.access_key_id,
                 secret_key=credentials.secret_key,
                 token=credentials.session_token,
-                expiry_time=credentials.expiration,
-                region_name=credentials.region)
+                expiry_time=credentials.expiration)
 
         fresh_metadata = refresh()
         session_credentials = RefreshableCredentials.create_from_metadata(
@@ -838,7 +837,7 @@ class S3BucketOperations(object):
 
         s = get_session()
         s._credentials = session_credentials
-        return Session(botocore_session=s, region_name=fresh_metadata['region_name'])
+        return Session(botocore_session=s)
 
     @classmethod
     def get_transfer_between_buckets_manager(cls, source_wrapper, destination_wrapper, command):


### PR DESCRIPTION
This PR provides implementation for issue #1469 

The current PR contains the following changes:
-  multi-region support added for AWS provider
-  multi-region actions disabled for AZURE and GCP
