### PR TITLE
Issue #1489: implement Lustre FS management API

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -173,6 +173,9 @@ dependencies {
     compile group: "com.amazonaws", name: "aws-java-sdk-sts", version: "1.11.211"
     // https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-iam
     compile group: "com.amazonaws", name: "aws-java-sdk-iam", version: "1.11.211"
+    // https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-fsx
+    compile group: 'com.amazonaws', name: 'aws-java-sdk-fsx', version: '1.11.880'
+
 
     // https://mvnrepository.com/artifact/com.microsoft.azure/azure-mgmt-resources
     compile group: "com.microsoft.azure", name: "azure-mgmt-resources", version: "1.19.0"

--- a/api/src/main/java/com/epam/pipeline/acl/datastorage/lustre/LustreFSApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/datastorage/lustre/LustreFSApiService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.acl.datastorage.lustre;
+
+import com.epam.pipeline.entity.datastorage.LustreFS;
+import com.epam.pipeline.manager.datastorage.lustre.LustreFSManager;
+import com.epam.pipeline.security.acl.AclExpressions;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LustreFSApiService {
+
+    private final LustreFSManager lustreFSManager;
+
+    @PreAuthorize(AclExpressions.RUN_ID_EXECUTE)
+    public LustreFS getOrCreateLustreFS(final Long runId, final Integer size) {
+        return lustreFSManager.getOrCreateLustreFS(runId, size);
+    }
+
+    @PreAuthorize(AclExpressions.RUN_ID_EXECUTE)
+    public LustreFS getLustreFS(final Long runId) {
+        return lustreFSManager.getLustreFS(runId);
+    }
+
+    @PreAuthorize(AclExpressions.RUN_ID_EXECUTE)
+    public LustreFS deleteLustreFS(final Long runId) {
+        return lustreFSManager.deleteLustreFs(runId);
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -533,6 +533,13 @@ public final class MessageConstants {
     //Other
     public static final String ERROR_KEEP_ALIVE_POLICY_NOT_SUPPORTED = "error.keep.alive.policy.not.supported";
 
+    //Lustre
+    public static final String ERROR_LUSTRE_NOT_FOUND = "error.lustre.not.found.for.run";
+    public static final String ERROR_LUSTRE_NOT_CREATED = "error.lustre.not.created.for.run";
+    public static final String ERROR_LUSTRE_REGION_NOT_SUPPORTED = "error.lustre.region.not.supported";
+    public static final String ERROR_LUSTRE_MISSING_CONFIG = "error.lustre.missing.config";
+    public static final String ERROR_LUSTRE_MISSING_INSTANCE = "error.lustre.missing.instance";
+
     private MessageConstants() {
         // no-op
     }

--- a/api/src/main/java/com/epam/pipeline/controller/datastorage/lustre/LustreFSController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/datastorage/lustre/LustreFSController.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.controller.datastorage.lustre;
+
+import com.epam.pipeline.acl.datastorage.lustre.LustreFSApiService;
+import com.epam.pipeline.controller.AbstractRestController;
+import com.epam.pipeline.controller.Result;
+import com.epam.pipeline.entity.datastorage.LustreFS;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@Api(value = "Lustre FS management methods")
+@RequestMapping(value = "/lustre")
+@RequiredArgsConstructor
+public class LustreFSController extends AbstractRestController {
+
+    private static final String RUN_ID = "run_id";
+    private static final String RUN_ID_PATH = "/{run_id}";
+
+    private final LustreFSApiService lustreFSApiService;
+
+    @PostMapping(value = RUN_ID_PATH)
+    @ApiOperation(
+            value = "Creates a new lustre FS for a run or returns an existing one.",
+            notes = "Creates a new lustre FS for a run or returns an existing one.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public Result<LustreFS> getOrCreateLustreFS(@PathVariable(value = RUN_ID) final Long runId,
+                                                @RequestParam(required = false) final Integer size) {
+        return Result.success(lustreFSApiService.getOrCreateLustreFS(runId, size));
+    }
+
+    @GetMapping(value = RUN_ID_PATH)
+    @ApiOperation(
+            value = "Returns an existing lustre FS for a run.",
+            notes = "Returns an existing lustre FS for a run.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public Result<LustreFS> getLustreFS(@PathVariable(value = RUN_ID) final Long runId) {
+        return Result.success(lustreFSApiService.getLustreFS(runId));
+    }
+
+    @DeleteMapping(value = RUN_ID_PATH)
+    @ApiOperation(
+            value = "Deletes lustre FS for a run.",
+            notes = "Deletes lustre FS for a run.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public Result<LustreFS> deleteLustreFS(@PathVariable(value = RUN_ID) final Long runId) {
+        return Result.success(lustreFSApiService.deleteLustreFS(runId));
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/entity/cluster/NetworkConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/entity/cluster/NetworkConfiguration.java
@@ -40,5 +40,8 @@ public class NetworkConfiguration {
     @JsonProperty("networks")
     private Map<String, String> allowedNetworks;
 
+    @JsonProperty("security_group_ids")
+    private List<String> securityGroups;
+
     private List<SwapConfiguration> swap;
 }

--- a/api/src/main/java/com/epam/pipeline/exception/datastorage/exception/LustreFSException.java
+++ b/api/src/main/java/com/epam/pipeline/exception/datastorage/exception/LustreFSException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.exception.datastorage.exception;
+
+public class LustreFSException extends RuntimeException {
+
+    public LustreFSException(String message) {
+        super(message);
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/cleaner/LustreRunCleaner.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/cleaner/LustreRunCleaner.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster.cleaner;
+
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.exception.datastorage.exception.LustreFSException;
+import com.epam.pipeline.manager.datastorage.lustre.LustreFSManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.ListUtils;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class LustreRunCleaner implements RunCleaner {
+
+    private static final String SHARED_FS_ENV_VAR = "CP_CAP_SHARE_FS_TYPE";
+    private static final String LUSTRE_TYPE = "lustre";
+
+    private final LustreFSManager lustreFSManager;
+
+    @Override
+    public void cleanResources(final PipelineRun run) {
+        if (!isLustreRequested(run)) {
+            return;
+        }
+        log.debug("Clearing lustre fs for run {}.", run.getId());
+        try {
+            lustreFSManager.deleteLustreFs(run.getId());
+        } catch (LustreFSException e) {
+            log.error("Failed to clean up lustre for run {}.", run.getId());
+            log.error(e.getMessage(), e);
+        }
+    }
+
+    public boolean isLustreRequested(PipelineRun run) {
+        return ListUtils.emptyIfNull(run.getPipelineRunParameters()).stream()
+                .anyMatch(param -> SHARED_FS_ENV_VAR.equals(param.getName()) && LUSTRE_TYPE.equals(param.getValue()));
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/cleaner/RunCleaner.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/cleaner/RunCleaner.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster.cleaner;
+
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+
+public interface RunCleaner {
+
+    void cleanResources(PipelineRun run);
+}

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/lustre/LustreFSManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/lustre/LustreFSManager.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.datastorage.lustre;
+
+import com.amazonaws.services.ec2.model.Instance;
+import com.amazonaws.services.fsx.AmazonFSx;
+import com.amazonaws.services.fsx.AmazonFSxClient;
+import com.amazonaws.services.fsx.model.CreateFileSystemLustreConfiguration;
+import com.amazonaws.services.fsx.model.CreateFileSystemRequest;
+import com.amazonaws.services.fsx.model.CreateFileSystemResult;
+import com.amazonaws.services.fsx.model.DeleteFileSystemRequest;
+import com.amazonaws.services.fsx.model.DescribeFileSystemsRequest;
+import com.amazonaws.services.fsx.model.DescribeFileSystemsResult;
+import com.amazonaws.services.fsx.model.FileSystem;
+import com.amazonaws.services.fsx.model.FileSystemType;
+import com.amazonaws.services.fsx.model.LustreDeploymentType;
+import com.amazonaws.services.fsx.model.StorageType;
+import com.amazonaws.services.fsx.model.Tag;
+import com.epam.pipeline.common.MessageConstants;
+import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.entity.cluster.CloudRegionsConfiguration;
+import com.epam.pipeline.entity.cluster.NetworkConfiguration;
+import com.epam.pipeline.entity.datastorage.LustreFS;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.region.AbstractCloudRegion;
+import com.epam.pipeline.entity.region.AwsRegion;
+import com.epam.pipeline.exception.datastorage.exception.LustreFSException;
+import com.epam.pipeline.manager.cloud.aws.AWSUtils;
+import com.epam.pipeline.manager.cloud.aws.EC2Helper;
+import com.epam.pipeline.manager.pipeline.PipelineRunManager;
+import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.epam.pipeline.manager.preference.SystemPreferences;
+import com.epam.pipeline.manager.region.CloudRegionManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class LustreFSManager {
+
+    private static final String RUN_ID_TAG_NAME = "RUN_ID";
+    private static final String LUSTRE_MOUNT_TEMPLATE = "%s@tcp:/%s";
+    public static final int LUSTRE_MIN_SIZE_GB = 1200;
+    public static final int LUSTRE_SIZE_STEP_GB = 2400;
+
+    private final PipelineRunManager runManager;
+    private final CloudRegionManager regionManager;
+    private final PreferenceManager preferenceManager;
+    private final EC2Helper ec2Helper;
+    private final MessageHelper messageHelper;
+
+    public LustreFS getOrCreateLustreFS(final Long runId, final Integer size) {
+        final AmazonFSx fsxClient = buildFsxClient(runId);
+        return findFsForRun(runId, null, fsxClient)
+                .map(this::convert)
+                .orElseGet(() -> createLustreFs(runId, size, fsxClient));
+    }
+
+    public LustreFS getLustreFS(final Long runId) {
+        final AmazonFSx fsxClient = buildFsxClient(runId);
+        return findFsForRun(runId, null, fsxClient)
+                .map(this::convert)
+                .orElseThrow(() -> new LustreFSException(
+                        messageHelper.getMessage(MessageConstants.ERROR_LUSTRE_NOT_FOUND, runId)));
+    }
+
+    public LustreFS deleteLustreFs(final Long runId) {
+        final AmazonFSx fsxClient = buildFsxClient(runId);
+        return findFsForRun(runId, null, fsxClient)
+                .map(fs -> deleteFs(fs, fsxClient))
+                .orElseThrow(() -> new LustreFSException(
+                        messageHelper.getMessage(MessageConstants.ERROR_LUSTRE_NOT_FOUND, runId)));
+    }
+
+    private LustreFS deleteFs(final FileSystem fs, final AmazonFSx fsxClient) {
+        log.debug("Deleting lustre fs with id {}.", fs.getFileSystemId());
+        fsxClient.deleteFileSystem(new DeleteFileSystemRequest()
+                .withFileSystemId(fs.getFileSystemId()));
+        return convert(fs);
+    }
+
+    private LustreFS createLustreFs(final Long runId, final Integer size, final AmazonFSx fsxClient) {
+        log.debug("Creating a new lustre fs for run id {}.", runId);
+        final PipelineRun pipelineRun = runManager.loadPipelineRun(runId);
+        final AwsRegion regionForRun = getRegion(pipelineRun);
+        final CreateFileSystemResult result = fsxClient.createFileSystem(new CreateFileSystemRequest()
+                .withFileSystemType(FileSystemType.LUSTRE)
+                .withStorageCapacity(getFSSize(size))
+                .withStorageType(StorageType.SSD)
+                .withSecurityGroupIds(getSecurityGroups(regionForRun))
+                .withSubnetIds(getSubnetId(pipelineRun, regionForRun))
+                .withKmsKeyId(regionForRun.getKmsKeyArn())
+                .withTags(new Tag().withKey(RUN_ID_TAG_NAME).withValue(String.valueOf(runId)))
+                .withLustreConfiguration(new CreateFileSystemLustreConfiguration()
+                        .withCopyTagsToBackups(false)
+                        .withAutomaticBackupRetentionDays(preferenceManager.getPreference(
+                                SystemPreferences.LUSTRE_FS_BKP_RETENTION_DAYS))
+                        .withDeploymentType(LustreDeploymentType.PERSISTENT_1)
+                        .withPerUnitStorageThroughput(preferenceManager.getPreference(
+                                SystemPreferences.LUSTRE_FS_DEFAULT_THROUGHPUT))));
+        final FileSystem fs = result.getFileSystem();
+        if (fs.getLifecycle().equals("FAILED")) {
+            log.debug("Lustre fs creation failed: {}", fs);
+            throw new LustreFSException(messageHelper.getMessage(MessageConstants.ERROR_LUSTRE_NOT_CREATED, runId));
+        }
+        return convert(fs);
+    }
+
+    private String getSubnetId(final PipelineRun run, final AwsRegion region) {
+        final Instance instance = ec2Helper.findInstance(run.getInstance().getNodeId(), region.getRegionCode())
+                .orElseThrow(() -> new LustreFSException(messageHelper.getMessage(
+                        MessageConstants.ERROR_LUSTRE_MISSING_INSTANCE, run.getInstance().getNodeId(), run.getId())));
+        return instance.getSubnetId();
+    }
+
+    private List<String> getSecurityGroups(final AwsRegion regionForRun) {
+        final CloudRegionsConfiguration networkSettings = preferenceManager.getPreference(
+                SystemPreferences.CLUSTER_NETWORKS_CONFIG);
+        final NetworkConfiguration settings = ListUtils.emptyIfNull(networkSettings.getRegions())
+                .stream()
+                .filter(region -> regionForRun.getId().equals(region.getRegionId()) ||
+                        regionForRun.getRegionCode().equals(region.getName()))
+                .findFirst()
+                .orElseThrow(() -> new LustreFSException(
+                        messageHelper.getMessage(MessageConstants.ERROR_LUSTRE_MISSING_CONFIG)));
+        return settings.getSecurityGroups();
+    }
+
+    private int getFSSize(final Integer size) {
+//        For PERSISTENT_1 SSD deployment types,
+//        valid values are 1200 GiB, 2400 GiB, and increments of 2400 GiB.
+        final Integer initialSize = Optional.ofNullable(size)
+                .orElseGet(() -> preferenceManager.getPreference(SystemPreferences.LUSTRE_FS_DEFAULT_SIZE_GB));
+        if (initialSize <= LUSTRE_MIN_SIZE_GB) {
+            return LUSTRE_MIN_SIZE_GB;
+        }
+        if (initialSize % LUSTRE_SIZE_STEP_GB == 0) {
+            return initialSize;
+        }
+        return LUSTRE_SIZE_STEP_GB * (1 + initialSize / LUSTRE_SIZE_STEP_GB);
+    }
+
+    private LustreFS convert(final FileSystem lustre) {
+        return LustreFS.builder()
+                .id(lustre.getFileSystemId())
+                .mountPath(String.format(LUSTRE_MOUNT_TEMPLATE, lustre.getDNSName(),
+                        lustre.getLustreConfiguration().getMountName()))
+                .status(lustre.getLifecycle())
+                .mountOptions(preferenceManager.getPreference(SystemPreferences.LUSTRE_FS_MOUNT_OPTIONS))
+                .build();
+    }
+
+    private Optional<FileSystem> findFsForRun(final Long runId, final String token, final AmazonFSx fsxClient) {
+        final DescribeFileSystemsResult result = fsxClient.describeFileSystems(
+                new DescribeFileSystemsRequest()
+                        .withNextToken(token));
+        final Optional<FileSystem> lustre = ListUtils.emptyIfNull(result.getFileSystems())
+                .stream()
+                .filter(fs -> FileSystemType.LUSTRE.name().equals(fs.getFileSystemType()) && hasRunTag(runId, fs))
+                .findFirst();
+        if (lustre.isPresent()) {
+            log.debug("Found a lustre fs with id {} for run {}.", lustre.get().getFileSystemId(), runId);
+            return lustre;
+        }
+        if (StringUtils.isNotBlank(result.getNextToken())) {
+            return findFsForRun(runId, result.getNextToken(), fsxClient);
+        }
+        return Optional.empty();
+    }
+
+    private boolean hasRunTag(Long runId, FileSystem fileSystem) {
+        return ListUtils.emptyIfNull(fileSystem.getTags())
+                .stream()
+                .anyMatch(tag -> RUN_ID_TAG_NAME.equals(tag.getKey()) && String.valueOf(runId).equals(tag.getValue()));
+    }
+
+    private AmazonFSx buildFsxClient(Long runId) {
+        final AwsRegion region = getRegionForRun(runId);
+        return AmazonFSxClient.builder()
+                .withCredentials(AWSUtils.getCredentialsProvider(region.getProfile()))
+                .withRegion(region.getRegionCode())
+                .build();
+    }
+
+    private AwsRegion getRegionForRun(Long runId) {
+        final PipelineRun pipelineRun = runManager.loadPipelineRun(runId);
+        return getRegion(pipelineRun);
+    }
+
+    private AwsRegion getRegion(PipelineRun pipelineRun) {
+        final Long cloudRegionId = pipelineRun.getInstance().getCloudRegionId();
+        final AbstractCloudRegion region = regionManager.load(cloudRegionId);
+        if (region instanceof AwsRegion) {
+            return (AwsRegion)region;
+        } else {
+            throw new LustreFSException(messageHelper.getMessage(MessageConstants.ERROR_LUSTRE_REGION_NOT_SUPPORTED));
+        }
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -104,6 +104,7 @@ public class SystemPreferences {
     private static final String GRID_ENGINE_AUTOSCALING_GROUP = "Grid engine autoscaling";
     private static final String GCP_GROUP = "GCP";
     private static final String BILLING_GROUP = "Billing Reports";
+    private static final String LUSTRE_GROUP = "Lustre FS";
     private static final String STORAGE_FSBROWSER_BLACK_LIST_DEFAULT =
             "/bin,/var,/home,/root,/sbin,/sys,/usr,/boot,/dev,/lib,/proc,/etc";
 
@@ -665,6 +666,16 @@ public class SystemPreferences {
             "billing.reports.enabled", true, BILLING_GROUP, pass);
     public static final BooleanPreference BILLING_REPORTS_ENABLED_ADMINS = new BooleanPreference(
             "billing.reports.enabled.admins", true, BILLING_GROUP, pass);
+
+    // Lustre FS
+    public static final IntPreference LUSTRE_FS_DEFAULT_SIZE_GB = new IntPreference(
+            "lustre.fs.default.size.gb", 1200, LUSTRE_GROUP, pass);
+    public static final IntPreference LUSTRE_FS_BKP_RETENTION_DAYS = new IntPreference(
+            "lustre.fs.backup.retention.days", 7, LUSTRE_GROUP, pass);
+    public static final IntPreference LUSTRE_FS_DEFAULT_THROUGHPUT = new IntPreference(
+            "lustre.fs.default.throughput", 50, LUSTRE_GROUP, pass);
+    public static final StringPreference LUSTRE_FS_MOUNT_OPTIONS = new StringPreference(
+            "lustre.fs.mount.options", null, LUSTRE_GROUP, pass);
 
 
     private static final Pattern GIT_VERSION_PATTERN = Pattern.compile("(\\d)\\.(\\d)");

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -495,3 +495,10 @@ user.not.registered.group.explicitly="Authentication failed! Registration policy
 #System dictionaries
 categorical.attribute.not.exist=Categorical attribute for key [{0}] doesn't exist
 categorical.attribute.invalid.link=Can not create link for [''{0}'':''{1}''] - no [''{2}'':''{3}''] value exists in dictionaries!
+
+#Lustre
+error.lustre.not.found.for.run=Failed to find Lustre FS for run id {0}.
+error.lustre.not.created.for.run=Failed to create Lustre FS for run id {0}.
+error.lustre.region.not.supported=Lustre FS is supported for AWS regions only.
+error.lustre.missing.config=Missing network configuration for Lustre FS setup.
+error.lustre.missing.instance=Lustre setup failed: failed to find instance {0} for run {1}.

--- a/api/src/test/java/com/epam/pipeline/app/AclTestConfiguration.java
+++ b/api/src/test/java/com/epam/pipeline/app/AclTestConfiguration.java
@@ -24,6 +24,7 @@ import com.epam.pipeline.manager.cluster.InstanceOfferManager;
 import com.epam.pipeline.manager.cluster.NodesManager;
 import com.epam.pipeline.manager.configuration.RunConfigurationManager;
 import com.epam.pipeline.manager.contextual.ContextualPreferenceManager;
+import com.epam.pipeline.manager.datastorage.lustre.LustreFSManager;
 import com.epam.pipeline.manager.docker.DockerRegistryManager;
 import com.epam.pipeline.manager.event.EntityEventServiceManager;
 import com.epam.pipeline.manager.filter.FilterManager;
@@ -173,6 +174,9 @@ public class AclTestConfiguration {
 
     @MockBean
     public BillingManager billingManager;
+
+    @MockBean
+    protected LustreFSManager lustreFSManager;
 
     @Bean
     public PermissionFactory permissionFactory() {

--- a/api/src/test/java/com/epam/pipeline/test/acl/AclTestBeans.java
+++ b/api/src/test/java/com/epam/pipeline/test/acl/AclTestBeans.java
@@ -31,6 +31,7 @@ import com.epam.pipeline.manager.datastorage.DataStoragePathLoader;
 import com.epam.pipeline.manager.datastorage.DataStorageRuleManager;
 import com.epam.pipeline.manager.datastorage.FileShareMountManager;
 import com.epam.pipeline.manager.datastorage.StorageProviderManager;
+import com.epam.pipeline.manager.datastorage.lustre.LustreFSManager;
 import com.epam.pipeline.manager.docker.DockerRegistryManager;
 import com.epam.pipeline.manager.docker.scan.ToolScanManager;
 import com.epam.pipeline.manager.docker.scan.ToolScanScheduler;
@@ -305,6 +306,9 @@ public class AclTestBeans {
 
     @MockBean
     protected RoleManager mockRoleManager;
+
+    @MockBean
+    protected LustreFSManager mockLustreFSManager;
 
     @Bean
     protected TemplatesScanner mockTemplatesScanner() {

--- a/api/src/test/java/com/epam/pipeline/test/web/ControllerTestBeans.java
+++ b/api/src/test/java/com/epam/pipeline/test/web/ControllerTestBeans.java
@@ -17,6 +17,7 @@
 package com.epam.pipeline.test.web;
 
 import com.epam.pipeline.acl.billing.BillingApiService;
+import com.epam.pipeline.acl.datastorage.lustre.LustreFSApiService;
 import com.epam.pipeline.acl.log.LogApiService;
 import com.epam.pipeline.acl.pipeline.PipelineApiService;
 import com.epam.pipeline.acl.run.RunApiService;
@@ -203,4 +204,7 @@ public class ControllerTestBeans {
 
     @MockBean
     protected CategoricalAttributeApiService categoricalAttributeApiService;
+
+    @MockBean
+    protected LustreFSApiService lustreFSApiService;
 }

--- a/core/src/main/java/com/epam/pipeline/entity/datastorage/LustreFS.java
+++ b/core/src/main/java/com/epam/pipeline/entity/datastorage/LustreFS.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.datastorage;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class LustreFS {
+
+    private String id;
+    private String status;
+    private String mountPath;
+    private String mountOptions;
+}


### PR DESCRIPTION
This PR is related to #1489  

### Implementation
- Create/Get/Delete API is provided to manage Lustre FS
- Deletion of Lustre FS is added to run tear down process