### PR TITLE
Allow to transfer objects between AWS regions using pipe cp/mv commands

### DIFF
--- a/pipe-cli/src/api/data_storage.py
+++ b/pipe-cli/src/api/data_storage.py
@@ -350,8 +350,7 @@ class DataStorage(API):
     @classmethod
     def get_region_info(cls):
         api = cls.instance()
-        endpoint = 'cloud/region/info'
-        response_data = api.call(endpoint, None)
+        response_data = api.call('cloud/region/info', None)
         if 'payload' in response_data:
             return response_data['payload']
         if response_data['status'] == 'OK':

--- a/pipe-cli/src/api/data_storage.py
+++ b/pipe-cli/src/api/data_storage.py
@@ -89,7 +89,7 @@ class DataStorage(API):
         api = cls.instance()
         response_data = api.call('datastorage/findByPath?id={}'.format(path), None)
         if 'payload' in response_data:
-            return DataStorageModel.load(response_data['payload'])
+            return DataStorageModel.load_with_region(response_data['payload'], cls.get_region_info())
         return None
 
     @classmethod
@@ -346,6 +346,20 @@ class DataStorage(API):
             raise RuntimeError(response_data['message'])
         else:
             raise RuntimeError("Failed to load usage statistic for storage '{}'.".format(name))
+
+    @classmethod
+    def get_region_info(cls):
+        api = cls.instance()
+        endpoint = 'cloud/region/info'
+        response_data = api.call(endpoint, None)
+        if 'payload' in response_data:
+            return response_data['payload']
+        if response_data['status'] == 'OK':
+            return []
+        if 'message' in response_data:
+            raise RuntimeError(response_data['message'])
+        else:
+            raise RuntimeError("Failed to load regions info")
 
 
 def __create_policy__(sts_duration, lts_duration, versioning, backup_duration):

--- a/pipe-cli/src/config.py
+++ b/pipe-cli/src/config.py
@@ -137,8 +137,13 @@ class Config(object):
         else:
             return decorator(_func)
 
-    def resolve_proxy(self, target_url=None):
+    def resolve_proxy(self, target_url=None, cross_region=False):
         if not self.proxy:
+            if cross_region:
+                return {
+                    'http': os.environ.get('http_proxy', ''),
+                    'https': os.environ.get('https_proxy', '')
+                }
             return None
         elif self.proxy == PROXY_TYPE_PAC:
             pac_file = PacAPI.get_pac()

--- a/pipe-cli/src/config.py
+++ b/pipe-cli/src/config.py
@@ -137,13 +137,8 @@ class Config(object):
         else:
             return decorator(_func)
 
-    def resolve_proxy(self, target_url=None, cross_region=False):
+    def resolve_proxy(self, target_url=None):
         if not self.proxy:
-            if cross_region:
-                return {
-                    'http': os.environ.get('http_proxy', ''),
-                    'https': os.environ.get('https_proxy', '')
-                }
             return None
         elif self.proxy == PROXY_TYPE_PAC:
             pac_file = PacAPI.get_pac()

--- a/pipe-cli/src/model/data_storage_model.py
+++ b/pipe-cli/src/model/data_storage_model.py
@@ -26,6 +26,7 @@ class DataStorageModel(DataStorageItemModel):
         self.parent_folder_id = None
         self.mask = 0
         self.policy = StoragePolicy()
+        self.region = None
 
     @classmethod
     def load(cls, json):
@@ -44,6 +45,30 @@ class DataStorageModel(DataStorageItemModel):
             instance.parent_folder_id = json['parentFolderId']
         if 'mask' in json:
             instance.mask = json['mask']
+        instance.policy = StoragePolicy()
+        if 'storagePolicy' in json:
+            cls.parse_policy(instance.policy, json['storagePolicy'])
+        return instance
+
+    @classmethod
+    def load_with_region(cls, json, region_data):
+        instance = DataStorageModel()
+        instance.initialize(json)
+        instance.identifier = json['id']
+        if 'description' in json:
+            instance.description = json['description']
+        if 'type' in json:
+            instance.type = json['type']
+        if 'delimiter' in json:
+            instance.delimiter = json['delimiter']
+        if 'createdDate' in json:
+            instance.changed = date_utilities.server_date_representation(json['createdDate'])
+        if 'parentFolderId' in json:
+            instance.parent_folder_id = json['parentFolderId']
+        if 'mask' in json:
+            instance.mask = json['mask']
+        if 'regionId' in json:
+            instance.region = cls._find_region_code(json['regionId'], region_data)
         instance.policy = StoragePolicy()
         if 'storagePolicy' in json:
             cls.parse_policy(instance.policy, json['storagePolicy'])
@@ -70,6 +95,13 @@ class DataStorageModel(DataStorageItemModel):
             return '{}{}{}'.format(self.root_path(), self.delimiter, path)
         else:
             return '{}/{}'.format(self.root_path(), path)
+
+    @staticmethod
+    def _find_region_code(region_id, region_data):
+        for region in region_data:
+            if int(region.get('id', 0)) == int(region_id):
+                return region.get('regionId', None)
+        return None
 
 
 class StoragePolicy(object):

--- a/pipe-cli/src/utilities/storage/s3.py
+++ b/pipe-cli/src/utilities/storage/s3.py
@@ -44,10 +44,6 @@ from src.utilities.storage.common import StorageOperations, AbstractListingManag
 from src.config import Config
 
 
-import boto3
-boto3.set_stream_logger(name='botocore')
-
-
 class StorageItemManager(object):
 
     def __init__(self, session, bucket=None, region_name=None, cross_region=False):

--- a/pipe-cli/src/utilities/storage/s3.py
+++ b/pipe-cli/src/utilities/storage/s3.py
@@ -662,21 +662,10 @@ class S3BucketOperations(object):
             cls.__config__ = Config.instance()
         if cls.__config__.proxy is None:
             if cross_region:
-                return AwsConfig(proxies=cls._build_no_proxy_config())
+                os.environ['no_proxy'] = ''
             return None
         else:
             return AwsConfig(proxies=cls.__config__.resolve_proxy(target_url=cls.S3_ENDPOINT_URL))
-
-    @classmethod
-    def _build_no_proxy_config(cls):
-        result = {}
-        if os.environ.get('http_proxy'):
-            result.update({'http': os.environ.get('http_proxy')})
-        if os.environ.get('https_proxy'):
-            result.update({'https': os.environ.get('https_proxy')})
-        if not result:
-            return None
-        return result
 
     @classmethod
     def _get_client(cls, session, region_name=None):


### PR DESCRIPTION
This PR proves additional cli fixes for issue #1469 

The current PR contains the following changes for `s3` provider:
- region shell be added to each client
- `no_proxy` envvar shell be empty if cross-region operation requested and proxy not specified