### PR TITLE
Implement pipe cli tunnel

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1245,18 +1245,20 @@ def create_tunnel(run_id, local_port, remote_port, log_file, log_level, foregrou
             import subprocess
             import os
             import platform
-            executable = [(sys.executable)] + sys.argv + ['-f']
             if platform.system() == 'Windows':
+                executable = sys.argv + ['-f']
                 # https://docs.microsoft.com/ru-ru/windows/win32/procthread/process-creation-flags?redirectedfrom=MSDN
                 CREATE_NEW_PROCESS_GROUP = 0x00000200
                 DETACHED_PROCESS = 0x00000008
 
                 with open(log_file or os.devnull, 'w') as output:
-                    subprocess.Popen(executable, stdout=output, stderr=subprocess.STDOUT, env=os.environ.copy(),
-                                     creationflags=DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP)
+                    subprocess.Popen(executable, stdout=output, stderr=subprocess.STDOUT, cwd=os.getcwd(),
+                                     env=os.environ.copy(), creationflags=DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP)
             else:
+                executable = [(sys.executable)] + sys.argv + ['-f']
                 with open(log_file or os.devnull, 'w') as output:
-                    subprocess.Popen(executable, stdout=output, stderr=subprocess.STDOUT, env=os.environ.copy())
+                    subprocess.Popen(executable, stdout=output, stderr=subprocess.STDOUT, cwd=os.getcwd(),
+                                     env=os.environ.copy())
     except Exception as runtime_error:
         click.echo('Error: {}'.format(str(runtime_error)), err=True)
         sys.exit(1)

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -35,7 +35,7 @@ from src.utilities.datastorage_operations import DataStorageOperations
 from src.utilities.metadata_operations import MetadataOperations
 from src.utilities.permissions_operations import PermissionsOperations
 from src.utilities.pipeline_run_operations import PipelineRunOperations
-from src.utilities.ssh_operations import run_ssh, create_tcp_tunnel
+from src.utilities.ssh_operations import run_ssh, create_tunnel
 from src.utilities.update_cli_version import UpdateCLIVersionManager
 from src.utilities.user_token_operations import UserTokenOperations
 from src.version import __version__
@@ -1224,41 +1224,37 @@ def ssh(ctx, run_id, retries):
 
 @cli.command(name='tunnel')
 @click.argument('run-id', required=True, type=int)
-@click.option('-lp', '--local-port', required=True, type=int, help='Local port')
-@click.option('-rp', '--remote-port', required=True, type=int, help='Remote port')
-@click.option('-l', '--log-file', required=False, help='Log file for tunnel')
-@click.option('-v', '--log-level', required=False, help='Log level for tunnel: '
+@click.option('-lp', '--local-port', required=True, type=int, help='Local port to establish connection from')
+@click.option('-rp', '--remote-port', required=True, type=int, help='Remote port to establish connection to')
+@click.option('-l', '--log-file', required=False, help='Logs file for tunnel in background mode')
+@click.option('-v', '--log-level', required=False, help='Logs level for tunnel: '
                                                         'CRITICAL, ERROR, WARNING, INFO or DEBUG')
+@click.option('-t', '--timeout', required=False, type=int, default=1000,
+              help='Time period in ms for background tunnel process health check')
 @click.option('-f', '--foreground', required=False, is_flag=True, default=False,
-              help='Launches tunnel process in foreground mode. '
-                   'By default it is launched as a background process.')
+              help='Establishes tunnel in foreground mode')
 @click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token
-def create_tunnel(run_id, local_port, remote_port, log_file, log_level, foreground):
+def tunnel(run_id, local_port, remote_port, log_file, log_level, timeout, foreground):
     """
-    Establishes tcp tunnel for the specified job run between specified local port and remote port.
+    Establishes tunnel connection to specified run instance port and server it as a local port.
+
+    It allows to transfer any tcp traffic from local machine to run instance.
+
+    For example it can be used to allow ssh connections to run instance.
+
+    \b
+    First of all establish tunnel connection from run #12345 instance ssh port (22) to some local port (4567).
+        pipe tunnel -lp 4567 -rp 22 12345
+
+    \b
+    Then connect to run instance using regular ssh client on the configured local port (4567).
+        ssh -p 4567 root@localhost
+
+    Its works both on Linux and Windows. On windows git bash can be used for ssh.
     """
     try:
-        if foreground:
-            create_tcp_tunnel(run_id, local_port, remote_port)
-        else:
-            import subprocess
-            import os
-            import platform
-            if platform.system() == 'Windows':
-                executable = sys.argv + ['-f']
-                # https://docs.microsoft.com/ru-ru/windows/win32/procthread/process-creation-flags?redirectedfrom=MSDN
-                CREATE_NEW_PROCESS_GROUP = 0x00000200
-                DETACHED_PROCESS = 0x00000008
-
-                with open(log_file or os.devnull, 'w') as output:
-                    subprocess.Popen(executable, stdout=output, stderr=subprocess.STDOUT, cwd=os.getcwd(),
-                                     env=os.environ.copy(), creationflags=DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP)
-            else:
-                executable = [(sys.executable)] + sys.argv + ['-f']
-                with open(log_file or os.devnull, 'w') as output:
-                    subprocess.Popen(executable, stdout=output, stderr=subprocess.STDOUT, cwd=os.getcwd(),
-                                     env=os.environ.copy())
+        create_tunnel(run_id, local_port, remote_port, log_file, log_level, timeout, foreground)
     except Exception as runtime_error:
         click.echo('Error: {}'.format(str(runtime_error)), err=True)
         sys.exit(1)

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1237,21 +1237,25 @@ def ssh(ctx, run_id, retries):
 @Config.validate_access_token
 def tunnel(run_id, local_port, remote_port, log_file, log_level, timeout, foreground):
     """
-    Establishes tunnel connection to specified run instance port and server it as a local port.
+    Establishes tunnel connection to specified run instance port and serves it as a local port.
 
-    It allows to transfer any tcp traffic from local machine to run instance.
+    It allows to transfer any tcp traffic from local machine to run instance and works both on Linux and Windows.
 
     For example it can be used to allow ssh connections to run instance.
 
     \b
-    First of all establish tunnel connection from run #12345 instance ssh port (22) to some local port (4567).
+    First of all establish tunnel connection from run (12345) instance ssh port (22) to some local port (4567).
         pipe tunnel -lp 4567 -rp 22 12345
 
     \b
     Then connect to run instance using regular ssh client on the configured local port (4567).
         ssh -p 4567 root@localhost
 
-    Its works both on Linux and Windows. On windows git bash can be used for ssh.
+    \b
+    Additionally the following environment variables can be used to specify the exact tunnel properties.
+        CP_CLI_TUNNEL_PROXY_HOST
+        CP_CLI_TUNNEL_PROXY_PORT
+        CP_CLI_TUNNEL_TARGET_HOST
     """
     try:
         create_tunnel(run_id, local_port, remote_port, log_file, log_level, timeout, foreground)

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -35,7 +35,7 @@ from src.utilities.datastorage_operations import DataStorageOperations
 from src.utilities.metadata_operations import MetadataOperations
 from src.utilities.permissions_operations import PermissionsOperations
 from src.utilities.pipeline_run_operations import PipelineRunOperations
-from src.utilities.ssh_operations import run_ssh
+from src.utilities.ssh_operations import run_ssh, create_tcp_tunnel
 from src.utilities.update_cli_version import UpdateCLIVersionManager
 from src.utilities.user_token_operations import UserTokenOperations
 from src.version import __version__
@@ -1217,6 +1217,23 @@ def ssh(ctx, run_id, retries):
     try:
         ssh_exit_code = run_ssh(run_id, ' '.join(ctx.args), retries)
         sys.exit(ssh_exit_code)
+    except Exception as runtime_error:
+        click.echo('Error: {}'.format(str(runtime_error)), err=True)
+        sys.exit(1)
+
+
+@cli.command(name='tunnel')
+@click.argument('run-id', required=True, type=int)
+@click.option('-lp', '--local-port', required=True, type=int, help='Local port')
+@click.option('-rp', '--remote-port', required=True, type=int, help='Remote port')
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
+@Config.validate_access_token
+def create_tunnel(run_id, local_port, remote_port):
+    """
+    Establishes tcp tunnel for the specified job run between specified local port and remote port.
+    """
+    try:
+        create_tcp_tunnel(run_id, local_port, remote_port)
     except Exception as runtime_error:
         click.echo('Error: {}'.format(str(runtime_error)), err=True)
         sys.exit(1)

--- a/pipe-cli/src/utilities/network_utilities.py
+++ b/pipe-cli/src/utilities/network_utilities.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import atexit
+import platform
 from contextlib import closing
 import os
 import signal
@@ -51,7 +52,14 @@ class NTLMProxy(object):
                         "--downstream-proxy-port", str(proxy_port)]
 
         with open(os.devnull, 'w') as dev_null:
-            ntlm_aps_proc = subprocess.Popen(ntlm_aps_cmd, stdout=dev_null, stderr=dev_null)
+            if platform.system() == 'Windows':
+                # See https://docs.microsoft.com/ru-ru/windows/win32/procthread/process-creation-flags
+                CREATE_NO_WINDOW = 0x08000000
+                creationflags = CREATE_NO_WINDOW
+            else:
+                creationflags = 0
+            ntlm_aps_proc = subprocess.Popen(ntlm_aps_cmd, stdout=dev_null, stderr=dev_null,
+                                             creationflags=creationflags)
             self.proxy_pid = ntlm_aps_proc.pid
 
     def kill_ntlm_aps(self):

--- a/pipe-cli/src/utilities/ssh_operations.py
+++ b/pipe-cli/src/utilities/ssh_operations.py
@@ -126,6 +126,7 @@ def create_foreground_tunnel(run_id, local_port, remote_port, log_file, log_leve
     server_socket.listen(5)
     inputs = []
     channel = {}
+    configure_graceful_exiting()
     logging.info('Serving tunnel...')
     try:
         inputs.append(server_socket)
@@ -183,6 +184,15 @@ def create_foreground_tunnel(run_id, local_port, remote_port, log_file, log_leve
         for input in inputs:
             input.close()
         logging.info('Exiting...')
+
+
+def configure_graceful_exiting():
+    def throw_keyboard_interrupt(signum, frame):
+        logging.info('Killed...')
+        raise KeyboardInterrupt()
+
+    import signal
+    signal.signal(signal.SIGTERM, throw_keyboard_interrupt)
 
 
 def create_background_tunnel(log_file, timeout):

--- a/pipe-cli/src/utilities/ssh_operations.py
+++ b/pipe-cli/src/utilities/ssh_operations.py
@@ -16,6 +16,11 @@ import base64
 import collections
 import logging
 import os
+import select
+import socket
+import sys
+import time
+
 import paramiko
 from src.utilities.pipe_shell import plain_shell, interactive_shell
 from src.api.pipeline_run import PipelineRun
@@ -57,7 +62,7 @@ def http_proxy_tunnel_connect(proxy, target, timeout=None):
                 break
     except socket.error as error:
         if "timed out" not in error:
-            response = [error]
+            response = [str(error)]
     response = ''.join(response)
     if "200 connection established" not in response.lower():
         raise RuntimeError("Unable to establish HTTP-Tunnel: %s" % repr(response))
@@ -90,9 +95,88 @@ def run_ssh_command(channel, command):
     plain_shell(channel)
     return channel.recv_exit_status()
 
+
 def run_ssh_session(channel):
     channel.invoke_shell()
     interactive_shell(channel)
+
+def create_tcp_tunnel(run_id, local_port, remote_port):
+    chunk_size = 4096
+    delay = 0.0001
+
+    logging.basicConfig(level=logging.INFO)
+
+    conn_info = get_conn_info(run_id)
+    proxy_endpoint = (os.getenv('CP_CLI_TUNNEL_PROXY_HOST', conn_info.ssh_proxy[0]),
+                      int(os.getenv('CP_CLI_TUNNEL_PROXY_PORT', conn_info.ssh_proxy[1])))
+    target_endpoint = (conn_info.ssh_endpoint[0], remote_port)
+
+    logging.info('Initializing tunnel on port %s...', local_port)
+    server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server_socket.bind(('0.0.0.0', local_port))
+    server_socket.listen(5)
+
+    inputs = []
+    channel = {}
+
+    logging.info('Serving tcp tunnel...')
+    try:
+        inputs.append(server_socket)
+        while True:
+            time.sleep(delay)
+            logging.info('Waiting for connections...')
+            inputs_ready, _, _ = select.select(inputs, [], [])
+            for input in inputs_ready:
+                if input == server_socket:
+                    try:
+                        logging.info('Initializing client connection...')
+                        client_socket, address = server_socket.accept()
+                    except KeyboardInterrupt:
+                        raise
+                    except:
+                        logging.exception('Cannot establish client connection')
+                        break
+                    try:
+                        logging.info('Initializing tunnel connection...')
+                        tunnel_socket = http_proxy_tunnel_connect(proxy_endpoint, target_endpoint, 5)
+                    except KeyboardInterrupt:
+                        raise
+                    except:
+                        logging.exception('Cannot establish tunnel connection')
+                        client_socket.close()
+                        break
+                    inputs.append(client_socket)
+                    inputs.append(tunnel_socket)
+                    channel[client_socket] = tunnel_socket
+                    channel[tunnel_socket] = client_socket
+                    break
+
+                logging.debug('Reading data...')
+                data = input.recv(chunk_size)
+                if data:
+                    logging.debug('Writing data...')
+                    channel[input].send(data)
+                else:
+                    logging.info('Closing client and tunnel connections...')
+                    out = channel[input]
+                    inputs.remove(input)
+                    inputs.remove(out)
+                    channel[out].close()
+                    channel[input].close()
+                    del channel[out]
+                    del channel[input]
+                    break
+    except KeyboardInterrupt:
+        logging.info('Interrupted...')
+    except:
+        logging.exception('Errored...')
+        sys.exit(1)
+    finally:
+        logging.info('Closing all sockets...')
+        for input in inputs:
+            input.close()
+        logging.info('Exiting...')
+
 
 def run_ssh(run_id, command, retries=10):
     # Grab the run information from the API to setup the run's IP and EDGE proxy address

--- a/pipe-cli/src/utilities/ssh_operations.py
+++ b/pipe-cli/src/utilities/ssh_operations.py
@@ -106,17 +106,20 @@ def run_ssh_session(channel):
 def create_tunnel(run_id, local_port, remote_port, log_file, log_level, timeout, foreground,
                   server_delay=0.0001, tunnel_timeout=5, chunk_size=4096):
     if foreground:
-        server_tunnel(run_id, local_port, remote_port, log_file, log_level, server_delay, tunnel_timeout, chunk_size)
+        create_foreground_tunnel(run_id, local_port, remote_port, log_file, log_level,
+                                 server_delay, tunnel_timeout, chunk_size)
     else:
         create_background_tunnel(log_file, timeout)
 
 
-def server_tunnel(run_id, local_port, remote_port, log_file, log_level, server_delay, tunnel_timeout, chunk_size):
+def create_foreground_tunnel(run_id, local_port, remote_port, log_file, log_level,
+                             server_delay, tunnel_timeout, chunk_size):
     logging.basicConfig(level=log_level or logging.ERROR)
     conn_info = get_conn_info(run_id)
     proxy_endpoint = (os.getenv('CP_CLI_TUNNEL_PROXY_HOST', conn_info.ssh_proxy[0]),
                       int(os.getenv('CP_CLI_TUNNEL_PROXY_PORT', conn_info.ssh_proxy[1])))
-    target_endpoint = (conn_info.ssh_endpoint[0], remote_port)
+    target_endpoint = (os.getenv('CP_CLI_TUNNEL_TARGET_HOST', conn_info.ssh_endpoint[0]),
+                       remote_port)
     logging.info('Initializing tunnel %s:pipeline-%s:%s...', local_port, run_id, remote_port)
     server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     server_socket.bind(('0.0.0.0', local_port))


### PR DESCRIPTION
Relates to #1501.

Implements `pipe tunnel` command which serves run instance port as a local port. The implementation is based on `pipe ssh` command ports tunneling.

Notice that this implementation requires ssh password to connect to run instances via ssh client. For passwordless ssh configuration see #1534.

See `pipe tunnel --help` output for more information:

```
    Establishes tunnel connection to specified run instance port and serves it as a local port.

    It allows to transfer any tcp traffic from local machine to run instance and works both on Linux and Windows.

    For example it can be used to allow ssh connections to run instance.
    
    First of all establish tunnel connection from run (12345) instance ssh port (22) to some local port (4567).
        pipe tunnel -lp 4567 -rp 22 12345
    
    Then connect to run instance using regular ssh client on the configured local port (4567).
        ssh -p 4567 root@localhost
    
    Additionally the following environment variables can be used to specify the exact tunnel properties.
        CP_CLI_TUNNEL_PROXY_HOST
        CP_CLI_TUNNEL_PROXY_PORT
        CP_CLI_TUNNEL_TARGET_HOST
```