### PR TITLE
Jobs, that were stopped by a "Timeout", shall move the interim data into the "output" storage

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/execution/PipelineExecutor.java
+++ b/api/src/main/java/com/epam/pipeline/manager/execution/PipelineExecutor.java
@@ -16,7 +16,6 @@
 
 package com.epam.pipeline.manager.execution;
 
-import com.epam.pipeline.config.Constants;
 import com.epam.pipeline.entity.cluster.DockerMount;
 import com.epam.pipeline.entity.cluster.container.ContainerMemoryResourcePolicy;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
@@ -167,9 +166,6 @@ public class PipelineExecutor {
         spec.setTerminationGracePeriodSeconds(KUBE_TERMINATION_PERIOD);
         spec.setDnsPolicy("ClusterFirst");
         spec.setNodeSelector(nodeSelector);
-        if (run.getTimeout() != null && run.getTimeout() > 0) {
-            spec.setActiveDeadlineSeconds(run.getTimeout() * Constants.SECONDS_IN_MINUTE);
-        }
         if (!StringUtils.isEmpty(secretName)) {
             spec.setImagePullSecrets(Collections.singletonList(new LocalObjectReference(secretName)));
         }

--- a/api/src/main/java/com/epam/pipeline/manager/execution/PipelineLauncher.java
+++ b/api/src/main/java/com/epam/pipeline/manager/execution/PipelineLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -213,6 +213,9 @@ public class PipelineLauncher {
         }
         if (run.getSensitive()) {
             systemParamsWithValue.put(SystemParams.CP_SENSITIVE_RUN, "true");
+        }
+        if (run.getTimeout() != null && run.getTimeout() > 0) {
+            systemParamsWithValue.put(SystemParams.CP_EXEC_TIMEOUT, String.valueOf(run.getTimeout()));
         }
         return systemParamsWithValue;
     }

--- a/api/src/main/java/com/epam/pipeline/manager/execution/SystemParams.java
+++ b/api/src/main/java/com/epam/pipeline/manager/execution/SystemParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +69,8 @@ public enum SystemParams {
     CONTAINER_CPU_RESOURCE("container-cpu-resource", "CP_CONTAINER_CPU_RESOURCE", false, true),
     CONTAINER_MEMORY_RESOURCE_POLICY("container-memory-resource-policy",
             "CP_CONTAINER_MEMORY_RESOURCE_POLICY", false, true),
-    CP_SENSITIVE_RUN("cp-sensitive-run", "CP_SENSITIVE_RUN", false, false);
+    CP_SENSITIVE_RUN("cp-sensitive-run", "CP_SENSITIVE_RUN", false, false),
+    CP_EXEC_TIMEOUT("cp-exec-timeout", "CP_EXEC_TIMEOUT");
 
     public static final String CLOUD_REGION_PREFIX = "CP_ACCOUNT_REGION_";
     public static final String CLOUD_ACCOUNT_PREFIX = "CP_ACCOUNT_ID_";

--- a/deploy/contents/install/preferences/launch.system.parameters.json
+++ b/deploy/contents/install/preferences/launch.system.parameters.json
@@ -294,5 +294,12 @@
         "description": "Controls the network interface name, to apply the CP_CAP_HW_ADDR. Default: eth0",
         "defaultValue": "eth0",
         "passToWorkers": false
+    },
+    {
+        "name": "CP_EXEC_TIMEOUT",
+        "type": "int",
+        "description": "If defined - will terminate job when specified duration in minutes is elapsed",
+        "defaultValue": "",
+        "passToWorkers": false
     }
 ]

--- a/scripts/pipeline-launch/launch.sh
+++ b/scripts/pipeline-launch/launch.sh
@@ -1678,7 +1678,15 @@ pipe_log SUCCESS "Environment initialization finished" "InitializeEnvironment"
 
 echo "Command text:"
 echo "${SCRIPT}"
-bash -c "${SCRIPT}"
+
+if [ ! -z "${CP_EXEC_TIMEOUT}" ] && [ "${CP_EXEC_TIMEOUT}" -gt 0 ];
+then
+  timeout ${CP_EXEC_TIMEOUT}m bash -c "${SCRIPT}"
+  echo "Timeout was elapsed"
+else
+  bash -c "${SCRIPT}"
+fi
+
 CP_EXEC_RESULT=$?
 
 echo "------"

--- a/scripts/pipeline-launch/launch.sh
+++ b/scripts/pipeline-launch/launch.sh
@@ -1682,12 +1682,15 @@ echo "${SCRIPT}"
 if [ ! -z "${CP_EXEC_TIMEOUT}" ] && [ "${CP_EXEC_TIMEOUT}" -gt 0 ];
 then
   timeout ${CP_EXEC_TIMEOUT}m bash -c "${SCRIPT}"
-  echo "Timeout was elapsed"
+  CP_EXEC_RESULT=$?
+  if [ $CP_EXEC_RESULT -eq 124 ];
+  then
+    echo "Timeout was elapsed"
+  fi
 else
   bash -c "${SCRIPT}"
+  CP_EXEC_RESULT=$?
 fi
-
-CP_EXEC_RESULT=$?
 
 echo "------"
 echo
@@ -1722,7 +1725,7 @@ else
 fi
 
 if [ "$CP_CAP_KEEP_FAILED_RUN" ] && \
-   ([ $CP_EXEC_RESULT -ne 0 ] || \
+   ( ! ([ $CP_EXEC_RESULT -eq 0 ] || [ $CP_EXEC_RESULT -eq 124 ]) || \
    [ $CP_OUTPUTS_RESULT -ne 0 ]); then
       echo "Script execution has failed or the outputs were not tansferred. The job will keep running for $CP_CAP_KEEP_FAILED_RUN"
       sleep $CP_CAP_KEEP_FAILED_RUN


### PR DESCRIPTION
This PR provides implementation for issue #1520 

The current PR contains the following changes:
- a new system parameter `CP_EXEC_TIMEOUT` was introduced
- if both `Timeout` field and `CP_EXEC_TIMEOUT` system parameter were specified the `CP_EXEC_TIMEOUT` will be used
- if timeout was specified the `launch.sh` script will continue its flow after the timeout elapsed 
