### PR TITLE
Issue #1526 Correct Azure storage price loading

### DIFF
--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/app/CommonSyncConfiguration.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/app/CommonSyncConfiguration.java
@@ -27,6 +27,7 @@ import com.epam.pipeline.billingreportagent.service.impl.converter.FileShareMoun
 import com.epam.pipeline.billingreportagent.service.impl.converter.GcpStoragePriceListLoader;
 import com.epam.pipeline.billingreportagent.service.impl.converter.PriceLoadingMode;
 import com.epam.pipeline.billingreportagent.service.impl.converter.StoragePricingService;
+import com.epam.pipeline.billingreportagent.service.impl.loader.CloudRegionLoader;
 import com.epam.pipeline.billingreportagent.service.impl.synchronizer.PipelineRunSynchronizer;
 import com.epam.pipeline.billingreportagent.service.impl.synchronizer.StorageSynchronizer;
 import com.epam.pipeline.billingreportagent.service.impl.converter.StorageToBillingRequestConverter;
@@ -184,15 +185,14 @@ public class CommonSyncConfiguration {
 
     @Bean
     @ConditionalOnProperty(value = "sync.storage.azure-blob.disable", matchIfMissing = true, havingValue = FALSE)
-    public StorageSynchronizer azureSynchronizer(final @Value("${sync.storage.azure.auth.file}") String authFile,
-                                                 final @Value("${sync.storage.azure.offer.id}") String offerId,
-                                                 final StorageLoader loader,
+    public StorageSynchronizer azureSynchronizer(final StorageLoader loader,
                                                  final ElasticIndexService indexService,
-                                                 final ElasticsearchServiceClient elasticsearchClient) {
+                                                 final ElasticsearchServiceClient elasticsearchClient,
+                                                 final CloudRegionLoader regionLoader) {
         final StorageBillingMapper mapper = new StorageBillingMapper(SearchDocumentType.AZ_BLOB_STORAGE,
                 billingCenterKey);
         final StoragePricingService pricingService =
-                new StoragePricingService(new AzureStoragePriceListLoader(offerId, authFile));
+                new StoragePricingService(new AzureStoragePriceListLoader(regionLoader));
         return new StorageSynchronizer(storageMapping,
                 commonIndexPrefix,
                 storageIndexName,

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/AzureStoragePriceListLoader.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/AzureStoragePriceListLoader.java
@@ -16,16 +16,21 @@
 
 package com.epam.pipeline.billingreportagent.service.impl.converter;
 
+import com.epam.pipeline.billingreportagent.model.EntityContainer;
 import com.epam.pipeline.billingreportagent.model.billing.StoragePricing;
 import com.epam.pipeline.billingreportagent.model.pricing.AzurePricingMeter;
 import com.epam.pipeline.billingreportagent.model.pricing.AzurePricingResult;
+import com.epam.pipeline.billingreportagent.service.impl.loader.CloudRegionLoader;
 import com.epam.pipeline.billingreportagent.service.impl.pricing.AzurePricingClient;
+import com.epam.pipeline.entity.region.AbstractCloudRegion;
+import com.epam.pipeline.entity.region.AzureRegion;
 import com.epam.pipeline.entity.region.CloudProvider;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.azure.credentials.ApplicationTokenCredentials;
 import okhttp3.OkHttpClient;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.util.Assert;
 import retrofit2.Response;
 import retrofit2.Retrofit;
 import retrofit2.converter.jackson.JacksonConverterFactory;
@@ -35,10 +40,15 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 public class AzureStoragePriceListLoader implements StoragePriceListLoader {
@@ -54,24 +64,10 @@ public class AzureStoragePriceListLoader implements StoragePriceListLoader {
     private static final String FILTER_TEMPLATE =
         "OfferDurableId eq '%s' and Currency eq 'USD' and Locale eq 'en-US' and RegionInfo eq 'US'";
 
-    private AzurePricingClient azurePricingClient;
-    private ApplicationTokenCredentials credentials;
-    private String authPath;
-    private String offerId;
+    private CloudRegionLoader regionLoader;
 
-    public AzureStoragePriceListLoader(final String offerId, final String authPath) {
-        this.offerId = offerId;
-        this.authPath = authPath;
-        initAzureCredentialsAndClient();
-    }
-
-    private void initAzureCredentialsAndClient() {
-        try {
-            credentials = ApplicationTokenCredentials.fromFile(new File(authPath));
-        } catch (IOException e) {
-            throw new IllegalArgumentException("Can't access given Azure auth file!");
-        }
-        azurePricingClient = buildRetrofitClient(credentials.environment().resourceManagerEndpoint());
+    public AzureStoragePriceListLoader(final CloudRegionLoader regionLoader) {
+        this.regionLoader = regionLoader;
     }
 
     @Override
@@ -81,15 +77,78 @@ public class AzureStoragePriceListLoader implements StoragePriceListLoader {
 
     @Override
     public Map<String, StoragePricing> loadFullPriceList() throws Exception {
-        final String token = credentials.getToken(credentials.environment().resourceManagerEndpoint());
-        final Response<AzurePricingResult> pricingResponse =
-            azurePricingClient.getPricing(String.format(AUTH_TOKEN_TEMPLATE, token),
-                                          credentials.defaultSubscriptionId(),
-                                          String.format(FILTER_TEMPLATE, offerId),
-                                          API_VERSION).execute();
-        if (!pricingResponse.isSuccessful()) {
-            throw new IllegalStateException("Can't load Azure price list!");
+        final List<AzureRegion> activeAzureRegions = regionLoader.loadAllEntities().stream()
+            .map(EntityContainer::getEntity)
+            .filter(AzureRegion.class::isInstance)
+            .map(AzureRegion.class::cast)
+            .collect(Collectors.toList());
+        Assert.isTrue(CollectionUtils.isNotEmpty(activeAzureRegions), "No Azure regions found in current deployment!");
+        assertOffersAndRegionMetersAreUnique(activeAzureRegions);
+        final Map<String, Response<AzurePricingResult>> azureRegionPricing = new HashMap<>();
+        for (final AzureRegion region : activeAzureRegions) {
+            final String offerAndSubscription = getRegionOfferAndSubscription(region);
+            if (!azureRegionPricing.containsKey(offerAndSubscription)) {
+                azureRegionPricing.put(offerAndSubscription, getAzurePricing(region));
+            }
         }
+        return activeAzureRegions.stream()
+            .collect(Collectors.toMap(AbstractCloudRegion::getRegionCode,
+                region -> {
+                    final String offerAndSubscription = getRegionOfferAndSubscription(region);
+                    return getStringStoragePricingForRegion(
+                    azureRegionPricing.get(offerAndSubscription),
+                    region.getMeterRegionName());
+                },
+                (region1, region2) -> region1));
+    }
+
+    private void assertOffersAndRegionMetersAreUnique(final List<AzureRegion> activeAzureRegions) {
+        final Map<String, Set<String>> regionOfferMapping =
+            mapRegionsOnFunctionResult(activeAzureRegions, this::getRegionOfferAndSubscription);
+        final Map<String, Set<String>> regionMeterMapping =
+            mapRegionsOnFunctionResult(activeAzureRegions, AzureRegion::getMeterRegionName);
+        for (final String regionName : regionOfferMapping.keySet()) {
+            if (regionOfferMapping.get(regionName).size() > 1) {
+                throw new IllegalArgumentException(
+                    String.format("Regions with the same name [%s] specifies different"
+                                  + " offerId or subscription!", regionName));
+            }
+            if (regionMeterMapping.get(regionName).size() > 1) {
+                throw new IllegalArgumentException(
+                    String.format("Regions with the same name [%s] specifies different"
+                                  + " meter region name!", regionName));
+            }
+        }
+    }
+
+    private Map<String, Set<String>> mapRegionsOnFunctionResult(final List<AzureRegion> activeAzureRegions,
+                                                                final Function<AzureRegion, String> function) {
+        return activeAzureRegions.stream()
+            .collect(Collectors.groupingBy(AbstractCloudRegion::getRegionCode,
+                                           Collector.of(HashSet::new,
+                                               (set, region) -> set.add(function.apply(region)),
+                                               (left, right) -> {
+                                                   left.addAll(right);
+                                                   return left;
+                                               },
+                                               Function.identity())));
+    }
+
+    private ApplicationTokenCredentials getCredentialsFromFile(final String credentialsPath) {
+        try {
+            return ApplicationTokenCredentials.fromFile(new File(credentialsPath));
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Can't access given Azure auth file!");
+        }
+    }
+
+    private String getRegionOfferAndSubscription(final AzureRegion region) {
+        return String.join(",", region.getPriceOfferId(), region.getSubscription());
+    }
+
+    private StoragePricing getStringStoragePricingForRegion(
+        final Response<AzurePricingResult> pricingResponse,
+        final String meterRegion) {
         return Optional.ofNullable(pricingResponse.body()).orElseGet(() -> {
             final AzurePricingResult azurePricingResult = new AzurePricingResult();
             azurePricingResult.setMeters(Collections.emptyList());
@@ -100,9 +159,27 @@ public class AzureStoragePriceListLoader implements StoragePriceListLoader {
             .filter(meter -> STORAGE_CATEGORY.equals(meter.getMeterCategory()))
             .filter(meter -> STORAGE_SUBCATEGORY_BLOCK_BLOB.equals(meter.getMeterSubCategory()))
             .filter(meter -> meter.getMeterName().startsWith(REDUNDANCY_TYPE))
-            .filter(meter -> StringUtils.isNotEmpty(meter.getMeterRegion()))
-            .collect(Collectors.toMap(AzurePricingMeter::getMeterRegion,
-                                      this::convertAzurePricing));
+            .filter(meter -> meterRegion.equals(meter.getMeterRegion()))
+            .findFirst()
+            .map(this::convertAzurePricing)
+            .orElseThrow(() -> new IllegalArgumentException(
+                String.format("No [%s] region is presented in prices retrieved!", meterRegion)));
+    }
+
+    private Response<AzurePricingResult> getAzurePricing(final AzureRegion region) throws IOException {
+        final ApplicationTokenCredentials credentials = getCredentialsFromFile(region.getAuthFile());
+        final String resourceManagerEndpoint = credentials.environment().resourceManagerEndpoint();
+        final Response<AzurePricingResult> pricingResponse = buildRetrofitClient(resourceManagerEndpoint)
+            .getPricing(String.format(AUTH_TOKEN_TEMPLATE,
+                                      credentials.getToken(resourceManagerEndpoint)),
+                        region.getSubscription(),
+                        String.format(FILTER_TEMPLATE, region.getPriceOfferId()),
+                        API_VERSION).execute();
+        if (!pricingResponse.isSuccessful()) {
+            throw new IllegalStateException(String.format("Can't load Azure price list for region with id=%s!",
+                                                          region.getId()));
+        }
+        return pricingResponse;
     }
 
     private StoragePricing convertAzurePricing(final AzurePricingMeter azurePricing) {

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/AzureStoragePriceListLoader.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/AzureStoragePriceListLoader.java
@@ -111,7 +111,8 @@ public class AzureStoragePriceListLoader implements StoragePriceListLoader {
         final List<StoragePricing.StoragePricingEntity> pricing = rates.entrySet().stream()
             .map(e -> {
                 final long rangeStart = Float.valueOf(e.getKey()).longValue();
-                final BigDecimal cost = BigDecimal.valueOf(e.getValue().doubleValue());
+                final BigDecimal cost = BigDecimal.valueOf(e.getValue().doubleValue())
+                    .multiply(BigDecimal.valueOf(CENTS_IN_DOLLAR));
                 return new StoragePricing.StoragePricingEntity(rangeStart * BYTES_TO_GB, null, cost);
             })
             .sorted(Comparator.comparing(StoragePricing.StoragePricingEntity::getBeginRangeBytes))

--- a/billing-report-agent/src/main/resources/application.properties
+++ b/billing-report-agent/src/main/resources/application.properties
@@ -48,6 +48,4 @@ sync.storage.price.load.mode=json
 sync.storage.index.mapping=classpath:/templates/storage_billing.json
 sync.storage.index.name=storage-
 sync.storage.file.index.pattern=*cp-%s-%s-%d
-sync.storage.azure.auth.file=
-sync.storage.azure.offer.id=
 sync.aws.json.price.endpoint.template=https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/%s/current/index.json

--- a/deploy/docker/cp-billing-srv/config/application.properties
+++ b/deploy/docker/cp-billing-srv/config/application.properties
@@ -48,6 +48,4 @@ sync.storage.index.mapping=classpath:/templates/storage_billing.json
 sync.storage.index.name=storage-
 sync.storage.price.load.mode=${CP_BILLING_AWS_PRICE_TYPE:json}
 sync.storage.file.index.pattern=${CP_BILLING_STORAGE_INDEX_PATTERN:*cp-%s-%s-%d}
-sync.storage.azure.auth.file=${CP_BILLING_AZURE_AUTH_FILE:}
-sync.storage.azure.offer.id=${CP_BILLING_AZURE_OFFER_ID:}
 sync.aws.json.price.endpoint.template=${CP_BILLING_AWS_PRICES_ENDPOINT:https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/%s/current/index.json}


### PR DESCRIPTION
This PR is related to issue #1526 

Azure prices were not built correctly: prices were matched to dollars/GB, should be in cents/GB

Also from now, we don't need to specify path to auth files and offerId, as they are extracted from region info.