### PR TITLE
Implement passwordless ssh support in pipe tunnel

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1273,12 +1273,13 @@ def tunnel(run_id, local_port, remote_port, ssh, log_file, log_level, timeout, f
 
         scp file.txt root@pipeline-12345:/common/workdir/file.txt
 
-    Additionally the following environment variables can be used to specify the exact tunnel properties.
+    Advanced tunnel configuration environment variables:
 
     \b
-        CP_CLI_TUNNEL_PROXY_HOST
-        CP_CLI_TUNNEL_PROXY_PORT
-        CP_CLI_TUNNEL_TARGET_HOST
+        CP_CLI_TUNNEL_PROXY_HOST - tunnel proxy host
+        CP_CLI_TUNNEL_PROXY_PORT - tunnel proxy port
+        CP_CLI_TUNNEL_TARGET_HOST - tunnel target host
+        CP_CLI_TUNNEL_SSH_PATH - .ssh directory path
     """
     if trace:
         create_tunnel(run_id, local_port, remote_port, ssh, log_file, log_level, timeout, foreground, retries)

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1279,6 +1279,8 @@ def tunnel(run_id, local_port, remote_port, ssh, log_file, log_level, timeout, f
         CP_CLI_TUNNEL_PROXY_HOST - tunnel proxy host
         CP_CLI_TUNNEL_PROXY_PORT - tunnel proxy port
         CP_CLI_TUNNEL_TARGET_HOST - tunnel target host
+        CP_CLI_TUNNEL_SERVER_ADDRESS - tunnel server address
+        CP_CLI_TUNNEL_CONNECTION_TIMEOUT - tunnel connection timeout
         CP_CLI_TUNNEL_SSH_PATH - .ssh directory path
     """
     if trace:

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1227,9 +1227,17 @@ def ssh(ctx, run_id, retries):
 @click.argument('run-id', required=True, type=int)
 @click.option('-lp', '--local-port', required=True, type=int, help='Local port to establish connection from')
 @click.option('-rp', '--remote-port', required=True, type=int, help='Remote port to establish connection to')
+@click.option('-ct', '--connection-timeout', required=False, type=float, default=0,
+              help='Socket connection timeout in seconds')
 @click.option('-s', '--ssh', required=False, is_flag=True, default=False,
               help='Configures passwordless ssh to specified run instance. '
-                   'Not supported for Windows OS')
+                   'Supported on Linux only.')
+@click.option('-sp', '--ssh-path', required=False, type=str,
+              help='Path to .ssh directory for passwordless ssh configuration')
+@click.option('-sh', '--ssh-host', required=False, type=str,
+              help='Host name for passwordless ssh configuration')
+@click.option('-sk', '--ssh-keep', required=False, is_flag=True, default=False,
+              help='Keeps passwordless ssh configuration after tunnel stopping')
 @click.option('-l', '--log-file', required=False, help='Logs file for tunnel in background mode')
 @click.option('-v', '--log-level', required=False, help='Logs level for tunnel: '
                                                         'CRITICAL, ERROR, WARNING, INFO or DEBUG')
@@ -1241,7 +1249,9 @@ def ssh(ctx, run_id, retries):
 @click.option('-r', '--retries', required=False, type=int, default=10, help=RETRIES_OPTION_DESCRIPTION)
 @click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
 @Config.validate_access_token
-def tunnel(run_id, local_port, remote_port, ssh, log_file, log_level, timeout, foreground, retries, trace):
+def tunnel(run_id, local_port, remote_port, connection_timeout,
+           ssh, ssh_path, ssh_host, ssh_keep, log_file, log_level,
+           timeout, foreground, retries, trace):
     """
     Establishes tunnel connection to specified run instance port and serves it as a local port.
 
@@ -1280,15 +1290,16 @@ def tunnel(run_id, local_port, remote_port, ssh, log_file, log_level, timeout, f
         CP_CLI_TUNNEL_PROXY_PORT - tunnel proxy port
         CP_CLI_TUNNEL_TARGET_HOST - tunnel target host
         CP_CLI_TUNNEL_SERVER_ADDRESS - tunnel server address
-        CP_CLI_TUNNEL_CONNECTION_TIMEOUT - tunnel connection timeout
-        CP_CLI_TUNNEL_SSH_PATH - .ssh directory path
-        CP_CLI_TUNNEL_SSH_HOST - ssh host name
     """
     if trace:
-        create_tunnel(run_id, local_port, remote_port, ssh, log_file, log_level, timeout, foreground, retries)
+        create_tunnel(run_id, local_port, remote_port, connection_timeout,
+                      ssh, ssh_path, ssh_host, ssh_keep, log_file, log_level,
+                      timeout, foreground, retries)
     else:
         try:
-            create_tunnel(run_id, local_port, remote_port, ssh, log_file, log_level, timeout, foreground, retries)
+            create_tunnel(run_id, local_port, remote_port, connection_timeout,
+                          ssh, ssh_path, ssh_host, ssh_keep, log_file, log_level,
+                          timeout, foreground, retries)
         except Exception as runtime_error:
             click.echo('Error: {}'.format(str(runtime_error)), err=True)
             sys.exit(1)

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1247,19 +1247,23 @@ def tunnel(run_id, local_port, remote_port, ssh, log_file, log_level, timeout, f
 
     It allows to transfer any tcp traffic from local machine to run instance and works both on Linux and Windows.
 
-    For example it can be used to allow ssh connections to run instance.
+    Additionally it enables passwordless ssh connections if the corresponding option is specified.
+    Once specified ssh is configured both locally and remotely to support passwordless connections.
+    Passwordless ssh configuration is supported only for openssh client on Linux.
+
+    Example of how to use pipe tunnel to establish passwordless ssh connection to run instance is shown below.
 
     \b
     First of all establish tunnel connection from run (12345) instance ssh port (22) to some local port (4567).
-        pipe tunnel -lp 4567 -rp 22 12345
+        pipe tunnel -lp 4567 -rp 22 --ssh 12345
 
     \b
-    Then connect to run instance using regular ssh client on the configured local port (4567).
-        ssh -p 4567 root@localhost
+    Then connect to run instance using regular ssh client.
+        ssh root@pipeline-12345
 
     \b
-    To setup passwordless ssh connections to run instances additional ssh option should be used.
-        pipe tunnel -lp 4567 -rp 22 -s 12345
+    Or transfer some files to and from run instance using regular scp client.
+        scp file.txt root@pipeline-12345:/common/workdir/file.txt
 
     \b
     Additionally the following environment variables can be used to specify the exact tunnel properties.

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -43,7 +43,8 @@ from src.version import __version__
 MAX_INSTANCE_COUNT = 1000
 MAX_CORES_COUNT = 10000
 USER_OPTION_DESCRIPTION = 'The user name to perform operation from specified user. Available for admins only'
-RETRIES_OPTION_DESCRIPTION = 'Number of retries to connect to specified pipeline run. Default is 10.'
+RETRIES_OPTION_DESCRIPTION = 'Number of retries to connect to specified pipeline run. Default is 10'
+TRACE_OPTION_DESCRIPTION = 'Enables error stack traces displaying'
 
 
 def silent_print_api_version():
@@ -1236,11 +1237,11 @@ def ssh(ctx, run_id, retries):
               help='Time period in ms for background tunnel process health check')
 @click.option('-f', '--foreground', required=False, is_flag=True, default=False,
               help='Establishes tunnel in foreground mode')
-@click.option('--trace', required=False, is_flag=True, default=False,
-              help='Enables error stack traces')
 @click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
+@click.option('-r', '--retries', required=False, type=int, default=10, help=RETRIES_OPTION_DESCRIPTION)
+@click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
 @Config.validate_access_token
-def tunnel(run_id, local_port, remote_port, ssh, log_file, log_level, timeout, foreground, trace):
+def tunnel(run_id, local_port, remote_port, ssh, log_file, log_level, timeout, foreground, retries, trace):
     """
     Establishes tunnel connection to specified run instance port and serves it as a local port.
 
@@ -1267,10 +1268,10 @@ def tunnel(run_id, local_port, remote_port, ssh, log_file, log_level, timeout, f
         CP_CLI_TUNNEL_TARGET_HOST
     """
     if trace:
-        create_tunnel(run_id, local_port, remote_port, ssh, log_file, log_level, timeout, foreground)
+        create_tunnel(run_id, local_port, remote_port, ssh, log_file, log_level, timeout, foreground, retries)
     else:
         try:
-            create_tunnel(run_id, local_port, remote_port, ssh, log_file, log_level, timeout, foreground)
+            create_tunnel(run_id, local_port, remote_port, ssh, log_file, log_level, timeout, foreground, retries)
         except Exception as runtime_error:
             click.echo('Error: {}'.format(str(runtime_error)), err=True)
             sys.exit(1)

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1233,7 +1233,7 @@ def ssh(ctx, run_id, retries):
 @click.option('-l', '--log-file', required=False, help='Logs file for tunnel in background mode')
 @click.option('-v', '--log-level', required=False, help='Logs level for tunnel: '
                                                         'CRITICAL, ERROR, WARNING, INFO or DEBUG')
-@click.option('-t', '--timeout', required=False, type=int, default=1000,
+@click.option('-t', '--timeout', required=False, type=int, default=5 * 1000,
               help='Time period in ms for background tunnel process health check')
 @click.option('-f', '--foreground', required=False, is_flag=True, default=False,
               help='Establishes tunnel in foreground mode')

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import traceback
 import click
 import requests
 import sys
@@ -1291,18 +1292,15 @@ def tunnel(run_id, local_port, remote_port, connection_timeout,
         CP_CLI_TUNNEL_TARGET_HOST - tunnel target host
         CP_CLI_TUNNEL_SERVER_ADDRESS - tunnel server address
     """
-    if trace:
+    try:
         create_tunnel(run_id, local_port, remote_port, connection_timeout,
                       ssh, ssh_path, ssh_host, ssh_keep, log_file, log_level,
                       timeout, foreground, retries)
-    else:
-        try:
-            create_tunnel(run_id, local_port, remote_port, connection_timeout,
-                          ssh, ssh_path, ssh_host, ssh_keep, log_file, log_level,
-                          timeout, foreground, retries)
-        except Exception as runtime_error:
-            click.echo('Error: {}'.format(str(runtime_error)), err=True)
-            sys.exit(1)
+    except Exception as runtime_error:
+        click.echo('Error: {}'.format(str(runtime_error)), err=True)
+        if trace:
+            traceback.print_exc()
+        sys.exit(1)
 
 
 @cli.command(name='update')

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1251,22 +1251,31 @@ def tunnel(run_id, local_port, remote_port, ssh, log_file, log_level, timeout, f
     Once specified ssh is configured both locally and remotely to support passwordless connections.
     Passwordless ssh configuration is supported only for openssh client on Linux.
 
-    Example of how to use pipe tunnel to establish passwordless ssh connection to run instance is shown below.
+    Examples:
 
-    \b
+    I. Example of simple tcp port tunnel connection establishing.
+
+    Establish tunnel connection from run (12345) instance port (4567) to the same local port.
+
+        pipe tunnel -lp 4567 -rp 4567 12345
+
+    II. Example of ssh port tunnel connection establishing with enabled passwordless ssh configuration.
+
     First of all establish tunnel connection from run (12345) instance ssh port (22) to some local port (4567).
+
         pipe tunnel -lp 4567 -rp 22 --ssh 12345
 
-    \b
     Then connect to run instance using regular ssh client.
+
         ssh root@pipeline-12345
 
-    \b
     Or transfer some files to and from run instance using regular scp client.
+
         scp file.txt root@pipeline-12345:/common/workdir/file.txt
 
-    \b
     Additionally the following environment variables can be used to specify the exact tunnel properties.
+
+    \b
         CP_CLI_TUNNEL_PROXY_HOST
         CP_CLI_TUNNEL_PROXY_PORT
         CP_CLI_TUNNEL_TARGET_HOST

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1282,6 +1282,7 @@ def tunnel(run_id, local_port, remote_port, ssh, log_file, log_level, timeout, f
         CP_CLI_TUNNEL_SERVER_ADDRESS - tunnel server address
         CP_CLI_TUNNEL_CONNECTION_TIMEOUT - tunnel connection timeout
         CP_CLI_TUNNEL_SSH_PATH - .ssh directory path
+        CP_CLI_TUNNEL_SSH_HOST - ssh host name
     """
     if trace:
         create_tunnel(run_id, local_port, remote_port, ssh, log_file, log_level, timeout, foreground, retries)

--- a/pipe-cli/requirements.txt
+++ b/pipe-cli/requirements.txt
@@ -21,6 +21,7 @@ azure-storage-blob==1.5.0
 google-resumable-media==0.3.2
 google-cloud-storage==1.15.0
 paramiko==2.6.0
+scp==0.13.3
 pyasn1-modules==0.2.4
 pyasn1==0.4.5
 colorama==0.4.1

--- a/pipe-cli/src/utilities/platform_utilities.py
+++ b/pipe-cli/src/utilities/platform_utilities.py
@@ -1,0 +1,22 @@
+import platform
+
+
+def is_windows():
+    """
+    Checks if the execution environment is Windows.
+    """
+    return platform.system() == 'Windows'
+
+
+def is_wsl():
+    """
+    Checks if the execution environment is Windows Subsystem for Linux.
+    """
+    if is_windows():
+        return False
+    platform_uname = platform.uname()
+    if platform_uname and len(platform_uname) > 3:
+        platform_version = platform_uname[3]
+        if platform_version:
+            return 'microsoft' in platform_version.lower()
+    return False

--- a/pipe-cli/src/utilities/ssh_operations.py
+++ b/pipe-cli/src/utilities/ssh_operations.py
@@ -211,7 +211,7 @@ def create_foreground_tunnel_with_ssh(run_id, local_port, remote_port, log_file,
     import platform
     if platform.system() == 'Windows':
         import click
-        click.echo('Passwordless ssh configuration is not support on Windows.', err=True)
+        click.echo('Passwordless ssh configuration is not supported on Windows.', err=True)
         sys.exit(1)
     remote_host = 'pipeline-%s' % run_id
     ssh_config_path = os.path.expanduser('~/.ssh/config')

--- a/pipe-cli/src/utilities/ssh_operations.py
+++ b/pipe-cli/src/utilities/ssh_operations.py
@@ -215,7 +215,7 @@ def remove_ssh_public_key_from_run(run_id, ssh_public_key_path, retries, remote_
             remove_ssh_public_keys_from_run_command += \
                 'grep -v "{key}" {authorized_keys_path} > {authorized_keys_temp_path};' \
                 'cp {authorized_keys_temp_path} {authorized_keys_path};' \
-                'chmod 600 {authorized_keys_path}' \
+                'chmod 600 {authorized_keys_path};' \
                 'rm {authorized_keys_temp_path};' \
                     .format(key=ssh_public_key,
                             authorized_keys_path=remote_ssh_authorized_keys_path,
@@ -262,6 +262,7 @@ def add_to_ssh_known_hosts(run_id, local_port, log_file, retries, ssh_known_host
     with open(ssh_known_hosts_path, 'a') as f:
         f.write('[127.0.0.1]:%s %s' % (local_port, public_key))
     perform_command(['ssh-keygen', '-H', '-f', ssh_known_hosts_path], log_file)
+    perform_command(['rm', ssh_known_hosts_path + '.old'], log_file)
 
 
 def remove_from_ssh_known_hosts(ssh_known_hosts_path, local_port, log_file):

--- a/pipe-cli/src/utilities/ssh_operations.py
+++ b/pipe-cli/src/utilities/ssh_operations.py
@@ -241,7 +241,7 @@ def create_foreground_tunnel_with_ssh(run_id, local_port, remote_port, log_file,
     ssh_private_key_name = 'pipeline-{}-{}-{}'.format(run_id, int(time.time()), random.randint(0, sys.maxsize))
     ssh_private_key_path = os.path.join(ssh_keys_path, ssh_private_key_name)
     ssh_public_key_path = '{}.pub'.format(ssh_private_key_path)
-    remote_host = 'pipeline-{}'.format(run_id)
+    remote_host = os.getenv('CP_CLI_TUNNEL_SSH_HOST', 'pipeline-{}'.format(run_id))
     conn_info = get_conn_info(run_id)
     remote_ssh_authorized_keys_paths = ['/root/.ssh/authorized_keys',
                                         '/home/{}/.ssh/authorized_keys'.format(conn_info.owner)]

--- a/pipe-cli/src/utilities/ssh_operations.py
+++ b/pipe-cli/src/utilities/ssh_operations.py
@@ -143,7 +143,7 @@ def setup_authenticated_paramiko_transport(run_id, retries):
         ssh_default_root_user_enabled_preference = PreferenceAPI.get_preference('system.ssh.default.root.user.enabled')
         ssh_default_root_user_enabled = ssh_default_root_user_enabled_preference.value.lower() == "true"
     except:
-        ssh_default_root_user_enabled = False
+        ssh_default_root_user_enabled = True
     if not ssh_default_root_user_enabled:
         # split owner by @ in case it represented by email address
         owner_user_name = conn_info.owner.split("@")[0]

--- a/pipe-cli/src/utilities/ssh_operations.py
+++ b/pipe-cli/src/utilities/ssh_operations.py
@@ -281,7 +281,7 @@ def resolve_ssh_path():
 
 
 def create_foreground_tunnel(run_id, local_port, remote_port, log_file, log_level, retries,
-                             tunnel_timeout=5, chunk_size=4096, server_delay=0.0001):
+                             tunnel_timeout=3600, chunk_size=4096, server_delay=0.0001):
     logging.basicConfig(level=log_level or logging.ERROR)
     conn_info = get_conn_info(run_id)
     proxy_endpoint = (os.getenv('CP_CLI_TUNNEL_PROXY_HOST', conn_info.ssh_proxy[0]),

--- a/pipe-cli/src/utilities/ssh_operations.py
+++ b/pipe-cli/src/utilities/ssh_operations.py
@@ -194,11 +194,16 @@ def create_background_tunnel(log_file, timeout):
             DETACHED_PROCESS = 0x00000008
             CREATE_NEW_PROCESS_GROUP = 0x00000200
             creationflags = DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP
+            stdin = None
         else:
             creationflags = 0
+            import pty
+            _, stdin = pty.openpty()
         executable = sys.argv + ['-f'] if is_frozen() else [sys.executable] + sys.argv + ['-f']
-        tunnel_proc = subprocess.Popen(executable, stdout=output, stderr=subprocess.STDOUT, cwd=os.getcwd(),
-                                       env=os.environ.copy(), creationflags=creationflags)
+        tunnel_proc = subprocess.Popen(executable, stdin=stdin, stdout=output, stderr=subprocess.STDOUT,
+                                       cwd=os.getcwd(), env=os.environ.copy(), creationflags=creationflags)
+        if stdin:
+            os.close(stdin)
         time.sleep(timeout / 1000)
         if tunnel_proc.poll() is not None:
             import click

--- a/pipe-cli/src/utilities/ssh_operations.py
+++ b/pipe-cli/src/utilities/ssh_operations.py
@@ -417,10 +417,11 @@ def remove_ssh_public_key_from_run(run_id, ssh_public_key_path, retries, remote_
 
 
 def add_to_ssh_config(ssh_config_path, remote_host, local_port, ssh_private_key_path):
-    with open(ssh_config_path, 'r') as f:
-        ssh_config = f.read()
-    if remote_host in ssh_config:
-        remove_from_ssh_config(ssh_config_path, remote_host)
+    if os.path.exists(ssh_config_path):
+        with open(ssh_config_path, 'r') as f:
+            ssh_config = f.read()
+        if remote_host in ssh_config:
+            remove_from_ssh_config(ssh_config_path, remote_host)
     with open(ssh_config_path, 'a') as f:
         f.write('Host {}\n'
                 '    Hostname 127.0.0.1\n'

--- a/pipe-cli/src/utilities/ssh_operations.py
+++ b/pipe-cli/src/utilities/ssh_operations.py
@@ -16,12 +16,14 @@ import base64
 import collections
 import logging
 import os
+import random
 import select
 import socket
 import sys
 import time
 
 import paramiko
+from scp import SCPClient
 
 from src.config import is_frozen
 from src.utilities.pipe_shell import plain_shell, interactive_shell
@@ -92,6 +94,31 @@ def get_conn_info(run_id):
                          owner=run_model.owner)
 
 
+def prepare_authenticated_ssh_transport(run_id, retries=10):
+    # Grab the run information from the API to setup the run's IP and EDGE proxy address
+    conn_info = get_conn_info(run_id)
+
+    # Initialize Paramiko SSH client
+    setup_paramiko_logging()
+    transport = setup_paramiko_transport(conn_info, retries)
+    # User password authentication, which available only to the OWNER and ROLE_ADMIN users
+    sshpass = conn_info.ssh_pass
+    sshuser = DEFAULT_SSH_USER
+    ssh_default_root_user_enabled = PreferenceAPI.get_preference('system.ssh.default.root.user.enabled')
+    if ssh_default_root_user_enabled is not None and ssh_default_root_user_enabled.value.lower() != "true":
+        # split owner by @ in case it represented by email address
+        owner_user_name = conn_info.owner.split("@")[0]
+        sshpass = owner_user_name
+        sshuser = owner_user_name
+    try:
+        transport.auth_password(sshuser, sshpass)
+        return transport
+    except paramiko.ssh_exception.AuthenticationException:
+        # Reraise authentication error to provide more details
+        raise RuntimeError('Authentication failed for {}@{}'.format(
+            sshuser, conn_info.ssh_endpoint[0]))
+
+
 def run_ssh_command(channel, command):
     channel.exec_command(command)
     plain_shell(channel)
@@ -103,13 +130,214 @@ def run_ssh_session(channel):
     interactive_shell(channel)
 
 
-def create_tunnel(run_id, local_port, remote_port, log_file, log_level, timeout, foreground,
+def run_ssh(run_id, command, retries=10):
+    transport = None
+    channel = None
+    try:
+        transport = prepare_authenticated_ssh_transport(run_id, retries)
+        channel = transport.open_session()
+        # "get_pty" is used for non-interactive commands too
+        # This allows to get stdout and stderr in a correct order
+        # Otherwise we'll need to combine them somehow
+        channel.get_pty()
+        if command:
+            # Execute command and wait for it's execution
+            return run_ssh_command(channel, command)
+        else:
+            # Open a remote shell
+            run_ssh_session(channel)
+            return 0
+    finally:
+        if channel:
+            channel.close()
+        if transport:
+            transport.close()
+
+
+def setup_paramiko_transport(conn_info, retries):
+    socket = None
+    transport = None
+    try:
+        socket = http_proxy_tunnel_connect(conn_info.ssh_proxy, conn_info.ssh_endpoint, 5)
+        transport = paramiko.Transport(socket)
+        transport.start_client()
+        return transport
+    except Exception as e:
+        if retries >= 1:
+            retries = retries - 1
+            if socket:
+                socket.close()
+            if transport:
+                transport.close()
+            return setup_paramiko_transport(conn_info, retries)
+        else:
+            raise e
+
+
+def create_tunnel(run_id, local_port, remote_port, ssh, log_file, log_level, timeout, foreground,
                   server_delay=0.0001, tunnel_timeout=5, chunk_size=4096):
     if foreground:
-        create_foreground_tunnel(run_id, local_port, remote_port, log_file, log_level,
-                                 server_delay, tunnel_timeout, chunk_size)
+        if ssh:
+            import platform
+            if platform.system() == 'Windows':
+                import click
+                click.echo('Passwordless ssh configuration is not support on Windows.', err=True)
+                sys.exit(1)
+            remote_host = 'pipeline-%s' % run_id
+            ssh_config_path = os.path.expanduser('~/.ssh/config')
+            ssh_known_hosts_path = os.path.expanduser('~/.ssh/known_hosts')
+            ssh_keys_path = os.path.expanduser('~/.pipe/.ssh')
+            ssh_private_key_name = 'pipeline-%s-%s-%s' % (run_id, int(time.time()), random.randint(0, sys.maxsize))
+            ssh_private_key_path = os.path.join(ssh_keys_path, ssh_private_key_name)
+            ssh_public_key_path = ssh_private_key_path + '.pub'
+            if not os.path.exists(ssh_keys_path):
+                os.makedirs(ssh_keys_path)
+            try:
+                configure_passwordless_ssh(run_id, ssh_config_path, ssh_known_hosts_path, remote_host,
+                                           local_port, ssh_public_key_path, ssh_private_key_path,  log_file)
+                create_foreground_tunnel(run_id, local_port, remote_port, log_file, log_level,
+                                         server_delay, tunnel_timeout, chunk_size)
+            finally:
+                deconfigure_passwordless_ssh(run_id, ssh_config_path, ssh_known_hosts_path, remote_host,
+                                             local_port, ssh_public_key_path, ssh_private_key_path, log_file)
+        else:
+            create_foreground_tunnel(run_id, local_port, remote_port, log_file, log_level,
+                                     server_delay, tunnel_timeout, chunk_size)
     else:
         create_background_tunnel(log_file, timeout)
+
+
+def configure_passwordless_ssh(run_id, ssh_config_path, ssh_known_hosts_path, remote_host,
+                               local_port, ssh_public_key_path, ssh_private_key_path, log_file):
+    generate_ssh_keys(log_file, ssh_private_key_path)
+    upload_ssh_public_key_to_run(run_id, ssh_public_key_path)
+    add_to_ssh_config(ssh_config_path, remote_host, local_port, ssh_private_key_path)
+    add_to_ssh_known_hosts(ssh_known_hosts_path, run_id, local_port, log_file)
+
+
+def deconfigure_passwordless_ssh(run_id, ssh_config_path, ssh_known_hosts_path, remote_host,
+                                 local_port, ssh_public_key_path, ssh_private_key_path, log_file):
+    remove_ssh_public_key_from_run(run_id, ssh_public_key_path)
+    remove_ssh_keys(ssh_public_key_path, ssh_private_key_path)
+    remove_from_ssh_config(ssh_config_path, remote_host)
+    remove_from_ssh_known_hosts(ssh_known_hosts_path, local_port, log_file)
+
+
+def generate_ssh_keys(log_file, ssh_private_key_path):
+    generate_ssh_keys_command = ['ssh-keygen', '-t', 'rsa', '-f', ssh_private_key_path, '-N', '', '-q']
+    perform_command(generate_ssh_keys_command, log_file)
+
+
+def remove_ssh_keys(ssh_public_key_path, ssh_private_key_path):
+    if os.path.exists(ssh_public_key_path):
+        os.remove(ssh_public_key_path)
+    if os.path.exists(ssh_private_key_path):
+        os.remove(ssh_private_key_path)
+
+
+def upload_ssh_public_key_to_run(run_id, ssh_public_key_path):
+    authorized_keys_path = '/root/.ssh/authorized_keys'
+    with open(ssh_public_key_path, 'r') as f:
+        ssh_public_key = f.read().strip()
+    run_ssh(run_id, 'echo "%s" >> %s' % (ssh_public_key, authorized_keys_path))
+
+
+def remove_ssh_public_key_from_run(run_id, ssh_public_key_path):
+    if os.path.exists(ssh_public_key_path):
+        with open(ssh_public_key_path, 'r') as f:
+            ssh_public_key = f.read().strip()
+        authorized_keys_temp_path = '/root/.ssh/authorized_keys_%s' % random.randint(0, sys.maxsize)
+        authorized_keys = '/root/.ssh/authorized_keys'
+        run_ssh(run_id, 'grep -v "%s" %s > %s; cp %s %s; rm %s'
+                % (ssh_public_key, authorized_keys, authorized_keys_temp_path,
+                   authorized_keys_temp_path, authorized_keys,
+                   authorized_keys_temp_path))
+
+
+def add_to_ssh_config(ssh_config_path, remote_host, local_port, ssh_private_key_path):
+    with open(ssh_config_path, 'r') as f:
+        ssh_config = f.read()
+    if remote_host in ssh_config:
+        remove_from_ssh_config(ssh_config_path, remote_host)
+    with open(ssh_config_path, 'a') as f:
+        f.write('Host %s\n'
+                '    Hostname 127.0.0.1\n'
+                '    User root\n'
+                '    Port %s\n'
+                '    IdentityFile %s\n'
+                % (remote_host, local_port, ssh_private_key_path))
+
+
+def remove_from_ssh_config(ssh_config_path, remote_host):
+    with open(ssh_config_path, 'r') as f:
+        ssh_config_lines = f.readlines()
+    updated_ssh_config_lines = []
+    skip_host = False
+    for line in ssh_config_lines:
+        if line.startswith('Host '):
+            if line.startswith('Host %s' % remote_host):
+                skip_host = True
+            else:
+                skip_host = False
+        if not skip_host:
+            updated_ssh_config_lines.append(line)
+    with open(ssh_config_path, 'w') as f:
+        f.writelines(updated_ssh_config_lines)
+
+
+def add_to_ssh_known_hosts(ssh_known_hosts_path, run_id, local_port, log_file):
+    run_ssh_public_key_path = '/root/.ssh/id_rsa.pub'
+    ssh_known_hosts_temp_path = ssh_known_hosts_path + '_%s' % random.randint(0, sys.maxsize)
+    run_scp_download(run_id, run_ssh_public_key_path, ssh_known_hosts_temp_path)
+    with open(ssh_known_hosts_temp_path, 'r') as f:
+        public_key = f.read().strip()
+    os.remove(ssh_known_hosts_temp_path)
+    with open(ssh_known_hosts_path, 'a') as f:
+        f.write('[127.0.0.1]:%s %s' % (local_port, public_key))
+    perform_command(['ssh-keygen', '-H', '-f', ssh_known_hosts_path], log_file)
+
+
+def remove_from_ssh_known_hosts(ssh_known_hosts_path, local_port, log_file):
+    perform_command(['ssh-keygen', '-R', '[127.0.0.1]:%s' % local_port, '-f', ssh_known_hosts_path], log_file)
+
+
+def perform_command(executable, log_file):
+    import subprocess
+    import os
+    with open(log_file or os.devnull, 'w') as output:
+        command_proc = subprocess.Popen(executable, stdout=output, stderr=subprocess.STDOUT, cwd=os.getcwd(),
+                                        env=os.environ.copy())
+        command_proc.wait()
+        if command_proc.returncode != 0:
+            raise RuntimeError('Command "%s" exited with return code: %d' % (executable, command_proc.returncode))
+
+
+def run_scp_upload(run_id, source, destination):
+    transport = None
+    scp = None
+    try:
+        transport = prepare_authenticated_ssh_transport(run_id)
+        scp = SCPClient(transport)
+        scp.put(source, destination)
+    finally:
+        if scp:
+            scp.close()
+        if transport:
+            transport.close()
+
+
+def run_scp_download(run_id, source, destination):
+    transport = None
+    scp = None
+    try:
+        transport = prepare_authenticated_ssh_transport(run_id)
+        scp = SCPClient(transport)
+        scp.get(source, destination)
+    finally:
+        if scp:
+            scp.close()
+        if transport:
+            transport.close()
 
 
 def create_foreground_tunnel(run_id, local_port, remote_port, log_file, log_level,
@@ -217,66 +445,3 @@ def create_background_tunnel(log_file, timeout):
                        % tunnel_proc.returncode, err=True)
             sys.exit(1)
 
-
-def run_ssh(run_id, command, retries=10):
-    # Grab the run information from the API to setup the run's IP and EDGE proxy address
-    conn_info = get_conn_info(run_id)
-
-    # Initialize Paramiko SSH client
-    channel = None
-    transport = None
-    try:
-        setup_paramiko_logging()
-        transport = setup_paramiko_transport(conn_info, retries)
-        # User password authentication, which available only to the OWNER and ROLE_ADMIN users
-        sshpass = conn_info.ssh_pass
-        sshuser = DEFAULT_SSH_USER
-        ssh_default_root_user_enabled = PreferenceAPI.get_preference('system.ssh.default.root.user.enabled')
-        if ssh_default_root_user_enabled is not None and ssh_default_root_user_enabled.value.lower() != "true":
-            # split owner by @ in case it represented by email address
-            owner_user_name = conn_info.owner.split("@")[0]
-            sshpass = owner_user_name
-            sshuser = owner_user_name
-        try:
-            transport.auth_password(sshuser, sshpass)
-        except paramiko.ssh_exception.AuthenticationException:
-            # Reraise authentication error to provide more details
-            raise PermissionError('Authentication failed for {}@{}'.format(
-                sshuser, conn_info.ssh_endpoint[0]))
-        channel = transport.open_session()
-        # "get_pty" is used for non-interactive commands too
-        # This allows to get stdout and stderr in a correct order
-        # Otherwise we'll need to combine them somehow
-        channel.get_pty()
-        if command:
-            # Execute command and wait for it's execution
-            return run_ssh_command(channel, command)
-        else:
-            # Open a remote shell
-            run_ssh_session(channel)
-            return 0
-    finally:
-        if channel:
-            channel.close()
-        if transport:
-            transport.close()
-
-
-def setup_paramiko_transport(conn_info, retries):
-    socket = None
-    transport = None
-    try:
-        socket = http_proxy_tunnel_connect(conn_info.ssh_proxy, conn_info.ssh_endpoint, 5)
-        transport = paramiko.Transport(socket)
-        transport.start_client()
-        return transport
-    except Exception as e:
-        if retries >= 1:
-            retries = retries - 1
-            if socket:
-                socket.close()
-            if transport:
-                transport.close()
-            return setup_paramiko_transport(conn_info, retries)
-        else:
-            raise e


### PR DESCRIPTION
Relates to #1501 and depends on #1502.

The pull request introduces additional `-s | --ssh` option for `pipe tunnel` which once specified configures passwordless ssh connections to run instances.

See `pipe tunnel --help` output for more information:
```
  Establishes tunnel connection to specified run instance port and serves it
  as a local port.

  It allows to transfer any tcp traffic from local machine to run instance
  and works both on Linux and Windows.

  Additionally it enables passwordless ssh connections if the corresponding
  option is specified. Once specified ssh is configured both locally and
  remotely to support passwordless connections. Passwordless ssh
  configuration is supported only for openssh client on Linux.

  Examples:

  I. Example of simple tcp port tunnel connection establishing.

  Establish tunnel connection from run (12345) instance port (4567) to the
  same local port.

      pipe tunnel -lp 4567 -rp 4567 12345

  II. Example of ssh port tunnel connection establishing with enabled
  passwordless ssh configuration.

  First of all establish tunnel connection from run (12345) instance ssh
  port (22) to some local port (4567).

      pipe tunnel -lp 4567 -rp 22 --ssh 12345

  Then connect to run instance using regular ssh client.

      ssh root@pipeline-12345

  Or transfer some files to and from run instance using regular scp client.

      scp file.txt root@pipeline-12345:/common/workdir/file.txt

  Additionally the following environment variables can be used to specify
  the exact tunnel properties.

      CP_CLI_TUNNEL_PROXY_HOST
      CP_CLI_TUNNEL_PROXY_PORT
      CP_CLI_TUNNEL_TARGET_HOST
```