### PR TITLE
Issue #1282 pipectl sync improvements

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -210,6 +210,8 @@ Environment variables for controlling execution flow:
                 --source-url {url_a} \          # URL of `source` environment's API host
                 --source-token {token_a} \      # JWT token to access `source` environment
                 --target-url {url_b} \          # URL of `destination` environment's API host
-                --target-token {token_b}        # JWT token to access `destination` environment
+                --target-token {token_b} \      # JWT token to access `destination` environment
+                --docker-cmd {path_to_docker}   # specifies the command, that will be used instead of simple `docker` 
+                                                # during tools synchronization
             
 ```

--- a/deploy/contents/sync/app/sync.sh
+++ b/deploy/contents/sync/app/sync.sh
@@ -52,6 +52,11 @@ function parse_options {
         shift
         shift
         ;;
+        --docker-cmd)
+        export CP_ENV_SYNC_DOCKER_CMD="$2"
+        shift
+        shift
+        ;;
         *)    # unknown option
         POSITIONAL+=("$1") # save it in an array for later
         shift
@@ -77,6 +82,7 @@ function parse_options {
         print_err "Token for the target deployment's API access is not defined. Please, specify it using \"--target-token\" flag"
         valid_params=1
     fi
+    export CP_ENV_SYNC_DOCKER_CMD="${CP_ENV_SYNC_DOCKER_CMD:-docker}"
     return $valid_params
 }
 
@@ -131,13 +137,7 @@ function prepare_environment {
 }
 
 function check_docker {
-    if ! check_installed "docker"; then
-        print_err "Docker is not detected"
-        return 1
-    else
-        print_info "Found Docker, checking if it is active"
-    fi
-    docker info > /dev/null 2>&1
+    $CP_ENV_SYNC_DOCKER_CMD info > /dev/null 2>&1
     return $?
 }
 
@@ -170,7 +170,11 @@ if [ ! -z "$CP_SYNC_TOOLS" ] ; then
         exit 1
     fi
     print_ok "Start tool synchronization from '$CP_ENV_SYNC_SRC_URL' to '$CP_ENV_SYNC_TARGET_URL'"
-    python sync_tools.py $CP_ENV_SYNC_SRC_URL $CP_ENV_SYNC_SRC_TOKEN $CP_ENV_SYNC_TARGET_URL $CP_ENV_SYNC_TARGET_TOKEN
+    python sync_tools.py $CP_ENV_SYNC_SRC_URL \
+                          $CP_ENV_SYNC_SRC_TOKEN \
+                          $CP_ENV_SYNC_TARGET_URL \
+                          $CP_ENV_SYNC_TARGET_TOKEN \
+                          $CP_ENV_SYNC_DOCKER_CMD
     if [ $? -ne 0 ]; then
         print_err "Errors during tools sync"
     else

--- a/deploy/contents/sync/app/sync_tools.py
+++ b/deploy/contents/sync/app/sync_tools.py
@@ -28,12 +28,12 @@ INSTANCE_TYPES = 'cluster.allowed.instance.types'
 IMAGE_FULL_NAME_PATTERN = '{registry_url}/{image_name}:{tag}'
 DEFAULT_REGISTRY_PATH_PREFIX = 'cp-docker-registry.default.svc.cluster.local:'
 DOCKER_CERTS_DIR = '/etc/docker/certs.d'
-DOCKER_LOG_IN_REGISTRY_CMD = 'docker login {server} -u {username} -p "{token}"'
-DOCKER_LOG_OUT_REGISTRY_CMD = 'docker logout {server}'
-DOCKER_PULL_CMD = 'docker pull {image}'
-DOCKER_TAG_CMD = 'docker tag {source_image} {target_image}'
-DOCKER_PUSH_CMD = 'docker push {image}'
-DOCKER_REMOVE_IMAGE_CMD = 'docker rmi {images_list}'
+DOCKER_LOG_IN_REGISTRY_CMD = ' login {server} -u {username} -p "{token}"'
+DOCKER_LOG_OUT_REGISTRY_CMD = ' logout {server}'
+DOCKER_PULL_CMD = ' pull {image}'
+DOCKER_TAG_CMD = ' tag {source_image} {target_image}'
+DOCKER_PUSH_CMD = ' push {image}'
+DOCKER_REMOVE_IMAGE_CMD = ' rmi {images_list}'
 MEMORY = 'memory'
 CPU = 'vcpu'
 GPU = 'gpu'
@@ -55,24 +55,9 @@ def execute_shell_cmd(cmd, return_output=False):
         return process.returncode
 
 
-def pull_image(image):
-    return execute_shell_cmd(DOCKER_PULL_CMD.format(image=image))
-
-
-def tag_image(source_image, target_image):
-    return execute_shell_cmd(DOCKER_TAG_CMD.format(source_image=source_image, target_image=target_image))
-
-
-def push_image(image):
-    return execute_shell_cmd(DOCKER_PUSH_CMD.format(image=image))
-
-
-def delete_images(images):
-    return execute_shell_cmd(DOCKER_REMOVE_IMAGE_CMD.format(images_list=' '.join(images)))
-
-
 class ToolSynchronizer(object):
-    def __init__(self, source_api_path, source_access_key, target_api_path, target_access_key, threads_count=1):
+    def __init__(self, source_api_path, source_access_key, target_api_path, target_access_key, docker_cmd, 
+                 threads_count=1):
         self.source_access_key = source_access_key
         self.target_access_key = target_access_key
         self.api_source = ReadOnlyToolSyncAPI(source_api_path, source_access_key)
@@ -93,6 +78,20 @@ class ToolSynchronizer(object):
         self.source_allowed_instance_types = {}
         self.allowed_instance_price_types = []
         self.default_instance_type = None
+        self.docker_cmd = docker_cmd
+
+    def pull_image(self, image):
+        return execute_shell_cmd(self.docker_cmd + DOCKER_PULL_CMD.format(image=image))
+
+    def tag_image(self, source_image, target_image):
+        return execute_shell_cmd(self.docker_cmd
+                                 + DOCKER_TAG_CMD.format(source_image=source_image, target_image=target_image))
+
+    def push_image(self, image):
+        return execute_shell_cmd(self.docker_cmd + DOCKER_PUSH_CMD.format(image=image))
+
+    def delete_images(self, images):
+        return execute_shell_cmd(self.docker_cmd + DOCKER_REMOVE_IMAGE_CMD.format(images_list=' '.join(images)))
 
     def transfer_tool(self, tool):
         registry_id = tool['registryId']
@@ -403,36 +402,34 @@ class ToolSynchronizer(object):
                                 tools_dict[tool['image']] = tool
         return groups_dict, tools_dict
 
-    @staticmethod
-    def log_in_registry(server, username, access_token):
-        docker_login_cmd = DOCKER_LOG_IN_REGISTRY_CMD.format(server=server, username=username, token=access_token)
+    def log_in_registry(self, server, username, access_token):
+        docker_login_cmd = self.docker_cmd \
+                           + DOCKER_LOG_IN_REGISTRY_CMD.format(server=server, username=username, token=access_token)
         res, out = execute_shell_cmd(docker_login_cmd, return_output=True)
         return res, out
 
-    @staticmethod
-    def log_out_registry(server):
-        docker_logout_cmd = DOCKER_LOG_OUT_REGISTRY_CMD.format(server=server)
+    def log_out_registry(self, server):
+        docker_logout_cmd = self.docker_cmd + DOCKER_LOG_OUT_REGISTRY_CMD.format(server=server)
         res, out = execute_shell_cmd(docker_logout_cmd, return_output=True)
         return res, out
 
-    @staticmethod
-    def transfer_tool_images(image_name, versions, source_registry_url, target_registry_url):
+    def transfer_tool_images(self, image_name, versions, source_registry_url, target_registry_url):
         images = []
         for version in versions:
             src_image = IMAGE_FULL_NAME_PATTERN.format(registry_url=source_registry_url, image_name=image_name,
                                                        tag=version)
             print_info_message('Pulling {}'.format(src_image))
-            pull_image(src_image)
+            self.pull_image(src_image)
             target_image = IMAGE_FULL_NAME_PATTERN.format(registry_url=target_registry_url, image_name=image_name,
                                                           tag=version)
             print_info_message('Tagging {} as {}'.format(src_image, target_image))
-            tag_image(src_image, target_image)
+            self.tag_image(src_image, target_image)
             print_info_message('Pushing {}'.format(target_image))
-            push_image(target_image)
+            self.push_image(target_image)
             images.append(src_image)
             images.append(target_image)
         print_info_message('Images are transferred for tool [{}], removing them'.format(image_name))
-        delete_images(images)
+        self.delete_images(images)
 
     @staticmethod
     def extract_group_from_tool_name(tool_name):
@@ -440,12 +437,15 @@ class ToolSynchronizer(object):
 
 
 if __name__ == '__main__':
-    if len(sys.argv[1:]) != 4:
+    if len(sys.argv[1:]) != 5:
         raise RuntimeError('Invalid count of an arguments for sync process!')
     else:
         source_api_host_url = sys.argv[1]
         source_api_token = sys.argv[2]
         target_api_host_url = sys.argv[3]
         target_api_token = sys.argv[4]
-    synchronizer = ToolSynchronizer(source_api_host_url, source_api_token, target_api_host_url, target_api_token)
+        docker_cmd = sys.argv[5]
+
+    synchronizer = ToolSynchronizer(source_api_host_url, source_api_token, target_api_host_url, target_api_token,
+                                    docker_cmd)
     synchronizer.sync_tools_routine()

--- a/deploy/contents/sync/app/sync_tools.py
+++ b/deploy/contents/sync/app/sync_tools.py
@@ -56,8 +56,7 @@ def execute_shell_cmd(cmd, return_output=False):
 
 
 class ToolSynchronizer(object):
-    def __init__(self, source_api_path, source_access_key, target_api_path, target_access_key, docker_cmd, 
-                 threads_count=1):
+    def __init__(self, source_api_path, source_access_key, target_api_path, target_access_key, docker_cmd):
         self.source_access_key = source_access_key
         self.target_access_key = target_access_key
         self.api_source = ReadOnlyToolSyncAPI(source_api_path, source_access_key)
@@ -66,7 +65,6 @@ class ToolSynchronizer(object):
         self.api_target_users = UserSyncAPI(target_api_path, target_access_key)
         self.target_current_user = self.api_target_users.get_current_user_name()
         self.source_current_user = self.api_source_users.get_current_user_name()
-        self.thread_pool_size = threads_count
         self.source_registries_dict = {}
         self.tool_groups_ids_mapping = {}
         self.tool_ids_mapping = {}

--- a/deploy/contents/sync/app/sync_users.py
+++ b/deploy/contents/sync/app/sync_users.py
@@ -72,8 +72,9 @@ def sync_groups_statuses(api_source, api_target):
 
 def create_new_user_in_target(api_target, roles_mapping, user):
     roles_ids = []
-    for role in user['roles']:
-        roles_ids.append(roles_mapping.get(role['name']))
+    if 'roles' in user and user['roles']:
+        for role in user['roles']:
+            roles_ids.append(roles_mapping.get(role['name']))
     return api_target.create_user(name=user['userName'], roles_ids=roles_ids)
 
 
@@ -88,8 +89,8 @@ def sync_users(api_source, api_target, roles_mapping):
         if username in target_users_dict:
             print_info_message('User [{}] exists in the target deployment already'.format(username))
             existing_user = target_users_dict[username]
-            source_user_roles = [role['name'] for role in user['roles']]
-            existing_user_roles = [role['name'] for role in existing_user['roles']]
+            source_user_roles = get_user_roles_names(user)
+            existing_user_roles = get_user_roles_names(existing_user)
             for role in source_user_roles:
                 if role not in existing_user_roles:
                     if role not in roles_to_assign:
@@ -110,6 +111,13 @@ def sync_users(api_source, api_target, roles_mapping):
         print_info_message('Syncing {} users for [{}] role'.format(len(users_ids), role_name))
         api_target.assign_users_to_roles(roles_mapping[role_name], users_ids)
     return user_ids_mapping
+
+
+def get_user_roles_names(user):
+    user_roles = []
+    if 'roles' in user and user['roles']:
+        user_roles = [role['name'] for role in user['roles']]
+    return user_roles
 
 
 def sync_metadata_for_entity_class(api_source, api_target, ids_mapping, entity_class):


### PR DESCRIPTION
This PR is related to issue #1282

It brings a new flag `--docker-cmd`, which specifies a command, that will be used during tools' synchronization (default value is 'docker'). Also, it checks, whether a user has roles specified, to avoid exceptions if not.