### PR TITLE
issue 1548 Separate cp-search-srv deploy. Part 2

### DIFF
--- a/deploy/contents/k8s/cp-search/cp-search-srv-nfs-only-dpl.yaml
+++ b/deploy/contents/k8s/cp-search/cp-search-srv-nfs-only-dpl.yaml
@@ -29,6 +29,10 @@ spec:
           env:
             - name: CP_SEARCH_SYNC_TIMEOUT
               value: "86400000"
+            - name: CP_SEARCH_DISABLE_AZ_BLOB_FILE
+              value: "true"
+            - name: CP_SEARCH_DISABLE_AZ_BLOB_STORAGE
+              value: "true"
             - name: CP_SEARCH_DISABLE_NFS_STORAGE
               value: "true"
             - name: CP_SEARCH_DISABLE_RUN


### PR DESCRIPTION
additionally switch off indexing for azure blobs in nfs-only deployment for cp-search-srv pod