### PR TITLE
Implement stop command for background pipe tunnels

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1269,14 +1269,13 @@ def stop_tunnel(run_id, local_port, timeout, force, log_level, trace):
         pipe tunnel stop -lp 4567 12345
 
     """
-    if trace:
+    try:
         kill_tunnels(run_id=run_id, local_port=local_port, timeout=timeout, force=force, log_level=log_level)
-    else:
-        try:
-            kill_tunnels(run_id=run_id, local_port=local_port, timeout=timeout, force=force, log_level=log_level)
-        except Exception as runtime_error:
-            click.echo('Error: {}'.format(str(runtime_error)), err=True)
-            sys.exit(1)
+    except Exception as runtime_error:
+        click.echo('Error: {}'.format(str(runtime_error)), err=True)
+        if trace:
+            traceback.print_exc()
+        sys.exit(1)
 
 
 @tunnel.command(name='start')

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1239,7 +1239,10 @@ def tunnel():
               help='Tunnels stopping timeout in ms')
 @click.option('-f', '--force', required=False, is_flag=True, default=False,
               help='Killing tunnels rather than stopping them')
-def stop_tunnel(run_id, local_port, timeout, force):
+@click.option('-v', '--log-level', required=False, help='Explicit logging level: '
+                                                        'CRITICAL, ERROR, WARNING, INFO or DEBUG.')
+@click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
+def stop_tunnel(run_id, local_port, timeout, force, log_level, trace):
     """
     Stops background tunnel processes.
 
@@ -1266,7 +1269,14 @@ def stop_tunnel(run_id, local_port, timeout, force):
         pipe tunnel stop -lp 4567 12345
 
     """
-    kill_tunnels(run_id=run_id, local_port=local_port, timeout=timeout, force=force)
+    if trace:
+        kill_tunnels(run_id=run_id, local_port=local_port, timeout=timeout, force=force, log_level=log_level)
+    else:
+        try:
+            kill_tunnels(run_id=run_id, local_port=local_port, timeout=timeout, force=force, log_level=log_level)
+        except Exception as runtime_error:
+            click.echo('Error: {}'.format(str(runtime_error)), err=True)
+            sys.exit(1)
 
 
 @tunnel.command(name='start')

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -36,7 +36,7 @@ from src.utilities.datastorage_operations import DataStorageOperations
 from src.utilities.metadata_operations import MetadataOperations
 from src.utilities.permissions_operations import PermissionsOperations
 from src.utilities.pipeline_run_operations import PipelineRunOperations
-from src.utilities.ssh_operations import run_ssh, create_tunnel
+from src.utilities.ssh_operations import run_ssh, create_tunnel, kill_tunnels
 from src.utilities.update_cli_version import UpdateCLIVersionManager
 from src.utilities.user_token_operations import UserTokenOperations
 from src.version import __version__
@@ -1224,7 +1224,52 @@ def ssh(ctx, run_id, retries):
         sys.exit(1)
 
 
-@cli.command(name='tunnel')
+@cli.group()
+def tunnel():
+    """
+    Run ports tunnelling operations
+    """
+    pass
+
+
+@tunnel.command(name='stop')
+@click.argument('run-id', required=False, type=int)
+@click.option('-lp', '--local-port', required=False, type=int, help='Local port to stop tunnel for')
+@click.option('-t', '--timeout', required=False, type=int, default=60 * 1000,
+              help='Tunnels stopping timeout in ms')
+@click.option('-f', '--force', required=False, is_flag=True, default=False,
+              help='Killing tunnels rather than stopping them')
+def stop_tunnel(run_id, local_port, timeout, force):
+    """
+    Stops background tunnel processes.
+
+    It allows to stop multiple tunnel processes for a single run, a single port or a single run port.
+
+    Additionally specified without arguments it allows to stop all background tunnels.
+
+    Examples:
+
+    I. Stop all active tunnels:
+
+        pipe tunnel stop
+
+    II. Stop all tunnels for a single run (12345):
+
+        pipe tunnel stop 12345
+
+    III. Stop a single tunnel which serves on specific local port (4567):
+
+        pipe tunnel stop -lp 4567
+
+    IV. Stop a single tunnel which serves for some run (12345) on specific local port (4567):
+
+        pipe tunnel stop -lp 4567 12345
+
+    """
+    kill_tunnels(run_id=run_id, local_port=local_port, timeout=timeout, force=force)
+
+
+@tunnel.command(name='start')
 @click.argument('run-id', required=True, type=int)
 @click.option('-lp', '--local-port', required=True, type=int, help='Local port to establish connection from')
 @click.option('-rp', '--remote-port', required=True, type=int, help='Remote port to establish connection to')
@@ -1250,9 +1295,9 @@ def ssh(ctx, run_id, retries):
 @click.option('-r', '--retries', required=False, type=int, default=10, help=RETRIES_OPTION_DESCRIPTION)
 @click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
 @Config.validate_access_token
-def tunnel(run_id, local_port, remote_port, connection_timeout,
-           ssh, ssh_path, ssh_host, ssh_keep, log_file, log_level,
-           timeout, foreground, retries, trace):
+def start_tunnel(run_id, local_port, remote_port, connection_timeout,
+                 ssh, ssh_path, ssh_host, ssh_keep, log_file, log_level,
+                 timeout, foreground, retries, trace):
     """
     Establishes tunnel connection to specified run instance port and serves it as a local port.
 
@@ -1268,13 +1313,13 @@ def tunnel(run_id, local_port, remote_port, connection_timeout,
 
     Establish tunnel connection from run (12345) instance port (4567) to the same local port.
 
-        pipe tunnel -lp 4567 -rp 4567 12345
+        pipe tunnel start -lp 4567 -rp 4567 12345
 
     II. Example of ssh port tunnel connection establishing with enabled passwordless ssh configuration.
 
     First of all establish tunnel connection from run (12345) instance ssh port (22) to some local port (4567).
 
-        pipe tunnel -lp 4567 -rp 22 --ssh 12345
+        pipe tunnel start -lp 4567 -rp 22 --ssh 12345
 
     Then connect to run instance using regular ssh client.
 

--- a/pipe-cli/requirements.txt
+++ b/pipe-cli/requirements.txt
@@ -30,3 +30,4 @@ setuptools
 treelib==1.5.5
 cryptography==2.9.2
 bcrypt==3.1.7
+psutil==5.7.3

--- a/pipe-cli/src/utilities/ssh_operations.py
+++ b/pipe-cli/src/utilities/ssh_operations.py
@@ -493,10 +493,13 @@ def perform_command(executable, log_file=None, collect_output=True):
         return out
 
 
-def kill_tunnels(run_id=None, local_port=None, timeout=None, force=False):
+def kill_tunnels(run_id=None, local_port=None, timeout=None, force=False, log_level=None):
+    logging.basicConfig(level=log_level or logging.ERROR, format=DEFAULT_LOGGING_FORMAT)
     import signal
 
     for tunnel_proc in find_tunnel_procs(run_id, local_port):
+        logging.info('Process with pid %s was found (%s)', tunnel_proc.pid, ' '.join(tunnel_proc.cmdline()))
+        logging.info('Killing the process...')
         tunnel_proc.send_signal(signal.SIGKILL if force else signal.SIGTERM)
         tunnel_proc.wait(timeout / 1000 if timeout else None)
 
@@ -510,6 +513,7 @@ def find_tunnel_procs(run_id=None, local_port=None):
     python_proc_prefix = 'python'
     pipe_script_name = 'pipe.py'
 
+    logging.info('Searching for pipe tunnel processes...')
     for proc in psutil.process_iter():
         proc_name = proc.name()
         if proc_name not in pipe_proc_names and not proc_name.startswith(python_proc_prefix):


### PR DESCRIPTION
Relates to #1501 and depends on #1534.

The pull request brings `pipe tunnel stop` functionality which helps to stop background tunnels. Old `pipe tunnel` functionality can now be reached using `pipe tunnel start` call.

See `pipe tunnel stop --help` output for more information:
```
  Stops background tunnel processes.

  It allows to stop multiple tunnel processes for a single run, a single
  port or a single run port.

  Additionally specified without arguments it allows to stop all background
  tunnels.

  Examples:

  I. Stop all active tunnels:

      pipe tunnel stop

  II. Stop all tunnels for a single run (12345):

      pipe tunnel stop 12345

  III. Stop a single tunnel which serves on specific local port (4567):

      pipe tunnel stop -lp 4567

  IV. Stop a single tunnel which serves for some run (12345) on specific
  local port (4567):

      pipe tunnel stop -lp 4567 12345
```