### PR TITLE
Support default non root ssh access in pipe tunnel

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1209,18 +1209,21 @@ def chown(user_name, entity_class, entity_name):
 @click.argument('run-id', required=True, type=int)
 @click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @click.option('-r', '--retries', required=False, type=int, default=10, help=RETRIES_OPTION_DESCRIPTION)
+@click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
 @click.pass_context
 @Config.validate_access_token
-def ssh(ctx, run_id, retries):
+def ssh(ctx, run_id, retries, trace):
     """Runs a single command or an interactive session over the SSH protocol for the specified job run\n
     Arguments:\n
     - run-id: ID of the job running in the platform to establish SSH connection with
     """
     try:
-        ssh_exit_code = run_ssh(run_id, ' '.join(ctx.args), retries)
+        ssh_exit_code = run_ssh(run_id, ' '.join(ctx.args), retries=retries)
         sys.exit(ssh_exit_code)
     except Exception as runtime_error:
         click.echo('Error: {}'.format(str(runtime_error)), err=True)
+        if trace:
+            traceback.print_exc()
         sys.exit(1)
 
 

--- a/workflows/pipe-common/shell/ssh_setup_personal_keys
+++ b/workflows/pipe-common/shell/ssh_setup_personal_keys
@@ -144,6 +144,9 @@ add_ssh_config  "$OWNER_SSH_CONFIG_LOCATION" \
                 "$GIT_HOST_PREF" \
                 "$OWNER_SSH_PRV_LOCATION"
 
+chown -R $OWNER:$OWNER $OWNER_SSH_DIR
+ssh_fix_permissions $OWNER_SSH_DIR
+
 ### Configure keys to be used for the gitlab by root
 add_ssh_config  "$ROOT_SSH_DIR/config" \
                 "$GIT_HOST_EXTERNAL_PREF" \
@@ -152,6 +155,3 @@ add_ssh_config  "$ROOT_SSH_DIR/config" \
 
 chown -R root:root $ROOT_SSH_DIR
 ssh_fix_permissions $ROOT_SSH_DIR
-
-chown -R $OWNER:$OWNER $OWNER_SSH_DIR
-ssh_fix_permissions $OWNER_SSH_DIR

--- a/workflows/pipe-common/shell/ssh_setup_personal_keys
+++ b/workflows/pipe-common/shell/ssh_setup_personal_keys
@@ -43,9 +43,10 @@ if [ -z "$OWNER" ]; then
     exit 1
 fi
 
-OWNER_SSH_PRV_LOCATION=/home/$OWNER/.ssh/id_${OWNER}
-OWNER_SSH_PUB_LOCATION=/home/$OWNER/.ssh/id_${OWNER}.pub
-OWNER_SSH_CONFIG_LOCATION=/home/$OWNER/.ssh/config
+OWNER_SSH_DIR=/home/$OWNER/.ssh
+OWNER_SSH_PRV_LOCATION=$OWNER_SSH_DIR/id_${OWNER}
+OWNER_SSH_PUB_LOCATION=$OWNER_SSH_DIR/id_${OWNER}.pub
+OWNER_SSH_CONFIG_LOCATION=$OWNER_SSH_DIR/config
 mkdir -p $(dirname $OWNER_SSH_PRV_LOCATION)
 
 ## SSH keys configuration
@@ -151,3 +152,6 @@ add_ssh_config  "$ROOT_SSH_DIR/config" \
 
 chown -R root:root $ROOT_SSH_DIR
 ssh_fix_permissions $ROOT_SSH_DIR
+
+chown -R $OWNER:$OWNER $OWNER_SSH_DIR
+ssh_fix_permissions $OWNER_SSH_DIR


### PR DESCRIPTION
Relates to #1501.

The pull request brings support for default non root ssh access in pipe tunnel. It means that depending on the value of `system.ssh.default.root.user.enabled` system preference pipe tunnel will configure either root or owner default passwordless user. At the same time passwordless configuration allows to establish passwordless ssh with both root and owner if specified explicitly.

Additionally it brings changes that neglect any possible owner ssh directory permission issues by setting it explicitly.