### PR TITLE
Add support for pipe scp

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1206,7 +1206,7 @@ def chown(user_name, entity_class, entity_name):
 @cli.command(name='ssh', context_settings=dict(
     ignore_unknown_options=True,
     allow_extra_args=True))
-@click.argument('run-id', required=True, type=int)
+@click.argument('run-id', required=True, type=str)
 @click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @click.option('-r', '--retries', required=False, type=int, default=10, help=RETRIES_OPTION_DESCRIPTION)
 @click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
@@ -1216,6 +1216,20 @@ def ssh(ctx, run_id, retries, trace):
     """Runs a single command or an interactive session over the SSH protocol for the specified job run\n
     Arguments:\n
     - run-id: ID of the job running in the platform to establish SSH connection with
+
+    Examples:
+
+    I. Open an interactive SSH session for some run (12345):
+
+        pipe ssh pipeline-12345
+
+        pipe ssh 12345
+
+    II. Execute a single command via SSH for some run (12345):
+
+        pipe ssh pipeline-12345 echo \$HOSTNAME
+
+        pipe ssh 12345 echo \$HOSTNAME
     """
     try:
         ssh_exit_code = run_ssh(run_id, ' '.join(ctx.args), retries=retries)
@@ -1250,17 +1264,25 @@ def scp(source, destination, recursive, quiet, retries, trace):
 
         pipe scp file.txt pipeline-12345:/common/workdir/file.txt
 
+        pipe scp file.txt 12345:/common/workdir/file.txt
+
     II. Upload some local directory (dir) to some run (12345):
 
         pipe scp -r dir pipeline-12345:/common/workdir/dir
+
+        pipe scp -r dir 12345:/common/workdir/dir
 
     III. Download some remote file (/common/workdir/file.txt) from run (12345) to some local file (file.txt):
 
         pipe scp pipeline-12345:/common/workdir/file.txt file.txt
 
+        pipe scp 12345:/common/workdir/file.txt file.txt
+
     IV. Download some remote directory (/common/workdir/dir) from run (12345) to some local directory (dir):
 
         pipe scp -r pipeline-12345:/common/workdir/dir dir
+
+        pipe scp -r 12345:/common/workdir/dir dir
     """
     try:
         run_scp(source, destination, recursive, quiet, retries)

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -36,7 +36,7 @@ from src.utilities.datastorage_operations import DataStorageOperations
 from src.utilities.metadata_operations import MetadataOperations
 from src.utilities.permissions_operations import PermissionsOperations
 from src.utilities.pipeline_run_operations import PipelineRunOperations
-from src.utilities.ssh_operations import run_ssh, create_tunnel, kill_tunnels
+from src.utilities.ssh_operations import run_ssh, run_scp, create_tunnel, kill_tunnels
 from src.utilities.update_cli_version import UpdateCLIVersionManager
 from src.utilities.user_token_operations import UserTokenOperations
 from src.version import __version__
@@ -1227,6 +1227,50 @@ def ssh(ctx, run_id, retries, trace):
         sys.exit(1)
 
 
+@cli.command(name='scp')
+@click.argument('source', required=True, type=str)
+@click.argument('destination', required=True, type=str)
+@click.option('-r', '--recursive', required=False, is_flag=True, default=False,
+              help='Recursive transferring (required for directories transferring)')
+@click.option('-q', '--quiet', help='Quiet mode', is_flag=True, default=False)
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
+@click.option('-r', '--retries', required=False, type=int, default=10, help=RETRIES_OPTION_DESCRIPTION)
+@click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
+@Config.validate_access_token
+def scp(source, destination, recursive, quiet, retries, trace):
+    """
+    Transfers files or directories between local workstation and run instance.
+
+    It allows to copy file from a local worstation to a remote run instance
+    and from a remote run instance to a local workstation.
+
+    Examples:
+
+    I. Upload some local file (file.txt) to some run (12345):
+
+        pipe scp file.txt pipeline-12345:/common/workdir/file.txt
+
+    II. Upload some local directory (dir) to some run (12345):
+
+        pipe scp -r dir pipeline-12345:/common/workdir/dir
+
+    III. Download some remote file (/common/workdir/file.txt) from run (12345) to some local file (file.txt):
+
+        pipe scp pipeline-12345:/common/workdir/file.txt file.txt
+
+    IV. Download some remote directory (/common/workdir/dir) from run (12345) to some local directory (dir):
+
+        pipe scp -r pipeline-12345:/common/workdir/dir dir
+    """
+    try:
+        run_scp(source, destination, recursive, quiet, retries)
+    except Exception as runtime_error:
+        click.echo('Error: {}'.format(str(runtime_error)), err=True)
+        if trace:
+            traceback.print_exc()
+        sys.exit(1)
+
+
 @cli.group()
 def tunnel():
     """
@@ -1245,6 +1289,7 @@ def tunnel():
 @click.option('-v', '--log-level', required=False, help='Explicit logging level: '
                                                         'CRITICAL, ERROR, WARNING, INFO or DEBUG.')
 @click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
+@Config.validate_access_token
 def stop_tunnel(run_id, local_port, timeout, force, log_level, trace):
     """
     Stops background tunnel processes.

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1234,7 +1234,7 @@ def ssh(ctx, run_id, retries, trace):
               help='Recursive transferring (required for directories transferring)')
 @click.option('-q', '--quiet', help='Quiet mode', is_flag=True, default=False)
 @click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@click.option('-r', '--retries', required=False, type=int, default=10, help=RETRIES_OPTION_DESCRIPTION)
+@click.option('--retries', required=False, type=int, default=10, help=RETRIES_OPTION_DESCRIPTION)
 @click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
 @Config.validate_access_token
 def scp(source, destination, recursive, quiet, retries, trace):

--- a/pipe-cli/src/model/pipeline_run_model.py
+++ b/pipe-cli/src/model/pipeline_run_model.py
@@ -44,6 +44,7 @@ class PipelineRunModel(object):
         self.owner = None
         self.endpoints = []
         self.run_sids = []
+        self.sensitive = None
 
     @property
     def is_initialized(self):
@@ -101,6 +102,9 @@ class PipelineRunModel(object):
         if 'runSids' in json and json['runSids'] is not None and len(json['runSids']) > 0:
             for item in json['runSids']:
                 instance.run_sids.append(RunSid(item['name'], item['isPrincipal'], item['accessType']))
+
+        if 'sensitive' in json:
+            instance.sensitive = json['sensitive']
 
         return instance
 

--- a/pipe-cli/src/utilities/progress_bar.py
+++ b/pipe-cli/src/utilities/progress_bar.py
@@ -35,6 +35,7 @@ class ProgressPercentage(object):
     def __init__(self, filename, size):
         self._filename = filename
         self._seen_so_far = 0.0
+        self._seen_so_far_in_bytes = 0
         self._lock = threading.Lock()
         self._size_in_bytes = size
         self._size = float(size)
@@ -78,6 +79,7 @@ class ProgressPercentage(object):
         with self._lock:
             if int(bytes_amount) <= 0:
                 return
+            self._seen_so_far_in_bytes += bytes_amount
             self._seen_so_far += float(bytes_amount) / self.unit_divider
             if self._size == 0:
                 percentage = 100.00

--- a/pipe-cli/src/utilities/ssh_operations.py
+++ b/pipe-cli/src/utilities/ssh_operations.py
@@ -24,7 +24,7 @@ import sys
 import time
 
 import paramiko
-from scp import SCPClient
+from scp import SCPClient, SCPException
 
 from src.config import is_frozen
 from src.utilities.pipe_shell import plain_shell, interactive_shell
@@ -105,14 +105,16 @@ def get_conn_info(run_id):
     if not ssh_proxy_port:
         ssh_proxy_port = 80 if ssh_url_parts.scheme == "http" else 443
 
-    run_conn_info = collections.namedtuple('conn_info', 'ssh_proxy ssh_endpoint ssh_pass owner')
+    run_conn_info = collections.namedtuple('conn_info', 'ssh_proxy ssh_endpoint ssh_pass owner sensitive')
     return run_conn_info(ssh_proxy=(ssh_proxy_host, ssh_proxy_port),
                          ssh_endpoint=(run_model.pod_ip, DEFAULT_SSH_PORT),
                          ssh_pass=run_model.ssh_pass,
-                         owner=run_model.owner)
+                         owner=run_model.owner,
+                         sensitive=run_model.sensitive)
 
 
 def setup_paramiko_transport(conn_info, retries):
+    retries = retries or 0
     sock = None
     transport = None
     try:
@@ -199,16 +201,58 @@ def run_ssh(run_id, command, user=None, retries=10):
             transport.close()
 
 
+def run_scp(source, destination, recursive, quiet, retries):
+    source_location, source_run_id = parse_scp_location(source)
+    destination_location, destination_run_id = parse_scp_location(destination)
+
+    if source_run_id and destination_run_id:
+        raise RuntimeError('Both source and destination are remote locations.')
+    if not source_run_id and not destination_run_id:
+        raise RuntimeError('Both source and destination are local locations.')
+
+    conn_info = get_conn_info(source_run_id if source_run_id else destination_run_id)
+    if conn_info.sensitive:
+        raise RuntimeError('Tunnel connections to sensitive runs are not allowed.')
+
+    if source_run_id:
+        try:
+            run_scp_download(source_run_id, source_location, destination_location,
+                             recursive=recursive, quiet=quiet, user=None, retries=retries)
+        except SCPException as e:
+            if not recursive and 'not a regular file' in str(e):
+                raise RuntimeError('Flag --recursive (-r) is required to copy directories.')
+            else:
+                raise e
+    else:
+        if not recursive and os.path.isdir(source_location):
+            raise RuntimeError('Flag --recursive (-r) is required to copy directories.')
+        run_scp_upload(destination_run_id, source_location, destination_location,
+                       recursive=recursive, quiet=quiet, user=None, retries=retries)
+
+
+def parse_scp_location(location):
+    import re
+    location_parts = location.split(':', 1)
+    if len(location_parts) == 2:
+        match = re.search('^pipeline-(\d+)$', location_parts[0])
+        if match:
+            return location_parts[1], int(match.group(1))
+    return location_parts[0], None
+
+
 def create_tunnel(run_id, local_port, remote_port, connection_timeout,
                   ssh, ssh_path, ssh_host, ssh_keep, log_file, log_level,
                   timeout, foreground, retries):
+    conn_info = get_conn_info(run_id)
+    if conn_info.sensitive:
+        raise RuntimeError('Tunnel connections to sensitive runs are not allowed.')
     if foreground:
         remote_host = ssh_host or 'pipeline-{}'.format(run_id)
         if ssh:
-            create_foreground_tunnel_with_ssh(run_id, local_port, remote_port, connection_timeout,
+            create_foreground_tunnel_with_ssh(run_id, local_port, remote_port, connection_timeout, conn_info,
                                               ssh_path, ssh_keep, remote_host, log_file, log_level, retries)
         else:
-            create_foreground_tunnel(run_id, local_port, remote_port, connection_timeout,
+            create_foreground_tunnel(run_id, local_port, remote_port, connection_timeout, conn_info,
                                      remote_host, log_level, retries)
     else:
         create_background_tunnel(log_file, timeout)
@@ -240,7 +284,7 @@ def create_background_tunnel(log_file, timeout):
             sys.exit(1)
 
 
-def create_foreground_tunnel_with_ssh(run_id, local_port, remote_port, connection_timeout,
+def create_foreground_tunnel_with_ssh(run_id, local_port, remote_port, connection_timeout, conn_info,
                                       ssh_path, ssh_keep, remote_host, log_file, log_level, retries):
     logging.basicConfig(level=log_level or logging.ERROR, format=DEFAULT_LOGGING_FORMAT)
     if is_windows():
@@ -254,7 +298,6 @@ def create_foreground_tunnel_with_ssh(run_id, local_port, remote_port, connectio
     ssh_private_key_name = 'pipeline-{}-{}-{}'.format(run_id, int(time.time()), random.randint(0, sys.maxsize))
     ssh_private_key_path = os.path.join(ssh_keys_path, ssh_private_key_name)
     ssh_public_key_path = '{}.pub'.format(ssh_private_key_path)
-    conn_info = get_conn_info(run_id)
     owner_user = conn_info.owner.split('@')[0]
     ssh_config_user = DEFAULT_SSH_USER if is_ssh_default_root_user_enabled() else owner_user
     remote_ssh_authorized_keys_paths = ['/root/.ssh/authorized_keys',
@@ -272,7 +315,7 @@ def create_foreground_tunnel_with_ssh(run_id, local_port, remote_port, connectio
         add_record_to_ssh_config(ssh_config_path, remote_host, local_port, ssh_private_key_path, ssh_config_user)
         copy_remote_ssh_public_key_to_ssh_known_hosts(run_id, local_port, log_file, retries,
                                                       ssh_known_hosts_path, remote_ssh_public_key_path)
-        create_foreground_tunnel(run_id, local_port, remote_port, connection_timeout,
+        create_foreground_tunnel(run_id, local_port, remote_port, connection_timeout, conn_info,
                                  remote_host, log_level, retries)
     except:
         logging.exception('Error occurred while trying set up tunnel')
@@ -286,11 +329,10 @@ def create_foreground_tunnel_with_ssh(run_id, local_port, remote_port, connectio
             remove_ssh_keys(ssh_public_key_path, ssh_private_key_path)
 
 
-def create_foreground_tunnel(run_id, local_port, remote_port, connection_timeout,
+def create_foreground_tunnel(run_id, local_port, remote_port, connection_timeout, conn_info,
                              remote_host, log_level, retries,
                              chunk_size=4096, server_delay=0.0001):
     logging.basicConfig(level=log_level or logging.ERROR, format=DEFAULT_LOGGING_FORMAT)
-    conn_info = get_conn_info(run_id)
     proxy_endpoint = (os.getenv('CP_CLI_TUNNEL_PROXY_HOST', conn_info.ssh_proxy[0]),
                       int(os.getenv('CP_CLI_TUNNEL_PROXY_PORT', conn_info.ssh_proxy[1])))
     target_endpoint = (os.getenv('CP_CLI_TUNNEL_TARGET_HOST', conn_info.ssh_endpoint[0]),
@@ -545,13 +587,13 @@ def find_tunnel_procs(run_id=None, local_port=None):
             yield proc
 
 
-def run_scp_upload(run_id, source, destination, user, retries):
+def run_scp_upload(run_id, source, destination, recursive=False, quiet=True, user=None, retries=None):
     transport = None
     scp = None
     try:
         transport = setup_authenticated_paramiko_transport(run_id, user, retries)
-        scp = SCPClient(transport)
-        scp.put(source, destination)
+        scp = SCPClient(transport, progress=None if quiet else build_scp_progress())
+        scp.put(source, destination, recursive=recursive)
     finally:
         if scp:
             scp.close()
@@ -559,15 +601,29 @@ def run_scp_upload(run_id, source, destination, user, retries):
             transport.close()
 
 
-def run_scp_download(run_id, source, destination, user, retries):
+def run_scp_download(run_id, source, destination, recursive=False, quiet=True, user=None, retries=None):
     transport = None
     scp = None
     try:
         transport = setup_authenticated_paramiko_transport(run_id, user, retries)
-        scp = SCPClient(transport)
-        scp.get(source, destination)
+        scp = SCPClient(transport, progress=None if quiet else build_scp_progress())
+        scp.get(source, destination, recursive=recursive)
     finally:
         if scp:
             scp.close()
         if transport:
             transport.close()
+
+
+def build_scp_progress():
+    from src.utilities.progress_bar import ProgressPercentage
+
+    progresses = {}
+
+    def scp_progress(filename, size, total):
+        progress = progresses.get(filename, None)
+        if not progress:
+            progress = progresses[filename] = ProgressPercentage(filename, size)
+        progress(total - progress._seen_so_far_in_bytes)
+
+    return scp_progress

--- a/pipe-cli/src/utilities/ssh_operations.py
+++ b/pipe-cli/src/utilities/ssh_operations.py
@@ -206,6 +206,8 @@ def run_ssh(run_identifier, command, user=None, retries=10):
 
 
 def parse_run_identifier(run_identifier):
+    if isinstance(run_identifier, int):
+        return run_identifier
     import re
     match = re.search('^(\d+)$', run_identifier)
     if match:


### PR DESCRIPTION
Resolves issue #640.

The pull request brings support for `pipe scp` command which behaves pretty much the same as a regular openssh scp client.

Regarding the original [comment](https://github.com/epam/cloud-pipeline/issues/640) describing  the possible implementation. At this point all but `-f, --force` flags are implemented. It means that there are no checks on the existing destination file or directory which can lead to the destination being overridden during the call. 

See the `pipe scp --help` output for more details on the command usage:
```
Usage: pipe scp [OPTIONS] SOURCE DESTINATION

  Transfers files or directories between local workstation and run instance.

  It allows to copy file from a local worstation to a remote run instance
  and from a remote run instance to a local workstation.

  Examples:

  I. Upload some local file (file.txt) to some run (12345):

      pipe scp file.txt pipeline-12345:/common/workdir/file.txt

      pipe scp file.txt 12345:/common/workdir/file.txt

  II. Upload some local directory (dir) to some run (12345):

      pipe scp -r dir pipeline-12345:/common/workdir/dir

      pipe scp -r dir 12345:/common/workdir/dir

  III. Download some remote file (/common/workdir/file.txt) from run (12345)
  to some local file (file.txt):

      pipe scp pipeline-12345:/common/workdir/file.txt file.txt

      pipe scp 12345:/common/workdir/file.txt file.txt

  IV. Download some remote directory (/common/workdir/dir) from run (12345)
  to some local directory (dir):

      pipe scp -r pipeline-12345:/common/workdir/dir dir

      pipe scp -r 12345:/common/workdir/dir dir

Options:
  -r, --recursive    Recursive transferring (required for directories
                     transferring)
  -q, --quiet        Quiet mode
  -u, --user TEXT    The user name to perform operation from specified user.
                     Available for admins only
  --retries INTEGER  Number of retries to connect to specified pipeline run.
                     Default is 10
  --trace            Enables error stack traces displaying
  --help             Show this message and exit.
```