### PR TITLE
Persist metadata entity creation date

### DIFF
--- a/api/src/main/java/com/epam/pipeline/dao/metadata/MetadataEntityDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/metadata/MetadataEntityDao.java
@@ -26,6 +26,7 @@ import com.epam.pipeline.entity.metadata.MetadataField;
 import com.epam.pipeline.entity.metadata.MetadataFilter;
 import com.epam.pipeline.entity.metadata.PipeConfValue;
 import com.epam.pipeline.entity.pipeline.Folder;
+import com.epam.pipeline.entity.utils.DateUtils;
 import com.epam.pipeline.manager.metadata.parser.EntityTypeField;
 import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,6 +43,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -94,6 +96,7 @@ public class MetadataEntityDao extends NamedParameterJdbcDaoSupport {
     @Transactional(propagation = Propagation.MANDATORY)
     public void createMetadataEntity(MetadataEntity metadataEntity) {
         metadataEntity.setId(daoHelper.createId(metadataEntitySequence));
+        metadataEntity.setCreatedDate(DateUtils.now());
         getNamedParameterJdbcTemplate().update(createMetadataEntityQuery,
                 MetadataEntityParameters.getParameters(metadataEntity));
     }
@@ -101,14 +104,16 @@ public class MetadataEntityDao extends NamedParameterJdbcDaoSupport {
     @Transactional(propagation = Propagation.MANDATORY)
     @SuppressWarnings("unchecked")
     public Collection<MetadataEntity> batchInsert(List<MetadataEntity> entitiesToCreate) {
+        final Date now = DateUtils.now();
         for (int i = 0; i < entitiesToCreate.size(); i += BATCH_SIZE) {
             final List<MetadataEntity> batchList = entitiesToCreate.subList(i,
-                    i + BATCH_SIZE > entitiesToCreate.size() ? entitiesToCreate.size() : i + BATCH_SIZE);
+                    Math.min(i + BATCH_SIZE, entitiesToCreate.size()));
             List<Long> ids = daoHelper.createIds(metadataEntitySequence, batchList.size());
             Map<String, Object>[] batchValues = new Map[batchList.size()];
             for (int j = 0; j < batchList.size(); j++) {
                 MetadataEntity entity = batchList.get(j);
                 entity.setId(ids.get(j));
+                entity.setCreatedDate(now);
                 batchValues[j] = MetadataEntityParameters.getParameters(entity).getValues();
             }
             getNamedParameterJdbcTemplate().batchUpdate(this.createMetadataEntityQuery, batchValues);
@@ -127,7 +132,7 @@ public class MetadataEntityDao extends NamedParameterJdbcDaoSupport {
     public Collection<MetadataEntity> batchUpdate(List<MetadataEntity> entitiesToUpdate) {
         for (int i = 0; i < entitiesToUpdate.size(); i += BATCH_SIZE) {
             final List<MetadataEntity> batchList = entitiesToUpdate.subList(i,
-                    i + BATCH_SIZE > entitiesToUpdate.size() ? entitiesToUpdate.size() : i + BATCH_SIZE);
+                    Math.min(i + BATCH_SIZE, entitiesToUpdate.size()));
             Map<String, Object>[] batchValues = new Map[batchList.size()];
             for (int j = 0; j < batchList.size(); j++) {
                 MetadataEntity entity = batchList.get(j);
@@ -377,6 +382,7 @@ public class MetadataEntityDao extends NamedParameterJdbcDaoSupport {
         EXTERNAL_ID,
         CLASS_NAME,
         DATA,
+        CREATED_DATE,
         EXTERNAL_IDS,
         KEY,
         TYPE,
@@ -390,6 +396,7 @@ public class MetadataEntityDao extends NamedParameterJdbcDaoSupport {
             fieldNames.put("ID", new MetadataField("id", "e.entity_id", true));
             fieldNames.put("NAME", new MetadataField("name", "e.entity_name", true));
             fieldNames.put("EXTERNALID", new MetadataField("externalId", "e.external_id", true));
+            fieldNames.put("CREATEDDATE", new MetadataField("createdDate", "e.created_date", true));
             fieldNames.put("PARENT.ID", new MetadataField("parent.id", "e.parent_id", true));
             fieldNames.put("CLASSENTITY.ID", new MetadataField("classEntity.id", "c.class_id", true));
             fieldNames.put("CLASSENTITY.NAME", new MetadataField("classEntity.name", "c.class_name", true));
@@ -414,6 +421,7 @@ public class MetadataEntityDao extends NamedParameterJdbcDaoSupport {
             params.addValue(ENTITY_NAME.name(), metadataEntity.getName());
             params.addValue(EXTERNAL_ID.name(), metadataEntity.getExternalId());
             params.addValue(DATA.name(), convertDataToJsonStringForQuery(metadataEntity.getData()));
+            params.addValue(CREATED_DATE.name(), metadataEntity.getCreatedDate());
             return params;
         }
 
@@ -482,6 +490,7 @@ public class MetadataEntityDao extends NamedParameterJdbcDaoSupport {
             entity.setName(rs.getString(ENTITY_NAME.name()));
             entity.setExternalId(rs.getString(EXTERNAL_ID.name()));
             entity.setData(MetadataDao.MetadataParameters.parseData(rs.getString(DATA.name())));
+            entity.setCreatedDate(new Date(rs.getTimestamp(CREATED_DATE.name()).getTime()));
             return entity;
         }
 

--- a/api/src/main/java/com/epam/pipeline/manager/metadata/MetadataEntityManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/metadata/MetadataEntityManager.java
@@ -82,7 +82,7 @@ public class MetadataEntityManager implements SecuredEntityManager {
     public Map<String, Integer> loadRootMetadataEntities() {
         Map<String, Integer> countEntities = new HashMap<>();
         List<MetadataEntity> entities = metadataEntityDao.loadRootMetadataEntities();
-        entities.forEach(e -> countEntities.merge(e.getClassEntity().getName(), 1, (p, i) -> p + i));
+        entities.forEach(e -> countEntities.merge(e.getClassEntity().getName(), 1, Integer::sum));
         return countEntities;
     }
 

--- a/api/src/main/resources/dao/metadata-entity-dao.xml
+++ b/api/src/main/resources/dao/metadata-entity-dao.xml
@@ -29,14 +29,16 @@
                         parent_id,
                         entity_name,
                         external_id,
-                        data)
+                        data,
+                        created_date)
                     VALUES (
                         :ENTITY_ID,
                         :CLASS_ID,
                         :PARENT_ID,
                         :ENTITY_NAME,
                         :EXTERNAL_ID,
-                        to_jsonb(:DATA::jsonb))
+                        to_jsonb(:DATA::jsonb),
+                        :CREATED_DATE)
                 ]]>
             </value>
         </property>
@@ -76,6 +78,7 @@
                         e.entity_name,
                         e.external_id,
                         e.data,
+                        e.created_date,
                         c.external_class_name
                     FROM
                         pipeline.metadata_entity e
@@ -95,6 +98,7 @@
                         e.entity_name,
                         e.external_id,
                         e.data,
+                        e.created_date,
                         c.external_class_name
                      FROM
                         pipeline.metadata_entity e
@@ -114,14 +118,16 @@
                         parent_id,
                         entity_name,
                         external_id,
-                        data
+                        data,
+                        created_date
                      ) SELECT
                         NEXTVAL('pipeline.s_metadata_entity') AS entity_id,
                         class_id,
                         ? AS parent_id,
                         entity_name,
                         external_id,
-                        data
+                        data,
+                        now() AS created_date
                      FROM pipeline.metadata_entity e WHERE e.parent_id = ?
                 ]]>
             </value>
@@ -137,6 +143,7 @@
                         null as class_id,
                         null as entity_name,
                         null as external_id,
+                        e.created_date,
                         c.external_class_name
                     FROM
                         pipeline.metadata_entity e
@@ -157,6 +164,7 @@
                         e.entity_name,
                         e.external_id,
                         e.data,
+                        e.created_date,
                         c.external_class_name
                      FROM
                         pipeline.metadata_entity e
@@ -255,6 +263,7 @@
                       e.entity_name,
                       e.external_id,
                       e.data,
+                      e.created_date,
                       c.external_class_name
                     FROM
                       children f
@@ -278,6 +287,7 @@
                       e.entity_name,
                       e.external_id,
                       e.data,
+                      e.created_date,
                       c.external_class_name
                     FROM
                       metadata_entity e
@@ -373,6 +383,7 @@
                       m.entity_id,
                       m.key,
                       m.data->m.key->>'type' as type,
+                      m.created_date,
                       m.external_class_name
                     FROM (
                       WITH RECURSIVE children AS (
@@ -402,6 +413,7 @@
                         m.entity_id,
                         jsonb_object_keys(m.data) as key,
                         m.data,
+                        m.created_date,
                         c.external_class_name
                       FROM metadata_entity m
                         INNER JOIN
@@ -444,6 +456,7 @@
                         e.entity_name,
                         e.external_id,
                         NULL as data,
+                        e.created_date,
                         c.c.external_class_name
                     FROM pipeline.metadata_entity e
                     INNER JOIN folders ON folders.folder_id = e.parent_id
@@ -463,6 +476,7 @@
                         e.entity_name,
                         e.external_id,
                         e.data,
+                        e.created_date,
                         c.external_class_name
                      FROM
                         pipeline.metadata_entity e
@@ -485,6 +499,7 @@
                         e.entity_name,
                         e.external_id,
                         e.data,
+                        e.created_date,
                         c.external_class_name
                      FROM
                         pipeline.metadata_entity e
@@ -510,6 +525,7 @@
                           p.field_type,
                           p.field_value,
                           p.data,
+                          p.created_date,
 						  p.external_class_name
                         FROM (SELECT
                                 entity_id,
@@ -519,6 +535,7 @@
                                 class_name,
                                 parent_id,
                                 data,
+                                created_date,
                                 key as field_name,
                                 regexp_replace(regexp_replace(value->>'type', '(:ID)|(Array\[)', ''), ']', '') as field_type,
                                 CASE
@@ -545,6 +562,7 @@
                           d.field_type,
                           d.field_value,
                           d.data,
+                          d.created_date,
 						  d.external_class_name
                         FROM (SELECT
                                 entity_id,
@@ -554,6 +572,7 @@
                                 class_name,
                                 parent_id,
                                 data,
+                                created_date,
                                 key as field_name,
                                 regexp_replace(regexp_replace(value->>'type', '(:ID)|(Array\[)', ''), ']', '') as field_type,
                                 CASE
@@ -576,6 +595,7 @@
                       external_id,
                       parent_id,
                       data,
+                      created_date,
 					  external_class_name
                     FROM links;
                 ]]>
@@ -592,6 +612,7 @@
                             p.class_id,
                             p.parent_id,
                             p.data,
+                            p.created_date,
 						    f.folder_id AS folder_id,
                             f.parent_id AS parent_folder_id
                         FROM pipeline.metadata_entity p
@@ -605,6 +626,7 @@
                             null AS class_id,
                             null AS parent_id,
                             null AS data,
+                            null AS created_date,
 		                    m.folder_id AS folder_id,
                             m.parent_id AS parent_folder_id
 	                    FROM pipeline.folder m

--- a/api/src/main/resources/db/migration/v2020.11.24_11.00__issue_1589_metadata_entity_creation_date.sql
+++ b/api/src/main/resources/db/migration/v2020.11.24_11.00__issue_1589_metadata_entity_creation_date.sql
@@ -1,0 +1,3 @@
+ALTER TABLE pipeline.metadata_entity ADD created_date TIMESTAMP WITH TIME ZONE;
+UPDATE pipeline.metadata_entity SET created_date = now();
+ALTER TABLE pipeline.metadata_entity ALTER COLUMN created_date SET NOT NULL;

--- a/api/src/test/java/com/epam/pipeline/dao/metadata/MetadataEntityDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/metadata/MetadataEntityDaoTest.java
@@ -528,9 +528,10 @@ public class MetadataEntityDaoTest extends AbstractSpringTest {
         actual.forEach(e -> compareMetadata(expectedMap.get(e.getId()), e, true));
     }
 
-    private void compareMetadata(MetadataEntity metadataEntity, MetadataEntity result, boolean compareIds) {
-        if (compareIds) {
+    private void compareMetadata(MetadataEntity metadataEntity, MetadataEntity result, boolean compareExactly) {
+        if (compareExactly) {
             Assert.assertEquals(metadataEntity.getId(), result.getId());
+            Assert.assertEquals(metadataEntity.getCreatedDate(), result.getCreatedDate());
         }
         Assert.assertEquals(metadataEntity.getName(), result.getName());
         Assert.assertEquals(metadataEntity.getClassEntity().getName(), result.getClassEntity().getName());


### PR DESCRIPTION
Resolves issue #1589.

The pull request brings support for metadata entity creation date persistence. From now on each metadata entity will have the correct created date. Notice that already existing metadata entities will have some default creation date which matches the database migration date.
