### PR TITLE
Return correct metadata entity fields

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/metadata/MetadataEntityManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/metadata/MetadataEntityManager.java
@@ -307,16 +307,7 @@ public class MetadataEntityManager implements SecuredEntityManager {
         Assert.notNull(folderId,
                 messageHelper.getMessage(MessageConstants.ERROR_INVALID_METADATA_FILTER, "folderId", folderId));
         folderManager.load(folderId);
-        Collection<MetadataClassDescription> metadataFields =
-                metadataEntityDao.getMetadataFields(folderId);
-        Set<String> presentClasses = metadataFields.stream()
-                .map(c -> c.getMetadataClass().getName())
-                .collect(Collectors.toSet());
-        metadataFields.stream()
-                .map(MetadataClassDescription::getFields)
-                .flatMap(Collection::stream)
-                .forEach(field -> field.setReference(presentClasses.contains(field.getType())));
-        return metadataFields;
+        return metadataEntityDao.getMetadataFields(folderId);
     }
 
     public Set<MetadataEntity> getExistingEntities(Set<String> externalIds, Long folderId, String className) {

--- a/api/src/main/java/com/epam/pipeline/manager/metadata/parser/EntityTypeField.java
+++ b/api/src/main/java/com/epam/pipeline/manager/metadata/parser/EntityTypeField.java
@@ -77,12 +77,15 @@ public class EntityTypeField {
     }
 
     public static EntityTypeField parseFromStringType(String name, String type) {
-        String className = parseClass(type);
-        if (StringUtils.isNotBlank(className)) {
-            return new EntityTypeField(name, className);
-        } else {
-            return new EntityTypeField(name, type);
+        Matcher matcher = REFERENCE_PATTERN.matcher(type);
+        if (matcher.matches()) {
+            return new EntityTypeField(name, matcher.group(1), true, false);
         }
+        matcher = ARRAY_PATTERN.matcher(type);
+        if (matcher.matches()) {
+            return new EntityTypeField(name, matcher.group(1), false, true);
+        }
+        return new EntityTypeField(name, type);
     }
 
     public static String parseClass(String type) {

--- a/api/src/test/java/com/epam/pipeline/dao/metadata/MetadataEntityDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/metadata/MetadataEntityDaoTest.java
@@ -443,7 +443,7 @@ public class MetadataEntityDaoTest extends AbstractSpringTest {
                 .collect(Collectors.toMap(e -> e.getMetadataClass().getId(), Function.identity()));
         Assert.assertEquals(Collections.singletonList(new EntityTypeField(DATA_KEY_1, DATA_TYPE_1)),
                 results.get(metadataClass1.getId()).getFields());
-        Assert.assertEquals(Collections.singletonList(new EntityTypeField(DATA_KEY_2, CLASS_NAME_2)),
+        Assert.assertEquals(Collections.singletonList(new EntityTypeField(DATA_KEY_2, CLASS_NAME_2, true, false)),
                 results.get(metadataClass2.getId()).getFields());
     }
 


### PR DESCRIPTION
Resolves issue #1600.

The pull request fixes metadata entity fields endpoint `GET metadataEntity/fields`. Previously it returned incorrect metadata entity type field `reference` and `multiValue` parameters.