### PR TITLE
Add proper error message for non unique metadata entity external ids

### DIFF
--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -331,6 +331,7 @@ public final class MessageConstants {
     public static final String ERROR_INVALID_METADATA_ENTITY_CLASS_ID = "error.invalid.metadata.entity.class.id";
     public static final String ERROR_METADATA_ENTITY_CLASS_NOT_FOUND = "error.metadata.entity.class.not.found";
     public static final String ERROR_METADATA_ENTITY_NOT_FOUND = "error.metadata.entity.not.found";
+    public static final String ERROR_METADATA_ENTITY_ALREADY_EXIST = "error.metadata.entity.already.exists";
     public static final String ERROR_METADATA_UPDATE_KEY_NOT_FOUND = "error.metadata.update.key.not.found";
     public static final String ERROR_INVALID_METADATA_FILTER = "error.invalid.metadata.filter";
     public static final String ERROR_METADATA_UPLOAD_CHANGED_TYPE = "error.metadata.upload.changed.type";

--- a/api/src/main/java/com/epam/pipeline/dao/metadata/MetadataEntityDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/metadata/MetadataEntityDao.java
@@ -48,6 +48,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -267,6 +268,11 @@ public class MetadataEntityDao extends NamedParameterJdbcDaoSupport {
                 .collect(Collectors.joining(","));
         return new HashSet<>(getJdbcTemplate().query(String.format(loadByExternalIdsQuery, idClause),
                 MetadataEntityParameters.getRowMapper(), folderId, className));
+    }
+
+    public Optional<MetadataEntity> loadByExternalId(Long folderId, String className, String externalId) {
+        return loadExisting(folderId, className, new HashSet<>(Collections.singletonList(externalId))).stream()
+                .findAny();
     }
 
     public List<MetadataEntity> loadAllReferences(List<Long> entitiesIds, Long parentId) {

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -310,6 +310,7 @@ error.invalid.metadata.entity.class=Error: invalid metadata entity class: ''{0}'
 error.invalid.metadata=Error: invalid metadata: ''{0}''.
 error.invalid.metadata.filter=Invalid metadata filter request parameter ''{0}'' value ''{1}''.
 error.metadata.entity.not.found=Metadata entity with id ''{0}'' is not found.
+error.metadata.entity.already.exists=Metadata entity with external id ''{0}'' already exists.
 error.metadata.update.key.not.found=One and only one key should be passed to "updateKey" method. Actual number of passed keys: ''{0}''.
 error.metadata.entity.class.not.found=Failed to found metadata class by identifier: ''{0}''.
 error.metadata.upload.changed.type=Type ''{0}'' for field ''{1}'' does not match already present type ''{2}''.


### PR DESCRIPTION
Resolves issue #1613.

The pull request adds proper error message for metadata entity id creation with non unique external id.