### PR TITLE
Configure fixed SGE parallel environment slots

### DIFF
--- a/workflows/pipe-common/scripts/autoscale_sge.py
+++ b/workflows/pipe-common/scripts/autoscale_sge.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -172,9 +172,6 @@ class GridEngine:
     _MAIN_Q = os.getenv('CP_CAP_SGE_QUEUE_NAME', 'main.q')
     _ALL_HOSTS = '@allhosts'
     _DELETE_HOST = 'qconf -de %s'
-    _SHOW_PARALLEL_ENVIRONMENTS = 'qconf -spl'
-    _SHOW_PARALLEL_ENVIRONMENT_SLOTS = 'qconf -sp %s | grep "^slots" | awk \'{print $2}\''
-    _REPLACE_PARALLEL_ENVIRONMENT_SLOTS = 'qconf -rattr pe slots %s %s'
     _SHOW_JOB_PARALLEL_ENVIRONMENT = 'qstat -j %s | grep "^parallel environment" | awk \'{print $3}\''
     _SHOW_JOB_PARALLEL_ENVIRONMENT_SLOTS = 'qstat -j %s | grep "^parallel environment" | awk \'{print $5}\''
     _SHOW_PE_ALLOCATION_RULE = 'qconf -sp %s | grep "^allocation_rule" | awk \'{print $2}\''
@@ -301,41 +298,6 @@ class GridEngine:
         :param queue: Queue that host is a part of.
         """
         self.cmd_executor.execute(GridEngine._QMOD_ENABLE % (queue, host))
-
-    def increase_parallel_environment_slots(self, slots):
-        """
-        Increases the number of parallel environment slots.
-
-        :param slots: Number of slots to append.
-        """
-        for pe in self.get_parallel_environments():
-            pe_slots = self.get_parallel_environment_slots(pe)
-            self.cmd_executor.execute(GridEngine._REPLACE_PARALLEL_ENVIRONMENT_SLOTS % (pe_slots + slots, pe))
-
-    def decrease_parallel_environment_slots(self, slots):
-        """
-        Decreases the number of parallel environment slots.
-
-        :param slots: Number of slots to subtract.
-        """
-        for pe in self.get_parallel_environments():
-            pe_slots = self.get_parallel_environment_slots(pe)
-            self.cmd_executor.execute(GridEngine._REPLACE_PARALLEL_ENVIRONMENT_SLOTS % (pe_slots - slots, pe))
-
-    def get_parallel_environments(self):
-        """
-        Returns number of the parallel environment slots.
-
-        """
-        return self.cmd_executor.execute_to_lines(GridEngine._SHOW_PARALLEL_ENVIRONMENTS)
-
-    def get_parallel_environment_slots(self, pe):
-        """
-        Returns number of the parallel environment slots.
-
-        :param pe: Parallel environment to return number of slots for.
-        """
-        return int(self.cmd_executor.execute(GridEngine._SHOW_PARALLEL_ENVIRONMENT_SLOTS % pe).strip())
 
     def get_pe_allocation_rule(self, pe):
         """
@@ -612,7 +574,6 @@ class GridEngineScaleUpHandler:
         self._add_worker_to_master_hosts(pod)
         self._await_worker_initialization(run_id)
         self._enable_worker_in_grid_engine(pod)
-        self._increase_parallel_environment_slots(instance_to_run.cpu)
         Logger.info('Additional worker with host=%s and instance type=%s has been created.' % (pod.name, instance_to_run.name), crucial=True)
 
         # todo: Some delay is needed for GE to submit task to a new host.
@@ -741,11 +702,6 @@ class GridEngineScaleUpHandler:
         Logger.warn(error_msg, crucial=True)
         raise ScalingError(error_msg)
 
-    def _increase_parallel_environment_slots(self, slots_to_append):
-        Logger.info('Increase number of parallel environment slots by %s.' % slots_to_append)
-        self.grid_engine.increase_parallel_environment_slots(slots_to_append)
-        Logger.info('Number of parallel environment slots was increased.')
-
     def _update_last_activity_for_currently_running_jobs(self):
         jobs = self.grid_engine.get_jobs()
         running_jobs = [job for job in jobs if job.state == GridEngineJobState.RUNNING]
@@ -786,18 +742,11 @@ class GridEngineScaleDownHandler:
             Logger.info('Enable additional worker with host=%s again.' % child_host)
             self.grid_engine.enable_host(child_host)
             return False
-        child_host_slots = self.grid_engine.get_host_resource(child_host).cpu
         self._remove_host_from_grid_engine_configuration(child_host)
-        self._decrease_parallel_environment_slots(child_host_slots)
         self._stop_pipeline(child_host)
         self._remove_host_from_hosts(child_host)
         Logger.info('Additional worker with host=%s has been stopped.' % child_host, crucial=True)
         return True
-
-    def _decrease_parallel_environment_slots(self, slots_to_remove):
-        Logger.info('Decrease number of parallel environment slots by %s.' % slots_to_remove)
-        self.grid_engine.decrease_parallel_environment_slots(slots_to_remove)
-        Logger.info('Number of parallel environment slots was decreased.')
 
     def _remove_host_from_grid_engine_configuration(self, host):
         Logger.info('Remove additional worker with host=%s from GE cluster configuration.' % host)

--- a/workflows/pipe-common/shell/sge_setup_master
+++ b/workflows/pipe-common/shell/sge_setup_master
@@ -222,7 +222,7 @@ configure_pe() {
     if [ -z "$pe_slots" ]; then
         pe_slots=${CLOUD_PIPELINE_CLUSTER_CORES:-999999}
     fi
-    
+
     cat > pe.conf <<EOL
         pe_name            $pe_name
         slots              $pe_slots
@@ -327,7 +327,9 @@ export SGE_CELL="default"
 export SGE_CLUSTER_NAME="CLOUD_PIPELINE"
 export CP_CAP_SGE_QUEUE_NAME="${CP_CAP_SGE_QUEUE_NAME:-main.q}"
 export CP_CAP_SGE_PE_NAME="${CP_CAP_SGE_PE_NAME:-local}"
+export CP_CAP_SGE_PE_SLOTS="${CP_CAP_SGE_PE_SLOTS:-999999}"
 export CP_CAP_SGE_PE_MPI_NAME="${CP_CAP_SGE_PE_MPI_NAME:-mpi}"
+export CP_CAP_SGE_PE_MPI_SLOTS="${CP_CAP_SGE_PE_MPI_SLOTS:-999999}"
 export CP_CAP_SGE_WORKER_FREE_CORES="${CP_CAP_SGE_WORKER_FREE_CORES:-0}"
 
 if [ "$LINUX_DISTRIBUTION" = "debian" ]; then
@@ -344,7 +346,9 @@ echo "export SGE_CELL=$SGE_CELL" >> $CP_CAP_SGE_MASTER_ENV_FILE
 echo "export SGE_CLUSTER_NAME=$SGE_CLUSTER_NAME" >> $CP_CAP_SGE_MASTER_ENV_FILE
 echo "export CP_CAP_SGE_QUEUE_NAME=$CP_CAP_SGE_QUEUE_NAME" >> $CP_CAP_SGE_MASTER_ENV_FILE
 echo "export CP_CAP_SGE_PE_NAME=$CP_CAP_SGE_PE_NAME" >> $CP_CAP_SGE_MASTER_ENV_FILE
+echo "export CP_CAP_SGE_PE_SLOTS=$CP_CAP_SGE_PE_SLOTS" >> $CP_CAP_SGE_MASTER_ENV_FILE
 echo "export CP_CAP_SGE_PE_MPI_NAME=$CP_CAP_SGE_PE_MPI_NAME" >> $CP_CAP_SGE_MASTER_ENV_FILE
+echo "export CP_CAP_SGE_PE_MPI_SLOTS=$CP_CAP_SGE_PE_MPI_SLOTS" >> $CP_CAP_SGE_MASTER_ENV_FILE
 echo "export CP_CAP_SGE_WORKER_FREE_CORES=$CP_CAP_SGE_WORKER_FREE_CORES" >> $CP_CAP_SGE_MASTER_ENV_FILE
 cat $CP_CAP_SGE_MASTER_ENV_FILE >> /etc/cp_env.sh
 
@@ -383,7 +387,7 @@ if [ "$LINUX_DISTRIBUTION" = "debian" ]; then
         # Install Grid Engine
         # Configure the master hostname for Grid Engine
         CP_CAP_SGE_VERSION="${CP_CAP_SGE_VERSION:-8.1.9+dfsg-4*}"
-        
+
         # First install SGE, and fail if error occurs
         DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" gridengine-exec="$CP_CAP_SGE_VERSION" \
             gridengine-client="$CP_CAP_SGE_VERSION" \
@@ -516,11 +520,13 @@ delete_pe all
 # - Add a "threaded/smp" PE, which schedules all threads to a single machine
 configure_pe "$CP_CAP_SGE_PE_NAME" \
              "\$pe_slots" \
-             "TRUE"
+             "TRUE" \
+             "$CP_CAP_SGE_PE_SLOTS"
 # - Add an "mpi" PE, which allows to spread processes across nodes
 configure_pe "$CP_CAP_SGE_PE_MPI_NAME" \
              "\$fill_up" \
-             "FALSE"
+             "FALSE" \
+             "$CP_CAP_SGE_PE_MPI_SLOTS"
 # - Add any other user-provided PEs
 if [ "$CP_CAP_SGE_EXTRA_PE_PATH" ] && [ -d "$CP_CAP_SGE_EXTRA_PE_PATH" ]; then
     pipe_log_info "Extra PEs are provided via ${CP_CAP_SGE_EXTRA_PE_PATH}, setting them up" "$SGE_MASTER_SETUP_TASK"


### PR DESCRIPTION
Resolves issue #948 and relates to #1521.

The pull request configures fixed parallel environment slots. It reduces autoscaling complexity because where is no need to autoscale parallel environment slots. Additionally it allows to use several independent SGE autoscaling proccesses in a single run.