### PR TITLE
Issue #1637 Node Pool filters

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/ReassignHandler.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/ReassignHandler.java
@@ -17,12 +17,18 @@ package com.epam.pipeline.manager.cluster.autoscale;
 
 import com.epam.pipeline.entity.cluster.InstanceDisk;
 import com.epam.pipeline.entity.cluster.pool.InstanceRequest;
+import com.epam.pipeline.entity.cluster.pool.NodePool;
 import com.epam.pipeline.entity.cluster.pool.RunningInstance;
+import com.epam.pipeline.entity.cluster.pool.filter.PoolFilter;
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.PoolInstanceFilter;
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.PoolInstanceFilterType;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.manager.cloud.CloudFacade;
+import com.epam.pipeline.manager.cluster.autoscale.filter.PoolFilterHandler;
 import com.epam.pipeline.manager.pipeline.PipelineRunManager;
+import com.epam.pipeline.utils.CommonUtils;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -31,17 +37,29 @@ import org.springframework.stereotype.Component;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
 
 @Component
-@RequiredArgsConstructor
 @Slf4j
 public class ReassignHandler {
 
     private final AutoscalerService autoscalerService;
     private final CloudFacade cloudFacade;
     private final PipelineRunManager pipelineRunManager;
+    private final Map<PoolInstanceFilterType, PoolFilterHandler> filterHandlers;
+
+
+    public ReassignHandler(final AutoscalerService autoscalerService,
+                           final CloudFacade cloudFacade,
+                           final PipelineRunManager pipelineRunManager,
+                           final List<PoolFilterHandler> filterHandlers) {
+        this.autoscalerService = autoscalerService;
+        this.cloudFacade = cloudFacade;
+        this.pipelineRunManager = pipelineRunManager;
+        this.filterHandlers = CommonUtils.groupByKey(filterHandlers, PoolFilterHandler::type);
+    }
 
     public boolean tryReassignNode(final KubernetesClient client,
                                    final Set<String> scheduledRuns,
@@ -56,10 +74,10 @@ public class ReassignHandler {
                     (map, id) -> map.put(id, autoscalerService.getPreviousRunInstance(id, client)),
                     HashMap::putAll);
         // Try to find match with pre-pulled image
-        final boolean matchWithImages = attemptReassign(freeInstances,
+        final boolean reassignedWithMatchingImage = attemptReassign(freeInstances,
                 autoscalerService::requirementsMatchWithImages, requiredInstance, runId,
                 longId, scheduledRuns, reassignedNodes);
-        if (matchWithImages) {
+        if (reassignedWithMatchingImage) {
             return true;
         }
         return attemptReassign(freeInstances,
@@ -83,8 +101,46 @@ public class ReassignHandler {
                     if (!matcher.apply(previousInstance, requiredInstance)) {
                         return false;
                     }
+                    final boolean passedPoolFilter = Optional.ofNullable(previousInstance.getPool())
+                            .map(pool -> matchesPoolFilter(pool, longId))
+                            .orElse(true);
+                    if (!passedPoolFilter) {
+                        return false;
+                    }
                     return reassignInstance(runId, longId, scheduledRuns, reassignedNodes,
                             previousId, previousInstance);
+                });
+    }
+
+    private boolean matchesPoolFilter(final NodePool pool, final Long runId) {
+        final PoolFilter filter = pool.getFilter();
+        if (filter == null || filter.isEmpty()) {
+            return true;
+        }
+        return pipelineRunManager.findRun(runId)
+                .map(run -> matchRun(filter, run))
+                .orElse(false);
+    }
+
+    private boolean matchRun(final PoolFilter filter, final PipelineRun run) {
+        final List<PoolInstanceFilter> filters = filter.getFilters();
+        switch (filter.getOperator()) {
+            case AND:
+                return filters.stream().allMatch(f -> matchRunToFilter(f, run));
+            case OR:
+                return filters.stream().anyMatch(f -> matchRunToFilter(f, run));
+            default:
+                throw new IllegalArgumentException("Unsupported filter operator: " + filter.getOperator());
+        }
+    }
+
+    private boolean matchRunToFilter(final PoolInstanceFilter filter, final PipelineRun run) {
+        log.debug("Matching run {} to filter pool filter {}.", run.getId(), filter);
+        return Optional.ofNullable(filterHandlers.get(filter.getType()))
+                .map(handler -> handler.matches(filter, run))
+                .orElseGet(() -> {
+                    log.debug("Failed to find a handler for pool filter {}.", filter);
+                    return false;
                 });
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/filter/ConfigurationFilterHandler.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/filter/ConfigurationFilterHandler.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster.autoscale.filter;
+
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.ConfigurationPoolInstanceFilter;
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.PoolInstanceFilterType;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class ConfigurationFilterHandler implements PoolFilterHandler<Long, ConfigurationPoolInstanceFilter> {
+
+    @Override
+    public boolean matches(final ConfigurationPoolInstanceFilter filter, final PipelineRun run) {
+        final Long configurationId = run.getConfigurationId();
+        log.debug("Matching run {} configuration id {} to filter {}.", run.getId(), configurationId, filter);
+        return filter.evaluate(configurationId);
+    }
+
+    @Override
+    public PoolInstanceFilterType type() {
+        return PoolInstanceFilterType.CONFIGURATION_ID;
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/filter/DockerImageFilterHandler.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/filter/DockerImageFilterHandler.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster.autoscale.filter;
+
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.DockerPoolInstanceFilter;
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.PoolInstanceFilterType;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class DockerImageFilterHandler implements PoolFilterHandler<String, DockerPoolInstanceFilter> {
+
+    @Override
+    public boolean matches(final DockerPoolInstanceFilter filter, final PipelineRun run) {
+        final String dockerImage = run.getActualDockerImage();
+        log.debug("Matching run {} docker {} to filter {}.", run.getId(), dockerImage, filter);
+        return filter.evaluate(dockerImage);
+    }
+
+    @Override
+    public PoolInstanceFilterType type() {
+        return PoolInstanceFilterType.DOCKER_IMAGE;
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/filter/ParameterFilterHandler.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/filter/ParameterFilterHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster.autoscale.filter;
+
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.ParameterPoolInstanceFilter;
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.PoolInstanceFilterType;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.ListUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@Slf4j
+public class ParameterFilterHandler implements
+        PoolFilterHandler<Map<String, String>, ParameterPoolInstanceFilter> {
+    @Override
+    public boolean matches(final ParameterPoolInstanceFilter filter, final PipelineRun run) {
+        final Map<String, String> params = ListUtils.emptyIfNull(run.getPipelineRunParameters())
+                .stream()
+                .collect(HashMap::new, (m, v) -> m.put(v.getName(), v.getValue()), HashMap::putAll);
+        log.debug("Matching run {} parameters {} to filter {}.", run.getId(), params, filter);
+        return filter.evaluate(params);
+    }
+
+    @Override
+    public PoolInstanceFilterType type() {
+        return PoolInstanceFilterType.RUN_PARAMETER;
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/filter/PipelineFilterHandler.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/filter/PipelineFilterHandler.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster.autoscale.filter;
+
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.PipelinePoolInstanceFilter;
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.PoolInstanceFilterType;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class PipelineFilterHandler implements PoolFilterHandler<Long, PipelinePoolInstanceFilter> {
+
+    @Override
+    public boolean matches(final PipelinePoolInstanceFilter filter, final PipelineRun run) {
+        final Long pipelineId = run.getPipelineId();
+        log.debug("Matching run {} pipeline id {} to filter {}.", run.getId(), pipelineId, filter);
+        return filter.evaluate(pipelineId);
+    }
+
+    @Override
+    public PoolInstanceFilterType type() {
+        return PoolInstanceFilterType.PIPELINE_ID;
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/filter/PoolFilterHandler.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/filter/PoolFilterHandler.java
@@ -13,30 +13,14 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.entity.cluster.pool.filter.value;
+package com.epam.pipeline.manager.cluster.autoscale.filter;
 
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.PoolInstanceFilter;
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.PoolInstanceFilterType;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
 
-import java.util.Objects;
+public interface PoolFilterHandler<E, T extends PoolInstanceFilter<E>> {
 
-@Data
-@NoArgsConstructor
-public class LongFilterValue implements FilterValue<Long> {
-
-    private Long value;
-
-    public LongFilterValue(final Long value) {
-        this.value = value;
-    }
-
-    @Override
-    public boolean matches(final Long anotherValue) {
-        return Objects.equals(getValue(), anotherValue);
-    }
-
-    @Override
-    public boolean empty(final Long anotherValue) {
-        return Objects.isNull(getValue());
-    }
+    boolean matches(T filter, PipelineRun run);
+    PoolInstanceFilterType type();
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/filter/RunOwnerFilterHandler.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/filter/RunOwnerFilterHandler.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster.autoscale.filter;
+
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.PoolInstanceFilterType;
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.RunOwnerPoolInstanceFilter;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class RunOwnerFilterHandler implements PoolFilterHandler<String, RunOwnerPoolInstanceFilter> {
+
+    @Override
+    public boolean matches(final RunOwnerPoolInstanceFilter filter, final PipelineRun run) {
+        final String owner = run.getOwner();
+        log.debug("Matching run {} owner {} to filter {}.", run.getId(), owner, filter);
+        return filter.evaluate(owner);
+    }
+
+    @Override
+    public PoolInstanceFilterType type() {
+        return PoolInstanceFilterType.RUN_OWNER;
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/filter/RunOwnerGroupFilterHandler.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/filter/RunOwnerGroupFilterHandler.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster.autoscale.filter;
+
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.PoolInstanceFilterType;
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.RunOwnerGroupPoolInstanceFilter;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.manager.user.UserManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.SetUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RunOwnerGroupFilterHandler implements PoolFilterHandler<String, RunOwnerGroupPoolInstanceFilter> {
+
+    private final UserManager userManager;
+
+    @Override
+    public boolean matches(final RunOwnerGroupPoolInstanceFilter filter, final PipelineRun run) {
+        log.debug("Matching run {} owner groups {} to filter {}.", run.getId(), run.getOwner(), filter);
+        return Optional.ofNullable(userManager.loadUserByName(run.getOwner()))
+                .map(user -> filter.evaluate(SetUtils.emptyIfNull(user.getAuthorities())))
+                .orElse(false);
+    }
+
+    @Override
+    public PoolInstanceFilterType type() {
+        return PoolInstanceFilterType.RUN_OWNER_GROUP;
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -470,6 +470,11 @@ public class PipelineRunManager {
     }
 
     @Transactional(propagation = Propagation.SUPPORTS)
+    public Optional<PipelineRun> findRun(final Long id) {
+        return Optional.ofNullable(pipelineRunDao.loadPipelineRun(id));
+    }
+
+    @Transactional(propagation = Propagation.SUPPORTS)
     public AbstractSecuredEntity loadRunParent(Long runId) {
         PipelineRun run = loadPipelineRun(runId);
         return loadRunParent(run);

--- a/api/src/main/resources/dao/node-pool-dao.xml
+++ b/api/src/main/resources/dao/node-pool-dao.xml
@@ -32,6 +32,7 @@
                         docker_image,
                         instance_image,
                         instance_count,
+                        filter,
                         schedule_id
                         )
                     VALUES (
@@ -44,6 +45,7 @@
                         :POOL_DOCKER_IMAGE,
                         :POOL_INSTANCE_IMAGE,
                         :POOL_INSTANCE_COUNT,
+                        :POOL_FILTER,
                         :SCHEDULE_ID)
                 ]]>
             </value>
@@ -55,6 +57,7 @@
                     UPDATE pipeline.node_pool SET
                         name = :POOL_NAME,
                         instance_count = :POOL_INSTANCE_COUNT,
+                        filter = :POOL_FILTER,
                         schedule_id = :SCHEDULE_ID
                     WHERE
                         id = :POOL_ID
@@ -85,6 +88,7 @@
                         n.docker_image as POOL_DOCKER_IMAGE,
                         n.instance_image as POOL_INSTANCE_IMAGE,
                         n.instance_count as POOL_INSTANCE_COUNT,
+                        n.filter as POOL_FILTER,
                         n.schedule_id as SCHEDULE_ID,
                         s.name as SCHEDULE_NAME,
                         s.created_date as SCHEDULE_CREATED_DATE,
@@ -116,6 +120,7 @@
                         n.docker_image as POOL_DOCKER_IMAGE,
                         n.instance_image as POOL_INSTANCE_IMAGE,
                         n.instance_count as POOL_INSTANCE_COUNT,
+                        n.filter as POOL_FILTER,
                         n.schedule_id as SCHEDULE_ID,
                         s.name as SCHEDULE_NAME,
                         s.created_date as SCHEDULE_CREATED_DATE,

--- a/api/src/main/resources/db/migration/v2020.12.08_19.00__issue_1637_node_pool_filters.sql
+++ b/api/src/main/resources/db/migration/v2020.12.08_19.00__issue_1637_node_pool_filters.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pipeline.node_pool ADD filter TEXT;

--- a/api/src/test/java/com/epam/pipeline/dao/cluster/pool/NodePoolDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/cluster/pool/NodePoolDaoTest.java
@@ -18,8 +18,8 @@ package com.epam.pipeline.dao.cluster.pool;
 import com.epam.pipeline.AbstractSpringTest;
 import com.epam.pipeline.entity.cluster.pool.NodePool;
 import com.epam.pipeline.entity.cluster.pool.NodeSchedule;
-import com.epam.pipeline.test.creator.cluster.schedule.NodeScheduleCreatorUtils;
 import com.epam.pipeline.test.creator.cluster.schedule.NodePoolCreatorUtils;
+import com.epam.pipeline.test.creator.cluster.schedule.NodeScheduleCreatorUtils;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
 
 @Transactional
 public class NodePoolDaoTest extends AbstractSpringTest {
@@ -45,6 +44,15 @@ public class NodePoolDaoTest extends AbstractSpringTest {
     @Test
     public void shouldCreateAndLoadNewPoolWithoutSchedule() {
         final NodePool pool = NodePoolCreatorUtils.getPoolWithoutSchedule();
+        final NodePool created = poolDao.create(pool);
+        assertThat(created.getId()).isNotNull();
+        findAndAssertPool(created);
+    }
+
+    @Test
+    public void shouldCreateAndLoadNewPoolWithFilter() {
+        final NodePool pool = NodePoolCreatorUtils.getPoolWithoutSchedule();
+        pool.setFilter(NodePoolCreatorUtils.getAllFilters());
         final NodePool created = poolDao.create(pool);
         assertThat(created.getId()).isNotNull();
         findAndAssertPool(created);

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/autoscale/filter/ConfigurationFilterHandlerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/autoscale/filter/ConfigurationFilterHandlerTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster.autoscale.filter;
+
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.ConfigurationPoolInstanceFilter;
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.PoolInstanceFilterOperator;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ConfigurationFilterHandlerTest {
+
+    private static final long CONFIGURATION_ID_1 = 1L;
+    private static final long CONFIGURATION_ID_2 = 2L;
+    private final ConfigurationFilterHandler handler = new ConfigurationFilterHandler();
+
+    @Test
+    public void shouldPassEqualFilterWithMatchingId() {
+        final PipelineRun run = getRunWithConfigurationId(CONFIGURATION_ID_1);
+        final ConfigurationPoolInstanceFilter filter =
+                getFilter(PoolInstanceFilterOperator.EQUAL, CONFIGURATION_ID_1);
+        assertTrue(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldFailEqualFilterWithNonMatchingId() {
+        final PipelineRun run = getRunWithConfigurationId(CONFIGURATION_ID_1);
+        final ConfigurationPoolInstanceFilter filter =
+                getFilter(PoolInstanceFilterOperator.EQUAL, CONFIGURATION_ID_2);
+        assertFalse(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldPassNotEqualFilterWithNotMatchingId() {
+        final PipelineRun run = getRunWithConfigurationId(CONFIGURATION_ID_2);
+        final ConfigurationPoolInstanceFilter filter =
+                getFilter(PoolInstanceFilterOperator.NOT_EQUAL, CONFIGURATION_ID_1);
+        assertTrue(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldFailNotEqualFilterWithMatchingId() {
+        final PipelineRun run = getRunWithConfigurationId(CONFIGURATION_ID_1);
+        final ConfigurationPoolInstanceFilter filter =
+                getFilter(PoolInstanceFilterOperator.NOT_EQUAL, CONFIGURATION_ID_1);
+        assertFalse(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldPassEmptyFilterWithoutId() {
+        final PipelineRun run = getRunWithConfigurationId(null);
+        final ConfigurationPoolInstanceFilter filter =
+                getFilter(PoolInstanceFilterOperator.EMPTY, null);
+        assertTrue(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldFailEmptyFilterWithId() {
+        final PipelineRun run = getRunWithConfigurationId(CONFIGURATION_ID_1);
+        final ConfigurationPoolInstanceFilter filter =
+                getFilter(PoolInstanceFilterOperator.EMPTY, null);
+        assertFalse(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldFailNotEmptyFilterWithoutId() {
+        final PipelineRun run = getRunWithConfigurationId(null);
+        final ConfigurationPoolInstanceFilter filter =
+                getFilter(PoolInstanceFilterOperator.NOT_EMPTY, null);
+        assertFalse(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldPassNotEmptyFilterWithId() {
+        final PipelineRun run = getRunWithConfigurationId(CONFIGURATION_ID_1);
+        final ConfigurationPoolInstanceFilter filter =
+                getFilter(PoolInstanceFilterOperator.NOT_EMPTY, null);
+        assertTrue(handler.matches(filter, run));
+    }
+
+    private PipelineRun getRunWithConfigurationId(final Long configurationId) {
+        final PipelineRun run = new PipelineRun();
+        run.setConfigurationId(configurationId);
+        return run;
+    }
+
+    private ConfigurationPoolInstanceFilter getFilter(final PoolInstanceFilterOperator operator,
+                                                      final Long value) {
+        final ConfigurationPoolInstanceFilter filter = new ConfigurationPoolInstanceFilter();
+        filter.setOperator(operator);
+        filter.setValue(value);
+        return filter;
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/autoscale/filter/DockerImageFilterHandlerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/autoscale/filter/DockerImageFilterHandlerTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster.autoscale.filter;
+
+
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.DockerPoolInstanceFilter;
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.PoolInstanceFilterOperator;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DockerImageFilterHandlerTest {
+
+    private static final String CENTOS_IMAGE = "library/centos:7";
+    private static final String UBUNTU_IMAGE = "library/ubuntu:18";
+    private final DockerImageFilterHandler handler = new DockerImageFilterHandler();
+
+    @Test
+    public void shouldPassEqualFilterWithMatchingDocker() {
+        final PipelineRun run = getRunWithDocker(CENTOS_IMAGE);
+        final DockerPoolInstanceFilter filter = getFilter(PoolInstanceFilterOperator.EQUAL, CENTOS_IMAGE);
+        assertTrue(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldPassNotEqualFilterWithNotMatchingDocker() {
+        final PipelineRun run = getRunWithDocker(CENTOS_IMAGE);
+        final DockerPoolInstanceFilter filter = getFilter(PoolInstanceFilterOperator.NOT_EQUAL, UBUNTU_IMAGE);
+        assertTrue(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldFailEqualFilterWithNotMatchingDocker() {
+        final PipelineRun run = getRunWithDocker(UBUNTU_IMAGE);
+        final DockerPoolInstanceFilter filter = getFilter(PoolInstanceFilterOperator.EQUAL, CENTOS_IMAGE);
+        assertFalse(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldFailNotEqualFilterWithMatchingDocker() {
+        final PipelineRun run = getRunWithDocker(CENTOS_IMAGE);
+        final DockerPoolInstanceFilter filter = getFilter(PoolInstanceFilterOperator.NOT_EQUAL, CENTOS_IMAGE);
+        assertFalse(handler.matches(filter, run));
+    }
+
+    private PipelineRun getRunWithDocker(final String centosImage) {
+        final PipelineRun run = new PipelineRun();
+        run.setActualDockerImage(centosImage);
+        return run;
+    }
+
+    public DockerPoolInstanceFilter getFilter(final PoolInstanceFilterOperator equal,
+                                              final String dockerImage) {
+        final DockerPoolInstanceFilter filter = new DockerPoolInstanceFilter();
+        filter.setOperator(equal);
+        filter.setValue(dockerImage);
+        return filter;
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/autoscale/filter/ParameterFilterHandlerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/autoscale/filter/ParameterFilterHandlerTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster.autoscale.filter;
+
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.ParameterPoolInstanceFilter;
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.PoolInstanceFilterOperator;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.pipeline.run.parameter.PipelineRunParameter;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ParameterFilterHandlerTest {
+
+    private static final String KEY_1 = "key1";
+    private static final String KEY_2 = "key2";
+    private static final String VAL_1 = "val1";
+    private static final String VAL_2 = "val2";
+    private final ParameterFilterHandler handler = new ParameterFilterHandler();
+
+    @Test
+    public void shouldPassEqualFilterWhenParameterValueMatches() {
+        final ParameterPoolInstanceFilter filter =
+                getFilter(PoolInstanceFilterOperator.EQUAL, Collections.singletonMap(KEY_1, VAL_1));
+        final PipelineRun run = getRunWithParameters(
+                new ImmutablePair<>(KEY_1, VAL_1),
+                new ImmutablePair<>(KEY_2, VAL_2));
+        assertTrue(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldFailEqualFilterWhenParameterValueNotMatches() {
+        final ParameterPoolInstanceFilter filter =
+                getFilter(PoolInstanceFilterOperator.EQUAL, Collections.singletonMap(KEY_1, VAL_2));
+        final PipelineRun run = getRunWithParameters(Collections.singletonMap(KEY_1, VAL_1));
+        assertFalse(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldFailEqualFilterWhenParameterNotPresent() {
+        final ParameterPoolInstanceFilter filter =
+                getFilter(PoolInstanceFilterOperator.EQUAL, Collections.singletonMap(KEY_2, VAL_2));
+        final PipelineRun run = getRunWithParameters(Collections.singletonMap(KEY_1, VAL_1));
+        assertFalse(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldPassNotEqualFilterWhenParameterNotPresent() {
+        final ParameterPoolInstanceFilter filter =
+                getFilter(PoolInstanceFilterOperator.NOT_EQUAL, Collections.singletonMap(KEY_2, VAL_2));
+        final PipelineRun run = getRunWithParameters(Collections.singletonMap(KEY_1, VAL_1));
+        assertTrue(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldPassNotEqualFilterWhenParameterValueNotMatches() {
+        final ParameterPoolInstanceFilter filter =
+                getFilter(PoolInstanceFilterOperator.NOT_EQUAL, Collections.singletonMap(KEY_2, VAL_2));
+        final PipelineRun run = getRunWithParameters(
+                new ImmutablePair<>(KEY_1, VAL_1),
+                new ImmutablePair<>(KEY_2, VAL_1));
+        assertTrue(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldFailNotEqualFilterWhenParameterValueMatches() {
+        final ParameterPoolInstanceFilter filter =
+                getFilter(PoolInstanceFilterOperator.NOT_EQUAL, Collections.singletonMap(KEY_1, VAL_1));
+        final PipelineRun run = getRunWithParameters(Collections.singletonMap(KEY_1, VAL_1));
+        assertFalse(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldPassEmptyFilterWhenParameterIsNotPresent() {
+        final ParameterPoolInstanceFilter filter =
+                getFilter(PoolInstanceFilterOperator.EMPTY, Collections.singletonMap(KEY_1, null));
+        final PipelineRun run = getRunWithParameters(Collections.singletonMap(KEY_2, VAL_2));
+        assertTrue(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldPassEmptyFilterWhenParameterHasNoValue() {
+        final ParameterPoolInstanceFilter filter =
+                getFilter(PoolInstanceFilterOperator.EMPTY, Collections.singletonMap(KEY_1, null));
+        final PipelineRun run = getRunWithParameters(Collections.singletonMap(KEY_1, null));
+        assertTrue(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldFailEmptyFilterWhenParameterHasValue() {
+        final ParameterPoolInstanceFilter filter =
+                getFilter(PoolInstanceFilterOperator.EMPTY, Collections.singletonMap(KEY_1, null));
+        final PipelineRun run = getRunWithParameters(Collections.singletonMap(KEY_1, VAL_2));
+        assertFalse(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldPassNotEmptyFilterWhenParameterIsPresent() {
+        final ParameterPoolInstanceFilter filter =
+                getFilter(PoolInstanceFilterOperator.NOT_EMPTY, Collections.singletonMap(KEY_1, null));
+        final PipelineRun run = getRunWithParameters(Collections.singletonMap(KEY_1, VAL_1));
+        assertTrue(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldPassNotEmptyFilterWhenParameterHasValue() {
+        final ParameterPoolInstanceFilter filter =
+                getFilter(PoolInstanceFilterOperator.NOT_EMPTY, Collections.singletonMap(KEY_1, null));
+        final PipelineRun run = getRunWithParameters(Collections.singletonMap(KEY_1, VAL_1));
+        assertTrue(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldFailNotEmptyFilterWhenParameterIsNotPresent() {
+        final ParameterPoolInstanceFilter filter =
+                getFilter(PoolInstanceFilterOperator.NOT_EMPTY, Collections.singletonMap(KEY_1, null));
+        final PipelineRun run = getRunWithParameters(Collections.singletonMap(KEY_2, VAL_2));
+        assertFalse(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldFailNotEmptyFilterWhenParameterHasNoValue() {
+        final ParameterPoolInstanceFilter filter =
+                getFilter(PoolInstanceFilterOperator.NOT_EMPTY, Collections.singletonMap(KEY_1, null));
+        final PipelineRun run = getRunWithParameters(Collections.singletonMap(KEY_1, null));
+        assertFalse(handler.matches(filter, run));
+    }
+
+    private PipelineRun getRunWithParameters(final Map<String, String> parameters) {
+        final PipelineRun pipelineRun = new PipelineRun();
+        pipelineRun.setPipelineRunParameters(parameters.entrySet()
+                .stream()
+                .map(entry -> new PipelineRunParameter(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toList()));
+        return pipelineRun;
+    }
+
+    private PipelineRun getRunWithParameters(final Pair<String, String>... parameters) {
+        final PipelineRun pipelineRun = new PipelineRun();
+        pipelineRun.setPipelineRunParameters(Arrays.stream(parameters)
+                .map(entry -> new PipelineRunParameter(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toList()));
+        return pipelineRun;
+    }
+
+    private ParameterPoolInstanceFilter getFilter(final PoolInstanceFilterOperator operator,
+                                                  final Map<String, String> values) {
+        final ParameterPoolInstanceFilter filter = new ParameterPoolInstanceFilter();
+        filter.setValue(values);
+        filter.setOperator(operator);
+        return filter;
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/autoscale/filter/PipelineFilterHandlerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/autoscale/filter/PipelineFilterHandlerTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster.autoscale.filter;
+
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.PipelinePoolInstanceFilter;
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.PoolInstanceFilterOperator;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+public class PipelineFilterHandlerTest {
+
+    private static final long PIPELINE_ID_1 = 1L;
+    private static final long PIPELINE_ID_2 = 2L;
+    private final PipelineFilterHandler handler = new PipelineFilterHandler();
+
+    @Test
+    public void shouldPassEqualFilterWithMatchingId() {
+        final PipelineRun run = getRunWithPipelineId(PIPELINE_ID_1);
+        final PipelinePoolInstanceFilter filter =
+                getFilter(PoolInstanceFilterOperator.EQUAL, PIPELINE_ID_1);
+        assertTrue(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldFailEqualFilterWithNonMatchingId() {
+        final PipelineRun run = getRunWithPipelineId(PIPELINE_ID_1);
+        final PipelinePoolInstanceFilter filter =
+                getFilter(PoolInstanceFilterOperator.EQUAL, PIPELINE_ID_2);
+        assertFalse(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldPassNotEqualFilterWithNotMatchingId() {
+        final PipelineRun run = getRunWithPipelineId(PIPELINE_ID_2);
+        final PipelinePoolInstanceFilter filter =
+                getFilter(PoolInstanceFilterOperator.NOT_EQUAL, PIPELINE_ID_1);
+        assertTrue(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldFailNotEqualFilterWithMatchingId() {
+        final PipelineRun run = getRunWithPipelineId(PIPELINE_ID_1);
+        final PipelinePoolInstanceFilter filter =
+                getFilter(PoolInstanceFilterOperator.NOT_EQUAL, PIPELINE_ID_1);
+        assertFalse(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldPassEmptyFilterWithoutId() {
+        final PipelineRun run = getRunWithPipelineId(null);
+        final PipelinePoolInstanceFilter filter =
+                getFilter(PoolInstanceFilterOperator.EMPTY, null);
+        assertTrue(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldFailEmptyFilterWithId() {
+        final PipelineRun run = getRunWithPipelineId(PIPELINE_ID_1);
+        final PipelinePoolInstanceFilter filter =
+                getFilter(PoolInstanceFilterOperator.EMPTY, null);
+        assertFalse(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldFailNotEmptyFilterWithoutId() {
+        final PipelineRun run = getRunWithPipelineId(null);
+        final PipelinePoolInstanceFilter filter =
+                getFilter(PoolInstanceFilterOperator.NOT_EMPTY, null);
+        assertFalse(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldPassNotEmptyFilterWithId() {
+        final PipelineRun run = getRunWithPipelineId(PIPELINE_ID_1);
+        final PipelinePoolInstanceFilter filter =
+                getFilter(PoolInstanceFilterOperator.NOT_EMPTY, null);
+        assertTrue(handler.matches(filter, run));
+    }
+
+    private PipelineRun getRunWithPipelineId(final Long pipelineId) {
+        final PipelineRun run = new PipelineRun();
+        run.setPipelineId(pipelineId);
+        return run;
+    }
+
+    private PipelinePoolInstanceFilter getFilter(final PoolInstanceFilterOperator operator,
+                                                 final Long value) {
+        final PipelinePoolInstanceFilter filter = new PipelinePoolInstanceFilter();
+        filter.setOperator(operator);
+        filter.setValue(value);
+        return filter;
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/autoscale/filter/RunOwnerFilterHandlerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/autoscale/filter/RunOwnerFilterHandlerTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster.autoscale.filter;
+
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.PoolInstanceFilterOperator;
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.RunOwnerPoolInstanceFilter;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class RunOwnerFilterHandlerTest {
+
+    public static final String USER = "USER";
+    private static final String FILTER_USER = "pipe_admin";
+    private static final String PIPE_ADMIN = "PIPE_ADMIN";
+    private final RunOwnerFilterHandler handler = new RunOwnerFilterHandler();
+
+    @Test
+    public void shouldPassEqualFilterWithMatchingOwner() {
+        final RunOwnerPoolInstanceFilter filter = getFilter(PoolInstanceFilterOperator.EQUAL);
+        final PipelineRun run = getRunWithOwner(PIPE_ADMIN);
+        assertTrue(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldFailNotEqualFilterWithMatchingOwner() {
+        final RunOwnerPoolInstanceFilter filter = getFilter(PoolInstanceFilterOperator.NOT_EQUAL);
+        final PipelineRun run = getRunWithOwner(PIPE_ADMIN);
+        assertFalse(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldFailEqualFilterWithNonMatchingOwner() {
+        final RunOwnerPoolInstanceFilter filter = getFilter(PoolInstanceFilterOperator.EQUAL);
+        final PipelineRun run = getRunWithOwner("USER");
+        assertFalse(handler.matches(filter, run));
+    }
+
+    @Test
+    public void shouldPassNotEqualFilterWithNonMatchingOwner() {
+        final RunOwnerPoolInstanceFilter filter = getFilter(PoolInstanceFilterOperator.NOT_EQUAL);
+        final PipelineRun run = getRunWithOwner(USER);
+        assertTrue(handler.matches(filter, run));
+    }
+
+    private RunOwnerPoolInstanceFilter getFilter(final PoolInstanceFilterOperator equal) {
+        final RunOwnerPoolInstanceFilter filter = new RunOwnerPoolInstanceFilter();
+        filter.setValue(FILTER_USER);
+        filter.setOperator(equal);
+        return filter;
+    }
+
+    private PipelineRun getRunWithOwner(final String pipeAdmin) {
+        final PipelineRun run = new PipelineRun();
+        run.setOwner(pipeAdmin);
+        return run;
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/autoscale/filter/RunOwnerGroupFilterHandlerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/autoscale/filter/RunOwnerGroupFilterHandlerTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster.autoscale.filter;
+
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.PoolInstanceFilterOperator;
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.RunOwnerGroupPoolInstanceFilter;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.entity.user.Role;
+import com.epam.pipeline.manager.user.UserManager;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+
+public class RunOwnerGroupFilterHandlerTest {
+
+    private static final String USER_NAME = "USER";
+    private static final String GROUP_1 = "GROUP1";
+    private static final String GROUP_2 = "GROUP2";
+    private static final String GROUP_3 = "group3";
+    private static final String ROLE_USER = "ROLE_USER";
+    private static final String ROLE_MANAGER = "ROLE_MANAGER";
+
+    private final UserManager userManager = Mockito.mock(UserManager.class);
+    private final RunOwnerGroupFilterHandler handler = new RunOwnerGroupFilterHandler(userManager);
+
+    @Test
+    public void shouldPassEqualFilterWithMatchingGroup() {
+        initUserWithGroups(GROUP_1, GROUP_2);
+        final PipelineRun pipelineRun = getRunWithOwner();
+        final RunOwnerGroupPoolInstanceFilter filter = getFilter(PoolInstanceFilterOperator.EQUAL, GROUP_1);
+        assertTrue(handler.matches(filter, pipelineRun));
+    }
+
+    @Test
+    public void shouldPassEqualFilterWithMatchingRole() {
+        initUserWithRoles(ROLE_USER, ROLE_MANAGER);
+        final PipelineRun pipelineRun = getRunWithOwner();
+        final RunOwnerGroupPoolInstanceFilter filter = getFilter(PoolInstanceFilterOperator.EQUAL, ROLE_USER);
+        assertTrue(handler.matches(filter, pipelineRun));
+    }
+
+    @Test
+    public void shouldFailEqualFilterWithoutMatchingGroup() {
+        initUserWithGroups(GROUP_1, GROUP_2);
+        final PipelineRun pipelineRun = getRunWithOwner();
+        final RunOwnerGroupPoolInstanceFilter filter = getFilter(PoolInstanceFilterOperator.EQUAL, GROUP_3);
+        assertFalse(handler.matches(filter, pipelineRun));
+    }
+
+    @Test
+    public void shouldPassNotEqualFilterWithoutMatchingGroup() {
+        initUserWithGroups(GROUP_1, GROUP_2);
+        final PipelineRun pipelineRun = getRunWithOwner();
+        final RunOwnerGroupPoolInstanceFilter filter = getFilter(PoolInstanceFilterOperator.NOT_EQUAL, GROUP_3);
+        assertTrue(handler.matches(filter, pipelineRun));
+    }
+
+    @Test
+    public void shouldFailNotEqualFilterWithMatchingGroup() {
+        initUserWithGroups(GROUP_1, GROUP_2);
+        final PipelineRun pipelineRun = getRunWithOwner();
+        final RunOwnerGroupPoolInstanceFilter filter = getFilter(PoolInstanceFilterOperator.NOT_EQUAL, GROUP_2);
+        assertFalse(handler.matches(filter, pipelineRun));
+    }
+
+    @Test
+    public void shouldFailNotEqualFilterWithMatchingRole() {
+        initUserWithRoles(ROLE_USER, ROLE_MANAGER);
+        final PipelineRun pipelineRun = getRunWithOwner();
+        final RunOwnerGroupPoolInstanceFilter filter =
+                getFilter(PoolInstanceFilterOperator.NOT_EQUAL, ROLE_USER);
+        assertFalse(handler.matches(filter, pipelineRun));
+    }
+
+    private void initUserWithRoles(final String... roles) {
+        final PipelineUser user = new PipelineUser();
+        user.setUserName(USER_NAME);
+        user.setRoles(Arrays.stream(roles).map(Role::new).collect(Collectors.toList()));
+        doReturn(user).when(userManager).loadUserByName(eq(USER_NAME));
+    }
+
+    private PipelineRun getRunWithOwner() {
+        final PipelineRun pipelineRun = new PipelineRun();
+        pipelineRun.setOwner(USER_NAME);
+        return pipelineRun;
+    }
+
+    private void initUserWithGroups(String... groups) {
+        final PipelineUser user = new PipelineUser();
+        user.setUserName(USER_NAME);
+        user.setGroups(Arrays.asList(groups));
+        doReturn(user).when(userManager).loadUserByName(eq(USER_NAME));
+    }
+
+    private RunOwnerGroupPoolInstanceFilter getFilter(final PoolInstanceFilterOperator equal,
+                                                      final String value) {
+        final RunOwnerGroupPoolInstanceFilter filter = new RunOwnerGroupPoolInstanceFilter();
+        filter.setOperator(equal);
+        filter.setValue(value.toLowerCase());
+        return filter;
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/test/creator/cluster/schedule/NodePoolCreatorUtils.java
+++ b/api/src/test/java/com/epam/pipeline/test/creator/cluster/schedule/NodePoolCreatorUtils.java
@@ -17,9 +17,21 @@ package com.epam.pipeline.test.creator.cluster.schedule;
 
 import com.epam.pipeline.entity.cluster.PriceType;
 import com.epam.pipeline.entity.cluster.pool.NodePool;
+import com.epam.pipeline.entity.cluster.pool.filter.PoolFilter;
+import com.epam.pipeline.entity.cluster.pool.filter.PoolFilterOperator;
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.ConfigurationPoolInstanceFilter;
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.DockerPoolInstanceFilter;
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.ParameterPoolInstanceFilter;
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.PipelinePoolInstanceFilter;
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.PoolInstanceFilter;
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.PoolInstanceFilterOperator;
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.RunOwnerGroupPoolInstanceFilter;
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.RunOwnerPoolInstanceFilter;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 public final class NodePoolCreatorUtils {
 
@@ -45,5 +57,44 @@ public final class NodePoolCreatorUtils {
         pool.setRegionId(REGION_ID);
         pool.setInstanceDisk(INSTANCE_DISK);
         return pool;
+    }
+
+    public static PoolFilter getAllFilters() {
+        return new PoolFilter(PoolFilterOperator.AND, buildAllFilters());
+    }
+
+    private static List<PoolInstanceFilter> buildAllFilters() {
+        final List<PoolInstanceFilter> filters = new ArrayList<>();
+
+        final RunOwnerPoolInstanceFilter ownerFilter = new RunOwnerPoolInstanceFilter();
+        ownerFilter.setOperator(PoolInstanceFilterOperator.EQUAL);
+        ownerFilter.setValue("user");
+        filters.add(ownerFilter);
+
+        final RunOwnerGroupPoolInstanceFilter groupFilter = new RunOwnerGroupPoolInstanceFilter();
+        groupFilter.setOperator(PoolInstanceFilterOperator.NOT_EQUAL);
+        groupFilter.setValue("group");
+        filters.add(groupFilter);
+
+        final ConfigurationPoolInstanceFilter configurationFilter = new ConfigurationPoolInstanceFilter();
+        configurationFilter.setOperator(PoolInstanceFilterOperator.EMPTY);
+        filters.add(configurationFilter);
+
+        final PipelinePoolInstanceFilter pipelineFilter = new PipelinePoolInstanceFilter();
+        pipelineFilter.setOperator(PoolInstanceFilterOperator.NOT_EMPTY);
+        pipelineFilter.setValue(1L);
+        filters.add(pipelineFilter);
+
+        final DockerPoolInstanceFilter dockerFilter = new DockerPoolInstanceFilter();
+        dockerFilter.setOperator(PoolInstanceFilterOperator.EQUAL);
+        dockerFilter.setValue("centos");
+        filters.add(dockerFilter);
+
+        final ParameterPoolInstanceFilter parameterFilter = new ParameterPoolInstanceFilter();
+        parameterFilter.setOperator(PoolInstanceFilterOperator.EQUAL);
+        parameterFilter.setValue(Collections.singletonMap("key", "val"));
+        filters.add(parameterFilter);
+
+        return filters;
     }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/NodePool.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/NodePool.java
@@ -68,6 +68,7 @@ public class NodePool {
         final RunningInstance runningInstance = new RunningInstance();
         runningInstance.setInstance(toRunInstance());
         runningInstance.setPrePulledImages(dockerImages);
+        runningInstance.setPool(this);
         return runningInstance;
     }
 

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/NodePool.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/NodePool.java
@@ -16,6 +16,7 @@
 package com.epam.pipeline.entity.cluster.pool;
 
 import com.epam.pipeline.entity.cluster.PriceType;
+import com.epam.pipeline.entity.cluster.pool.filter.PoolFilter;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import lombok.Data;
 
@@ -37,6 +38,7 @@ public class NodePool {
     private String instanceImage;
     private int count;
     private NodeSchedule schedule;
+    private PoolFilter filter;
 
     public boolean isActive(final LocalDateTime timestamp) {
         if (count == 0) {

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/RunningInstance.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/RunningInstance.java
@@ -23,5 +23,6 @@ import java.util.Set;
 @Data
 public class RunningInstance {
     private RunInstance instance;
+    private NodePool pool;
     private Set<String> prePulledImages;
 }

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/PoolFilter.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/PoolFilter.java
@@ -13,27 +13,15 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.controller.vo.cluster.pool;
+package com.epam.pipeline.entity.cluster.pool.filter;
 
-import com.epam.pipeline.entity.cluster.PriceType;
-import com.epam.pipeline.entity.cluster.pool.filter.PoolFilter;
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.PoolInstanceFilter;
 import lombok.Data;
 
-import java.util.Set;
-
+import java.util.List;
 
 @Data
-public class NodePoolVO {
-
-    private Long id;
-    private String name;
-    private Long regionId;
-    private String instanceType;
-    private int instanceDisk;
-    private PriceType priceType;
-    private Set<String> dockerImages;
-    private String instanceImage;
-    private int count;
-    private Long scheduleId;
-    private PoolFilter filter;
+public class PoolFilter {
+    private final PoolFilterOperator operator;
+    private final List<PoolInstanceFilter> filters;
 }

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/PoolFilterOperator.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/PoolFilterOperator.java
@@ -13,27 +13,8 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.controller.vo.cluster.pool;
+package com.epam.pipeline.entity.cluster.pool.filter;
 
-import com.epam.pipeline.entity.cluster.PriceType;
-import com.epam.pipeline.entity.cluster.pool.filter.PoolFilter;
-import lombok.Data;
-
-import java.util.Set;
-
-
-@Data
-public class NodePoolVO {
-
-    private Long id;
-    private String name;
-    private Long regionId;
-    private String instanceType;
-    private int instanceDisk;
-    private PriceType priceType;
-    private Set<String> dockerImages;
-    private String instanceImage;
-    private int count;
-    private Long scheduleId;
-    private PoolFilter filter;
+public enum PoolFilterOperator {
+    AND, OR
 }

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/ConfigurationPoolInstanceFilter.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/ConfigurationPoolInstanceFilter.java
@@ -13,27 +13,14 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.controller.vo.cluster.pool;
+package com.epam.pipeline.entity.cluster.pool.filter.instancefilter;
 
-import com.epam.pipeline.entity.cluster.PriceType;
-import com.epam.pipeline.entity.cluster.pool.filter.PoolFilter;
 import lombok.Data;
 
-import java.util.Set;
-
-
 @Data
-public class NodePoolVO {
+public class ConfigurationPoolInstanceFilter implements PoolInstanceFilter<Long> {
 
-    private Long id;
-    private String name;
-    private Long regionId;
-    private String instanceType;
-    private int instanceDisk;
-    private PriceType priceType;
-    private Set<String> dockerImages;
-    private String instanceImage;
-    private int count;
-    private Long scheduleId;
-    private PoolFilter filter;
+    private PoolInstanceFilterOperator operator;
+    private Long value;
+    private PoolInstanceFilterType type = PoolInstanceFilterType.CONFIGURATION_ID;
 }

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/ConfigurationPoolInstanceFilter.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/ConfigurationPoolInstanceFilter.java
@@ -18,7 +18,7 @@ package com.epam.pipeline.entity.cluster.pool.filter.instancefilter;
 import lombok.Data;
 
 @Data
-public class ConfigurationPoolInstanceFilter implements PoolInstanceFilter<Long> {
+public class ConfigurationPoolInstanceFilter implements LongInstanceFilter {
 
     private PoolInstanceFilterOperator operator;
     private Long value;

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/DockerPoolInstanceFilter.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/DockerPoolInstanceFilter.java
@@ -18,7 +18,7 @@ package com.epam.pipeline.entity.cluster.pool.filter.instancefilter;
 import lombok.Data;
 
 @Data
-public class DockerPoolInstanceFilter implements PoolInstanceFilter<String> {
+public class DockerPoolInstanceFilter implements StringInstanceFilter {
 
     private PoolInstanceFilterOperator operator;
     private String value;

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/DockerPoolInstanceFilter.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/DockerPoolInstanceFilter.java
@@ -13,27 +13,14 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.controller.vo.cluster.pool;
+package com.epam.pipeline.entity.cluster.pool.filter.instancefilter;
 
-import com.epam.pipeline.entity.cluster.PriceType;
-import com.epam.pipeline.entity.cluster.pool.filter.PoolFilter;
 import lombok.Data;
 
-import java.util.Set;
-
-
 @Data
-public class NodePoolVO {
+public class DockerPoolInstanceFilter implements PoolInstanceFilter<String> {
 
-    private Long id;
-    private String name;
-    private Long regionId;
-    private String instanceType;
-    private int instanceDisk;
-    private PriceType priceType;
-    private Set<String> dockerImages;
-    private String instanceImage;
-    private int count;
-    private Long scheduleId;
-    private PoolFilter filter;
+    private PoolInstanceFilterOperator operator;
+    private String value;
+    private PoolInstanceFilterType type = PoolInstanceFilterType.DOCKER_IMAGE;
 }

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/LongInstanceFilter.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/LongInstanceFilter.java
@@ -13,23 +13,15 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.entity.cluster.pool.filter;
+package com.epam.pipeline.entity.cluster.pool.filter.instancefilter;
 
-import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.PoolInstanceFilter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import lombok.Data;
-import org.apache.commons.collections4.CollectionUtils;
+import com.epam.pipeline.entity.cluster.pool.filter.value.LongValueMatcher;
+import com.epam.pipeline.entity.cluster.pool.filter.value.ValueMatcher;
 
-import java.util.Collections;
-import java.util.List;
+public interface LongInstanceFilter extends PoolInstanceFilter<Long> {
 
-@Data
-public class PoolFilter {
-    private final PoolFilterOperator operator;
-    private final List<PoolInstanceFilter> filters;
-
-    @JsonIgnore
-    public boolean isEmpty() {
-        return CollectionUtils.isEmpty(filters);
+    @Override
+    default ValueMatcher<Long> getMatcher() {
+        return new LongValueMatcher(getValue());
     }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/MapInstanceFilter.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/MapInstanceFilter.java
@@ -13,23 +13,17 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.entity.cluster.pool.filter;
+package com.epam.pipeline.entity.cluster.pool.filter.instancefilter;
 
-import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.PoolInstanceFilter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import lombok.Data;
-import org.apache.commons.collections4.CollectionUtils;
+import com.epam.pipeline.entity.cluster.pool.filter.value.MapValueMatcher;
+import com.epam.pipeline.entity.cluster.pool.filter.value.ValueMatcher;
 
-import java.util.Collections;
-import java.util.List;
+import java.util.Map;
 
-@Data
-public class PoolFilter {
-    private final PoolFilterOperator operator;
-    private final List<PoolInstanceFilter> filters;
+public interface MapInstanceFilter extends PoolInstanceFilter<Map<String, String>> {
 
-    @JsonIgnore
-    public boolean isEmpty() {
-        return CollectionUtils.isEmpty(filters);
+    @Override
+    default ValueMatcher<Map<String, String>> getMatcher() {
+        return new MapValueMatcher(getValue());
     }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/ParameterPoolInstanceFilter.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/ParameterPoolInstanceFilter.java
@@ -20,7 +20,7 @@ import lombok.Data;
 import java.util.Map;
 
 @Data
-public class ParameterPoolInstanceFilter implements PoolInstanceFilter<Map<String, String>> {
+public class ParameterPoolInstanceFilter implements MapInstanceFilter {
 
     private PoolInstanceFilterOperator operator;
     private Map<String, String> value;

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/ParameterPoolInstanceFilter.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/ParameterPoolInstanceFilter.java
@@ -13,27 +13,16 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.controller.vo.cluster.pool;
+package com.epam.pipeline.entity.cluster.pool.filter.instancefilter;
 
-import com.epam.pipeline.entity.cluster.PriceType;
-import com.epam.pipeline.entity.cluster.pool.filter.PoolFilter;
 import lombok.Data;
 
-import java.util.Set;
-
+import java.util.Map;
 
 @Data
-public class NodePoolVO {
+public class ParameterPoolInstanceFilter implements PoolInstanceFilter<Map<String, String>> {
 
-    private Long id;
-    private String name;
-    private Long regionId;
-    private String instanceType;
-    private int instanceDisk;
-    private PriceType priceType;
-    private Set<String> dockerImages;
-    private String instanceImage;
-    private int count;
-    private Long scheduleId;
-    private PoolFilter filter;
+    private PoolInstanceFilterOperator operator;
+    private Map<String, String> value;
+    private PoolInstanceFilterType type = PoolInstanceFilterType.RUN_PARAMETER;
 }

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/PipelinePoolInstanceFilter.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/PipelinePoolInstanceFilter.java
@@ -18,7 +18,7 @@ package com.epam.pipeline.entity.cluster.pool.filter.instancefilter;
 import lombok.Data;
 
 @Data
-public class PipelinePoolInstanceFilter implements PoolInstanceFilter<Long> {
+public class PipelinePoolInstanceFilter implements LongInstanceFilter {
 
     private PoolInstanceFilterOperator operator;
     private Long value;

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/PipelinePoolInstanceFilter.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/PipelinePoolInstanceFilter.java
@@ -13,27 +13,14 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.controller.vo.cluster.pool;
+package com.epam.pipeline.entity.cluster.pool.filter.instancefilter;
 
-import com.epam.pipeline.entity.cluster.PriceType;
-import com.epam.pipeline.entity.cluster.pool.filter.PoolFilter;
 import lombok.Data;
 
-import java.util.Set;
-
-
 @Data
-public class NodePoolVO {
+public class PipelinePoolInstanceFilter implements PoolInstanceFilter<Long> {
 
-    private Long id;
-    private String name;
-    private Long regionId;
-    private String instanceType;
-    private int instanceDisk;
-    private PriceType priceType;
-    private Set<String> dockerImages;
-    private String instanceImage;
-    private int count;
-    private Long scheduleId;
-    private PoolFilter filter;
+    private PoolInstanceFilterOperator operator;
+    private Long value;
+    private PoolInstanceFilterType type = PoolInstanceFilterType.PIPELINE_ID;
 }

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/PoolInstanceFilter.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/PoolInstanceFilter.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.cluster.pool.filter.instancefilter;
+
+import com.epam.pipeline.entity.cluster.pool.filter.value.FilterValue;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        property = "type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = RunOwnerPoolInstanceFilter.class, name = "RUN_OWNER"),
+        @JsonSubTypes.Type(value = RunOwnerGroupPoolInstanceFilter.class, name = "RUN_OWNER_GROUP"),
+        @JsonSubTypes.Type(value = PipelinePoolInstanceFilter.class, name = "PIPELINE_ID"),
+        @JsonSubTypes.Type(value = ConfigurationPoolInstanceFilter.class, name = "CONFIGURATION_ID"),
+        @JsonSubTypes.Type(value = DockerPoolInstanceFilter.class, name = "DOCKER_IMAGE"),
+        @JsonSubTypes.Type(value = ParameterPoolInstanceFilter.class, name = "RUN_PARAMETER")
+})
+public interface PoolInstanceFilter<T> {
+
+    PoolInstanceFilterOperator getOperator();
+    T getValue();
+    PoolInstanceFilterType getType();
+}

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/PoolInstanceFilter.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/PoolInstanceFilter.java
@@ -15,10 +15,13 @@
 
 package com.epam.pipeline.entity.cluster.pool.filter.instancefilter;
 
-import com.epam.pipeline.entity.cluster.pool.filter.value.FilterValue;
+import com.epam.pipeline.entity.cluster.pool.filter.value.ValueMatcher;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import java.util.Collection;
+import java.util.List;
 
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
@@ -34,6 +37,19 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 public interface PoolInstanceFilter<T> {
 
     PoolInstanceFilterOperator getOperator();
+
     T getValue();
+
     PoolInstanceFilterType getType();
+
+    @JsonIgnore
+    ValueMatcher<T> getMatcher();
+
+    default boolean evaluate(T value) {
+        return getOperator().evaluate(getMatcher(), value);
+    }
+
+    default boolean evaluate(Collection<T> value) {
+        return getOperator().evaluate(getMatcher(), value);
+    }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/PoolInstanceFilterOperator.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/PoolInstanceFilterOperator.java
@@ -13,27 +13,8 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.controller.vo.cluster.pool;
+package com.epam.pipeline.entity.cluster.pool.filter.instancefilter;
 
-import com.epam.pipeline.entity.cluster.PriceType;
-import com.epam.pipeline.entity.cluster.pool.filter.PoolFilter;
-import lombok.Data;
-
-import java.util.Set;
-
-
-@Data
-public class NodePoolVO {
-
-    private Long id;
-    private String name;
-    private Long regionId;
-    private String instanceType;
-    private int instanceDisk;
-    private PriceType priceType;
-    private Set<String> dockerImages;
-    private String instanceImage;
-    private int count;
-    private Long scheduleId;
-    private PoolFilter filter;
+public enum PoolInstanceFilterOperator {
+    EQUAL, NOT_EQUAL, EMPTY, NOT_EMPTY
 }

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/PoolInstanceFilterOperator.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/PoolInstanceFilterOperator.java
@@ -15,6 +15,39 @@
 
 package com.epam.pipeline.entity.cluster.pool.filter.instancefilter;
 
+import com.epam.pipeline.entity.cluster.pool.filter.value.ValueMatcher;
+import org.apache.commons.collections4.CollectionUtils;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Stream;
+
 public enum PoolInstanceFilterOperator {
-    EQUAL, NOT_EQUAL, EMPTY, NOT_EMPTY
+    EQUAL, NOT_EQUAL, EMPTY, NOT_EMPTY;
+
+    public <T> boolean evaluate(final ValueMatcher<T> matcher, final T value) {
+        return evaluate(matcher, Collections.singletonList(value));
+    }
+
+    public <T> boolean evaluate(final ValueMatcher<T> matcher, final Collection<T> values) {
+        switch (this) {
+            case EQUAL:
+                return stream(values).anyMatch(matcher::matches);
+            case NOT_EQUAL:
+                return stream(values).allMatch(matcher::notMatches);
+            case EMPTY:
+                return stream(values).anyMatch(matcher::empty);
+            case NOT_EMPTY:
+                return stream(values).allMatch(matcher::notEmpty);
+            default:
+                throw new IllegalArgumentException("Unsupported operator type " + this);
+        }
+    }
+
+    private <T> Stream<T> stream(final Collection<T> values) {
+        if (CollectionUtils.isEmpty(values)) {
+            return Stream.empty();
+        }
+        return values.stream();
+    }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/PoolInstanceFilterType.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/PoolInstanceFilterType.java
@@ -13,27 +13,8 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.controller.vo.cluster.pool;
+package com.epam.pipeline.entity.cluster.pool.filter.instancefilter;
 
-import com.epam.pipeline.entity.cluster.PriceType;
-import com.epam.pipeline.entity.cluster.pool.filter.PoolFilter;
-import lombok.Data;
-
-import java.util.Set;
-
-
-@Data
-public class NodePoolVO {
-
-    private Long id;
-    private String name;
-    private Long regionId;
-    private String instanceType;
-    private int instanceDisk;
-    private PriceType priceType;
-    private Set<String> dockerImages;
-    private String instanceImage;
-    private int count;
-    private Long scheduleId;
-    private PoolFilter filter;
+public enum PoolInstanceFilterType {
+    RUN_OWNER, RUN_OWNER_GROUP, PIPELINE_ID, CONFIGURATION_ID, DOCKER_IMAGE, RUN_PARAMETER
 }

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/RunOwnerGroupPoolInstanceFilter.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/RunOwnerGroupPoolInstanceFilter.java
@@ -15,12 +15,19 @@
 
 package com.epam.pipeline.entity.cluster.pool.filter.instancefilter;
 
+import com.epam.pipeline.entity.cluster.pool.filter.value.StringCaseInsensitiveValueMatcher;
+import com.epam.pipeline.entity.cluster.pool.filter.value.ValueMatcher;
 import lombok.Data;
 
 @Data
-public class RunOwnerGroupPoolInstanceFilter implements PoolInstanceFilter<String> {
+public class RunOwnerGroupPoolInstanceFilter implements StringInstanceFilter {
 
     private PoolInstanceFilterOperator operator;
     private String value;
     private PoolInstanceFilterType type = PoolInstanceFilterType.RUN_OWNER_GROUP;
+
+    @Override
+    public ValueMatcher<String> getMatcher() {
+        return new StringCaseInsensitiveValueMatcher(value);
+    }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/RunOwnerGroupPoolInstanceFilter.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/RunOwnerGroupPoolInstanceFilter.java
@@ -13,27 +13,14 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.controller.vo.cluster.pool;
+package com.epam.pipeline.entity.cluster.pool.filter.instancefilter;
 
-import com.epam.pipeline.entity.cluster.PriceType;
-import com.epam.pipeline.entity.cluster.pool.filter.PoolFilter;
 import lombok.Data;
 
-import java.util.Set;
-
-
 @Data
-public class NodePoolVO {
+public class RunOwnerGroupPoolInstanceFilter implements PoolInstanceFilter<String> {
 
-    private Long id;
-    private String name;
-    private Long regionId;
-    private String instanceType;
-    private int instanceDisk;
-    private PriceType priceType;
-    private Set<String> dockerImages;
-    private String instanceImage;
-    private int count;
-    private Long scheduleId;
-    private PoolFilter filter;
+    private PoolInstanceFilterOperator operator;
+    private String value;
+    private PoolInstanceFilterType type = PoolInstanceFilterType.RUN_OWNER_GROUP;
 }

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/RunOwnerPoolInstanceFilter.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/RunOwnerPoolInstanceFilter.java
@@ -13,27 +13,14 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.controller.vo.cluster.pool;
+package com.epam.pipeline.entity.cluster.pool.filter.instancefilter;
 
-import com.epam.pipeline.entity.cluster.PriceType;
-import com.epam.pipeline.entity.cluster.pool.filter.PoolFilter;
 import lombok.Data;
 
-import java.util.Set;
-
-
 @Data
-public class NodePoolVO {
+public class RunOwnerPoolInstanceFilter implements PoolInstanceFilter<String> {
 
-    private Long id;
-    private String name;
-    private Long regionId;
-    private String instanceType;
-    private int instanceDisk;
-    private PriceType priceType;
-    private Set<String> dockerImages;
-    private String instanceImage;
-    private int count;
-    private Long scheduleId;
-    private PoolFilter filter;
+    private PoolInstanceFilterOperator operator;
+    private String value;
+    private PoolInstanceFilterType type = PoolInstanceFilterType.RUN_OWNER;
 }

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/RunOwnerPoolInstanceFilter.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/RunOwnerPoolInstanceFilter.java
@@ -15,12 +15,19 @@
 
 package com.epam.pipeline.entity.cluster.pool.filter.instancefilter;
 
+import com.epam.pipeline.entity.cluster.pool.filter.value.StringCaseInsensitiveValueMatcher;
+import com.epam.pipeline.entity.cluster.pool.filter.value.ValueMatcher;
 import lombok.Data;
 
 @Data
-public class RunOwnerPoolInstanceFilter implements PoolInstanceFilter<String> {
+public class RunOwnerPoolInstanceFilter implements StringInstanceFilter {
 
     private PoolInstanceFilterOperator operator;
     private String value;
     private PoolInstanceFilterType type = PoolInstanceFilterType.RUN_OWNER;
+
+    @Override
+    public ValueMatcher<String> getMatcher() {
+        return new StringCaseInsensitiveValueMatcher(value);
+    }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/StringInstanceFilter.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/StringInstanceFilter.java
@@ -13,23 +13,15 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.entity.cluster.pool.filter;
+package com.epam.pipeline.entity.cluster.pool.filter.instancefilter;
 
-import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.PoolInstanceFilter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import lombok.Data;
-import org.apache.commons.collections4.CollectionUtils;
+import com.epam.pipeline.entity.cluster.pool.filter.value.StringValueMatcher;
+import com.epam.pipeline.entity.cluster.pool.filter.value.ValueMatcher;
 
-import java.util.Collections;
-import java.util.List;
+public interface StringInstanceFilter extends PoolInstanceFilter<String> {
 
-@Data
-public class PoolFilter {
-    private final PoolFilterOperator operator;
-    private final List<PoolInstanceFilter> filters;
-
-    @JsonIgnore
-    public boolean isEmpty() {
-        return CollectionUtils.isEmpty(filters);
+    @Override
+    default ValueMatcher<String> getMatcher() {
+        return new StringValueMatcher(getValue());
     }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/value/FilterValue.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/value/FilterValue.java
@@ -13,27 +13,17 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.controller.vo.cluster.pool;
+package com.epam.pipeline.entity.cluster.pool.filter.value;
 
-import com.epam.pipeline.entity.cluster.PriceType;
-import com.epam.pipeline.entity.cluster.pool.filter.PoolFilter;
-import lombok.Data;
+public interface FilterValue<T> {
 
-import java.util.Set;
-
-
-@Data
-public class NodePoolVO {
-
-    private Long id;
-    private String name;
-    private Long regionId;
-    private String instanceType;
-    private int instanceDisk;
-    private PriceType priceType;
-    private Set<String> dockerImages;
-    private String instanceImage;
-    private int count;
-    private Long scheduleId;
-    private PoolFilter filter;
+    T getValue();
+    boolean matches(T anotherValue);
+    default boolean notMatches(T anotherValue) {
+        return !matches(anotherValue);
+    }
+    boolean empty(T anotherValue);
+    default boolean notEmpty(T anotherValue) {
+        return !empty(anotherValue);
+    }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/value/LongFilterValue.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/value/LongFilterValue.java
@@ -13,27 +13,30 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.controller.vo.cluster.pool;
+package com.epam.pipeline.entity.cluster.pool.filter.value;
 
-import com.epam.pipeline.entity.cluster.PriceType;
-import com.epam.pipeline.entity.cluster.pool.filter.PoolFilter;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
-import java.util.Set;
-
+import java.util.Objects;
 
 @Data
-public class NodePoolVO {
+@NoArgsConstructor
+public class LongFilterValue implements FilterValue<Long> {
 
-    private Long id;
-    private String name;
-    private Long regionId;
-    private String instanceType;
-    private int instanceDisk;
-    private PriceType priceType;
-    private Set<String> dockerImages;
-    private String instanceImage;
-    private int count;
-    private Long scheduleId;
-    private PoolFilter filter;
+    private Long value;
+
+    public LongFilterValue(final Long value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean matches(final Long anotherValue) {
+        return Objects.equals(getValue(), anotherValue);
+    }
+
+    @Override
+    public boolean empty(final Long anotherValue) {
+        return Objects.isNull(getValue());
+    }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/value/LongValueMatcher.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/value/LongValueMatcher.java
@@ -15,29 +15,24 @@
 
 package com.epam.pipeline.entity.cluster.pool.filter.value;
 
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import org.apache.commons.lang3.StringUtils;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 import java.util.Objects;
 
-@Data
-@NoArgsConstructor
-public class StringFilterValue implements FilterValue<String> {
+@RequiredArgsConstructor
+@Getter
+public class LongValueMatcher implements ValueMatcher<Long> {
 
-    private String value;
-
-    public StringFilterValue(final String value) {
-        this.value = value;
-    }
+    private final Long value;
 
     @Override
-    public boolean matches(final String anotherValue) {
+    public boolean matches(final Long anotherValue) {
         return Objects.equals(getValue(), anotherValue);
     }
 
     @Override
-    public boolean empty(final String anotherValue) {
-        return StringUtils.isBlank(getValue());
+    public boolean empty(final Long anotherValue) {
+        return Objects.isNull(anotherValue);
     }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/value/MapFilterValue.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/value/MapFilterValue.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.cluster.pool.filter.value;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Map;
+import java.util.Objects;
+
+@Data
+@NoArgsConstructor
+public class MapFilterValue implements FilterValue<Map<String, String>> {
+
+    private Map<String, String> value;
+
+    public MapFilterValue(final Map<String, String> value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean matches(final Map<String, String> anotherValue) {
+        final Map<String, String> currentValue = getValue();
+        if (Objects.isNull(currentValue) || Objects.isNull(anotherValue)) {
+            return false;
+        }
+        return anotherValue.entrySet()
+                .stream()
+                .allMatch(anotherEntry -> {
+                    final String value = currentValue.get(anotherEntry.getKey());
+                    if (Objects.isNull(value)) {
+                        return false;
+                    }
+                    return Objects.equals(value, anotherEntry.getValue());
+                });
+    }
+
+    /**
+     * @param anotherValue
+     * @return {@code true} if current map does not contain any value for
+     * any of {@param anotherValue} keys
+     */
+    @Override
+    public boolean empty(final Map<String, String> anotherValue) {
+        final Map<String, String> currentValue = getValue();
+        if (Objects.isNull(currentValue)) {
+            return Objects.nonNull(anotherValue);
+        }
+        return MapUtils.emptyIfNull(anotherValue)
+                .keySet()
+                .stream()
+                .allMatch(key -> {
+                    final String value = currentValue.get(key);
+                    return StringUtils.isBlank(value);
+                });
+    }
+}

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/value/MapValueMatcher.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/value/MapValueMatcher.java
@@ -15,23 +15,19 @@
 
 package com.epam.pipeline.entity.cluster.pool.filter.value;
 
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Map;
 import java.util.Objects;
 
-@Data
-@NoArgsConstructor
-public class MapFilterValue implements FilterValue<Map<String, String>> {
+@RequiredArgsConstructor
+@Getter
+public class MapValueMatcher implements ValueMatcher<Map<String, String>> {
 
-    private Map<String, String> value;
-
-    public MapFilterValue(final Map<String, String> value) {
-        this.value = value;
-    }
+    private final Map<String, String> value;
 
     @Override
     public boolean matches(final Map<String, String> anotherValue) {

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/value/MapValueMatcher.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/value/MapValueMatcher.java
@@ -35,21 +35,21 @@ public class MapValueMatcher implements ValueMatcher<Map<String, String>> {
         if (Objects.isNull(currentValue) || Objects.isNull(anotherValue)) {
             return false;
         }
-        return anotherValue.entrySet()
+        return currentValue.entrySet()
                 .stream()
-                .allMatch(anotherEntry -> {
-                    final String value = currentValue.get(anotherEntry.getKey());
+                .allMatch(entry -> {
+                    final String value = anotherValue.get(entry.getKey());
                     if (Objects.isNull(value)) {
                         return false;
                     }
-                    return Objects.equals(value, anotherEntry.getValue());
+                    return Objects.equals(value, entry.getValue());
                 });
     }
 
     /**
      * @param anotherValue
      * @return {@code true} if current map does not contain any value for
-     * any of {@param anotherValue} keys
+     * any of {@param anotherValue} keys or does not contain key at all
      */
     @Override
     public boolean empty(final Map<String, String> anotherValue) {
@@ -57,11 +57,11 @@ public class MapValueMatcher implements ValueMatcher<Map<String, String>> {
         if (Objects.isNull(currentValue)) {
             return Objects.nonNull(anotherValue);
         }
-        return MapUtils.emptyIfNull(anotherValue)
+        return MapUtils.emptyIfNull(currentValue)
                 .keySet()
                 .stream()
                 .allMatch(key -> {
-                    final String value = currentValue.get(key);
+                    final String value = anotherValue.get(key);
                     return StringUtils.isBlank(value);
                 });
     }

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/value/StringCaseInsensitiveValueMatcher.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/value/StringCaseInsensitiveValueMatcher.java
@@ -13,23 +13,18 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.entity.cluster.pool.filter;
+package com.epam.pipeline.entity.cluster.pool.filter.value;
 
-import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.PoolInstanceFilter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import lombok.Data;
-import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 
-import java.util.Collections;
-import java.util.List;
+public class StringCaseInsensitiveValueMatcher extends StringValueMatcher {
 
-@Data
-public class PoolFilter {
-    private final PoolFilterOperator operator;
-    private final List<PoolInstanceFilter> filters;
+    public StringCaseInsensitiveValueMatcher(final String value) {
+        super(value);
+    }
 
-    @JsonIgnore
-    public boolean isEmpty() {
-        return CollectionUtils.isEmpty(filters);
+    @Override
+    public boolean matches(final String anotherValue) {
+        return StringUtils.equalsIgnoreCase(getValue(), anotherValue);
     }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/value/StringFilterValue.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/value/StringFilterValue.java
@@ -13,27 +13,31 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.controller.vo.cluster.pool;
+package com.epam.pipeline.entity.cluster.pool.filter.value;
 
-import com.epam.pipeline.entity.cluster.PriceType;
-import com.epam.pipeline.entity.cluster.pool.filter.PoolFilter;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 
-import java.util.Set;
-
+import java.util.Objects;
 
 @Data
-public class NodePoolVO {
+@NoArgsConstructor
+public class StringFilterValue implements FilterValue<String> {
 
-    private Long id;
-    private String name;
-    private Long regionId;
-    private String instanceType;
-    private int instanceDisk;
-    private PriceType priceType;
-    private Set<String> dockerImages;
-    private String instanceImage;
-    private int count;
-    private Long scheduleId;
-    private PoolFilter filter;
+    private String value;
+
+    public StringFilterValue(final String value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean matches(final String anotherValue) {
+        return Objects.equals(getValue(), anotherValue);
+    }
+
+    @Override
+    public boolean empty(final String anotherValue) {
+        return StringUtils.isBlank(getValue());
+    }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/value/StringValueMatcher.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/value/StringValueMatcher.java
@@ -13,23 +13,25 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.entity.cluster.pool.filter;
+package com.epam.pipeline.entity.cluster.pool.filter.value;
 
-import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.PoolInstanceFilter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import lombok.Data;
-import org.apache.commons.collections4.CollectionUtils;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 
-import java.util.Collections;
-import java.util.List;
+@RequiredArgsConstructor
+@Getter
+public class StringValueMatcher implements ValueMatcher<String> {
 
-@Data
-public class PoolFilter {
-    private final PoolFilterOperator operator;
-    private final List<PoolInstanceFilter> filters;
+    private final String value;
 
-    @JsonIgnore
-    public boolean isEmpty() {
-        return CollectionUtils.isEmpty(filters);
+    @Override
+    public boolean matches(final String anotherValue) {
+        return StringUtils.equals(getValue(), anotherValue);
+    }
+
+    @Override
+    public boolean empty(final String anotherValue) {
+        return StringUtils.isBlank(anotherValue);
     }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/value/ValueMatcher.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/value/ValueMatcher.java
@@ -15,7 +15,7 @@
 
 package com.epam.pipeline.entity.cluster.pool.filter.value;
 
-public interface FilterValue<T> {
+public interface ValueMatcher<T> {
 
     T getValue();
     boolean matches(T anotherValue);


### PR DESCRIPTION
This PR provides implementation for #1637

### Implementation
- `NodePool` model now accepts `PoolFilter` field
- During instance reassignment autoscaler checks whether pending `PipelineRun` matches `PoolFilter` if it is specified