### PR TITLE
Issue #1636 Abstract scaling service

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/cloud/AbstractScalingService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/AbstractScalingService.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cloud;
+
+import com.epam.pipeline.entity.cluster.pool.NodePool;
+import com.epam.pipeline.entity.pipeline.RunInstance;
+import com.epam.pipeline.entity.region.AbstractCloudRegion;
+import com.epam.pipeline.manager.CmdExecutor;
+import com.epam.pipeline.manager.cloud.commands.ClusterCommandService;
+import com.epam.pipeline.manager.cloud.commands.NodeUpCommand;
+import com.epam.pipeline.manager.cluster.KubernetesConstants;
+import com.epam.pipeline.manager.parallel.ParallelExecutorService;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+@Service
+public abstract class AbstractScalingService<T extends AbstractCloudRegion> implements CloudScalingService<T> {
+
+    protected final ClusterCommandService commandService;
+    protected final CommonCloudInstanceService instanceService;
+    protected final String nodeTerminateScript;
+    protected final String nodeDownScript;
+    protected final CmdExecutor cmdExecutor = new CmdExecutor();
+    private final ParallelExecutorService executorService;
+    private final String nodeUpScript;
+    private final String nodeReassignScript;
+
+    public AbstractScalingService(final ClusterCommandService commandService,
+                                  final CommonCloudInstanceService instanceService,
+                                  final ParallelExecutorService executorService,
+                                  final String nodeUpScript,
+                                  final String nodeDownScript,
+                                  final String nodeReassignScript,
+                                  final String nodeTerminateScript) {
+        this.commandService = commandService;
+        this.instanceService = instanceService;
+        this.executorService = executorService;
+        this.nodeUpScript = nodeUpScript;
+        this.nodeDownScript = nodeDownScript;
+        this.nodeReassignScript = nodeReassignScript;
+        this.nodeTerminateScript = nodeTerminateScript;
+    }
+
+    @Override
+    public RunInstance scaleUpNode(final T region, final Long runId, final RunInstance instance) {
+        return scaleUpNode(region, instance, runId, String.valueOf(runId), Collections.emptyMap());
+    }
+
+    @Override
+    public RunInstance scaleUpPoolNode(final T region, final String nodeId, final NodePool node) {
+        return scaleUpNode(region, node.toRunInstance(), null, nodeId, getPoolLabels(node));
+    }
+
+    @Override
+    public void scaleDownNode(final T region, final Long runId) {
+        scaleDownPoolNode(region, String.valueOf(runId));
+    }
+
+    @Override
+    public void scaleDownPoolNode(final T region, final String nodeLabel) {
+        final String command = commandService.buildNodeDownCommand(nodeDownScript, nodeLabel, getProviderName());
+        final Map<String, String> envVars = buildScriptEnvVars(region);
+        instanceService.runNodeDownScript(cmdExecutor, command, envVars);
+    }
+
+    @Override
+    public boolean reassignNode(final T region, final Long oldId, final Long newId) {
+        return reassignPoolNode(region, String.valueOf(oldId), newId);
+    }
+
+    @Override
+    public boolean reassignPoolNode(final T region, final String nodeLabel, final Long newId) {
+        final String command = commandService
+            .buildNodeReassignCommand(nodeReassignScript, nodeLabel, newId, getProviderName());
+        return instanceService.runNodeReassignScript(cmdExecutor, command, nodeLabel, String.valueOf(newId),
+                                                     buildScriptEnvVars(region));
+    }
+
+    @Override
+    public void terminateNode(final T region, final String internalIp, final String nodeName) {
+        final String command = commandService.buildTerminateNodeCommand(nodeTerminateScript, internalIp, nodeName,
+                                                                        getProviderName());
+        runAsync(() -> instanceService.runTerminateNodeScript(command, cmdExecutor, buildScriptEnvVars(region)));
+    }
+
+    @Override
+    public LocalDateTime getNodeLaunchTime(final T region, final Long runId) {
+        return instanceService.getNodeLaunchTimeFromKube(runId);
+    }
+
+    protected CompletableFuture<Void> runAsync(final Runnable task) {
+        if (executorService == null) {
+            throw new UnsupportedOperationException(
+                "Selected ProviderInstance service doesn't require asynchronous task execution.");
+        }
+        return CompletableFuture.runAsync(task, executorService.getExecutorService());
+    }
+
+    protected Map<String, String> buildScriptEnvVars(T region) {
+        return Collections.emptyMap();
+    }
+
+    protected abstract void extendNodeUpScript(NodeUpCommand.NodeUpCommandBuilder commandBuilder, T region,
+                                               RunInstance instance);
+
+    private String buildNodeUpCommand(final T region, final String nodeLabel, final RunInstance instance,
+                                      final Map<String, String> labels) {
+        final NodeUpCommand.NodeUpCommandBuilder commandBuilder =
+            commandService.buildNodeUpCommand(nodeUpScript, region, nodeLabel, instance, getProviderName(), labels);
+        extendNodeUpScript(commandBuilder, region, instance);
+        return commandBuilder.build().getCommand();
+    }
+
+    private RunInstance scaleUpNode(final T region, final RunInstance instance, final Long runId, final String nodeId,
+                                    final Map<String, String> labels) {
+        final String command = buildNodeUpCommand(region, nodeId, instance, labels);
+        final Map<String, String> envVars = buildScriptEnvVars(region);
+        return instanceService.runNodeUpScript(cmdExecutor, runId, instance, command, envVars);
+    }
+
+    private Map<String, String> getPoolLabels(final NodePool pool) {
+        return Collections.singletonMap(KubernetesConstants.NODE_POOL_ID_LABEL, String.valueOf(pool.getId()));
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/CloudScalingService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/CloudScalingService.java
@@ -19,22 +19,16 @@ package com.epam.pipeline.manager.cloud;
 import com.epam.pipeline.entity.cluster.pool.NodePool;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.region.AbstractCloudRegion;
-import com.epam.pipeline.manager.cluster.KubernetesConstants;
 import com.epam.pipeline.manager.cluster.autoscale.AutoscalerServiceImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.LocalDateTime;
-import java.util.Collections;
 import java.util.Map;
 
 public interface CloudScalingService<T extends AbstractCloudRegion> extends CloudAwareService {
 
     Logger log = LoggerFactory.getLogger(AutoscalerServiceImpl.class);
-
-    default Map<String, String> getPoolLabels(final NodePool pool) {
-        return Collections.singletonMap(KubernetesConstants.NODE_POOL_ID_LABEL, String.valueOf(pool.getId()));
-    }
 
     /**
      * Creates new instance using specified cloud and adds it to cluster

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/CommonCloudInstanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/CommonCloudInstanceService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,14 +83,6 @@ public class CommonCloudInstanceService {
                                   final Map<String, String> envVars) {
         log.debug("Scaling cluster down. Command: {}.", command);
         executeCmd(cmdExecutor, command, envVars);
-    }
-
-    public boolean runNodeReassignScript(final CmdExecutor cmdExecutor,
-                                         final String command,
-                                         final Long oldId,
-                                         final Long newId,
-                                         final Map<String, String> envVars) {
-        return runNodeReassignScript(cmdExecutor, command, String.valueOf(oldId), String.valueOf(newId), envVars);
     }
 
     public boolean runNodeReassignScript(final CmdExecutor cmdExecutor,

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSScalingService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSScalingService.java
@@ -18,12 +18,10 @@ package com.epam.pipeline.manager.cloud.aws;
 
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.BasicSessionCredentials;
-import com.epam.pipeline.entity.cluster.pool.NodePool;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.region.AwsRegion;
 import com.epam.pipeline.entity.region.CloudProvider;
-import com.epam.pipeline.manager.CmdExecutor;
-import com.epam.pipeline.manager.cloud.CloudScalingService;
+import com.epam.pipeline.manager.cloud.AbstractScalingService;
 import com.epam.pipeline.manager.cloud.CommonCloudInstanceService;
 import com.epam.pipeline.manager.cloud.commands.ClusterCommandService;
 import com.epam.pipeline.manager.cloud.commands.NodeUpCommand;
@@ -38,14 +36,13 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
 @Service
 @Slf4j
-public class AWSScalingService implements CloudScalingService<AwsRegion> {
+public class AWSScalingService extends AbstractScalingService<AwsRegion> {
 
     private static final String MANUAL = "manual";
     private static final String ON_DEMAND = "on_demand";
@@ -53,13 +50,6 @@ public class AWSScalingService implements CloudScalingService<AwsRegion> {
     private final EC2Helper ec2Helper;
     private final PreferenceManager preferenceManager;
     private final InstanceOfferManager instanceOfferManager;
-    private final CommonCloudInstanceService instanceService;
-    private final ClusterCommandService commandService;
-    private final String nodeUpScript;
-    private final String nodeDownScript;
-    private final String nodeReassignScript;
-    private final String nodeTerminateScript;
-    private final CmdExecutor cmdExecutor = new CmdExecutor();
 
     // TODO: 25-10-2019 @Lazy annotation added to resolve issue with circular dependency.
     // It would be great fix this issue by actually removing this dependency:
@@ -73,71 +63,23 @@ public class AWSScalingService implements CloudScalingService<AwsRegion> {
                              @Value("${cluster.nodedown.script}") final String nodeDownScript,
                              @Value("${cluster.reassign.script}") final String nodeReassignScript,
                              @Value("${cluster.node.terminate.script}") final String nodeTerminateScript) {
+        super(commandService, instanceService, null, nodeUpScript, nodeDownScript, nodeReassignScript,
+              nodeTerminateScript);
         this.ec2Helper = ec2Helper;
         this.preferenceManager = preferenceManager;
         this.instanceOfferManager = instanceOfferManager;
-        this.instanceService = instanceService;
-        this.commandService = commandService;
-        this.nodeUpScript = nodeUpScript;
-        this.nodeDownScript = nodeDownScript;
-        this.nodeReassignScript = nodeReassignScript;
-        this.nodeTerminateScript = nodeTerminateScript;
     }
 
     @Override
-    public RunInstance scaleUpNode(final AwsRegion region,
-                                   final Long runId,
-                                   final RunInstance instance) {
-        final String command = buildNodeUpCommand(region, String.valueOf(runId), instance, Collections.emptyMap());
-        return instanceService.runNodeUpScript(cmdExecutor, runId, instance, command, buildScriptEnvVars());
-    }
-
-    @Override
-    public RunInstance scaleUpPoolNode(final AwsRegion region,
-                                       final String nodeIdLabel,
-                                       final NodePool node) {
-        final RunInstance instance = node.toRunInstance();
-        final String command = buildNodeUpCommand(region, nodeIdLabel, instance, getPoolLabels(node));
-        return instanceService.runNodeUpScript(cmdExecutor, null, instance, command, buildScriptEnvVars());
-    }
-
-    @Override
-    public void scaleDownNode(final AwsRegion region, final Long runId) {
-        final String command = commandService.buildNodeDownCommand(nodeDownScript, runId, getProviderName());
-        instanceService.runNodeDownScript(cmdExecutor, command, buildScriptEnvVars());
-    }
-
-    @Override
-    public void scaleDownPoolNode(final AwsRegion region, final String nodeLabel) {
-        final String command = commandService.buildNodeDownCommand(nodeDownScript, nodeLabel, getProviderName());
-        instanceService.runNodeDownScript(cmdExecutor, command, buildScriptEnvVars());
-    }
-
-    @Override
-    public boolean reassignNode(final AwsRegion region, final Long oldId, final Long newId) {
-        final String command = commandService.buildNodeReassignCommand(
-                nodeReassignScript, oldId, newId, getProvider().name());
-        return instanceService.runNodeReassignScript(cmdExecutor, command, oldId, newId, buildScriptEnvVars());
-    }
-
-    @Override
-    public boolean reassignPoolNode(final AwsRegion region, final String nodeLabel, final Long newId) {
-        final String command = commandService.buildNodeReassignCommand(
-                nodeReassignScript, nodeLabel, newId, getProvider().name());
-        return instanceService.runNodeReassignScript(cmdExecutor, command, nodeLabel,
-                String.valueOf(newId), buildScriptEnvVars());
+    public CloudProvider getProvider() {
+        return CloudProvider.AWS;
     }
 
     @Override
     public void terminateNode(final AwsRegion region, final String internalIp, final String nodeName) {
         final String command = commandService.buildTerminateNodeCommand(nodeTerminateScript, internalIp, nodeName,
                 getProviderName());
-        instanceService.runTerminateNodeScript(command, cmdExecutor, buildScriptEnvVars());
-    }
-
-    @Override
-    public CloudProvider getProvider() {
-        return CloudProvider.AWS;
+        instanceService.runTerminateNodeScript(command, cmdExecutor, buildScriptEnvVars(region));
     }
 
     @Override
@@ -160,19 +102,14 @@ public class AWSScalingService implements CloudScalingService<AwsRegion> {
         return envVars;
     }
 
-    private String buildNodeUpCommand(final AwsRegion region,
-                                      final String nodeLabel,
-                                      final RunInstance instance,
-                                      final Map<String, String> labels) {
-        final NodeUpCommand.NodeUpCommandBuilder commandBuilder =
-                commandService.buildNodeUpCommand(nodeUpScript, region, nodeLabel, instance, getProviderName(), labels)
-                               .sshKey(region.getSshKeyName());
-
+    @Override
+    protected void extendNodeUpScript(final NodeUpCommand.NodeUpCommandBuilder commandBuilder, final AwsRegion region,
+                                      final RunInstance instance) {
+        commandBuilder.sshKey(region.getSshKeyName());
         if (StringUtils.isNotBlank(region.getKmsKeyId())) {
             commandBuilder.encryptionKey(region.getKmsKeyId());
         }
         addSpotArguments(instance, commandBuilder, region.getId());
-        return commandBuilder.build().getCommand();
     }
 
     private void addSpotArguments(final RunInstance instance,
@@ -213,9 +150,5 @@ public class AWSScalingService implements CloudScalingService<AwsRegion> {
         commandBuilder.isSpot(true);
         commandBuilder.bidPrice(Optional.ofNullable(bidPrice)
                 .map(p -> String.valueOf(bidPrice)).orElse(StringUtils.EMPTY));
-    }
-
-    private Map<String, String> buildScriptEnvVars() {
-        return Collections.emptyMap();
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzureScalingService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzureScalingService.java
@@ -17,18 +17,14 @@
 package com.epam.pipeline.manager.cloud.azure;
 
 
-import com.epam.pipeline.entity.cluster.pool.NodePool;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.region.AzureRegion;
 import com.epam.pipeline.entity.region.AzureRegionCredentials;
 import com.epam.pipeline.entity.region.CloudProvider;
-import com.epam.pipeline.manager.CmdExecutor;
-import com.epam.pipeline.manager.cloud.CloudScalingService;
+import com.epam.pipeline.manager.cloud.AbstractScalingService;
 import com.epam.pipeline.manager.cloud.CommonCloudInstanceService;
-import com.epam.pipeline.manager.cloud.commands.AbstractClusterCommand;
 import com.epam.pipeline.manager.cloud.commands.ClusterCommandService;
 import com.epam.pipeline.manager.cloud.commands.NodeUpCommand;
-import com.epam.pipeline.manager.cloud.commands.RunIdArgCommand;
 import com.epam.pipeline.manager.execution.SystemParams;
 import com.epam.pipeline.manager.parallel.ParallelExecutorService;
 import com.epam.pipeline.manager.preference.PreferenceManager;
@@ -40,28 +36,17 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 @Service
 @Slf4j
-public class AzureScalingService implements CloudScalingService<AzureRegion> {
+public class AzureScalingService extends AbstractScalingService<AzureRegion> {
 
     private static final String AZURE_AUTH_LOCATION = "AZURE_AUTH_LOCATION";
     private static final String AZURE_RESOURCE_GROUP = "AZURE_RESOURCE_GROUP";
-    private final CommonCloudInstanceService instanceService;
-    private final ClusterCommandService commandService;
     private final PreferenceManager preferenceManager;
     private final CloudRegionManager cloudRegionManager;
-    private final ParallelExecutorService executorService;
-    private final CmdExecutor cmdExecutor = new CmdExecutor();
-    private final String nodeUpScript;
-    private final String nodeDownScript;
-    private final String nodeReassignScript;
-    private final String nodeTerminateScript;
 
     public AzureScalingService(final CommonCloudInstanceService instanceService,
                                final ClusterCommandService commandService,
@@ -72,78 +57,21 @@ public class AzureScalingService implements CloudScalingService<AzureRegion> {
                                @Value("${cluster.azure.nodedown.script:}") final String nodeDownScript,
                                @Value("${cluster.azure.reassign.script:}") final String nodeReassignScript,
                                @Value("${cluster.azure.node.terminate.script:}") final String nodeTerminateScript) {
-        this.instanceService = instanceService;
-        this.commandService = commandService;
+        super(commandService, instanceService, executorService, nodeUpScript, nodeDownScript, nodeReassignScript,
+              nodeTerminateScript);
         this.cloudRegionManager = regionManager;
         this.preferenceManager = preferenceManager;
-        this.executorService = executorService;
-        this.nodeUpScript = nodeUpScript;
-        this.nodeDownScript = nodeDownScript;
-        this.nodeReassignScript = nodeReassignScript;
-        this.nodeTerminateScript = nodeTerminateScript;
     }
 
     @Override
-    public RunInstance scaleUpNode(final AzureRegion region,
-                                   final Long runId,
-                                   final RunInstance instance) {
-        final String command = buildNodeUpCommand(region, String.valueOf(runId), instance, Collections.emptyMap());
-        return instanceService.runNodeUpScript(cmdExecutor, runId, instance, command, buildScriptAzureEnvVars(region));
-    }
-
-    @Override
-    public RunInstance scaleUpPoolNode(final AzureRegion region,
-                                       final String nodeId,
-                                       final NodePool nodePool) {
-        final RunInstance instance = nodePool.toRunInstance();
-        final String command = buildNodeUpCommand(region, nodeId, instance, getPoolLabels(nodePool));
-        return instanceService.runNodeUpScript(cmdExecutor, null, instance, command, buildScriptAzureEnvVars(region));
-    }
-
-    @Override
-    public void scaleDownNode(final AzureRegion region, final Long runId) {
-        final String command = buildNodeDownCommand(String.valueOf(runId));
-        final Map<String, String> envVars = buildScriptAzureEnvVars(region);
-        CompletableFuture.runAsync(() -> instanceService.runNodeDownScript(cmdExecutor, command, envVars),
-                executorService.getExecutorService());
+    public CloudProvider getProvider() {
+        return CloudProvider.AZURE;
     }
 
     @Override
     public void scaleDownPoolNode(final AzureRegion region, final String nodeLabel) {
-        final String command = buildNodeDownCommand(nodeLabel);
-        final Map<String, String> envVars = buildScriptAzureEnvVars(region);
-        CompletableFuture.runAsync(() -> instanceService.runNodeDownScript(cmdExecutor, command, envVars),
-                                   executorService.getExecutorService());
-    }
-
-    @Override
-    public boolean reassignNode(final AzureRegion region, final Long oldId, final Long newId) {
-        final String command = commandService.buildNodeReassignCommand(
-                nodeReassignScript, oldId, newId, getProvider().name());
-        return instanceService.runNodeReassignScript(cmdExecutor, command, oldId, newId,
-                buildScriptAzureEnvVars(region));
-    }
-
-    @Override
-    public boolean reassignPoolNode(final AzureRegion region, final String nodeLabel, final Long newId) {
-        final String command = commandService.
-            buildNodeReassignCommand(nodeReassignScript, nodeLabel, newId, getProvider().name());
-        return instanceService.runNodeReassignScript(cmdExecutor, command, nodeLabel,
-                                                     String.valueOf(newId), buildScriptAzureEnvVars(region));
-    }
-
-    @Override
-    public void terminateNode(final AzureRegion region, final String internalIp, final String nodeName) {
-        final String command = commandService.buildTerminateNodeCommand(nodeTerminateScript, internalIp, nodeName,
-                getProviderName());
-        final Map<String, String> envVars = buildScriptAzureEnvVars(region);
-        CompletableFuture.runAsync(() -> instanceService.runTerminateNodeScript(command, cmdExecutor, envVars),
-                executorService.getExecutorService());
-    }
-
-    @Override
-    public LocalDateTime getNodeLaunchTime(final AzureRegion region, final Long runId) {
-        return instanceService.getNodeLaunchTimeFromKube(runId);
+        final String command = commandService.buildNodeDownCommand(nodeDownScript, nodeLabel, null);
+        runAsync(() -> instanceService.runNodeDownScript(cmdExecutor, command, buildScriptEnvVars(region)));
     }
 
     @Override
@@ -158,11 +86,7 @@ public class AzureScalingService implements CloudScalingService<AzureRegion> {
     }
 
     @Override
-    public CloudProvider getProvider() {
-        return CloudProvider.AZURE;
-    }
-
-    private Map<String, String> buildScriptAzureEnvVars(final AzureRegion region) {
+    protected Map<String, String> buildScriptEnvVars(final AzureRegion region) {
         final Map<String, String> envVars = new HashMap<>();
         if (StringUtils.isNotBlank(region.getAuthFile())) {
             envVars.put(AZURE_AUTH_LOCATION, region.getAuthFile());
@@ -171,28 +95,15 @@ public class AzureScalingService implements CloudScalingService<AzureRegion> {
         return envVars;
     }
 
-    private String buildNodeUpCommand(final AzureRegion region, final String nodeLabel, final RunInstance instance,
-                                      final Map<String, String> labels) {
-        final NodeUpCommand.NodeUpCommandBuilder commandBuilder =
-            commandService.buildNodeUpCommand(nodeUpScript, region, nodeLabel, instance, null, labels)
-                .sshKey(region.getSshPublicKeyPath());
-
+    @Override
+    protected void extendNodeUpScript(final NodeUpCommand.NodeUpCommandBuilder commandBuilder, final AzureRegion region,
+                                      final RunInstance instance) {
+        commandBuilder.sshKey(region.getSshPublicKeyPath());
         final Boolean clusterSpotStrategy = instance.getSpot() == null
-                ? preferenceManager.getPreference(SystemPreferences.CLUSTER_SPOT)
-                : instance.getSpot();
-
+                                            ? preferenceManager.getPreference(SystemPreferences.CLUSTER_SPOT)
+                                            : instance.getSpot();
         if (BooleanUtils.isTrue(clusterSpotStrategy)) {
             commandBuilder.isSpot(true);
         }
-        return commandBuilder.build().getCommand();
-    }
-
-    private String buildNodeDownCommand(final String nodeLabel) {
-        return RunIdArgCommand.builder()
-                .executable(AbstractClusterCommand.EXECUTABLE)
-                .script(nodeDownScript)
-                .runId(nodeLabel)
-                .build()
-                .getCommand();
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPScalingService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPScalingService.java
@@ -16,14 +16,13 @@
 
 package com.epam.pipeline.manager.cloud.gcp;
 
-import com.epam.pipeline.entity.cluster.pool.NodePool;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.region.CloudProvider;
 import com.epam.pipeline.entity.region.GCPRegion;
-import com.epam.pipeline.manager.CmdExecutor;
-import com.epam.pipeline.manager.cloud.CloudScalingService;
+import com.epam.pipeline.manager.cloud.AbstractScalingService;
 import com.epam.pipeline.manager.cloud.CommonCloudInstanceService;
 import com.epam.pipeline.manager.cloud.commands.ClusterCommandService;
+import com.epam.pipeline.manager.cloud.commands.NodeUpCommand;
 import com.epam.pipeline.manager.execution.SystemParams;
 import com.epam.pipeline.manager.parallel.ParallelExecutorService;
 import lombok.extern.slf4j.Slf4j;
@@ -35,27 +34,16 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Paths;
-import java.time.LocalDateTime;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 @Service
 @Slf4j
-public class GCPScalingService implements CloudScalingService<GCPRegion> {
+public class GCPScalingService extends AbstractScalingService<GCPRegion> {
+
     private static final String GOOGLE_PROJECT_ID = "GOOGLE_PROJECT_ID";
     protected static final String GOOGLE_APPLICATION_CREDENTIALS = "GOOGLE_APPLICATION_CREDENTIALS";
-
-    private final ClusterCommandService commandService;
-    private final CommonCloudInstanceService instanceService;
-    private final String nodeUpScript;
-    private final String nodeDownScript;
-    private final String nodeReassignScript;
-    private final String nodeTerminateScript;
-    private final ParallelExecutorService executorService;
-    private final CmdExecutor cmdExecutor = new CmdExecutor();
 
     public GCPScalingService(final ClusterCommandService commandService,
                              final CommonCloudInstanceService instanceService,
@@ -64,70 +52,13 @@ public class GCPScalingService implements CloudScalingService<GCPRegion> {
                              @Value("${cluster.gcp.nodedown.script}") final String nodeDownScript,
                              @Value("${cluster.gcp.reassign.script}") final String nodeReassignScript,
                              @Value("${cluster.gcp.node.terminate.script}") final String nodeTerminateScript) {
-        this.commandService = commandService;
-        this.instanceService = instanceService;
-        this.nodeUpScript = nodeUpScript;
-        this.executorService = executorService;
-        this.nodeDownScript = nodeDownScript;
-        this.nodeReassignScript = nodeReassignScript;
-        this.nodeTerminateScript = nodeTerminateScript;
+        super(commandService, instanceService, executorService, nodeUpScript, nodeDownScript, nodeReassignScript,
+              nodeTerminateScript);
     }
 
     @Override
-    public RunInstance scaleUpNode(final GCPRegion region, final Long runId, final RunInstance instance) {
-
-        final String command = buildNodeUpCommand(region, String.valueOf(runId), instance, Collections.emptyMap());
-        return instanceService.runNodeUpScript(cmdExecutor, runId, instance, command, buildScriptGCPEnvVars(region));
-    }
-
-    @Override
-    public RunInstance scaleUpPoolNode(final GCPRegion region, final String nodeId, final NodePool node) {
-        final RunInstance instance = node.toRunInstance();
-        final String command = buildNodeUpCommand(region, nodeId, instance, getPoolLabels(node));
-        return instanceService.runNodeUpScript(cmdExecutor, null, instance, command, buildScriptGCPEnvVars(region));
-    }
-
-    @Override
-    public void scaleDownNode(final GCPRegion region, final Long runId) {
-        final String command = commandService.buildNodeDownCommand(nodeDownScript, runId, getProviderName());
-        final Map<String, String> envVars = buildScriptGCPEnvVars(region);
-        instanceService.runNodeDownScript(cmdExecutor, command, envVars);
-    }
-
-    @Override
-    public void scaleDownPoolNode(final GCPRegion region, final String nodeLabel) {
-        final String command = commandService.buildNodeDownCommand(nodeDownScript, nodeLabel, getProviderName());
-        instanceService.runNodeDownScript(cmdExecutor, command, buildScriptGCPEnvVars(region));
-    }
-
-    @Override
-    public boolean reassignNode(final GCPRegion region, final Long oldId, final Long newId) {
-        final String command = commandService.buildNodeReassignCommand(
-                nodeReassignScript, oldId, newId, getProviderName());
-        return instanceService.runNodeReassignScript(cmdExecutor, command, oldId, newId,
-                buildScriptGCPEnvVars(region));
-    }
-
-    @Override
-    public boolean reassignPoolNode(final GCPRegion region, final String nodeLabel, final Long newId) {
-        final String command = commandService
-            .buildNodeReassignCommand(nodeReassignScript, nodeLabel, newId, getProviderName());
-        return instanceService.runNodeReassignScript(cmdExecutor, command, nodeLabel, String.valueOf(newId),
-                                                     buildScriptGCPEnvVars(region));
-    }
-
-    @Override
-    public void terminateNode(final GCPRegion region, final String internalIp, final String nodeName) {
-        final String command = commandService.buildTerminateNodeCommand(nodeTerminateScript, internalIp,
-                nodeName, getProviderName());
-        final Map<String, String> envVars = buildScriptGCPEnvVars(region);
-        CompletableFuture.runAsync(() -> instanceService.runTerminateNodeScript(command, cmdExecutor, envVars),
-                executorService.getExecutorService());
-    }
-
-    @Override
-    public LocalDateTime getNodeLaunchTime(final GCPRegion region, final Long runId) {
-        return instanceService.getNodeLaunchTimeFromKube(runId);
+    public CloudProvider getProvider() {
+        return CloudProvider.GCP;
     }
 
     @Override
@@ -149,34 +80,27 @@ public class GCPScalingService implements CloudScalingService<GCPRegion> {
     }
 
     @Override
-    public CloudProvider getProvider() {
-        return CloudProvider.GCP;
-    }
-
-    private String buildNodeUpCommand(final GCPRegion region, final String nodeLabel, final RunInstance instance,
-                                      final Map<String, String> labels) {
-        return commandService
-            .buildNodeUpCommand(nodeUpScript, region, nodeLabel, instance, getProviderName(), labels)
-            .sshKey(region.getSshPublicKeyPath())
-            .isSpot(Optional.ofNullable(instance.getSpot())
-                        .orElse(false))
-            .bidPrice(StringUtils.EMPTY)
-            .build()
-            .getCommand();
-    }
-
-    private String getCredentialsFilePath(GCPRegion region) {
-        return StringUtils.isEmpty(region.getAuthFile())
-                ? System.getenv(GOOGLE_APPLICATION_CREDENTIALS)
-                : region.getAuthFile();
-    }
-
-    private Map<String, String> buildScriptGCPEnvVars(final GCPRegion region) {
+    protected Map<String, String> buildScriptEnvVars(GCPRegion region) {
         final Map<String, String> envVars = new HashMap<>();
         if (StringUtils.isNotBlank(region.getAuthFile())) {
             envVars.put(GOOGLE_APPLICATION_CREDENTIALS, region.getAuthFile());
         }
         envVars.put(GOOGLE_PROJECT_ID, region.getProject());
         return envVars;
+    }
+
+    @Override
+    protected void extendNodeUpScript(final NodeUpCommand.NodeUpCommandBuilder commandBuilder, final GCPRegion region,
+                                      final RunInstance instance) {
+        commandBuilder
+            .sshKey(region.getSshPublicKeyPath())
+            .isSpot(Optional.ofNullable(instance.getSpot()).orElse(false))
+            .bidPrice(StringUtils.EMPTY);
+    }
+
+    private String getCredentialsFilePath(GCPRegion region) {
+        return StringUtils.isEmpty(region.getAuthFile())
+                ? System.getenv(GOOGLE_APPLICATION_CREDENTIALS)
+                : region.getAuthFile();
     }
 }


### PR DESCRIPTION
This PR is related to issue #1636

It brings `AbstractProviderScalingService`, which is gathering common methods regarding node and pool scaling. Concrete classes are specifying details regarding build script env vars, additional nodeup command fields, synchronously/asynchronously methods execution.