### PR TITLE
Issue #1652: VMMonitor shall handle pool nodes

### DIFF
--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
@@ -19,6 +19,7 @@ package com.epam.pipeline.client.pipeline;
 import com.epam.pipeline.entity.cluster.InstanceType;
 import com.epam.pipeline.entity.cluster.NodeDisk;
 import com.epam.pipeline.entity.cluster.NodeInstance;
+import com.epam.pipeline.entity.cluster.pool.NodePool;
 import com.epam.pipeline.entity.configuration.RunConfiguration;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.DataStorageAction;
@@ -219,4 +220,7 @@ public interface CloudPipelineAPI {
 
     @GET("cluster/node/{id}/disks")
     Call<Result<List<NodeDisk>>> loadNodeDisks(@Path(ID) String nodeId);
+
+    @GET("/cluster/pool")
+    Call<Result<List<NodePool>>> loadNodePools();
 }

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/NodePool.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/NodePool.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.cluster.pool;
+
+import com.epam.pipeline.entity.cluster.PriceType;
+import com.epam.pipeline.entity.cluster.pool.filter.PoolFilter;
+import com.epam.pipeline.entity.pipeline.RunInstance;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.Set;
+
+@Data
+public class NodePool {
+
+    private Long id;
+    private String name;
+    private LocalDateTime created;
+    private Long regionId;
+    private String instanceType;
+    private int instanceDisk;
+    private PriceType priceType;
+    private Set<String> dockerImages;
+    private String instanceImage;
+    private int count;
+    private NodeSchedule schedule;
+    private PoolFilter filter;
+
+    public boolean isActive(final LocalDateTime timestamp) {
+        if (count == 0) {
+            return false;
+        }
+        return Optional.ofNullable(schedule)
+                .map(s -> s.isActive(timestamp))
+                .orElse(false);
+    }
+
+    @Override
+    public String toString() {
+        return "NodePool{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", regionId=" + regionId +
+                ", instanceType='" + instanceType + '\'' +
+                ", instanceDisk=" + instanceDisk +
+                ", priceType=" + priceType +
+                ", dockerImages=" + dockerImages +
+                ", instanceImage='" + instanceImage + '\'' +
+                ", count=" + count +
+                '}';
+    }
+
+    public RunningInstance toRunningInstance() {
+        final RunningInstance runningInstance = new RunningInstance();
+        runningInstance.setInstance(toRunInstance());
+        runningInstance.setPrePulledImages(dockerImages);
+        runningInstance.setPool(this);
+        return runningInstance;
+    }
+
+    public RunInstance toRunInstance() {
+        final RunInstance runInstance = new RunInstance();
+        runInstance.setNodeType(instanceType);
+        runInstance.setCloudRegionId(regionId);
+        runInstance.setNodeDisk(instanceDisk);
+        runInstance.setEffectiveNodeDisk(instanceDisk);
+        runInstance.setSpot(PriceType.SPOT.equals(priceType));
+        runInstance.setNodeImage(instanceImage);
+        runInstance.setPrePulledDockerImages(dockerImages);
+        return runInstance;
+    }
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/NodeSchedule.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/NodeSchedule.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.cluster.pool;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Data;
+import org.apache.commons.collections4.CollectionUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+public class NodeSchedule {
+    private Long id;
+    private String name;
+    private LocalDateTime created;
+    private List<ScheduleEntry> scheduleEntries;
+
+    @JsonIgnore
+    public boolean isActive(final LocalDateTime timestamp) {
+        if (CollectionUtils.isEmpty(scheduleEntries)) {
+            return true;
+        }
+        return scheduleEntries.stream()
+                .anyMatch(s -> s.isActive(timestamp));
+    }
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/RunningInstance.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/RunningInstance.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.cluster.pool;
+
+import com.epam.pipeline.entity.pipeline.RunInstance;
+import lombok.Data;
+
+import java.util.Set;
+
+@Data
+public class RunningInstance {
+    private RunInstance instance;
+    private NodePool pool;
+    private Set<String> prePulledImages;
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/ScheduleEntry.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/ScheduleEntry.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.cluster.pool;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Data;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.TemporalAdjusters;
+
+@Data
+public class ScheduleEntry {
+    private DayOfWeek from;
+    private LocalTime fromTime;
+    private DayOfWeek to;
+    private LocalTime toTime;
+
+    @JsonIgnore
+    public boolean isActive(final LocalDateTime timestamp) {
+        final LocalDateTime start = getFromDay(timestamp).with(fromTime);
+        final LocalDateTime end = getToDay(timestamp, start).with(toTime);
+        return timestamp.compareTo(start) >= 0 && timestamp.isBefore(end);
+    }
+
+    @JsonIgnore
+    private LocalDateTime getFromDay(final LocalDateTime timestamp) {
+        return timestamp.getDayOfWeek().equals(from) ? timestamp :
+                timestamp.with(TemporalAdjusters.previous(from));
+    }
+
+    @JsonIgnore
+    private LocalDateTime getToDay(final LocalDateTime timestamp,
+                                   final LocalDateTime start) {
+        if (timestamp.getDayOfWeek().equals(to)) {
+            return timestamp;
+        }
+        if (from.equals(to)) {
+            return start;
+        }
+        return start.with(TemporalAdjusters.next(to));
+    }
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/PoolFilter.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/PoolFilter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.cluster.pool.filter;
+
+import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.PoolInstanceFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Data;
+import org.apache.commons.collections4.CollectionUtils;
+
+import java.util.List;
+
+@Data
+public class PoolFilter {
+    private final PoolFilterOperator operator;
+    private final List<PoolInstanceFilter> filters;
+
+    @JsonIgnore
+    public boolean isEmpty() {
+        return CollectionUtils.isEmpty(filters);
+    }
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/PoolFilterOperator.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/PoolFilterOperator.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.cluster.pool.filter;
+
+public enum PoolFilterOperator {
+    AND, OR
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/ConfigurationPoolInstanceFilter.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/ConfigurationPoolInstanceFilter.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.cluster.pool.filter.instancefilter;
+
+import lombok.Data;
+
+@Data
+public class ConfigurationPoolInstanceFilter implements LongInstanceFilter {
+
+    private PoolInstanceFilterOperator operator;
+    private Long value;
+    private PoolInstanceFilterType type = PoolInstanceFilterType.CONFIGURATION_ID;
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/DockerPoolInstanceFilter.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/DockerPoolInstanceFilter.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.cluster.pool.filter.instancefilter;
+
+import lombok.Data;
+
+@Data
+public class DockerPoolInstanceFilter implements StringInstanceFilter {
+
+    private PoolInstanceFilterOperator operator;
+    private String value;
+    private PoolInstanceFilterType type = PoolInstanceFilterType.DOCKER_IMAGE;
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/LongInstanceFilter.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/LongInstanceFilter.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.cluster.pool.filter.instancefilter;
+
+import com.epam.pipeline.entity.cluster.pool.filter.value.LongValueMatcher;
+import com.epam.pipeline.entity.cluster.pool.filter.value.ValueMatcher;
+
+public interface LongInstanceFilter extends PoolInstanceFilter<Long> {
+
+    @Override
+    default ValueMatcher<Long> getMatcher() {
+        return new LongValueMatcher(getValue());
+    }
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/MapInstanceFilter.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/MapInstanceFilter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.cluster.pool.filter.instancefilter;
+
+import com.epam.pipeline.entity.cluster.pool.filter.value.MapValueMatcher;
+import com.epam.pipeline.entity.cluster.pool.filter.value.ValueMatcher;
+
+import java.util.Map;
+
+public interface MapInstanceFilter extends PoolInstanceFilter<Map<String, String>> {
+
+    @Override
+    default ValueMatcher<Map<String, String>> getMatcher() {
+        return new MapValueMatcher(getValue());
+    }
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/ParameterPoolInstanceFilter.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/ParameterPoolInstanceFilter.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.cluster.pool.filter.instancefilter;
+
+import lombok.Data;
+
+import java.util.Map;
+
+@Data
+public class ParameterPoolInstanceFilter implements MapInstanceFilter {
+
+    private PoolInstanceFilterOperator operator;
+    private Map<String, String> value;
+    private PoolInstanceFilterType type = PoolInstanceFilterType.RUN_PARAMETER;
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/PipelinePoolInstanceFilter.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/PipelinePoolInstanceFilter.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.cluster.pool.filter.instancefilter;
+
+import lombok.Data;
+
+@Data
+public class PipelinePoolInstanceFilter implements LongInstanceFilter {
+
+    private PoolInstanceFilterOperator operator;
+    private Long value;
+    private PoolInstanceFilterType type = PoolInstanceFilterType.PIPELINE_ID;
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/PoolInstanceFilter.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/PoolInstanceFilter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.cluster.pool.filter.instancefilter;
+
+import com.epam.pipeline.entity.cluster.pool.filter.value.ValueMatcher;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import java.util.Collection;
+
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        property = "type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = RunOwnerPoolInstanceFilter.class, name = "RUN_OWNER"),
+        @JsonSubTypes.Type(value = RunOwnerGroupPoolInstanceFilter.class, name = "RUN_OWNER_GROUP"),
+        @JsonSubTypes.Type(value = PipelinePoolInstanceFilter.class, name = "PIPELINE_ID"),
+        @JsonSubTypes.Type(value = ConfigurationPoolInstanceFilter.class, name = "CONFIGURATION_ID"),
+        @JsonSubTypes.Type(value = DockerPoolInstanceFilter.class, name = "DOCKER_IMAGE"),
+        @JsonSubTypes.Type(value = ParameterPoolInstanceFilter.class, name = "RUN_PARAMETER")
+    })
+public interface PoolInstanceFilter<T> {
+
+    PoolInstanceFilterOperator getOperator();
+
+    T getValue();
+
+    PoolInstanceFilterType getType();
+
+    @JsonIgnore
+    ValueMatcher<T> getMatcher();
+
+    default boolean evaluate(T value) {
+        return getOperator().evaluate(getMatcher(), value);
+    }
+
+    default boolean evaluate(Collection<T> value) {
+        return getOperator().evaluate(getMatcher(), value);
+    }
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/PoolInstanceFilterOperator.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/PoolInstanceFilterOperator.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.cluster.pool.filter.instancefilter;
+
+import com.epam.pipeline.entity.cluster.pool.filter.value.ValueMatcher;
+import org.apache.commons.collections4.CollectionUtils;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Stream;
+
+public enum PoolInstanceFilterOperator {
+    EQUAL, NOT_EQUAL, EMPTY, NOT_EMPTY;
+
+    public <T> boolean evaluate(final ValueMatcher<T> matcher, final T value) {
+        return evaluate(matcher, Collections.singletonList(value));
+    }
+
+    public <T> boolean evaluate(final ValueMatcher<T> matcher, final Collection<T> values) {
+        switch (this) {
+            case EQUAL:
+                return stream(values).anyMatch(matcher::matches);
+            case NOT_EQUAL:
+                return stream(values).allMatch(matcher::notMatches);
+            case EMPTY:
+                return stream(values).anyMatch(matcher::empty);
+            case NOT_EMPTY:
+                return stream(values).allMatch(matcher::notEmpty);
+            default:
+                throw new IllegalArgumentException("Unsupported operator type " + this);
+        }
+    }
+
+    private <T> Stream<T> stream(final Collection<T> values) {
+        if (CollectionUtils.isEmpty(values)) {
+            return Stream.empty();
+        }
+        return values.stream();
+    }
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/PoolInstanceFilterType.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/PoolInstanceFilterType.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.cluster.pool.filter.instancefilter;
+
+public enum PoolInstanceFilterType {
+    RUN_OWNER, RUN_OWNER_GROUP, PIPELINE_ID, CONFIGURATION_ID, DOCKER_IMAGE, RUN_PARAMETER
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/RunOwnerGroupPoolInstanceFilter.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/RunOwnerGroupPoolInstanceFilter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.cluster.pool.filter.instancefilter;
+
+import com.epam.pipeline.entity.cluster.pool.filter.value.StringCaseInsensitiveValueMatcher;
+import com.epam.pipeline.entity.cluster.pool.filter.value.ValueMatcher;
+import lombok.Data;
+
+@Data
+public class RunOwnerGroupPoolInstanceFilter implements StringInstanceFilter {
+
+    private PoolInstanceFilterOperator operator;
+    private String value;
+    private PoolInstanceFilterType type = PoolInstanceFilterType.RUN_OWNER_GROUP;
+
+    @Override
+    public ValueMatcher<String> getMatcher() {
+        return new StringCaseInsensitiveValueMatcher(value);
+    }
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/RunOwnerPoolInstanceFilter.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/RunOwnerPoolInstanceFilter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.cluster.pool.filter.instancefilter;
+
+import com.epam.pipeline.entity.cluster.pool.filter.value.StringCaseInsensitiveValueMatcher;
+import com.epam.pipeline.entity.cluster.pool.filter.value.ValueMatcher;
+import lombok.Data;
+
+@Data
+public class RunOwnerPoolInstanceFilter implements StringInstanceFilter {
+
+    private PoolInstanceFilterOperator operator;
+    private String value;
+    private PoolInstanceFilterType type = PoolInstanceFilterType.RUN_OWNER;
+
+    @Override
+    public ValueMatcher<String> getMatcher() {
+        return new StringCaseInsensitiveValueMatcher(value);
+    }
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/StringInstanceFilter.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/instancefilter/StringInstanceFilter.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.cluster.pool.filter.instancefilter;
+
+import com.epam.pipeline.entity.cluster.pool.filter.value.StringValueMatcher;
+import com.epam.pipeline.entity.cluster.pool.filter.value.ValueMatcher;
+
+public interface StringInstanceFilter extends PoolInstanceFilter<String> {
+
+    @Override
+    default ValueMatcher<String> getMatcher() {
+        return new StringValueMatcher(getValue());
+    }
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/value/LongValueMatcher.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/value/LongValueMatcher.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.cluster.pool.filter.value;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Objects;
+
+@RequiredArgsConstructor
+@Getter
+public class LongValueMatcher implements ValueMatcher<Long> {
+
+    private final Long value;
+
+    @Override
+    public boolean matches(final Long anotherValue) {
+        return Objects.equals(getValue(), anotherValue);
+    }
+
+    @Override
+    public boolean empty(final Long anotherValue) {
+        return Objects.isNull(anotherValue);
+    }
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/value/MapValueMatcher.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/value/MapValueMatcher.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.cluster.pool.filter.value;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Map;
+import java.util.Objects;
+
+@RequiredArgsConstructor
+@Getter
+public class MapValueMatcher implements ValueMatcher<Map<String, String>> {
+
+    private final Map<String, String> value;
+
+    @Override
+    public boolean matches(final Map<String, String> anotherValue) {
+        final Map<String, String> currentValue = getValue();
+        if (Objects.isNull(currentValue) || Objects.isNull(anotherValue)) {
+            return false;
+        }
+        return currentValue.entrySet()
+                .stream()
+                .allMatch(entry -> {
+                    final String value = anotherValue.get(entry.getKey());
+                    if (Objects.isNull(value)) {
+                        return false;
+                    }
+                    return Objects.equals(value, entry.getValue());
+                });
+    }
+
+    /**
+     * @param anotherValue
+     * @return {@code true} if current map does not contain any value for
+     * any of {@param anotherValue} keys or does not contain key at all
+     */
+    @Override
+    public boolean empty(final Map<String, String> anotherValue) {
+        final Map<String, String> currentValue = getValue();
+        if (Objects.isNull(currentValue)) {
+            return Objects.nonNull(anotherValue);
+        }
+        return MapUtils.emptyIfNull(currentValue)
+                .keySet()
+                .stream()
+                .allMatch(key -> {
+                    final String value = anotherValue.get(key);
+                    return StringUtils.isBlank(value);
+                });
+    }
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/value/StringCaseInsensitiveValueMatcher.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/value/StringCaseInsensitiveValueMatcher.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.cluster.pool.filter.value;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class StringCaseInsensitiveValueMatcher extends StringValueMatcher {
+
+    public StringCaseInsensitiveValueMatcher(final String value) {
+        super(value);
+    }
+
+    @Override
+    public boolean matches(final String anotherValue) {
+        return StringUtils.equalsIgnoreCase(getValue(), anotherValue);
+    }
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/value/StringValueMatcher.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/value/StringValueMatcher.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.cluster.pool.filter.value;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+
+@RequiredArgsConstructor
+@Getter
+public class StringValueMatcher implements ValueMatcher<String> {
+
+    private final String value;
+
+    @Override
+    public boolean matches(final String anotherValue) {
+        return StringUtils.equals(getValue(), anotherValue);
+    }
+
+    @Override
+    public boolean empty(final String anotherValue) {
+        return StringUtils.isBlank(anotherValue);
+    }
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/value/ValueMatcher.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/pool/filter/value/ValueMatcher.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.cluster.pool.filter.value;
+
+public interface ValueMatcher<T> {
+
+    T getValue();
+    boolean matches(T anotherValue);
+    default boolean notMatches(T anotherValue) {
+        return !matches(anotherValue);
+    }
+    boolean empty(T anotherValue);
+    default boolean notEmpty(T anotherValue) {
+        return !empty(anotherValue);
+    }
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/pipeline/RunInstance.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/pipeline/RunInstance.java
@@ -19,6 +19,8 @@ package com.epam.pipeline.entity.pipeline;
 import com.epam.pipeline.entity.region.CloudProvider;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.Objects;
+import java.util.Set;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -51,6 +53,10 @@ public class RunInstance {
     private Boolean spot;
     private Long cloudRegionId;
     private CloudProvider cloudProvider;
+    /**
+     * Docker images that shall be pre-pulled to the instance
+     */
+    private Set<String> prePulledDockerImages;
 
     @JsonIgnore
     public boolean isEmpty() {

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/pipeline/CloudPipelineAPIClient.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/pipeline/CloudPipelineAPIClient.java
@@ -20,6 +20,7 @@ package com.epam.pipeline.vmmonitor.service.pipeline;
 import com.epam.pipeline.client.pipeline.CloudPipelineAPI;
 import com.epam.pipeline.client.pipeline.CloudPipelineApiBuilder;
 import com.epam.pipeline.entity.cluster.NodeInstance;
+import com.epam.pipeline.entity.cluster.pool.NodePool;
 import com.epam.pipeline.entity.notification.NotificationMessage;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.region.AbstractCloudRegion;
@@ -84,6 +85,10 @@ public class CloudPipelineAPIClient {
 
     public PipelineRun loadRun(final Long runId) {
         return QueryUtils.execute(cloudPipelineAPI.loadPipelineRun(runId));
+    }
+
+    public List<NodePool> loadNodePools() {
+        return QueryUtils.execute(cloudPipelineAPI.loadNodePools());
     }
 
     public static class APIVersion implements Comparable<APIVersion> {

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitor.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitor.java
@@ -48,24 +48,26 @@ import java.util.stream.Collectors;
 @Service
 public class VMMonitor {
 
-    private static final String POOL_ID_LABEL = "poolid";
     private final CloudPipelineAPIClient apiClient;
     private final VMNotifier notifier;
     private final Map<CloudProvider, VMMonitorService> services;
     private final List<String> requiredLabels;
     private final String runIdLabel;
+    private final String poolIdLabel;
 
     public VMMonitor(final CloudPipelineAPIClient apiClient,
                      final VMNotifier notifier,
                      final List<VMMonitorService> services,
                      @Value("${monitor.required.labels:}") final String requiredLabels,
-                     @Value("${monitor.runid.label:}") final String runIdLabel) {
+                     @Value("${monitor.runid.label:}") final String runIdLabel,
+                     @Value("${monitor.poolid.label:}") final String poolIdLabel) {
         this.apiClient = apiClient;
         this.notifier = notifier;
         this.services = ListUtils.emptyIfNull(services).stream()
                 .collect(Collectors.toMap(VMMonitorService::provider, Function.identity()));
         this.requiredLabels = Arrays.asList(requiredLabels.split(","));
         this.runIdLabel = runIdLabel;
+        this.poolIdLabel = poolIdLabel;
     }
 
     public void monitor() {
@@ -128,7 +130,7 @@ public class VMMonitor {
 
     private boolean poolIdExists(final VirtualMachine vm) {
         log.debug("Checking whether a node pool with corresponding pool id exists.");
-        final String poolIdValue = MapUtils.emptyIfNull(vm.getTags()).get(POOL_ID_LABEL);
+        final String poolIdValue = MapUtils.emptyIfNull(vm.getTags()).get(poolIdLabel);
         if (StringUtils.isNotBlank(poolIdValue) && NumberUtils.isDigits(poolIdValue)) {
             final long poolId = Long.parseLong(poolIdValue);
             log.debug("VM {} {} is associated with pool id {}. Checking node pool existence.",

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitor.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitor.java
@@ -18,6 +18,7 @@
 package com.epam.pipeline.vmmonitor.service.vm;
 
 import com.epam.pipeline.entity.cluster.NodeInstance;
+import com.epam.pipeline.entity.cluster.pool.NodePool;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.region.AbstractCloudRegion;
 import com.epam.pipeline.entity.region.CloudProvider;
@@ -47,6 +48,7 @@ import java.util.stream.Collectors;
 @Service
 public class VMMonitor {
 
+    private static final String POOL_ID_LABEL = "poolid";
     private final CloudPipelineAPIClient apiClient;
     private final VMNotifier notifier;
     private final Map<CloudProvider, VMMonitorService> services;
@@ -102,7 +104,7 @@ public class VMMonitor {
                 checkMatchingNodes(nodes, vm);
             } else {
                 log.debug("No matching nodes were found for VM {} {}.", vm.getInstanceId(), vm.getCloudProvider());
-                if (!matchingRunExists(vm)) {
+                if (!matchingRunExists(vm) && !poolIdExists(vm)) {
                     notifier.notifyMissingNode(vm);
                 }
             }
@@ -122,6 +124,23 @@ public class VMMonitor {
             return isRunActive(vm, runId);
         }
         return false;
+    }
+
+    private boolean poolIdExists(final VirtualMachine vm) {
+        log.debug("Checking whether a node pool with corresponding pool id exists.");
+        final String poolIdValue = MapUtils.emptyIfNull(vm.getTags()).get(POOL_ID_LABEL);
+        if (StringUtils.isNotBlank(poolIdValue) && NumberUtils.isDigits(poolIdValue)) {
+            final long poolId = Long.parseLong(poolIdValue);
+            log.debug("VM {} {} is associated with pool id {}. Checking node pool existence.",
+                    vm.getInstanceId(), vm.getCloudProvider(), poolId);
+            return isNodePoolExists(poolId);
+        }
+        return false;
+    }
+
+    private boolean isNodePoolExists(final long poolId) {
+        final List<NodePool> nodePools = apiClient.loadNodePools();
+        return nodePools.stream().map(NodePool::getId).collect(Collectors.toList()).contains(poolId);
     }
 
     private boolean isRunActive(final VirtualMachine vm, final long runId) {
@@ -145,7 +164,7 @@ public class VMMonitor {
 
     private void checkLabels(final NodeInstance node, final VirtualMachine vm) {
         log.debug("Checking status of node {} for VM {} {}", node.getName(), vm.getInstanceId(), vm.getCloudProvider());
-        if (matchingRunExists(vm)) {
+        if (matchingRunExists(vm) || poolIdExists(vm)) {
             return;
         }
         log.debug("Checking whether node {} is labeled with required tags.", node.getName());

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitor.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitor.java
@@ -128,13 +128,13 @@ public class VMMonitor {
         return false;
     }
 
-    private boolean poolIdExists(final VirtualMachine vm) {
+    private boolean poolIdExists(final NodeInstance node) {
         log.debug("Checking whether a node pool with corresponding pool id exists.");
-        final String poolIdValue = MapUtils.emptyIfNull(vm.getTags()).get(poolIdLabel);
+        final String poolIdValue = MapUtils.emptyIfNull(node.getLabels()).get(poolIdLabel);
         if (StringUtils.isNotBlank(poolIdValue) && NumberUtils.isDigits(poolIdValue)) {
             final long poolId = Long.parseLong(poolIdValue);
-            log.debug("VM {} {} is associated with pool id {}. Checking node pool existence.",
-                    vm.getInstanceId(), vm.getCloudProvider(), poolId);
+            log.debug("NodeInstance {} {} is associated with pool id {}. Checking node pool existence.",
+                    node.getUid(), node.getClusterName(), poolId);
             return isNodePoolExists(poolId);
         }
         return false;
@@ -166,7 +166,7 @@ public class VMMonitor {
 
     private void checkLabels(final NodeInstance node, final VirtualMachine vm) {
         log.debug("Checking status of node {} for VM {} {}", node.getName(), vm.getInstanceId(), vm.getCloudProvider());
-        if (matchingRunExists(vm) || poolIdExists(vm)) {
+        if (matchingRunExists(vm) || poolIdExists(node)) {
             return;
         }
         log.debug("Checking whether node {} is labeled with required tags.", node.getName());

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitor.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitor.java
@@ -106,7 +106,7 @@ public class VMMonitor {
                 checkMatchingNodes(nodes, vm);
             } else {
                 log.debug("No matching nodes were found for VM {} {}.", vm.getInstanceId(), vm.getCloudProvider());
-                if (!matchingRunExists(vm) && !poolIdExists(vm)) {
+                if (!matchingRunExists(vm)) {
                     notifier.notifyMissingNode(vm);
                 }
             }

--- a/vm-monitor/src/main/resources/application.properties
+++ b/vm-monitor/src/main/resources/application.properties
@@ -11,6 +11,7 @@ monitor.schedule.cron=0 */2 * ? * *
 monitor.instance.tag=monitored=true
 monitor.required.labels=runid
 monitor.runid.label=Name
+monitor.poolid.label=pool_id
 
 #Certificate-monitoring settings
 monitor.cert.schedule.cron=0 0 0 ? * *

--- a/vm-monitor/src/test/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitorTest.java
+++ b/vm-monitor/src/test/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitorTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.mockito.Mockito.doReturn;
@@ -44,7 +43,8 @@ public class VMMonitorTest {
     private static final String RUN_ID_VALUE = "p-123";
     private static final String POOL_ID_VALUE = "123";
     private static final Long POOL_ID = 123L;
-    private final Map<String, String> reqLabels = new HashMap<>();
+    private final Map<String, String> vmTags = Collections.singletonMap(RUN_ID_LABEL, RUN_ID_VALUE);
+    private final Map<String, String> nodeLabels = Collections.singletonMap(POOL_ID_LABEL, POOL_ID_VALUE);
     private final AwsRegion region = new AwsRegion(CloudProvider.AWS, TEST_STRING, TEST_STRING, TEST_STRING,
             TEST_STRING, TEST_STRING, TEST_STRING, TEST_STRING, 0, true);
     private VirtualMachine vm;
@@ -56,10 +56,8 @@ public class VMMonitorTest {
 
     @BeforeEach
     public void setUp() {
-        reqLabels.put(RUN_ID_LABEL, RUN_ID_VALUE);
-        reqLabels.put(POOL_ID_LABEL, POOL_ID_VALUE);
         doReturn(CloudProvider.AWS).when(mockService).provider();
-        vm = VirtualMachine.builder().tags(reqLabels).build();
+        vm = VirtualMachine.builder().tags(vmTags).build();
         monitor = new VMMonitor(mockApiClient, notifier, Collections.singletonList(mockService),
                 RUN_ID_LABEL, RUN_ID_LABEL, POOL_ID_LABEL);
 
@@ -69,7 +67,7 @@ public class VMMonitorTest {
     public void shouldNotNotifyMissingNodeWhenRunIdIsNotNumericAndPoolIdExists() {
         final NodeInstance nodeInstance = new NodeInstance();
         nodeInstance.setRunId(RUN_ID_VALUE);
-        nodeInstance.setLabels(reqLabels);
+        nodeInstance.setLabels(nodeLabels);
         final PipelineRun pipelineRun = new PipelineRun();
         pipelineRun.setStatus(TaskStatus.RUNNING);
         final NodePool nodePool = new NodePool();

--- a/vm-monitor/src/test/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitorTest.java
+++ b/vm-monitor/src/test/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitorTest.java
@@ -40,7 +40,7 @@ public class VMMonitorTest {
 
     private static final String TEST_STRING = "TEST";
     private static final String RUN_ID_LABEL = "runid";
-    private static final String POOL_ID_LABEL = "poolid";
+    private static final String POOL_ID_LABEL = "pool_id";
     private static final String RUN_ID_VALUE = "p-123";
     private static final String POOL_ID_VALUE = "123";
     private static final Long POOL_ID = 123L;
@@ -54,7 +54,6 @@ public class VMMonitorTest {
     private final VMMonitorService mockService = mock(AWSMonitorService.class);
     private final VMNotifier notifier = mock(VMNotifier.class);
 
-
     @BeforeEach
     public void setUp() {
         reqLabels.put(RUN_ID_LABEL, RUN_ID_VALUE);
@@ -62,7 +61,7 @@ public class VMMonitorTest {
         doReturn(CloudProvider.AWS).when(mockService).provider();
         vm = VirtualMachine.builder().tags(reqLabels).build();
         monitor = new VMMonitor(mockApiClient, notifier, Collections.singletonList(mockService),
-                RUN_ID_LABEL, RUN_ID_LABEL);
+                RUN_ID_LABEL, RUN_ID_LABEL, POOL_ID_LABEL);
 
     }
 

--- a/vm-monitor/src/test/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitorTest.java
+++ b/vm-monitor/src/test/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitorTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.vmmonitor.service.vm;
+
+import com.epam.pipeline.entity.cluster.NodeInstance;
+import com.epam.pipeline.entity.cluster.pool.NodePool;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.pipeline.TaskStatus;
+import com.epam.pipeline.entity.region.AwsRegion;
+import com.epam.pipeline.entity.region.CloudProvider;
+import com.epam.pipeline.vmmonitor.model.vm.VirtualMachine;
+import com.epam.pipeline.vmmonitor.service.pipeline.CloudPipelineAPIClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class VMMonitorTest {
+
+    private static final String TEST_STRING = "TEST";
+    private static final String RUN_ID_LABEL = "runid";
+    private static final String POOL_ID_LABEL = "poolid";
+    private static final String RUN_ID_VALUE = "p-123";
+    private static final String POOL_ID_VALUE = "123";
+    private static final Long POOL_ID = 123L;
+    private final Map<String, String> reqLabels = new HashMap<>();
+    private final AwsRegion region = new AwsRegion(CloudProvider.AWS, TEST_STRING, TEST_STRING, TEST_STRING,
+            TEST_STRING, TEST_STRING, TEST_STRING, TEST_STRING, 0, true);
+    private VirtualMachine vm;
+    private VMMonitor monitor;
+
+    private final CloudPipelineAPIClient mockApiClient = mock(CloudPipelineAPIClient.class);
+    private final VMMonitorService mockService = mock(AWSMonitorService.class);
+    private final VMNotifier notifier = mock(VMNotifier.class);
+
+
+    @BeforeEach
+    public void setUp() {
+        reqLabels.put(RUN_ID_LABEL, RUN_ID_VALUE);
+        reqLabels.put(POOL_ID_LABEL, POOL_ID_VALUE);
+        doReturn(CloudProvider.AWS).when(mockService).provider();
+        vm = VirtualMachine.builder().tags(reqLabels).build();
+        monitor = new VMMonitor(mockApiClient, notifier, Collections.singletonList(mockService),
+                RUN_ID_LABEL, RUN_ID_LABEL);
+
+    }
+
+    @Test
+    public void shouldNotNotifyMissingNodeWhenRunIdIsNotNumericAndPoolIdExists() {
+        final NodeInstance nodeInstance = new NodeInstance();
+        nodeInstance.setRunId(RUN_ID_VALUE);
+        nodeInstance.setLabels(reqLabels);
+        final PipelineRun pipelineRun = new PipelineRun();
+        pipelineRun.setStatus(TaskStatus.RUNNING);
+        final NodePool nodePool = new NodePool();
+        nodePool.setId(POOL_ID);
+        doReturn(Collections.singletonList(region)).when(mockApiClient).loadRegions();
+        doReturn(Collections.singletonList(vm)).when(mockService).fetchRunningVms(region);
+        doReturn(Collections.singletonList(nodeInstance)).when(mockApiClient).findNodes(vm.getPrivateIp());
+        doReturn(pipelineRun).when(mockApiClient).loadRun(POOL_ID);
+        doReturn(Collections.singletonList(nodePool)).when(mockApiClient).loadNodePools();
+        monitor.monitor();
+
+        verify(notifier, never()).notifyMissingNode(vm);
+    }
+
+    @Test
+    public void shouldNotifyMissingNodeWhenRunIdIsNotNumericAndPoolIdDoesNotExist() {
+        doReturn(Collections.singletonList(region)).when(mockApiClient).loadRegions();
+        doReturn(Collections.singletonList(vm)).when(mockService).fetchRunningVms(region);
+        monitor.monitor();
+
+        verify(notifier).notifyMissingNode(vm);
+    }
+}


### PR DESCRIPTION
This PR is related to issue #1652 and enables monitor to validate nodes with non-numeric `runid` and existing `pool_id` 