### PR TITLE
`pipe` shall allow to import users from CSV

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/user/UserApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/user/UserApiService.java
@@ -24,8 +24,8 @@ import com.epam.pipeline.entity.user.CustomControl;
 import com.epam.pipeline.entity.user.GroupStatus;
 import com.epam.pipeline.entity.user.PipelineUser;
 import com.epam.pipeline.entity.user.PipelineUserEvent;
-import com.epam.pipeline.manager.user.UserImportManager;
 import com.epam.pipeline.manager.user.UserManager;
+import com.epam.pipeline.manager.user.UsersFileImportManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
@@ -45,7 +45,7 @@ public class UserApiService {
     private UserManager userManager;
 
     @Autowired
-    private UserImportManager userImportManager;
+    private UsersFileImportManager usersFileImportManager;
 
     /**
      * Registers a new user
@@ -200,6 +200,6 @@ public class UserApiService {
     public List<PipelineUserEvent> importUsersFromCsv(final boolean createUser, final boolean createGroup,
                                                       final List<String> systemDictionariesToCreate,
                                                       final MultipartFile file) {
-        return userImportManager.importUsersFromFile(createUser, createGroup, systemDictionariesToCreate, file);
+        return usersFileImportManager.importUsersFromFile(createUser, createGroup, systemDictionariesToCreate, file);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/acl/user/UserApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/user/UserApiService.java
@@ -23,10 +23,13 @@ import com.epam.pipeline.entity.security.JwtRawToken;
 import com.epam.pipeline.entity.user.CustomControl;
 import com.epam.pipeline.entity.user.GroupStatus;
 import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.entity.user.PipelineUserEvent;
+import com.epam.pipeline.manager.user.UserImportManager;
 import com.epam.pipeline.manager.user.UserManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,6 +43,9 @@ public class UserApiService {
 
     @Autowired
     private UserManager userManager;
+
+    @Autowired
+    private UserImportManager userImportManager;
 
     /**
      * Registers a new user
@@ -188,5 +194,12 @@ public class UserApiService {
     @PreAuthorize(ADMIN_ONLY)
     public JwtRawToken issueToken(final String userName, final Long expiration) {
         return userManager.issueToken(userName, expiration);
+    }
+
+    @PreAuthorize(ADMIN_ONLY)
+    public List<PipelineUserEvent> importUsersFromCsv(final boolean createUser, final boolean createGroup,
+                                                      final List<String> systemDictionariesToCreate,
+                                                      final MultipartFile file) {
+        return userImportManager.importUsersFromFile(createUser, createGroup, systemDictionariesToCreate, file);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -565,6 +565,14 @@ public final class MessageConstants {
     public static final String ERROR_NODE_POOL_INVALID_DISK_SIZE = "error.node.pool.invalid.disk.size";
     public static final String ERROR_NODE_POOL_INVALID_COUNT = "error.node.pool.invalid.count";
 
+    // Users import events
+    public static final String EVENT_USER_CREATED = "user.import.event.user.created";
+    public static final String EVENT_USER_CREATION_NOT_ALLOWED = "user.import.event.user.creation.not.allowed";
+    public static final String EVENT_ROLE_CREATED = "user.import.event.role.created";
+    public static final String EVENT_ROLE_CREATION_NOT_ALLOWED = "user.import.event.role.creation.not.allowed";
+    public static final String EVENT_ROLE_ASSIGNED = "user.import.event.role.assigned";
+    public static final String EVENT_METADATA_ASSIGNED = "user.import.event.metadata.assigned";
+
     private MessageConstants() {
         // no-op
     }

--- a/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
@@ -26,27 +26,32 @@ import com.epam.pipeline.entity.security.JwtRawToken;
 import com.epam.pipeline.entity.user.CustomControl;
 import com.epam.pipeline.entity.user.GroupStatus;
 import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.entity.user.PipelineUserEvent;
 import com.epam.pipeline.manager.security.AuthManager;
 import com.epam.pipeline.acl.user.UserApiService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import org.apache.commons.fileupload.FileUploadException;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
@@ -366,5 +371,21 @@ public class UserController extends AbstractRestController {
         })
     public Result<List<GroupStatus>> loadGroupsBlockingStatuses() {
         return Result.success(userApiService.loadAllGroupsBlockingStatuses());
+    }
+
+    @PostMapping("/users/import")
+    @ResponseBody
+    @ApiOperation(
+            value = "Imports users from csv file.",
+            notes = "Imports users from csv file.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<List<PipelineUserEvent>> importUsersFromCsv(
+            @RequestParam(defaultValue = "false") final boolean createUser,
+            @RequestParam(defaultValue = "false") final boolean createGroup,
+            @RequestParam(required = false) final List<String> dictionaries,
+            final HttpServletRequest request) throws FileUploadException {
+        final MultipartFile file = consumeMultipartFile(request);
+        return Result.success(userApiService.importUsersFromCsv(createUser, createGroup, dictionaries, file));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
@@ -383,9 +383,9 @@ public class UserController extends AbstractRestController {
     public Result<List<PipelineUserEvent>> importUsersFromCsv(
             @RequestParam(defaultValue = "false") final boolean createUser,
             @RequestParam(defaultValue = "false") final boolean createGroup,
-            @RequestParam(required = false) final List<String> dictionaries,
+            @RequestParam(required = false) final List<String> createMetadata,
             final HttpServletRequest request) throws FileUploadException {
         final MultipartFile file = consumeMultipartFile(request);
-        return Result.success(userApiService.importUsersFromCsv(createUser, createGroup, dictionaries, file));
+        return Result.success(userApiService.importUsersFromCsv(createUser, createGroup, createMetadata, file));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/entity/user/PipelineUserEvent.java
+++ b/api/src/main/java/com/epam/pipeline/entity/user/PipelineUserEvent.java
@@ -16,7 +16,6 @@
 
 package com.epam.pipeline.entity.user;
 
-import com.epam.pipeline.controller.ResultStatus;
 import lombok.Builder;
 import lombok.Data;
 
@@ -27,7 +26,7 @@ import java.time.LocalDateTime;
 public class PipelineUserEvent {
     private String userName;
     private String message;
-    private ResultStatus status;
+    private PipelineUserEventStatus status;
     private LocalDateTime created;
 
     public static PipelineUserEvent error(final String userName, final String message) {
@@ -35,7 +34,7 @@ public class PipelineUserEvent {
                 .created(LocalDateTime.now())
                 .userName(userName)
                 .message(message)
-                .status(ResultStatus.ERROR)
+                .status(PipelineUserEventStatus.ERROR)
                 .build();
     }
 
@@ -43,7 +42,7 @@ public class PipelineUserEvent {
         return PipelineUserEvent.builder()
                 .created(LocalDateTime.now())
                 .message(message)
-                .status(ResultStatus.INFO)
+                .status(PipelineUserEventStatus.INFO)
                 .build();
     }
 }

--- a/api/src/main/java/com/epam/pipeline/entity/user/PipelineUserEvent.java
+++ b/api/src/main/java/com/epam/pipeline/entity/user/PipelineUserEvent.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.user;
+
+import com.epam.pipeline.controller.ResultStatus;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class PipelineUserEvent {
+    private String userName;
+    private String message;
+    private ResultStatus status;
+    private LocalDateTime created;
+
+    public static PipelineUserEvent error(final String userName, final String message) {
+        return PipelineUserEvent.builder()
+                .created(LocalDateTime.now())
+                .userName(userName)
+                .message(message)
+                .status(ResultStatus.ERROR)
+                .build();
+    }
+
+    public static PipelineUserEvent info(final String message) {
+        return PipelineUserEvent.builder()
+                .created(LocalDateTime.now())
+                .message(message)
+                .status(ResultStatus.INFO)
+                .build();
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/entity/user/PipelineUserEventStatus.java
+++ b/api/src/main/java/com/epam/pipeline/entity/user/PipelineUserEventStatus.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.user;
+
+public enum PipelineUserEventStatus {
+    ERROR, INFO
+}

--- a/api/src/main/java/com/epam/pipeline/entity/user/PipelineUserEventsList.java
+++ b/api/src/main/java/com/epam/pipeline/entity/user/PipelineUserEventsList.java
@@ -16,7 +16,6 @@
 
 package com.epam.pipeline.entity.user;
 
-import com.epam.pipeline.controller.ResultStatus;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -37,7 +36,7 @@ public class PipelineUserEventsList {
         events.add(PipelineUserEvent.builder()
                 .userName(userName)
                 .message(message)
-                .status(ResultStatus.ERROR)
+                .status(PipelineUserEventStatus.ERROR)
                 .created(LocalDateTime.now())
                 .build());
     }
@@ -46,7 +45,7 @@ public class PipelineUserEventsList {
         events.add(PipelineUserEvent.builder()
                 .userName(userName)
                 .message(message)
-                .status(ResultStatus.INFO)
+                .status(PipelineUserEventStatus.INFO)
                 .created(LocalDateTime.now())
                 .build());
     }

--- a/api/src/main/java/com/epam/pipeline/entity/user/PipelineUserEventsList.java
+++ b/api/src/main/java/com/epam/pipeline/entity/user/PipelineUserEventsList.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.user;
+
+import com.epam.pipeline.controller.ResultStatus;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class PipelineUserEventsList {
+    private final List<PipelineUserEvent> events;
+    private final String userName;
+
+    public PipelineUserEventsList(final String userName) {
+        this.events = new ArrayList<>();
+        this.userName = userName;
+    }
+
+    public void error(final String message) {
+        events.add(PipelineUserEvent.builder()
+                .userName(userName)
+                .message(message)
+                .status(ResultStatus.ERROR)
+                .created(LocalDateTime.now())
+                .build());
+    }
+
+    public void info(final String message) {
+        events.add(PipelineUserEvent.builder()
+                .userName(userName)
+                .message(message)
+                .status(ResultStatus.INFO)
+                .created(LocalDateTime.now())
+                .build());
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/user/RoleManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/RoleManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ import org.springframework.util.Assert;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -166,6 +167,10 @@ public class RoleManager {
         return roleDao.loadRoleByName(name)
                 .orElseThrow(() -> new IllegalArgumentException(
                         messageHelper.getMessage(MessageConstants.ERROR_ROLE_NAME_NOT_FOUND, name)));
+    }
+
+    public Optional<Role> findRoleByName(final String name) {
+        return roleDao.loadRoleByName(name);
     }
 
     public ExtendedRole loadRoleWithUsers(Long roleId) {

--- a/api/src/main/java/com/epam/pipeline/manager/user/UserImportManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/UserImportManager.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.user;
+
+import com.epam.pipeline.dao.user.RoleDao;
+import com.epam.pipeline.entity.metadata.CategoricalAttribute;
+import com.epam.pipeline.entity.metadata.CategoricalAttributeValue;
+import com.epam.pipeline.entity.metadata.MetadataEntry;
+import com.epam.pipeline.entity.metadata.PipeConfValue;
+import com.epam.pipeline.entity.security.acl.AclClass;
+import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.entity.user.PipelineUserEvent;
+import com.epam.pipeline.entity.user.PipelineUserEventsList;
+import com.epam.pipeline.entity.user.PipelineUserWithStoragePath;
+import com.epam.pipeline.entity.user.Role;
+import com.epam.pipeline.manager.metadata.CategoricalAttributeManager;
+import com.epam.pipeline.manager.metadata.MetadataManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.collections4.MapUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class UserImportManager {
+    private final UserManager userManager;
+    private final CategoricalAttributeManager categoricalAttributeManager;
+    private final MetadataManager metadataManager;
+    private final RoleManager roleManager;
+    private final RoleDao roleDao;
+
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    public List<PipelineUserEvent> importUsersFromFile(final boolean createUser, final boolean createGroup,
+                                                       final List<String> attributesToCreate,
+                                                       final MultipartFile file) {
+        final List<PipelineUserEvent> events = new ArrayList<>();
+        final List<CategoricalAttribute> categoricalAttributes = ListUtils
+                .emptyIfNull(categoricalAttributeManager.loadAll());
+        final List<PipelineUserWithStoragePath> users =
+                new UserImporter(events, categoricalAttributes, attributesToCreate).importUsers(file);
+        categoricalAttributeManager.updateCategoricalAttributes(categoricalAttributes);
+
+        users.forEach(user -> {
+            try {
+                events.addAll(ListUtils.emptyIfNull(processUser(user, createUser, createGroup, categoricalAttributes)));
+            } catch (Exception e) {
+                log.error(String.format("Failed to process user '%s'", user.getUserName()), e);
+                events.add(PipelineUserEvent.error(user.getUserName(), e.getMessage()));
+            }
+        });
+        return events;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public List<PipelineUserEvent> processUser(final PipelineUserWithStoragePath pipelineUserWithMetadata,
+                                               final boolean createUser, final boolean createGroup,
+                                               final List<CategoricalAttribute> categoricalAttributes) {
+        final PipelineUserEventsList events = new PipelineUserEventsList(
+                pipelineUserWithMetadata.getPipelineUser().getUserName());
+
+        final PipelineUser pipelineUser = getOrCreateUser(pipelineUserWithMetadata.getPipelineUser(),
+                createUser, events);
+
+        if (Objects.isNull(pipelineUser)) {
+            return events.getEvents();
+        }
+
+        pipelineUserWithMetadata.getRoles().forEach(role -> processRole(role, pipelineUser, createGroup, events));
+
+        addMetadataToUser(pipelineUser, pipelineUserWithMetadata.getMetadata(), events,
+                categoricalAttributes.stream()
+                        .collect(Collectors.toMap(CategoricalAttribute::getKey, Function.identity())));
+
+        return events.getEvents();
+    }
+
+    private PipelineUser getOrCreateUser(final PipelineUser pipelineUser, final boolean createUser,
+                                         final PipelineUserEventsList events) {
+        final String userName = pipelineUser.getUserName();
+        final PipelineUser loadedUser = userManager.loadUserByName(userName);
+        if (!createUser && Objects.isNull(loadedUser)) {
+            events.info(String.format("Pipeline user '%s' doesn't exist and cannot be created.", userName));
+            return null;
+        }
+        if (Objects.isNull(loadedUser)) {
+            final PipelineUser user = userManager.createUser(userName, Collections.emptyList(), Collections.emptyList(),
+                    pipelineUser.getAttributes(), null);
+            events.info(String.format("User '%s' successfully created.", userName));
+            return user;
+        }
+        return loadedUser;
+    }
+
+    private boolean roleAssignedToUser(final String roleNameToAdd, final List<Role> userRoles) {
+        return ListUtils.emptyIfNull(userRoles).stream()
+                .anyMatch(userRole -> userRole.getName().equalsIgnoreCase(roleNameToAdd));
+    }
+
+    private Role createRoleIfAllowed(final Role role, final boolean createRole, final PipelineUserEventsList events) {
+        if (!createRole) {
+            events.info(String.format("Role '%s' doesn't exist and cannot be created.", role.getName()));
+            return null;
+        }
+        final Role createdRole = roleManager.createRole(role.getName(), role.isPredefined(), role.isUserDefault(),
+                role.getDefaultStorageId());
+        events.info(String.format("Role '%s' successfully created.", role.getName()));
+        return createdRole;
+    }
+
+    private Role getOrCreateRole(final Role role, final boolean createRoles, final PipelineUserEventsList events) {
+        return roleDao.loadRoleByName(role.getName())
+                .orElseGet(() -> createRoleIfAllowed(role, createRoles, events));
+    }
+
+    private void processRole(final Role roleToAdd, final PipelineUser user, final boolean createRoles,
+                             final PipelineUserEventsList events) {
+        if (roleAssignedToUser(roleToAdd.getName(), user.getRoles())) {
+            return;
+        }
+        final Role role = getOrCreateRole(roleToAdd, createRoles, events);
+        if (Objects.isNull(role)) {
+            return;
+        }
+        roleManager.assignRole(role.getId(), Collections.singletonList(user.getId()));
+        events.info(String.format("Role '%s' successfully assigned to user '%s'",
+                role.getName(), user.getUserName()));
+    }
+
+    private Map<String, PipeConfValue> getCurrentMetadata(final Long userId) {
+        final MetadataEntry currentMetadataEntry = metadataManager.loadMetadataItem(userId, AclClass.PIPELINE_USER);
+        return Objects.isNull(currentMetadataEntry)
+                ? new HashMap<>()
+                : MapUtils.emptyIfNull(currentMetadataEntry.getData());
+    }
+
+    private void addMetadataToUser(final PipelineUser pipelineUser,
+                                   final Map<String, PipeConfValue> metadataToImport,
+                                   final PipelineUserEventsList events,
+                                   final Map<String, CategoricalAttribute> categoricalAttributes) {
+        final Map<String, PipeConfValue> currentMetadata = getCurrentMetadata(pipelineUser.getId());
+        metadataToImport
+                .forEach((key, value) -> fillMetadata(categoricalAttributes, currentMetadata, events, key, value));
+        metadataManager.updateEntityMetadata(currentMetadata, pipelineUser.getId(), AclClass.PIPELINE_USER);
+    }
+
+    private void fillMetadata(final Map<String, CategoricalAttribute> categoricalAttributes,
+                              final Map<String, PipeConfValue> metadata,
+                              final PipelineUserEventsList events,
+                              final String keyToAdd, final PipeConfValue valueToAdd) {
+        categoricalAttributes.computeIfPresent(keyToAdd, (attributeKey, attribute) -> {
+            ListUtils.emptyIfNull(attribute.getValues()).stream()
+                    .filter(attributeValue -> attributeValue.getValue().equals(valueToAdd.getValue()))
+                    .findFirst()
+                    .ifPresent(attributeValue -> {
+                        addDataToMetadata(metadata, events, keyToAdd, valueToAdd);
+                        addLinksToMetadata(attributeValue.getLinks(), metadata, events);
+                    });
+            return attribute;
+        });
+    }
+
+    private void addDataToMetadata(final Map<String, PipeConfValue> metadata,
+                                   final PipelineUserEventsList events,
+                                   final String keyToAdd, final PipeConfValue valueToAdd) {
+        if (metadata.containsKey(keyToAdd) && metadata.get(keyToAdd).getValue().equals(valueToAdd.getValue())) {
+            return;
+        }
+        metadata.put(keyToAdd, valueToAdd);
+        events.info(String.format("A new metadata '%s'='%s' added to user '%s'", keyToAdd, valueToAdd.getValue(),
+                events.getUserName()));
+    }
+
+    private void addLinksToMetadata(final List<CategoricalAttributeValue> links,
+                                    final Map<String, PipeConfValue> metadata,
+                                    final PipelineUserEventsList events) {
+        if (CollectionUtils.isEmpty(links)) {
+            return;
+        }
+        links.forEach(link -> {
+            addDataToMetadata(metadata, events, link.getKey(), new PipeConfValue("string", link.getValue()));
+            addLinksToMetadata(link.getLinks(), metadata, events);
+        });
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/user/UserImporter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/UserImporter.java
@@ -24,7 +24,6 @@ import com.epam.pipeline.entity.user.PipelineUserEvent;
 import com.epam.pipeline.entity.user.PipelineUserWithStoragePath;
 import com.epam.pipeline.entity.user.Role;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.csv.CSVFormat;
@@ -46,15 +45,23 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 /**
- * Generates users structure according to the given scv file
+ * Generates users structure according to the given csv file
  */
-@Slf4j
 @RequiredArgsConstructor
 public class UserImporter {
     private final List<PipelineUserEvent> events;
     private final List<CategoricalAttribute> currentAttributes;
     private final List<String> attributesToCreate;
 
+    /**
+     * Returns List of {@link PipelineUserWithStoragePath}
+     * @param file the input csv file. The header should have the following format:
+     *             1 column - the user name
+     *             2 column - the list of roles that shall be assigned to user (separated by '|' symbol)
+     *             remains - the metadata keys
+     *             The header example: UserName,Groups,MetadataItem1,MetadataItem2,MetadataItemN
+     * @return the list of users specified in the input file
+     */
     public List<PipelineUserWithStoragePath> importUsers(final MultipartFile file) {
         try (CSVParser csvParser = buildCsvParser(file)) {
             final List<String> metadataHeaders = getMetadataHeader(csvParser.getHeaderMap());
@@ -113,7 +120,7 @@ public class UserImporter {
                     "Metadata '%s' doesn't exist and cannot be created.", key)));
             return;
         }
-        userMetadata.put(key, new PipeConfValue("string", value));
+        userMetadata.put(key, new PipeConfValue(null, value));
     }
 
     private CSVParser buildCsvParser(final MultipartFile file) throws IOException {

--- a/api/src/main/java/com/epam/pipeline/manager/user/UserImporter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/UserImporter.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.user;
+
+import com.epam.pipeline.entity.metadata.CategoricalAttribute;
+import com.epam.pipeline.entity.metadata.CategoricalAttributeValue;
+import com.epam.pipeline.entity.metadata.PipeConfValue;
+import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.entity.user.PipelineUserEvent;
+import com.epam.pipeline.entity.user.PipelineUserWithStoragePath;
+import com.epam.pipeline.entity.user.Role;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * Generates users structure according to the given scv file
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class UserImporter {
+    private final List<PipelineUserEvent> events;
+    private final List<CategoricalAttribute> currentAttributes;
+    private final List<String> attributesToCreate;
+
+    public List<PipelineUserWithStoragePath> importUsers(final MultipartFile file) {
+        try (CSVParser csvParser = buildCsvParser(file)) {
+            final List<String> metadataHeaders = getMetadataHeader(csvParser.getHeaderMap());
+            return StreamSupport.stream(csvParser.spliterator(), false)
+                    .map(record -> parseRecord(record, metadataHeaders))
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Failed to parse users from CSV file", e);
+        }
+    }
+
+    private PipelineUserWithStoragePath parseRecord(final CSVRecord record, final List<String> metadataHeaders) {
+        final String userName = record.get(0);
+        if (StringUtils.isBlank(userName)) {
+            return null;
+        }
+        final List<String> roles = parseGroups(record.get(1));
+        final PipelineUser pipelineUser = PipelineUser.builder()
+                .userName(userName.toUpperCase())
+                .roles(buildRoles(roles))
+                .build();
+        return PipelineUserWithStoragePath.builder()
+                .pipelineUser(pipelineUser)
+                .metadata(processMetadata(record.toMap(), metadataHeaders))
+                .build();
+    }
+
+    private Map<String, PipeConfValue> processMetadata(final Map<String, String> valuesByHeader,
+                                                       final List<String> metadataHeaders) {
+        final Map<String, CategoricalAttribute> attributes = currentAttributes.stream()
+                .collect(Collectors.toMap(CategoricalAttribute::getKey, Function.identity()));
+        final Map<String, PipeConfValue> userMetadata = new HashMap<>();
+        valuesByHeader.entrySet().stream()
+                .filter(entry -> StringUtils.isNotBlank(entry.getValue()))
+                .filter(entry -> metadataHeaders.contains(entry.getKey()))
+                .forEach(entry -> processMetadataItem(attributes, userMetadata, entry.getKey(), entry.getValue()));
+        return userMetadata;
+    }
+
+    private void processMetadataItem(final Map<String, CategoricalAttribute> attributes,
+                                     final Map<String, PipeConfValue> userMetadata,
+                                     final String key, final String value) {
+        if (attributes.containsKey(key)) {
+            final List<CategoricalAttributeValue> values = ListUtils.emptyIfNull(attributes.get(key).getValues());
+            if (values.stream().noneMatch(attributeValue -> attributeValue.getValue().equals(value))) {
+                values.add(new CategoricalAttributeValue(key, value));
+            }
+        } else if (CollectionUtils.isNotEmpty(attributesToCreate) && attributesToCreate.contains(key)) {
+            final List<CategoricalAttributeValue> attributeValues = new ArrayList<>();
+            attributeValues.add(new CategoricalAttributeValue(key, value));
+            currentAttributes.add(new CategoricalAttribute(key, attributeValues));
+            events.add(PipelineUserEvent.info(String.format("A new metadata '%s' will be created.", key)));
+        } else {
+            events.add(PipelineUserEvent.info(String.format(
+                    "Metadata '%s' doesn't exist and cannot be created.", key)));
+            return;
+        }
+        userMetadata.put(key, new PipeConfValue("string", value));
+    }
+
+    private CSVParser buildCsvParser(final MultipartFile file) throws IOException {
+        return new CSVParser(new InputStreamReader(file.getInputStream()), CSVFormat.DEFAULT
+                .withFirstRecordAsHeader()
+                .withIgnoreHeaderCase()
+                .withTrim());
+    }
+
+    private List<String> parseGroups(final String rawGroups) {
+        return Arrays.stream(rawGroups.split("\\|"))
+                .collect(Collectors.toList());
+    }
+
+    private List<String> getMetadataHeader(final Map<String, Integer> fullHeader) {
+        return fullHeader.entrySet().stream()
+                .filter(this::notUserOrGroup)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
+    }
+
+    private boolean notUserOrGroup(final Map.Entry<String, Integer> entry) {
+        return entry.getValue() != 0 && entry.getValue() != 1;
+    }
+
+    private List<Role> buildRoles(final List<String> roleNames) {
+        return roleNames.stream()
+                .filter(StringUtils::isNotBlank)
+                .map(String::trim)
+                .map(String::toUpperCase)
+                .map(this::prepareRoleName)
+                .map(Role::new)
+                .collect(Collectors.toList());
+    }
+
+    private String prepareRoleName(final String rawName) {
+        return rawName.startsWith(Role.ROLE_PREFIX) ? rawName : Role.ROLE_PREFIX + rawName;
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/user/UsersFileImportManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/UsersFileImportManager.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.user;
+
+import com.epam.pipeline.entity.metadata.CategoricalAttribute;
+import com.epam.pipeline.entity.metadata.MetadataEntry;
+import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.entity.user.PipelineUserEvent;
+import com.epam.pipeline.entity.user.PipelineUserWithStoragePath;
+import com.epam.pipeline.entity.user.Role;
+import com.epam.pipeline.manager.metadata.CategoricalAttributeManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.ListUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UsersFileImportManager {
+    private final UserImportManager userImportManager;
+    private final CategoricalAttributeManager categoricalAttributeManager;
+
+    /**
+     * Registers a new {@link PipelineUser}, {@link Role} and {@link MetadataEntry} for users
+     * if allowed. Otherwise, log event and skip action.
+     * @param createUser true if user shall be created if not exists
+     * @param createGroup true if role shall be created if not exists
+     * @param attributesToCreate the list of metadata keys that shall be created if not exists
+     * @param file the input file with users
+     * @return the list of events that happened during user processing
+     */
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    public List<PipelineUserEvent> importUsersFromFile(final boolean createUser, final boolean createGroup,
+                                                       final List<String> attributesToCreate,
+                                                       final MultipartFile file) {
+        final List<CategoricalAttribute> categoricalAttributes = ListUtils
+                .emptyIfNull(categoricalAttributeManager.loadAll());
+        final List<PipelineUserWithStoragePath> users =
+                new UserImporter(categoricalAttributes, attributesToCreate).importUsers(file);
+        if (CollectionUtils.isNotEmpty(categoricalAttributes)) {
+            categoricalAttributeManager.updateCategoricalAttributes(categoricalAttributes);
+        }
+
+        return users.stream()
+                .flatMap(user -> {
+                    try {
+                        return ListUtils.emptyIfNull(userImportManager
+                                .processUser(user, createUser, createGroup, categoricalAttributes)).stream();
+                    } catch (Exception e) {
+                        log.error(String.format("Failed to process user '%s'", user.getUserName()), e);
+                        return Stream.of(PipelineUserEvent.error(user.getUserName(), e.getMessage()));
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -527,3 +527,11 @@ error.node.pool.price.type.not.allowed=Price type ''{0}'' is not allowed.
 error.node.pool.instance.type.not.allowed=Instance type ''{0}'' is not allowed.
 error.node.pool.invalid.disk.size=Disk size shall be greater than zero.
 error.node.pool.invalid.count=Instance count shall be greater or equal to zero.
+
+#Users import events
+user.import.event.user.created=User ''{0}'' successfully created.
+user.import.event.user.creation.not.allowed=Pipeline user ''{0}'' doesn't exist and cannot be created.
+user.import.event.role.created=Role ''{0}'' successfully created.
+user.import.event.role.creation.not.allowed=Role ''{0}'' doesn't exist and cannot be created.
+user.import.event.role.assigned=Role ''{0}'' successfully assigned to user ''{1}''.
+user.import.event.metadata.assigned=A new metadata ''{0}''=''{1}'' added to user ''{2}''.

--- a/api/src/test/java/com/epam/pipeline/app/AclTestConfiguration.java
+++ b/api/src/test/java/com/epam/pipeline/app/AclTestConfiguration.java
@@ -70,6 +70,7 @@ import com.epam.pipeline.manager.pipeline.runner.ConfigurationRunner;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.region.CloudRegionManager;
 import com.epam.pipeline.manager.user.RoleManager;
+import com.epam.pipeline.manager.user.UserImportManager;
 import com.epam.pipeline.manager.user.UserManager;
 import com.epam.pipeline.manager.utils.UtilsManager;
 import com.epam.pipeline.security.acl.AclPermissionFactory;
@@ -273,6 +274,9 @@ public class AclTestConfiguration {
 
     @MockBean
     protected SystemNotificationManager systemNotificationManager;
+
+    @MockBean
+    protected UserImportManager userImportManager;
 
     @Bean
     public PermissionFactory permissionFactory() {

--- a/api/src/test/java/com/epam/pipeline/app/AclTestConfiguration.java
+++ b/api/src/test/java/com/epam/pipeline/app/AclTestConfiguration.java
@@ -70,8 +70,8 @@ import com.epam.pipeline.manager.pipeline.runner.ConfigurationRunner;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.region.CloudRegionManager;
 import com.epam.pipeline.manager.user.RoleManager;
-import com.epam.pipeline.manager.user.UserImportManager;
 import com.epam.pipeline.manager.user.UserManager;
+import com.epam.pipeline.manager.user.UsersFileImportManager;
 import com.epam.pipeline.manager.utils.UtilsManager;
 import com.epam.pipeline.security.acl.AclPermissionFactory;
 import com.epam.pipeline.security.jwt.JwtTokenGenerator;
@@ -276,7 +276,7 @@ public class AclTestConfiguration {
     protected SystemNotificationManager systemNotificationManager;
 
     @MockBean
-    protected UserImportManager userImportManager;
+    protected UsersFileImportManager usersFileImportManager;
 
     @Bean
     public PermissionFactory permissionFactory() {

--- a/api/src/test/java/com/epam/pipeline/manager/user/UserImportManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/user/UserImportManagerTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.user;
+
+import com.epam.pipeline.controller.vo.EntityVO;
+import com.epam.pipeline.entity.metadata.CategoricalAttribute;
+import com.epam.pipeline.entity.metadata.CategoricalAttributeValue;
+import com.epam.pipeline.entity.metadata.MetadataEntry;
+import com.epam.pipeline.entity.metadata.PipeConfValue;
+import com.epam.pipeline.entity.security.acl.AclClass;
+import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.entity.user.PipelineUserEvent;
+import com.epam.pipeline.entity.user.PipelineUserWithStoragePath;
+import com.epam.pipeline.entity.user.Role;
+import com.epam.pipeline.manager.metadata.CategoricalAttributeManager;
+import com.epam.pipeline.manager.metadata.MetadataManager;
+import org.apache.commons.collections4.CollectionUtils;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.epam.pipeline.test.creator.user.UserCreatorUtils.getPipelineUser;
+import static com.epam.pipeline.test.creator.user.UserCreatorUtils.getUserWithMetadata;
+import static com.epam.pipeline.util.CustomAssertions.notInvoked;
+import static com.epam.pipeline.util.CustomMatchers.anyLongList;
+import static com.epam.pipeline.util.CustomMatchers.anyStringList;
+import static com.epam.pipeline.util.CustomMatchers.anyStringMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class UserImportManagerTest {
+    private static final String USER_NAME = "user";
+    private static final String ROLE_NAME = "role";
+    private static final String KEY = "key";
+    private static final String VALUE = "value";
+    private static final String LINKED_KEY = "key1";
+    private static final String LINKED_VALUE = "value1";
+    private static final String LINKED_KEY_2 = "key2";
+    private static final String LINKED_VALUE_2 = "value2";
+
+    private final UserManager userManager = mock(UserManager.class);
+    private final CategoricalAttributeManager categoricalAttributeManager = mock(CategoricalAttributeManager.class);
+    private final MetadataManager metadataManager = mock(MetadataManager.class);
+    private final RoleManager roleManager = mock(RoleManager.class);
+    private final UserImportManager userImportManager = new UserImportManager(userManager,
+            categoricalAttributeManager, metadataManager, roleManager);
+
+    @Test
+    public void shouldCreateUserAndRolesAndMetadataIfAllowed() {
+        final PipelineUser pipelineUser = getPipelineUser(USER_NAME);
+        final Role role = new Role(ROLE_NAME);
+        pipelineUser.setRoles(Collections.singletonList(role));
+        final PipelineUserWithStoragePath userWithMetadata = getUserWithMetadata(pipelineUser, buildMetadata());
+        final CategoricalAttribute categoricalAttribute = getCategoricalAttribute(KEY, VALUE, null);
+
+        when(userManager.createUser(anyString(), anyLongList(), anyStringList(), anyStringMap(), anyLong()))
+                .thenReturn(getPipelineUser(USER_NAME));
+        when(roleManager.findRoleByName(ROLE_NAME)).thenReturn(Optional.empty());
+        when(roleManager.createRole(anyString(), anyBoolean(), anyBoolean(), anyLong())).thenReturn(role);
+
+        final List<PipelineUserEvent> resultEvents = userImportManager
+                .processUser(userWithMetadata, true, true,
+                        Collections.singletonList(categoricalAttribute));
+
+        verify(userManager).createUser(anyString(), anyLongList(), anyStringList(), anyStringMap(), anyLong());
+        verify(roleManager).createRole(anyString(), anyBoolean(), anyBoolean(), anyLong());
+        verify(roleManager).assignRole(anyLong(), anyLongList());
+        verify(metadataManager).updateEntityMetadata(any(), any(), any());
+        assertThat(resultEvents).hasSize(4);
+    }
+
+    @Test
+    public void shouldNotCreateUserRoleAndMetadataIfExists() {
+        final PipelineUser pipelineUser = getPipelineUser(USER_NAME);
+        final Role role = new Role(ROLE_NAME);
+        pipelineUser.setRoles(Collections.singletonList(role));
+        final PipelineUserWithStoragePath userWithMetadata = getUserWithMetadata(pipelineUser, buildMetadata());
+        final CategoricalAttribute categoricalAttribute = getCategoricalAttribute(KEY, VALUE, null);
+
+        when(userManager.loadUserByName(USER_NAME)).thenReturn(pipelineUser);
+        when(roleManager.findRoleByName(ROLE_NAME)).thenReturn(Optional.of(role));
+        when(metadataManager.loadMetadataItem(pipelineUser.getId(), AclClass.PIPELINE_USER))
+                .thenReturn(userMetadata(pipelineUser.getId(), buildMetadata()));
+
+        final List<PipelineUserEvent> resultEvents = userImportManager
+                .processUser(userWithMetadata, true, true,
+                        Collections.singletonList(categoricalAttribute));
+
+        notInvoked(userManager).createUser(anyString(), anyLongList(), anyStringList(), anyStringMap(), anyLong());
+        notInvoked(roleManager).createRole(anyString(), anyBoolean(), anyBoolean(), anyLong());
+        notInvoked(roleManager).assignRole(anyLong(), anyLongList());
+        verify(metadataManager).updateEntityMetadata(any(), any(), any());
+        assertThat(CollectionUtils.isEmpty(resultEvents)).isTrue();
+    }
+
+    @Test
+    public void shouldNotCreateRoleIfNotAllowed() {
+        final PipelineUser pipelineUser = getPipelineUser(USER_NAME);
+        final Role role = new Role(ROLE_NAME);
+        pipelineUser.setRoles(Collections.singletonList(role));
+        final PipelineUserWithStoragePath userWithMetadata = getUserWithMetadata(pipelineUser, buildMetadata());
+
+        when(userManager.loadUserByName(USER_NAME)).thenReturn(getPipelineUser(USER_NAME));
+        when(roleManager.findRoleByName(ROLE_NAME)).thenReturn(Optional.empty());
+
+        final List<PipelineUserEvent> resultEvents = userImportManager
+                .processUser(userWithMetadata, false, false, Collections.emptyList());
+
+        notInvoked(roleManager).createRole(anyString(), anyBoolean(), anyBoolean(), anyLong());
+        notInvoked(roleManager).assignRole(anyLong(), anyLongList());
+        assertThat(resultEvents).hasSize(1);
+    }
+
+    @Test
+    public void shouldNotCreateUserIfNotAllowed() {
+        final PipelineUser pipelineUser = getPipelineUser(USER_NAME);
+        final PipelineUserWithStoragePath userWithMetadata = getUserWithMetadata(pipelineUser, buildMetadata());
+
+        when(userManager.loadUserByName(USER_NAME)).thenReturn(null);
+
+        final List<PipelineUserEvent> resultEvents = userImportManager
+                .processUser(userWithMetadata, false, true, Collections.emptyList());
+
+        notInvoked(userManager).createUser(anyString(), anyLongList(), anyStringList(), anyStringMap(), anyLong());
+        assertThat(resultEvents).hasSize(1);
+    }
+
+    @Test
+    public void shouldNotUpdateMetadataIfNotAllowed() {
+        final PipelineUser pipelineUser = getPipelineUser(USER_NAME);
+        final Map<String, PipeConfValue> metadata = buildMetadata();
+        metadata.put(LINKED_KEY, new PipeConfValue(null, LINKED_VALUE));
+        metadata.put(LINKED_KEY_2, new PipeConfValue(null, LINKED_VALUE_2));
+        final PipelineUserWithStoragePath userWithMetadata = getUserWithMetadata(pipelineUser, metadata);
+
+        when(userManager.loadUserByName(USER_NAME)).thenReturn(pipelineUser);
+        when(metadataManager.loadMetadataItem(pipelineUser.getId(), AclClass.PIPELINE_USER))
+                .thenReturn(userMetadata(pipelineUser.getId(), buildMetadata()));
+
+        final List<PipelineUserEvent> resultEvents = userImportManager
+                .processUser(userWithMetadata, true, true, Collections.emptyList());
+
+        final ArgumentCaptor<Map<String, PipeConfValue>> dataCaptor = getCaptor();
+        verify(metadataManager).updateEntityMetadata(dataCaptor.capture(), any(), any());
+        final Map<String, PipeConfValue> capturedData = dataCaptor.getValue();
+        assertThat(capturedData)
+                .hasSize(1)
+                .containsKey(KEY);
+        assertThat(capturedData.get(KEY).getValue()).isEqualTo(VALUE);
+
+        assertThat(CollectionUtils.isEmpty(resultEvents)).isTrue();
+    }
+
+    @Test
+    public void shouldUpdateLinkedMetadata() {
+        final PipelineUser pipelineUser = getPipelineUser(USER_NAME);
+        final PipelineUserWithStoragePath userWithMetadata = getUserWithMetadata(pipelineUser, buildMetadata());
+
+        final CategoricalAttribute attribute1 = getCategoricalAttribute(KEY, VALUE,
+                Collections.singletonList(getCategoricalAttributeValue(LINKED_KEY, LINKED_VALUE)));
+        final CategoricalAttribute attribute2 = getCategoricalAttribute(LINKED_KEY, LINKED_VALUE,
+                Collections.singletonList(getCategoricalAttributeValue(LINKED_KEY_2, LINKED_VALUE_2)));
+        final CategoricalAttribute attribute3 = getCategoricalAttribute(LINKED_KEY_2, LINKED_VALUE_2, null);
+
+        when(userManager.loadUserByName(USER_NAME)).thenReturn(pipelineUser);
+
+        final List<PipelineUserEvent> resultEvents = userImportManager
+                .processUser(userWithMetadata, true, true,
+                        Arrays.asList(attribute1, attribute2, attribute3));
+
+        final ArgumentCaptor<Map<String, PipeConfValue>> dataCaptor = getCaptor();
+        verify(metadataManager).updateEntityMetadata(dataCaptor.capture(), any(), any());
+        final Map<String, PipeConfValue> capturedData = dataCaptor.getValue();
+        assertThat(capturedData)
+                .hasSize(3)
+                .containsKeys(KEY, LINKED_KEY, LINKED_KEY_2);
+        assertThat(capturedData.get(KEY).getValue()).isEqualTo(VALUE);
+        assertThat(capturedData.get(LINKED_KEY).getValue()).isEqualTo(LINKED_VALUE);
+        assertThat(capturedData.get(LINKED_KEY_2).getValue()).isEqualTo(LINKED_VALUE_2);
+
+        assertThat(resultEvents).hasSize(3);
+    }
+
+    private Map<String, PipeConfValue> buildMetadata() {
+        final Map<String, PipeConfValue> metadata = new HashMap<>();
+        metadata.put(KEY, new PipeConfValue(null, VALUE));
+        return metadata;
+    }
+
+    private CategoricalAttribute getCategoricalAttribute(final String key, final String value,
+                                                         final List<CategoricalAttributeValue> links) {
+        final CategoricalAttributeValue attributeValue = getCategoricalAttributeValue(key, value);
+        attributeValue.setLinks(links);
+        return new CategoricalAttribute(key, Collections.singletonList(attributeValue));
+    }
+
+    private CategoricalAttributeValue getCategoricalAttributeValue(final String key, final String value) {
+        final CategoricalAttributeValue attributeValue = new CategoricalAttributeValue();
+        attributeValue.setKey(key);
+        attributeValue.setValue(value);
+        return attributeValue;
+    }
+
+    private MetadataEntry userMetadata(final Long userId, final Map<String, PipeConfValue> data) {
+        final MetadataEntry metadataEntry = new MetadataEntry();
+        metadataEntry.setEntity(new EntityVO(userId, AclClass.PIPELINE_USER));
+        metadataEntry.setData(data);
+        return metadataEntry;
+    }
+
+    private ArgumentCaptor<Map<String, PipeConfValue>> getCaptor() {
+        return ArgumentCaptor.forClass((Class) Map.class);
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/manager/user/UserImporterTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/user/UserImporterTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.user;
+
+import com.epam.pipeline.entity.metadata.CategoricalAttribute;
+import com.epam.pipeline.entity.metadata.CategoricalAttributeValue;
+import com.epam.pipeline.entity.user.PipelineUserEvent;
+import com.epam.pipeline.entity.user.PipelineUserWithStoragePath;
+import com.epam.pipeline.entity.user.Role;
+import org.junit.Test;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UserImporterTest {
+    private static final String HEADER = "UserName,Groups,Key1,Key2,Key3\n";
+    private static final String CONTENT = HEADER + "user1,test1|test2,Value1,Value2,Value3";
+    private static final String EMPTY_USER_CONTENT = HEADER + ",test1|test2,Value1,Value2,Value3";
+    private static final String EMPTY_CONTENT = HEADER + "user1,,,,";
+    private static final String TEST_USER = "USER1";
+    private static final String TEST_ROLE_1 = "ROLE_TEST1";
+    private static final String TEST_ROLE_2 = "ROLE_TEST2";
+    private static final String KEY1 = "Key1";
+    private static final String KEY2 = "Key2";
+    private static final String VALUE1 = "Value1";
+    private static final String VALUE2 = "Value2";
+
+    @Test
+    public void shouldParseCsvFile() {
+        final MultipartFile file = getFile(CONTENT);
+        final List<String> allowedMetadata = Arrays.asList(KEY1, KEY2);
+        final ArrayList<CategoricalAttribute> attributes = new ArrayList<>();
+        final ArrayList<PipelineUserEvent> events = new ArrayList<>();
+
+        final List<PipelineUserWithStoragePath> resultUsers =
+                new UserImporter(events, attributes, allowedMetadata).importUsers(file);
+
+        assertThat(resultUsers).hasSize(1);
+        final PipelineUserWithStoragePath resultUser = resultUsers.get(0);
+        assertThat(resultUser.getUserName()).isEqualTo(TEST_USER);
+        assertThat(resultUser.getRoles().stream().map(Role::getName).collect(Collectors.toList()))
+                .hasSize(2)
+                .contains(TEST_ROLE_1)
+                .contains(TEST_ROLE_2);
+        assertThat(resultUser.getMetadata()).hasSize(2).containsKeys(KEY1, KEY2);
+        assertThat(resultUser.getMetadata().get(KEY1).getValue()).isEqualTo(VALUE1);
+        assertThat(resultUser.getMetadata().get(KEY2).getValue()).isEqualTo(VALUE2);
+        assertThat(attributes).hasSize(2);
+        assertThat(attributes.stream().map(CategoricalAttribute::getKey).collect(Collectors.toList()))
+                .contains(KEY1, KEY2);
+        attributes.forEach(attribute -> {
+            assertThat(attribute.getValues()).hasSize(1);
+            assertAttributeValue(attribute, KEY1, VALUE1);
+            assertAttributeValue(attribute, KEY2, VALUE2);
+        });
+        assertThat(events).hasSize(3);
+    }
+
+    @Test
+    public void shouldSkipUserIfNameNotFound() {
+        final MultipartFile file = getFile(EMPTY_USER_CONTENT);
+        final List<String> allowedMetadata = Arrays.asList(KEY1, KEY2);
+        final ArrayList<CategoricalAttribute> attributes = new ArrayList<>();
+        final ArrayList<PipelineUserEvent> events = new ArrayList<>();
+        final UserImporter userImporter = new UserImporter(events, attributes, allowedMetadata);
+
+        assertThat(userImporter.importUsers(file)).hasSize(0);
+        assertThat(attributes).hasSize(0);
+        assertThat(events).hasSize(0);
+    }
+
+    @Test
+    public void shouldParseIfRolesAndMetadataEmpty() {
+        final MultipartFile file = getFile(EMPTY_CONTENT);
+        final List<String> allowedMetadata = Arrays.asList(KEY1, KEY2);
+        final ArrayList<CategoricalAttribute> attributes = new ArrayList<>();
+        final ArrayList<PipelineUserEvent> events = new ArrayList<>();
+
+        final List<PipelineUserWithStoragePath> resultUsers =
+                new UserImporter(events, attributes, allowedMetadata).importUsers(file);
+
+        assertThat(resultUsers).hasSize(1);
+        final PipelineUserWithStoragePath resultUser = resultUsers.get(0);
+        assertThat(resultUser.getUserName()).isEqualTo(TEST_USER);
+        assertThat(resultUser.getRoles()).hasSize(0);
+        assertThat(resultUser.getMetadata()).hasSize(0);
+        assertThat(attributes).hasSize(0);
+        assertThat(events).hasSize(0);
+    }
+
+    private void assertAttributeValue(final CategoricalAttribute attribute,
+                                      final String expectedKey, final String expectedValue) {
+        if (Objects.equals(attribute.getKey(), expectedKey)) {
+            final CategoricalAttributeValue attributeValue = attribute.getValues().get(0);
+            assertThat(attributeValue.getKey()).isEqualTo(expectedKey);
+            assertThat(attributeValue.getValue()).isEqualTo(expectedValue);
+        }
+    }
+
+    private MultipartFile getFile(final String content) {
+        return new MockMultipartFile(content, content.getBytes());
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/manager/user/UserImporterTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/user/UserImporterTest.java
@@ -18,7 +18,6 @@ package com.epam.pipeline.manager.user;
 
 import com.epam.pipeline.entity.metadata.CategoricalAttribute;
 import com.epam.pipeline.entity.metadata.CategoricalAttributeValue;
-import com.epam.pipeline.entity.user.PipelineUserEvent;
 import com.epam.pipeline.entity.user.PipelineUserWithStoragePath;
 import com.epam.pipeline.entity.user.Role;
 import org.junit.Test;
@@ -27,6 +26,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -34,27 +34,33 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class UserImporterTest {
-    private static final String HEADER = "UserName,Groups,Key1,Key2,Key3\n";
-    private static final String CONTENT = HEADER + "user1,test1|test2,Value1,Value2,Value3";
-    private static final String EMPTY_USER_CONTENT = HEADER + ",test1|test2,Value1,Value2,Value3";
-    private static final String EMPTY_CONTENT = HEADER + "user1,,,,";
+    private static final String HEADER = "UserName,Groups,Key1,Key2,Key3,Key4\n";
+    private static final String CONTENT = HEADER + "user1,test1|test2,Value1,Value2,Value3,Value4";
+    private static final String EMPTY_USER_CONTENT = HEADER + ",test1|test2,Value1,Value2,Value3,Value4";
+    private static final String EMPTY_CONTENT = HEADER + "user1,,,,,";
     private static final String TEST_USER = "USER1";
     private static final String TEST_ROLE_1 = "ROLE_TEST1";
     private static final String TEST_ROLE_2 = "ROLE_TEST2";
     private static final String KEY1 = "Key1";
     private static final String KEY2 = "Key2";
+    private static final String KEY3 = "Key3";
+    private static final String KEY4 = "Key4";
     private static final String VALUE1 = "Value1";
     private static final String VALUE2 = "Value2";
+    private static final String VALUE3 = "Value3";
 
     @Test
     public void shouldParseCsvFile() {
         final MultipartFile file = getFile(CONTENT);
         final List<String> allowedMetadata = Arrays.asList(KEY1, KEY2);
-        final ArrayList<CategoricalAttribute> attributes = new ArrayList<>();
-        final ArrayList<PipelineUserEvent> events = new ArrayList<>();
+
+        final List<CategoricalAttribute> attributes = new ArrayList<>();
+        attributes.add(new CategoricalAttribute(KEY1, attributesList(KEY1, VALUE1)));
+        attributes.add(new CategoricalAttribute(KEY2, attributesList(KEY2, VALUE1)));
+        attributes.add(new CategoricalAttribute(KEY4, attributesList(KEY4, VALUE1)));
 
         final List<PipelineUserWithStoragePath> resultUsers =
-                new UserImporter(events, attributes, allowedMetadata).importUsers(file);
+                new UserImporter(attributes, allowedMetadata).importUsers(file);
 
         assertThat(resultUsers).hasSize(1);
         final PipelineUserWithStoragePath resultUser = resultUsers.get(0);
@@ -63,18 +69,18 @@ public class UserImporterTest {
                 .hasSize(2)
                 .contains(TEST_ROLE_1)
                 .contains(TEST_ROLE_2);
-        assertThat(resultUser.getMetadata()).hasSize(2).containsKeys(KEY1, KEY2);
+        assertThat(resultUser.getMetadata()).hasSize(3).containsKeys(KEY1, KEY2, KEY3);
         assertThat(resultUser.getMetadata().get(KEY1).getValue()).isEqualTo(VALUE1);
         assertThat(resultUser.getMetadata().get(KEY2).getValue()).isEqualTo(VALUE2);
-        assertThat(attributes).hasSize(2);
+        assertThat(resultUser.getMetadata().get(KEY3).getValue()).isEqualTo(VALUE3);
+        assertThat(attributes).hasSize(3);
         assertThat(attributes.stream().map(CategoricalAttribute::getKey).collect(Collectors.toList()))
-                .contains(KEY1, KEY2);
+                .contains(KEY1, KEY2, KEY4);
         attributes.forEach(attribute -> {
-            assertThat(attribute.getValues()).hasSize(1);
-            assertAttributeValue(attribute, KEY1, VALUE1);
-            assertAttributeValue(attribute, KEY2, VALUE2);
+            assertAttributeValue(attribute, KEY1, Collections.singletonList(VALUE1));
+            assertAttributeValue(attribute, KEY2, Arrays.asList(VALUE1, VALUE2));
+            assertAttributeValue(attribute, KEY4, Collections.singletonList(VALUE1));
         });
-        assertThat(events).hasSize(2);
     }
 
     @Test
@@ -82,12 +88,10 @@ public class UserImporterTest {
         final MultipartFile file = getFile(EMPTY_USER_CONTENT);
         final List<String> allowedMetadata = Arrays.asList(KEY1, KEY2);
         final ArrayList<CategoricalAttribute> attributes = new ArrayList<>();
-        final ArrayList<PipelineUserEvent> events = new ArrayList<>();
-        final UserImporter userImporter = new UserImporter(events, attributes, allowedMetadata);
+        final UserImporter userImporter = new UserImporter(attributes, allowedMetadata);
 
         assertThat(userImporter.importUsers(file)).hasSize(0);
         assertThat(attributes).hasSize(0);
-        assertThat(events).hasSize(0);
     }
 
     @Test
@@ -95,10 +99,9 @@ public class UserImporterTest {
         final MultipartFile file = getFile(EMPTY_CONTENT);
         final List<String> allowedMetadata = Arrays.asList(KEY1, KEY2);
         final ArrayList<CategoricalAttribute> attributes = new ArrayList<>();
-        final ArrayList<PipelineUserEvent> events = new ArrayList<>();
 
         final List<PipelineUserWithStoragePath> resultUsers =
-                new UserImporter(events, attributes, allowedMetadata).importUsers(file);
+                new UserImporter(attributes, allowedMetadata).importUsers(file);
 
         assertThat(resultUsers).hasSize(1);
         final PipelineUserWithStoragePath resultUser = resultUsers.get(0);
@@ -106,16 +109,27 @@ public class UserImporterTest {
         assertThat(resultUser.getRoles()).hasSize(0);
         assertThat(resultUser.getMetadata()).hasSize(0);
         assertThat(attributes).hasSize(0);
-        assertThat(events).hasSize(0);
     }
 
     private void assertAttributeValue(final CategoricalAttribute attribute,
-                                      final String expectedKey, final String expectedValue) {
+                                      final String expectedKey, final List<String> expectedValues) {
         if (Objects.equals(attribute.getKey(), expectedKey)) {
-            final CategoricalAttributeValue attributeValue = attribute.getValues().get(0);
-            assertThat(attributeValue.getKey()).isEqualTo(expectedKey);
-            assertThat(attributeValue.getValue()).isEqualTo(expectedValue);
+            assertThat(attribute.getValues().stream()
+                    .peek(attributeValue -> assertThat(attributeValue.getKey()).isEqualTo(expectedKey))
+                    .map(CategoricalAttributeValue::getValue)
+                    .collect(Collectors.toList()))
+                    .hasSize(expectedValues.size())
+                    .containsAll(expectedValues);
         }
+    }
+
+    private List<CategoricalAttributeValue> attributesList(final String key, final String value) {
+        final CategoricalAttributeValue attributeValue = new CategoricalAttributeValue();
+        attributeValue.setKey(key);
+        attributeValue.setValue(value);
+        final List<CategoricalAttributeValue> attributeValues = new ArrayList<>();
+        attributeValues.add(attributeValue);
+        return attributeValues;
     }
 
     private MultipartFile getFile(final String content) {

--- a/api/src/test/java/com/epam/pipeline/manager/user/UserImporterTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/user/UserImporterTest.java
@@ -74,7 +74,7 @@ public class UserImporterTest {
             assertAttributeValue(attribute, KEY1, VALUE1);
             assertAttributeValue(attribute, KEY2, VALUE2);
         });
-        assertThat(events).hasSize(3);
+        assertThat(events).hasSize(2);
     }
 
     @Test

--- a/api/src/test/java/com/epam/pipeline/test/acl/AclTestBeans.java
+++ b/api/src/test/java/com/epam/pipeline/test/acl/AclTestBeans.java
@@ -110,8 +110,8 @@ import com.epam.pipeline.manager.security.AuthManager;
 import com.epam.pipeline.manager.security.GrantPermissionManager;
 import com.epam.pipeline.manager.security.PermissionsService;
 import com.epam.pipeline.manager.user.RoleManager;
-import com.epam.pipeline.manager.user.UserImportManager;
 import com.epam.pipeline.manager.user.UserManager;
+import com.epam.pipeline.manager.user.UsersFileImportManager;
 import com.epam.pipeline.manager.utils.JsonService;
 import com.epam.pipeline.manager.utils.UtilsManager;
 import com.epam.pipeline.mapper.AbstractEntityPermissionMapper;
@@ -458,7 +458,7 @@ public class AclTestBeans {
     protected MetadataDownloadManager mockMetadataDownloadManager;
 
     @MockBean
-    protected UserImportManager userImportManager;
+    protected UsersFileImportManager usersFileImportManager;
 
     @Bean
     protected TemplatesScanner mockTemplatesScanner() {

--- a/api/src/test/java/com/epam/pipeline/test/acl/AclTestBeans.java
+++ b/api/src/test/java/com/epam/pipeline/test/acl/AclTestBeans.java
@@ -110,6 +110,7 @@ import com.epam.pipeline.manager.security.AuthManager;
 import com.epam.pipeline.manager.security.GrantPermissionManager;
 import com.epam.pipeline.manager.security.PermissionsService;
 import com.epam.pipeline.manager.user.RoleManager;
+import com.epam.pipeline.manager.user.UserImportManager;
 import com.epam.pipeline.manager.user.UserManager;
 import com.epam.pipeline.manager.utils.JsonService;
 import com.epam.pipeline.manager.utils.UtilsManager;
@@ -455,6 +456,9 @@ public class AclTestBeans {
 
     @MockBean
     protected MetadataDownloadManager mockMetadataDownloadManager;
+
+    @MockBean
+    protected UserImportManager userImportManager;
 
     @Bean
     protected TemplatesScanner mockTemplatesScanner() {

--- a/api/src/test/java/com/epam/pipeline/test/creator/user/UserCreatorUtils.java
+++ b/api/src/test/java/com/epam/pipeline/test/creator/user/UserCreatorUtils.java
@@ -26,6 +26,7 @@ import com.epam.pipeline.entity.user.CustomControl;
 import com.epam.pipeline.entity.user.ExtendedRole;
 import com.epam.pipeline.entity.user.GroupStatus;
 import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.entity.user.PipelineUserEvent;
 import com.epam.pipeline.entity.user.PipelineUserWithStoragePath;
 import com.epam.pipeline.entity.user.Role;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -119,5 +120,12 @@ public final class UserCreatorUtils {
 
     public static ExtendedRole getExtendedRole() {
         return new ExtendedRole();
+    }
+
+    public static PipelineUserEvent getPipelineUserEvent(final String name) {
+        return PipelineUserEvent.builder()
+                .message(TEST_STRING)
+                .userName(name)
+                .build();
     }
 }

--- a/api/src/test/java/com/epam/pipeline/test/creator/user/UserCreatorUtils.java
+++ b/api/src/test/java/com/epam/pipeline/test/creator/user/UserCreatorUtils.java
@@ -21,16 +21,20 @@ import com.epam.pipeline.controller.vo.PipelineUserExportVO;
 import com.epam.pipeline.controller.vo.PipelineUserVO;
 import com.epam.pipeline.controller.vo.user.RoleVO;
 import com.epam.pipeline.entity.info.UserInfo;
+import com.epam.pipeline.entity.metadata.PipeConfValue;
 import com.epam.pipeline.entity.user.CustomControl;
 import com.epam.pipeline.entity.user.ExtendedRole;
 import com.epam.pipeline.entity.user.GroupStatus;
 import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.entity.user.PipelineUserWithStoragePath;
 import com.epam.pipeline.entity.user.Role;
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+
+import java.util.Map;
 
 import static com.epam.pipeline.test.creator.CommonCreatorConstants.ID;
 import static com.epam.pipeline.test.creator.CommonCreatorConstants.TEST_STRING;
@@ -67,6 +71,14 @@ public final class UserCreatorUtils {
         pipelineUser.setId(ID);
         pipelineUser.setUserName(name);
         return pipelineUser;
+    }
+
+    public static PipelineUserWithStoragePath getUserWithMetadata(final PipelineUser user,
+                                                                  final Map<String, PipeConfValue> metadata) {
+        return PipelineUserWithStoragePath.builder()
+                .pipelineUser(user)
+                .metadata(metadata)
+                .build();
     }
 
     public static PipelineUser getPipelineUser() {

--- a/api/src/test/java/com/epam/pipeline/util/CustomAssertions.java
+++ b/api/src/test/java/com/epam/pipeline/util/CustomAssertions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ import lombok.SneakyThrows;
 import java.util.function.Predicate;
 
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @SuppressWarnings("PMD.AvoidCatchingGenericException")
 public final class CustomAssertions {
@@ -72,5 +74,9 @@ public final class CustomAssertions {
     @SneakyThrows
     private static void sneakyThrowing(final CheckedRunnable runnable) {
         runnable.run();
+    }
+
+    public static <T> T notInvoked(T mock) {
+        return verify(mock, times(0));
     }
 }

--- a/api/src/test/java/com/epam/pipeline/util/CustomMatchers.java
+++ b/api/src/test/java/com/epam/pipeline/util/CustomMatchers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,15 @@
 package com.epam.pipeline.util;
 
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
+
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.anyMapOf;
 
 public final class CustomMatchers {
 
@@ -38,5 +44,17 @@ public final class CustomMatchers {
                 description.appendText("collection is empty");
             }
         };
+    }
+
+    public static List<Long> anyLongList() {
+        return anyListOf(Long.class);
+    }
+
+    public static List<String> anyStringList() {
+        return anyListOf(String.class);
+    }
+
+    public static Map<String, String> anyStringMap() {
+        return anyMapOf(String.class, String.class);
     }
 }

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1644,7 +1644,7 @@ def users():
 @click.option('-cu', '--create-user', required=False, is_flag=True, default=False, help='Allow new user creation')
 @click.option('-cg', '--create-group', required=False, is_flag=True, default=False, help='Allow new group creation')
 @click.option('-cm', '--create-metadata', required=False, multiple=True,
-              help='Allow to create a new metadata with specified key')
+              help='Allow to create a new metadata with specified key. Multiple options supported.')
 @click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token
 def import_users(file_path, create_user, create_group, create_metadata):

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -39,6 +39,7 @@ from src.utilities.permissions_operations import PermissionsOperations
 from src.utilities.pipeline_run_operations import PipelineRunOperations
 from src.utilities.ssh_operations import run_ssh, run_scp, create_tunnel, kill_tunnels
 from src.utilities.update_cli_version import UpdateCLIVersionManager
+from src.utilities.user_operations_manager import UserOperationsManager
 from src.utilities.user_token_operations import UserTokenOperations
 from src.version import __version__
 
@@ -1629,6 +1630,28 @@ def monitor(instance_id, run_id, output, date_from, date_to, interval):
     Downloads node utilization report
     """
     ClusterMonitoringManager().generate_report(instance_id, run_id, output, date_from, date_to, interval)
+
+
+@cli.group()
+def users():
+    """ Users commands
+    """
+    pass
+
+
+@users.command(name='import')
+@click.argument('file-path', required=True)
+@click.option('-cu', '--create-user', required=False, is_flag=True, default=False, help='Allow new user creation')
+@click.option('-cg', '--create-group', required=False, is_flag=True, default=False, help='Allow new group creation')
+@click.option('-cm', '--create-metadata', required=False, multiple=True,
+              help='Allow to create a new metadata with specified key')
+@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
+@Config.validate_access_token
+def import_users(file_path, create_user, create_group, create_metadata):
+    """
+    Registers a new users, roles and metadata specified in input file
+    """
+    UserOperationsManager().import_users(file_path, create_user, create_group, create_metadata)
 
 
 # Used to run a PyInstaller "freezed" version

--- a/pipe-cli/src/api/user.py
+++ b/pipe-cli/src/api/user.py
@@ -82,3 +82,17 @@ class User(API):
             raise RuntimeError(response_data['message'])
         else:
             raise RuntimeError("Failed to generate user token.")
+
+    @classmethod
+    def import_users(cls, file_path, create_user, create_group, create_metadata):
+        api = cls.instance()
+        query = '/users/import?createUser=%s&createGroup=%s' % (create_user, create_group)
+        if create_metadata:
+            query = '%s&dictionaries=%s' % (query, ",".join(create_metadata))
+        response_data = api.upload(query, file_path)
+        if 'payload' in response_data:
+            return response_data['payload']
+        if 'message' in response_data:
+            raise RuntimeError(response_data['message'])
+        else:
+            return []

--- a/pipe-cli/src/api/user.py
+++ b/pipe-cli/src/api/user.py
@@ -88,7 +88,7 @@ class User(API):
         api = cls.instance()
         query = '/users/import?createUser=%s&createGroup=%s' % (create_user, create_group)
         if create_metadata:
-            query = '%s&dictionaries=%s' % (query, ",".join(create_metadata))
+            query = '%s&createMetadata=%s' % (query, ",".join(create_metadata))
         response_data = api.upload(query, file_path)
         if 'payload' in response_data:
             return response_data['payload']

--- a/pipe-cli/src/utilities/user_operations_manager.py
+++ b/pipe-cli/src/utilities/user_operations_manager.py
@@ -1,0 +1,38 @@
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+
+import click
+
+from src.api.user import User
+
+
+class UserOperationsManager:
+
+    def __init__(self):
+        pass
+
+    @classmethod
+    def import_users(cls, file_path, create_user, create_group, metadata_list):
+        full_path = os.path.abspath(file_path)
+        if not os.path.exists(full_path):
+            click.echo("Specified file path '%s' doesn't exist" % full_path, err=True)
+            sys.exit(1)
+        if not os.path.isfile(full_path):
+            click.echo("Specified path '%s' exists but not a file" % full_path, err=True)
+            sys.exit(1)
+        events = User().import_users(full_path, create_user, create_group, metadata_list)
+        for event in events:
+            click.echo("[%s] %s" % (event.get('status', ''), event.get('message', '')))


### PR DESCRIPTION
The current PR provides implementation for issue #1639 and contains the following changes:
- a new API method `POST users/import` was implemented. This method registers users, roles and metadata specified in input file. Supports optional query parameters:
  - `createUser` - true if user shall be created if not exists. Default: `false`
  - `createGroup` - true if group shall be created if not exists. Default: `false` 
  - `createMetadata` - the list of metadata keys that shall be created if not exists
- a new CLI command `pipe users import <path-to-file>` implemented. This command provides the following options:
  - `--create-user (-cu)` - true if user shall be created if not exists. Default: `false`
  - `--create-group (-cg)` - true if group shall be created if not exists. Default: `false` 
  - `--create-metadata (-cm)` - metadata keys that shall be created. Multiple options supported.