### PR TITLE
Implement passwordless ssh support in pipe tunnel for Windows

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1356,10 +1356,9 @@ def stop_tunnel(run_id, local_port, timeout, force, log_level, trace):
 @click.option('-ct', '--connection-timeout', required=False, type=float, default=0,
               help='Socket connection timeout in seconds')
 @click.option('-s', '--ssh', required=False, is_flag=True, default=False,
-              help='Configures passwordless ssh to specified run instance. '
-                   'Supported on Linux only.')
+              help='Configures passwordless ssh to specified run instance')
 @click.option('-sp', '--ssh-path', required=False, type=str,
-              help='Path to .ssh directory for passwordless ssh configuration')
+              help='Path to .ssh directory for passwordless ssh configuration on Linux')
 @click.option('-sh', '--ssh-host', required=False, type=str,
               help='Host name for passwordless ssh configuration')
 @click.option('-sk', '--ssh-keep', required=False, is_flag=True, default=False,
@@ -1385,7 +1384,6 @@ def start_tunnel(run_id, local_port, remote_port, connection_timeout,
 
     Additionally it enables passwordless ssh connections if the corresponding option is specified.
     Once specified ssh is configured both locally and remotely to support passwordless connections.
-    Passwordless ssh configuration is supported only for openssh client on Linux.
 
     Examples:
 
@@ -1401,13 +1399,21 @@ def start_tunnel(run_id, local_port, remote_port, connection_timeout,
 
         pipe tunnel start -lp 4567 -rp 22 --ssh 12345
 
-    Then connect to run instance using regular ssh client.
+    Then connect to run instance using regular ssh client from Linux workstation.
 
-        ssh root@pipeline-12345
+        ssh pipeline-12345
 
-    Or transfer some files to and from run instance using regular scp client.
+    Or transfer some files to and from run instance using regular scp client from Linux workstation.
 
-        scp file.txt root@pipeline-12345:/common/workdir/file.txt
+        scp file.txt pipeline-12345:/common/workdir/file.txt
+
+    Or connect to run instance using plink client from Windows workstation.
+
+        plink pipeline-12345
+
+    Or transfer some files to and from run instance using regular scp client from Windows workstation.
+
+        pscp file.txt pipeline-12345:/common/workdir/file.txt
 
     Advanced tunnel configuration environment variables:
 

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1384,6 +1384,10 @@ def start_tunnel(run_id, local_port, remote_port, connection_timeout,
 
     Additionally it enables passwordless ssh connections if the corresponding option is specified.
     Once specified ssh is configured both locally and remotely to support passwordless connections.
+    For Linux workstations openssh library is configured to allow passwordless access
+    using ssh and scp command line clients usage.
+    For Windows workstations putty utils are configured to allow passwordless access
+    using putty application as well as plink and pscp command line clients.
 
     Examples:
 
@@ -1399,19 +1403,19 @@ def start_tunnel(run_id, local_port, remote_port, connection_timeout,
 
         pipe tunnel start -lp 4567 -rp 22 --ssh 12345
 
-    Then connect to run instance using regular ssh client from Linux workstation.
+    [Linux] Then connect to run instance using regular ssh client.
 
         ssh pipeline-12345
 
-    Or transfer some files to and from run instance using regular scp client from Linux workstation.
+    [Linux] Or transfer some files to and from run instance using regular scp client.
 
         scp file.txt pipeline-12345:/common/workdir/file.txt
 
-    Or connect to run instance using plink client from Windows workstation.
+    [Windows] Or connect to run instance using regular plink client.
 
         plink pipeline-12345
 
-    Or transfer some files to and from run instance using regular scp client from Windows workstation.
+    [Windows] Or transfer some files to and from run instance using regular pscp client.
 
         pscp file.txt pipeline-12345:/common/workdir/file.txt
 

--- a/pipe-cli/src/utilities/putty/LICENSE
+++ b/pipe-cli/src/utilities/putty/LICENSE
@@ -1,0 +1,28 @@
+PuTTY is copyright 1997-2020 Simon Tatham.
+
+Portions copyright Robert de Bath, Joris van Rantwijk, Delian
+Delchev, Andreas Schultz, Jeroen Massar, Wez Furlong, Nicolas Barry,
+Justin Bradford, Ben Harris, Malcolm Smith, Ahmad Khalifa, Markus
+Kuhn, Colin Watson, Christopher Staite, Lorenz Diener, Christian
+Brabandt, Jeff Smith, Pavel Kryukov, Maxim Kuznetsov, Svyatoslav
+Kuzmich, Nico Williams, Viktor Dukhovni, Josh Dersch, Lars Brinkhoff,
+and CORE SDI S.A.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation files
+(the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT.  IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE
+FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/pipe-cli/src/utilities/putty/__init__.py
+++ b/pipe-cli/src/utilities/putty/__init__.py
@@ -1,0 +1,28 @@
+# PuTTY is copyright 1997-2020 Simon Tatham.
+#
+# Portions copyright Robert de Bath, Joris van Rantwijk, Delian
+# Delchev, Andreas Schultz, Jeroen Massar, Wez Furlong, Nicolas Barry,
+# Justin Bradford, Ben Harris, Malcolm Smith, Ahmad Khalifa, Markus
+# Kuhn, Colin Watson, Christopher Staite, Lorenz Diener, Christian
+# Brabandt, Jeff Smith, Pavel Kryukov, Maxim Kuznetsov, Svyatoslav
+# Kuzmich, Nico Williams, Viktor Dukhovni, Josh Dersch, Lars Brinkhoff,
+# and CORE SDI S.A.
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT.  IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE
+# FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+# CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/pipe-cli/src/utilities/putty/__init__.py
+++ b/pipe-cli/src/utilities/putty/__init__.py
@@ -26,3 +26,16 @@
 # FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
 # CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+def get_putty_fingerprint(ssh_public_key):
+    from .kh2reg import handle_line
+
+    class _PuttyFingerprintsDict(dict):
+        def key(self, key, value):
+            self[key] = value
+
+    putty_fingerprints = _PuttyFingerprintsDict()
+    known_host_line = '{} {}'.format('cloud-pipeline', ssh_public_key)
+    handle_line(known_host_line, putty_fingerprints, [])
+    return next(iter(putty_fingerprints.values())) if putty_fingerprints else None

--- a/pipe-cli/src/utilities/putty/kh2reg.py
+++ b/pipe-cli/src/utilities/putty/kh2reg.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+
+# PuTTY is copyright 1997-2020 Simon Tatham.
+#
+# Portions copyright Robert de Bath, Joris van Rantwijk, Delian
+# Delchev, Andreas Schultz, Jeroen Massar, Wez Furlong, Nicolas Barry,
+# Justin Bradford, Ben Harris, Malcolm Smith, Ahmad Khalifa, Markus
+# Kuhn, Colin Watson, Christopher Staite, Lorenz Diener, Christian
+# Brabandt, Jeff Smith, Pavel Kryukov, Maxim Kuznetsov, Svyatoslav
+# Kuzmich, Nico Williams, Viktor Dukhovni, Josh Dersch, Lars Brinkhoff,
+# and CORE SDI S.A.
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT.  IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE
+# FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+# CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# Convert OpenSSH known_hosts and known_hosts2 files to "new format" PuTTY
+# host keys.
+#   usage:
+#     kh2reg.py [ --win ] known_hosts1 2 3 4 ... > hosts.reg
+#       Creates a Windows .REG file (double-click to install).
+#     kh2reg.py --unix    known_hosts1 2 3 4 ... > sshhostkeys
+#       Creates data suitable for storing in ~/.putty/sshhostkeys (Unix).
+# Line endings are someone else's problem as is traditional.
+# Should run under either Python 2 or 3.
+
+import fileinput
+import base64
+import struct
+import string
+import re
+import sys
+import argparse
+import itertools
+import collections
+import hashlib
+from functools import reduce
+
+def winmungestr(s):
+    "Duplicate of PuTTY's mungestr() in winstore.c:1.10 for Registry keys"
+    candot = 0
+    r = ""
+    for c in s:
+        if c in ' \*?%~' or ord(c)<ord(' ') or (c == '.' and not candot):
+            r = r + ("%%%02X" % ord(c))
+        else:
+            r = r + c
+        candot = 1
+    return r
+
+def strtoint(s):
+    "Convert arbitrary-length big-endian binary data to a Python int"
+    bytes = struct.unpack(">{:d}B".format(len(s)), s)
+    return reduce ((lambda a, b: (int(a) << 8) + int(b)), bytes)
+
+def strtoint_le(s):
+    "Convert arbitrary-length little-endian binary data to a Python int"
+    bytes = reversed(struct.unpack(">{:d}B".format(len(s)), s))
+    return reduce ((lambda a, b: (int(a) << 8) + int(b)), bytes)
+
+def inttohex(n):
+    "Convert int to lower-case hex."
+    return "0x{:x}".format(n)
+
+def warn(s):
+    "Warning with file/line number"
+    sys.stderr.write("%s:%d: %s\n"
+                     % (fileinput.filename(), fileinput.filelineno(), s))
+
+class HMAC(object):
+    def __init__(self, hashclass, blocksize):
+        self.hashclass = hashclass
+        self.blocksize = blocksize
+        self.struct = struct.Struct(">{:d}B".format(self.blocksize))
+    def pad_key(self, key):
+        return key + b'\0' * (self.blocksize - len(key))
+    def xor_key(self, key, xor):
+        return self.struct.pack(*[b ^ xor for b in self.struct.unpack(key)])
+    def keyed_hash(self, key, padbyte, string):
+        return self.hashclass(self.xor_key(key, padbyte) + string).digest()
+    def compute(self, key, string):
+        if len(key) > self.blocksize:
+            key = self.hashclass(key).digest()
+        key = self.pad_key(key)
+        return self.keyed_hash(key, 0x5C, self.keyed_hash(key, 0x36, string))
+
+def openssh_hashed_host_match(hashed_host, try_host):
+    if hashed_host.startswith(b'|1|'):
+        salt, expected = hashed_host[3:].split(b'|')
+        salt = base64.decodebytes(salt)
+        expected = base64.decodebytes(expected)
+        mac = HMAC(hashlib.sha1, 64)
+    else:
+        return False # unrecognised magic number prefix
+
+    return mac.compute(salt, try_host) == expected
+
+def invert(n, p):
+    """Compute inverse mod p."""
+    if n % p == 0:
+        raise ZeroDivisionError()
+    a = n, 1, 0
+    b = p, 0, 1
+    while b[0]:
+        q = a[0] // b[0]
+        a = a[0] - q*b[0], a[1] - q*b[1], a[2] - q*b[2]
+        b, a = a, b
+    assert abs(a[0]) == 1
+    return a[1]*a[0]
+
+def jacobi(n,m):
+    """Compute the Jacobi symbol.
+
+    The special case of this when m is prime is the Legendre symbol,
+    which is 0 if n is congruent to 0 mod m; 1 if n is congruent to a
+    non-zero square number mod m; -1 if n is not congruent to any
+    square mod m.
+
+    """
+    assert m & 1
+    acc = 1
+    while True:
+        n %= m
+        if n == 0:
+            return 0
+        while not (n & 1):
+            n >>= 1
+            if (m & 7) not in {1,7}:
+                acc *= -1
+        if n == 1:
+            return acc
+        if (n & 3) == 3 and (m & 3) == 3:
+            acc *= -1
+        n, m = m, n
+
+class SqrtModP(object):
+    """Class for finding square roots of numbers mod p.
+
+    p must be an odd prime (but its primality is not checked)."""
+
+    def __init__(self, p):
+        p = abs(p)
+        assert p & 1
+        self.p = p
+
+        # Decompose p as 2^e k + 1 for odd k.
+        self.k = p-1
+        self.e = 0
+        while not (self.k & 1):
+            self.k >>= 1
+            self.e += 1
+
+        # Find a non-square mod p.
+        for self.z in itertools.count(1):
+            if jacobi(self.z, self.p) == -1:
+                break
+        self.zinv = invert(self.z, self.p)
+
+    def sqrt_recurse(self, a):
+        ak = pow(a, self.k, self.p)
+        for i in range(self.e, -1, -1):
+            if ak == 1:
+                break
+            ak = ak*ak % self.p
+        assert i > 0
+        if i == self.e:
+            return pow(a, (self.k+1) // 2, self.p)
+        r_prime = self.sqrt_recurse(a * pow(self.z, 2**i, self.p))
+        return r_prime * pow(self.zinv, 2**(i-1), self.p) % self.p
+
+    def sqrt(self, a):
+        j = jacobi(a, self.p)
+        if j == 0:
+            return 0
+        if j < 0:
+            raise ValueError("{} has no square root mod {}".format(a, self.p))
+        a %= self.p
+        r = self.sqrt_recurse(a)
+        assert r*r % self.p == a
+        # Normalise to the smaller (or 'positive') one of the two roots.
+        return min(r, self.p - r)
+
+    def __str__(self):
+        return "{}({})".format(type(self).__name__, self.p)
+    def __repr__(self):
+        return self.__str__()
+
+    instances = {}
+
+    @classmethod
+    def make(cls, p):
+        if p not in cls.instances:
+            cls.instances[p] = cls(p)
+        return cls.instances[p]
+
+    @classmethod
+    def root(cls, n, p):
+        return cls.make(p).sqrt(n)
+
+NistCurve = collections.namedtuple("NistCurve", "p a b")
+nist_curves = {
+    "ecdsa-sha2-nistp256": NistCurve(0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff, 0xffffffff00000001000000000000000000000000fffffffffffffffffffffffc, 0x5ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b),
+    "ecdsa-sha2-nistp384": NistCurve(0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000fffffffc, 0xb3312fa7e23ee7e4988e056be3f82d19181d9c6efe8141120314088f5013875ac656398d8a2ed19d2a85c8edd3ec2aef),
+    "ecdsa-sha2-nistp521": NistCurve(0x01ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 0x01fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc, 0x0051953eb9618e1c9a1f929a21a0b68540eea2da725b99b315f3b8b489918ef109e156193951ec7e937b1652c0bd3bb1bf073573df883d2c34f1ef451fd46b503f00),
+}
+
+class BlankInputLine(Exception):
+    pass
+
+class UnknownKeyType(Exception):
+    def __init__(self, keytype):
+        self.keytype = keytype
+
+class KeyFormatError(Exception):
+    def __init__(self, msg):
+        self.msg = msg
+
+def handle_line(line, output_formatter, try_hosts):
+    try:
+        # Remove leading/trailing whitespace (should zap CR and LF)
+        line = line.strip()
+
+        # Skip blanks and comments
+        if line == '' or line[0] == '#':
+            raise BlankInputLine
+
+        # Split line on spaces.
+        fields = line.split(' ')
+
+        # Common fields
+        hostpat = fields[0]
+        keyparams = []      # placeholder
+        keytype = ""        # placeholder
+
+        # Grotty heuristic to distinguish known_hosts from known_hosts2:
+        # is second field entirely decimal digits?
+        if re.match (r"\d*$", fields[1]):
+
+            # Treat as SSH-1-type host key.
+            # Format: hostpat bits10 exp10 mod10 comment...
+            # (PuTTY doesn't store the number of bits.)
+            keyparams = list(map(int, fields[2:4]))
+            keytype = "rsa"
+
+        else:
+
+            # Treat as SSH-2-type host key.
+            # Format: hostpat keytype keyblob64 comment...
+            sshkeytype, blob = fields[1], base64.decodebytes(
+                fields[2].encode("ASCII"))
+
+            # 'blob' consists of a number of
+            #   uint32    N (big-endian)
+            #   uint8[N]  field_data
+            subfields = []
+            while blob:
+                sizefmt = ">L"
+                (size,) = struct.unpack (sizefmt, blob[0:4])
+                size = int(size)   # req'd for slicage
+                (data,) = struct.unpack (">%lus" % size, blob[4:size+4])
+                subfields.append(data)
+                blob = blob [struct.calcsize(sizefmt) + size : ]
+
+            # The first field is keytype again.
+            if subfields[0].decode("ASCII") != sshkeytype:
+                raise KeyFormatError("""
+                    outer and embedded key types do not match: '%s', '%s'
+                    """ % (sshkeytype, subfields[1]))
+
+            # Translate key type string into something PuTTY can use, and
+            # munge the rest of the data.
+            if sshkeytype == "ssh-rsa":
+                keytype = "rsa2"
+                # The rest of the subfields we can treat as an opaque list
+                # of bignums (same numbers and order as stored by PuTTY).
+                keyparams = list(map(strtoint, subfields[1:]))
+
+            elif sshkeytype == "ssh-dss":
+                keytype = "dss"
+                # Same again.
+                keyparams = list(map(strtoint, subfields[1:]))
+
+            elif sshkeytype in nist_curves:
+                keytype = sshkeytype
+                # Have to parse this a bit.
+                if len(subfields) > 3:
+                    raise KeyFormatError("too many subfields in blob")
+                (curvename, Q) = subfields[1:]
+                # First is yet another copy of the key name.
+                if not re.match("ecdsa-sha2-" + re.escape(
+                        curvename.decode("ASCII")), sshkeytype):
+                    raise KeyFormatError("key type mismatch ('%s' vs '%s')"
+                            % (sshkeytype, curvename))
+                # Second contains key material X and Y (hopefully).
+                # First a magic octet indicating point compression.
+                point_type = struct.unpack_from("B", Q, 0)[0]
+                Qrest = Q[1:]
+                if point_type == 4:
+                    # Then two equal-length bignums (X and Y).
+                    bnlen = len(Qrest)
+                    if (bnlen % 1) != 0:
+                        raise KeyFormatError("odd-length X+Y")
+                    bnlen = bnlen // 2
+                    x = strtoint(Qrest[:bnlen])
+                    y = strtoint(Qrest[bnlen:])
+                elif 2 <= point_type <= 3:
+                    # A compressed point just specifies X, and leaves
+                    # Y implicit except for parity, so we have to
+                    # recover it from the curve equation.
+                    curve = nist_curves[sshkeytype]
+                    x = strtoint(Qrest)
+                    yy = (x*x*x + curve.a*x + curve.b) % curve.p
+                    y = SqrtModP.root(yy, curve.p)
+                    if y % 2 != point_type % 2:
+                        y = curve.p - y
+
+                keyparams = [curvename, x, y]
+
+            elif sshkeytype in { "ssh-ed25519",  "ssh-ed448" }:
+                keytype = sshkeytype
+
+                if len(subfields) != 2:
+                    raise KeyFormatError("wrong number of subfields in blob")
+                # Key material y, with the top bit being repurposed as
+                # the expected parity of the associated x (point
+                # compression).
+                y = strtoint_le(subfields[1])
+                x_parity = y >> 255
+                y &= ~(1 << 255)
+
+                # Curve parameters.
+                p, d, a = {
+                    "ssh-ed25519": (2**255 - 19, 0x52036cee2b6ffe738cc740797779e89800700a4d4141d8ab75eb4dca135978a3, -1),
+                    "ssh-ed448": (2**448-2**224-1, -39081, +1),
+                }[sshkeytype]
+
+                # Recover x^2 = (y^2 - 1) / (d y^2 - a).
+                xx = (y*y - 1) * invert(d*y*y - a, p) % p
+
+                # Take the square root.
+                x = SqrtModP.root(xx, p)
+
+                # Pick the square root of the correct parity.
+                if (x % 2) != x_parity:
+                    x = p - x
+
+                keyparams = [x, y]
+            else:
+                raise UnknownKeyType(sshkeytype)
+
+        # Now print out one line per host pattern, discarding wildcards.
+        for host in hostpat.split(','):
+            if re.search (r"[*?!]", host):
+                warn("skipping wildcard host pattern '%s'" % host)
+                continue
+
+            if re.match (r"\|", host):
+                for try_host in try_hosts:
+                    if openssh_hashed_host_match(host.encode('ASCII'),
+                                                 try_host.encode('UTF-8')):
+                        host = try_host
+                        break
+                else:
+                    warn("unable to match hashed hostname '%s'" % host)
+                    continue
+
+            m = re.match (r"\[([^]]*)\]:(\d*)$", host)
+            if m:
+                (host, port) = m.group(1,2)
+                port = int(port)
+            else:
+                port = 22
+            # Slightly bizarre output key format: 'type@port:hostname'
+            # XXX: does PuTTY do anything useful with literal IP[v4]s?
+            key = keytype + ("@%d:%s" % (port, host))
+            # Most of these are numbers, but there's the occasional
+            # string that needs passing through
+            value = ",".join(map(
+                lambda x: x if isinstance(x, str)
+                else x.decode('ASCII') if isinstance(x, bytes)
+                else inttohex(x), keyparams))
+            output_formatter.key(key, value)
+
+    except UnknownKeyType as k:
+        warn("unknown SSH key type '%s', skipping" % k.keytype)
+    except KeyFormatError as k:
+        warn("trouble parsing key (%s), skipping" % k.msg)
+    except BlankInputLine:
+        pass
+
+class OutputFormatter(object):
+    def __init__(self, fh):
+        self.fh = fh
+    def header(self):
+        pass
+    def trailer(self):
+        pass
+
+class WindowsOutputFormatter(OutputFormatter):
+    def header(self):
+        # Output REG file header.
+        self.fh.write("""REGEDIT4
+
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\SshHostKeys]
+""")
+
+    def key(self, key, value):
+        # XXX: worry about double quotes?
+        self.fh.write("\"%s\"=\"%s\"\n" % (winmungestr(key), value))
+
+    def trailer(self):
+        # The spec at http://support.microsoft.com/kb/310516 says we need
+        # a blank line at the end of the reg file:
+        #
+        #   Note the registry file should contain a blank line at the
+        #   bottom of the file.
+        #
+        self.fh.write("\n")
+
+class UnixOutputFormatter(OutputFormatter):
+    def key(self, key, value):
+        self.fh.write('%s %s\n' % (key, value))
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert OpenSSH known hosts files to PuTTY's format.")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--windows", "--win", action='store_const',
+        dest="output_formatter_class", const=WindowsOutputFormatter,
+        help="Produce Windows .reg file output that regedit.exe can import"
+        " (default).")
+    group.add_argument(
+        "--unix", action='store_const',
+        dest="output_formatter_class", const=UnixOutputFormatter,
+        help="Produce a file suitable for use as ~/.putty/sshhostkeys.")
+    parser.add_argument("-o", "--output", type=argparse.FileType("w"),
+                        default=argparse.FileType("w")("-"),
+                        help="Output file to write to (default stdout).")
+    parser.add_argument("--hostname", action="append",
+                        help="Host name(s) to try matching against hashed "
+                        "host entries in input.")
+    parser.add_argument("infile", nargs="*",
+                        help="Input file(s) to read from (default stdin).")
+    parser.set_defaults(output_formatter_class=WindowsOutputFormatter,
+                        hostname=[])
+    args = parser.parse_args()
+
+    output_formatter = args.output_formatter_class(args.output)
+    output_formatter.header()
+    for line in fileinput.input(args.infile):
+        handle_line(line, output_formatter, args.hostname)
+    output_formatter.trailer()
+
+if __name__ == "__main__":
+    main()

--- a/pipe-cli/src/utilities/ssh_operations.py
+++ b/pipe-cli/src/utilities/ssh_operations.py
@@ -39,6 +39,39 @@ DEFAULT_SSH_USER = 'root'
 DEFAULT_LOGGING_FORMAT = '%(asctime)s:%(levelname)s: %(message)s'
 
 
+class PasswordlessConfig:
+
+    def __init__(self, run_id, conn_info, ssh_path=None):
+        self.owner_user = conn_info.owner.split('@')[0]
+        self.user = DEFAULT_SSH_USER if is_ssh_default_root_user_enabled() else self.owner_user
+        self.key_name = 'pipeline-{}-{}-{}'.format(run_id, int(time.time()), random.randint(0, sys.maxsize))
+
+        self.remote_keys_path = '/root/.pipe/.ssh/'
+        self.remote_private_key_path = os.path.join(self.remote_keys_path, self.key_name)
+        self.remote_public_key_path = '{}.pub'.format(self.remote_private_key_path)
+        self.remote_ppk_key_path = '{}.ppk'.format(self.remote_private_key_path)
+        self.remote_host_rsa_public_key_path = '/etc/ssh/ssh_host_rsa_key.pub'
+        self.remote_host_ed25519_public_key_path = '/etc/ssh/ssh_host_ed25519_key.pub'
+        self.remote_authorized_keys_paths = ['/root/.ssh/authorized_keys',
+                                             '/home/{}/.ssh/authorized_keys'.format(self.owner_user)]
+
+        self.local_keys_path = os.path.expanduser('~/.pipe/.keys')
+        self.local_private_key_path = os.path.join(self.local_keys_path, self.key_name)
+        self.local_public_key_path = '{}.pub'.format(self.local_private_key_path)
+        self.local_ppk_key_path = '{}.ppk'.format(self.local_private_key_path)
+        self.local_host_ed25519_public_key_path = os.path.join(self.local_keys_path,
+                                                               '{}_{}'.format(self.key_name,
+                                                                              'ssh_host_ed25519_key.pub'))
+
+        self.local_openssh_path = ssh_path or os.path.expanduser('~/.ssh')
+        self.local_openssh_config_path = os.path.join(self.local_openssh_path, 'config')
+        self.local_openssh_known_hosts_path = os.path.join(self.local_openssh_path, 'known_hosts')
+
+        self.local_putty_registry_path = r'Software\SimonTatham\PuTTY'
+        self.local_putty_sessions_registry_path = r'{}\{}'.format(self.local_putty_registry_path, 'Sessions')
+        self.local_putty_ssh_host_keys_registry_path = r'{}\{}'.format(self.local_putty_registry_path, 'SshHostKeys')
+
+
 def setup_paramiko_logging():
     # Log to "null" file by default
     paramiko_log_file = os.getenv("PARAMIKO_LOG_FILE", os.devnull)
@@ -306,42 +339,24 @@ def create_foreground_tunnel_with_ssh(run_id, local_port, remote_port, connectio
     logging.basicConfig(level=log_level or logging.ERROR, format=DEFAULT_LOGGING_FORMAT)
     if is_windows():
         create_foreground_tunnel_with_ssh_on_windows(run_id, local_port, remote_port, connection_timeout, conn_info,
-                                                     ssh_path, ssh_keep, remote_host, log_file, log_level, retries)
+                                                     ssh_keep, remote_host, log_level, retries)
     else:
         create_foreground_tunnel_with_ssh_on_linux(run_id, local_port, remote_port, connection_timeout, conn_info,
                                                    ssh_path, ssh_keep, remote_host, log_file, log_level, retries)
 
 
 def create_foreground_tunnel_with_ssh_on_windows(run_id, local_port, remote_port, connection_timeout, conn_info,
-                                                 ssh_path, ssh_keep, remote_host, log_file, log_level, retries):
+                                                 ssh_keep, remote_host, log_level, retries):
     logging.info('Configuring putty passwordless ssh...')
-    ssh_keys_path = os.path.expanduser('~/.pipe/.ssh')
-    ssh_private_key_name = 'pipeline-{}-{}-{}'.format(run_id, int(time.time()), random.randint(0, sys.maxsize))
-    ssh_private_key_path = os.path.join(ssh_keys_path, ssh_private_key_name)
-    ssh_public_key_path = '{}.pub'.format(ssh_private_key_path)
-    ssh_ppk_key_path = '{}.ppk'.format(ssh_private_key_path)
-    ssh_host_public_key_path = '{}.host.pub'.format(ssh_private_key_path)
-    owner_user = conn_info.owner.split('@')[0]
-    ssh_config_user = DEFAULT_SSH_USER if is_ssh_default_root_user_enabled() else owner_user
-    remote_ssh_authorized_keys_paths = ['/root/.ssh/authorized_keys',
-                                        '/home/{}/.ssh/authorized_keys'.format(owner_user)]
-    remote_ssh_keys_path = '/root/.pipe/.ssh/'
-    remote_ssh_private_key_path = os.path.join(remote_ssh_keys_path, ssh_private_key_name)
-    remote_ssh_public_key_path = '{}.pub'.format(remote_ssh_private_key_path)
-    remote_ssh_ppk_key_path = '{}.ppk'.format(remote_ssh_private_key_path)
-    remote_ssh_host_public_key_path = '/etc/ssh/ssh_host_ed25519_key.pub'
-    known_host_name = 'ssh-ed25519@{}:127.0.0.1'.format(local_port)
-
-    if not os.path.exists(ssh_keys_path):
-        os.makedirs(ssh_keys_path, mode=stat.S_IRWXU)
+    passwordless_config = PasswordlessConfig(run_id, conn_info)
+    if not os.path.exists(passwordless_config.local_keys_path):
+        os.makedirs(passwordless_config.local_keys_path, mode=stat.S_IRWXU)
     try:
         logging.info('Initializing passwordless ssh %s:%s:%s...', local_port, remote_host, remote_port)
-        generate_remote_ssh_keys(run_id, retries, remote_ssh_public_key_path, remote_ssh_private_key_path,
-                                 remote_ssh_ppk_key_path, remote_ssh_authorized_keys_paths)
-        copy_remote_ssh_ppk_key(run_id, retries, remote_ssh_ppk_key_path, ssh_ppk_key_path)
-        add_record_to_putty_config(local_port, remote_host, ssh_ppk_key_path, ssh_config_user)
-        copy_remote_ssh_host_public_key_to_putty_known_hosts(run_id, remote_host, retries, known_host_name,
-                                                             remote_ssh_host_public_key_path, ssh_host_public_key_path)
+        generate_remote_ssh_keys(run_id, retries, passwordless_config)
+        copy_remote_ssh_ppk_key(run_id, retries, passwordless_config)
+        add_record_to_putty_config(local_port, remote_host, passwordless_config)
+        copy_remote_ssh_host_public_key_to_putty_known_hosts(run_id, local_port, retries, passwordless_config)
         create_foreground_tunnel(run_id, local_port, remote_port, connection_timeout, conn_info,
                                  remote_host, log_level, retries)
     except:
@@ -350,29 +365,30 @@ def create_foreground_tunnel_with_ssh_on_windows(run_id, local_port, remote_port
     finally:
         if not ssh_keep:
             logging.info('Deinitializing passwordless ssh %s:%s:%s...', local_port, remote_host, remote_port)
-            remove_remote_ssh_keys(run_id, retries, remote_ssh_public_key_path, remote_ssh_private_key_path,
-                                   remote_ssh_ppk_key_path, remote_ssh_authorized_keys_paths)
-            remove_remote_ssh_host_public_key_from_putty_known_hosts(known_host_name)
-            remove_record_from_putty_config(remote_host)
-            remove_ssh_keys(ssh_ppk_key_path)
+            remove_remote_ssh_keys(run_id, retries, passwordless_config)
+            remove_remote_ssh_host_public_key_from_putty_known_hosts(local_port, passwordless_config)
+            remove_record_from_putty_config(remote_host, passwordless_config)
+            remove_ssh_keys(passwordless_config.local_ppk_key_path, passwordless_config.local_host_ed25519_public_key_path)
 
 
-def remove_record_from_putty_config(remote_host):
+def remove_record_from_putty_config(remote_host, passworless_config):
     import winreg
 
     logging.info('Removing host record from putty sessions...')
-    with winreg.CreateKey(winreg.HKEY_CURRENT_USER, r'Software\SimonTatham\PuTTY\Sessions') as key:
+    with winreg.CreateKey(winreg.HKEY_CURRENT_USER, passworless_config.local_putty_sessions_registry_path) as key:
         if winreg_subkey_exists(key, remote_host):
-            winreg.DeleteKey(winreg.HKEY_CURRENT_USER, r'Software\SimonTatham\PuTTY\Sessions\{}'.format(remote_host))
+            winreg.DeleteKey(winreg.HKEY_CURRENT_USER,
+                             r'{}\{}'.format(passworless_config.local_putty_sessions_registry_path, remote_host))
 
 
-def remove_remote_ssh_host_public_key_from_putty_known_hosts(known_host_name):
+def remove_remote_ssh_host_public_key_from_putty_known_hosts(local_port, passwordless_config):
     import winreg
 
     logging.info('Removing host record from putty known hosts...')
-    with winreg.CreateKey(winreg.HKEY_CURRENT_USER, r'Software\SimonTatham\PuTTY\SshHostKeys') as key:
-        if winreg_value_exists(key, known_host_name):
-            winreg.DeleteValue(key, known_host_name)
+    with winreg.CreateKey(winreg.HKEY_CURRENT_USER, passwordless_config.local_putty_ssh_host_keys_registry_path) as key:
+        putty_ssh_host_key_name = 'ssh-ed25519@{}:127.0.0.1'.format(local_port)
+        if winreg_value_exists(key, putty_ssh_host_key_name):
+            winreg.DeleteValue(key, putty_ssh_host_key_name)
 
 
 def winreg_subkey_exists(key, expected_subkey_name):
@@ -403,46 +419,46 @@ def winreg_value_exists(key, expected_value_name):
     return False
 
 
-def add_record_to_putty_config(local_port, remote_host, ssh_ppk_key_path, ssh_config_user):
+def add_record_to_putty_config(local_port, remote_host, passwordless_config):
     import winreg
     logging.info('Appending host record to putty sessions...')
     with winreg.CreateKey(winreg.HKEY_CURRENT_USER,
-                          r'Software\SimonTatham\PuTTY\Sessions\{}'.format(remote_host)) as key:
-        winreg.SetValueEx(key, 'HostName', 0, winreg.REG_SZ, '{}@127.0.0.1'.format(ssh_config_user))
+                          r'{}\{}'.format(passwordless_config.local_putty_sessions_registry_path, remote_host)) as key:
+        winreg.SetValueEx(key, 'HostName', 0, winreg.REG_SZ, '{}@127.0.0.1'.format(passwordless_config.user))
         winreg.SetValueEx(key, 'PortNumber', 0, winreg.REG_DWORD, local_port)
         winreg.SetValueEx(key, 'Protocol', 0, winreg.REG_SZ, 'ssh')
-        winreg.SetValueEx(key, 'PublicKeyFile', 0, winreg.REG_SZ, ssh_ppk_key_path)
+        winreg.SetValueEx(key, 'PublicKeyFile', 0, winreg.REG_SZ, passwordless_config.local_ppk_key_path)
 
 
-def copy_remote_ssh_host_public_key_to_putty_known_hosts(run_id, remote_host, retries, known_host_name,
-                                                         remote_ssh_host_public_key_path, ssh_host_public_key_path):
+def copy_remote_ssh_host_public_key_to_putty_known_hosts(run_id, local_port, retries, passwordless_config):
     import winreg
     from src.utilities.putty import get_putty_fingerprint
     logging.info('Copying remote host public key...')
-    run_scp_download(run_id, remote_ssh_host_public_key_path, ssh_host_public_key_path,
+    run_scp_download(run_id, passwordless_config.remote_host_ed25519_public_key_path, passwordless_config.local_host_ed25519_public_key_path,
                      user=DEFAULT_SSH_USER, retries=retries)
 
     logging.info('Calculating putty host hash...')
-    with open(ssh_host_public_key_path, 'r') as f:
+    with open(passwordless_config.local_host_ed25519_public_key_path, 'r') as f:
         ssh_host_public_key = f.read().strip()
 
     remote_host_fingerprint = get_putty_fingerprint(ssh_host_public_key)
     if not remote_host_fingerprint:
         raise RuntimeError('Putty host hash calculation has failed for host public key')
 
+    os.remove(passwordless_config.local_host_ed25519_public_key_path)
+
     logging.info('Appending host record to putty known hosts...')
-    with winreg.CreateKey(winreg.HKEY_CURRENT_USER, r'Software\SimonTatham\PuTTY\SshHostKeys') as key:
-        winreg.SetValueEx(key, known_host_name, 0, winreg.REG_SZ, remote_host_fingerprint)
+    with winreg.CreateKey(winreg.HKEY_CURRENT_USER, passwordless_config.local_putty_ssh_host_keys_registry_path) as key:
+        winreg.SetValueEx(key, 'ssh-ed25519@{}:127.0.0.1'.format(local_port), 0, winreg.REG_SZ, remote_host_fingerprint)
 
 
-def copy_remote_ssh_ppk_key(run_id, retries, remote_ssh_ppk_key_path, ssh_ppk_key_path):
+def copy_remote_ssh_ppk_key(run_id, retries, passwordless_config):
     logging.info('Copying remote ppk key...')
-    run_scp_download(run_id, remote_ssh_ppk_key_path, ssh_ppk_key_path,
+    run_scp_download(run_id, passwordless_config.remote_ppk_key_path, passwordless_config.local_ppk_key_path,
                      user=DEFAULT_SSH_USER, retries=retries)
 
 
-def generate_remote_ssh_keys(run_id, retries, remote_ssh_public_key_path, remote_ssh_private_key_path,
-                             remote_ssh_ppk_key_path, remote_ssh_authorized_keys_paths):
+def generate_remote_ssh_keys(run_id, retries, passwordless_config):
     logging.info('Generating tunnel remote ssh keys and copying ssh public key to authorized keys...')
     exit_code = run_ssh(run_id,
                         'ssh-keygen -t rsa -f {remote_ssh_private_key_path} -N "" -q;'
@@ -450,10 +466,10 @@ def generate_remote_ssh_keys(run_id, retries, remote_ssh_public_key_path, remote
                         'apt-get install putty-tools;'
                         'yum install putty;'
                         'puttygen {remote_ssh_private_key_path} -o {remote_ssh_ppk_key_path} -O private;'
-                        .format(remote_ssh_private_key_path=remote_ssh_private_key_path,
-                                remote_ssh_public_key_path=remote_ssh_public_key_path,
-                                remote_ssh_authorized_keys_paths=' '.join(remote_ssh_authorized_keys_paths),
-                                remote_ssh_ppk_key_path=remote_ssh_ppk_key_path),
+                        .format(remote_ssh_private_key_path=passwordless_config.remote_private_key_path,
+                                remote_ssh_public_key_path=passwordless_config.remote_public_key_path,
+                                remote_ssh_authorized_keys_paths=' '.join(passwordless_config.remote_authorized_keys_paths),
+                                remote_ssh_ppk_key_path=passwordless_config.remote_ppk_key_path),
                         user=DEFAULT_SSH_USER, retries=retries)
     if exit_code:
         raise RuntimeError(
@@ -461,62 +477,47 @@ def generate_remote_ssh_keys(run_id, retries, remote_ssh_public_key_path, remote
                 exit_code))
 
 
-def remove_remote_ssh_keys(run_id, retries, remote_ssh_public_key_path, remote_ssh_private_key_path,
-                           remote_ssh_ppk_key_path, remote_ssh_authorized_keys_paths):
+def remove_remote_ssh_keys(run_id, retries, passwordless_config):
     logging.info('Deleting remote ssh keys...')
-    if os.path.exists(remote_ssh_public_key_path) and remote_ssh_authorized_keys_paths:
-        remove_ssh_keys_from_run_command = ''
-        for remote_ssh_authorized_keys_path in remote_ssh_authorized_keys_paths:
-            remote_ssh_authorized_keys_temp_path = '{}_{}'.format(remote_ssh_authorized_keys_path,
-                                                                  random.randint(0, sys.maxsize))
-            remove_ssh_keys_from_run_command += \
-                'cat {public_key_path} | xargs -I {{}} grep -v "{{}}" {authorized_keys_path} > {authorized_keys_temp_path};' \
-                'cp {authorized_keys_temp_path} {authorized_keys_path};' \
-                'chmod 600 {authorized_keys_path};' \
-                'rm {authorized_keys_temp_path};' \
-                    .format(public_key_path=remote_ssh_public_key_path,
-                            private_key_path=remote_ssh_private_key_path,
-                            ppk_key_path=remote_ssh_ppk_key_path,
-                            authorized_keys_path=remote_ssh_authorized_keys_path,
-                            authorized_keys_temp_path=remote_ssh_authorized_keys_temp_path)
-        remove_ssh_keys_from_run_command += 'rm {public_key_path} {private_key_path} {ppk_key_path};' \
-            .format(public_key_path=remote_ssh_public_key_path,
-                    private_key_path=remote_ssh_private_key_path,
-                    ppk_key_path=remote_ssh_ppk_key_path)
-        exit_code = run_ssh(run_id, remove_ssh_keys_from_run_command.rstrip(';'),
-                            user=DEFAULT_SSH_USER, retries=retries)
-        if exit_code:
-            raise RuntimeError('Deleting remote ssh keys has failed with {} exit code'
-                               .format(exit_code))
+    remove_ssh_keys_from_run_command = ''
+    for remote_authorized_keys_path in passwordless_config.remote_authorized_keys_paths:
+        remote_authorized_keys_temp_path = '{}_{}'.format(remote_authorized_keys_path,
+                                                          random.randint(0, sys.maxsize))
+        remove_ssh_keys_from_run_command += \
+            'cat {public_key_path} | xargs -I {{}} grep -v "{{}}" {authorized_keys_path} > {authorized_keys_temp_path};' \
+            'cp {authorized_keys_temp_path} {authorized_keys_path};' \
+            'chmod 600 {authorized_keys_path};' \
+            'rm {authorized_keys_temp_path};' \
+                .format(public_key_path=passwordless_config.remote_public_key_path,
+                        private_key_path=passwordless_config.remote_private_key_path,
+                        ppk_key_path=passwordless_config.remote_ppk_key_path,
+                        authorized_keys_path=remote_authorized_keys_path,
+                        authorized_keys_temp_path=remote_authorized_keys_temp_path)
+    for key_path in [passwordless_config.remote_public_key_path,
+                     passwordless_config.remote_private_key_path,
+                     passwordless_config.remote_ppk_key_path]:
+        remove_ssh_keys_from_run_command += '[ -f {key_path} ] && rm {key_path};'.format(key_path=key_path)
+    exit_code = run_ssh(run_id, remove_ssh_keys_from_run_command.rstrip(';'),
+                        user=DEFAULT_SSH_USER, retries=retries)
+    if exit_code:
+        raise RuntimeError('Deleting remote ssh keys has failed with {} exit code'
+                           .format(exit_code))
 
 
 def create_foreground_tunnel_with_ssh_on_linux(run_id, local_port, remote_port, connection_timeout, conn_info,
                                                ssh_path, ssh_keep, remote_host, log_file, log_level, retries):
     logging.info('Configuring openssh passwordless ssh...')
-    ssh_path = ssh_path or os.path.expanduser('~/.ssh')
-    ssh_config_path = '{}/config'.format(ssh_path)
-    ssh_known_hosts_path = '{}/known_hosts'.format(ssh_path)
-    ssh_keys_path = os.path.expanduser('~/.pipe/.ssh')
-    ssh_private_key_name = 'pipeline-{}-{}-{}'.format(run_id, int(time.time()), random.randint(0, sys.maxsize))
-    ssh_private_key_path = os.path.join(ssh_keys_path, ssh_private_key_name)
-    ssh_public_key_path = '{}.pub'.format(ssh_private_key_path)
-    owner_user = conn_info.owner.split('@')[0]
-    ssh_config_user = DEFAULT_SSH_USER if is_ssh_default_root_user_enabled() else owner_user
-    remote_ssh_authorized_keys_paths = ['/root/.ssh/authorized_keys',
-                                        '/home/{}/.ssh/authorized_keys'.format(owner_user)]
-    remote_ssh_public_key_path = '/root/.ssh/id_rsa.pub'
-    if not os.path.exists(ssh_path):
-        os.makedirs(ssh_path, mode=stat.S_IRWXU)
-    if not os.path.exists(ssh_keys_path):
-        os.makedirs(ssh_keys_path, mode=stat.S_IRWXU)
+    passwordless_config = PasswordlessConfig(run_id, conn_info, ssh_path)
+    if not os.path.exists(passwordless_config.local_openssh_path):
+        os.makedirs(passwordless_config.local_openssh_path, mode=stat.S_IRWXU)
+    if not os.path.exists(passwordless_config.local_keys_path):
+        os.makedirs(passwordless_config.local_keys_path, mode=stat.S_IRWXU)
     try:
         logging.info('Initializing passwordless ssh %s:%s:%s...', local_port, remote_host, remote_port)
-        generate_ssh_keys(log_file, ssh_private_key_path)
-        copy_ssh_public_key_to_remote_authorized_hosts(run_id, ssh_public_key_path, retries,
-                                                       remote_ssh_authorized_keys_paths)
-        add_record_to_ssh_config(ssh_config_path, remote_host, local_port, ssh_private_key_path, ssh_config_user)
-        copy_remote_ssh_public_key_to_ssh_known_hosts(run_id, local_port, log_file, retries,
-                                                      ssh_known_hosts_path, remote_ssh_public_key_path)
+        generate_ssh_keys(log_file, passwordless_config)
+        copy_ssh_public_key_to_remote_authorized_hosts(run_id, retries, passwordless_config)
+        add_record_to_ssh_config(local_port, remote_host, passwordless_config)
+        copy_remote_ssh_public_key_to_ssh_known_hosts(run_id, local_port, log_file, retries, passwordless_config)
         create_foreground_tunnel(run_id, local_port, remote_port, connection_timeout, conn_info,
                                  remote_host, log_level, retries)
     except:
@@ -525,11 +526,10 @@ def create_foreground_tunnel_with_ssh_on_linux(run_id, local_port, remote_port, 
     finally:
         if not ssh_keep:
             logging.info('Deinitializing passwordless ssh %s:%s:%s...', local_port, remote_host, remote_port)
-            remove_ssh_public_key_from_remote_authorized_hosts(run_id, ssh_public_key_path, retries,
-                                                               remote_ssh_authorized_keys_paths)
-            remove_remote_ssh_public_key_from_ssh_known_hosts(ssh_known_hosts_path, local_port, log_file)
-            remove_record_from_ssh_config(ssh_config_path, remote_host)
-            remove_ssh_keys(ssh_public_key_path, ssh_private_key_path)
+            remove_ssh_public_key_from_remote_authorized_hosts(run_id, retries, passwordless_config)
+            remove_remote_ssh_public_key_from_ssh_known_hosts(local_port, log_file, passwordless_config)
+            remove_record_from_ssh_config(remote_host, passwordless_config)
+            remove_ssh_keys(passwordless_config.local_public_key_path, passwordless_config.local_private_key_path)
 
 
 def create_foreground_tunnel(run_id, local_port, remote_port, connection_timeout, conn_info,
@@ -630,9 +630,9 @@ def configure_graceful_exiting():
     signal.signal(signal.SIGTERM, throw_keyboard_interrupt)
 
 
-def generate_ssh_keys(log_file, ssh_private_key_path):
+def generate_ssh_keys(log_file, passwordless_config):
     logging.info('Generating tunnel ssh keys...')
-    perform_command(['ssh-keygen', '-t', 'rsa', '-f', ssh_private_key_path, '-N', '', '-q'], log_file)
+    perform_command(['ssh-keygen', '-t', 'rsa', '-f', passwordless_config.local_private_key_path, '-N', '', '-q'], log_file)
 
 
 def remove_ssh_keys(*key_paths):
@@ -642,25 +642,25 @@ def remove_ssh_keys(*key_paths):
             os.remove(key_path)
 
 
-def copy_ssh_public_key_to_remote_authorized_hosts(run_id, ssh_public_key_path, retries, remote_ssh_authorized_keys_paths):
+def copy_ssh_public_key_to_remote_authorized_hosts(run_id, retries, passwordless_config):
     logging.info('Copying ssh public key to remote authorized keys...')
-    with open(ssh_public_key_path, 'r') as f:
+    with open(passwordless_config.local_public_key_path, 'r') as f:
         ssh_public_key = f.read().strip()
     exit_code = run_ssh(run_id,
                         'echo "{}" | tee -a {} > /dev/null'
-                        .format(ssh_public_key, ' '.join(remote_ssh_authorized_keys_paths)),
+                        .format(ssh_public_key, ' '.join(passwordless_config.remote_authorized_keys_paths)),
                         user=DEFAULT_SSH_USER, retries=retries)
     if exit_code:
         raise RuntimeError('Copying ssh public key to remote authorized keys has failed with {} exit code'.format(exit_code))
 
 
-def remove_ssh_public_key_from_remote_authorized_hosts(run_id, ssh_public_key_path, retries, remote_ssh_authorized_keys_paths):
+def remove_ssh_public_key_from_remote_authorized_hosts(run_id, retries, passwordless_config):
     logging.info('Removing ssh public keys from remote authorized hosts...')
-    if os.path.exists(ssh_public_key_path) and remote_ssh_authorized_keys_paths:
-        with open(ssh_public_key_path, 'r') as f:
+    if os.path.exists(passwordless_config.local_public_key_path):
+        with open(passwordless_config.local_public_key_path, 'r') as f:
             ssh_public_key = f.read().strip()
         remove_ssh_public_keys_from_run_command = ''
-        for remote_ssh_authorized_keys_path in remote_ssh_authorized_keys_paths:
+        for remote_ssh_authorized_keys_path in passwordless_config.remote_authorized_keys_paths:
             remote_ssh_authorized_keys_temp_path = '{}_{}'.format(remote_ssh_authorized_keys_path,
                                                                   random.randint(0, sys.maxsize))
             remove_ssh_public_keys_from_run_command += \
@@ -677,25 +677,26 @@ def remove_ssh_public_key_from_remote_authorized_hosts(run_id, ssh_public_key_pa
             raise RuntimeError('Removing ssh public keys from remote authorized hosts has failed with {} exit code'.format(exit_code))
 
 
-def add_record_to_ssh_config(ssh_config_path, remote_host, local_port, ssh_private_key_path, user):
-    remove_record_from_ssh_config(ssh_config_path, remote_host)
+def add_record_to_ssh_config(local_port, remote_host, passwordless_config):
+    remove_record_from_ssh_config(remote_host, passwordless_config)
     logging.info('Appending host record to ssh config...')
-    ssh_config_path_existed = os.path.exists(ssh_config_path)
-    with open(ssh_config_path, 'a') as f:
+    ssh_config_path_existed = os.path.exists(passwordless_config.local_openssh_config_path)
+    with open(passwordless_config.local_openssh_config_path, 'a') as f:
         f.write('Host {}\n'
                 '    Hostname 127.0.0.1\n'
                 '    Port {}\n'
                 '    IdentityFile {}\n'
                 '    User {}\n'
-                .format(remote_host, local_port, ssh_private_key_path, user))
+                .format(remote_host, local_port,
+                        passwordless_config.local_private_key_path, passwordless_config.user))
     if not ssh_config_path_existed:
-        os.chmod(ssh_config_path, stat.S_IRUSR | stat.S_IWUSR)
+        os.chmod(passwordless_config.local_openssh_config_path, stat.S_IRUSR | stat.S_IWUSR)
 
 
-def remove_record_from_ssh_config(ssh_config_path, remote_host):
+def remove_record_from_ssh_config(remote_host, passwordless_config):
     logging.info('Removing host record from ssh config...')
-    if os.path.exists(ssh_config_path):
-        with open(ssh_config_path, 'r') as f:
+    if os.path.exists(passwordless_config.local_openssh_config_path):
+        with open(passwordless_config.local_openssh_config_path, 'r') as f:
             ssh_config_lines = f.readlines()
         updated_ssh_config_lines = []
         skip_host = False
@@ -707,31 +708,31 @@ def remove_record_from_ssh_config(ssh_config_path, remote_host):
                     skip_host = False
             if not skip_host:
                 updated_ssh_config_lines.append(line)
-        with open(ssh_config_path, 'w') as f:
+        with open(passwordless_config.local_openssh_config_path, 'w') as f:
             f.writelines(updated_ssh_config_lines)
-        os.chmod(ssh_config_path, stat.S_IRUSR | stat.S_IWUSR)
+        os.chmod(passwordless_config.local_openssh_config_path, stat.S_IRUSR | stat.S_IWUSR)
 
 
-def copy_remote_ssh_public_key_to_ssh_known_hosts(run_id, local_port, log_file, retries, ssh_known_hosts_path, remote_ssh_public_key_path):
+def copy_remote_ssh_public_key_to_ssh_known_hosts(run_id, local_port, log_file, retries, passwordless_config):
     logging.info('Copying remote public key to known hosts...')
-    ssh_known_hosts_temp_path = ssh_known_hosts_path + '_{}'.format(random.randint(0, sys.maxsize))
-    run_scp_download(run_id, remote_ssh_public_key_path, ssh_known_hosts_temp_path,
+    ssh_known_hosts_temp_path = passwordless_config.local_openssh_known_hosts_path + '_{}'.format(random.randint(0, sys.maxsize))
+    run_scp_download(run_id, passwordless_config.remote_host_rsa_public_key_path, ssh_known_hosts_temp_path,
                      user=DEFAULT_SSH_USER, retries=retries)
     with open(ssh_known_hosts_temp_path, 'r') as f:
         public_key = f.read().strip()
     os.remove(ssh_known_hosts_temp_path)
-    ssh_known_hosts_path_existed = os.path.exists(ssh_known_hosts_path)
-    with open(ssh_known_hosts_path, 'a') as f:
+    ssh_known_hosts_path_existed = os.path.exists(passwordless_config.local_openssh_known_hosts_path)
+    with open(passwordless_config.local_openssh_known_hosts_path, 'a') as f:
         f.write('[127.0.0.1]:{} {}\n'.format(local_port, public_key))
     if not ssh_known_hosts_path_existed:
-        os.chmod(ssh_known_hosts_path, stat.S_IRUSR | stat.S_IWUSR)
-    perform_command(['ssh-keygen', '-H', '-f', ssh_known_hosts_path], log_file)
+        os.chmod(passwordless_config.local_openssh_known_hosts_path, stat.S_IRUSR | stat.S_IWUSR)
+    perform_command(['ssh-keygen', '-H', '-f', passwordless_config.local_openssh_known_hosts_path], log_file)
 
 
-def remove_remote_ssh_public_key_from_ssh_known_hosts(ssh_known_hosts_path, local_port, log_file):
+def remove_remote_ssh_public_key_from_ssh_known_hosts(local_port, log_file, passwordless_config):
     logging.info('Removing remote public key from known hosts...')
-    if os.path.exists(ssh_known_hosts_path):
-        perform_command(['ssh-keygen', '-R', '[127.0.0.1]:{}'.format(local_port), '-f', ssh_known_hosts_path], log_file)
+    if os.path.exists(passwordless_config.local_openssh_known_hosts_path):
+        perform_command(['ssh-keygen', '-R', '[127.0.0.1]:{}'.format(local_port), '-f', passwordless_config.local_openssh_known_hosts_path], log_file)
 
 
 def perform_command(executable, log_file=None, collect_output=True):

--- a/pipe-cli/src/utilities/ssh_operations.py
+++ b/pipe-cli/src/utilities/ssh_operations.py
@@ -14,6 +14,7 @@
 
 import base64
 import collections
+import itertools
 import logging
 import os
 import random
@@ -304,9 +305,194 @@ def create_foreground_tunnel_with_ssh(run_id, local_port, remote_port, connectio
                                       ssh_path, ssh_keep, remote_host, log_file, log_level, retries):
     logging.basicConfig(level=log_level or logging.ERROR, format=DEFAULT_LOGGING_FORMAT)
     if is_windows():
-        import click
-        click.echo('Passwordless ssh configuration is not supported on Windows.', err=True)
-        sys.exit(1)
+        create_foreground_tunnel_with_ssh_on_windows(run_id, local_port, remote_port, connection_timeout, conn_info,
+                                                     ssh_path, ssh_keep, remote_host, log_file, log_level, retries)
+    else:
+        create_foreground_tunnel_with_ssh_on_linux(run_id, local_port, remote_port, connection_timeout, conn_info,
+                                                   ssh_path, ssh_keep, remote_host, log_file, log_level, retries)
+
+
+def create_foreground_tunnel_with_ssh_on_windows(run_id, local_port, remote_port, connection_timeout, conn_info,
+                                                 ssh_path, ssh_keep, remote_host, log_file, log_level, retries):
+    logging.info('Configuring putty passwordless ssh...')
+    ssh_keys_path = os.path.expanduser('~/.pipe/.ssh')
+    ssh_private_key_name = 'pipeline-{}-{}-{}'.format(run_id, int(time.time()), random.randint(0, sys.maxsize))
+    ssh_private_key_path = os.path.join(ssh_keys_path, ssh_private_key_name)
+    ssh_public_key_path = '{}.pub'.format(ssh_private_key_path)
+    ssh_ppk_key_path = '{}.ppk'.format(ssh_private_key_path)
+    ssh_host_public_key_path = '{}.host.pub'.format(ssh_private_key_path)
+    owner_user = conn_info.owner.split('@')[0]
+    ssh_config_user = DEFAULT_SSH_USER if is_ssh_default_root_user_enabled() else owner_user
+    remote_ssh_authorized_keys_paths = ['/root/.ssh/authorized_keys',
+                                        '/home/{}/.ssh/authorized_keys'.format(owner_user)]
+    remote_ssh_keys_path = '/root/.pipe/.ssh/'
+    remote_ssh_private_key_path = os.path.join(remote_ssh_keys_path, ssh_private_key_name)
+    remote_ssh_public_key_path = '{}.pub'.format(remote_ssh_private_key_path)
+    remote_ssh_ppk_key_path = '{}.ppk'.format(remote_ssh_private_key_path)
+    remote_ssh_host_public_key_path = '/etc/ssh/ssh_host_ed25519_key.pub'
+    known_host_name = 'ssh-ed25519@{}:127.0.0.1'.format(local_port)
+
+    if not os.path.exists(ssh_keys_path):
+        os.makedirs(ssh_keys_path, mode=stat.S_IRWXU)
+    try:
+        logging.info('Initializing passwordless ssh %s:%s:%s...', local_port, remote_host, remote_port)
+        generate_remote_ssh_keys(run_id, retries, remote_ssh_public_key_path, remote_ssh_private_key_path,
+                                 remote_ssh_ppk_key_path, remote_ssh_authorized_keys_paths)
+        copy_remote_ssh_ppk_key(run_id, retries, remote_ssh_ppk_key_path, ssh_ppk_key_path)
+        add_record_to_putty_config(local_port, remote_host, ssh_ppk_key_path, ssh_config_user)
+        copy_remote_ssh_host_public_key_to_putty_known_hosts(run_id, remote_host, retries, known_host_name,
+                                                             remote_ssh_host_public_key_path, ssh_host_public_key_path)
+        create_foreground_tunnel(run_id, local_port, remote_port, connection_timeout, conn_info,
+                                 remote_host, log_level, retries)
+    except:
+        logging.exception('Error occurred while trying set up tunnel')
+        raise
+    finally:
+        if not ssh_keep:
+            logging.info('Deinitializing passwordless ssh %s:%s:%s...', local_port, remote_host, remote_port)
+            remove_remote_ssh_keys(run_id, retries, remote_ssh_public_key_path, remote_ssh_private_key_path,
+                                   remote_ssh_ppk_key_path, remote_ssh_authorized_keys_paths)
+            remove_remote_ssh_host_public_key_from_putty_known_hosts(known_host_name)
+            remove_record_from_putty_config(remote_host)
+            remove_ssh_keys(ssh_ppk_key_path)
+
+
+def remove_record_from_putty_config(remote_host):
+    import winreg
+
+    logging.info('Removing host record from putty sessions...')
+    with winreg.CreateKey(winreg.HKEY_CURRENT_USER, r'Software\SimonTatham\PuTTY\Sessions') as key:
+        if winreg_subkey_exists(key, remote_host):
+            winreg.DeleteKey(winreg.HKEY_CURRENT_USER, r'Software\SimonTatham\PuTTY\Sessions\{}'.format(remote_host))
+
+
+def remove_remote_ssh_host_public_key_from_putty_known_hosts(known_host_name):
+    import winreg
+
+    logging.info('Removing host record from putty known hosts...')
+    with winreg.CreateKey(winreg.HKEY_CURRENT_USER, r'Software\SimonTatham\PuTTY\SshHostKeys') as key:
+        if winreg_value_exists(key, known_host_name):
+            winreg.DeleteValue(key, known_host_name)
+
+
+def winreg_subkey_exists(key, expected_subkey_name):
+    import winreg
+
+    try:
+        for i in itertools.count():
+            actual_subkey_name = winreg.EnumKey(key, i)
+            print(actual_subkey_name)
+            if actual_subkey_name == expected_subkey_name:
+                return True
+    except OSError:
+        pass
+    return False
+
+
+def winreg_value_exists(key, expected_value_name):
+    import winreg
+
+    try:
+        for i in itertools.count():
+            actual_value_name, _, _ = winreg.EnumValue(key, i)
+            print(actual_value_name)
+            if actual_value_name == expected_value_name:
+                return True
+    except OSError:
+        pass
+    return False
+
+
+def add_record_to_putty_config(local_port, remote_host, ssh_ppk_key_path, ssh_config_user):
+    import winreg
+    logging.info('Appending host record to putty sessions...')
+    with winreg.CreateKey(winreg.HKEY_CURRENT_USER,
+                          r'Software\SimonTatham\PuTTY\Sessions\{}'.format(remote_host)) as key:
+        winreg.SetValueEx(key, 'HostName', 0, winreg.REG_SZ, '{}@127.0.0.1'.format(ssh_config_user))
+        winreg.SetValueEx(key, 'PortNumber', 0, winreg.REG_DWORD, local_port)
+        winreg.SetValueEx(key, 'Protocol', 0, winreg.REG_SZ, 'ssh')
+        winreg.SetValueEx(key, 'PublicKeyFile', 0, winreg.REG_SZ, ssh_ppk_key_path)
+
+
+def copy_remote_ssh_host_public_key_to_putty_known_hosts(run_id, remote_host, retries, known_host_name,
+                                                         remote_ssh_host_public_key_path, ssh_host_public_key_path):
+    import winreg
+    from src.utilities.putty import get_putty_fingerprint
+    logging.info('Copying remote host public key...')
+    run_scp_download(run_id, remote_ssh_host_public_key_path, ssh_host_public_key_path,
+                     user=DEFAULT_SSH_USER, retries=retries)
+
+    logging.info('Calculating putty host hash...')
+    with open(ssh_host_public_key_path, 'r') as f:
+        ssh_host_public_key = f.read().strip()
+
+    remote_host_fingerprint = get_putty_fingerprint(ssh_host_public_key)
+    if not remote_host_fingerprint:
+        raise RuntimeError('Putty host hash calculation has failed for host public key')
+
+    logging.info('Appending host record to putty known hosts...')
+    with winreg.CreateKey(winreg.HKEY_CURRENT_USER, r'Software\SimonTatham\PuTTY\SshHostKeys') as key:
+        winreg.SetValueEx(key, known_host_name, 0, winreg.REG_SZ, remote_host_fingerprint)
+
+
+def copy_remote_ssh_ppk_key(run_id, retries, remote_ssh_ppk_key_path, ssh_ppk_key_path):
+    logging.info('Copying remote ppk key...')
+    run_scp_download(run_id, remote_ssh_ppk_key_path, ssh_ppk_key_path,
+                     user=DEFAULT_SSH_USER, retries=retries)
+
+
+def generate_remote_ssh_keys(run_id, retries, remote_ssh_public_key_path, remote_ssh_private_key_path,
+                             remote_ssh_ppk_key_path, remote_ssh_authorized_keys_paths):
+    logging.info('Generating tunnel remote ssh keys and copying ssh public key to authorized keys...')
+    exit_code = run_ssh(run_id,
+                        'ssh-keygen -t rsa -f {remote_ssh_private_key_path} -N "" -q;'
+                        'cat {remote_ssh_public_key_path} | tee -a {remote_ssh_authorized_keys_paths} > /dev/null;'
+                        'apt-get install putty-tools;'
+                        'yum install putty;'
+                        'puttygen {remote_ssh_private_key_path} -o {remote_ssh_ppk_key_path} -O private;'
+                        .format(remote_ssh_private_key_path=remote_ssh_private_key_path,
+                                remote_ssh_public_key_path=remote_ssh_public_key_path,
+                                remote_ssh_authorized_keys_paths=' '.join(remote_ssh_authorized_keys_paths),
+                                remote_ssh_ppk_key_path=remote_ssh_ppk_key_path),
+                        user=DEFAULT_SSH_USER, retries=retries)
+    if exit_code:
+        raise RuntimeError(
+            'Generating tunnel remote ssh keys and copying ssh public key to authorized keys have failed with {} exit code'.format(
+                exit_code))
+
+
+def remove_remote_ssh_keys(run_id, retries, remote_ssh_public_key_path, remote_ssh_private_key_path,
+                           remote_ssh_ppk_key_path, remote_ssh_authorized_keys_paths):
+    logging.info('Deleting remote ssh keys...')
+    if os.path.exists(remote_ssh_public_key_path) and remote_ssh_authorized_keys_paths:
+        remove_ssh_keys_from_run_command = ''
+        for remote_ssh_authorized_keys_path in remote_ssh_authorized_keys_paths:
+            remote_ssh_authorized_keys_temp_path = '{}_{}'.format(remote_ssh_authorized_keys_path,
+                                                                  random.randint(0, sys.maxsize))
+            remove_ssh_keys_from_run_command += \
+                'cat {public_key_path} | xargs -I {{}} grep -v "{{}}" {authorized_keys_path} > {authorized_keys_temp_path};' \
+                'cp {authorized_keys_temp_path} {authorized_keys_path};' \
+                'chmod 600 {authorized_keys_path};' \
+                'rm {authorized_keys_temp_path};' \
+                    .format(public_key_path=remote_ssh_public_key_path,
+                            private_key_path=remote_ssh_private_key_path,
+                            ppk_key_path=remote_ssh_ppk_key_path,
+                            authorized_keys_path=remote_ssh_authorized_keys_path,
+                            authorized_keys_temp_path=remote_ssh_authorized_keys_temp_path)
+        remove_ssh_keys_from_run_command += 'rm {public_key_path} {private_key_path} {ppk_key_path};' \
+            .format(public_key_path=remote_ssh_public_key_path,
+                    private_key_path=remote_ssh_private_key_path,
+                    ppk_key_path=remote_ssh_ppk_key_path)
+        exit_code = run_ssh(run_id, remove_ssh_keys_from_run_command.rstrip(';'),
+                            user=DEFAULT_SSH_USER, retries=retries)
+        if exit_code:
+            raise RuntimeError('Deleting remote ssh keys has failed with {} exit code'
+                               .format(exit_code))
+
+
+def create_foreground_tunnel_with_ssh_on_linux(run_id, local_port, remote_port, connection_timeout, conn_info,
+                                               ssh_path, ssh_keep, remote_host, log_file, log_level, retries):
+    logging.info('Configuring openssh passwordless ssh...')
     ssh_path = ssh_path or os.path.expanduser('~/.ssh')
     ssh_config_path = '{}/config'.format(ssh_path)
     ssh_known_hosts_path = '{}/known_hosts'.format(ssh_path)
@@ -338,6 +524,7 @@ def create_foreground_tunnel_with_ssh(run_id, local_port, remote_port, connectio
         raise
     finally:
         if not ssh_keep:
+            logging.info('Deinitializing passwordless ssh %s:%s:%s...', local_port, remote_host, remote_port)
             remove_ssh_public_key_from_remote_authorized_hosts(run_id, ssh_public_key_path, retries,
                                                                remote_ssh_authorized_keys_paths)
             remove_remote_ssh_public_key_from_ssh_known_hosts(ssh_known_hosts_path, local_port, log_file)
@@ -448,12 +635,11 @@ def generate_ssh_keys(log_file, ssh_private_key_path):
     perform_command(['ssh-keygen', '-t', 'rsa', '-f', ssh_private_key_path, '-N', '', '-q'], log_file)
 
 
-def remove_ssh_keys(ssh_public_key_path, ssh_private_key_path):
+def remove_ssh_keys(*key_paths):
     logging.info('Removing tunnel ssh keys...')
-    if os.path.exists(ssh_public_key_path):
-        os.remove(ssh_public_key_path)
-    if os.path.exists(ssh_private_key_path):
-        os.remove(ssh_private_key_path)
+    for key_path in key_paths:
+        if os.path.exists(key_path):
+            os.remove(key_path)
 
 
 def copy_ssh_public_key_to_remote_authorized_hosts(run_id, ssh_public_key_path, retries, remote_ssh_authorized_keys_paths):
@@ -465,7 +651,7 @@ def copy_ssh_public_key_to_remote_authorized_hosts(run_id, ssh_public_key_path, 
                         .format(ssh_public_key, ' '.join(remote_ssh_authorized_keys_paths)),
                         user=DEFAULT_SSH_USER, retries=retries)
     if exit_code:
-        RuntimeError('Copying ssh public key to remote authorized keys has failed with {} exit code'.format(exit_code))
+        raise RuntimeError('Copying ssh public key to remote authorized keys has failed with {} exit code'.format(exit_code))
 
 
 def remove_ssh_public_key_from_remote_authorized_hosts(run_id, ssh_public_key_path, retries, remote_ssh_authorized_keys_paths):
@@ -488,7 +674,7 @@ def remove_ssh_public_key_from_remote_authorized_hosts(run_id, ssh_public_key_pa
         exit_code = run_ssh(run_id, remove_ssh_public_keys_from_run_command.rstrip(';'),
                             user=DEFAULT_SSH_USER, retries=retries)
         if exit_code:
-            RuntimeError('Removing ssh public keys from remote authorized hosts has failed with {} exit code'.format(exit_code))
+            raise RuntimeError('Removing ssh public keys from remote authorized hosts has failed with {} exit code'.format(exit_code))
 
 
 def add_record_to_ssh_config(ssh_config_path, remote_host, local_port, ssh_private_key_path, user):

--- a/pipe-cli/src/utilities/ssh_operations.py
+++ b/pipe-cli/src/utilities/ssh_operations.py
@@ -39,15 +39,15 @@ DEFAULT_SSH_USER = 'root'
 DEFAULT_LOGGING_FORMAT = '%(asctime)s:%(levelname)s: %(message)s'
 
 
-class PasswordlessConfig:
+class PasswordlessSSHConfig:
 
     def __init__(self, run_id, conn_info, ssh_path=None):
         self.owner_user = conn_info.owner.split('@')[0]
         self.user = DEFAULT_SSH_USER if is_ssh_default_root_user_enabled() else self.owner_user
         self.key_name = 'pipeline-{}-{}-{}'.format(run_id, int(time.time()), random.randint(0, sys.maxsize))
 
-        self.remote_keys_path = '/root/.pipe/.ssh/'
-        self.remote_private_key_path = os.path.join(self.remote_keys_path, self.key_name)
+        self.remote_keys_path = '/root/.pipe/.keys'
+        self.remote_private_key_path = '{}/{}'.format(self.remote_keys_path, self.key_name)
         self.remote_public_key_path = '{}.pub'.format(self.remote_private_key_path)
         self.remote_ppk_key_path = '{}.ppk'.format(self.remote_private_key_path)
         self.remote_host_rsa_public_key_path = '/etc/ssh/ssh_host_rsa_key.pub'
@@ -55,7 +55,7 @@ class PasswordlessConfig:
         self.remote_authorized_keys_paths = ['/root/.ssh/authorized_keys',
                                              '/home/{}/.ssh/authorized_keys'.format(self.owner_user)]
 
-        self.local_keys_path = os.path.expanduser('~/.pipe/.keys')
+        self.local_keys_path = os.path.join(os.path.expanduser('~'), '.pipe', '.keys')
         self.local_private_key_path = os.path.join(self.local_keys_path, self.key_name)
         self.local_public_key_path = '{}.pub'.format(self.local_private_key_path)
         self.local_ppk_key_path = '{}.ppk'.format(self.local_private_key_path)
@@ -348,15 +348,15 @@ def create_foreground_tunnel_with_ssh(run_id, local_port, remote_port, connectio
 def create_foreground_tunnel_with_ssh_on_windows(run_id, local_port, remote_port, connection_timeout, conn_info,
                                                  ssh_keep, remote_host, log_level, retries):
     logging.info('Configuring putty passwordless ssh...')
-    passwordless_config = PasswordlessConfig(run_id, conn_info)
+    passwordless_config = PasswordlessSSHConfig(run_id, conn_info)
     if not os.path.exists(passwordless_config.local_keys_path):
         os.makedirs(passwordless_config.local_keys_path, mode=stat.S_IRWXU)
     try:
         logging.info('Initializing passwordless ssh %s:%s:%s...', local_port, remote_host, remote_port)
-        generate_remote_ssh_keys(run_id, retries, passwordless_config)
-        copy_remote_ssh_ppk_key(run_id, retries, passwordless_config)
+        generate_remote_openssh_and_putty_keys(run_id, retries, passwordless_config)
+        copy_remote_putty_key(run_id, retries, passwordless_config)
         add_record_to_putty_config(local_port, remote_host, passwordless_config)
-        copy_remote_ssh_host_public_key_to_putty_known_hosts(run_id, local_port, retries, passwordless_config)
+        copy_remote_openssh_public_host_key_to_putty_known_hosts(run_id, local_port, retries, passwordless_config)
         create_foreground_tunnel(run_id, local_port, remote_port, connection_timeout, conn_info,
                                  remote_host, log_level, retries)
     except:
@@ -365,159 +365,26 @@ def create_foreground_tunnel_with_ssh_on_windows(run_id, local_port, remote_port
     finally:
         if not ssh_keep:
             logging.info('Deinitializing passwordless ssh %s:%s:%s...', local_port, remote_host, remote_port)
-            remove_remote_ssh_keys(run_id, retries, passwordless_config)
-            remove_remote_ssh_host_public_key_from_putty_known_hosts(local_port, passwordless_config)
+            remove_remote_openssh_and_putty_keys(run_id, retries, passwordless_config)
+            remove_remote_openssh_host_public_key_from_putty_known_hosts(local_port, passwordless_config)
             remove_record_from_putty_config(remote_host, passwordless_config)
             remove_ssh_keys(passwordless_config.local_ppk_key_path, passwordless_config.local_host_ed25519_public_key_path)
-
-
-def remove_record_from_putty_config(remote_host, passworless_config):
-    import winreg
-
-    logging.info('Removing host record from putty sessions...')
-    with winreg.CreateKey(winreg.HKEY_CURRENT_USER, passworless_config.local_putty_sessions_registry_path) as key:
-        if winreg_subkey_exists(key, remote_host):
-            winreg.DeleteKey(winreg.HKEY_CURRENT_USER,
-                             r'{}\{}'.format(passworless_config.local_putty_sessions_registry_path, remote_host))
-
-
-def remove_remote_ssh_host_public_key_from_putty_known_hosts(local_port, passwordless_config):
-    import winreg
-
-    logging.info('Removing host record from putty known hosts...')
-    with winreg.CreateKey(winreg.HKEY_CURRENT_USER, passwordless_config.local_putty_ssh_host_keys_registry_path) as key:
-        putty_ssh_host_key_name = 'ssh-ed25519@{}:127.0.0.1'.format(local_port)
-        if winreg_value_exists(key, putty_ssh_host_key_name):
-            winreg.DeleteValue(key, putty_ssh_host_key_name)
-
-
-def winreg_subkey_exists(key, expected_subkey_name):
-    import winreg
-
-    try:
-        for i in itertools.count():
-            actual_subkey_name = winreg.EnumKey(key, i)
-            print(actual_subkey_name)
-            if actual_subkey_name == expected_subkey_name:
-                return True
-    except OSError:
-        pass
-    return False
-
-
-def winreg_value_exists(key, expected_value_name):
-    import winreg
-
-    try:
-        for i in itertools.count():
-            actual_value_name, _, _ = winreg.EnumValue(key, i)
-            print(actual_value_name)
-            if actual_value_name == expected_value_name:
-                return True
-    except OSError:
-        pass
-    return False
-
-
-def add_record_to_putty_config(local_port, remote_host, passwordless_config):
-    import winreg
-    logging.info('Appending host record to putty sessions...')
-    with winreg.CreateKey(winreg.HKEY_CURRENT_USER,
-                          r'{}\{}'.format(passwordless_config.local_putty_sessions_registry_path, remote_host)) as key:
-        winreg.SetValueEx(key, 'HostName', 0, winreg.REG_SZ, '{}@127.0.0.1'.format(passwordless_config.user))
-        winreg.SetValueEx(key, 'PortNumber', 0, winreg.REG_DWORD, local_port)
-        winreg.SetValueEx(key, 'Protocol', 0, winreg.REG_SZ, 'ssh')
-        winreg.SetValueEx(key, 'PublicKeyFile', 0, winreg.REG_SZ, passwordless_config.local_ppk_key_path)
-
-
-def copy_remote_ssh_host_public_key_to_putty_known_hosts(run_id, local_port, retries, passwordless_config):
-    import winreg
-    from src.utilities.putty import get_putty_fingerprint
-    logging.info('Copying remote host public key...')
-    run_scp_download(run_id, passwordless_config.remote_host_ed25519_public_key_path, passwordless_config.local_host_ed25519_public_key_path,
-                     user=DEFAULT_SSH_USER, retries=retries)
-
-    logging.info('Calculating putty host hash...')
-    with open(passwordless_config.local_host_ed25519_public_key_path, 'r') as f:
-        ssh_host_public_key = f.read().strip()
-
-    remote_host_fingerprint = get_putty_fingerprint(ssh_host_public_key)
-    if not remote_host_fingerprint:
-        raise RuntimeError('Putty host hash calculation has failed for host public key')
-
-    os.remove(passwordless_config.local_host_ed25519_public_key_path)
-
-    logging.info('Appending host record to putty known hosts...')
-    with winreg.CreateKey(winreg.HKEY_CURRENT_USER, passwordless_config.local_putty_ssh_host_keys_registry_path) as key:
-        winreg.SetValueEx(key, 'ssh-ed25519@{}:127.0.0.1'.format(local_port), 0, winreg.REG_SZ, remote_host_fingerprint)
-
-
-def copy_remote_ssh_ppk_key(run_id, retries, passwordless_config):
-    logging.info('Copying remote ppk key...')
-    run_scp_download(run_id, passwordless_config.remote_ppk_key_path, passwordless_config.local_ppk_key_path,
-                     user=DEFAULT_SSH_USER, retries=retries)
-
-
-def generate_remote_ssh_keys(run_id, retries, passwordless_config):
-    logging.info('Generating tunnel remote ssh keys and copying ssh public key to authorized keys...')
-    exit_code = run_ssh(run_id,
-                        'ssh-keygen -t rsa -f {remote_ssh_private_key_path} -N "" -q;'
-                        'cat {remote_ssh_public_key_path} | tee -a {remote_ssh_authorized_keys_paths} > /dev/null;'
-                        'apt-get install putty-tools;'
-                        'yum install putty;'
-                        'puttygen {remote_ssh_private_key_path} -o {remote_ssh_ppk_key_path} -O private;'
-                        .format(remote_ssh_private_key_path=passwordless_config.remote_private_key_path,
-                                remote_ssh_public_key_path=passwordless_config.remote_public_key_path,
-                                remote_ssh_authorized_keys_paths=' '.join(passwordless_config.remote_authorized_keys_paths),
-                                remote_ssh_ppk_key_path=passwordless_config.remote_ppk_key_path),
-                        user=DEFAULT_SSH_USER, retries=retries)
-    if exit_code:
-        raise RuntimeError(
-            'Generating tunnel remote ssh keys and copying ssh public key to authorized keys have failed with {} exit code'.format(
-                exit_code))
-
-
-def remove_remote_ssh_keys(run_id, retries, passwordless_config):
-    logging.info('Deleting remote ssh keys...')
-    remove_ssh_keys_from_run_command = ''
-    for remote_authorized_keys_path in passwordless_config.remote_authorized_keys_paths:
-        remote_authorized_keys_temp_path = '{}_{}'.format(remote_authorized_keys_path,
-                                                          random.randint(0, sys.maxsize))
-        remove_ssh_keys_from_run_command += \
-            'cat {public_key_path} | xargs -I {{}} grep -v "{{}}" {authorized_keys_path} > {authorized_keys_temp_path};' \
-            'cp {authorized_keys_temp_path} {authorized_keys_path};' \
-            'chmod 600 {authorized_keys_path};' \
-            'rm {authorized_keys_temp_path};' \
-                .format(public_key_path=passwordless_config.remote_public_key_path,
-                        private_key_path=passwordless_config.remote_private_key_path,
-                        ppk_key_path=passwordless_config.remote_ppk_key_path,
-                        authorized_keys_path=remote_authorized_keys_path,
-                        authorized_keys_temp_path=remote_authorized_keys_temp_path)
-    for key_path in [passwordless_config.remote_public_key_path,
-                     passwordless_config.remote_private_key_path,
-                     passwordless_config.remote_ppk_key_path]:
-        remove_ssh_keys_from_run_command += '[ -f {key_path} ] && rm {key_path};'.format(key_path=key_path)
-    exit_code = run_ssh(run_id, remove_ssh_keys_from_run_command.rstrip(';'),
-                        user=DEFAULT_SSH_USER, retries=retries)
-    if exit_code:
-        raise RuntimeError('Deleting remote ssh keys has failed with {} exit code'
-                           .format(exit_code))
 
 
 def create_foreground_tunnel_with_ssh_on_linux(run_id, local_port, remote_port, connection_timeout, conn_info,
                                                ssh_path, ssh_keep, remote_host, log_file, log_level, retries):
     logging.info('Configuring openssh passwordless ssh...')
-    passwordless_config = PasswordlessConfig(run_id, conn_info, ssh_path)
+    passwordless_config = PasswordlessSSHConfig(run_id, conn_info, ssh_path)
     if not os.path.exists(passwordless_config.local_openssh_path):
         os.makedirs(passwordless_config.local_openssh_path, mode=stat.S_IRWXU)
     if not os.path.exists(passwordless_config.local_keys_path):
         os.makedirs(passwordless_config.local_keys_path, mode=stat.S_IRWXU)
     try:
         logging.info('Initializing passwordless ssh %s:%s:%s...', local_port, remote_host, remote_port)
-        generate_ssh_keys(log_file, passwordless_config)
-        copy_ssh_public_key_to_remote_authorized_hosts(run_id, retries, passwordless_config)
-        add_record_to_ssh_config(local_port, remote_host, passwordless_config)
-        copy_remote_ssh_public_key_to_ssh_known_hosts(run_id, local_port, log_file, retries, passwordless_config)
+        generate_openssh_keys(log_file, passwordless_config)
+        copy_openssh_public_key_to_remote_authorized_hosts(run_id, retries, passwordless_config)
+        add_record_to_openssh_config(local_port, remote_host, passwordless_config)
+        copy_remote_openssh_public_key_to_openssh_known_hosts(run_id, local_port, log_file, retries, passwordless_config)
         create_foreground_tunnel(run_id, local_port, remote_port, connection_timeout, conn_info,
                                  remote_host, log_level, retries)
     except:
@@ -526,9 +393,9 @@ def create_foreground_tunnel_with_ssh_on_linux(run_id, local_port, remote_port, 
     finally:
         if not ssh_keep:
             logging.info('Deinitializing passwordless ssh %s:%s:%s...', local_port, remote_host, remote_port)
-            remove_ssh_public_key_from_remote_authorized_hosts(run_id, retries, passwordless_config)
-            remove_remote_ssh_public_key_from_ssh_known_hosts(local_port, log_file, passwordless_config)
-            remove_record_from_ssh_config(remote_host, passwordless_config)
+            remove_openssh_public_key_from_remote_authorized_hosts(run_id, retries, passwordless_config)
+            remove_remote_openssh_public_key_from_openssh_known_hosts(local_port, log_file, passwordless_config)
+            remove_record_from_openssh_config(remote_host, passwordless_config)
             remove_ssh_keys(passwordless_config.local_public_key_path, passwordless_config.local_private_key_path)
 
 
@@ -630,7 +497,141 @@ def configure_graceful_exiting():
     signal.signal(signal.SIGTERM, throw_keyboard_interrupt)
 
 
-def generate_ssh_keys(log_file, passwordless_config):
+def generate_remote_openssh_and_putty_keys(run_id, retries, passwordless_config):
+    logging.info('Generating tunnel remote ssh keys and copying ssh public key to authorized keys...')
+    exit_code = run_ssh(run_id,
+                        'mkdir -p $(dirname {remote_private_key_path});'
+                        'ssh-keygen -t rsa -f {remote_private_key_path} -N "" -q;'
+                        'cat {remote_public_key_path} | tee -a {remote_authorized_keys_paths} > /dev/null;'
+                        'apt-get install putty-tools;'
+                        'yum install putty;'
+                        'puttygen {remote_private_key_path} -o {remote_ppk_key_path} -O private;'
+                        .format(remote_public_key_path=passwordless_config.remote_public_key_path,
+                                remote_private_key_path=passwordless_config.remote_private_key_path,
+                                remote_ppk_key_path=passwordless_config.remote_ppk_key_path,
+                                remote_authorized_keys_paths=' '.join(passwordless_config.remote_authorized_keys_paths)),
+                        user=DEFAULT_SSH_USER, retries=retries)
+    if exit_code:
+        raise RuntimeError(
+            'Generating tunnel remote ssh keys and copying ssh public key to authorized keys have failed with {} exit code'.format(
+                exit_code))
+
+
+def remove_remote_openssh_and_putty_keys(run_id, retries, passwordless_config):
+    logging.info('Deleting remote ssh keys...')
+    remove_ssh_keys_from_run_command = ''
+    for remote_authorized_keys_path in passwordless_config.remote_authorized_keys_paths:
+        remote_authorized_keys_temp_path = '{}_{}'.format(remote_authorized_keys_path,
+                                                          random.randint(0, sys.maxsize))
+        remove_ssh_keys_from_run_command += \
+            ('[ -f {public_key_path} ] &&'
+             'cat {public_key_path} | xargs -I {{}} grep -v "{{}}" {authorized_keys_path} > {authorized_keys_temp_path} &&'
+             'cp {authorized_keys_temp_path} {authorized_keys_path} &&'
+             'chmod 600 {authorized_keys_path} &&'
+             'rm {authorized_keys_temp_path};') \
+                .format(public_key_path=passwordless_config.remote_public_key_path,
+                        private_key_path=passwordless_config.remote_private_key_path,
+                        ppk_key_path=passwordless_config.remote_ppk_key_path,
+                        authorized_keys_path=remote_authorized_keys_path,
+                        authorized_keys_temp_path=remote_authorized_keys_temp_path)
+    for key_path in [passwordless_config.remote_public_key_path,
+                     passwordless_config.remote_private_key_path,
+                     passwordless_config.remote_ppk_key_path]:
+        remove_ssh_keys_from_run_command += '[ -f {key_path} ] && rm {key_path};'.format(key_path=key_path)
+    exit_code = run_ssh(run_id, remove_ssh_keys_from_run_command.rstrip(';'),
+                        user=DEFAULT_SSH_USER, retries=retries)
+    if exit_code:
+        raise RuntimeError('Deleting remote ssh keys has failed with {} exit code'
+                           .format(exit_code))
+
+
+def copy_remote_putty_key(run_id, retries, passwordless_config):
+    logging.info('Copying remote ppk key...')
+    run_scp_download(run_id, passwordless_config.remote_ppk_key_path, passwordless_config.local_ppk_key_path,
+                     user=DEFAULT_SSH_USER, retries=retries)
+
+
+def add_record_to_putty_config(local_port, remote_host, passwordless_config):
+    import winreg
+    logging.info('Appending host record to putty sessions...')
+    with winreg.CreateKey(winreg.HKEY_CURRENT_USER,
+                          r'{}\{}'.format(passwordless_config.local_putty_sessions_registry_path, remote_host)) as key:
+        winreg.SetValueEx(key, 'HostName', 0, winreg.REG_SZ, '{}@127.0.0.1'.format(passwordless_config.user))
+        winreg.SetValueEx(key, 'PortNumber', 0, winreg.REG_DWORD, local_port)
+        winreg.SetValueEx(key, 'Protocol', 0, winreg.REG_SZ, 'ssh')
+        winreg.SetValueEx(key, 'PublicKeyFile', 0, winreg.REG_SZ, passwordless_config.local_ppk_key_path)
+
+
+def remove_record_from_putty_config(remote_host, passworless_config):
+    import winreg
+
+    logging.info('Removing host record from putty sessions...')
+    with winreg.CreateKey(winreg.HKEY_CURRENT_USER, passworless_config.local_putty_sessions_registry_path) as key:
+        if winreg_subkey_exists(key, remote_host):
+            winreg.DeleteKey(winreg.HKEY_CURRENT_USER,
+                             r'{}\{}'.format(passworless_config.local_putty_sessions_registry_path, remote_host))
+
+
+def copy_remote_openssh_public_host_key_to_putty_known_hosts(run_id, local_port, retries, passwordless_config):
+    import winreg
+    from src.utilities.putty import get_putty_fingerprint
+    logging.info('Copying remote host public key...')
+    run_scp_download(run_id, passwordless_config.remote_host_ed25519_public_key_path,
+                     passwordless_config.local_host_ed25519_public_key_path,
+                     user=DEFAULT_SSH_USER, retries=retries)
+
+    logging.info('Calculating putty host hash...')
+    with open(passwordless_config.local_host_ed25519_public_key_path, 'r') as f:
+        ssh_host_public_key = f.read().strip()
+
+    os.remove(passwordless_config.local_host_ed25519_public_key_path)
+
+    remote_host_fingerprint = get_putty_fingerprint(ssh_host_public_key)
+    if not remote_host_fingerprint:
+        raise RuntimeError('Putty host hash calculation has failed for host public key')
+
+    logging.info('Appending host record to putty known hosts...')
+    with winreg.CreateKey(winreg.HKEY_CURRENT_USER, passwordless_config.local_putty_ssh_host_keys_registry_path) as key:
+        winreg.SetValueEx(key, 'ssh-ed25519@{}:127.0.0.1'.format(local_port), 0, winreg.REG_SZ, remote_host_fingerprint)
+
+
+def remove_remote_openssh_host_public_key_from_putty_known_hosts(local_port, passwordless_config):
+    import winreg
+
+    logging.info('Removing host record from putty known hosts...')
+    with winreg.CreateKey(winreg.HKEY_CURRENT_USER, passwordless_config.local_putty_ssh_host_keys_registry_path) as key:
+        putty_ssh_host_key_name = 'ssh-ed25519@{}:127.0.0.1'.format(local_port)
+        if winreg_value_exists(key, putty_ssh_host_key_name):
+            winreg.DeleteValue(key, putty_ssh_host_key_name)
+
+
+def winreg_subkey_exists(key, expected_subkey_name):
+    import winreg
+
+    try:
+        for i in itertools.count():
+            actual_subkey_name = winreg.EnumKey(key, i)
+            if actual_subkey_name == expected_subkey_name:
+                return True
+    except OSError:
+        pass
+    return False
+
+
+def winreg_value_exists(key, expected_value_name):
+    import winreg
+
+    try:
+        for i in itertools.count():
+            actual_value_name, _, _ = winreg.EnumValue(key, i)
+            if actual_value_name == expected_value_name:
+                return True
+    except OSError:
+        pass
+    return False
+
+
+def generate_openssh_keys(log_file, passwordless_config):
     logging.info('Generating tunnel ssh keys...')
     perform_command(['ssh-keygen', '-t', 'rsa', '-f', passwordless_config.local_private_key_path, '-N', '', '-q'], log_file)
 
@@ -642,7 +643,7 @@ def remove_ssh_keys(*key_paths):
             os.remove(key_path)
 
 
-def copy_ssh_public_key_to_remote_authorized_hosts(run_id, retries, passwordless_config):
+def copy_openssh_public_key_to_remote_authorized_hosts(run_id, retries, passwordless_config):
     logging.info('Copying ssh public key to remote authorized keys...')
     with open(passwordless_config.local_public_key_path, 'r') as f:
         ssh_public_key = f.read().strip()
@@ -654,7 +655,7 @@ def copy_ssh_public_key_to_remote_authorized_hosts(run_id, retries, passwordless
         raise RuntimeError('Copying ssh public key to remote authorized keys has failed with {} exit code'.format(exit_code))
 
 
-def remove_ssh_public_key_from_remote_authorized_hosts(run_id, retries, passwordless_config):
+def remove_openssh_public_key_from_remote_authorized_hosts(run_id, retries, passwordless_config):
     logging.info('Removing ssh public keys from remote authorized hosts...')
     if os.path.exists(passwordless_config.local_public_key_path):
         with open(passwordless_config.local_public_key_path, 'r') as f:
@@ -677,8 +678,8 @@ def remove_ssh_public_key_from_remote_authorized_hosts(run_id, retries, password
             raise RuntimeError('Removing ssh public keys from remote authorized hosts has failed with {} exit code'.format(exit_code))
 
 
-def add_record_to_ssh_config(local_port, remote_host, passwordless_config):
-    remove_record_from_ssh_config(remote_host, passwordless_config)
+def add_record_to_openssh_config(local_port, remote_host, passwordless_config):
+    remove_record_from_openssh_config(remote_host, passwordless_config)
     logging.info('Appending host record to ssh config...')
     ssh_config_path_existed = os.path.exists(passwordless_config.local_openssh_config_path)
     with open(passwordless_config.local_openssh_config_path, 'a') as f:
@@ -693,7 +694,7 @@ def add_record_to_ssh_config(local_port, remote_host, passwordless_config):
         os.chmod(passwordless_config.local_openssh_config_path, stat.S_IRUSR | stat.S_IWUSR)
 
 
-def remove_record_from_ssh_config(remote_host, passwordless_config):
+def remove_record_from_openssh_config(remote_host, passwordless_config):
     logging.info('Removing host record from ssh config...')
     if os.path.exists(passwordless_config.local_openssh_config_path):
         with open(passwordless_config.local_openssh_config_path, 'r') as f:
@@ -713,7 +714,7 @@ def remove_record_from_ssh_config(remote_host, passwordless_config):
         os.chmod(passwordless_config.local_openssh_config_path, stat.S_IRUSR | stat.S_IWUSR)
 
 
-def copy_remote_ssh_public_key_to_ssh_known_hosts(run_id, local_port, log_file, retries, passwordless_config):
+def copy_remote_openssh_public_key_to_openssh_known_hosts(run_id, local_port, log_file, retries, passwordless_config):
     logging.info('Copying remote public key to known hosts...')
     ssh_known_hosts_temp_path = passwordless_config.local_openssh_known_hosts_path + '_{}'.format(random.randint(0, sys.maxsize))
     run_scp_download(run_id, passwordless_config.remote_host_rsa_public_key_path, ssh_known_hosts_temp_path,
@@ -729,7 +730,7 @@ def copy_remote_ssh_public_key_to_ssh_known_hosts(run_id, local_port, log_file, 
     perform_command(['ssh-keygen', '-H', '-f', passwordless_config.local_openssh_known_hosts_path], log_file)
 
 
-def remove_remote_ssh_public_key_from_ssh_known_hosts(local_port, log_file, passwordless_config):
+def remove_remote_openssh_public_key_from_openssh_known_hosts(local_port, log_file, passwordless_config):
     logging.info('Removing remote public key from known hosts...')
     if os.path.exists(passwordless_config.local_openssh_known_hosts_path):
         perform_command(['ssh-keygen', '-R', '[127.0.0.1]:{}'.format(local_port), '-f', passwordless_config.local_openssh_known_hosts_path], log_file)

--- a/pipe-cli/src/utilities/ssh_operations.py
+++ b/pipe-cli/src/utilities/ssh_operations.py
@@ -503,8 +503,8 @@ def generate_remote_openssh_and_putty_keys(run_id, retries, passwordless_config)
                         'mkdir -p $(dirname {remote_private_key_path});'
                         'ssh-keygen -t rsa -f {remote_private_key_path} -N "" -q;'
                         'cat {remote_public_key_path} | tee -a {remote_authorized_keys_paths} > /dev/null;'
-                        'apt-get install putty-tools;'
-                        'yum install putty;'
+                        'command -v puttygen || apt-get -y install putty-tools;'
+                        'command -v puttygen || yum -y install putty;'
                         'puttygen {remote_private_key_path} -o {remote_ppk_key_path} -O private;'
                         .format(remote_public_key_path=passwordless_config.remote_public_key_path,
                                 remote_private_key_path=passwordless_config.remote_private_key_path,


### PR DESCRIPTION
Relates to #1501.

The pull request brings support for passwordless ssh connections to run instances from Windows workstation. The overall approach is pretty similar to Linux passwordless ssh support in #1534.

Passwordless ssh configuration is performed for [putty utils](https://www.putty.org/). Once tunnel is set up then both putty GUI and its command line clients are allowed to access a run instance in passwordless manner. Putty's configuration is basically a bunch of records in Windows registry. Therefore in order to use passwordless ssh autoconfiguration a windows user should have permissions to modify Windows registry under putty's path `HKEY_CURRENT_USER\Software\SimonTatham\PuTTY`.

Notice that the pull request brings `kh2reg.py` script from [putty repository](https://github.com/github/putty). It is included in pipe cli source code tree in order to allow putty host fingerprints generation. Original `LICENSE` file is included as well. Original commit is [this one](https://github.com/github/putty/commit/7003b43963aef6cdf2841c2a882a684025f1d806).

See `pipe tunnel --help` output for more information:
```
  Establishes tunnel connection to specified run instance port and serves it
  as a local port.

  It allows to transfer any tcp traffic from local machine to run instance
  and works both on Linux and Windows.

  Additionally it enables passwordless ssh connections if the corresponding
  option is specified. Once specified ssh is configured both locally and
  remotely to support passwordless connections. For Linux workstations
  openssh library is configured to allow passwordless access using ssh and
  scp command line clients usage. For Windows workstations putty utils are
  configured to allow passwordless access using putty application as well as
  plink and pscp command line clients.

  Examples:

  I. Example of simple tcp port tunnel connection establishing.

  Establish tunnel connection from run (12345) instance port (4567) to the
  same local port.

      pipe tunnel start -lp 4567 -rp 4567 12345

  II. Example of ssh port tunnel connection establishing with enabled
  passwordless ssh configuration.

  First of all establish tunnel connection from run (12345) instance ssh
  port (22) to some local port (4567).

      pipe tunnel start -lp 4567 -rp 22 --ssh 12345

  [Linux] Then connect to run instance using regular ssh client.

      ssh pipeline-12345

  [Linux] Or transfer some files to and from run instance using regular scp
  client.

      scp file.txt pipeline-12345:/common/workdir/file.txt

  [Windows] Or connect to run instance using regular plink client.

      plink pipeline-12345

  [Windows] Or transfer some files to and from run instance using regular
  pscp client.

      pscp file.txt pipeline-12345:/common/workdir/file.txt

  Advanced tunnel configuration environment variables:

      CP_CLI_TUNNEL_PROXY_HOST - tunnel proxy host
      CP_CLI_TUNNEL_PROXY_PORT - tunnel proxy port
      CP_CLI_TUNNEL_TARGET_HOST - tunnel target host
      CP_CLI_TUNNEL_SERVER_ADDRESS - tunnel server address
```