### PR TITLE
Issue #1646 Add exported monitoring report type selection to CLI

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1623,8 +1623,8 @@ def cluster():
 @click.option('-p', '--interval', required=False, help='The time interval. This option shall have the following format:'
                                                        ' <N>m for minutes or <N>h for hours, where <N> is the required '
                                                        'number of minutes/hours. Default: 1m.')
-@click.option('-rt', '--report-type', required=False, help='Exported report type (case insensitive).'
-                                                           'Currently `CSV` and `XLS` are supported. Default: XLS')
+@click.option('-rt', '--report-type', required=False, default='CSV',
+              help='Exported report type (case insensitive). Currently `CSV` and `XLS` are supported. Default: CSV')
 @click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token
 def monitor(instance_id, run_id, output, date_from, date_to, interval, report_type):

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1623,13 +1623,15 @@ def cluster():
 @click.option('-p', '--interval', required=False, help='The time interval. This option shall have the following format:'
                                                        ' <N>m for minutes or <N>h for hours, where <N> is the required '
                                                        'number of minutes/hours. Default: 1m.')
+@click.option('-rt', '--report-type', required=False, help='Exported report type (case insensitive).'
+                                                           'Currently `CSV` and `XLS` are supported. Default: XLS')
 @click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token
-def monitor(instance_id, run_id, output, date_from, date_to, interval):
+def monitor(instance_id, run_id, output, date_from, date_to, interval, report_type):
     """
     Downloads node utilization report
     """
-    ClusterMonitoringManager().generate_report(instance_id, run_id, output, date_from, date_to, interval)
+    ClusterMonitoringManager().generate_report(instance_id, run_id, output, date_from, date_to, interval, report_type)
 
 
 @cli.group()

--- a/pipe-cli/src/api/cluster.py
+++ b/pipe-cli/src/api/cluster.py
@@ -58,8 +58,8 @@ class Cluster(API):
         return result
 
     @classmethod
-    def download_usage_report(cls, instance_id, date_from, date_to, interval, file_path):
+    def download_usage_report(cls, instance_id, date_from, date_to, interval, file_path, report_type):
         api = cls.instance()
-        url_path = 'cluster/node/%s/usage/report?interval=%s&from=%s&to=%s' \
-                   % (instance_id, interval, date_from, date_to)
+        url_path = 'cluster/node/%s/usage/report?interval=%s&from=%s&to=%s&type=%s' \
+                   % (instance_id, interval, date_from, date_to, str.upper(report_type))
         api.download(url_path, file_path)

--- a/pipe-cli/src/utilities/cluster_monitoring_manager.py
+++ b/pipe-cli/src/utilities/cluster_monitoring_manager.py
@@ -53,9 +53,7 @@ class ClusterMonitoringManager:
             else date_utilities.parse_parameter_date_to_utc(raw_to_date)
         date_from = date_utilities.minus_day(date_to) if not raw_from_date \
             else date_utilities.parse_parameter_date_to_utc(raw_from_date)
-        if not report_type:
-            report_type = 'xls'
-        elif str.lower(report_type) not in SUPPORTED_REPORT_TYPES:
+        if str.lower(report_type) not in SUPPORTED_REPORT_TYPES:
             click.echo("Given report type '%s' is not supported" % report_type, err=True)
             sys.exit(1)
         output_path = cls._build_output_path(output, run_id, instance_id, date_from, date_to, interval, report_type)

--- a/pipe-cli/src/utilities/cluster_monitoring_manager.py
+++ b/pipe-cli/src/utilities/cluster_monitoring_manager.py
@@ -22,6 +22,7 @@ from src.api.pipeline_run import PipelineRun
 
 
 OUTPUT_FILE_DATE_FORMAT = '%Y-%m-%d'
+SUPPORTED_REPORT_TYPES = ['xls', 'csv']
 
 
 class ClusterMonitoringManager:
@@ -30,7 +31,7 @@ class ClusterMonitoringManager:
         pass
 
     @classmethod
-    def generate_report(cls, instance_id, run_id, output, raw_from_date, raw_to_date, interval):
+    def generate_report(cls, instance_id, run_id, output, raw_from_date, raw_to_date, interval, report_type):
         if not instance_id and not run_id:
             click.echo("One of '--instance-id' or '--run-id' options shall be specified", err=True)
             sys.exit(1)
@@ -52,26 +53,32 @@ class ClusterMonitoringManager:
             else date_utilities.parse_parameter_date_to_utc(raw_to_date)
         date_from = date_utilities.minus_day(date_to) if not raw_from_date \
             else date_utilities.parse_parameter_date_to_utc(raw_from_date)
-        output_path = cls._build_output_path(output, run_id, instance_id, date_from, date_to, interval)
+        if not report_type:
+            report_type = 'xls'
+        elif str.lower(report_type) not in SUPPORTED_REPORT_TYPES:
+            click.echo("Given report type '%s' is not supported" % report_type, err=True)
+            sys.exit(1)
+        output_path = cls._build_output_path(output, run_id, instance_id, date_from, date_to, interval, report_type)
         Cluster.download_usage_report(instance_id,
                                       date_utilities.format_date(date_from),
                                       date_utilities.format_date(date_to),
                                       cls._convert_to_duration_format(interval),
-                                      output_path)
+                                      output_path,
+                                      report_type)
         click.echo("Usage report downloaded to '%s'" % output_path)
 
     @staticmethod
-    def _build_output_path(output, run_id, instance_id, date_from, date_to, interval):
+    def _build_output_path(output, run_id, instance_id, date_from, date_to, interval, report_type):
         if not output:
             output_name = ClusterMonitoringManager._build_output_file_name(run_id, instance_id, date_from, date_to,
-                                                                           interval)
+                                                                           interval, report_type)
             return os.path.abspath(output_name)
         output_path = os.path.abspath(output)
         if output.endswith(os.path.sep) and not os.path.exists(output_path):
             os.makedirs(output_path)
         if output.endswith(os.path.sep) or os.path.isdir(output_path):
             output_name = ClusterMonitoringManager._build_output_file_name(run_id, instance_id, date_from, date_to,
-                                                                           interval)
+                                                                           interval, report_type)
             return os.path.join(output_path, output_name)
         output_name = os.path.basename(output_path)
         folder_path = output_path.rstrip(output_name)
@@ -80,13 +87,14 @@ class ClusterMonitoringManager:
         return output_path
 
     @staticmethod
-    def _build_output_file_name(run_id, instance_id, date_from, date_to, interval):
+    def _build_output_file_name(run_id, instance_id, date_from, date_to, interval, report_type):
         instance_indicator = str(run_id or instance_id)
-        return "cluster_monitor_%s_%s_%s_%s.csv" % (
+        return "cluster_monitor_%s_%s_%s_%s.%s" % (
             instance_indicator,
             date_utilities.format_date(date_utilities.to_local(date_from), OUTPUT_FILE_DATE_FORMAT),
             date_utilities.format_date(date_utilities.to_local(date_to), OUTPUT_FILE_DATE_FORMAT),
-            interval)
+            interval,
+            str.lower(report_type))
 
     @staticmethod
     def _convert_to_duration_format(raw_interval):


### PR DESCRIPTION
This PR is related to issue #1646

It allows specifying the type of monitoring report, that a user wants to export via pipe-cli (`XLS` or `CSV`).