### PR TITLE
Issue #1694 Run network policy manager 

### DIFF
--- a/deploy/contents/install/app/install.sh
+++ b/deploy/contents/install/app/install.sh
@@ -258,6 +258,10 @@ CP_TP_KUBE_NODE_NAME=${CP_TP_KUBE_NODE_NAME:-$KUBE_MASTER_NODE_NAME}
 print_info "-> Assigning cloud-pipeline/cp-tinyproxy to $CP_TP_KUBE_NODE_NAME"
 kubectl label nodes "$CP_TP_KUBE_NODE_NAME" cloud-pipeline/cp-tinyproxy="true" --overwrite
 
+# Allow to schedule policy-manager service to the master
+CP_POLICY_MANAGER_KUBE_NODE_NAME=${CP_POLICY_MANAGER_KUBE_NODE_NAME:-$KUBE_MASTER_NODE_NAME}
+print_info "-> Assigning cloud-pipeline/cp-run-policy-manager to $CP_POLICY_MANAGER_KUBE_NODE_NAME"
+kubectl label nodes "$CP_POLICY_MANAGER_KUBE_NODE_NAME" cloud-pipeline/cp-run-policy-manager="true" --overwrite
 
 echo
 
@@ -1189,6 +1193,15 @@ kubectl delete daemonset cp-oom-reporter
 
 print_info "-> Deploying OOM reporter daemonset"
 create_kube_resource $K8S_SPECS_HOME/cp-oom-reporter/cp-oom-reporter.yaml
+
+
+# Run-policy manager - monitor and manage network policies to implement restrictions on inter-run connections
+print_ok "[Starting run-policy manager deployment]"
+print_info "-> Deleting existing instance of run-policy manager"
+delete_deployment_and_service "cp-run-policy-manager" \
+                                "/opt/run-policy-manager"
+print_info "-> Deploying run-policy manager"
+create_kube_resource $K8S_SPECS_HOME/cp-run-policy-manager/cp-run-policy-manager-dpl.yaml
 
 print_ok "Installation done"
 echo -e $CP_INSTALL_SUMMARY

--- a/deploy/contents/k8s/cp-run-policy-manager/cp-run-policy-manager-dpl.yaml
+++ b/deploy/contents/k8s/cp-run-policy-manager/cp-run-policy-manager-dpl.yaml
@@ -21,7 +21,7 @@ spec:
             privileged: true
           command: [ "/policy-manager/init" ]
           env:
-            - name: RUN_OWNER_POLICY_POLL_PERIOD_SEC
+            - name: CP_RUN_POLICY_MANAGER_POLL_PERIOD_SEC
               value: "5"
           envFrom:
             - configMapRef:

--- a/deploy/contents/k8s/cp-run-policy-manager/cp-run-policy-manager-dpl.yaml
+++ b/deploy/contents/k8s/cp-run-policy-manager/cp-run-policy-manager-dpl.yaml
@@ -1,0 +1,41 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cp-run-policy-manager
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    metadata:
+      namespace: default
+      labels:
+        cloud-pipeline/cp-run-policy-manager: "true"
+    spec:
+      nodeSelector:
+        cloud-pipeline/cp-run-policy-manager: "true"
+      containers:
+        - name: cp-run-policy-manager
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:run-policy-manager-$CP_VERSION
+          imagePullPolicy: "Always"
+          securityContext:
+            privileged: true
+          command: [ "/policy-manager/init" ]
+          env:
+            - name: RUN_OWNER_POLICY_POLL_PERIOD_SEC
+              value: "5"
+          envFrom:
+            - configMapRef:
+                name: cp-config-global
+          volumeMounts:
+            - mountPath: /root/.kube
+              name: kube-config
+              readOnly: true
+            - mountPath: /policy-manager/logs
+              name: run-policy-manager-logs
+      volumes:
+        - name: kube-config
+          hostPath:
+            path: /root/.kube
+        - name: run-policy-manager-logs
+          hostPath:
+            path: /opt/run-policy-manager/logs

--- a/deploy/docker/build-dockers.sh
+++ b/deploy/docker/build-dockers.sh
@@ -256,6 +256,12 @@ docker build    $DOCKERS_SOURCES_PATH/cp-leader-elector \
                 -t "$CP_ELECTOR_DIST_NAME"
 docker push "$CP_ELECTOR_DIST_NAME"
 
+# Run owner's policy manager
+CP_RUN_POLICY_MANAGER_DIST_NAME=${CP_RUN_POLICY_MANAGER_DIST_NAME:-"$CP_DIST_REPO_NAME:run-policy-manager-${DOCKERS_VERSION}"}
+docker build    $DOCKERS_SOURCES_PATH/cp-run-policy-manager \
+                -t "$CP_RUN_POLICY_MANAGER_DIST_NAME"
+docker push "$CP_RUN_POLICY_MANAGER_DIST_NAME"
+
 ########################
 # Base tools dockers
 ########################

--- a/deploy/docker/cp-run-policy-manager/Dockerfile
+++ b/deploy/docker/cp-run-policy-manager/Dockerfile
@@ -1,0 +1,30 @@
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM centos:7
+
+RUN yum install -y curl python3
+
+RUN  curl -s https://bootstrap.pypa.io/get-pip.py | python3 - && \
+     pip3 install -I kubernetes==12.0.1
+
+RUN mkdir /policy-manager
+ADD common-run-policy-template.yaml /policy-manager
+ADD sensitive-run-policy-template.yaml /policy-manager
+ADD policy_manager.py /policy-manager
+
+ADD init /policy-manager/init
+RUN chmod +x /policy-manager/init
+
+CMD ["/policy-manager/init"]

--- a/deploy/docker/cp-run-policy-manager/common-run-policy-template.yaml
+++ b/deploy/docker/cp-run-policy-manager/common-run-policy-template.yaml
@@ -1,0 +1,15 @@
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: <POLICY_NAME_PREFIX>-runs-policy-non-sensitive
+  namespace: default
+  labels:
+    owner: <OWNER>
+spec:
+  selector: owner == '<OWNER>' && sensitive != 'true'
+  types:
+    - Ingress
+  ingress:
+    - action: Allow
+      source:
+        selector: (!has(owner) || (sensitive != 'true' && owner == '<OWNER>'))

--- a/deploy/docker/cp-run-policy-manager/init
+++ b/deploy/docker/cp-run-policy-manager/init
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+RUN_POLICY_MANAGER_LOG_FILE="/policy-manager/logs/policy-manager.log"
+mkdir -p $(dirname $RUN_POLICY_MANAGER_LOG_FILE)
+python3 -u /policy-manager/policy_manager.py >> "$RUN_POLICY_MANAGER_LOG_FILE" 2>&1 &
+MANAGER_PID="$!"
+
+function stop_pid {
+    local pid="$1"
+    if [ $pid -ne 0 ]; then
+        kill -SIGTERM "$pid"
+        wait "$pid"
+    fi
+}
+
+function sigterm_handler {
+    echo "Got SIGTERM, stopping service ($MANAGER_PID)"
+    stop_pid $MANAGER_PID
+    exit 143
+}
+
+trap 'kill $! ; sigterm_handler' SIGTERM

--- a/deploy/docker/cp-run-policy-manager/policy_manager.py
+++ b/deploy/docker/cp-run-policy-manager/policy_manager.py
@@ -20,10 +20,10 @@ import uuid
 import yaml
 from kubernetes import client, config
 
-NAMESPACE = "default"
-CALICO_NETPOL_PLURAL = "networkpolicies"
-CALICO_RESOURCES_VERSION = "v1"
-CALICO_RESOURCES_GROUP = "crd.projectcalico.org"
+NAMESPACE = 'default'
+CALICO_NETPOL_PLURAL = 'networkpolicies'
+CALICO_RESOURCES_VERSION = 'v1'
+CALICO_RESOURCES_GROUP = 'crd.projectcalico.org'
 K8S_OBJ_NAME_KEY = 'name'
 K8S_LABELS_KEY = 'labels'
 K8S_METADATA_KEY = 'metadata'
@@ -41,7 +41,7 @@ MONITORING_PERIOD_SEC = int(os.getenv('RUN_OWNER_POLICY_POLL_PERIOD_SEC', 5))
 
 
 def log_message(message):
-    print('[{}] {}'.format(datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"), message))
+    print('[{}] {}'.format(datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'), message))
 
 
 def get_custom_resource_api():
@@ -72,7 +72,8 @@ def create_policy(owner, is_sensitive):
                                              namespace=NAMESPACE,
                                              plural=CALICO_NETPOL_PLURAL,
                                              name=policy_name_candidate)
-            log_message("Policy named [{}] exists already: generating suffix for the current one.")
+            log_message('Policy with name [{}] exists already: generating suffix for the current one.'
+                        .format(policy_name_candidate))
             policy_name_candidate = policy_name_template.replace(NETPOL_NAME_PREFIX_PLACEHOLDER,
                                                                  sanitized_owner_name + '-' + str(uuid.uuid4())[:8])
         except client.exceptions.ApiException as e:
@@ -83,15 +84,15 @@ def create_policy(owner, is_sensitive):
                                                     namespace=NAMESPACE,
                                                     plural=CALICO_NETPOL_PLURAL,
                                                     body=policy_yaml)
-                log_message("Policy [{}] created successfully".format(policy_name_candidate))
+                log_message('Policy [{}] created successfully'.format(policy_name_candidate))
             else:
-                log_message("Unexpected error occurred during creation of the policy for [{}]: {}".format(owner,
+                log_message('Unexpected error occurred during creation of the policy for [{}]: {}'.format(owner,
                                                                                                           e.reason))
             break
 
 
 def sanitize_name(name: str):
-    return re.sub("[^A-Za-z0-9]+", "-", name).lower()
+    return re.sub('[^A-Za-z0-9]+', '-', name).lower()
 
 
 def create_policy_yaml_object(owner, is_sensitive):

--- a/deploy/docker/cp-run-policy-manager/policy_manager.py
+++ b/deploy/docker/cp-run-policy-manager/policy_manager.py
@@ -67,14 +67,14 @@ def create_policy(owner, is_sensitive):
     policy_name_candidate = policy_name_template.replace(NETPOL_NAME_PREFIX_PLACEHOLDER, sanitized_owner_name)
     while True:
         try:
-            api.get_namespaced_custom_object_status(group=CALICO_RESOURCES_GROUP,
-                                                    version=CALICO_RESOURCES_VERSION,
-                                                    namespace=NAMESPACE,
-                                                    plural=CALICO_NETPOL_PLURAL,
-                                                    name=policy_name_candidate)
+            api.get_namespaced_custom_object(group=CALICO_RESOURCES_GROUP,
+                                             version=CALICO_RESOURCES_VERSION,
+                                             namespace=NAMESPACE,
+                                             plural=CALICO_NETPOL_PLURAL,
+                                             name=policy_name_candidate)
             log_message("Policy named [{}] exists already: generating suffix for the current one.")
             policy_name_candidate = policy_name_template.replace(NETPOL_NAME_PREFIX_PLACEHOLDER,
-                                                                 sanitized_owner_name + uuid.uuid4().get_hex()[:8])
+                                                                 sanitized_owner_name + '-' + str(uuid.uuid4())[:8])
         except client.exceptions.ApiException as e:
             if e.status == 404:
                 policy_yaml[K8S_METADATA_KEY][K8S_OBJ_NAME_KEY] = policy_name_candidate

--- a/deploy/docker/cp-run-policy-manager/policy_manager.py
+++ b/deploy/docker/cp-run-policy-manager/policy_manager.py
@@ -91,7 +91,7 @@ def create_policy(owner, is_sensitive):
 
 
 def sanitize_name(name: str):
-    return re.sub("[^A-a0-9]+", "-", name).lower()
+    return re.sub("[^A-Za-z0-9]+", "-", name).lower()
 
 
 def create_policy_yaml_object(owner, is_sensitive):

--- a/deploy/docker/cp-run-policy-manager/policy_manager.py
+++ b/deploy/docker/cp-run-policy-manager/policy_manager.py
@@ -1,0 +1,156 @@
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+import os
+import re
+import time
+import yaml
+from kubernetes import client, config
+
+PIPELINE_POD_SELECTOR = 'type=pipeline'
+
+NAMESPACE = "default"
+CALICO_NETPOL_PLURAL = "networkpolicies"
+CALICO_RESOURCES_VERSION = "v1"
+CALICO_RESOURCES_GROUP = "crd.projectcalico.org"
+NETPOL_OWNER_PLACEHOLDER = '<OWNER>'
+NETPOL_NAME_PREFIX_PLACEHOLDER = '<POLICY_NAME_PREFIX>'
+OWNER_LABEL = 'owner'
+SENSITIVE_LABEL = 'sensitive'
+COMMON_NETPOL_TEMPLATE_PATH = '/policy-manager/common-run-policy-template.yaml'
+SENSITIVE_NETPOL_TEMPLATE_PATH = '/policy-manager/sensitive-run-policy-template.yaml'
+
+MONITORING_PERIOD_SEC = int(os.getenv('RUN_OWNER_POLICY_POLL_PERIOD_SEC', 5))
+
+
+def log_message(message):
+    print('[{}] {}'.format(datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"), message))
+
+
+def get_custom_resource_api():
+    config.load_kube_config()
+    return client.CustomObjectsApi()
+
+
+def load_all_active_policies():
+    api = get_custom_resource_api()
+    policies_response = api.list_namespaced_custom_object(group=CALICO_RESOURCES_GROUP,
+                                                          version=CALICO_RESOURCES_VERSION,
+                                                          namespace=NAMESPACE,
+                                                          plural=CALICO_NETPOL_PLURAL)
+    return policies_response['items']
+
+
+def create_policy(owner, is_sensitive):
+    log_message('Creating policy for [{}{}]'.format(owner, '-sensitive' if is_sensitive else ''))
+    api = get_custom_resource_api()
+    api.create_namespaced_custom_object(group=CALICO_RESOURCES_GROUP,
+                                        version=CALICO_RESOURCES_VERSION,
+                                        namespace=NAMESPACE,
+                                        plural=CALICO_NETPOL_PLURAL,
+                                        body=create_policy_yaml_object(owner, is_sensitive))
+
+
+def sanitize_name(name: str):
+    return re.sub("[^A-a0-9]+", "-", name).lower()
+
+
+def create_policy_yaml_object(owner, is_sensitive):
+    with open(SENSITIVE_NETPOL_TEMPLATE_PATH if is_sensitive else COMMON_NETPOL_TEMPLATE_PATH, 'r') as file:
+        new_policy_as_string = file.read()
+        new_policy_as_string = new_policy_as_string.replace(NETPOL_OWNER_PLACEHOLDER, owner)
+        new_policy_as_string = new_policy_as_string.replace(NETPOL_NAME_PREFIX_PLACEHOLDER, sanitize_name(owner))
+    return yaml.load(new_policy_as_string, Loader=yaml.FullLoader) if new_policy_as_string else None
+
+
+def delete_policy(policy_name):
+    log_message('Removing policy [{}]'.format(policy_name))
+    api = get_custom_resource_api()
+    api.delete_namespaced_custom_object(group=CALICO_RESOURCES_GROUP,
+                                        version=CALICO_RESOURCES_VERSION,
+                                        namespace=NAMESPACE,
+                                        plural=CALICO_NETPOL_PLURAL,
+                                        name=policy_name)
+
+
+def load_all_pipeline_pods():
+    pods_response = client.CoreV1Api().list_namespaced_pod(namespace=NAMESPACE, label_selector=PIPELINE_POD_SELECTOR)
+    return pods_response.items
+
+
+def is_sensitive_policy(policy):
+    return SENSITIVE_LABEL in policy['metadata']['labels']
+
+
+def is_sensitive_pod(pod):
+    return SENSITIVE_LABEL in pod.metadata.labels
+
+
+def get_pods_owners_set(pods):
+    owners = set()
+    for pod in pods:
+        owners.add(pod.metadata.labels.get(OWNER_LABEL))
+    return owners
+
+
+def get_policies_owners_set(policies):
+    owners = set()
+    for policy in policies:
+        owners.add(policy['metadata']['labels'][OWNER_LABEL])
+    return owners
+
+
+def create_missed_policies(active_pods, active_policies, is_sensitive):
+    pods_owners = get_pods_owners_set(active_pods)
+    users_affected_by_policies = get_policies_owners_set(active_policies)
+    for owner in pods_owners:
+        if owner not in users_affected_by_policies:
+            create_policy(owner, is_sensitive)
+
+
+def drop_excess_policies(active_pods, active_policies):
+    pods_owners = get_pods_owners_set(active_pods)
+    for policy in active_policies:
+        user_affected_by_policy = policy['metadata']['labels'][OWNER_LABEL]
+        if user_affected_by_policy not in pods_owners:
+            delete_policy(policy['metadata']['name'])
+
+
+def main():
+    log_message('===Starting run policies monitoring===')
+    while True:
+        active_policies = load_all_active_policies()
+        sensitive_policies = []
+        common_policies = []
+        for policy in active_policies:
+            sensitive_policies.append(policy) if is_sensitive_policy(policy) else common_policies.append(policy)
+
+        active_pods = load_all_pipeline_pods()
+        sensitive_pods = []
+        common_pods = []
+        for pod in active_pods:
+            sensitive_pods.append(pod) if is_sensitive_pod(pod) else common_pods.append(pod)
+
+        create_missed_policies(common_pods, common_policies, False)
+        create_missed_policies(sensitive_pods, sensitive_policies, True)
+
+        drop_excess_policies(common_pods, common_policies)
+        drop_excess_policies(sensitive_pods, sensitive_policies)
+
+        time.sleep(float(MONITORING_PERIOD_SEC))
+
+
+if __name__ == '__main__':
+    main()

--- a/deploy/docker/cp-run-policy-manager/policy_manager.py
+++ b/deploy/docker/cp-run-policy-manager/policy_manager.py
@@ -35,10 +35,12 @@ PIPELINE_POD_LABEL_SELECTOR = 'type=pipeline'
 PIPELINE_POD_PHASE_SELECTOR = 'status.phase={}'
 SENSITIVE_LABEL = 'sensitive'
 TRACKED_POD_PHASES = ['Pending', 'Running']
-COMMON_NETPOL_TEMPLATE_PATH = '/policy-manager/common-run-policy-template.yaml'
-SENSITIVE_NETPOL_TEMPLATE_PATH = '/policy-manager/sensitive-run-policy-template.yaml'
 
-MONITORING_PERIOD_SEC = int(os.getenv('RUN_OWNER_POLICY_POLL_PERIOD_SEC', 5))
+COMMON_NETPOL_TEMPLATE_PATH = os.getenv('CP_RUN_POLICY_MANAGER_COMMON_POLICY_PATH',
+                                        '/policy-manager/common-run-policy-template.yaml')
+SENSITIVE_NETPOL_TEMPLATE_PATH = os.getenv('CP_RUN_POLICY_MANAGER_SENSITIVE_POLICY_PATH',
+                                           '/policy-manager/sensitive-run-policy-template.yaml')
+MONITORING_PERIOD_SEC = int(os.getenv('CP_RUN_POLICY_MANAGER_POLL_PERIOD_SEC', 5))
 
 
 def log_message(message):

--- a/deploy/docker/cp-run-policy-manager/policy_manager.py
+++ b/deploy/docker/cp-run-policy-manager/policy_manager.py
@@ -88,6 +88,7 @@ def delete_policy(policy_name):
 
 
 def load_all_pipeline_pods():
+    config.load_kube_config()
     pods_response = client.CoreV1Api().list_namespaced_pod(namespace=NAMESPACE, label_selector=PIPELINE_POD_SELECTOR)
     return pods_response.items
 

--- a/deploy/docker/cp-run-policy-manager/sensitive-run-policy-template.yaml
+++ b/deploy/docker/cp-run-policy-manager/sensitive-run-policy-template.yaml
@@ -1,0 +1,16 @@
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: <POLICY_NAME_PREFIX>-runs-policy-sensitive
+  namespace: default
+  labels:
+    owner: <OWNER>
+    sensitive: 'true'
+spec:
+  selector: owner == '<OWNER>' && sensitive == 'true'
+  types:
+    - Ingress
+  ingress:
+    - action: Allow
+      source:
+        selector: cloud-pipeline/cp-edge == 'true' || (sensitive == 'true' && owner == '<OWNER>')


### PR DESCRIPTION
This PR is related to issue #1694 

It introduces a new `cp-run-policy-manager` service, which is using Calico network policies to control incoming pod's traffic.
The service performs periodical polls of the Kubernetes API and compares the list of the active pods' owners with users, affected by active network policies.