### PR TITLE
Add missing hidden imports to pipe fuse build scripts

### DIFF
--- a/pipe-cli/build_linux.sh
+++ b/pipe-cli/build_linux.sh
@@ -65,6 +65,20 @@ cd $PIPE_MOUNT_SOURCES_DIR && \
 python2 $PYINSTALLER_PATH/pyinstaller/pyinstaller.py \
                                 --hidden-import=UserList \
                                 --hidden-import=UserString \
+                                --hidden-import=commands \
+                                --hidden-import=ConfigParser \
+                                --hidden-import=UserDict \
+                                --hidden-import=itertools \
+                                --hidden-import=collections \
+                                --hidden-import=future.backports.misc \
+                                --hidden-import=commands \
+                                --hidden-import=base64 \
+                                --hidden-import=__builtin__ \
+                                --hidden-import=math \
+                                --hidden-import=reprlib \
+                                --hidden-import=functools \
+                                --hidden-import=re \
+                                --hidden-import=subprocess \
                                 --additional-hooks-dir="${PIPE_MOUNT_SOURCES_DIR}/hooks" \
                                 -y \
                                 --clean \

--- a/pipe-cli/mount/build_mount.sh
+++ b/pipe-cli/mount/build_mount.sh
@@ -43,6 +43,20 @@ cd $PIPE_MOUNT_SOURCES_DIR && \
 python2 $PYINSTALLER_PATH/pyinstaller/pyinstaller.py \
                                 --hidden-import=UserList \
                                 --hidden-import=UserString \
+                                --hidden-import=commands \
+                                --hidden-import=ConfigParser \
+                                --hidden-import=UserDict \
+                                --hidden-import=itertools \
+                                --hidden-import=collections \
+                                --hidden-import=future.backports.misc \
+                                --hidden-import=commands \
+                                --hidden-import=base64 \
+                                --hidden-import=__builtin__ \
+                                --hidden-import=math \
+                                --hidden-import=reprlib \
+                                --hidden-import=functools \
+                                --hidden-import=re \
+                                --hidden-import=subprocess \
                                 --additional-hooks-dir="${PIPE_MOUNT_SOURCES_DIR}/hooks" \
                                 -y \
                                 --clean \

--- a/pipe-cli/mount/pipe-fuse.py
+++ b/pipe-cli/mount/pipe-fuse.py
@@ -17,6 +17,8 @@ import errno
 import logging
 import os
 import sys
+import traceback
+
 import future.utils
 
 is_frozen = getattr(sys, 'frozen', False)
@@ -236,4 +238,5 @@ if __name__ == '__main__':
               threads=args.threads, monitoring_delay=args.monitoring_delay, recording=recording)
     except BaseException as e:
         logging.error('Unhandled error: %s' % str(e))
+        traceback.print_exc()
         sys.exit(1)


### PR DESCRIPTION
Resolves #1697.

The pull request adds hidden imports to pipe fuse build just the same way it is done for pipe build. Additionally it brings stacktrace printing for pipe fuse initialization errors.