### PR TITLE
Test CLI: fix for test entities naming

### DIFF
--- a/e2e/cli/autoscaling/test_instance_kill_by_timout.py
+++ b/e2e/cli/autoscaling/test_instance_kill_by_timout.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 
 import datetime as dt
 from common_utils.entity_managers import PipelineManager
+from common_utils.test_utils import format_name
 from utils.pipeline_utils import *
 
 MAX_REP_COUNT = 600
@@ -31,7 +32,7 @@ class TestTerminateNodeByTimeout(object):
     def setup_class(cls):
         logging.basicConfig(filename=get_log_filename(), level=logging.INFO,
                             format='%(levelname)s %(asctime)s %(module)s:%(message)s')
-        pipeline_name = "instance_kill_by_timeout_test"
+        pipeline_name = format_name("instance_kill_by_timeout_test")
         cls.pipeline_id = PipelineManager.create(pipeline_name)
         logging.info("Pipeline {} with ID {} created.".format(pipeline_name, cls.pipeline_id))
 

--- a/e2e/cli/autoscaling/test_kill_node_manually.py
+++ b/e2e/cli/autoscaling/test_kill_node_manually.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ import logging
 import pytest
 
 from common_utils.entity_managers import PipelineManager
+from common_utils.test_utils import format_name
 from utils.pipeline_utils import *
 
 MAX_REP_COUNT = 120
@@ -34,7 +35,7 @@ class TestTerminateNodeManually(object):
     def setup_class(cls):
         logging.basicConfig(filename=get_log_filename(), level=logging.INFO,
                             format='%(levelname)s %(asctime)s %(module)s:%(message)s')
-        pipeline_name = "kill_node_manually_test"
+        pipeline_name = format_name("kill_node_manually_test")
         cls.pipeline_id = PipelineManager.create(pipeline_name)
         logging.info("Pipeline {} with ID {} created.".format(pipeline_name, cls.pipeline_id))
 

--- a/e2e/cli/autoscaling/test_node_reassign.py
+++ b/e2e/cli/autoscaling/test_node_reassign.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ import os
 import pytest
 
 from common_utils.entity_managers import PipelineManager
+from common_utils.test_utils import format_name
 from utils.pipeline_utils import *
 
 MAX_REP_COUNT = 120
@@ -37,7 +38,7 @@ class TestNodeReassign(object):
     def setup_class(cls):
         logging.basicConfig(filename=get_log_filename(), level=logging.INFO,
                             format='%(levelname)s %(asctime)s %(module)s:%(message)s')
-        pipeline_name = "node_reassign_test"
+        pipeline_name = format_name("node_reassign_test")
         cls.pipeline_id = PipelineManager.create(pipeline_name)
         logging.info("Pipeline {} with ID {} created.".format(pipeline_name, cls.pipeline_id))
 

--- a/e2e/cli/autoscaling/test_on_demand_pipe_run.py
+++ b/e2e/cli/autoscaling/test_on_demand_pipe_run.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from common_utils.entity_managers import PipelineManager
+from common_utils.test_utils import format_name
 from utils.pipeline_utils import *
 
 MAX_REPETITIONS = 100
@@ -22,7 +23,7 @@ MAX_REPETITIONS = 100
                     reason="Spot instances (low priority virtual machines) are not supported for launching AZURE")
 class TestOnDemandPipelineRun(object):
     pipeline_id = None
-    pipeline_name = 'on_demand_integration_pipeline_test'
+    pipeline_name = format_name('on_demand_integration_pipeline_test')
     run_id = None
     node_name = None
     state = FailureIndicator()

--- a/e2e/cli/autoscaling/test_pipline_run_sync.py
+++ b/e2e/cli/autoscaling/test_pipline_run_sync.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ import logging
 import pytest
 
 from common_utils.entity_managers import PipelineManager
+from common_utils.test_utils import format_name
 from utils.pipeline_utils import *
 
 
@@ -31,7 +32,7 @@ class TestPipelineRunSync(object):
     def setup_class(cls):
         logging.basicConfig(filename=get_log_filename(), level=logging.INFO,
                             format='%(levelname)s %(asctime)s %(module)s:%(message)s')
-        cls.pipeline_name = "test_pipeline_run_sync"
+        cls.pipeline_name = format_name("test_pipeline_run_sync")
         cls.pipeline_id = PipelineManager.create(cls.pipeline_name)
         logging.info("Pipeline {} with ID {} created.".format(cls.pipeline_name, cls.pipeline_id))
 

--- a/e2e/cli/autoscaling/test_spot_pipe_run.py
+++ b/e2e/cli/autoscaling/test_spot_pipe_run.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from common_utils.entity_managers import PipelineManager
+from common_utils.test_utils import format_name
 from utils.pipeline_utils import *
 
 MAX_REPETITIONS = 100
@@ -22,7 +23,7 @@ MAX_REPETITIONS = 100
                     reason="Spot instances (low priority virtual machines) are not supported for launching AZURE")
 class TestSpotPipelineRun(object):
     pipeline_id = None
-    pipeline_name = 'spot_integration_pipeline_test'
+    pipeline_name = format_name('spot_integration_pipeline_test')
     run_id = None
     node_name = None
     state = FailureIndicator()

--- a/e2e/cli/autoscaling/test_start_stop_pipe.py
+++ b/e2e/cli/autoscaling/test_start_stop_pipe.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ import logging
 import pytest
 
 from common_utils.entity_managers import PipelineManager
+from common_utils.test_utils import format_name
 from utils.pipeline_utils import *
 
 MAX_REP_COUNT = 120
@@ -34,7 +35,7 @@ class TestStartStopPipe(object):
     def setup_class(cls):
         logging.basicConfig(filename=get_log_filename(), level=logging.INFO,
                             format='%(levelname)s %(asctime)s %(module)s:%(message)s')
-        pipeline_name = "start_stop_pipe_test"
+        pipeline_name = format_name("start_stop_pipe_test")
         cls.pipeline_id = PipelineManager.create(pipeline_name)
         logging.info("Pipeline {} with ID {} created.".format(pipeline_name, cls.pipeline_id))
 

--- a/e2e/cli/autoscaling/test_stop_pipe_before_labeling.py
+++ b/e2e/cli/autoscaling/test_stop_pipe_before_labeling.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ import logging
 import pytest
 
 from common_utils.entity_managers import PipelineManager
+from common_utils.test_utils import format_name
 from utils.pipeline_utils import *
 
 MAX_REP_COUNT = 300
@@ -37,7 +38,7 @@ class TestStopPipelineBeforeLabeling(object):
     def setup_class(cls):
         logging.basicConfig(filename=get_log_filename(), level=logging.INFO,
                             format='%(levelname)s %(asctime)s %(module)s:%(message)s')
-        pipeline_name = "stop_pipe_before_labeling_test"
+        pipeline_name = format_name("stop_pipe_before_labeling_test")
         cls.pipeline_name = pipeline_name
         cls.pipeline_id = PipelineManager.create(pipeline_name)
         logging.info("Pipeline {} with ID {} created.".format(pipeline_name, cls.pipeline_id))

--- a/e2e/cli/autoscaling/test_terminate_instance_before_registration.py
+++ b/e2e/cli/autoscaling/test_terminate_instance_before_registration.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ import logging
 import pytest
 
 from common_utils.entity_managers import PipelineManager
+from common_utils.test_utils import format_name
 from utils.pipeline_utils import *
 
 MAX_REP_COUNT = 150
@@ -33,7 +34,7 @@ class TestTerminateInstanceBeforeKubeRegistration(object):
     def setup_class(cls):
         logging.basicConfig(filename=get_log_filename(), level=logging.INFO,
                             format='%(levelname)s %(asctime)s %(module)s:%(message)s')
-        pipeline_name = "test_terminate_instance_before_registration"
+        pipeline_name = format_name("test_terminate_instance_before_registration")
         cls.pipeline_id = PipelineManager.create(pipeline_name)
         logging.info("Pipeline {} with ID {} created.".format(pipeline_name, cls.pipeline_id))
 

--- a/e2e/cli/autoscaling/test_terminate_instance_during_pipe_work.py
+++ b/e2e/cli/autoscaling/test_terminate_instance_during_pipe_work.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ import logging
 import pytest
 
 from common_utils.entity_managers import PipelineManager
+from common_utils.test_utils import format_name
 from utils.pipeline_utils import *
 
 MAX_REP_COUNT = 300
@@ -34,7 +35,7 @@ class TestTerminateInstanceDuringPipelineWork(object):
     def setup_class(cls):
         logging.basicConfig(filename=get_log_filename(), level=logging.INFO,
                             format='%(levelname)s %(asctime)s %(module)s:%(message)s')
-        pipeline_name = "terminate_instance_during_pipe_work_test"
+        pipeline_name = format_name("terminate_instance_during_pipe_work_test")
         cls.pipeline_id = PipelineManager.create(pipeline_name)
         logging.info("Pipeline {} with ID {} created.".format(pipeline_name, cls.pipeline_id))
 

--- a/e2e/cli/autoscaling/test_terminate_node_during_pipe_work.py
+++ b/e2e/cli/autoscaling/test_terminate_node_during_pipe_work.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ import logging
 import pytest
 
 from common_utils.entity_managers import PipelineManager
+from common_utils.test_utils import format_name
 from utils.pipeline_utils import *
 
 MAX_REP_COUNT = 100
@@ -34,7 +35,7 @@ class TestTerminateNodeDuringPipelineWork(object):
     def setup_class(cls):
         logging.basicConfig(filename=get_log_filename(), level=logging.INFO,
                             format='%(levelname)s %(asctime)s %(module)s:%(message)s')
-        pipeline_name = "terminate_node_during_pipe_works_test"
+        pipeline_name = format_name("terminate_node_during_pipe_works_test")
         cls.pipeline_id = PipelineManager.create(pipeline_name)
         logging.info("Pipeline {} with ID {} created.".format(pipeline_name, cls.pipeline_id))
 

--- a/e2e/cli/autoscaling/test_two_pipes_simultaneously.py
+++ b/e2e/cli/autoscaling/test_two_pipes_simultaneously.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ import logging
 import pytest
 
 from common_utils.entity_managers import PipelineManager
+from common_utils.test_utils import format_name
 from utils.pipeline_utils import *
 
 MAX_REP_COUNT = 120
@@ -36,7 +37,7 @@ class TestTwoPipesRunSimultaneously(object):
     def setup_class(cls):
         logging.basicConfig(filename=get_log_filename(), level=logging.INFO,
                             format='%(levelname)s %(asctime)s %(module)s:%(message)s')
-        pipeline_name = "two_pipes_simultaneously_test"
+        pipeline_name = format_name("two_pipes_simultaneously_test")
         cls.pipeline_id = PipelineManager.create(pipeline_name)
         logging.info("Pipeline {} with ID {} created.".format(pipeline_name, cls.pipeline_id))
 

--- a/e2e/cli/autoscaling/test_unused_instance_termination.py
+++ b/e2e/cli/autoscaling/test_unused_instance_termination.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ import logging
 import pytest
 
 from common_utils.entity_managers import PipelineManager
+from common_utils.test_utils import format_name
 from utils.pipeline_utils import *
 
 MAX_REP_COUNT = 150
@@ -34,7 +35,7 @@ class TestUnusedInstanceTermination(object):
     def setup_class(cls):
         logging.basicConfig(filename=get_log_filename(), level=logging.INFO,
                             format='%(levelname)s %(asctime)s %(module)s:%(message)s')
-        pipeline_name = "unused_instance_termination_test"
+        pipeline_name = format_name("unused_instance_termination_test")
         pipeline_id = PipelineManager.create(pipeline_name)
         logging.info("Pipeline {} with ID {} created.".format(pipeline_name, pipeline_id))
         cls.pipeline_id = pipeline_id

--- a/e2e/cli/buckets/cp/test_cp_role_model.py
+++ b/e2e/cli/buckets/cp/test_cp_role_model.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from common_utils.pipe_cli import *
+from common_utils.test_utils import format_name
 from ..utils.assertions_utils import *
 from ..utils.file_utils import *
 from ..utils.utilities_for_test import *
@@ -20,8 +21,9 @@ from ..utils.utilities_for_test import *
 
 class TestCpWithRoleModel(object):
     epam_test_case = "EPMCMBIBPC-600"
-    bucket_name = "epmcmbibpc-it-cp-roles{}".format(get_test_prefix())
-    other_bucket_name = "{}-other".format(bucket_name)
+    raw_bucket_name = "epmcmbibpc-it-cp-roles{}".format(get_test_prefix())
+    bucket_name = format_name(raw_bucket_name)
+    other_bucket_name = format_name("{}-other".format(raw_bucket_name))
     token = os.environ['USER_TOKEN']
     user = os.environ['TEST_USER']
     output_folder = epam_test_case + "-" + TestFiles.TEST_FOLDER_FOR_OUTPUT

--- a/e2e/cli/buckets/cp/test_cp_with_files.py
+++ b/e2e/cli/buckets/cp/test_cp_with_files.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from common_utils.pipe_cli import pipe_storage_rm
+from common_utils.test_utils import format_name
 
 from ..utils.assertions_utils import *
 from ..utils.cloud.utilities import *
@@ -23,9 +24,10 @@ from ..utils.utilities_for_test import *
 
 class TestCopyWithFiles(object):
 
-    bucket_name = "epmcmbibpc-it-cp-files{}".format(get_test_prefix())
-    other_bucket_name = "{}-other".format(bucket_name)
-    empty_bucket_name = "{}-empty".format(bucket_name)
+    raw_bucket_name = "epmcmbibpc-it-cp-files{}".format(get_test_prefix())
+    bucket_name = format_name(raw_bucket_name)
+    other_bucket_name = format_name("{}-other".format(raw_bucket_name))
+    empty_bucket_name = format_name("{}-empty".format(raw_bucket_name))
     current_directory = os.getcwd()
     home_dir = "test_cp_home_dir-594%s/" % get_test_prefix()
     checkout_dir = "checkout/"

--- a/e2e/cli/buckets/cp/test_cp_with_folders.py
+++ b/e2e/cli/buckets/cp/test_cp_with_folders.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from common_utils.test_utils import format_name
 from ..utils.assertions_utils import *
 from ..utils.file_utils import *
 from ..utils.utilities_for_test import *
@@ -19,8 +20,9 @@ from ..utils.utilities_for_test import *
 
 class TestCopyWithFolders(object):
 
-    bucket_name = "epmcmbibpc-it-cp-folders{}".format(get_test_prefix())
-    other_bucket_name = "{}-other".format(bucket_name)
+    raw_bucket_name = "epmcmbibpc-it-cp-folders{}".format(get_test_prefix())
+    bucket_name = format_name(raw_bucket_name)
+    other_bucket_name = format_name("{}-other".format(raw_bucket_name))
     current_directory = os.getcwd()
     home_dir = "test_cp_home_dir-597%s/" % get_test_prefix()
     checkout_dir = "checkout/"

--- a/e2e/cli/buckets/ls/test_list_folder.py
+++ b/e2e/cli/buckets/ls/test_list_folder.py
@@ -15,6 +15,7 @@
 from buckets.utils.listing import *
 from buckets.utils.assertions_utils import *
 from buckets.utils.utilities_for_test import *
+from common_utils.test_utils import format_name
 
 
 class TestLsFolder(object):
@@ -25,7 +26,7 @@ class TestLsFolder(object):
     epam_test_case_ls_wrong_scheme = "EPMCMBIBPC-654"
     suffix = "EPMCMBIBPC-633-634"
     resources_root = "resources-{}/".format(suffix).lower()
-    bucket_name = "epmcmbibpc-it-{}{}".format(suffix, get_test_prefix()).lower()
+    bucket_name = format_name("epmcmbibpc-it-{}{}".format(suffix, get_test_prefix()).lower())
 
     @classmethod
     def setup_class(cls):

--- a/e2e/cli/buckets/ls/test_list_role_model.py
+++ b/e2e/cli/buckets/ls/test_list_role_model.py
@@ -15,12 +15,13 @@
 from buckets.utils.listing import *
 from buckets.utils.assertions_utils import *
 from buckets.utils.utilities_for_test import *
+from common_utils.test_utils import format_name
 
 
 class TestLsWithRoleModel(object):
     epam_test_case = "EPMCMBIBPC-629"
     resources_root = "resources-{}/".format(epam_test_case).lower()
-    bucket_name = "epmcmbibpc-it-{}{}".format(epam_test_case, get_test_prefix()).lower()
+    bucket_name = format_name("epmcmbibpc-it-{}{}".format(epam_test_case, get_test_prefix()).lower())
     token = os.environ['USER_TOKEN']
     user = os.environ['TEST_USER']
 

--- a/e2e/cli/buckets/ls/test_list_single_file.py
+++ b/e2e/cli/buckets/ls/test_list_single_file.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ from buckets.utils.cloud.utilities import get_modification_date
 from buckets.utils.listing import *
 from buckets.utils.file_utils import *
 from buckets.utils.utilities_for_test import *
+from common_utils.test_utils import format_name
+
 
 # TODO: disable test until the GCP support is merged
 @pytest.mark.skip()
@@ -25,7 +27,7 @@ class TestLsSingleFile(object):
     epam_test_case = "EPMCMBIBPC-617"
     resources_root = "resources-{}/".format(epam_test_case)
     relative_path = os.path.join(resources_root, "test_file.txt")
-    bucket_name = "epmcmbibpc-it-{}{}".format(epam_test_case, get_test_prefix()).lower()
+    bucket_name = format_name("epmcmbibpc-it-{}{}".format(epam_test_case, get_test_prefix()).lower())
     another_bucket_alias = "{}-alias".format(bucket_name)
     another_bucket_path = "{}-path".format(bucket_name)
 

--- a/e2e/cli/buckets/mkdir_mvtodir/test_mkdir_mvtodir.py
+++ b/e2e/cli/buckets/mkdir_mvtodir/test_mkdir_mvtodir.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ import pytest
 from buckets.utils.listing import *
 from common_utils.entity_managers import EntityManager
 from common_utils.pipe_cli import *
+from common_utils.test_utils import format_name
 
 ERROR_MESSAGE = "An error occurred in case "
 
@@ -25,7 +26,7 @@ class TestMkdirMvtodir(object):
     test_folder = "mkdir-test-folder"
     test_folder_1 = "test-folder1"
     test_folder_2 = "test-folder2"
-    bucket = 'epmcmbibpc-mkdir-mvtodir-it{}'.format(get_test_prefix())
+    bucket = format_name('epmcmbibpc-mkdir-mvtodir-it{}'.format(get_test_prefix()))
     path_to_bucket = 'cp://{}'.format(bucket)
     negative_test_case = "epmcmbibpc-1022"
 

--- a/e2e/cli/buckets/mv/test_mv_with_files.py
+++ b/e2e/cli/buckets/mv/test_mv_with_files.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from common_utils.pipe_cli import *
+from common_utils.test_utils import format_name
 from ..utils.assertions_utils import *
 from ..utils.cloud.utilities import *
 from ..utils.file_utils import *
@@ -21,9 +22,10 @@ from ..utils.utilities_for_test import *
 
 class TestMoveWithFiles(object):
 
-    bucket_name = "epmcmbibpc-it-mv-files{}".format(get_test_prefix())
-    other_bucket_name = "{}-other".format(bucket_name)
-    empty_bucket_name = "{}-empty".format(bucket_name)
+    raw_bucket_name = "epmcmbibpc-it-mv-files{}".format(get_test_prefix())
+    bucket_name = format_name(raw_bucket_name)
+    other_bucket_name = format_name("{}-other".format(raw_bucket_name))
+    empty_bucket_name = format_name("{}-empty".format(raw_bucket_name))
     current_directory = os.getcwd()
     home_dir = "test_mv_home_dir-670%s/" % get_test_prefix()
     test_prefix = "mv-files-"

--- a/e2e/cli/buckets/mv/test_mv_with_folders.py
+++ b/e2e/cli/buckets/mv/test_mv_with_folders.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from common_utils.pipe_cli import *
+from common_utils.test_utils import format_name
 from ..utils.assertions_utils import *
 from ..utils.file_utils import *
 from ..utils.utilities_for_test import *
@@ -20,8 +21,9 @@ from ..utils.utilities_for_test import *
 
 class TestMoveWithFolders(object):
 
-    bucket_name = "epmcmbibpc-it-mv-folders{}".format(get_test_prefix())
-    other_bucket_name = "{}-other".format(bucket_name)
+    raw_bucket_name = "epmcmbibpc-it-mv-folders{}".format(get_test_prefix())
+    bucket_name = format_name(raw_bucket_name)
+    other_bucket_name = format_name("{}-other".format(raw_bucket_name))
     current_directory = os.getcwd()
     home_dir = "test_cp_home_dir-681%s/" % get_test_prefix()
     checkout_dir = "mv-folders-checkout/"

--- a/e2e/cli/buckets/mv/test_mv_with_role_model.py
+++ b/e2e/cli/buckets/mv/test_mv_with_role_model.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from common_utils.pipe_cli import *
+from common_utils.test_utils import format_name
 from ..utils.assertions_utils import *
 from ..utils.file_utils import *
 from ..utils.utilities_for_test import *
@@ -20,8 +21,9 @@ from ..utils.utilities_for_test import *
 
 class TestMvWithRoleModel(object):
     epam_test_case = "EPMCMBIBPC-666"
-    bucket_name = "epmcmbibpc-it-mv-roles{}".format(get_test_prefix())
-    other_bucket_name = "{}-other".format(bucket_name)
+    raw_bucket_name = "epmcmbibpc-it-mv-roles{}".format(get_test_prefix())
+    bucket_name = format_name(raw_bucket_name)
+    other_bucket_name = format_name("{}-other".format(bucket_name))
     token = os.environ['USER_TOKEN']
     user = os.environ['TEST_USER']
     output_folder = epam_test_case + "-" + TestFiles.TEST_FOLDER_FOR_OUTPUT

--- a/e2e/cli/buckets/policy/test_policy.py
+++ b/e2e/cli/buckets/policy/test_policy.py
@@ -23,12 +23,14 @@ from common_utils.entity_managers import UtilsManager
 from common_utils.pipe_cli import pipe_storage_policy
 from time import sleep
 
+from common_utils.test_utils import format_name
+
 ERROR_MESSAGE = "An error occurred in case "
 
 
 @pytest.mark.skipif(os.environ['CP_PROVIDER'] == AzureClient.name, reason="Storage policy is not supported for AZURE provider")
 class TestPolicy(object):
-    bucket_name = "epmcmbibpc-it-policy{}".format(get_test_prefix())
+    bucket_name = format_name("epmcmbibpc-it-policy{}".format(get_test_prefix()))
 
     @classmethod
     def setup_class(cls):

--- a/e2e/cli/buckets/rm/test_remove_files_folders.py
+++ b/e2e/cli/buckets/rm/test_remove_files_folders.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from common_utils.pipe_cli import *
+from common_utils.test_utils import format_name
 from ..utils.listing import get_pipe_listing, compare_listing, f
 from ..utils.assertions_utils import *
 from ..utils.utilities_for_test import *
@@ -29,8 +30,8 @@ class TestRmFileFolder(object):
 
     suffix = "EPMCMBIBPC-611-612-648-644-645"
     resources_root = "resources-{}/".format(suffix).lower()
-    bucket_name = "epmcmbibpc-it-rm-{}{}".format(suffix, get_test_prefix()).lower()
-    empty_bucket_name = "cmbi-pipe-integration-tests-rm-empty"
+    bucket_name = format_name("epmcmbibpc-it-rm-{}{}".format(suffix, get_test_prefix()).lower())
+    empty_bucket_name = format_name("cmbi-pipe-integration-tests-rm-empty")
     file_in_root = "file_in_root.txt"
     root_file_path = os.path.abspath(os.path.join(resources_root, file_in_root))
 

--- a/e2e/cli/buckets/rm/test_remove_with_patterns.py
+++ b/e2e/cli/buckets/rm/test_remove_with_patterns.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from common_utils.pipe_cli import *
+from common_utils.test_utils import format_name
 from ..utils.assertions_utils import *
 from ..utils.utilities_for_test import *
 
@@ -20,7 +21,7 @@ from ..utils.utilities_for_test import *
 class TestRmWithPatterns(object):
     epam_test_case = "EPMCMBIBPC-615"
     resources_root = "resources-{}/".format(epam_test_case).lower()
-    bucket_name = "epmcmbibpc-it-rm-{}{}".format(epam_test_case, get_test_prefix()).lower()
+    bucket_name = format_name("epmcmbibpc-it-rm-{}{}".format(epam_test_case, get_test_prefix()).lower())
     json_file = "test.json"
     text_file = "test.txt"
     json_file_in_folder = "folder.json"

--- a/e2e/cli/buckets/rm/test_remove_with_role_model.py
+++ b/e2e/cli/buckets/rm/test_remove_with_role_model.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from common_utils.pipe_cli import *
+from common_utils.test_utils import format_name
 from ..utils.assertions_utils import *
 from ..utils.file_utils import *
 from ..utils.utilities_for_test import *
@@ -21,7 +22,7 @@ from ..utils.utilities_for_test import *
 class TestRmWithRoleModel(object):
     epam_test_case = "EPMCMBIBPC-609"
     resources_root = "resources-{}/".format(epam_test_case).lower()
-    bucket_name = "epmcmbibpc-it-rm-{}{}".format(epam_test_case, get_test_prefix()).lower()
+    bucket_name = format_name("epmcmbibpc-it-rm-{}{}".format(epam_test_case, get_test_prefix()).lower())
     token = os.environ['USER_TOKEN']
     user = os.environ['TEST_USER']
     test_file = "test_file.txt"

--- a/e2e/cli/buckets/tag/test_tag.py
+++ b/e2e/cli/buckets/tag/test_tag.py
@@ -16,6 +16,7 @@ from buckets.utils.tag_assertion_utils import *
 from buckets.utils.assertions_utils import *
 from buckets.utils.listing import *
 from common_utils.entity_managers import EntityManager
+from common_utils.test_utils import format_name
 
 ERROR_MESSAGE = "An error occurred in case "
 
@@ -25,7 +26,7 @@ class TestTagging(object):
     test_file2 = "test-tag2.txt"
     test_file_in_folder = "tags/" + test_file
     test_file2_in_folder = "tags/" + test_file2
-    bucket = 'epmcmbibpc-storage-tagging-{}'.format(get_test_prefix()).lower()
+    bucket = format_name('epmcmbibpc-storage-tagging-{}'.format(get_test_prefix()).lower())
     path_to_bucket = 'cp://{}'.format(bucket)
     tag1 = ("key1", "value1")
     tag2 = ("key2", "value2")

--- a/e2e/cli/buckets/tag/test_tag_role_model.py
+++ b/e2e/cli/buckets/tag/test_tag_role_model.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,13 +17,14 @@ from buckets.utils.tag_assertion_utils import *
 from buckets.utils.assertions_utils import *
 from buckets.utils.file_utils import *
 from buckets.utils.listing import *
+from common_utils.test_utils import format_name
 
 ERROR_MESSAGE = "An error occurred in case "
 
 
 class TestS3TaggingRolModel(object):
     test_file = "s3-tagging-role.txt"
-    bucket = 'epmcmbibpc-s3-tagging-role-{}'.format(get_test_prefix()).lower()
+    bucket = format_name('epmcmbibpc-s3-tagging-role-{}'.format(get_test_prefix()).lower())
     path_to_bucket = 'cp://{}'.format(bucket)
     tag1 = ("key1", "value1")
     user_token = os.environ['USER_TOKEN']

--- a/e2e/cli/buckets/versioning/test_data_storage_versioning.py
+++ b/e2e/cli/buckets/versioning/test_data_storage_versioning.py
@@ -19,6 +19,7 @@ from buckets.utils.cloud.utilities import object_exists, get_versions
 from buckets.utils.listing import *
 from buckets.utils.file_utils import *
 from common_utils.pipe_cli import *
+from common_utils.test_utils import format_name
 
 ERROR_MESSAGE = "An error occurred in case "
 
@@ -33,7 +34,7 @@ class TestDataStorageVersioning(object):
     test_folder_1 = "test_folder1"
     test_folder_2 = "test_folder2"
     test_folder_3 = "test_folder3"
-    bucket = 'epmcmbibpc-versioning-it{}'.format(get_test_prefix())
+    bucket = format_name('epmcmbibpc-versioning-it{}'.format(get_test_prefix()))
     path_to_bucket = 'cp://{}'.format(bucket)
     token = os.environ['USER_TOKEN']
     user = os.environ['TEST_USER']

--- a/e2e/cli/common_utils/test_utils.py
+++ b/e2e/cli/common_utils/test_utils.py
@@ -1,0 +1,22 @@
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import datetime as dt
+import uuid
+
+
+def format_name(name):
+    random_suffix = str(uuid.uuid4()).replace("-", "")[:5]
+    return "%s-%s-%s" % (name, dt.datetime.now().strftime("%Y-%m-%d"), random_suffix)

--- a/e2e/cli/requirements.txt
+++ b/e2e/cli/requirements.txt
@@ -6,7 +6,6 @@ pytest-cov==2.5.1
 pytest-metadata==1.8.0
 google-api-python-client==1.7.9
 azure-storage-blob==1.5.0
-google-cloud-storage==1.14.0
 tzlocal==1.5.1
 azure-mgmt-compute==5.0.0
 azure-mgmt-network==3.0.0

--- a/e2e/cli/run_tests.sh
+++ b/e2e/cli/run_tests.sh
@@ -25,6 +25,7 @@ git checkout ${GIT_BRANCH}
 
 pip install -r ${CP_SRC}/pipe-cli/requirements.txt
 pip install -r ${CP_SRC}/e2e/cli/requirements.txt
+pip install -I requests==2.22.0
 
 if [[ -z $PIPE_CLI_DOWNLOAD_URL ]]; then
     cd pipe-cli

--- a/e2e/cli/tag/test_tag.py
+++ b/e2e/cli/tag/test_tag.py
@@ -17,6 +17,7 @@ import pytest
 from assertion_utils import *
 from common_utils.entity_managers import EntityManager
 from common_utils.pipe_cli import *
+from common_utils.test_utils import format_name
 
 ERROR_MESSAGE = "An error occurred in case "
 PIPELINE = 'pipeline'
@@ -46,7 +47,7 @@ class TestMetadataOperations(object):
     @pytest.mark.parametrize("test_case,entity_class,by_id", test_case_for_crud)
     def test_crud_metadata(self, test_case, entity_class, by_id):
         manager = EntityManager.get_manager(entity_class)
-        object_name = "".join([test_case, get_test_prefix()])
+        object_name = format_name("".join([test_case, get_test_prefix()]))
         object_id = manager.create(object_name)
         entity_identifier = str(object_id) if by_id else object_name
         try:
@@ -76,7 +77,7 @@ class TestMetadataOperations(object):
     @pytest.mark.parametrize("test_case,entity_class,by_id", test_case_for_permissions)
     def test_metadata_permissions(self, test_case, entity_class, by_id):
         manager = EntityManager.get_manager(entity_class)
-        object_name = "".join([get_test_prefix(), "-", test_case])
+        object_name = format_name("".join([get_test_prefix(), "-", test_case]))
         object_id = manager.create(object_name)
         entity_identifier = str(object_id) if by_id else object_name
         try:
@@ -141,7 +142,7 @@ class TestMetadataOperations(object):
     @pytest.mark.parametrize("test_case,entity_class,by_id", test_case_for_non_existing_class)
     def test_metadata_non_existing_class(self, test_case, entity_class, by_id):
         manager = EntityManager.get_manager(entity_class)
-        object_name = "".join([test_case, get_test_prefix()])
+        object_name = format_name("".join([test_case, get_test_prefix()]))
         object_id = manager.create(object_name)
         entity_identifier = str(object_id) if by_id else object_name
         non_existing = 'non-existing'
@@ -184,7 +185,7 @@ class TestMetadataOperations(object):
     @pytest.mark.parametrize("test_case,entity_class,by_id", test_case_for_set_incorrect_key_value_pair)
     def test_metadata_set_incorrect_key_value_pair(self, test_case, entity_class, by_id):
         manager = EntityManager.get_manager(entity_class)
-        object_name = "".join([test_case, get_test_prefix()])
+        object_name = format_name("".join([test_case, get_test_prefix()]))
         object_id = manager.create(object_name)
         entity_identifier = str(object_id) if by_id else object_name
         try:
@@ -215,7 +216,7 @@ class TestMetadataOperations(object):
     @pytest.mark.parametrize("test_case,entity_class,by_id", test_case_for_set_incorrect_key_value_pair)
     def test_delete_keys_from_empty_metadata(self, test_case, entity_class, by_id):
         manager = EntityManager.get_manager(entity_class)
-        object_name = "".join([test_case, get_test_prefix()])
+        object_name = format_name("".join([test_case, get_test_prefix()]))
         object_id = manager.create(object_name)
         entity_identifier = str(object_id) if by_id else object_name
         try:
@@ -253,7 +254,7 @@ class TestMetadataOperations(object):
     @pytest.mark.parametrize("test_case,entity_class,by_id", test_case_for_set_incorrect_key_value_pair)
     def test_delete_non_existing_key(self, test_case, entity_class, by_id):
         manager = EntityManager.get_manager(entity_class)
-        object_name = "".join([test_case, get_test_prefix()])
+        object_name = format_name("".join([test_case, get_test_prefix()]))
         object_id = manager.create(object_name)
         entity_identifier = str(object_id) if by_id else object_name
         non_existing = 'non-existing'


### PR DESCRIPTION
### Background
CLI tests generate a constant names for entities. Also, according to test strategy, the tests entity shall not be deleted if test was failed. This way, it would be great to make entity names more flexible.

The current PR provides fix for test entities naming. A new names have the following format:
- `<test name>-<current date>-<random value>`

For example,`test_pipeline` -> `test_pipeline-2020-12-29-asdfg`