### PR TITLE
Issue #1694 run-policy-manager improvements

### DIFF
--- a/deploy/contents/k8s/cp-run-policy-manager/cp-run-policy-manager-dpl.yaml
+++ b/deploy/contents/k8s/cp-run-policy-manager/cp-run-policy-manager-dpl.yaml
@@ -13,6 +13,9 @@ spec:
     spec:
       nodeSelector:
         cloud-pipeline/cp-run-policy-manager: "true"
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       containers:
         - name: cp-run-policy-manager
           image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:run-policy-manager-$CP_VERSION

--- a/deploy/docker/cp-run-policy-manager/init
+++ b/deploy/docker/cp-run-policy-manager/init
@@ -34,3 +34,5 @@ function sigterm_handler {
 }
 
 trap 'kill $! ; sigterm_handler' SIGTERM
+tail -F $RUN_POLICY_MANAGER_LOG_FILE &
+wait "$!"


### PR DESCRIPTION
This PR is related to issue #1694

1. Add `tolerations` section to k8s deployment spec to assign `run-policy-manager` only to the master node
2. Add `wait` command to init script to prevent the pod from instant finishing
3. Tail run-policy-manager activity to expose it to pod's log 