### PR TITLE
Issue #1708: `pipe storage ls` works incorrect for not admin/owner users

### DIFF
--- a/pipe-cli/src/api/data_storage.py
+++ b/pipe-cli/src/api/data_storage.py
@@ -243,6 +243,7 @@ class DataStorage(API):
             operation = {'id': source_bucket, 'list': True}
             if versioning:
                 operation['listVersion'] = True
+                operation['readVersion'] = True
             operations.append(operation)
         if source_bucket and command == 'cp':
             operation = {'id': source_bucket, 'read': True, 'write': False}


### PR DESCRIPTION
The current PR provides fix for issue #1708 