### PR TITLE
AWS: Data storage versions listing behavior is different

### DIFF
--- a/pipe-cli/src/utilities/storage/s3.py
+++ b/pipe-cli/src/utilities/storage/s3.py
@@ -283,34 +283,23 @@ class RestoreManager(StorageItemManager, AbstractRestoreManager):
         client = self._get_client()
         bucket = self.bucket.bucket.path
 
-        if not recursive:
-            if version:
-                self.restore_file_version(version, bucket, client)
-                return
-            item = self.load_delete_marker(bucket, self.bucket.path, client)
-            if not item:
-                raise RuntimeError('Failed to receive deleted marker')
-            self.restore_last_file_version(item, client, bucket)
-            return
-        item = self.load_delete_marker(bucket, self.bucket.path, client, quite=True)
-        if item:
-            self.restore_last_file_version(item, client, bucket)
+        file_items = self._list_file_items()
+        if not recursive or self._has_deleted_file(file_items):
+            if not version:
+                version = self._find_last_version(self.bucket.path, file_items)
+            self.restore_file_version(version, bucket, client, file_items)
             return
         self.restore_folder(bucket, client, exclude, include, recursive)
 
-    @staticmethod
-    def restore_last_file_version(item, client, bucket):
-        delete_us = dict(Objects=[])
-        delete_us['Objects'].append(dict(Key=item['Key'], VersionId=item['VersionId']))
-        client.delete_objects(Bucket=bucket, Delete=delete_us)
-
-    def restore_file_version(self, version, bucket, client):
-        current_item = self.load_item(bucket, client)
+    def restore_file_version(self, version, bucket, client, file_items):
         relative_path = self.bucket.path
-        self._validate_version(current_item, version, relative_path)
+        self._validate_version(bucket, client, version, file_items)
         try:
             client.copy_object(Bucket=bucket, Key=relative_path,
                                CopySource=dict(Bucket=bucket, Key=relative_path, VersionId=version))
+            delete_us = dict(Objects=[])
+            delete_us['Objects'].append(dict(Key=relative_path, VersionId=version))
+            client.delete_objects(Bucket=bucket, Delete=delete_us)
         except ClientError as e:
             error_message = str(e)
             if 'delete marker' in error_message:
@@ -333,6 +322,12 @@ class RestoreManager(StorageItemManager, AbstractRestoreManager):
             raise RuntimeError('Path "{}" doesn\'t exist'.format(self.bucket.path))
         return item
 
+    def _list_file_items(self):
+        relative_path = self.bucket.path
+        all_items = self.listing_manager.list_items(relative_path, show_all=True)
+        item_name = relative_path.split(S3BucketOperations.S3_PATH_SEPARATOR)[-1]
+        return [item for item in all_items if item.type == 'File' and item.name == item_name]
+
     def load_delete_marker(self, bucket, path, client, quite=False):
         operation_parameters = {
             'Bucket': bucket,
@@ -350,6 +345,27 @@ class RestoreManager(StorageItemManager, AbstractRestoreManager):
                     return item
         if not quite:
             raise RuntimeError('Latest file version is not deleted. Please specify "--version" parameter.')
+
+    @staticmethod
+    def _find_last_version(relative_path, file_items):
+        if not file_items or not len(file_items):
+            raise RuntimeError('Requested file "%s" doesn\'t exist.' % relative_path)
+        item = file_items[0]
+        if not item:
+            raise RuntimeError('Failed to receive deleted marker')
+        if not item.delete_marker:
+            raise RuntimeError('Latest file version is not deleted. Please specify "--version" parameter.')
+        versions = [item_version for item_version in item.versions if not item_version.delete_marker]
+        if not versions or not len(versions):
+            raise RuntimeError('Latest file version is not deleted. Please specify "--version" parameter.')
+        version = versions[0].version
+        if not version:
+            raise RuntimeError('Failed to find last version')
+        return version
+
+    @staticmethod
+    def _has_deleted_file(file_items):
+        return file_items and len(file_items) and file_items[0] and file_items[0].delete_marker
 
     def restore_folder(self, bucket, client, exclude, include, recursive):
         delimiter = S3BucketOperations.S3_PATH_SEPARATOR
@@ -377,12 +393,10 @@ class RestoreManager(StorageItemManager, AbstractRestoreManager):
         if len(restore_us['Objects']):
             client.delete_objects(Bucket=bucket, Delete=restore_us)
 
-    def _validate_version(self, current_item, version, relative_path):
+    def _validate_version(self, bucket, client, version, file_items):
+        current_item = self.load_item(bucket, client)
         if current_item['VersionId'] == version:
             raise RuntimeError('Version "{}" is already the latest version'.format(version))
-        all_items = self.listing_manager.list_items(relative_path, show_all=True)
-        item_name = relative_path.split(S3BucketOperations.S3_PATH_SEPARATOR)[-1]
-        file_items = [item for item in all_items if item.type == 'File' and item.name == item_name]
         if not file_items:
             raise RuntimeError(self.VERSION_NOT_EXISTS_ERROR % version)
         item = file_items[0]


### PR DESCRIPTION
The current PR provides fix for issue #424. 

The issue is that restore operation behaves differently depending on whether `--version (-v)` specified or not:
- if `--version (-v)` specified the `aws` client copies certain version (this behavior contains a bug too - the old version shall be removed)
- if `--version (-v)` not specified the `aws` client removes delete marker

This way, the current PR contains the following changes:
- delete old version for restored objects
- find the last object version and restore this certain version 