### PR TITLE
Add proper error messages to all cluster scripts

### DIFF
--- a/workflows/pipe-common/scripts/cluster_setup.py
+++ b/workflows/pipe-common/scripts/cluster_setup.py
@@ -214,8 +214,8 @@ def main():
         BuildHostfile().run(workers, hostfile, run_id)
     except Exception:
         ShutDownCluster().run(workers, StatusEntry(TaskStatus.FAILURE))
-        raise RuntimeError('Failed to setup cluster')
-    
-    
+        raise
+
+
 if __name__ == '__main__':
     main()

--- a/workflows/pipe-common/scripts/cluster_setup.py
+++ b/workflows/pipe-common/scripts/cluster_setup.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pipeline import Logger, TaskStatus, PipelineAPI, StatusEntry
 import argparse
 import os
 import subprocess
 import time
+import traceback
+
+from pipeline import Logger, TaskStatus, PipelineAPI, StatusEntry
 
 try:
     from pykube.config import KubeConfig
@@ -30,13 +32,27 @@ except ImportError:
 
 class Task:
 
-    def __init__(self):
-        self.task_name = 'Task'
+    def __init__(self, task_name):
+        self.task_name = task_name
 
-    def fail_task(self, message):
-        error_text = '{} task failed: {}.'.format(self.task_name, message)
-        Logger.fail(error_text, task_name=self.task_name)
-        raise RuntimeError(error_text)
+    def fail_task(self, e):
+        Logger.fail('Error in task {}: {}: {}.'
+                    .format(self.task_name, e, traceback.format_exc()), task_name=self.task_name)
+
+    def warn_task(self, e):
+        Logger.warn('Warning in task {}: {}: {}'
+                    .format(self.task_name, e, traceback.format_exc()), task_name=self.task_name)
+
+
+def fail_task_on_error(f):
+    def wrapper(*args, **kwargs):
+        self = args[0]
+        try:
+            return f(*args, **kwargs)
+        except Exception as e:
+            self.fail_task(e)
+            raise
+    return wrapper
 
 
 class PodModel:
@@ -70,32 +86,29 @@ class CreateWorkerNodes(Task):
     INIT_WORKER_TASK = "InitializeFSClient"
 
     def __init__(self):
-        Task.__init__(self)
-        self.task_name = 'CreateWorkerNodes'
+        Task.__init__(self, task_name='CreateWorkerNodes')
         self.kube = Kubernetes()
         self.pipe_api = PipelineAPI(os.environ['API'], 'logs')
 
+    @fail_task_on_error
     def run(self, nodes_number, worker_image, worker_disk, worker_type, worker_cmd, parent_id, master_shared,
             worker_shared):
         if nodes_number == 0:
             Logger.success('No workers requested. Processing will run on a master node', task_name=self.task_name)
             return []
-        try:
-            worker_cmd = self.build_worker_start_command(parent_id, worker_cmd, master_shared, worker_shared)
-            Logger.info('Launching {} node(s) with docker image "{}" '
-                        'instance type "{}" disk "{}" and cmd "{}" for master run {}.'
-                        .format(nodes_number, worker_image, worker_type, worker_disk, worker_cmd, parent_id),
-                        task_name=self.task_name)
-            worker_ids = self.launch_workers(nodes_number, worker_image, worker_type, worker_disk, worker_cmd, parent_id)
-            if len(worker_ids) != nodes_number:
-                Logger.fail('Failed to launch all workers.')
-                raise RuntimeError('Failed to launch all workers.')
-            Logger.info('Requested {} worker(s): {}'.format(len(worker_ids), worker_ids), task_name=self.task_name)
-            worker_pods = self.await_workers_start(worker_ids)
-            Logger.success('All workers started', task_name=self.task_name)
-            return worker_pods
-        except Exception as e:
-            self.fail_task(e.message)
+        worker_cmd = self.build_worker_start_command(parent_id, worker_cmd, master_shared, worker_shared)
+        Logger.info('Launching {} node(s) with docker image "{}" '
+                    'instance type "{}" disk "{}" and cmd "{}" for master run {}.'
+                    .format(nodes_number, worker_image, worker_type, worker_disk, worker_cmd, parent_id),
+                    task_name=self.task_name)
+        worker_ids = self.launch_workers(nodes_number, worker_image, worker_type, worker_disk, worker_cmd, parent_id)
+        if len(worker_ids) != nodes_number:
+            Logger.fail('Failed to launch all workers.')
+            raise RuntimeError('Failed to launch all workers.')
+        Logger.info('Requested {} worker(s): {}'.format(len(worker_ids), worker_ids), task_name=self.task_name)
+        worker_pods = self.await_workers_start(worker_ids)
+        Logger.success('All workers started', task_name=self.task_name)
+        return worker_pods
 
     def launch_workers(self, nodes_number, image, type, disk, cmd, parent_id):
         result = []
@@ -154,22 +167,19 @@ class CreateWorkerNodes(Task):
 class BuildHostfile(Task):
 
     def __init__(self):
-        Task.__init__(self)
-        self.task_name = 'BuildHostfile'
+        Task.__init__(self, task_name='BuildHostfile')
         self.kube = Kubernetes()
 
+    @fail_task_on_error
     def run(self, worker_pods, path, run_id):
-        try:
-            Logger.info('Creating hostfile {}'.format(path), task_name=self.task_name)
-            with open(path, 'w') as file:
-                master_pod = self.kube.get_pod(run_id)
-                file.write('{}\n'.format(master_pod.name))
-                for pod in worker_pods:
-                    file.write('{}\n'.format(pod.name))
-                    self.add_to_hosts(pod)
-            Logger.success('Successfully created hostfile {}'.format(path), task_name=self.task_name)
-        except Exception as e:
-            self.fail_task(e.message)
+        Logger.info('Creating hostfile {}'.format(path), task_name=self.task_name)
+        with open(path, 'w') as file:
+            master_pod = self.kube.get_pod(run_id)
+            file.write('{}\n'.format(master_pod.name))
+            for pod in worker_pods:
+                file.write('{}\n'.format(pod.name))
+                self.add_to_hosts(pod)
+        Logger.success('Successfully created hostfile {}'.format(path), task_name=self.task_name)
 
     def execute_command(self, cmd):
         process = subprocess.Popen(cmd, shell=True)
@@ -182,21 +192,19 @@ class BuildHostfile(Task):
 
 
 class ShutDownCluster(Task):
-    def __init__(self):
-        Task.__init__(self)
-        self.task_name = 'ShutDownCluster'
 
+    def __init__(self):
+        Task.__init__(self, task_name='ShutDownCluster')
+
+    @fail_task_on_error
     def run(self, worker_ids, status):
-        try:
-            Logger.info('Shutting down {} node(s)'.format(len(worker_ids)), task_name=self.task_name)
-            api = PipelineAPI(os.environ['API'], 'logs')
-            for pod in worker_ids:
-                Logger.info('Shutting down {} node with status {}.'.format(pod.run_id, status.status),
-                            task_name=self.task_name)
-                api.update_status(pod.run_id, status)
-            Logger.success('Successfully scaled cluster down', task_name=self.task_name)
-        except Exception as e:
-            self.fail_task(e.message)
+        Logger.info('Shutting down {} node(s)'.format(len(worker_ids)), task_name=self.task_name)
+        api = PipelineAPI(os.environ['API'], 'logs')
+        for pod in worker_ids:
+            Logger.info('Shutting down {} node with status {}.'.format(pod.run_id, status.status),
+                        task_name=self.task_name)
+            api.update_status(pod.run_id, status)
+        Logger.success('Successfully scaled cluster down', task_name=self.task_name)
 
 
 def get_env_value(default_name, user_name):
@@ -223,18 +231,15 @@ def main():
     worker_image = get_env_value('docker_image', 'worker_image')
     worker_disk = get_env_value('instance_disk', 'worker_disk')
     worker_type = get_env_value('instance_size', 'worker_type')
-    status = StatusEntry(TaskStatus.SUCCESS)
+
     workers = []
     try:
         workers = CreateWorkerNodes().run(args.nodes_number, worker_image,
                                           worker_disk, worker_type, args.worker_cmd,
                                           run_id, master_shared_dir, worker_shared_dir)
         BuildHostfile().run(workers, hostfile, run_id)
-    except Exception as e:
-        Logger.warn(e.message)
-        status = StatusEntry(TaskStatus.FAILURE)
-        ShutDownCluster().run(workers, status)
-    if status.status == TaskStatus.FAILURE:
+    except Exception:
+        ShutDownCluster().run(workers, StatusEntry(TaskStatus.FAILURE))
         raise RuntimeError('Failed to setup cluster')
     
     

--- a/workflows/pipe-common/scripts/cluster_wait_for_master.py
+++ b/workflows/pipe-common/scripts/cluster_wait_for_master.py
@@ -15,45 +15,19 @@
 import argparse
 import os
 import time
-import traceback
 
-from pipeline import Logger, PipelineAPI
+from pipeline import Logger, LoggerTask, PipelineAPI
 from pipeline import Kubernetes
 
 
-class Task:
-
-    def __init__(self, task_name):
-        self.task_name = task_name
-
-    def fail_task(self, e):
-        Logger.fail('Error in task {}: {}: {}.'
-                    .format(self.task_name, e, traceback.format_exc()), task_name=self.task_name)
-
-    def warn_task(self, e):
-        Logger.warn('Warning in task {}: {}: {}'
-                    .format(self.task_name, e, traceback.format_exc()), task_name=self.task_name)
-
-
-def fail_task_on_error(f):
-    def wrapper(*args, **kwargs):
-        self = args[0]
-        try:
-            return f(*args, **kwargs)
-        except Exception as e:
-            self.fail_task(e)
-            raise
-    return wrapper
-
-
-class MasterNode(Task):
+class MasterNode(LoggerTask):
 
     def __init__(self):
-        Task.__init__(self, task_name='WaitForMasterNode')
+        LoggerTask.__init__(self, task_name='WaitForMasterNode')
         self.kube = Kubernetes()
         self.pipe_api = PipelineAPI(os.environ['API'], 'logs')
 
-    @fail_task_on_error
+    @LoggerTask.fail_on_error
     def await_master_start(self, master_id, task_name):
         Logger.info('Waiting for master node (run id: {}), task: {}'.format(master_id, task_name),
                     task_name=self.task_name)

--- a/workflows/pipe-common/scripts/cluster_wait_for_master.py
+++ b/workflows/pipe-common/scripts/cluster_wait_for_master.py
@@ -12,51 +12,66 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pipeline import Logger, TaskStatus, PipelineAPI, StatusEntry
-from pipeline import Kubernetes
 import argparse
 import os
-import subprocess
 import time
+import traceback
+
+from pipeline import Logger, PipelineAPI
+from pipeline import Kubernetes
+
 
 class Task:
 
-    def __init__(self):
-        self.task_name = 'Task'
+    def __init__(self, task_name):
+        self.task_name = task_name
 
-    def fail_task(self, message):
-        error_text = '{} task failed: {}.'.format(self.task_name, message)
-        Logger.fail(error_text, task_name=self.task_name)
-        raise RuntimeError(error_text)
+    def fail_task(self, e):
+        Logger.fail('Error in task {}: {}: {}.'
+                    .format(self.task_name, e, traceback.format_exc()), task_name=self.task_name)
+
+    def warn_task(self, e):
+        Logger.warn('Warning in task {}: {}: {}'
+                    .format(self.task_name, e, traceback.format_exc()), task_name=self.task_name)
+
+
+def fail_task_on_error(f):
+    def wrapper(*args, **kwargs):
+        self = args[0]
+        try:
+            return f(*args, **kwargs)
+        except Exception as e:
+            self.fail_task(e)
+            raise
+    return wrapper
+
 
 class MasterNode(Task):
 
     def __init__(self):
-        Task.__init__(self)
-        self.task_name = 'WaitForMasterNode'
+        Task.__init__(self, task_name='WaitForMasterNode')
         self.kube = Kubernetes()
         self.pipe_api = PipelineAPI(os.environ['API'], 'logs')
 
+    @fail_task_on_error
     def await_master_start(self, master_id, task_name):
-        try:
-            Logger.info('Waiting for master node (run id: {}), task: {}'.format(master_id, task_name), task_name=self.task_name)
+        Logger.info('Waiting for master node (run id: {}), task: {}'.format(master_id, task_name),
+                    task_name=self.task_name)
 
-            # approximately 1 day. we really do not need this timeout, as if something will go wrong with a master - workers will be killed automatically
-            # but for any unpredictable case - this task will be killed eventually
-            attempts = 8640
-            master = None
-            Logger.info('Waiting for master node ...', task_name=self.task_name)
-            while not master and attempts > 0:
-                master = self.get_master_node_info(master_id, task_name)
-                attempts -= 1
-                time.sleep(10)
-            if not master:
-                raise RuntimeError('Failed to attach to master node')
+        # approximately 1 day. we really do not need this timeout, as if something will go wrong with a master - workers will be killed automatically
+        # but for any unpredictable case - this task will be killed eventually
+        attempts = 8640
+        master = None
+        Logger.info('Waiting for master node ...', task_name=self.task_name)
+        while not master and attempts > 0:
+            master = self.get_master_node_info(master_id, task_name)
+            attempts -= 1
+            time.sleep(10)
+        if not master:
+            raise RuntimeError('Failed to attach to master node')
 
-            Logger.success('Attached to master node (run id {})'.format(master_id), task_name=self.task_name)
-            return master
-        except Exception as e:
-            self.fail_task(e.message)
+        Logger.success('Attached to master node (run id {})'.format(master_id), task_name=self.task_name)
+        return master
 
     def get_master_node_info(self, master_id, task_name):
         pod = self.kube.get_pod(master_id)
@@ -71,26 +86,16 @@ class MasterNode(Task):
                 raise RuntimeError('Worker failed to start as it cannot attach to master node (run id {})'.format(master_id))
         return None
 
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--master-id', type=int, required=True)
     parser.add_argument('--task-name', required=True)
     args = parser.parse_args()
-    run_id = os.environ['RUN_ID']
 
-    status = StatusEntry(TaskStatus.SUCCESS)
-    workers = []
-    try:
-        master = MasterNode().await_master_start(args.master_id, args.task_name)
-        print(master.name + " " + master.ip)
-        exit(0)
-    except Exception as e:
-        Logger.warn(e.message)
-        status = StatusEntry(TaskStatus.FAILURE)
-    if status.status == TaskStatus.FAILURE:
-        raise RuntimeError('Failed to setup cluster')
+    master = MasterNode().await_master_start(args.master_id, args.task_name)
+    print('{} {}'.format(master.name, master.ip))
 
-    
-    
+
 if __name__ == '__main__':
     main()

--- a/workflows/pipe-common/scripts/cluster_wait_for_node.py
+++ b/workflows/pipe-common/scripts/cluster_wait_for_node.py
@@ -12,37 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import traceback
 import argparse
 import os
 import time
 
-from pipeline import Logger, PipelineAPI
-
-
-class Task:
-
-    def __init__(self, task_name):
-        self.task_name = task_name
-
-    def fail_task(self, e):
-        Logger.fail('Error in task {}: {}: {}.'
-                    .format(self.task_name, e, traceback.format_exc()), task_name=self.task_name)
-
-    def warn_task(self, e):
-        Logger.warn('Warning in task {}: {}: {}'
-                    .format(self.task_name, e, traceback.format_exc()), task_name=self.task_name)
-
-
-def fail_task_on_error(f):
-    def wrapper(*args, **kwargs):
-        self = args[0]
-        try:
-            return f(*args, **kwargs)
-        except Exception as e:
-            self.fail_task(e)
-            raise
-    return wrapper
+from pipeline import Logger, LoggerTask, PipelineAPI
 
 
 class Node:
@@ -55,14 +29,14 @@ class Node:
             self.ip = None
 
 
-class WaitForNode(Task):
+class WaitForNode(LoggerTask):
 
     def __init__(self):
-        Task.__init__(self, task_name='WaitForNode')
+        LoggerTask.__init__(self, task_name='WaitForNode')
         self.run_id = os.environ.get('RUN_ID', '')
         self.pipe_api = PipelineAPI(os.environ['API'], 'logs')
 
-    @fail_task_on_error
+    @LoggerTask.fail_on_error
     def await_node_start(self, task_name, run_id, parameters=None):
         Logger.info('Waiting for node with parameters = {}, task: {}'
                     .format(','.join(parameters if parameters else ['NA']), task_name),

--- a/workflows/pipe-common/scripts/cluster_wait_for_workers.py
+++ b/workflows/pipe-common/scripts/cluster_wait_for_workers.py
@@ -140,7 +140,7 @@ def main():
         BuildHostfile().run(workers, hostfile, run_id)
     except Exception:
         ShutDownCluster().run(workers, StatusEntry(TaskStatus.FAILURE))
-        raise RuntimeError('Failed to setup cluster')
+        raise
     
     
 if __name__ == '__main__':


### PR DESCRIPTION
Relates to #1705 and depends on #1725.

The pull request applies changes introduced in #1725 to all the scripts similar to `cluster_wait_for_node.py`. Additionally it extract some common code to pipe common library.
