### PR TITLE
Update Dockerfile for e2e-empty and e2e-endpoint tools

### DIFF
--- a/deploy/docker/cp-tests/e2e-empty/Dockerfile
+++ b/deploy/docker/cp-tests/e2e-empty/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian
+FROM debian:9
 
 RUN apt-get update -y && \
     apt-get install -y wget \

--- a/deploy/docker/cp-tests/e2e-endpoints/Dockerfile
+++ b/deploy/docker/cp-tests/e2e-endpoints/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian
+FROM debian:9
 
 RUN apt-get update -y && \
     apt-get install -y wget \


### PR DESCRIPTION
This PR consists of setting Debian version to 9 in Dockerfile for tools e2e-empty and e2e-endpoint