### PR TITLE
Issue-1735: Unit tests: Rewrite FolderTemplateManagerTest

### DIFF
--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/FolderTemplateManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/FolderTemplateManagerTest.java
@@ -18,19 +18,25 @@ package com.epam.pipeline.manager.pipeline;
 
 import com.epam.pipeline.AbstractSpringTest;
 import com.epam.pipeline.app.TestApplicationWithAclSecurity;
+import com.epam.pipeline.controller.vo.DataStorageVO;
 import com.epam.pipeline.controller.vo.EntityVO;
 import com.epam.pipeline.controller.vo.PermissionVO;
 import com.epam.pipeline.controller.vo.data.storage.DataStorageWithMetadataVO;
 import com.epam.pipeline.dao.region.CloudRegionDao;
 import com.epam.pipeline.dao.util.AclTestDao;
+import com.epam.pipeline.entity.SecuredEntityWithAction;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.DataStorageType;
 import com.epam.pipeline.entity.datastorage.aws.S3bucketDataStorage;
+import com.epam.pipeline.entity.metadata.MetadataEntity;
+import com.epam.pipeline.entity.metadata.MetadataEntry;
 import com.epam.pipeline.entity.metadata.PipeConfValue;
 import com.epam.pipeline.entity.pipeline.Folder;
 import com.epam.pipeline.entity.region.AwsRegion;
 import com.epam.pipeline.entity.security.acl.AclClass;
 import com.epam.pipeline.entity.security.acl.AclPermissionEntry;
+import com.epam.pipeline.entity.security.acl.AclSecuredEntry;
+import com.epam.pipeline.entity.security.acl.AclSid;
 import com.epam.pipeline.entity.templates.FolderTemplate;
 import com.epam.pipeline.manager.MockS3Helper;
 import com.epam.pipeline.manager.datastorage.DataStorageManager;
@@ -38,10 +44,15 @@ import com.epam.pipeline.manager.datastorage.providers.aws.s3.S3StorageProvider;
 import com.epam.pipeline.manager.metadata.MetadataManager;
 import com.epam.pipeline.manager.security.GrantPermissionManager;
 import com.epam.pipeline.security.acl.AclPermission;
+import com.epam.pipeline.test.acl.AbstractAclTest;
+import com.epam.pipeline.test.creator.datastorage.DatastorageCreatorUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.annotation.DirtiesContext;
@@ -49,22 +60,15 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.*;
 
-@DirtiesContext
-@ContextConfiguration(classes = TestApplicationWithAclSecurity.class)
-@Transactional
-public class FolderTemplateManagerTest extends AbstractSpringTest {
+public class FolderTemplateManagerTest extends AbstractAclTest {
     private static final String TEST_PATH = "path";
-    private static final String TEST_USER = "USER1";
     private static final String TEST_ROLE = "TEST_ROLE";
 
     private static final String DATA_KEY_1 = "tag";
@@ -75,70 +79,27 @@ public class FolderTemplateManagerTest extends AbstractSpringTest {
     private static final String CHILD_TEMPLATE_FOLDER_NAME_1 = "test-1";
     private static final String DATASTORAGE_NAME_1 = "ds-1";
 
-    @Autowired
+    @SpyBean
     private FolderTemplateManager folderTemplateManager;
     @Autowired
     private FolderManager folderManager;
     @Autowired
     private MetadataManager metadataManager;
-    @Autowired
+    @MockBean
     private DataStorageManager dataStorageManager;
-    @SpyBean
-    private S3StorageProvider storageProviderManager;
-    @Autowired
-    private AclTestDao aclTestDao;
-    @Autowired
+    @MockBean
     private GrantPermissionManager permissionManager;
-    @Autowired
-    private CloudRegionDao cloudRegionDao;
+    @MockBean
+    private FolderCrudManager crudManager;
 
-    private AwsRegion awsRegion;
-
-
-    @Before
-    public void setUp() {
-        doReturn(new MockS3Helper()).when(storageProviderManager).getS3Helper(any(S3bucketDataStorage.class));
-
-        awsRegion = new AwsRegion();
-        awsRegion.setName("US");
-        awsRegion.setRegionCode("us-east-1");
-        awsRegion.setDefault(true);
-        cloudRegionDao.create(awsRegion);
-
-        AclTestDao.AclSid testUserSid = new AclTestDao.AclSid(true, TEST_USER);
-        aclTestDao.createAclSid(testUserSid);
-        AclTestDao.AclSid testRole = new AclTestDao.AclSid(false, TEST_ROLE);
-        aclTestDao.createAclSid(testRole);
-
-        AclTestDao.AclClass folderAclClass = new AclTestDao.AclClass(Folder.class.getCanonicalName());
-        aclTestDao.createAclClassIfNotPresent(folderAclClass);
-    }
+    private Map<String, PipeConfValue> metadata;
+    private PermissionVO permissionVO;
+    private FolderTemplate folderTemplate;
 
     @Test
-    @WithMockUser(username = TEST_USER)
     public void createFolderFromTemplateTest() throws IOException {
-        Map<String, PipeConfValue> metadata = new HashMap<>();
-        metadata.put(DATA_KEY_1, new PipeConfValue(DATA_TYPE_1, DATA_VALUE_1));
-
-        DataStorageWithMetadataVO dataStorageVO = new DataStorageWithMetadataVO();
-        dataStorageVO.setName(DATASTORAGE_NAME_1);
-        dataStorageVO.setType(DataStorageType.S3);
-        dataStorageVO.setPath(TEST_PATH);
-        dataStorageVO.setMetadata(metadata);
-
-        PermissionVO permissionVO = new PermissionVO();
-        permissionVO.setMask(AclPermission.READ.getMask());
-        permissionVO.setUserName(TEST_ROLE);
-        permissionVO.setPrincipal(false);
-
-        FolderTemplate childFolderTemplate1 = FolderTemplate.builder().name(CHILD_TEMPLATE_FOLDER_NAME_1).build();
-        FolderTemplate folderTemplate = FolderTemplate.builder()
-                .name(TEMPLATE_FOLDER_NAME)
-                .datastorages(Stream.of(dataStorageVO).collect(Collectors.toList()))
-                .children(Stream.of(childFolderTemplate1).collect(Collectors.toList()))
-                .metadata(metadata)
-                .permissions(Stream.of(permissionVO).collect(Collectors.toList()))
-                .build();
+        initializeParameters();
+        preConditions();
 
         Folder folder = new Folder();
         folder.setName(TEMPLATE_FOLDER_NAME);
@@ -147,18 +108,23 @@ public class FolderTemplateManagerTest extends AbstractSpringTest {
         Folder savedRootFolder = folderManager.loadByNameOrId(TEMPLATE_FOLDER_NAME);
         savedRootFolder = folderManager.load(savedRootFolder.getId());
         Assert.assertNotNull(savedRootFolder);
+
         Long rootFolderId = savedRootFolder.getId();
         List<EntityVO> metadataEntries = Collections.singletonList(new EntityVO(rootFolderId, AclClass.FOLDER));
         Assert.assertEquals(metadata, metadataManager.listMetadataItems(metadataEntries).get(0).getData());
+
         AbstractDataStorage clonedDataStorage = savedRootFolder.getStorages().get(0);
         clonedDataStorage = dataStorageManager.load(clonedDataStorage.getId());
         Assert.assertTrue(clonedDataStorage.getName().startsWith(DATASTORAGE_NAME_1));
         Assert.assertTrue(clonedDataStorage.getPath().startsWith(TEST_PATH));
+
         metadataEntries = Collections.singletonList(new EntityVO(clonedDataStorage.getId(), AclClass.DATA_STORAGE));
         Assert.assertEquals(metadata, metadataManager.listMetadataItems(metadataEntries).get(0).getData());
+
         List<AclPermissionEntry> rootFolderPermissions = permissionManager.getPermissions(rootFolderId, AclClass.FOLDER)
                 .getPermissions();
         Assert.assertEquals(1, rootFolderPermissions.size());
+
         AclPermissionEntry actualPermission = rootFolderPermissions.get(0);
         Assert.assertEquals(permissionVO.getMask(), actualPermission.getMask());
         Assert.assertEquals(permissionVO.getPrincipal(), actualPermission.getSid().isPrincipal());
@@ -168,5 +134,116 @@ public class FolderTemplateManagerTest extends AbstractSpringTest {
                 CHILD_TEMPLATE_FOLDER_NAME_1);
         Assert.assertNotNull(savedChildFolder);
         Assert.assertEquals(rootFolderId, savedChildFolder.getParentId());
+
+        postValidation();
+    }
+
+    private void initializeParameters() {
+        metadata = getMetadata();
+
+        DataStorageWithMetadataVO dataStorageVO = new DataStorageWithMetadataVO();
+        dataStorageVO.setName(DATASTORAGE_NAME_1);
+        dataStorageVO.setType(DataStorageType.S3);
+        dataStorageVO.setPath(TEST_PATH);
+        dataStorageVO.setMetadata(metadata);
+
+        permissionVO = new PermissionVO();
+        permissionVO.setMask(AclPermission.READ.getMask());
+        permissionVO.setUserName(TEST_ROLE);
+        permissionVO.setPrincipal(false);
+
+        FolderTemplate childFolderTemplate1 = FolderTemplate.builder().name(CHILD_TEMPLATE_FOLDER_NAME_1).build();
+
+        folderTemplate = FolderTemplate.builder()
+                .name(TEMPLATE_FOLDER_NAME)
+                .datastorages(Stream.of(dataStorageVO).collect(Collectors.toList()))
+                .children(Stream.of(childFolderTemplate1).collect(Collectors.toList()))
+                .metadata(metadata)
+                .permissions(Stream.of(permissionVO).collect(Collectors.toList()))
+                .build();
+    }
+
+    private void preConditions() {
+        doReturn(getMockFolder()).when(crudManager).create(any());
+        doReturn(getMockSecurityEntity()).when(dataStorageManager).create(any(), anyBoolean(), anyBoolean(), anyBoolean());
+        doNothing().when(metadataManager).updateEntityMetadata(any(), anyLong(), any());
+        doNothing().when(permissionManager).setPermissionsToEntity(any(), anyLong(), any());
+
+        doReturn(getMockFolder()).when(folderManager).loadByNameOrId(anyString());
+        doReturn(getMockFolderChild()).when(folderManager).loadByNameOrId(startsWith(TEMPLATE_FOLDER_NAME));
+        doReturn(getMockFolder()).when(folderManager).load(anyLong());
+
+        doReturn(getMockListMetadataEntry()).when(metadataManager).listMetadataItems(any());
+        doReturn(getS3BucketDataStorage()).when(dataStorageManager).load(anyLong());
+
+        doReturn(getMockAclSecuredEntry()).when(permissionManager).getPermissions(anyLong(), any());
+    }
+
+    private void postValidation() {
+        int oneInvocation = 1;
+        int twoInvocations = 2;
+        int threeInvocations = 3;
+
+        verify(crudManager, times(twoInvocations)).create(any());
+        verify(dataStorageManager, times(oneInvocation)).create(any(), anyBoolean(), anyBoolean(), anyBoolean());
+        verify(dataStorageManager, times(oneInvocation)).load(anyLong());
+        verify(metadataManager, times(threeInvocations)).updateEntityMetadata(any(), anyLong(), any());
+        verify(metadataManager, times(twoInvocations)).listMetadataItems(any());
+        verify(permissionManager, times(twoInvocations)).setPermissionsToEntity(any(), anyLong(), any());
+        verify(permissionManager, times(oneInvocation)).getPermissions(anyLong(), any());
+        verify(folderManager, times(oneInvocation)).load(anyLong());
+        verify(folderManager, times(twoInvocations)).loadByNameOrId(any());
+    }
+
+    private SecuredEntityWithAction<AbstractDataStorage> getMockSecurityEntity() {
+        SecuredEntityWithAction<AbstractDataStorage> action = new SecuredEntityWithAction<>();
+        action.setEntity(new S3bucketDataStorage());
+        return action;
+    }
+
+    private Folder getMockFolder() {
+        Folder folder = new Folder();
+        folder.setId(1L);
+        folder.setStorages(Collections.singletonList(new S3bucketDataStorage()));
+        return folder;
+    }
+
+    private Folder getMockFolderChild() {
+        Folder folder = getMockFolder();
+        folder.setParentId(1L);
+        return folder;
+    }
+
+    private List<MetadataEntry> getMockListMetadataEntry() {
+        List<MetadataEntry> list = new ArrayList<>();
+        MetadataEntry entry = new MetadataEntry();
+        entry.setData(metadata);
+        list.add(entry);
+        return list;
+    }
+
+    private Map<String, PipeConfValue> getMetadata() {
+        Map<String, PipeConfValue> metadata = new HashMap<>();
+        metadata.put(DATA_KEY_1, new PipeConfValue(DATA_TYPE_1, DATA_VALUE_1));
+        return metadata;
+    }
+
+    private AbstractDataStorage getS3BucketDataStorage() {
+        AbstractDataStorage storage = new S3bucketDataStorage();
+        storage.setName(DATASTORAGE_NAME_1);
+        storage.setPath(TEST_PATH);
+        return storage;
+    }
+
+    private AclSecuredEntry getMockAclSecuredEntry() {
+        AclSecuredEntry securedEntry = new AclSecuredEntry();
+        AclPermissionEntry permissionEntry = new AclPermissionEntry();
+        permissionEntry.setMask(permissionVO.getMask());
+        AclSid sid = new AclSid();
+        sid.setName(permissionVO.getUserName());
+        sid.setPrincipal(permissionVO.getPrincipal());
+        permissionEntry.setSid(sid);
+        securedEntry.addPermission(permissionEntry);
+        return securedEntry;
     }
 }

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/FolderTemplateManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/FolderTemplateManagerTest.java
@@ -16,48 +16,31 @@
 
 package com.epam.pipeline.manager.pipeline;
 
-import com.epam.pipeline.AbstractSpringTest;
-import com.epam.pipeline.app.TestApplicationWithAclSecurity;
-import com.epam.pipeline.controller.vo.DataStorageVO;
 import com.epam.pipeline.controller.vo.EntityVO;
 import com.epam.pipeline.controller.vo.PermissionVO;
 import com.epam.pipeline.controller.vo.data.storage.DataStorageWithMetadataVO;
-import com.epam.pipeline.dao.region.CloudRegionDao;
-import com.epam.pipeline.dao.util.AclTestDao;
 import com.epam.pipeline.entity.SecuredEntityWithAction;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.DataStorageType;
 import com.epam.pipeline.entity.datastorage.aws.S3bucketDataStorage;
-import com.epam.pipeline.entity.metadata.MetadataEntity;
 import com.epam.pipeline.entity.metadata.MetadataEntry;
 import com.epam.pipeline.entity.metadata.PipeConfValue;
 import com.epam.pipeline.entity.pipeline.Folder;
-import com.epam.pipeline.entity.region.AwsRegion;
 import com.epam.pipeline.entity.security.acl.AclClass;
 import com.epam.pipeline.entity.security.acl.AclPermissionEntry;
 import com.epam.pipeline.entity.security.acl.AclSecuredEntry;
 import com.epam.pipeline.entity.security.acl.AclSid;
 import com.epam.pipeline.entity.templates.FolderTemplate;
-import com.epam.pipeline.manager.MockS3Helper;
 import com.epam.pipeline.manager.datastorage.DataStorageManager;
-import com.epam.pipeline.manager.datastorage.providers.aws.s3.S3StorageProvider;
 import com.epam.pipeline.manager.metadata.MetadataManager;
 import com.epam.pipeline.manager.security.GrantPermissionManager;
 import com.epam.pipeline.security.acl.AclPermission;
 import com.epam.pipeline.test.acl.AbstractAclTest;
-import com.epam.pipeline.test.creator.datastorage.DatastorageCreatorUtils;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.util.*;
@@ -165,7 +148,8 @@ public class FolderTemplateManagerTest extends AbstractAclTest {
 
     private void preConditions() {
         doReturn(getMockFolder()).when(crudManager).create(any());
-        doReturn(getMockSecurityEntity()).when(dataStorageManager).create(any(), anyBoolean(), anyBoolean(), anyBoolean());
+        doReturn(getMockSecurityEntity()).when(dataStorageManager)
+                .create(any(), anyBoolean(), anyBoolean(), anyBoolean());
         doNothing().when(metadataManager).updateEntityMetadata(any(), anyLong(), any());
         doNothing().when(permissionManager).setPermissionsToEntity(any(), anyLong(), any());
 


### PR DESCRIPTION
Issue-1735: Refactored FolderTemplateManagerTest. Removed @DirtiesContextAnnotation, inherited class from AbstractAclTest, reduced configuration.

Link to issue: https://github.com/epam/cloud-pipeline/issues/1735