### PR TITLE
Introduce mount timeout for EFS and Lustre

### DIFF
--- a/deploy/contents/install/preferences/launch.system.parameters.json
+++ b/deploy/contents/install/preferences/launch.system.parameters.json
@@ -313,5 +313,12 @@
         "type": "string",
         "description": "If defined - will limit mounts for the run",
         "passToWorkers": true
+    },
+    {
+        "name": "CP_FS_MOUNT_ATTEMPT",
+        "type": "int",
+        "description": "Allows to specify the number of times the NFS client attempts to retries an NFS mount operation after the first attempt fails",
+        "defaultValue": "0",
+        "passToWorkers": false
     }
 ]

--- a/deploy/contents/install/preferences/launch.system.parameters.json
+++ b/deploy/contents/install/preferences/launch.system.parameters.json
@@ -320,5 +320,12 @@
         "description": "Allows to specify the number of times the NFS client attempts to retries an NFS mount operation after the first attempt fails",
         "defaultValue": "0",
         "passToWorkers": false
+    },
+    {
+        "name": "CP_FS_MOUNT_TIMEOUT",
+        "type": "int",
+        "description": "Allows to specify the time in deciseconds the NFS client waits for a response before it retries an NFS request",
+        "defaultValue": "7",
+        "passToWorkers": false
     }
 ]

--- a/workflows/pipe-common/scripts/mount_storage.py
+++ b/workflows/pipe-common/scripts/mount_storage.py
@@ -587,8 +587,9 @@ class NFSMounter(StorageMounter):
             else:
                 mount_options += ',' + file_mode_options
 
-        mount_attempt = os.getenv('CP_FS_MOUNT_ATTEMPT', 0)
-        mount_attempt_option = 'retry={}'.format(mount_attempt)
+        mount_timeo = os.getenv('CP_FS_MOUNT_TIMEOUT', 7)
+        mount_retry = os.getenv('CP_FS_MOUNT_ATTEMPT', 0)
+        mount_attempt_option = 'timeo={timeo},retry={retry}'.format(timeo=mount_timeo, retry=mount_retry)
         if not mount_options:
             mount_options = mount_attempt_option
         else:

--- a/workflows/pipe-common/scripts/mount_storage.py
+++ b/workflows/pipe-common/scripts/mount_storage.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -586,6 +586,13 @@ class NFSMounter(StorageMounter):
                 mount_options = file_mode_options
             else:
                 mount_options += ',' + file_mode_options
+
+        mount_attempt = os.getenv('CP_FS_MOUNT_ATTEMPT', 0)
+        mount_attempt_option = 'retry={}'.format(mount_attempt)
+        if not mount_options:
+            mount_options = mount_attempt_option
+        else:
+            mount_options += ',' + mount_attempt_option
         if mount_options:
             command += ' -o {}'.format(mount_options)
         command += ' {path} {mount}'.format(**params)


### PR DESCRIPTION
Resolves issue #1750  
A `retry={n}` option was added to the NFS mount command. The option allows specifying the number of times the NFS client attempts to retries an NFS mount operation after the first attempt fails.