### PR TITLE
Insert EFS and Lustre mount options to NFS mounting if not exist

### DIFF
--- a/deploy/contents/install/preferences/launch.system.parameters.json
+++ b/deploy/contents/install/preferences/launch.system.parameters.json
@@ -315,6 +315,13 @@
         "passToWorkers": true
     },
     {
+        "name": "CP_PIPE_FUSE_TIMEOUT",
+        "type": "int",
+        "description": "Allows to specify the pipe fuse timeout",
+        "defaultValue": "500",
+        "passToWorkers": false
+    },
+    {
         "name": "CP_FS_MOUNT_ATTEMPT",
         "type": "int",
         "description": "Allows to specify the number of times the NFS client attempts to retries an NFS mount operation after the first attempt fails",

--- a/workflows/pipe-common/scripts/mount_storage.py
+++ b/workflows/pipe-common/scripts/mount_storage.py
@@ -589,14 +589,14 @@ class NFSMounter(StorageMounter):
 
         mount_timeo = os.getenv('CP_FS_MOUNT_TIMEOUT', 7)
         mount_retry = os.getenv('CP_FS_MOUNT_ATTEMPT', 0)
-        mount_attempt_option = 'timeo={timeo},retry={retry}'.format(timeo=mount_timeo, retry=mount_retry)
-        if not mount_options:
-            mount_options = mount_attempt_option
-        else:
-            mount_options += ',' + mount_attempt_option
         if mount_options:
-            command += ' -o {}'.format(mount_options)
-        command += ' {path} {mount}'.format(**params)
+            if "timeo" not in mount_options:
+                mount_options += ',timeo={}'.format(mount_timeo)
+            if "retry" not in mount_options:
+                mount_options += ',retry={}'.format(mount_retry)
+        else:
+            mount_options = 'timeo={timeo},retry={retry}'.format(timeo=mount_timeo, retry=mount_retry)
+        command += ' -o {mount_option} {path} {mount}'.format(mount_option=mount_options, **params)
         if PermissionHelper.is_storage_writable(self.storage):
             command += ' && chmod {permission} {mount}'.format(permission=permission, **params)
         return command


### PR DESCRIPTION
The addition to issue #1750
A mount `timeo` and/or `retry` options for NFS mounting is inserting if they don't exist in `CP_FSMOUNT_OPTIONS`.
