### PR TITLE
Introduce the new system preference for NFS mount of sensitive runs

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/datastorage/nfs/NFSMountPolicy.java
+++ b/api/src/main/java/com/epam/pipeline/entity/datastorage/nfs/NFSMountPolicy.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.epam.pipeline.entity.datastorage.nfs;
+
+/**
+ * Describe how an NFS mount shall be handled for sensitive runs.
+ */
+public enum NFSMountPolicy {
+    /**
+     *  NFS mount shall be skipped
+     */
+    SKIP,
+    /**
+     * NFS mount shall be mounted with retry and timeo options
+     */
+    TIMEOUT,
+    /**
+     * NFS mount shall be handled in a common way (mount with options provided for storage)
+     */
+    NONE
+}

--- a/api/src/main/java/com/epam/pipeline/manager/preference/PreferenceValidators.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/PreferenceValidators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -254,6 +254,9 @@ public final class PreferenceValidators {
 
     public static final BiPredicate<String, Map<String, Preference>> isValidLongPauseRunAction =
             (pref, ignored) -> LongPausedRunAction.contains(pref);
+
+    public static final BiPredicate<String, Map<String, Preference>> isValidNFSMountSensitivePolicy = (pref, ignored) ->
+            StringUtils.isBlank(pref) || pref.equals("SKIP") || pref.equals("TIMEOUT") || pref.equals("NONE");
 
     private PreferenceValidators() {
         // No-op

--- a/api/src/main/java/com/epam/pipeline/manager/preference/PreferenceValidators.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/PreferenceValidators.java
@@ -186,6 +186,15 @@ public final class PreferenceValidators {
         return (pref, dependencies) -> EnumUtils.isValidEnum(enumClass, pref);
     }
 
+    public static BiPredicate<String, Map<String, Preference>> isNullOrValidEnum(final Class<? extends Enum>
+                                                                                         enumClass) {
+        return (pref, dependencies) -> {
+            if (StringUtils.isBlank(pref)) {
+                return true;
+            }
+            return EnumUtils.isValidEnum(enumClass, pref);
+        };
+    }
     /**
      * A no-op validator, that is always true
      */
@@ -254,9 +263,6 @@ public final class PreferenceValidators {
 
     public static final BiPredicate<String, Map<String, Preference>> isValidLongPauseRunAction =
             (pref, ignored) -> LongPausedRunAction.contains(pref);
-
-    public static final BiPredicate<String, Map<String, Preference>> isValidNFSMountSensitivePolicy = (pref, ignored) ->
-            StringUtils.isBlank(pref) || pref.equals("SKIP") || pref.equals("TIMEOUT") || pref.equals("NONE");
 
     private PreferenceValidators() {
         // No-op

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -25,6 +25,7 @@ import com.epam.pipeline.entity.cluster.DockerMount;
 import com.epam.pipeline.entity.cluster.EnvVarsSettings;
 import com.epam.pipeline.entity.cluster.PriceType;
 import com.epam.pipeline.entity.cluster.container.ContainerMemoryResourcePolicy;
+import com.epam.pipeline.entity.datastorage.nfs.NFSMountPolicy;
 import com.epam.pipeline.entity.git.GitlabVersion;
 import com.epam.pipeline.entity.monitoring.IdleRunAction;
 import com.epam.pipeline.entity.monitoring.LongPausedRunAction;
@@ -78,6 +79,7 @@ import static com.epam.pipeline.manager.preference.PreferenceValidators.isGreate
 import static com.epam.pipeline.manager.preference.PreferenceValidators.isLessThan;
 import static com.epam.pipeline.manager.preference.PreferenceValidators.isNotLessThanValueOrNull;
 import static com.epam.pipeline.manager.preference.PreferenceValidators.isNullOrGreaterThan;
+import static com.epam.pipeline.manager.preference.PreferenceValidators.isNullOrValidEnum;
 import static com.epam.pipeline.manager.preference.PreferenceValidators.isNullOrValidJson;
 import static com.epam.pipeline.manager.preference.PreferenceValidators.isValidEnum;
 import static com.epam.pipeline.manager.preference.PreferenceValidators.pass;
@@ -157,7 +159,7 @@ public class SystemPreferences {
             "storage.mounts.nfs.sensitive.policy",
             null,
             DATA_STORAGE_GROUP,
-            PreferenceValidators.isValidNFSMountSensitivePolicy);
+            isNullOrValidEnum(NFSMountPolicy.class));
 
     /**
      * Configures a system data storage for storing attachments and etc.

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -149,6 +149,16 @@ public class SystemPreferences {
             "storage.mount.black.list",
             "/,/etc,/runs,/common,/bin,/opt,/var,/home,/root,/sbin,/sys,/usr,/boot,/dev,/lib,/proc,/tmp",
             DATA_STORAGE_GROUP, PreferenceValidators.isEmptyOrValidBatchOfPaths);
+
+    /**
+     * Defines NFS mounting policy for sensitive runs. Can take SKIP, TIMEOUT, NONE values.
+     * */
+    public static final StringPreference DATA_STORAGE_NFS_MOUNT_SENSITIVE_POLICY = new StringPreference(
+            "storage.mounts.nfs.sensitive.policy",
+            null,
+            DATA_STORAGE_GROUP,
+            PreferenceValidators.isValidNFSMountSensitivePolicy);
+
     /**
      * Configures a system data storage for storing attachments and etc.
      */


### PR DESCRIPTION
The addition to issue #1750
`storage.mounts.nfs.sensitive.policy` system preference was added for NFS mount of sensitive runs.
The preference supports `SKIP`, `TIMEOUT`, `NONE` values.
-   `SKIP` - NFS mounts shall be skipped for sensitive runs
-   `TIMEOUT` - NFS mounts shall be mounted with retry & timeo options for sensitive runs
-   `NONE` or missing value - handle NFS mount in common way (mount with options provided for storage)