### PR TITLE
Issue 1745 custom dns for Azure

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacadeImpl.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacadeImpl.java
@@ -262,13 +262,13 @@ public class CloudFacadeImpl implements CloudFacade {
 
     public InstanceDNSRecord createDNSRecord(final Long regionId, final InstanceDNSRecord dnsRecord) {
         final AbstractCloudRegion cloudRegion = regionManager.loadOrDefault(regionId);
-        return getInstanceService(cloudRegion).getOrCreateInstanceDNSRecord(dnsRecord);
+        return getInstanceService(cloudRegion).getOrCreateInstanceDNSRecord(cloudRegion, dnsRecord);
     }
 
     @Override
     public InstanceDNSRecord removeDNSRecord(final Long regionId, final InstanceDNSRecord dnsRecord) {
         final AbstractCloudRegion cloudRegion = regionManager.loadOrDefault(regionId);
-        return getInstanceService(cloudRegion).deleteInstanceDNSRecord(dnsRecord);
+        return getInstanceService(cloudRegion).deleteInstanceDNSRecord(cloudRegion, dnsRecord);
     }
 
     private AbstractCloudRegion getRegionByRunId(final Long runId) {

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/CloudInstanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/CloudInstanceService.java
@@ -199,8 +199,8 @@ public interface CloudInstanceService<T extends AbstractCloudRegion>
 
     CloudInstanceState getInstanceState(T region, String nodeLabel);
 
-    InstanceDNSRecord getOrCreateInstanceDNSRecord(InstanceDNSRecord dnsRecord);
+    InstanceDNSRecord getOrCreateInstanceDNSRecord(T cloudRegion, InstanceDNSRecord dnsRecord);
 
-    InstanceDNSRecord deleteInstanceDNSRecord(InstanceDNSRecord dnsRecord);
+    InstanceDNSRecord deleteInstanceDNSRecord(T cloudRegion, InstanceDNSRecord dnsRecord);
 
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSInstanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSInstanceService.java
@@ -278,7 +278,8 @@ public class AWSInstanceService implements CloudInstanceService<AwsRegion> {
     }
 
     @Override
-    public InstanceDNSRecord getOrCreateInstanceDNSRecord(final InstanceDNSRecord dnsRecord) {
+    public InstanceDNSRecord getOrCreateInstanceDNSRecord(final AwsRegion cloudRegion,
+                                                          final InstanceDNSRecord dnsRecord) {
         if (dnsRecord.getDnsRecord().contains(
                 preferenceManager.getPreference(SystemPreferences.INSTANCE_DNS_HOSTED_ZONE_BASE))) {
             return route53Helper
@@ -291,7 +292,8 @@ public class AWSInstanceService implements CloudInstanceService<AwsRegion> {
     }
 
     @Override
-    public InstanceDNSRecord deleteInstanceDNSRecord(final InstanceDNSRecord dnsRecord) {
+    public InstanceDNSRecord deleteInstanceDNSRecord(final AwsRegion cloudRegion,
+                                                     final InstanceDNSRecord dnsRecord) {
         if (dnsRecord.getDnsRecord().contains(
                 preferenceManager.getPreference(SystemPreferences.INSTANCE_DNS_HOSTED_ZONE_BASE))) {
             return route53Helper

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzureDNSZoneHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzureDNSZoneHelper.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cloud.azure;
+
+import com.epam.pipeline.entity.cloud.InstanceDNSRecord;
+import com.epam.pipeline.entity.region.AzureRegion;
+import com.epam.pipeline.manager.datastorage.providers.azure.AzureHelper;
+import com.microsoft.azure.management.Azure;
+import com.microsoft.azure.management.dns.DnsZone;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AzureDNSZoneHelper {
+
+    private static final long TTL_TIME = 60L;
+    private static final String EMPTY = "";
+
+    public InstanceDNSRecord createDNSRecord(final AzureRegion azureRegion,
+                                             final String hostedZoneId, final InstanceDNSRecord dnsRecord) {
+        log.info("Creating DNS record for hostedZoneId: {} record: {} and target: {}",
+                hostedZoneId, dnsRecord.getDnsRecord(), dnsRecord.getTarget());
+        final Azure azure = AzureHelper.buildClient(azureRegion.getAuthFile());
+        final DnsZone rootDnsZone = azure.dnsZones().getById(hostedZoneId);
+        if (isDnsRecordDoesntExist(dnsRecord, rootDnsZone)) {
+            if (aName(dnsRecord.getTarget())) {
+                rootDnsZone.update()
+                        .defineARecordSet(extractRecordSetName(dnsRecord, rootDnsZone))
+                        .withIPv4Address(dnsRecord.getTarget())
+                        .withTimeToLive(TTL_TIME)
+                        .attach()
+                        .apply();
+            } else {
+                rootDnsZone.update()
+                        .defineCNameRecordSet(extractRecordSetName(dnsRecord, rootDnsZone))
+                        .withAlias(dnsRecord.getTarget())
+                        .withTimeToLive(TTL_TIME)
+                        .attach()
+                        .apply();
+            }
+        }
+
+        return buildInstanceDNSRecord(dnsRecord.getDnsRecord(), dnsRecord.getTarget(),
+                InstanceDNSRecord.DNSRecordStatus.INSYNC);
+    }
+
+    private String extractRecordSetName(final InstanceDNSRecord dnsRecord, final DnsZone rootDnsZone) {
+        return dnsRecord.getDnsRecord().replace("." + rootDnsZone.name(), EMPTY);
+    }
+
+    public InstanceDNSRecord removeDNSRecord(final AzureRegion azureRegion,
+                                             final String hostedZoneId, final InstanceDNSRecord dnsRecord) {
+        log.info("Removing DNS record: {} for target: {} in hostedZoneId: {}",
+                dnsRecord.getDnsRecord(), dnsRecord.getTarget(), hostedZoneId);
+        final Azure azure = AzureHelper.buildClient(azureRegion.getAuthFile());
+        final DnsZone rootDnsZone = azure.dnsZones().getById(hostedZoneId);
+
+        if (isDnsRecordDoesntExist(dnsRecord, rootDnsZone)) {
+            log.info("DNS record: {} type: {} for target: {} in hostedZoneId: {} doesn't exists",
+                    dnsRecord.getDnsRecord(), aName(dnsRecord.getTarget()) ? "A" : "CNAME",
+                    dnsRecord.getTarget(), hostedZoneId);
+        } else {
+            if (aName(dnsRecord.getTarget())) {
+                rootDnsZone.update()
+                        .withoutARecordSet(extractRecordSetName(dnsRecord, rootDnsZone))
+                        .apply();
+            } else {
+                rootDnsZone.update()
+                        .withoutCNameRecordSet(extractRecordSetName(dnsRecord, rootDnsZone))
+                        .apply();
+            }
+        }
+        return buildInstanceDNSRecord(dnsRecord.getDnsRecord(), dnsRecord.getTarget(),
+                InstanceDNSRecord.DNSRecordStatus.INSYNC);
+
+    }
+
+    private boolean isDnsRecordDoesntExist(final InstanceDNSRecord dnsRecord, final DnsZone rootDnsZone) {
+        return rootDnsZone.listRecordSets(dnsRecord.getDnsRecord()).isEmpty();
+    }
+
+    private InstanceDNSRecord buildInstanceDNSRecord(final String dnsRecord,
+                                                     final String target,
+                                                     final InstanceDNSRecord.DNSRecordStatus status) {
+        return new InstanceDNSRecord(dnsRecord, target, status);
+    }
+
+    private InstanceDNSRecord.DNSRecordStatus getStatus(final String status) {
+        return InstanceDNSRecord.DNSRecordStatus.valueOf(status);
+    }
+
+    private static boolean aName(final String target) {
+        return target.matches("\\d+\\.\\d+\\.\\d+\\.\\d+");
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzureDNSZoneHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzureDNSZoneHelper.java
@@ -57,7 +57,7 @@ public class AzureDNSZoneHelper {
             }
         }
 
-        return buildInstanceDNSRecord(dnsRecord.getDnsRecord(), dnsRecord.getTarget(),
+        return new InstanceDNSRecord(dnsRecord.getDnsRecord(), dnsRecord.getTarget(),
                 InstanceDNSRecord.DNSRecordStatus.INSYNC);
     }
 
@@ -87,23 +87,13 @@ public class AzureDNSZoneHelper {
                         .apply();
             }
         }
-        return buildInstanceDNSRecord(dnsRecord.getDnsRecord(), dnsRecord.getTarget(),
+        return new InstanceDNSRecord(dnsRecord.getDnsRecord(), dnsRecord.getTarget(),
                 InstanceDNSRecord.DNSRecordStatus.INSYNC);
 
     }
 
     private boolean isDnsRecordDoesntExist(final InstanceDNSRecord dnsRecord, final DnsZone rootDnsZone) {
-        return rootDnsZone.listRecordSets(dnsRecord.getDnsRecord()).isEmpty();
-    }
-
-    private InstanceDNSRecord buildInstanceDNSRecord(final String dnsRecord,
-                                                     final String target,
-                                                     final InstanceDNSRecord.DNSRecordStatus status) {
-        return new InstanceDNSRecord(dnsRecord, target, status);
-    }
-
-    private InstanceDNSRecord.DNSRecordStatus getStatus(final String status) {
-        return InstanceDNSRecord.DNSRecordStatus.valueOf(status);
+        return rootDnsZone.listRecordSets(extractRecordSetName(dnsRecord, rootDnsZone)).isEmpty();
     }
 
     private static boolean aName(final String target) {

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzureInstanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzureInstanceService.java
@@ -285,7 +285,14 @@ public class AzureInstanceService implements CloudInstanceService<AzureRegion> {
 
     @Override
     public InstanceDNSRecord deleteInstanceDNSRecord(final AzureRegion cloudRegion, final InstanceDNSRecord dnsRecord) {
-        throw new UnsupportedOperationException("Deletion of DNS record doesn't work with Azure provider yet.");
+        if (dnsRecord.getDnsRecord().contains(
+                preferenceManager.getPreference(SystemPreferences.INSTANCE_DNS_HOSTED_ZONE_BASE))) {
+            return  dnsZoneHelper.removeDNSRecord(cloudRegion, preferenceManager.getPreference(
+                    SystemPreferences.INSTANCE_DNS_HOSTED_ZONE_ID), dnsRecord
+            );
+        } else {
+            return NO_OP_INSTANCE_DNS_RECORD;
+        }
     }
 
     private Map<String, String> buildScriptAzureEnvVars(final AzureRegion region) {

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPInstanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPInstanceService.java
@@ -215,12 +215,14 @@ public class GCPInstanceService implements CloudInstanceService<GCPRegion> {
     }
 
     @Override
-    public InstanceDNSRecord getOrCreateInstanceDNSRecord(final InstanceDNSRecord dnsRecord) {
+    public InstanceDNSRecord getOrCreateInstanceDNSRecord(final GCPRegion cloudRegion,
+                                                          final InstanceDNSRecord dnsRecord) {
         throw new UnsupportedOperationException("Creation of DNS record doesn't work with GCP provider yet.");
     }
 
     @Override
-    public InstanceDNSRecord deleteInstanceDNSRecord(final InstanceDNSRecord dnsRecord) {
+    public InstanceDNSRecord deleteInstanceDNSRecord(final GCPRegion cloudRegion,
+                                                     final InstanceDNSRecord dnsRecord) {
         throw new UnsupportedOperationException("Deletion of DNS record doesn't work with GCP provider yet.");
     }
 


### PR DESCRIPTION
Issue #1745 
Add realization of `getOrCreateInstanceDNSRecord` `deleteInstanceDNSRecord` for `AzureInstanceService` class, to be able to use custom DNS functionality with Azure cloud provider