### PR TITLE
Issue 1713: Seamless authentication in AWS - fix for API

### DIFF
--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -581,7 +581,6 @@ public final class MessageConstants {
     public static final String ERROR_PROFILE_ID_NOT_FOUND = "error.profile.id.not.found";
     public static final String ERROR_PROFILE_HAS_LINKS = "error.profile.has.links";
     public static final String ERROR_PROFILE_ASSUMED_ROLE_NOT_FOUND = "error.profile.assumed.role.not.found";
-    public static final String ERROR_PROFILE_POLICY_NOT_FOUND = "error.profile.policy.not.found";
     public static final String ERROR_PROFILE_NAME_NOT_FOUND = "error.profile.name.not.found";
 
     private MessageConstants() {

--- a/api/src/main/java/com/epam/pipeline/controller/cloud/credentials/CloudProfileCredentialsController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/cloud/credentials/CloudProfileCredentialsController.java
@@ -26,6 +26,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -37,6 +38,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -104,7 +106,8 @@ public class CloudProfileCredentialsController extends AbstractRestController {
             @RequestParam final Long sidId, @RequestParam final boolean principal,
             @RequestParam(required = false) final Set<Long> profileIds,
             @RequestParam(required = false) final Long defaultProfileId) {
-        return Result.success(cloudProfileCredentialsApiService.assignProfiles(sidId, principal, profileIds,
+        return Result.success(cloudProfileCredentialsApiService.assignProfiles(sidId, principal,
+                CollectionUtils.isEmpty(profileIds) ? new HashSet<>() : profileIds,
                 defaultProfileId));
     }
 

--- a/api/src/main/java/com/epam/pipeline/controller/cloud/credentials/CloudProfileCredentialsController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/cloud/credentials/CloudProfileCredentialsController.java
@@ -102,7 +102,8 @@ public class CloudProfileCredentialsController extends AbstractRestController {
     @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
     public Result<List<? extends AbstractCloudProfileCredentials>> assignProfiles(
             @RequestParam final Long sidId, @RequestParam final boolean principal,
-            @RequestParam final Set<Long> profileIds, @RequestParam(required = false) final Long defaultProfileId) {
+            @RequestParam(required = false) final Set<Long> profileIds,
+            @RequestParam(required = false) final Long defaultProfileId) {
         return Result.success(cloudProfileCredentialsApiService.assignProfiles(sidId, principal, profileIds,
                 defaultProfileId));
     }

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/credentials/CloudProfileCredentialsManagerProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/credentials/CloudProfileCredentialsManagerProvider.java
@@ -114,7 +114,7 @@ public class CloudProfileCredentialsManagerProvider {
     public List<? extends AbstractCloudProfileCredentials> assignProfiles(final Long sidId, final boolean principal,
                                                                           final Set<Long> profileIds,
                                                                           final Long defaultProfileId) {
-        if (CollectionUtils.isNotEmpty(profileIds) && Objects.nonNull(defaultProfileId)) {
+        if (Objects.nonNull(defaultProfileId)) {
             profileIds.add(defaultProfileId);
         }
         final List<CloudProfileCredentialsEntity> profiles = SetUtils.emptyIfNull(profileIds).stream()

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/credentials/CloudProfileCredentialsManagerProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/credentials/CloudProfileCredentialsManagerProvider.java
@@ -33,6 +33,7 @@ import com.epam.pipeline.repository.user.PipelineUserRepository;
 import com.epam.pipeline.utils.CommonUtils;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.collections4.SetUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
@@ -113,10 +114,10 @@ public class CloudProfileCredentialsManagerProvider {
     public List<? extends AbstractCloudProfileCredentials> assignProfiles(final Long sidId, final boolean principal,
                                                                           final Set<Long> profileIds,
                                                                           final Long defaultProfileId) {
-        if (Objects.nonNull(defaultProfileId)) {
+        if (CollectionUtils.isNotEmpty(profileIds) && Objects.nonNull(defaultProfileId)) {
             profileIds.add(defaultProfileId);
         }
-        final List<CloudProfileCredentialsEntity> profiles = profileIds.stream()
+        final List<CloudProfileCredentialsEntity> profiles = SetUtils.emptyIfNull(profileIds).stream()
                 .map(this::findEntity)
                 .collect(Collectors.toList());
         if (principal) {

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/credentials/aws/AWSProfileCredentialsManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/credentials/aws/AWSProfileCredentialsManager.java
@@ -78,11 +78,10 @@ public class AWSProfileCredentialsManager implements CloudProfileCredentialsMana
         final Integer duration = preferenceManager.getPreference(SystemPreferences.PROFILE_TEMP_CREDENTIALS_DURATION);
 
         final String role = credentials.getAssumedRole();
-        final String profile = credentials.getProfileName();
         final String policy = credentials.getPolicy();
         final String regionCode = getRegionCode(region);
 
-        return AWSUtils.generate(duration, policy, role, profile, regionCode);
+        return AWSUtils.generate(duration, policy, role, null, regionCode);
     }
 
     private AWSProfileCredentialsEntity findEntity(final Long id) {
@@ -94,8 +93,6 @@ public class AWSProfileCredentialsManager implements CloudProfileCredentialsMana
     private void validateProfileCredentials(final AWSProfileCredentials credentials) {
         Assert.state(StringUtils.isNotBlank(credentials.getAssumedRole()),
                 messageHelper.getMessage(MessageConstants.ERROR_PROFILE_ASSUMED_ROLE_NOT_FOUND));
-        Assert.state(StringUtils.isNotBlank(credentials.getPolicy()),
-                messageHelper.getMessage(MessageConstants.ERROR_PROFILE_POLICY_NOT_FOUND));
         Assert.state(StringUtils.isNotBlank(credentials.getProfileName()),
                 messageHelper.getMessage(MessageConstants.ERROR_PROFILE_NAME_NOT_FOUND));
     }

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -544,5 +544,4 @@ user.import.event.metadata.assigned=A new metadata ''{0}''=''{1}'' added to user
 error.profile.id.not.found=Profile credentials with id ''{0}'' wasn't found.
 error.profile.has.links=Profile credentials ''{0}'' have links to user or role and cannot be deleted.
 error.profile.assumed.role.not.found=Assumed role shall be specified.
-error.profile.policy.not.found=Policy shall be specified.
 error.profile.name.not.found=Profile name shall be specified


### PR DESCRIPTION
The current PR provides fixes for API part for issue #1713

Contains the following changes:
- `policy` is not required (set `null` to inherit role policy)
- fixed user profiles removing 