### PR TITLE
API method to load attributes for a specific tool version

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/docker/ToolApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/docker/ToolApiService.java
@@ -185,11 +185,10 @@ public class ToolApiService {
         return toolManager.loadToolVersionAttributes(id, version);
     }
 
-    @PreAuthorize(AclExpressions.ADMIN_ONLY + AclExpressions.OR +
-            "hasPermission(#toolId, 'com.epam.pipeline.entity.pipeline.Tool', 'WRITE')")
-    public ToolVersion createToolVersionSettings(final Long toolId, final String version,
+    @PreAuthorize(AclExpressions.TOOL_WRITE)
+    public ToolVersion createToolVersionSettings(final Long id, final String version,
                                                  final List<ConfigurationEntry> settings) {
-        return toolVersionManager.createToolVersionSettings(toolId, version, settings);
+        return toolVersionManager.createToolVersionSettings(id, version, settings);
     }
 
     @PreAuthorize(AclExpressions.TOOL_READ)

--- a/api/src/main/java/com/epam/pipeline/acl/docker/ToolApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/docker/ToolApiService.java
@@ -21,6 +21,7 @@ import com.epam.pipeline.entity.docker.ImageDescription;
 import com.epam.pipeline.entity.docker.ImageHistoryLayer;
 import com.epam.pipeline.entity.docker.ToolDescription;
 import com.epam.pipeline.entity.docker.ToolVersion;
+import com.epam.pipeline.entity.docker.ToolVersionAttributes;
 import com.epam.pipeline.entity.pipeline.Tool;
 import com.epam.pipeline.entity.scan.ToolScanPolicy;
 import com.epam.pipeline.entity.scan.ToolScanResult;
@@ -159,41 +160,41 @@ public class ToolApiService {
         return toolScanManager.getPolicy();
     }
 
-    @PreAuthorize(AclExpressions.ADMIN_ONLY +
-            "OR hasPermission(#toolId, 'com.epam.pipeline.entity.pipeline.Tool', 'WRITE')")
-    public long updateToolIcon(long toolId, String fileName, byte[] image) {
-        return toolManager.updateToolIcon(toolId, fileName, image);
+    @PreAuthorize(AclExpressions.TOOL_WRITE)
+    public long updateToolIcon(long id, String fileName, byte[] image) {
+        return toolManager.updateToolIcon(id, fileName, image);
     }
 
-    @PreAuthorize(AclExpressions.ADMIN_ONLY +
-            "OR hasPermission(#toolId, 'com.epam.pipeline.entity.pipeline.Tool', 'WRITE')")
-    public void deleteToolIcon(long toolId) {
-        toolManager.deleteToolIcon(toolId);
+    @PreAuthorize(AclExpressions.TOOL_WRITE)
+    public void deleteToolIcon(long id) {
+        toolManager.deleteToolIcon(id);
     }
 
-    @PreAuthorize(AclExpressions.ADMIN_ONLY +
-            "OR hasPermission(#toolId, 'com.epam.pipeline.entity.pipeline.Tool', 'READ')")
-    public Pair<String, InputStream> loadToolIcon(long toolId) {
-        return toolManager.loadToolIcon(toolId);
+    @PreAuthorize(AclExpressions.TOOL_READ)
+    public Pair<String, InputStream> loadToolIcon(long id) {
+        return toolManager.loadToolIcon(id);
     }
 
-    @PreAuthorize(AclExpressions.ADMIN_ONLY +
-            "OR hasPermission(#toolId, 'com.epam.pipeline.entity.pipeline.Tool', 'READ')")
-    public ToolDescription loadToolAttributes(Long toolId) {
-        return toolManager.loadToolAttributes(toolId);
+    @PreAuthorize(AclExpressions.TOOL_READ)
+    public ToolDescription loadToolAttributes(Long id) {
+        return toolManager.loadToolAttributes(id);
     }
 
-    @PreAuthorize(AclExpressions.ADMIN_ONLY +
-            "OR hasPermission(#toolId, 'com.epam.pipeline.entity.pipeline.Tool', 'WRITE')")
+    @PreAuthorize(AclExpressions.TOOL_READ)
+    public ToolVersionAttributes loadToolVersionAttributes(final Long id, final String version) {
+        return toolManager.loadToolVersionAttributes(id, version);
+    }
+
+    @PreAuthorize(AclExpressions.ADMIN_ONLY + AclExpressions.OR +
+            "hasPermission(#toolId, 'com.epam.pipeline.entity.pipeline.Tool', 'WRITE')")
     public ToolVersion createToolVersionSettings(final Long toolId, final String version,
                                                  final List<ConfigurationEntry> settings) {
         return toolVersionManager.createToolVersionSettings(toolId, version, settings);
     }
 
-    @PreAuthorize(AclExpressions.ADMIN_ONLY +
-            "OR hasPermission(#toolId, 'com.epam.pipeline.entity.pipeline.Tool', 'READ')")
-    public List<ToolVersion> loadToolVersionSettings(final Long toolId, final String version) {
-        return toolVersionManager.loadToolVersionSettings(toolId, version);
+    @PreAuthorize(AclExpressions.TOOL_READ)
+    public List<ToolVersion> loadToolVersionSettings(final Long id, final String version) {
+        return toolVersionManager.loadToolVersionSettings(id, version);
     }
 
     @PreAuthorize(AclExpressions.ADMIN_ONLY +

--- a/api/src/main/java/com/epam/pipeline/controller/docker/ToolController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/docker/ToolController.java
@@ -23,6 +23,7 @@ import com.epam.pipeline.entity.docker.ImageDescription;
 import com.epam.pipeline.entity.docker.ImageHistoryLayer;
 import com.epam.pipeline.entity.docker.ToolDescription;
 import com.epam.pipeline.entity.docker.ToolVersion;
+import com.epam.pipeline.entity.docker.ToolVersionAttributes;
 import com.epam.pipeline.entity.pipeline.Tool;
 import com.epam.pipeline.entity.scan.ToolScanPolicy;
 import com.epam.pipeline.entity.scan.ToolScanResultView;
@@ -68,6 +69,7 @@ public class ToolController extends AbstractRestController {
     public static final String LABELS_PARAM = "labels";
     private static final Set<String> ALLOWED_ICON_EXTENSIONS = new HashSet<>(
         Arrays.asList("jpg", "jpeg", "png", "gif"));
+    private static final String VERSION = "version";
 
     @Autowired
     private ToolApiService toolApiService;
@@ -145,7 +147,7 @@ public class ToolController extends AbstractRestController {
             })
     public Result<Tool> deleteTool(@RequestParam(required = false, value = REGISTRY_PARAM) final String registry,
                                    @RequestParam(value = IMAGE_PARAM) final String image,
-                                   @RequestParam(value = "version", required = false) final String version,
+                                   @RequestParam(value = VERSION, required = false) final String version,
                                    @RequestParam(value = "hard", defaultValue = "false") boolean hard) {
         if (version == null) {
             return Result.success(toolApiService.delete(registry, image, hard));
@@ -191,7 +193,7 @@ public class ToolController extends AbstractRestController {
         value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
         })
     public Result<List<ImageHistoryLayer>> loadImageHistory(@PathVariable final Long id,
-                                                            @RequestParam(value = "version") final String version) {
+                                                            @RequestParam(value = VERSION) final String version) {
         return Result.success(toolApiService.getImageHistory(id, version));
     }
 
@@ -205,7 +207,7 @@ public class ToolController extends AbstractRestController {
         value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
         })
     public Result<String> loadDefaultImageCmd(@PathVariable final Long id,
-                                              @RequestParam(value = "version") final String version) {
+                                              @RequestParam(value = VERSION) final String version) {
         return Result.success(toolApiService.getImageDefaultCommand(id, version));
     }
 
@@ -273,14 +275,28 @@ public class ToolController extends AbstractRestController {
     @GetMapping(value = "/tool/{toolId}/attributes")
     @ResponseBody
     @ApiOperation(
-            value = "Loads tool attributes for each tool version, specified by tool ID.",
-            notes = "Loads tool attributes for each tool version, specified by tool ID.",
+            value = "Loads tool attributes for all tool versions, specified by tool ID.",
+            notes = "Loads tool attributes for all tool versions, specified by tool ID.",
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiResponses(
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
             })
     public Result<ToolDescription> loadToolAttributes(@PathVariable Long toolId) {
         return Result.success(toolApiService.loadToolAttributes(toolId));
+    }
+
+    @GetMapping(value = "/tool/{toolId}/attributes", params = VERSION)
+    @ResponseBody
+    @ApiOperation(
+            value = "Loads tool attributes for a tool version, specified by tool ID.",
+            notes = "Loads tool attributes for a tool version, specified by tool ID.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public Result<ToolVersionAttributes> loadToolVersionAttributes(@PathVariable final Long toolId,
+                                                                   @RequestParam final String version) {
+        return Result.success(toolApiService.loadToolVersionAttributes(toolId, version));
     }
 
     @PostMapping(value = "/tool/{toolId}/settings")

--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerRegistryManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerRegistryManager.java
@@ -619,10 +619,8 @@ public class DockerRegistryManager implements SecuredEntityManager {
         if (registry.isPipelineAuth()) {
             List<DockerRegistryClaim> claims = claim == null ? Collections.emptyList() :
                     Collections.singletonList(claim);
-//            token = dockerAuthService.issueDockerToken(
-//                    authManager.getUserContext(), registry.getPath(), claims).getToken();
             token = dockerAuthService.issueDockerToken(
-                    authManager.getUserContext(), registry.getExternalUrl(), claims).getToken();
+                    authManager.getUserContext(), registry.getPath(), claims).getToken();
         }
         return token;
     }

--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerRegistryManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerRegistryManager.java
@@ -619,8 +619,10 @@ public class DockerRegistryManager implements SecuredEntityManager {
         if (registry.isPipelineAuth()) {
             List<DockerRegistryClaim> claims = claim == null ? Collections.emptyList() :
                     Collections.singletonList(claim);
+//            token = dockerAuthService.issueDockerToken(
+//                    authManager.getUserContext(), registry.getPath(), claims).getToken();
             token = dockerAuthService.issueDockerToken(
-                    authManager.getUserContext(), registry.getPath(), claims).getToken();
+                    authManager.getUserContext(), registry.getExternalUrl(), claims).getToken();
         }
         return token;
     }

--- a/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
+++ b/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
@@ -18,8 +18,8 @@ package com.epam.pipeline.security.acl;
 
 public final class AclExpressions {
 
-    private static final String OR = " OR ";
-    private static final String AND = " AND ";
+    public static final String OR = " OR ";
+    public static final String AND = " AND ";
 
     public static final String ADMIN_ONLY = "hasRole('ADMIN')";
 
@@ -125,6 +125,9 @@ public final class AclExpressions {
 
     public static final String TOOL_READ = ADMIN_ONLY + OR +
             "hasPermission(#id, 'com.epam.pipeline.entity.pipeline.Tool', 'READ')";
+
+    public static final String TOOL_WRITE = ADMIN_ONLY + OR +
+            "hasPermission(#id, 'com.epam.pipeline.entity.pipeline.Tool', 'WRITE')";
 
     public static final String OR_HAS_ASSIGNED_USER_OR_ROLE =
             " OR @grantPermissionManager.hasCloudProfilePermissions(#profileId)";


### PR DESCRIPTION
This PR is related to #1811. It adds an API method to get attributes (dependencies, vulnerabilities) for a specific tool version. If API method `/tool/{toolId}/attributes` is called with `version` parameter, e.g. `GET /tool/123/attributes?version=latest`, it will return results for the specified version only instead of returning data for all tool versions.