### PR TITLE
issue 1792 fix for DIND

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/execution/PipelineExecutor.java
+++ b/api/src/main/java/com/epam/pipeline/manager/execution/PipelineExecutor.java
@@ -78,10 +78,6 @@ public class PipelineExecutor {
             .name("host-cgroups")
             .hostPath("/sys/fs/cgroup")
             .mountPath("/sys/fs/cgroup").build();
-    private static final DockerMount HOST_SYS_MOUNT = DockerMount.builder()
-            .name("sys")
-            .hostPath("/sys")
-            .mountPath("/sys").build();
     private static final String DOMAIN_DELIMITER = "@";
 
     private final PreferenceManager preferenceManager;
@@ -267,7 +263,6 @@ public class PipelineExecutor {
         volumes.add(createVolume(REF_DATA_MOUNT, "/ebs/reference"));
         volumes.add(createVolume(RUNS_DATA_MOUNT, "/ebs/runs"));
         volumes.add(createEmptyVolume(EMPTY_MOUNT, "Memory"));
-        volumes.add(createVolume(HOST_SYS_MOUNT.getName(), HOST_SYS_MOUNT.getMountPath()));
         final List<DockerMount> dockerMounts = preferenceManager.getPreference(
                 SystemPreferences.DOCKER_IN_DOCKER_MOUNTS);
         if (isDockerInDockerEnabled &&
@@ -285,7 +280,6 @@ public class PipelineExecutor {
         mounts.add(getVolumeMount(REF_DATA_MOUNT, "/common"));
         mounts.add(getVolumeMount(RUNS_DATA_MOUNT, "/runs"));
         mounts.add(getVolumeMount(EMPTY_MOUNT, "/dev/shm"));
-        mounts.add(getVolumeMount(HOST_SYS_MOUNT.getName(), HOST_SYS_MOUNT.getMountPath()));
         final List<DockerMount> dockerMounts = preferenceManager.getPreference(
                 SystemPreferences.DOCKER_IN_DOCKER_MOUNTS);
         if (isDockerInDockerEnabled &&

--- a/scripts/pipeline-launch/launch.sh
+++ b/scripts/pipeline-launch/launch.sh
@@ -603,6 +603,7 @@ function add_self_to_no_proxy() {
 }
 
 function configureHyperThreading() {
+    mount -o rw,remount /sys
     if [ "${CP_DISABLE_HYPER_THREADING:-false}" == 'true' ]; then
       _current_processor=-1
       declare -a used_cores


### PR DESCRIPTION
This PR changes the way of how to mount `sysfs` with `rw` option, now `sysfs` will be remounted during `launch.sh` instead of using kube mount option because of `DIND` functionality conflict 