### PR TITLE
Issue #1808 Escape unsupported special characters in search queries

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchRequestBuilder.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchRequestBuilder.java
@@ -69,6 +69,8 @@ public class SearchRequestBuilder {
     private static final String SIZE_FIELD = "size";
     private static final String NAME_FIELD = "id";
     private static final String ES_FILE_INDEX_PATTERN = "cp-%s-file-%d";
+    private static final Set<Character> UNSUPPORTED_SPECIAL_ES_QUERY_CHARACTERS =
+        new HashSet<>(Arrays.asList('\\', '!', ':', '^', '[', ']', '{', '}', '?', '&', '/'));
 
     private final PreferenceManager preferenceManager;
     private final AuthManager authManager;
@@ -271,8 +273,7 @@ public class SearchRequestBuilder {
         final StringBuilder sb = new StringBuilder();
         for (int i = 0; i < string.length(); i++) {
             final char c = string.charAt(i);
-            if (c == '\\' || c == '!' || c == ':' || c == '^' || c == '[' || c == ']' || c == '{' || c == '}'
-                || c == '?' || c == '&' || c == '/') {
+            if (UNSUPPORTED_SPECIAL_ES_QUERY_CHARACTERS.contains(c)) {
                 sb.append('\\');
             }
             sb.append(c);

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchRequestBuilder.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchRequestBuilder.java
@@ -184,7 +184,8 @@ public class SearchRequestBuilder {
     }
 
     private QueryBuilder getBasicQuery(final String searchQuery) {
-        QueryStringQueryBuilder query = QueryBuilders.queryStringQuery(searchQuery);
+        QueryStringQueryBuilder query = QueryBuilders
+            .queryStringQuery(escapeUnsupportedSpecialCharacters(searchQuery));
         ListUtils.emptyIfNull(preferenceManager.getPreference(SystemPreferences.SEARCH_ELASTIC_SEARCH_FIELDS))
                 .forEach(query::field);
         return query;
@@ -264,5 +265,18 @@ public class SearchRequestBuilder {
 
     private String buildKeywordName(final String fieldName) {
         return String.format("%s.keyword", fieldName);
+    }
+
+    private String escapeUnsupportedSpecialCharacters(final String string) {
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < string.length(); i++) {
+            final char c = string.charAt(i);
+            if (c == '\\' || c == '!' || c == ':' || c == '^' || c == '[' || c == ']' || c == '{' || c == '}'
+                || c == '?' || c == '&' || c == '/') {
+                sb.append('\\');
+            }
+            sb.append(c);
+        }
+        return sb.toString();
     }
 }


### PR DESCRIPTION
This PR is related to issue #1808.

The user is aware of 'Special expressions' of the Global Search and [characters](https://cloud-pipeline.com/release_notes/v.0.14/v.0.14_-_Release_notes/#global-search), which function as operators in a query.
But since not all the symbols are declared as supported, it would be convenient to automatically escape them to avoid search failures and side-effects.
From now, all the special symbols of the `QueryString` query, which are not described as an operator for Global Search, are escaped automatically.