### PR TITLE
New optimized method `/tool/{toolId}/info` to get aggregated vulnerability data

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/docker/ToolApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/docker/ToolApiService.java
@@ -33,10 +33,11 @@ import com.epam.pipeline.manager.docker.ToolVersionManager;
 import com.epam.pipeline.manager.docker.scan.ToolScanManager;
 import com.epam.pipeline.manager.docker.scan.ToolScanScheduler;
 import com.epam.pipeline.manager.pipeline.ToolManager;
+import com.epam.pipeline.manager.pipeline.ToolScanInfoManager;
 import com.epam.pipeline.manager.security.acl.AclMask;
 import com.epam.pipeline.security.acl.AclExpressions;
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.tuple.Pair;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PostAuthorize;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
@@ -47,19 +48,14 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class ToolApiService {
 
-    @Autowired
-    private ToolManager toolManager;
-
-    @Autowired
-    private ToolScanScheduler toolScanScheduler;
-
-    @Autowired
-    private ToolScanManager toolScanManager;
-
-    @Autowired
-    private ToolVersionManager toolVersionManager;
+    private final ToolManager toolManager;
+    private final ToolScanScheduler toolScanScheduler;
+    private final ToolScanManager toolScanManager;
+    private final ToolVersionManager toolVersionManager;
+    private final ToolScanInfoManager toolScanInfoManager;
 
     @PreAuthorize(AclExpressions.ADMIN_ONLY +
             "OR hasPermission(#tool.toolGroupId, 'com.epam.pipeline.entity.pipeline.ToolGroup', 'WRITE')")
@@ -178,6 +174,11 @@ public class ToolApiService {
     @PreAuthorize(AclExpressions.TOOL_READ)
     public ToolDescription loadToolAttributes(Long id) {
         return toolManager.loadToolAttributes(id);
+    }
+
+    @PreAuthorize(AclExpressions.TOOL_READ)
+    public ToolDescription loadToolInfo(Long id) {
+        return toolScanInfoManager.loadToolInfo(id);
     }
 
     @PreAuthorize(AclExpressions.TOOL_READ)

--- a/api/src/main/java/com/epam/pipeline/controller/docker/ToolController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/docker/ToolController.java
@@ -285,6 +285,19 @@ public class ToolController extends AbstractRestController {
         return Result.success(toolApiService.loadToolAttributes(toolId));
     }
 
+    @GetMapping(value = "/tool/{toolId}/info")
+    @ResponseBody
+    @ApiOperation(
+            value = "Loads tool and info for all its versions",
+            notes = "Loads tool and info for all its versions",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public Result<ToolDescription> loadToolInfo(@PathVariable Long toolId) {
+        return Result.success(toolApiService.loadToolInfo(toolId));
+    }
+
     @GetMapping(value = "/tool/{toolId}/attributes", params = VERSION)
     @ResponseBody
     @ApiOperation(

--- a/api/src/main/java/com/epam/pipeline/dao/tool/ToolVersionDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/tool/ToolVersionDao.java
@@ -34,7 +34,10 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class ToolVersionDao extends NamedParameterJdbcDaoSupport {
 
@@ -46,61 +49,12 @@ public class ToolVersionDao extends NamedParameterJdbcDaoSupport {
     private String loadToolVersionQuery;
     private String loadToolVersionSettingsQuery;
     private String loadToolSettingsQuery;
+    private String loadToolVersionListSettingsQuery;
     private String createToolVersionWithSettingsQuery;
     private String updateToolVersionWithSettingsQuery;
 
     @Autowired
     private DaoHelper daoHelper;
-
-    @Required
-    public void setToolVersionSequenceQuery(String toolVersionSequenceQuery) {
-        this.toolVersionSequenceQuery = toolVersionSequenceQuery;
-    }
-
-    @Required
-    public void setCreateToolVersionQuery(String createToolVersionQuery) {
-        this.createToolVersionQuery = createToolVersionQuery;
-    }
-
-    @Required
-    public void setUpdateToolVersionQuery(String updateToolVersionQuery) {
-        this.updateToolVersionQuery = updateToolVersionQuery;
-    }
-
-    @Required
-    public void setDeleteToolVersionsQuery(String deleteToolVersionsQuery) {
-        this.deleteToolVersionsQuery = deleteToolVersionsQuery;
-    }
-
-    @Required
-    public void setDeleteToolVersionQuery(String deleteToolVersionQuery) {
-        this.deleteToolVersionQuery = deleteToolVersionQuery;
-    }
-
-    @Required
-    public void setLoadToolVersionQuery(String loadToolVersionQuery) {
-        this.loadToolVersionQuery = loadToolVersionQuery;
-    }
-
-    @Required
-    public void setLoadToolVersionSettingsQuery(String loadToolVersionSettingsQuery) {
-        this.loadToolVersionSettingsQuery = loadToolVersionSettingsQuery;
-    }
-
-    @Required
-    public void setCreateToolVersionWithSettingsQuery(String createToolVersionWithSettingsQuery) {
-        this.createToolVersionWithSettingsQuery = createToolVersionWithSettingsQuery;
-    }
-
-    @Required
-    public void setUpdateToolVersionWithSettingsQuery(String updateToolVersionWithSettingsQuery) {
-        this.updateToolVersionWithSettingsQuery = updateToolVersionWithSettingsQuery;
-    }
-
-    @Required
-    public void setLoadToolSettingsQuery(final String loadToolSettingsQuery) {
-        this.loadToolSettingsQuery = loadToolSettingsQuery;
-    }
 
     @Transactional(propagation = Propagation.MANDATORY)
     public void createToolVersion(ToolVersion toolVersion) {
@@ -155,6 +109,16 @@ public class ToolVersionDao extends NamedParameterJdbcDaoSupport {
     public void updateToolVersionWithSettings(ToolVersion toolVersion) {
         getNamedParameterJdbcTemplate().update(updateToolVersionWithSettingsQuery,
                         ToolVersionParameters.getParametersWithSettings(toolVersion));
+    }
+
+    public Map<String, ToolVersion> loadToolVersions(final Long toolId, final List<String> versions) {
+        final MapSqlParameterSource params = new MapSqlParameterSource();
+        params.addValue(ToolVersionParameters.TOOL_ID.name(), toolId);
+        params.addValue("VERSIONS", versions);
+        return getNamedParameterJdbcTemplate()
+                .query(loadToolVersionListSettingsQuery, params, ToolVersionParameters.getRowMapper())
+                .stream()
+                .collect(Collectors.toMap(ToolVersion::getVersion, Function.identity()));
     }
 
     enum ToolVersionParameters {
@@ -219,5 +183,60 @@ public class ToolVersionDao extends NamedParameterJdbcDaoSupport {
         private static List<ConfigurationEntry> parseData(String data) {
             return JsonMapper.parseData(data, new TypeReference<List<ConfigurationEntry>>() {});
         }
+    }
+
+    @Required
+    public void setToolVersionSequenceQuery(String toolVersionSequenceQuery) {
+        this.toolVersionSequenceQuery = toolVersionSequenceQuery;
+    }
+
+    @Required
+    public void setCreateToolVersionQuery(String createToolVersionQuery) {
+        this.createToolVersionQuery = createToolVersionQuery;
+    }
+
+    @Required
+    public void setUpdateToolVersionQuery(String updateToolVersionQuery) {
+        this.updateToolVersionQuery = updateToolVersionQuery;
+    }
+
+    @Required
+    public void setDeleteToolVersionsQuery(String deleteToolVersionsQuery) {
+        this.deleteToolVersionsQuery = deleteToolVersionsQuery;
+    }
+
+    @Required
+    public void setDeleteToolVersionQuery(String deleteToolVersionQuery) {
+        this.deleteToolVersionQuery = deleteToolVersionQuery;
+    }
+
+    @Required
+    public void setLoadToolVersionQuery(String loadToolVersionQuery) {
+        this.loadToolVersionQuery = loadToolVersionQuery;
+    }
+
+    @Required
+    public void setLoadToolVersionSettingsQuery(String loadToolVersionSettingsQuery) {
+        this.loadToolVersionSettingsQuery = loadToolVersionSettingsQuery;
+    }
+
+    @Required
+    public void setCreateToolVersionWithSettingsQuery(String createToolVersionWithSettingsQuery) {
+        this.createToolVersionWithSettingsQuery = createToolVersionWithSettingsQuery;
+    }
+
+    @Required
+    public void setUpdateToolVersionWithSettingsQuery(String updateToolVersionWithSettingsQuery) {
+        this.updateToolVersionWithSettingsQuery = updateToolVersionWithSettingsQuery;
+    }
+
+    @Required
+    public void setLoadToolSettingsQuery(final String loadToolSettingsQuery) {
+        this.loadToolSettingsQuery = loadToolSettingsQuery;
+    }
+
+    @Required
+    public void setLoadToolVersionListSettingsQuery(final String loadToolVersionListSettingsQuery) {
+        this.loadToolVersionListSettingsQuery = loadToolVersionListSettingsQuery;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/tool/ToolVulnerabilityDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/tool/ToolVulnerabilityDao.java
@@ -23,16 +23,21 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import com.epam.pipeline.config.JsonMapper;
 import com.epam.pipeline.entity.pipeline.ToolScanStatus;
 import com.epam.pipeline.entity.scan.ToolDependency;
 import com.epam.pipeline.entity.scan.ToolOSVersion;
 import com.epam.pipeline.entity.scan.ToolVersionScanResult;
 import com.epam.pipeline.entity.scan.Vulnerability;
 import com.epam.pipeline.entity.scan.VulnerabilitySeverity;
+import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Required;
+import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcDaoSupport;
@@ -46,6 +51,7 @@ public class ToolVulnerabilityDao extends NamedParameterJdbcDaoSupport {
     private String loadVulnerabilitiesByToolAndVersionQuery;
     private String loadVulnerabilitiesByToolQuery;
     private String deleteVulnerabilitiesQuery;
+    private String loadVulnerabilityCountQuery;
 
     private String insertToolVersionScanQuery;
     private String updateToolVersionScanQuery;
@@ -53,6 +59,7 @@ public class ToolVulnerabilityDao extends NamedParameterJdbcDaoSupport {
     private String updateToolVersionScanWithSuccessQuery;
     private String loadToolVersionScanQuery;
     private String loadToolAllVersionScansQuery;
+    private String loadToolListVersionsScanQuery;
     private String deleteToolVersionScansQuery;
 
     private String insertToolDependencyQuery;
@@ -148,19 +155,21 @@ public class ToolVulnerabilityDao extends NamedParameterJdbcDaoSupport {
 
     @Transactional(propagation = Propagation.MANDATORY)
     public void insertToolVersionScan(long toolId, String version, ToolOSVersion toolOSVersion, String layerRef,
-                                      String digest, ToolScanStatus newStatus, Date scanDate) {
+                                      String digest, ToolScanStatus newStatus, Date scanDate,
+                                      Map<VulnerabilitySeverity, Integer> vulnerabilitiesCount) {
 
         MapSqlParameterSource params = ToolVulnerabilityColumns.getParams(
-                toolId, version, toolOSVersion, layerRef, digest, newStatus, scanDate, false
+                toolId, version, toolOSVersion, layerRef, digest, newStatus, scanDate, false, vulnerabilitiesCount
         );
         getNamedParameterJdbcTemplate().update(insertToolVersionScanQuery, params);
     }
 
     @Transactional(propagation = Propagation.MANDATORY)
     public void updateToolVersionScan(long toolId, String version, ToolOSVersion toolOSVersion, String layerRef,
-                                      String digest, ToolScanStatus newStatus, Date scanDate, boolean whiteList) {
+                                      String digest, ToolScanStatus newStatus, Date scanDate, boolean whiteList,
+                                      Map<VulnerabilitySeverity, Integer> vulnerabilitiesCount) {
         MapSqlParameterSource params = ToolVulnerabilityColumns.getParams(
-                toolId, version, toolOSVersion, layerRef, digest, newStatus, scanDate, whiteList
+                toolId, version, toolOSVersion, layerRef, digest, newStatus, scanDate, whiteList, vulnerabilitiesCount
         );
         if (newStatus == ToolScanStatus.COMPLETED) {
             getNamedParameterJdbcTemplate().update(updateToolVersionScanWithSuccessQuery, params);
@@ -206,6 +215,17 @@ public class ToolVulnerabilityDao extends NamedParameterJdbcDaoSupport {
         return optional;
     }
 
+    public Map<String, ToolVersionScanResult> loadToolVersionScanInfo(final long toolId,
+                                                                      final List<String> versions) {
+        final MapSqlParameterSource params = new MapSqlParameterSource();
+        params.addValue(ToolVersionColumns.TOOL_ID.name(), toolId);
+        params.addValue("VERSIONS", versions);
+        return getNamedParameterJdbcTemplate()
+                .query(loadToolListVersionsScanQuery, params, ToolVersionColumns.getRowMapper())
+                .stream()
+                .collect(Collectors.toMap(ToolVersionScanResult::getVersion, Function.identity()));
+    }
+
     public Map<String, ToolVersionScanResult> loadAllToolVersionScans(long toolId) {
         MapSqlParameterSource params = new MapSqlParameterSource();
         params.addValue(ToolVersionColumns.TOOL_ID.name(), toolId);
@@ -222,118 +242,23 @@ public class ToolVulnerabilityDao extends NamedParameterJdbcDaoSupport {
         return resultMap;
     }
 
-    private enum ToolVulnerabilityColumns {
-        TOOL_ID,
-        VERSION,
-        VULNERABILITY_NAME,
-        FEATURE,
-        FEATURE_VERSION,
-        DESCRIPTION,
-        LINK,
-        SEVERITY,
-        FIXED_BY,
-        CREATED_DATE;
-
-        private static MapSqlParameterSource getParams(Vulnerability vulnerability, long toolId, String version) {
-            MapSqlParameterSource params = new MapSqlParameterSource();
-            params.addValue(TOOL_ID.name(), toolId);
-            params.addValue(VERSION.name(), version);
-            params.addValue(VULNERABILITY_NAME.name(), vulnerability.getName());
-            params.addValue(FEATURE.name(), vulnerability.getFeature());
-            params.addValue(FEATURE_VERSION.name(), vulnerability.getFeatureVersion());
-            params.addValue(DESCRIPTION.name(), vulnerability.getDescription());
-            params.addValue(LINK.name(), vulnerability.getLink());
-            params.addValue(SEVERITY.name(), vulnerability.getSeverity().getCode());
-            params.addValue(FIXED_BY.name(), vulnerability.getFixedBy());
-            params.addValue(CREATED_DATE.name(), vulnerability.getCreatedDate());
-
-            return params;
-        }
-
-        private static MapSqlParameterSource getParams(long toolId, String version, ToolOSVersion toolOSVersion,
-                                                       String layerRef, String digest,
-                                                       ToolScanStatus newStatus, Date scanDate, boolean whiteList) {
-            MapSqlParameterSource params = new MapSqlParameterSource();
-            params.addValue(ToolVersionColumns.TOOL_ID.name(), toolId);
-            params.addValue(ToolVersionColumns.VERSION.name(), version);
-            params.addValue(ToolVersionColumns.LAYER_REFERENCE.name(), layerRef);
-            params.addValue(ToolVersionColumns.DIGEST.name(), digest);
-            params.addValue(ToolVersionColumns.SCAN_STATUS.name(), newStatus.getCode());
-            params.addValue(ToolVersionColumns.SCAN_DATE.name(), scanDate);
-            params.addValue(ToolVersionColumns.SUCCESS_SCAN_DATE.name(),
-                            newStatus == ToolScanStatus.COMPLETED ? scanDate : null);
-            params.addValue(ToolVersionColumns.WHITE_LIST.name(), whiteList);
-            params.addValue(ToolVersionColumns.OS_NAME.name(),
-                    Optional.ofNullable(toolOSVersion).map(ToolOSVersion::getDistribution).orElse(null));
-            params.addValue(ToolVersionColumns.OS_VERSION.name(),
-                    Optional.ofNullable(toolOSVersion).map(ToolOSVersion::getVersion).orElse(null));
-            return params;
-        }
-
-        private static RowMapper<Vulnerability> getRowMapper() {
-            return (rs, rowNum) -> {
-                Vulnerability vulnerability = new Vulnerability();
-
-                vulnerability.setName(rs.getString(VULNERABILITY_NAME.name()));
-                vulnerability.setFeature(rs.getString(FEATURE.name()));
-                vulnerability.setFeatureVersion(rs.getString(FEATURE_VERSION.name()));
-                vulnerability.setDescription(rs.getString(DESCRIPTION.name()));
-                vulnerability.setLink(rs.getString(LINK.name()));
-                vulnerability.setSeverity(VulnerabilitySeverity.getByCode(rs.getInt(SEVERITY.name())));
-                vulnerability.setFixedBy(rs.getString(FIXED_BY.name()));
-                vulnerability.setCreatedDate(new Date(rs.getTimestamp(CREATED_DATE.name()).getTime()));
-
-                return vulnerability;
-            };
-        }
-
+    public Map<String, Map<VulnerabilitySeverity, Integer>> loadVulnerabilityCount(final Long toolId,
+                                                                                   final List<String> versions) {
+        final MapSqlParameterSource params = new MapSqlParameterSource();
+        params.addValue(ToolVersionColumns.TOOL_ID.name(), toolId);
+        params.addValue("VERSIONS", versions);
+        return getNamedParameterJdbcTemplate()
+                .query(loadVulnerabilityCountQuery, params, ToolVulnerabilityColumns.getCountResultExtractor());
     }
-    private enum ToolVersionColumns {
-        TOOL_ID,
-        VERSION,
-        LAYER_REFERENCE,
-        DIGEST,
-        SCAN_STATUS,
-        SCAN_DATE,
-        SUCCESS_SCAN_DATE,
-        WHITE_LIST,
-        OS_NAME,
-        OS_VERSION;
 
-        private static RowMapper<ToolVersionScanResult> getRowMapper() {
-            return (rs, rowNum) -> {
-                ToolVersionScanResult versionScan = new ToolVersionScanResult();
-                versionScan.setToolId(rs.getLong(ToolVersionColumns.TOOL_ID.name()));
-                versionScan.setVersion(rs.getString(ToolVersionColumns.VERSION.name()));
-                versionScan.setLastLayerRef(rs.getString(ToolVersionColumns.LAYER_REFERENCE.name()));
-                versionScan.setDigest(rs.getString(ToolVersionColumns.DIGEST.name()));
-                versionScan.setFromWhiteList(rs.getBoolean(ToolVersionColumns.WHITE_LIST.name()));
+    @Required
+    public void setLoadToolListVersionsScanQuery(final String loadToolListVersionsScanQuery) {
+        this.loadToolListVersionsScanQuery = loadToolListVersionsScanQuery;
+    }
 
-                Timestamp timestamp = rs.getTimestamp(ToolVersionColumns.SCAN_DATE.name());
-                if (!rs.wasNull()) {
-                    versionScan.setScanDate(new Date(timestamp.getTime()));
-                }
-
-                timestamp = rs.getTimestamp(ToolVersionColumns.SUCCESS_SCAN_DATE.name());
-                if (!rs.wasNull()) {
-                    versionScan.setSuccessScanDate(new Date(timestamp.getTime()));
-                }
-
-                int statusCode = rs.getInt(ToolVersionColumns.SCAN_STATUS.name());
-                if (!rs.wasNull()) {
-                    ToolScanStatus status = ToolScanStatus.getByCode(statusCode);
-                    versionScan.setStatus(status);
-                }
-
-                String osVersion = rs.getString(ToolVersionColumns.OS_VERSION.name());
-                String osName = rs.getString(ToolVersionColumns.OS_NAME.name());
-                if (!rs.wasNull()) {
-                    versionScan.setToolOSVersion(new ToolOSVersion(osName, osVersion));
-                }
-                return versionScan;
-            };
-        }
-
+    @Required
+    public void setLoadVulnerabilityCountQuery(final String loadVulnerabilityCountQuery) {
+        this.loadVulnerabilityCountQuery = loadVulnerabilityCountQuery;
     }
     private enum ToolDependencyColumns {
         TOOL_ID,
@@ -452,5 +377,147 @@ public class ToolVulnerabilityDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setUpdateWhiteListWithToolVersionQuery(String updateWhiteListWithToolVersionQuery) {
         this.updateWhiteListWithToolVersionQuery = updateWhiteListWithToolVersionQuery;
+    }
+
+    private enum ToolVulnerabilityColumns {
+        TOOL_ID,
+        VERSION,
+        VULNERABILITY_NAME,
+        FEATURE,
+        FEATURE_VERSION,
+        DESCRIPTION,
+        LINK,
+        SEVERITY,
+        FIXED_BY,
+        CREATED_DATE,
+        COUNT;
+
+        private static MapSqlParameterSource getParams(Vulnerability vulnerability, long toolId, String version) {
+            MapSqlParameterSource params = new MapSqlParameterSource();
+            params.addValue(TOOL_ID.name(), toolId);
+            params.addValue(VERSION.name(), version);
+            params.addValue(VULNERABILITY_NAME.name(), vulnerability.getName());
+            params.addValue(FEATURE.name(), vulnerability.getFeature());
+            params.addValue(FEATURE_VERSION.name(), vulnerability.getFeatureVersion());
+            params.addValue(DESCRIPTION.name(), vulnerability.getDescription());
+            params.addValue(LINK.name(), vulnerability.getLink());
+            params.addValue(SEVERITY.name(), vulnerability.getSeverity().getCode());
+            params.addValue(FIXED_BY.name(), vulnerability.getFixedBy());
+            params.addValue(CREATED_DATE.name(), vulnerability.getCreatedDate());
+
+            return params;
+        }
+
+        private static MapSqlParameterSource getParams(final long toolId, final String version,
+                                                       final ToolOSVersion toolOSVersion, final String layerRef,
+                                                       final String digest, final ToolScanStatus newStatus,
+                                                       final Date scanDate, final boolean whiteList,
+                                                       final Map<VulnerabilitySeverity, Integer> vulnerabilitiesCount) {
+            MapSqlParameterSource params = new MapSqlParameterSource();
+            params.addValue(ToolVersionColumns.TOOL_ID.name(), toolId);
+            params.addValue(ToolVersionColumns.VERSION.name(), version);
+            params.addValue(ToolVersionColumns.LAYER_REFERENCE.name(), layerRef);
+            params.addValue(ToolVersionColumns.DIGEST.name(), digest);
+            params.addValue(ToolVersionColumns.SCAN_STATUS.name(), newStatus.getCode());
+            params.addValue(ToolVersionColumns.SCAN_DATE.name(), scanDate);
+            params.addValue(ToolVersionColumns.SUCCESS_SCAN_DATE.name(),
+                            newStatus == ToolScanStatus.COMPLETED ? scanDate : null);
+            params.addValue(ToolVersionColumns.WHITE_LIST.name(), whiteList);
+            params.addValue(ToolVersionColumns.OS_NAME.name(),
+                    Optional.ofNullable(toolOSVersion).map(ToolOSVersion::getDistribution).orElse(null));
+            params.addValue(ToolVersionColumns.OS_VERSION.name(),
+                    Optional.ofNullable(toolOSVersion).map(ToolOSVersion::getVersion).orElse(null));
+            params.addValue(ToolVersionColumns.VULNERABILITIES_COUNT.name(),
+                    Optional.ofNullable(vulnerabilitiesCount)
+                            .map(count -> JsonMapper.convertDataToJsonStringForQuery(vulnerabilitiesCount))
+                            .orElse(null));
+            return params;
+        }
+
+        private static RowMapper<Vulnerability> getRowMapper() {
+            return (rs, rowNum) -> {
+                Vulnerability vulnerability = new Vulnerability();
+
+                vulnerability.setName(rs.getString(VULNERABILITY_NAME.name()));
+                vulnerability.setFeature(rs.getString(FEATURE.name()));
+                vulnerability.setFeatureVersion(rs.getString(FEATURE_VERSION.name()));
+                vulnerability.setDescription(rs.getString(DESCRIPTION.name()));
+                vulnerability.setLink(rs.getString(LINK.name()));
+                vulnerability.setSeverity(VulnerabilitySeverity.getByCode(rs.getInt(SEVERITY.name())));
+                vulnerability.setFixedBy(rs.getString(FIXED_BY.name()));
+                vulnerability.setCreatedDate(new Date(rs.getTimestamp(CREATED_DATE.name()).getTime()));
+
+                return vulnerability;
+            };
+        }
+
+        private static ResultSetExtractor<Map<String, Map<VulnerabilitySeverity, Integer>>> getCountResultExtractor() {
+            return rs -> {
+                final Map<String, Map<VulnerabilitySeverity, Integer>> result = new HashMap<>();
+                while (rs.next()) {
+                    final String version = rs.getString(VERSION.name());
+                    result.putIfAbsent(version, new HashMap<>());
+                    final VulnerabilitySeverity severity = VulnerabilitySeverity.getByCode(rs.getInt(SEVERITY.name()));
+                    final Integer count = rs.getInt(COUNT.name());
+                    result.get(version).put(severity, count);
+                }
+                return result;
+            };
+        }
+
+    }
+
+    private enum ToolVersionColumns {
+        TOOL_ID,
+        VERSION,
+        LAYER_REFERENCE,
+        DIGEST,
+        SCAN_STATUS,
+        SCAN_DATE,
+        SUCCESS_SCAN_DATE,
+        WHITE_LIST,
+        OS_NAME,
+        OS_VERSION,
+        VULNERABILITIES_COUNT;
+
+        private static RowMapper<ToolVersionScanResult> getRowMapper() {
+            return (rs, rowNum) -> {
+                ToolVersionScanResult versionScan = new ToolVersionScanResult();
+                versionScan.setToolId(rs.getLong(ToolVersionColumns.TOOL_ID.name()));
+                versionScan.setVersion(rs.getString(ToolVersionColumns.VERSION.name()));
+                versionScan.setLastLayerRef(rs.getString(ToolVersionColumns.LAYER_REFERENCE.name()));
+                versionScan.setDigest(rs.getString(ToolVersionColumns.DIGEST.name()));
+                versionScan.setFromWhiteList(rs.getBoolean(ToolVersionColumns.WHITE_LIST.name()));
+
+                Timestamp timestamp = rs.getTimestamp(ToolVersionColumns.SCAN_DATE.name());
+                if (!rs.wasNull()) {
+                    versionScan.setScanDate(new Date(timestamp.getTime()));
+                }
+
+                timestamp = rs.getTimestamp(ToolVersionColumns.SUCCESS_SCAN_DATE.name());
+                if (!rs.wasNull()) {
+                    versionScan.setSuccessScanDate(new Date(timestamp.getTime()));
+                }
+
+                int statusCode = rs.getInt(ToolVersionColumns.SCAN_STATUS.name());
+                if (!rs.wasNull()) {
+                    ToolScanStatus status = ToolScanStatus.getByCode(statusCode);
+                    versionScan.setStatus(status);
+                }
+
+                String osVersion = rs.getString(ToolVersionColumns.OS_VERSION.name());
+                String osName = rs.getString(ToolVersionColumns.OS_NAME.name());
+                if (!rs.wasNull()) {
+                    versionScan.setToolOSVersion(new ToolOSVersion(osName, osVersion));
+                }
+                final String vulnerabilitiesCount = rs.getString(VULNERABILITIES_COUNT.name());
+                if (StringUtils.isNotBlank(vulnerabilitiesCount)) {
+                    versionScan.setVulnerabilitiesCount(JsonMapper.parseData(vulnerabilitiesCount,
+                            new TypeReference<Map<VulnerabilitySeverity, Integer>>() {}));
+                }
+                return versionScan;
+            };
+        }
+
     }
 }

--- a/api/src/main/java/com/epam/pipeline/entity/scan/ToolVersionScanResult.java
+++ b/api/src/main/java/com/epam/pipeline/entity/scan/ToolVersionScanResult.java
@@ -26,7 +26,9 @@ import lombok.Setter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Getter
 @Setter
@@ -45,6 +47,7 @@ public class ToolVersionScanResult {
     private boolean isAllowedToExecute;
     private boolean fromWhiteList;
     private Date gracePeriod;
+    private Map<VulnerabilitySeverity, Integer> vulnerabilitiesCount = new HashMap<>();
 
     @JsonIgnore
     private String lastLayerRef;

--- a/api/src/main/java/com/epam/pipeline/entity/scan/ToolVersionScanResultView.java
+++ b/api/src/main/java/com/epam/pipeline/entity/scan/ToolVersionScanResultView.java
@@ -23,6 +23,8 @@ import lombok.Getter;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 @Getter
 @Builder
@@ -40,22 +42,24 @@ public class ToolVersionScanResultView {
     private boolean isAllowedToExecute;
     private boolean fromWhiteList;
     private Date gracePeriod;
+    private Map<VulnerabilitySeverity, Integer> vulnerabilitiesCount;
 
     public static ToolVersionScanResultView from(final ToolVersionScanResult scanResult, final boolean isOSAllowed) {
-        return scanResult != null
-                ? ToolVersionScanResultView.builder()
-                    .toolId(scanResult.getToolId())
-                    .version(scanResult.getVersion())
-                    .toolOSVersion(ToolOSVersionView.from(scanResult.getToolOSVersion(), isOSAllowed))
-                    .status(scanResult.getStatus())
-                    .scanDate(scanResult.getScanDate())
-                    .successScanDate(scanResult.getSuccessScanDate())
-                    .vulnerabilities(scanResult.getVulnerabilities())
-                    .dependencies(scanResult.getDependencies())
-                    .isAllowedToExecute(scanResult.isAllowedToExecute())
-                    .fromWhiteList(scanResult.isFromWhiteList())
-                    .gracePeriod(scanResult.getGracePeriod()).build()
-                : null;
+        return Optional.ofNullable(scanResult).map(scan ->
+            ToolVersionScanResultView.builder()
+                    .toolId(scan.getToolId())
+                    .version(scan.getVersion())
+                    .toolOSVersion(ToolOSVersionView.from(scan.getToolOSVersion(), isOSAllowed))
+                    .status(scan.getStatus())
+                    .scanDate(scan.getScanDate())
+                    .successScanDate(scan.getSuccessScanDate())
+                    .vulnerabilities(scan.getVulnerabilities())
+                    .dependencies(scan.getDependencies())
+                    .isAllowedToExecute(scan.isAllowedToExecute())
+                    .fromWhiteList(scan.isFromWhiteList())
+                    .gracePeriod(scan.getGracePeriod())
+                    .vulnerabilitiesCount(scan.getVulnerabilitiesCount())
+                    .build()
+        ).orElse(null);
     }
-
 }

--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerRegistryManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerRegistryManager.java
@@ -69,6 +69,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -497,7 +498,7 @@ public class DockerRegistryManager implements SecuredEntityManager {
                     toolGroup.getName()));
             toolManager.updateToolVersionScanStatus(toolInGroup.get().getId(),
                     ToolScanStatus.NOT_SCANNED, DateUtils.now(), event.getTarget().getTag(),
-                    null, event.getTarget().getDigest());
+                    null, event.getTarget().getDigest(), new HashMap<>());
             return toolInGroup;
         }
         if (!permissionManager.isActionAllowedForUser(toolGroup, actor, AclPermission.WRITE)) {

--- a/api/src/main/java/com/epam/pipeline/manager/docker/ToolVersionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/ToolVersionManager.java
@@ -33,6 +33,7 @@ import org.springframework.util.StringUtils;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Service
@@ -97,6 +98,16 @@ public class ToolVersionManager {
     }
 
     /**
+     * Loads tool version attributes for a tool ID and list of versions
+     * @param toolId
+     * @param versions
+     * @return
+     */
+    public Map<String, ToolVersion> loadToolVersions(final Long toolId, final List<String> versions) {
+        return toolVersionDao.loadToolVersions(toolId, versions);
+    }
+
+    /**
      * Creates settings for specific tool version.
      * @param toolId tool ID
      * @param version tool version (tag)
@@ -152,4 +163,5 @@ public class ToolVersionManager {
         Assert.isTrue(tool.isNotSymlink(), messageHelper.getMessage(
                 MessageConstants.ERROR_TOOL_SYMLINK_MODIFICATION_NOT_SUPPORTED));
     }
+
 }

--- a/api/src/main/java/com/epam/pipeline/manager/docker/scan/ToolScanManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/scan/ToolScanManager.java
@@ -46,6 +46,8 @@ public interface ToolScanManager {
 
     ToolExecutionCheckStatus checkTool(Tool tool, String tag);
 
+    ToolExecutionCheckStatus checkScan(Tool tool, String tag, ToolVersionScanResult scan);
+
     /**
      * Loads current security policy.
      * @return a {@link ToolScanPolicy}

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/ToolScanInfoManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/ToolScanInfoManager.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.pipeline;
+
+import com.epam.pipeline.dao.tool.ToolVulnerabilityDao;
+import com.epam.pipeline.entity.docker.ToolDescription;
+import com.epam.pipeline.entity.docker.ToolVersion;
+import com.epam.pipeline.entity.docker.ToolVersionAttributes;
+import com.epam.pipeline.entity.pipeline.Tool;
+import com.epam.pipeline.entity.pipeline.ToolScanStatus;
+import com.epam.pipeline.entity.scan.ToolVersionScanResult;
+import com.epam.pipeline.entity.scan.ToolVersionScanResultView;
+import com.epam.pipeline.entity.scan.VulnerabilitySeverity;
+import com.epam.pipeline.manager.docker.ToolVersionManager;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.MapUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Class returns aggregated scan info without detailed vulnerability or dependency data
+ */
+@Service
+@RequiredArgsConstructor
+public class ToolScanInfoManager {
+
+    private final ToolManager toolManager;
+    private final ToolVersionManager toolVersionManager;
+    private final ToolVulnerabilityDao toolVulnerabilityDao;
+
+    public ToolDescription loadToolInfo(final Long toolId) {
+        final Tool tool = toolManager.loadExisting(toolId);
+        return tool.isSymlink() ? loadToolInfo(tool.getLink()) : loadToolInfo(tool);
+    }
+
+    public Optional<ToolVersionScanResult> loadToolVersionScanInfo(final Long toolId, final String version) {
+        final Tool tool = toolManager.loadExisting(toolId);
+        return tool.isSymlink() ? loadToolVersionScanInfo(tool.getLink(), version) :
+                loadToolVersionScanInfo(tool, version);
+    }
+
+    private ToolDescription loadToolInfo(final Tool tool) {
+        final ToolDescription result = new ToolDescription(tool.getId());
+        final List<String> activeVersions = toolManager.loadTags(tool);
+        if (StringUtils.isEmpty(activeVersions)) {
+            return result;
+        }
+        final Map<String, ToolVersionScanResult> scanInfo = loadScanInfo(tool, activeVersions);
+        final Map<String, ToolVersion> versionInfo = toolVersionManager.loadToolVersions(tool.getId(), activeVersions);
+        final List<ToolVersionAttributes> versionsAttributes = activeVersions.stream()
+                .map(version -> {
+                    final ToolVersionScanResult scanResult = scanInfo.get(version);
+                    return ToolVersionAttributes.builder()
+                            .version(version)
+                            .attributes(versionInfo.get(version))
+                            .scanResult(ToolVersionScanResultView.from(scanResult,
+                                    toolManager.isToolOSVersionAllowed(scanResult.getToolOSVersion())))
+                            .build();
+                })
+                .collect(Collectors.toList());
+        result.setVersions(versionsAttributes);
+        return result;
+    }
+
+    private Map<String, ToolVersionScanResult> loadScanInfo(final Tool tool, final List<String> versions) {
+        final Map<String, ToolVersionScanResult> scanInfo = loadScanInfoForVersions(tool, versions);
+        scanInfo.forEach((version, scan) -> toolManager.setExecutePermission(tool, version, scan));
+        return scanInfo;
+    }
+
+    private Map<String, ToolVersionScanResult> loadScanInfoForVersions(final Tool tool, final List<String> versions) {
+        final Map<String, ToolVersionScanResult> scanInfo =
+                toolVulnerabilityDao.loadToolVersionScanInfo(tool.getId(), versions);
+
+        //try to calculate vulnerability data from DB if precalculated info is not available
+        final List<String> versionsWithoutVulnerabilityStats = scanInfo.entrySet().stream().filter(e -> {
+            final ToolVersionScanResult scan = e.getValue();
+            return !scan.getStatus().equals(ToolScanStatus.NOT_SCANNED) &&
+                    MapUtils.isEmpty(scan.getVulnerabilitiesCount());
+        }).map(Map.Entry::getKey).collect(Collectors.toList());
+
+        if (!CollectionUtils.isEmpty(versionsWithoutVulnerabilityStats)) {
+            final Map<String, Map<VulnerabilitySeverity, Integer>> missingVulnerabilityCount =
+                    toolVulnerabilityDao.loadVulnerabilityCount(tool.getId(), versionsWithoutVulnerabilityStats);
+            missingVulnerabilityCount.forEach(
+                (version, vulnerabilities) -> scanInfo.get(version).setVulnerabilitiesCount(vulnerabilities));
+        }
+        return scanInfo;
+    }
+
+    private Optional<ToolVersionScanResult> loadToolVersionScanInfo(final Tool tool, final String version) {
+        final Map<String, ToolVersionScanResult> result =
+                loadScanInfoForVersions(tool, Collections.singletonList(version));
+        return Optional.ofNullable(result.get(version));
+    }
+}

--- a/api/src/main/resources/dao/tool-version.xml
+++ b/api/src/main/resources/dao/tool-version.xml
@@ -124,6 +124,22 @@
                 ]]>
             </value>
         </property>
+        <property name="loadToolVersionListSettingsQuery">
+            <value>
+                <![CDATA[
+                    SELECT
+                        DISTINCT tv.id,
+                        tv.tool_id,
+                        tv.version,
+                        tv.settings,
+                        tv.size
+                    FROM pipeline.tool_version AS tv
+                    INNER JOIN pipeline.tool tl ON (tl.id = tv.tool_id)
+                    LEFT JOIN pipeline.tool t ON (t.link = tl.id)
+                    WHERE :TOOL_ID IN (t.id, tl.id) AND tv.version IN (:VERSIONS)
+                ]]>
+            </value>
+        </property>
         <property name="createToolVersionWithSettingsQuery">
             <value>
                 <![CDATA[

--- a/api/src/main/resources/dao/tool-vulnerability-dao.xml
+++ b/api/src/main/resources/dao/tool-vulnerability-dao.xml
@@ -88,6 +88,21 @@
                 ]]>
             </value>
         </property>
+        <property name="loadVulnerabilityCountQuery">
+            <value>
+                <![CDATA[
+                    SELECT
+                        tv.version,
+                        tv.severity,
+                        count(*)
+                    FROM
+                        pipeline.tool_vulnerability tv
+                    WHERE
+                        tv.tool_id = :TOOL_ID AND tv.version IN (:VERSIONS)
+                    GROUP BY tv.version, tv.severity
+                ]]>
+            </value>
+        </property>
         <property name="deleteVulnerabilitiesQuery">
             <value>
                 <![CDATA[
@@ -176,7 +191,8 @@
                         scan_date,
                         success_scan_date,
                         os_name,
-                        os_version
+                        os_version,
+                        vulnerabilities_count
                     ) VALUES (
                         :TOOL_ID,
                         :VERSION,
@@ -186,7 +202,8 @@
                         :SCAN_DATE,
                         :SUCCESS_SCAN_DATE,
                         :OS_NAME,
-                        :OS_VERSION
+                        :OS_VERSION,
+                        :VULNERABILITIES_COUNT
                     )
                 ]]>
             </value>
@@ -202,7 +219,8 @@
                         scan_date=:SCAN_DATE,
                         white_list=:WHITE_LIST,
                         os_name=:OS_NAME,
-                        os_version=:OS_VERSION
+                        os_version=:OS_VERSION,
+                        vulnerabilities_count=:VULNERABILITIES_COUNT
                     WHERE
                         tool_id=:TOOL_ID
                         AND version=:VERSION
@@ -233,7 +251,8 @@
                         success_scan_date=:SUCCESS_SCAN_DATE,
                         white_list=:WHITE_LIST,
                         os_name=:OS_NAME,
-                        os_version=:OS_VERSION
+                        os_version=:OS_VERSION,
+                        vulnerabilities_count=:VULNERABILITIES_COUNT
                     WHERE
                         tool_id=:TOOL_ID
                         AND version=:VERSION
@@ -253,7 +272,8 @@
                         scan_status,
                         white_list,
                         os_name,
-                        os_version
+                        os_version,
+                        vulnerabilities_count
                     FROM
                         pipeline.tool_version_scan
                     WHERE
@@ -275,11 +295,34 @@
                         scan_status,
                         white_list,
                         os_name,
-                        os_version
+                        os_version,
+                        vulnerabilities_count
                     FROM
                         pipeline.tool_version_scan
                     WHERE
                         tool_id = :TOOL_ID
+                ]]>
+            </value>
+        </property>
+        <property name="loadToolListVersionsScanQuery">
+            <value>
+                <![CDATA[
+                    SELECT
+                        tool_id,
+                        version,
+                        layer_reference,
+                        digest,
+                        scan_date,
+                        success_scan_date,
+                        scan_status,
+                        white_list,
+                        os_name,
+                        os_version,
+                        vulnerabilities_count
+                    FROM
+                        pipeline.tool_version_scan
+                    WHERE
+                        tool_id = :TOOL_ID AND version in (:VERSIONS)
                 ]]>
             </value>
         </property>

--- a/api/src/main/resources/db/migration/v2021.02.18_12.00__issue_1811_tool_requests_performance.sql
+++ b/api/src/main/resources/db/migration/v2021.02.18_12.00__issue_1811_tool_requests_performance.sql
@@ -1,11 +1,10 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
- *
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,20 +13,4 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.entity.docker;
-
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-import java.util.List;
-
-@Data
-@NoArgsConstructor
-public class ToolDescription {
-    private Long toolId;
-    private List<ToolVersionAttributes> versions;
-
-    public ToolDescription(final long toolId) {
-        this.toolId = toolId;
-    }
-}
+ALTER TABLE tool_version_scan ADD COLUMN vulnerabilities_count TEXT NULL;

--- a/api/src/test/java/com/epam/pipeline/dao/tool/ToolVulnerabilityDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/tool/ToolVulnerabilityDaoTest.java
@@ -20,6 +20,9 @@ import com.epam.pipeline.dao.docker.DockerRegistryDao;
 import com.epam.pipeline.entity.pipeline.DockerRegistry;
 import com.epam.pipeline.entity.pipeline.Tool;
 import com.epam.pipeline.entity.pipeline.ToolGroup;
+import com.epam.pipeline.entity.pipeline.ToolScanStatus;
+import com.epam.pipeline.entity.scan.ToolOSVersion;
+import com.epam.pipeline.entity.scan.ToolVersionScanResult;
 import com.epam.pipeline.entity.scan.Vulnerability;
 import com.epam.pipeline.entity.scan.VulnerabilitySeverity;
 import com.epam.pipeline.test.jdbc.AbstractJdbcTest;
@@ -29,15 +32,18 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import static com.epam.pipeline.dao.tool.ToolDaoTest.generateTool;
 
+@Transactional
 public class ToolVulnerabilityDaoTest extends AbstractJdbcTest {
 
     private static final String LATEST_VERSION = "latest";
@@ -74,7 +80,6 @@ public class ToolVulnerabilityDaoTest extends AbstractJdbcTest {
     }
 
     @Test
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void testLoadVulnerabilities() {
         Vulnerability vulnerability = createVulnerability(tool, LATEST_VERSION);
 
@@ -86,7 +91,6 @@ public class ToolVulnerabilityDaoTest extends AbstractJdbcTest {
     }
 
     @Test
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void testLoadVulnerabilitiesByVersion() {
         Vulnerability prevVulnerability = createVulnerability(tool, PREV, "test1", "feature-1", PREV);
         Vulnerability latestVulnerability = createVulnerability(tool, LATEST_VERSION,
@@ -104,7 +108,6 @@ public class ToolVulnerabilityDaoTest extends AbstractJdbcTest {
     }
 
     @Test
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void testDeleteVulnerabilities() {
         createVulnerability(tool, LATEST_VERSION);
         Assert.assertFalse(toolVulnerabilityDao.loadVulnerabilities(tool.getId(), LATEST_VERSION).isEmpty());
@@ -112,6 +115,33 @@ public class ToolVulnerabilityDaoTest extends AbstractJdbcTest {
         toolVulnerabilityDao.deleteVulnerabilities(tool.getId(), LATEST_VERSION);
 
         Assert.assertTrue(toolVulnerabilityDao.loadVulnerabilities(tool.getId(), LATEST_VERSION).isEmpty());
+    }
+
+    @Test
+    public void shouldSaveAndLoadVersionWithVulnerabilitiesCount() {
+        final HashMap<VulnerabilitySeverity, Integer> vulnerabilitiesCount = new HashMap<>();
+        vulnerabilitiesCount.put(VulnerabilitySeverity.Critical, 1);
+        vulnerabilitiesCount.put(VulnerabilitySeverity.Medium, 2);
+        toolVulnerabilityDao.insertToolVersionScan(tool.getId(), LATEST_VERSION,
+                new ToolOSVersion("centos", "7"), "", "digest",
+                ToolScanStatus.COMPLETED, new Date(), vulnerabilitiesCount);
+        final Optional<ToolVersionScanResult> result = toolVulnerabilityDao
+                .loadToolVersionScan(tool.getId(), LATEST_VERSION);
+        Assert.assertTrue(result.isPresent());
+        Assert.assertEquals(vulnerabilitiesCount, result.get().getVulnerabilitiesCount());
+    }
+
+    @Test
+    public void shouldLoadVulnerabilitiesCount() {
+        createVulnerability(tool, LATEST_VERSION);
+        createVulnerability(tool, LATEST_VERSION);
+        createVulnerability(tool, PREV);
+        final Map<String, Map<VulnerabilitySeverity, Integer>> result =
+                toolVulnerabilityDao.loadVulnerabilityCount(tool.getId(), Collections.singletonList(LATEST_VERSION));
+        final Map<VulnerabilitySeverity, Integer> versionResult = result.get(LATEST_VERSION);
+        Assert.assertEquals(1, versionResult.size());
+        final int highCount = versionResult.get(VulnerabilitySeverity.High);
+        Assert.assertEquals(2, highCount);
     }
 
     private Vulnerability createVulnerability(Tool tool, String version) {

--- a/api/src/test/java/com/epam/pipeline/manager/docker/scan/AggregatingToolScanManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/docker/scan/AggregatingToolScanManagerTest.java
@@ -42,6 +42,7 @@ import com.epam.pipeline.manager.docker.scan.dockercompscan.DockerComponentScanS
 import com.epam.pipeline.manager.pipeline.PipelineConfigurationManager;
 import com.epam.pipeline.manager.pipeline.PipelineVersionManager;
 import com.epam.pipeline.manager.pipeline.ToolManager;
+import com.epam.pipeline.manager.pipeline.ToolScanInfoManager;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.manager.security.AuthManager;
@@ -125,6 +126,9 @@ public class AggregatingToolScanManagerTest {
 
     @Mock
     private PreferenceManager preferenceManager;
+
+    @Mock
+    private ToolScanInfoManager toolScanInfoManager;
 
     private ToolVersionScanResult toolScanResult = new ToolVersionScanResult();
     private ToolVersionScanResult actual = new ToolVersionScanResult();
@@ -234,6 +238,10 @@ public class AggregatingToolScanManagerTest {
         when(toolManager.loadByNameOrId(TEST_IMAGE)).thenReturn(testTool);
         when(toolManager.loadToolVersionScan(testTool.getId(), LATEST_VERSION)).thenReturn(Optional.of(toolScanResult));
         when(toolManager.loadToolVersionScan(testTool.getId(), ACTUAL_SCANNED_VERSION)).thenReturn(Optional.of(actual));
+        when(toolScanInfoManager.loadToolVersionScanInfo(testTool.getId(), LATEST_VERSION))
+                .thenReturn(Optional.of(toolScanResult));
+        when(toolScanInfoManager.loadToolVersionScanInfo(testTool.getId(), ACTUAL_SCANNED_VERSION))
+                .thenReturn(Optional.of(actual));
 
         ToolVersion actual = new ToolVersion();
         actual.setDigest(DIGEST_3);
@@ -327,7 +335,8 @@ public class AggregatingToolScanManagerTest {
         scanResult.setFromWhiteList(true);
         scanResult.setScanDate(DateUtils.now());
         scanResult.setVulnerabilities(Collections.emptyList());
-        when(toolManager.loadToolVersionScan(testTool.getId(), LATEST_VERSION)).thenReturn(Optional.of(scanResult));
+        when(toolScanInfoManager.loadToolVersionScanInfo(testTool.getId(), LATEST_VERSION))
+                .thenReturn(Optional.of(scanResult));
         Assert.assertTrue(aggregatingToolScanManager.checkTool(testTool, LATEST_VERSION).isAllowed());
     }
 

--- a/api/src/test/java/com/epam/pipeline/manager/docker/scan/ToolScanSchedulerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/docker/scan/ToolScanSchedulerTest.java
@@ -279,7 +279,8 @@ public class ToolScanSchedulerTest extends AbstractSpringTest {
 
         @Override
         public void updateToolVersionScanStatus(long toolId, ToolScanStatus newStatus, Date scanDate, String version,
-                                                ToolOSVersion toolOSVersion, String layerRef, String digest) {
+                                                ToolOSVersion toolOSVersion, String layerRef, String digest,
+                                                Map<VulnerabilitySeverity, Integer> vulnerabilityCount) {
             Assert.assertNotNull(version);
 
             ToolVersionScanResult versionScan = new ToolVersionScanResult();
@@ -302,8 +303,10 @@ public class ToolScanSchedulerTest extends AbstractSpringTest {
 
         @Override
         public void updateToolVersionScanStatus(long toolId, ToolScanStatus newStatus, Date scanDate, String version,
-                                                String layerRef, String digest) {
-            updateToolVersionScanStatus(toolId, newStatus, scanDate, version, null, layerRef, digest);
+                                                String layerRef, String digest,
+                                                Map<VulnerabilitySeverity, Integer> vulnerabilityCount) {
+            updateToolVersionScanStatus(toolId, newStatus, scanDate, version, null, layerRef,
+                    digest, vulnerabilityCount);
         }
 
         @Override

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunManagerTest.java
@@ -164,6 +164,9 @@ public class PipelineRunManagerTest extends AbstractManagerTest {
     @MockBean
     private CheckPermissionHelper permissionHelper;
 
+    @MockBean
+    private ToolScanInfoManager toolScanInfoManager;
+
     @Autowired
     private PipelineRunDao pipelineRunDao;
 
@@ -218,7 +221,7 @@ public class PipelineRunManagerTest extends AbstractManagerTest {
                 .thenReturn(price);
         when(pipelineLauncher.launch(any(PipelineRun.class), any(), any(), anyString(), anyString()))
             .thenReturn("sleep");
-        when(toolManager.loadToolVersionScan(notScannedTool.getId(), null))
+        when(toolScanInfoManager.loadToolVersionScanInfo(notScannedTool.getId(), null))
                 .thenReturn(Optional.empty());
         when(toolVersionManager.loadToolVersion(anyLong(), anyString()))
                 .thenReturn(ToolVersion.builder().size(1L).build());

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/ToolManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/ToolManagerTest.java
@@ -471,7 +471,7 @@ public class ToolManagerTest extends AbstractManagerTest {
 
         toolManager.updateToolVersionScanStatus(
                 tool.getId(), ToolScanStatus.COMPLETED, new Date(), LATEST_TAG,
-                new ToolOSVersion(TEST, TEST), LAYER_REF, DIGEST
+                new ToolOSVersion(TEST, TEST), LAYER_REF, DIGEST, new HashMap<>()
         );
         toolManager.updateToolVulnerabilities(Collections.emptyList(), tool.getId(), LATEST_TAG);
         toolManager.updateToolDependencies(Collections.emptyList(), tool.getId(), LATEST_TAG);
@@ -519,7 +519,7 @@ public class ToolManagerTest extends AbstractManagerTest {
         ToolScanStatus status = ToolScanStatus.COMPLETED;
 
         toolManager.updateToolVersionScanStatus(tool.getId(), status, now, LATEST_TAG, new ToolOSVersion(TEST, TEST),
-                layerRef, digest);
+                layerRef, digest, new HashMap<>());
         toolManager.updateWhiteListWithToolVersionStatus(tool.getId(), LATEST_TAG, true);
         ToolVersionScanResult versionScan = toolManager.loadToolVersionScan(
                 tool.getId(), LATEST_TAG).get();
@@ -533,7 +533,7 @@ public class ToolManagerTest extends AbstractManagerTest {
         now = new Date();
 
         toolManager.updateToolVersionScanStatus(tool.getId(), status, now, LATEST_TAG, new ToolOSVersion(TEST, TEST),
-                layerRef, digest);
+                layerRef, digest, new HashMap<>());
         Assert.assertEquals(1, toolManager.loadToolScanResult(tool).getToolVersionScanResults().values().size());
         versionScan = toolManager.loadToolVersionScan(tool.getId(), LATEST_TAG).get();
         Assert.assertEquals(now, versionScan.getScanDate());
@@ -560,7 +560,7 @@ public class ToolManagerTest extends AbstractManagerTest {
         toolManager.create(tool, true);
 
         toolManager.updateToolVersionScanStatus(tool.getId(), ToolScanStatus.COMPLETED, scanDate,
-                latestVersion, new ToolOSVersion(CENTOS, CENTOS_VERSION), testRef, testRef);
+                latestVersion, new ToolOSVersion(CENTOS, CENTOS_VERSION), testRef, testRef, new HashMap<>());
 
         ToolScanResult loaded = toolManager.loadToolScanResult(tool);
         ToolOSVersion toolOSVersion = loaded.getToolVersionScanResults().get(LATEST_TAG).getToolOSVersion();
@@ -592,7 +592,7 @@ public class ToolManagerTest extends AbstractManagerTest {
         toolManager.create(tool, true);
 
         toolManager.updateToolVersionScanStatus(tool.getId(), ToolScanStatus.COMPLETED, scanDate,
-                latestVersion, new ToolOSVersion(TEST, TEST), testRef, testRef);
+                latestVersion, new ToolOSVersion(TEST, TEST), testRef, testRef, new HashMap<>());
 
         ToolScanResult loaded = toolManager.loadToolScanResult(tool);
         Assert.assertEquals(
@@ -667,7 +667,8 @@ public class ToolManagerTest extends AbstractManagerTest {
         Date now = new Date();
         ToolScanStatus status = ToolScanStatus.FAILED;
 
-        toolManager.updateToolVersionScanStatus(tool.getId(), status, now, LATEST_TAG, layerRef, digest);
+        toolManager.updateToolVersionScanStatus(tool.getId(), status, now, LATEST_TAG, layerRef,
+                digest, new HashMap<>());
         ToolVersionScanResult versionScan = toolManager.loadToolVersionScan(
                 tool.getId(), LATEST_TAG).get();
         Assert.assertEquals(status, versionScan.getStatus());
@@ -691,7 +692,8 @@ public class ToolManagerTest extends AbstractManagerTest {
         ToolScanStatus status = ToolScanStatus.COMPLETED;
 
         toolManager.updateToolVersionScanStatus(
-                tool.getId(), status, scanDate, LATEST_TAG, new ToolOSVersion(TEST, TEST), layerRef, digest);
+                tool.getId(), status, scanDate, LATEST_TAG, new ToolOSVersion(TEST, TEST), layerRef, digest,
+                new HashMap<>());
         ToolVersionScanResult versionScan =
                 toolManager.loadToolVersionScan(tool.getId(), LATEST_TAG).get();
         Assert.assertEquals(status, versionScan.getStatus());
@@ -704,7 +706,7 @@ public class ToolManagerTest extends AbstractManagerTest {
         Date newScanDate = new Date();
 
         toolManager.updateToolVersionScanStatus(
-                tool.getId(), status, newScanDate, LATEST_TAG, layerRef, digest);
+                tool.getId(), status, newScanDate, LATEST_TAG, layerRef, digest, new HashMap<>());
         Assert.assertEquals(1, toolManager.loadToolScanResult(tool).getToolVersionScanResults().values().size());
         versionScan = toolManager.loadToolVersionScan(tool.getId(), LATEST_TAG).get();
         Assert.assertEquals(newScanDate, versionScan.getScanDate());
@@ -786,10 +788,11 @@ public class ToolManagerTest extends AbstractManagerTest {
         assertThrows(IllegalArgumentException.class, () -> toolManager.updateTool(symlink));
         assertThrows(IllegalArgumentException.class, 
             () -> toolManager.updateToolVersionScanStatus(symlink.getId(), ToolScanStatus.COMPLETED, 
-                    DateUtils.now(), LATEST_TAG, new ToolOSVersion(CENTOS, CENTOS_VERSION), LAYER_REF, DIGEST));
+                    DateUtils.now(), LATEST_TAG, new ToolOSVersion(CENTOS, CENTOS_VERSION), LAYER_REF, DIGEST,
+                    new HashMap<>()));
         assertThrows(IllegalArgumentException.class, 
             () -> toolManager.updateToolVersionScanStatus(symlink.getId(), ToolScanStatus.COMPLETED, 
-                    DateUtils.now(), LATEST_TAG, LAYER_REF, DIGEST));
+                    DateUtils.now(), LATEST_TAG, LAYER_REF, DIGEST, new HashMap<>()));
         assertThrows(IllegalArgumentException.class, 
             () -> toolManager.updateToolDependencies(Collections.emptyList(), symlink.getId(), LATEST_TAG));
         assertThrows(IllegalArgumentException.class, 

--- a/api/src/test/java/com/epam/pipeline/test/acl/AclTestBeans.java
+++ b/api/src/test/java/com/epam/pipeline/test/acl/AclTestBeans.java
@@ -103,6 +103,7 @@ import com.epam.pipeline.manager.pipeline.RunStatusManager;
 import com.epam.pipeline.manager.pipeline.StopServerlessRunManager;
 import com.epam.pipeline.manager.pipeline.ToolGroupManager;
 import com.epam.pipeline.manager.pipeline.ToolManager;
+import com.epam.pipeline.manager.pipeline.ToolScanInfoManager;
 import com.epam.pipeline.manager.pipeline.runner.ConfigurationProviderManager;
 import com.epam.pipeline.manager.pipeline.runner.ConfigurationRunner;
 import com.epam.pipeline.manager.preference.PreferenceManager;
@@ -481,6 +482,9 @@ public class AclTestBeans {
 
     @MockBean
     protected TemplatesScanner mockTemplatesScanner;
+
+    @MockBean
+    protected ToolScanInfoManager toolScanInfoManager;
 
     @Bean
     public GrantPermissionManager grantPermissionManager() {

--- a/api/src/test/java/com/epam/pipeline/util/TestUtils.java
+++ b/api/src/test/java/com/epam/pipeline/util/TestUtils.java
@@ -39,11 +39,10 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -101,17 +100,11 @@ public final class TestUtils {
 
     public static void generateScanResult(int criticalVulnerabilitiesCount, int highVulnerabilitiesCount,
                                     int mediumVulnerabilitiesCount, ToolVersionScanResult versionScanResult) {
-        List<Vulnerability> testVulnerabilities = IntStream
-            .range(0, criticalVulnerabilitiesCount)
-            .mapToObj(i -> createVulnerability(VulnerabilitySeverity.Critical))
-            .collect(Collectors.toList());
-        testVulnerabilities.addAll(IntStream.range(0, highVulnerabilitiesCount)
-                                       .mapToObj(i -> createVulnerability(VulnerabilitySeverity.High))
-                                       .collect(Collectors.toList()));
-        testVulnerabilities.addAll(IntStream.range(0, mediumVulnerabilitiesCount)
-                                       .mapToObj(i -> createVulnerability(VulnerabilitySeverity.Medium))
-                                       .collect(Collectors.toList()));
-        versionScanResult.setVulnerabilities(testVulnerabilities);
+        final HashMap<VulnerabilitySeverity, Integer> count = new HashMap<>();
+        count.put(VulnerabilitySeverity.Critical, criticalVulnerabilitiesCount);
+        count.put(VulnerabilitySeverity.High, highVulnerabilitiesCount);
+        count.put(VulnerabilitySeverity.Medium, mediumVulnerabilitiesCount);
+        versionScanResult.setVulnerabilitiesCount(count);
         versionScanResult.setScanDate(new Date());
         versionScanResult.setSuccessScanDate(new Date());
         versionScanResult.setStatus(ToolScanStatus.COMPLETED);


### PR DESCRIPTION
This PR is related to #1811.

### Implementation
A new method `/tool/{toolId}/info` is added to Tool API methods. This method is similar to `/tool/{toolId}/attributes` with the following optimizations:
- `dependency` data is not loaded
- detailed `vulnerability` data is not loaded
- aggregated vulnerability data is returned for each version in field `vulnerabilitiesCount` containing map with vulnerability count for each level: `{"High": 1, "Critical": 3}`
- number of db requests reduced