### PR TITLE
Issue #1816: Create a new API method to get list of runs along with associated tools

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
@@ -31,6 +31,7 @@ import com.epam.pipeline.entity.cluster.PipelineRunPrice;
 import com.epam.pipeline.entity.pipeline.CommitStatus;
 import com.epam.pipeline.entity.pipeline.DiskAttachRequest;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.pipeline.PipelineRunWithTool;
 import com.epam.pipeline.entity.pipeline.PipelineTask;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.RunLog;
@@ -290,5 +291,10 @@ public class RunApiService {
     @PreAuthorize("hasRole('ADMIN') OR @grantPermissionManager.hasPermissionToRun(#runVO.pipelineStart, 'EXECUTE')")
     public String generateLaunchCommand(final PipeRunCmdStartVO runVO) {
         return runManager.generateLaunchCommand(runVO);
+    }
+
+    @PreAuthorize(ADMIN_ONLY)
+    public List<PipelineRunWithTool> getRunsWithTools(final List<Long> runIds) {
+        return runManager.loadRunsWithTools(runIds);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
@@ -33,6 +33,7 @@ import com.epam.pipeline.controller.vo.configuration.RunConfigurationWithEntitie
 import com.epam.pipeline.entity.cluster.PipelineRunPrice;
 import com.epam.pipeline.entity.pipeline.DiskAttachRequest;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.pipeline.PipelineRunWithTool;
 import com.epam.pipeline.entity.pipeline.PipelineTask;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.RunLog;
@@ -529,5 +530,16 @@ public class PipelineRunController extends AbstractRestController {
     @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
     public Result<String> generateLaunchCommand(@RequestBody final PipeRunCmdStartVO runVO) {
         return Result.success(runApiService.generateLaunchCommand(runVO));
+    }
+
+    @GetMapping(value = "/runs")
+    @ResponseBody
+    @ApiOperation(
+            value = "Returns runs with associated tools",
+            notes = "Returns runs with associated tools",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<List<PipelineRunWithTool>> getRunsWithTools(@RequestParam final List<Long> runIds) {
+        return Result.success(runApiService.getRunsWithTools(runIds));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -122,6 +122,7 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     private String updateTagsQuery;
     private String loadAllRunsPossiblyActiveInPeriodQuery;
     private String loadAllRunsByStatusQuery;
+    private String loadAllRunsByIdsQuery;
     private String loadRunByPodIPQuery;
 
     // We put Propagation.REQUIRED here because this method can be called from non-transaction context
@@ -298,23 +299,7 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
                 .replaceFirst(makeRunSidsCondition(user, params));
         final List<PipelineRun> services = getNamedParameterJdbcTemplate()
                 .query(query, params, PipelineRunParameters.getRowMapper());
-        if (CollectionUtils.isEmpty(services)) {
-            return services;
-        }
-        final MapSqlParameterSource sidParams = new MapSqlParameterSource();
-        final Map<Long, PipelineRun> idToRun = services.stream().collect(Collectors.toMap(BaseEntity::getId,
-                Function.identity()));
-        sidParams.addValue(LIST_PARAMETER, idToRun.keySet());
-        final List<RunSid> runSids = getNamedParameterJdbcTemplate()
-                .query(loadRunSidsQueryForList, sidParams, PipelineRunParameters.getRunSidsRowMapper());
-        ListUtils.emptyIfNull(runSids).forEach(sid -> {
-            final PipelineRun run = idToRun.get(sid.getRunId());
-            if (run.getRunSids() == null) {
-                run.setRunSids(new ArrayList<>());
-            }
-            run.getRunSids().add(sid);
-        });
-        return services;
+        return loadSidsForRuns(services);
     }
 
     @Transactional(propagation = Propagation.SUPPORTS)
@@ -672,6 +657,34 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
                 DaoHelper.POSTGRES_LIKE_CHARACTER + serviceUrl + DaoHelper.POSTGRES_LIKE_CHARACTER);
         return getNamedParameterJdbcTemplate().query(loadAllRunsByServiceURL, params,
                 PipelineRunParameters.getRowMapper());
+    }
+
+    public List<PipelineRun> loadRunByIdIn(final List<Long> runIds) {
+        final MapSqlParameterSource params = new MapSqlParameterSource();
+        params.addValue(LIST_PARAMETER, runIds);
+        final List<PipelineRun> runs = ListUtils.emptyIfNull(getNamedParameterJdbcTemplate()
+                .query(loadAllRunsByIdsQuery, params, PipelineRunParameters.getRowMapper()));
+        return loadSidsForRuns(runs);
+    }
+
+    private List<PipelineRun> loadSidsForRuns(final List<PipelineRun> runs) {
+        if (CollectionUtils.isEmpty(runs)) {
+            return runs;
+        }
+        final MapSqlParameterSource sidParams = new MapSqlParameterSource();
+        final Map<Long, PipelineRun> idToRun = runs.stream().collect(Collectors.toMap(BaseEntity::getId,
+                Function.identity()));
+        sidParams.addValue(LIST_PARAMETER, idToRun.keySet());
+        final List<RunSid> runSids = getNamedParameterJdbcTemplate()
+                .query(loadRunSidsQueryForList, sidParams, PipelineRunParameters.getRunSidsRowMapper());
+        ListUtils.emptyIfNull(runSids).forEach(sid -> {
+            final PipelineRun run = idToRun.get(sid.getRunId());
+            if (run.getRunSids() == null) {
+                run.setRunSids(new ArrayList<>());
+            }
+            run.getRunSids().add(sid);
+        });
+        return runs;
     }
 
     public enum PipelineRunParameters {
@@ -1199,6 +1212,11 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setLoadAllRunsByStatusQuery(final String loadAllRunsByStatusQuery) {
         this.loadAllRunsByStatusQuery = loadAllRunsByStatusQuery;
+    }
+
+    @Required
+    public void setLoadAllRunsByIdsQuery(final String loadAllRunsByIdsQuery) {
+        this.loadAllRunsByIdsQuery = loadAllRunsByIdsQuery;
     }
 
     @Required

--- a/api/src/main/java/com/epam/pipeline/dao/tool/ToolDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/tool/ToolDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.sql.Types;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -51,6 +52,7 @@ import com.epam.pipeline.entity.pipeline.ToolGroup;
 import com.epam.pipeline.entity.pipeline.ToolWithIssuesCount;
 
 public class ToolDao extends NamedParameterJdbcDaoSupport {
+    private static final String LIST_PARAMETER = "list";
 
     private String toolSequence;
     private String toolIconSequence;
@@ -65,6 +67,7 @@ public class ToolDao extends NamedParameterJdbcDaoSupport {
     private String deleteToolQuery;
     private String loadToolByRegistryAndImageQuery;
     private String loadToolsFromOtherRegistriesByImageQuery;
+    private String loadAllByRegistryAndImageInQuery;
     private String loadToolByGroupAndImageQuery;
 
     private String deleteToolIconQuery;
@@ -217,6 +220,13 @@ public class ToolDao extends NamedParameterJdbcDaoSupport {
         params.addValue(ToolParameters.IMAGE.name(), image);
         params.addValue(ToolParameters.REGISTRY.name(), registry);
         return getNamedParameterJdbcTemplate().query(loadToolsFromOtherRegistriesByImageQuery, params, getRowMapper());
+    }
+
+    public List<Tool> loadAllByRegistryAndImageIn(final Long registryId, final Set<String> images) {
+        final MapSqlParameterSource params = new MapSqlParameterSource();
+        params.addValue(ToolParameters.REGISTRY_ID.name(), registryId);
+        params.addValue(LIST_PARAMETER, images);
+        return getNamedParameterJdbcTemplate().query(loadAllByRegistryAndImageInQuery, params, getRowMapper());
     }
 
     enum ToolParameters {
@@ -410,6 +420,11 @@ public class ToolDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setLoadToolsWithIssueCountByGroupQuery(String loadToolsWithIssueCountByGroupQuery) {
         this.loadToolsWithIssueCountByGroupQuery = loadToolsWithIssueCountByGroupQuery;
+    }
+
+    @Required
+    public void setLoadAllByRegistryAndImageInQuery(final String loadAllByRegistryAndImageInQuery) {
+        this.loadAllByRegistryAndImageInQuery = loadAllByRegistryAndImageInQuery;
     }
 
     @Required

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunCRUDService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunCRUDService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -18,10 +18,14 @@ package com.epam.pipeline.manager.pipeline;
 import com.epam.pipeline.dao.pipeline.PipelineRunDao;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
+
+import java.util.Collections;
+import java.util.List;
 
 //TODO: Move all CRUD and DB persistence methods from PipelineRunManager to this class
 @Service
@@ -43,5 +47,12 @@ public class PipelineRunCRUDService {
             run.setPrettyUrl(null);
             pipelineRunDao.updateRun(run);
         }
+    }
+
+    public List<PipelineRun> loadRunsByIds(final List<Long> runIds) {
+        if (CollectionUtils.isEmpty(runIds)) {
+            return Collections.emptyList();
+        }
+        return pipelineRunDao.loadRunByIdIn(runIds);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,9 +39,11 @@ import com.epam.pipeline.entity.contextual.ContextualPreferenceLevel;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.pipeline.CommitStatus;
 import com.epam.pipeline.entity.pipeline.DiskAttachRequest;
+import com.epam.pipeline.entity.pipeline.DockerRegistry;
 import com.epam.pipeline.entity.pipeline.Folder;
 import com.epam.pipeline.entity.pipeline.Pipeline;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.pipeline.PipelineRunWithTool;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.epam.pipeline.entity.pipeline.Tool;
@@ -61,6 +63,7 @@ import com.epam.pipeline.manager.cluster.InstanceOfferManager;
 import com.epam.pipeline.manager.cluster.KubernetesConstants;
 import com.epam.pipeline.manager.cluster.NodesManager;
 import com.epam.pipeline.manager.datastorage.DataStorageManager;
+import com.epam.pipeline.manager.docker.DockerRegistryManager;
 import com.epam.pipeline.manager.docker.scan.ToolSecurityPolicyCheck;
 import com.epam.pipeline.manager.execution.PipelineLauncher;
 import com.epam.pipeline.manager.git.GitManager;
@@ -77,6 +80,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.math.NumberUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -98,12 +102,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.epam.pipeline.entity.configuration.RunConfigurationUtils.getNodeCount;
+import static com.epam.pipeline.manager.pipeline.ToolUtils.REPOSITORY_AND_IMAGE;
+import static com.epam.pipeline.manager.pipeline.ToolUtils.getImageWithoutTag;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toSet;
 
 @Service
 public class PipelineRunManager {
@@ -192,6 +202,9 @@ public class PipelineRunManager {
 
     @Autowired
     private StopServerlessRunManager stopServerlessRunManager;
+
+    @Autowired
+    private DockerRegistryManager dockerRegistryManager;
 
     /**
      * Launches cmd command execution, uses Tool as ACL identity
@@ -1076,6 +1089,31 @@ public class PipelineRunManager {
         stopServerlessRunManager.deleteByRunId(runId);
     }
 
+    public List<PipelineRunWithTool> loadRunsWithTools(final List<Long> runIds) {
+        final List<PipelineRun> runs = runCRUDService.loadRunsByIds(runIds);
+        if (CollectionUtils.isEmpty(runs)) {
+            return Collections.emptyList();
+        }
+        final Map<String, DockerRegistry> allRegistries = ListUtils.emptyIfNull(
+                dockerRegistryManager.loadAllDockerRegistry()).stream()
+                .collect(Collectors.toMap(DockerRegistry::getPath, Function.identity()));
+        final Map<String, Set<String>> imagesByRegistries = runs.stream()
+                .map(PipelineRun::getDockerImage)
+                .map(this::parseDockerImage)
+                .filter(Objects::nonNull)
+                .collect(Collectors.groupingBy(Pair::getKey, mapping(Pair::getValue, toSet())));
+        final Map<String, Tool> tools = imagesByRegistries.entrySet().stream()
+                .flatMap(entry -> ListUtils.emptyIfNull(toolManager.loadAllByRegistryAndImageIn(
+                        parseRegistryId(entry.getKey(), allRegistries), entry.getValue())).stream())
+                .collect(Collectors.toMap(this::buildRegistryPath, Function.identity()));
+        return runs.stream()
+                .map(run -> PipelineRunWithTool.builder()
+                        .pipelineRun(run)
+                        .tool(tools.get(run.getDockerImage()))
+                        .build())
+                .collect(Collectors.toList());
+    }
+
     private int getTotalSize(final List<InstanceDisk> disks) {
         return (int) disks.stream().mapToLong(InstanceDisk::getSize).sum();
     }
@@ -1382,5 +1420,28 @@ public class PipelineRunManager {
             runInstance.setCloudProvider(i.getCloudProvider());
             return runInstance;
         }).orElse(new RunInstance());
+    }
+
+    private Pair<String, String> parseDockerImage(final String dockerImage) {
+        final Matcher matcher = REPOSITORY_AND_IMAGE.matcher(dockerImage);
+
+        if (!matcher.find()) {
+            LOGGER.error("Failed to parse docker image ['{}']", dockerImage);
+            return null;
+        }
+
+        final String repository = matcher.group(1);
+        final String imageWithTag = matcher.group(2);
+        final String imageName = getImageWithoutTag(imageWithTag);
+
+        return Pair.of(repository, imageName);
+    }
+
+    private Long parseRegistryId(final String registry, final Map<String, DockerRegistry> allRegistries) {
+        return allRegistries.getOrDefault(registry, new DockerRegistry()).getId();
+    }
+
+    private String buildRegistryPath(final Tool tool) {
+        return String.format("%s/%s", tool.getRegistry(), tool.getImage());
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/ToolManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/ToolManager.java
@@ -78,9 +78,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import static com.epam.pipeline.manager.pipeline.ToolUtils.getImageWithoutTag;
 
 @Slf4j
 @Service
@@ -863,6 +866,10 @@ public class ToolManager implements SecuredEntityManager {
         return load(tool.getId());
     }
 
+    public List<Tool> loadAllByRegistryAndImageIn(final Long registryId, final Set<String> images) {
+        return toolDao.loadAllByRegistryAndImageIn(registryId, images);
+    }
+
     private String getSymlinkTargetImage(final Tool sourceTool, final ToolGroup targetGroup) {
         return targetGroup.getName() + TOOL_DELIMETER +
                 toolGroupManager.getGroupAndTool(sourceTool.getImage()).getRight();
@@ -900,10 +907,6 @@ public class ToolManager implements SecuredEntityManager {
         Tool tool = toolDao.loadTool(registryId, getImageWithoutTag(image));
         validateToolNotNull(tool, image);
         return tool;
-    }
-
-    private String getImageWithoutTag(String imageWithTag) {
-        return imageWithTag.split(TAG_DELIMITER)[0];
     }
 
     private String getImageTag(String imageWithTag) {

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/ToolUtils.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/ToolUtils.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.pipeline;
+
+import java.util.regex.Pattern;
+
+public interface ToolUtils {
+    Pattern REPOSITORY_AND_IMAGE = Pattern.compile("^(.*)\\/(.*\\/.*)$");
+    String TAG_DELIMITER = ":";
+
+    static String getImageWithoutTag(final String imageWithTag) {
+        return imageWithTag.split(TAG_DELIMITER)[0];
+    }
+}

--- a/api/src/main/resources/dao/pipeline-run-dao.xml
+++ b/api/src/main/resources/dao/pipeline-run-dao.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+  ~ Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -1629,6 +1629,66 @@
                         pipeline.pipeline_run
                     WHERE
                         status IN (:list)
+                    ORDER BY
+                        start_date
+                ]]>
+            </value>
+        </property>
+        <property name="loadAllRunsByIdsQuery">
+            <value>
+                <![CDATA[
+                    SELECT
+                        run_id,
+                        pipeline_id,
+                        version,
+                        start_date,
+                        end_date,
+                        parameters,
+                        status,
+                        terminating,
+                        pod_id,
+                        node_type,
+                        node_disk,
+                        node_ip,
+                        node_id,
+                        node_name,
+                        node_image,
+                        node_cloud_region,
+                        docker_image,
+                        actual_docker_image,
+                        cmd_template,
+                        actual_cmd,
+                        timeout,
+                        owner,
+                        service_url,
+                        pod_ip,
+                        commit_status,
+                        last_change_commit_time,
+                        config_name,
+                        node_count,
+                        parent_id,
+                        entities_ids,
+                        is_spot,
+                        configuration_id,
+                        pod_status,
+                        prolonged_at_time,
+                        last_notification_time,
+                        last_idle_notification_time,
+                        exec_preferences,
+                        pretty_url,
+                        price_per_hour,
+                        compute_price_per_hour,
+                        disk_price_per_hour,
+                        state_reason,
+                        non_pause,
+                        node_real_disk,
+                        node_cloud_provider,
+                        tags,
+                        sensitive
+                    FROM
+                        pipeline.pipeline_run
+                    WHERE
+                        run_id IN (:list)
                     ORDER BY
                         start_date
                 ]]>

--- a/api/src/main/resources/dao/tool-dao.xml
+++ b/api/src/main/resources/dao/tool-dao.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+  ~ Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -154,6 +154,40 @@
                     INNER JOIN pipeline.docker_registry dr ON (t.registry_id = dr.id)
                     LEFT JOIN pipeline.tool tl ON (t.link = tl.id)
                     WHERE t.id = ?
+                ]]>
+            </value>
+        </property>
+        <property name="loadAllByRegistryAndImageInQuery">
+            <value>
+                <![CDATA[
+                    SELECT
+                        t.id,
+                        t.image,
+                        COALESCE(tl.description, t.description) AS description,
+                        COALESCE(tl.short_description, t.short_description) AS short_description,
+                        COALESCE(tl.cpu, t.cpu) AS cpu,
+                        COALESCE(tl.ram, t.ram) AS ram,
+                        t.registry_id,
+                        t.tool_group_id,
+                        COALESCE(tl.default_command, t.default_command) AS default_command,
+                        COALESCE(tl.labels, t.labels) AS labels,
+                        COALESCE(tl.endpoints, t.endpoints) AS endpoints,
+                        t.owner,
+                        COALESCE(tl.disk, t.disk) AS disk,
+                        COALESCE(tl.instance_type, t.instance_type) AS instance_type,
+                        COALESCE(tl.icon_id, t.icon_id) AS icon_id,
+                        t.link,
+                        COALESCE(tl.allow_sensitive, t.allow_sensitive) as allow_sensitive,
+                        dr.path as registry,
+                        dr.secret_name
+                    FROM
+                        pipeline.tool t
+                    INNER JOIN pipeline.docker_registry dr ON (t.registry_id = dr.id)
+                    LEFT JOIN pipeline.tool tl ON (t.link = tl.id)
+                    WHERE
+                        t.image IN (:list)
+                        AND
+                        (:REGISTRY_ID IS NULL OR t.registry_id = :REGISTRY_ID)
                 ]]>
             </value>
         </property>

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunManagerUnitTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunManagerUnitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,20 +19,44 @@ package com.epam.pipeline.manager.pipeline;
 import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.dao.pipeline.PipelineRunDao;
 import com.epam.pipeline.entity.pipeline.DiskAttachRequest;
+import com.epam.pipeline.entity.pipeline.DockerRegistry;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.pipeline.PipelineRunWithTool;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
+import com.epam.pipeline.entity.pipeline.Tool;
 import com.epam.pipeline.manager.cluster.NodesManager;
+import com.epam.pipeline.manager.docker.DockerRegistryManager;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static com.epam.pipeline.test.creator.CommonCreatorConstants.ID;
+import static com.epam.pipeline.test.creator.CommonCreatorConstants.ID_2;
+import static com.epam.pipeline.test.creator.CommonCreatorConstants.ID_3;
+import static com.epam.pipeline.test.creator.docker.DockerCreatorUtils.IMAGE1;
+import static com.epam.pipeline.test.creator.docker.DockerCreatorUtils.IMAGE2;
+import static com.epam.pipeline.test.creator.docker.DockerCreatorUtils.REGISTRY1;
+import static com.epam.pipeline.test.creator.docker.DockerCreatorUtils.REGISTRY2;
+import static com.epam.pipeline.test.creator.docker.DockerCreatorUtils.getDockerRegistry;
+import static com.epam.pipeline.test.creator.docker.DockerCreatorUtils.getTool;
+import static com.epam.pipeline.test.creator.pipeline.PipelineCreatorUtils.getPipelineRun;
 import static com.epam.pipeline.util.CustomAssertions.assertThrows;
 import static com.epam.pipeline.util.CustomMatchers.matches;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -42,6 +66,8 @@ public class PipelineRunManagerUnitTest {
     private static final long NOT_EXISTING_RUN_ID = -1L;
     private static final String NODE_NAME = "node_name";
     private static final Long SIZE = 10L;
+    private static final Long ID_4 = 4L;
+    private static final String OWNER = "USER";
 
     @Mock
     private NodesManager nodesManager;
@@ -54,8 +80,13 @@ public class PipelineRunManagerUnitTest {
     private MessageHelper messageHelper;
 
     @Mock
-    @SuppressWarnings("PMD.UnusedPrivateField")
     private PipelineRunCRUDService runCRUDService;
+
+    @Mock
+    private DockerRegistryManager dockerRegistryManager;
+
+    @Mock
+    private ToolManager toolManager;
 
     @InjectMocks
     private PipelineRunManager pipelineRunManager;
@@ -121,6 +152,32 @@ public class PipelineRunManagerUnitTest {
         assertAttachSucceed(run(TaskStatus.RESUMING));
     }
 
+    @Test
+    public void shouldLoadRunsWithTools() {
+        final List<Long> runIds = Arrays.asList(ID, ID_2, ID_3, ID_4);
+        doReturn(Arrays.asList(dockerRegistry(ID, REGISTRY1), dockerRegistry(ID_2, REGISTRY2)))
+                .when(dockerRegistryManager).loadAllDockerRegistry();
+        doReturn(Arrays.asList(
+                pipelineRun(ID, buildDockerImage(REGISTRY1, IMAGE1)),
+                pipelineRun(ID_2, buildDockerImage(REGISTRY2, IMAGE1)),
+                pipelineRun(ID_3, buildDockerImage(REGISTRY1, IMAGE2)),
+                pipelineRun(ID_4, buildDockerImage(REGISTRY1, IMAGE2))))
+                .when(runCRUDService).loadRunsByIds(runIds);
+        doReturn(Arrays.asList(tool(ID, REGISTRY1, IMAGE1), tool(ID_2, REGISTRY1, IMAGE2))).when(toolManager)
+                .loadAllByRegistryAndImageIn(eq(ID), any());
+        doReturn(Collections.singletonList(tool(ID, REGISTRY2, IMAGE1))).when(toolManager)
+                .loadAllByRegistryAndImageIn(eq(ID_2), any());
+
+        final List<PipelineRunWithTool> result = pipelineRunManager.loadRunsWithTools(runIds);
+        assertThat(result).hasSize(4);
+        final Map<Long, PipelineRunWithTool> resultByRunId = result.stream()
+                .collect(Collectors.toMap(runWithTool -> runWithTool.getPipelineRun().getId(), Function.identity()));
+        verifyRunWithTool(resultByRunId.get(ID), REGISTRY1, IMAGE1);
+        verifyRunWithTool(resultByRunId.get(ID_2), REGISTRY2, IMAGE1);
+        verifyRunWithTool(resultByRunId.get(ID_3), REGISTRY1, IMAGE2);
+        verifyRunWithTool(resultByRunId.get(ID_4), REGISTRY1, IMAGE2);
+    }
+
     private void assertAttachFails(final DiskAttachRequest request) {
         assertAttachFails(RUN_ID, request);
     }
@@ -162,5 +219,36 @@ public class PipelineRunManagerUnitTest {
 
     private DiskAttachRequest diskAttachRequest(final Long size) {
         return new DiskAttachRequest(size);
+    }
+
+    private DockerRegistry dockerRegistry(final Long id, final String path) {
+        final DockerRegistry registry = getDockerRegistry(id, OWNER);
+        registry.setPath(path);
+        return registry;
+    }
+
+    private PipelineRun pipelineRun(final Long id, final String dockerImage) {
+        final PipelineRun pipelineRun = getPipelineRun(id, OWNER);
+        pipelineRun.setDockerImage(dockerImage);
+        return pipelineRun;
+    }
+
+    private Tool tool(final Long id, final String registry, final String image) {
+        final Tool tool = getTool(id, OWNER);
+        tool.setImage(image);
+        tool.setRegistry(registry);
+        return tool;
+    }
+
+    private void verifyRunWithTool(final PipelineRunWithTool result, final String expectedRegistry,
+                                   final String expectedImage) {
+        assertThat(result.getPipelineRun().getDockerImage())
+                .contains(expectedRegistry)
+                .contains(expectedImage);
+        assertThat(result.getTool().getImage()).contains(expectedImage);
+    }
+
+    private String buildDockerImage(final String registry, final String image) {
+        return String.format("%s/%s", registry, image);
     }
 }

--- a/api/src/test/java/com/epam/pipeline/test/creator/docker/DockerCreatorUtils.java
+++ b/api/src/test/java/com/epam/pipeline/test/creator/docker/DockerCreatorUtils.java
@@ -44,6 +44,10 @@ import static com.epam.pipeline.test.creator.CommonCreatorConstants.ID;
 import static com.epam.pipeline.test.creator.CommonCreatorConstants.TEST_STRING;
 
 public final class DockerCreatorUtils {
+    public static final String IMAGE1 = "library/image1";
+    public static final String IMAGE2 = "library/image2";
+    public static final String REGISTRY1 = "registry1:8080";
+    public static final String REGISTRY2 = "registry2:8080";
 
     public static final TypeReference<Result<ImageDescription>> IMAGE_DESCRIPTION_INSTANCE_TYPE =
             new TypeReference<Result<ImageDescription>>() {};

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRunWithTool.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRunWithTool.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.pipeline;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class PipelineRunWithTool {
+    private PipelineRun pipelineRun;
+    private Tool tool;
+}


### PR DESCRIPTION
The current PR provides implementation for issue #1816 

This PR provides a new API method `GET /runs?runIds=1,2..` that return specified runs with associated tools