### PR TITLE
Issue #1829: Introduce "faceted filter" capability

### DIFF
--- a/api/src/main/java/com/epam/pipeline/controller/search/SearchController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/search/SearchController.java
@@ -19,6 +19,8 @@ package com.epam.pipeline.controller.search;
 import com.epam.pipeline.controller.AbstractRestController;
 import com.epam.pipeline.controller.Result;
 import com.epam.pipeline.controller.vo.search.ElasticSearchRequest;
+import com.epam.pipeline.controller.vo.search.FacetedSearchRequest;
+import com.epam.pipeline.entity.search.FacetedSearchResult;
 import com.epam.pipeline.entity.search.SearchResult;
 import com.epam.pipeline.manager.search.SearchManager;
 import io.swagger.annotations.ApiOperation;
@@ -26,6 +28,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -38,7 +41,6 @@ public class SearchController extends AbstractRestController {
 
     private final SearchManager searchManager;
 
-
     @RequestMapping(value = "/search", method = RequestMethod.POST)
     @ResponseBody
     @ApiOperation(
@@ -50,5 +52,18 @@ public class SearchController extends AbstractRestController {
             })
     public Result<SearchResult> search(@RequestBody ElasticSearchRequest searchRequest) {
         return Result.success(searchManager.search(searchRequest));
+    }
+
+    @PostMapping(value = "/search/facet")
+    @ResponseBody
+    @ApiOperation(
+            value = "Search with faceted filters",
+            notes = "Search with faceted filters",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public Result<FacetedSearchResult> facetedSearch(@RequestBody final FacetedSearchRequest searchRequest) {
+        return Result.success(searchManager.facetedSearch(searchRequest));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/vo/search/FacetedSearchRequest.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/search/FacetedSearchRequest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.controller.vo.search;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FacetedSearchRequest {
+    private String query;
+    private Map<String, List<String>> filters;
+    private List<String> facets;
+    private Integer pageSize;
+    private Integer offset;
+    private boolean highlight = false;
+}

--- a/api/src/main/java/com/epam/pipeline/entity/search/FacetedSearchResult.java
+++ b/api/src/main/java/com/epam/pipeline/entity/search/FacetedSearchResult.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.search;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FacetedSearchResult {
+    private long totalHits;
+    private List<SearchDocument> documents;
+    private Map<String, Map<String, Long>> facets;
+}

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/EntityMapper.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/EntityMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,15 @@ public interface EntityMapper<T> {
 
     default XContentBuilder buildMetadata(final Map<String, String> metadata,
                                           final XContentBuilder jsonBuilder) throws IOException {
-        return buildMap(metadata, jsonBuilder, "metadata");
+        buildMap(metadata, jsonBuilder, "metadata");
+        MapUtils.emptyIfNull(metadata).forEach((key, value) -> {
+            try {
+                jsonBuilder.field(key, value);
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Failed to add metadata to elasticsearch document: ", e);
+            }
+        });
+        return jsonBuilder;
     }
 
     default XContentBuilder buildMap(final Map<String, String> data,

--- a/elasticsearch-agent/src/main/resources/templates/data_storage.json
+++ b/elasticsearch-agent/src/main/resources/templates/data_storage.json
@@ -40,5 +40,20 @@
         "file_path_tokenizer": { "type": "simple_pattern_split", "pattern": "/"}
       }
     }
-  }
+  },
+  "dynamic_templates": [
+    {
+      "metadata": {
+        "match_mapping_type": "string",
+        "mapping": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type":  "keyword"
+            }
+          }
+        }
+      }
+    }
+  ]
 }

--- a/elasticsearch-agent/src/main/resources/templates/docker_registry.json
+++ b/elasticsearch-agent/src/main/resources/templates/docker_registry.json
@@ -22,6 +22,21 @@
       }
     }
   },
+  "dynamic_templates": [
+    {
+      "metadata": {
+        "match_mapping_type": "string",
+        "mapping": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type":  "keyword"
+            }
+          }
+        }
+      }
+    }
+  ],
   "settings": {
     "index": {
       "number_of_shards" : 1,

--- a/elasticsearch-agent/src/main/resources/templates/folder.json
+++ b/elasticsearch-agent/src/main/resources/templates/folder.json
@@ -19,6 +19,21 @@
       }
     }
   },
+  "dynamic_templates": [
+    {
+      "metadata": {
+        "match_mapping_type": "string",
+        "mapping": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type":  "keyword"
+            }
+          }
+        }
+      }
+    }
+  ],
   "settings": {
     "index": {
       "number_of_shards" : 1,

--- a/elasticsearch-agent/src/main/resources/templates/pipeline.json
+++ b/elasticsearch-agent/src/main/resources/templates/pipeline.json
@@ -23,6 +23,21 @@
       }
     }
   },
+  "dynamic_templates": [
+    {
+      "metadata": {
+        "match_mapping_type": "string",
+        "mapping": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type":  "keyword"
+            }
+          }
+        }
+      }
+    }
+  ],
   "settings": {
     "index": {
       "number_of_shards" : 1,

--- a/elasticsearch-agent/src/main/resources/templates/run_configuration.json
+++ b/elasticsearch-agent/src/main/resources/templates/run_configuration.json
@@ -33,6 +33,21 @@
       }
     }
   },
+  "dynamic_templates": [
+    {
+      "metadata": {
+        "match_mapping_type": "string",
+        "mapping": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type":  "keyword"
+            }
+          }
+        }
+      }
+    }
+  ],
   "settings": {
     "index": {
       "number_of_shards" : 1,

--- a/elasticsearch-agent/src/main/resources/templates/tool.json
+++ b/elasticsearch-agent/src/main/resources/templates/tool.json
@@ -28,6 +28,21 @@
       }
     }
   },
+  "dynamic_templates": [
+    {
+      "metadata": {
+        "match_mapping_type": "string",
+        "mapping": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type":  "keyword"
+            }
+          }
+        }
+      }
+    }
+  ],
   "settings": {
     "index": {
       "number_of_shards" : 1,

--- a/elasticsearch-agent/src/main/resources/templates/tool_group.json
+++ b/elasticsearch-agent/src/main/resources/templates/tool_group.json
@@ -21,6 +21,21 @@
       }
     }
   },
+  "dynamic_templates": [
+    {
+      "metadata": {
+        "match_mapping_type": "string",
+        "mapping": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type":  "keyword"
+            }
+          }
+        }
+      }
+    }
+  ],
   "settings": {
     "index": {
       "number_of_shards" : 1,


### PR DESCRIPTION
The current PR provides API implementation for issue #1829 

This PR contains the following changes:
- a new method `POST /search/facet` added (according to requirements from https://github.com/epam/cloud-pipeline/issues/1829#issuecomment-789610734)
- elasticsearch mappings files updated