### PR TITLE
Issue #1840 SGE workers idle timeout

### DIFF
--- a/workflows/pipe-common/scripts/autoscale_sge.py
+++ b/workflows/pipe-common/scripts/autoscale_sge.py
@@ -1421,9 +1421,13 @@ if __name__ == '__main__':
                                          storage_file=os.path.join(shared_work_dir, '.autoscaler.storage'))
     scale_up_timeout = int(api.retrieve_preference('ge.autoscaling.scale.up.timeout', default_value=30))
     scale_down_timeout = int(api.retrieve_preference('ge.autoscaling.scale.down.timeout', default_value=30))
-    run_custom_scale_down_timeout = os.getenv('CP_CAP_AUTOSCALE_IDLE_TIMEOUT', None)
+    run_custom_scale_down_timeout = os.getenv('CP_CAP_AUTOSCALE_IDLE_TIMEOUT')
     if run_custom_scale_down_timeout:
-        scale_down_timeout = int(run_custom_scale_down_timeout)
+        if run_custom_scale_down_timeout.isdigit():
+            scale_down_timeout = int(run_custom_scale_down_timeout)
+        else:
+            Logger.warn('Idle timeout [%s], specified for workers via run parameter, is illegal. '
+                        'Using global value [%s] instead.' % (run_custom_scale_down_timeout, scale_down_timeout))
     scale_up_polling_timeout = int(api.retrieve_preference('ge.autoscaling.scale.up.polling.timeout',
                                                            default_value=900))
     scale_up_polling_delay = int(os.getenv('CP_CAP_AUTOSCALE_SCALE_UP_POLLING_DELAY', 10))

--- a/workflows/pipe-common/scripts/autoscale_sge.py
+++ b/workflows/pipe-common/scripts/autoscale_sge.py
@@ -249,9 +249,6 @@ class GridEngine:
                 current_host = None
         return jobs.values()
 
-    def filter_running_job(self, jobs):
-        return [job for job in jobs if job.state == GridEngineJobState.RUNNING]
-
     def _parse_date(self, date):
         return datetime.strptime(date, GridEngine._QSTAT_DATETIME_FORMAT)
 
@@ -737,7 +734,7 @@ class GridEngineScaleUpHandler:
 
     def _update_last_activity_for_currently_running_jobs(self):
         jobs = self.grid_engine.get_jobs()
-        running_jobs = self.grid_engine.filter_running_job(jobs)
+        running_jobs = [job for job in jobs if job.state == GridEngineJobState.RUNNING]
         if running_jobs:
             GridEngineAutoscaler.update_running_jobs_host_activity(running_jobs, self.host_storage, self.clock.now())
 
@@ -992,7 +989,7 @@ class GridEngineAutoscaler:
         additional_hosts = self.host_storage.load_hosts()
         Logger.info('There are %s additional pipelines.' % len(additional_hosts))
         updated_jobs = self.grid_engine.get_jobs()
-        running_jobs = self.grid_engine.filter_running_job(updated_jobs)
+        running_jobs = [job for job in updated_jobs if job.state == GridEngineJobState.RUNNING]
         pending_jobs = self._filter_pending_job(updated_jobs)
         self.update_running_jobs_host_activity(running_jobs, self.host_storage, now)
         if running_jobs:

--- a/workflows/pipe-common/scripts/autoscale_sge.py
+++ b/workflows/pipe-common/scripts/autoscale_sge.py
@@ -881,7 +881,8 @@ class FileSystemHostStorage:
     def get_hosts_activity(self, hosts):
         hosts_activity = {}
         latest_hosts_activity = self._load_hosts_stats()
-        hosts.remove(self.master_host)
+        if self.master_host in hosts:
+            hosts.remove(self.master_host)
         for host in hosts:
             self._validate_existence(host, latest_hosts_activity)
             hosts_activity[host] = latest_hosts_activity[host]
@@ -911,7 +912,8 @@ class FileSystemHostStorage:
 
     def load_hosts(self):
         latest_hosts_stats = self._load_hosts_stats()
-        latest_hosts_stats.pop(self.master_host)
+        if self.master_host in latest_hosts_stats:
+            latest_hosts_stats.pop(self.master_host)
         return list(latest_hosts_stats.keys())
 
     def _load_hosts_stats(self):

--- a/workflows/pipe-common/scripts/autoscale_sge.py
+++ b/workflows/pipe-common/scripts/autoscale_sge.py
@@ -898,7 +898,7 @@ class FileSystemHostStorage:
     def _update_storage_file(self, hosts):
         hosts_summary_table = []
         for host, last_activity in hosts.items():
-            formatted_activity = last_activity.strftime(FileSystemHostStorage._DATETIME_FORMAT) if last_activity else ''
+            formatted_activity = last_activity.strftime(FileSystemHostStorage._DATETIME_FORMAT)
             hosts_summary_table.append(FileSystemHostStorage._VALUE_BREAKER.join([host, formatted_activity]))
         self.executor.execute(FileSystemHostStorage._REPLACE_FILE % {'content': '\n'.join(hosts_summary_table),
                                                                      'file': self.storage_file})
@@ -921,9 +921,7 @@ class FileSystemHostStorage:
                         host_stats = stripped_line.strip().split(FileSystemHostStorage._VALUE_BREAKER)
                         if host_stats:
                             hostname = host_stats[0]
-                            last_activity = datetime.strptime(host_stats[1], FileSystemHostStorage._DATETIME_FORMAT) \
-                                if len(host_stats) > 1 \
-                                else None
+                            last_activity = datetime.strptime(host_stats[1], FileSystemHostStorage._DATETIME_FORMAT)
                             hosts[hostname] = last_activity
                 return hosts
         else:
@@ -1086,7 +1084,7 @@ class GridEngineAutoscaler:
         inactive_hosts = []
         hosts_activity = self.host_storage.get_hosts_activity(inactive_host_candidates)
         for host, last_activity in hosts_activity.items():
-            if not last_activity or scaling_period_start > last_activity + self.idle_timeout:
+            if scaling_period_start > last_activity + self.idle_timeout:
                 inactive_hosts.append(host)
         return inactive_hosts
 

--- a/workflows/pipe-common/scripts/autoscale_sge.py
+++ b/workflows/pipe-common/scripts/autoscale_sge.py
@@ -841,7 +841,7 @@ class FileSystemHostStorage:
     _REPLACE_FILE = 'echo "%(content)s" > %(file)s_MODIFIED; ' \
                     'mv %(file)s_MODIFIED %(file)s'
     _DATETIME_FORMAT = '%m/%d/%Y %H:%M:%S'
-    _VALUE_BREAKER = ' '
+    _VALUE_BREAKER = '|'
     _LINE_BREAKER = '\n'
 
     def __init__(self, cmd_executor, storage_file, clock=Clock()):

--- a/workflows/pipe-common/scripts/autoscale_sge.py
+++ b/workflows/pipe-common/scripts/autoscale_sge.py
@@ -1028,7 +1028,7 @@ class GridEngineAutoscaler:
     def _update_hosts_activity(self, scaling_step_start, running_jobs):
         active_hosts = set()
         for job in running_jobs:
-            active_hosts.add(job.hosts)
+            active_hosts.update(job.hosts)
         if active_hosts:
             self.host_storage.update_hosts_activity(active_hosts, scaling_step_start)
 

--- a/workflows/pipe-common/scripts/autoscale_sge.py
+++ b/workflows/pipe-common/scripts/autoscale_sge.py
@@ -858,7 +858,7 @@ class FileSystemHostStorage:
     _VALUE_BREAKER = '|'
     _LINE_BREAKER = '\n'
 
-    def __init__(self, cmd_executor, storage_file, clock=Clock(), master_host=None):
+    def __init__(self, cmd_executor, storage_file, clock=Clock()):
         """
         Additional hosts storage.
         Contains the hostname along with the time of the last activity on it.
@@ -870,7 +870,6 @@ class FileSystemHostStorage:
         self.executor = cmd_executor
         self.storage_file = storage_file
         self.clock = clock
-        self.master_host = master_host
 
     def add_host(self, host):
         """
@@ -887,16 +886,13 @@ class FileSystemHostStorage:
     def update_hosts_activity(self, hosts, timestamp):
         latest_hosts_stats = self._load_hosts_stats()
         for host in hosts:
-            if host != self.master_host:
-                self._validate_existence(host, latest_hosts_stats)
-            latest_hosts_stats[host] = timestamp
+            if host in latest_hosts_stats:
+                latest_hosts_stats[host] = timestamp
         self._update_storage_file(latest_hosts_stats)
 
     def get_hosts_activity(self, hosts):
         hosts_activity = {}
         latest_hosts_activity = self._load_hosts_stats()
-        if self.master_host in hosts:
-            hosts.remove(self.master_host)
         for host in hosts:
             self._validate_existence(host, latest_hosts_activity)
             hosts_activity[host] = latest_hosts_activity[host]
@@ -908,9 +904,6 @@ class FileSystemHostStorage:
 
         :param host: Additional host name.
         """
-        if host == self.master_host:
-            Logger.warn('Master host shouldn\'t be removed from the host storage, skipping...')
-            return
         hosts = self._load_hosts_stats()
         self._validate_existence(host, hosts)
         hosts.pop(host)
@@ -925,10 +918,7 @@ class FileSystemHostStorage:
                                                                      'file': self.storage_file})
 
     def load_hosts(self):
-        latest_hosts_stats = self._load_hosts_stats()
-        if self.master_host in latest_hosts_stats:
-            latest_hosts_stats.pop(self.master_host)
-        return list(latest_hosts_stats.keys())
+        return list(self._load_hosts_stats().keys())
 
     def _load_hosts_stats(self):
         """
@@ -1507,11 +1497,9 @@ if __name__ == '__main__':
     scaling_operations_clock = Clock()
     grid_engine = GridEngine(cmd_executor=cmd_executor, max_instance_cores=max_instance_cores,
                              max_cluster_cores=max_cluster_cores)
-    master_host = os.getenv('PARENT')
     host_storage = FileSystemHostStorage(cmd_executor=cmd_executor,
                                          storage_file=os.path.join(shared_work_dir, '.autoscaler.storage'),
-                                         clock=scaling_operations_clock,
-                                         master_host=master_host)
+                                         clock=scaling_operations_clock)
     scale_up_timeout = int(api.retrieve_preference('ge.autoscaling.scale.up.timeout', default_value=30))
     scale_down_timeout = int(api.retrieve_preference('ge.autoscaling.scale.down.timeout', default_value=30))
     idle_timeout = int(os.getenv('CP_CAP_AUTOSCALE_IDLE_TIMEOUT', 30))

--- a/workflows/pipe-common/scripts/autoscale_sge.py
+++ b/workflows/pipe-common/scripts/autoscale_sge.py
@@ -908,12 +908,13 @@ class FileSystemHostStorage:
                 for line in file.readlines():
                     stripped_line = line.strip().strip(FileSystemHostStorage._LINE_BREAKER)
                     if stripped_line:
-                        host_stats = stripped_line.strip().strip(FileSystemHostStorage._VALUE_BREAKER)
-                        hostname = host_stats[0]
-                        last_activity = datetime.strptime(host_stats[1], FileSystemHostStorage._DATETIME_FORMAT) \
-                            if len(host_stats) > 1 \
-                            else None
-                        hosts[hostname] = last_activity
+                        host_stats = stripped_line.strip().split(FileSystemHostStorage._VALUE_BREAKER)
+                        if host_stats:
+                            hostname = host_stats[0]
+                            last_activity = datetime.strptime(host_stats[1], FileSystemHostStorage._DATETIME_FORMAT) \
+                                if len(host_stats) > 1 \
+                                else None
+                            hosts[hostname] = last_activity
                 return hosts
         else:
             return {}


### PR DESCRIPTION
This PR is related to issue #1840.

It allows specifying an idle timeout for the cluster workers, using `CP_CAP_AUTOSCALE_IDLE_TIMEOUT` run parameter.
That means, that if a node was active (performing a task) it will be scaled down not exactly after 'scaling down' timeout since the last active cluster task, but after passing the idle timeout of activity for that specific node.