### PR TITLE
Pipeline Runs shall not be deleted with parent Pipeline - fix

### DIFF
--- a/api/src/main/java/com/epam/pipeline/dao/filter/FilterRunParameters.java
+++ b/api/src/main/java/com/epam/pipeline/dao/filter/FilterRunParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -143,7 +143,7 @@ public enum FilterRunParameters {
     POD_ID,
     @FilterField(
             displayName = "pipeline.name",
-            databaseTableAlias = "pipelines",
+            databaseTableAlias = "r",
             description = "Pipeline name",
             composer = WildCardComposer.class,
             converter = WildCardConverter.class,
@@ -257,10 +257,6 @@ public enum FilterRunParameters {
     OTHER_PARAMETER;
 
     static RowMapper<PipelineRun> getRowMapper() {
-        return (rs, rowNum) -> {
-            PipelineRun run = PipelineRunDao.PipelineRunParameters.parsePipelineRun(rs);
-            run.setPipelineName(rs.getString(PIPELINE_NAME.name()));
-            return run;
-        };
+        return (rs, rowNum) -> PipelineRunDao.PipelineRunParameters.parsePipelineRun(rs);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/notification/MonitoringNotificationDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/notification/MonitoringNotificationDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,6 @@ public class MonitoringNotificationDao extends NamedParameterJdbcDaoSupport {
     private String updateNotificationTimestampQuery;
     private String loadNotificationTimestampQuery;
     private String deleteNotificationTimestampsByRunIdQuery;
-    private String deleteNotificationTimestampsByPipelineIdQuery;
     private String deleteNotificationsByUserIdQuery;
 
     @Transactional(propagation = Propagation.MANDATORY)
@@ -125,11 +124,6 @@ public class MonitoringNotificationDao extends NamedParameterJdbcDaoSupport {
     @Transactional(propagation = Propagation.MANDATORY)
     public void deleteNotificationTimestampsForRun(final Long runId) {
         getJdbcTemplate().update(deleteNotificationTimestampsByRunIdQuery, runId);
-    }
-
-    @Transactional(propagation = Propagation.MANDATORY)
-    public void deleteNotificationTimestampsForPipeline(final Long pipelineId) {
-        getJdbcTemplate().update(deleteNotificationTimestampsByPipelineIdQuery, pipelineId);
     }
 
     @Transactional(propagation = Propagation.MANDATORY)
@@ -248,11 +242,6 @@ public class MonitoringNotificationDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setDeleteNotificationTimestampsByRunIdQuery(String deleteNotificationTimestampsByRunIdQuery) {
         this.deleteNotificationTimestampsByRunIdQuery = deleteNotificationTimestampsByRunIdQuery;
-    }
-
-    @Required
-    public void setDeleteNotificationTimestampsByPipelineIdQuery(String deleteNotificationTimestampsByPipelineIdQuery) {
-        this.deleteNotificationTimestampsByPipelineIdQuery = deleteNotificationTimestampsByPipelineIdQuery;
     }
 
     @Required

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
@@ -111,7 +111,6 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     private String deleteRunSidsByRunIdQuery;
     private String loadRunSidsQuery;
     private String loadRunSidsQueryForList;
-    private String deleteRunSidsByPipelineIdQuery;
     private String updatePodStatusQuery;
     private String loadEnvVarsQuery;
     private String updateLastNotificationQuery;
@@ -402,11 +401,6 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     @Transactional(propagation = Propagation.MANDATORY)
     public void deleteRunSids(Long runId) {
         getJdbcTemplate().update(deleteRunSidsByRunIdQuery, runId);
-    }
-
-    @Transactional(propagation = Propagation.MANDATORY)
-    public void deleteRunSidsByPipelineId(final Long pipelineId) {
-        getJdbcTemplate().update(deleteRunSidsByPipelineIdQuery, pipelineId);
     }
 
     @Transactional(propagation = Propagation.SUPPORTS)
@@ -1223,10 +1217,5 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setLoadRunByPodIPQuery(final String loadRunByPodIPQuery) {
         this.loadRunByPodIPQuery = loadRunByPodIPQuery;
-    }
-
-    @Required
-    public void setDeleteRunSidsByPipelineIdQuery(final String deleteRunSidsByPipelineIdQuery) {
-        this.deleteRunSidsByPipelineIdQuery = deleteRunSidsByPipelineIdQuery;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/RestartRunDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/RestartRunDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,6 @@ public class RestartRunDao extends NamedParameterJdbcDaoSupport {
     private String loadPipelineRestartedRunForParentRunQuery;
     private String loadAllRestartedRunsQuery;
     private String loadAllRestartedRunsForInitialRunQuery;
-    private String deleteRestartedRunsByPipelineQuery;
 
     @Transactional(propagation = Propagation.MANDATORY)
     public void createPipelineRestartRun(RestartRun restartRun) {
@@ -63,11 +62,6 @@ public class RestartRunDao extends NamedParameterJdbcDaoSupport {
     public List<RestartRun> loadAllRestartedRunsForInitialRun(Long runId) {
         return getJdbcTemplate().query(loadAllRestartedRunsForInitialRunQuery,
                 PipelineRestartRunParameters.getRowMapper(), runId, runId);
-    }
-
-    @Transactional(propagation = Propagation.MANDATORY)
-    public void deleteRestartedRunsForPipeline(Long pipelineId) {
-        getJdbcTemplate().update(deleteRestartedRunsByPipelineQuery, pipelineId);
     }
 
     enum PipelineRestartRunParameters {
@@ -120,10 +114,5 @@ public class RestartRunDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setLoadAllRestartedRunsForInitialRunQuery(String loadAllRestartedRunsForInitialRunQuery) {
         this.loadAllRestartedRunsForInitialRunQuery = loadAllRestartedRunsForInitialRunQuery;
-    }
-
-    @Required
-    public void setDeleteRestartedRunsByPipelineQuery(String deleteRestartedRunsByPipelineQuery) {
-        this.deleteRestartedRunsByPipelineQuery = deleteRestartedRunsByPipelineQuery;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/RunLogDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/RunLogDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,6 @@ public class RunLogDao extends NamedParameterJdbcDaoSupport {
     private String loadTasksByRunIdQuery;
     private String loadTaskForInstanceQuery;
     private String loadTaskStatusQuery;
-    private String deleteLogsByPipelineQuery;
 
     @Transactional(propagation = Propagation.MANDATORY)
     public void createRunLog(RunLog runLog) {
@@ -81,11 +80,6 @@ public class RunLogDao extends NamedParameterJdbcDaoSupport {
     public List<PipelineTask> loadTaskByInstance(Long runId, String instance) {
         return getJdbcTemplate().query(loadTaskForInstanceQuery,
                 PipelineLogParameters.getTaskRowMapper(false), runId, instance);
-    }
-
-    @Transactional(propagation = Propagation.MANDATORY)
-    public void deleteLogsForPipeline(Long id) {
-        getJdbcTemplate().update(deleteLogsByPipelineQuery, id);
     }
 
     enum PipelineLogParameters {
@@ -195,8 +189,4 @@ public class RunLogDao extends NamedParameterJdbcDaoSupport {
         this.loadTaskStatusQuery = loadTaskStatusQuery;
     }
 
-    @Required
-    public void setDeleteLogsByPipelineQuery(String deleteLogsByPipelineQuery) {
-        this.deleteLogsByPipelineQuery = deleteLogsByPipelineQuery;
-    }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/RunScheduleDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/RunScheduleDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,8 +50,6 @@ public class RunScheduleDao extends NamedParameterJdbcDaoSupport {
     private String loadRunScheduleQuery;
     private String loadAllRunSchedulesQuery;
     private String loadAllRunSchedulesByRunIdQuery;
-    private String deleteRunSchedulesForRunByPipelineIdQuery;
-
 
     @Transactional(propagation = Propagation.MANDATORY)
     public Long createScheduleId() {
@@ -112,10 +110,6 @@ public class RunScheduleDao extends NamedParameterJdbcDaoSupport {
         params.addValue(SCHEDULABLE_ID.name(), runId);
         params.addValue(TYPE.name(), scheduleType.name());
         getNamedParameterJdbcTemplate().update(deleteRunSchedulesForRunQuery, params);
-    }
-
-    public void deleteRunSchedulesForRunByPipeline(final Long pipelineId) {
-        getJdbcTemplate().update(deleteRunSchedulesForRunByPipelineIdQuery, pipelineId);
     }
 
     enum RunScheduleParameters {
@@ -201,10 +195,5 @@ public class RunScheduleDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setDeleteRunSchedulesForRunQuery(final String deleteRunSchedulesForRunQuery) {
         this.deleteRunSchedulesForRunQuery = deleteRunSchedulesForRunQuery;
-    }
-
-    @Required
-    public void setDeleteRunSchedulesForRunByPipelineIdQuery(final String deleteRunSchedulesForRunByPipelineIdQuery) {
-        this.deleteRunSchedulesForRunByPipelineIdQuery = deleteRunSchedulesForRunByPipelineIdQuery;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/RunStatusDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/RunStatusDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,8 +33,6 @@ public class RunStatusDao extends NamedParameterJdbcDaoSupport {
     private String loadRunStatusQuery;
     private String loadRunStatusByListQuery;
     private String deleteRunStatusQuery;
-    private String deleteRunStatusForPipelineQuery;
-
 
     @Transactional(propagation = Propagation.MANDATORY)
     public void saveStatus(RunStatus runStatus) {
@@ -57,10 +55,6 @@ public class RunStatusDao extends NamedParameterJdbcDaoSupport {
     @Transactional(propagation = Propagation.MANDATORY)
     public void deleteRunStatus(Long runId) {
         getJdbcTemplate().update(deleteRunStatusQuery, runId);
-    }
-
-    public void deleteRunStatusForPipeline(final Long pipelineId) {
-        getJdbcTemplate().update(deleteRunStatusForPipelineQuery, pipelineId);
     }
 
     enum RunStatusParameters {
@@ -114,10 +108,5 @@ public class RunStatusDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setDeleteRunStatusQuery(final String deleteRunStatusQuery) {
         this.deleteRunStatusQuery = deleteRunStatusQuery;
-    }
-
-    @Required
-    public void setDeleteRunStatusForPipelineQuery(final String deleteRunStatusForPipelineQuery) {
-        this.deleteRunStatusForPipelineQuery = deleteRunStatusForPipelineQuery;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/notification/NotificationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/notification/NotificationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -462,11 +462,6 @@ public class NotificationManager { // TODO: rewrite with Strategy pattern?
     @Transactional(propagation = Propagation.REQUIRED)
     public void removeNotificationTimestamps(final Long runId) {
         monitoringNotificationDao.deleteNotificationTimestampsForRun(runId);
-    }
-
-    @Transactional(propagation = Propagation.REQUIRED)
-    public void removeNotificationTimestampsByPipelineId(final Long id) {
-        monitoringNotificationDao.deleteNotificationTimestampsForPipeline(id);
     }
 
     public Optional<NotificationTimestamp> loadLastNotificationTimestamp(final Long runId,

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineManager.java
@@ -24,7 +24,6 @@ import com.epam.pipeline.controller.vo.PipelineVO;
 import com.epam.pipeline.dao.datastorage.rules.DataStorageRuleDao;
 import com.epam.pipeline.dao.pipeline.PipelineDao;
 import com.epam.pipeline.dao.pipeline.PipelineRunDao;
-import com.epam.pipeline.dao.pipeline.RunLogDao;
 import com.epam.pipeline.entity.AbstractSecuredEntity;
 import com.epam.pipeline.entity.datastorage.rules.DataStorageRule;
 import com.epam.pipeline.entity.git.GitProject;
@@ -36,7 +35,6 @@ import com.epam.pipeline.entity.security.acl.AclClass;
 import com.epam.pipeline.exception.git.GitClientException;
 import com.epam.pipeline.manager.git.GitManager;
 import com.epam.pipeline.manager.metadata.MetadataManager;
-import com.epam.pipeline.manager.notification.NotificationManager;
 import com.epam.pipeline.manager.security.AuthManager;
 import com.epam.pipeline.manager.security.SecuredEntityManager;
 import com.epam.pipeline.manager.security.acl.AclSync;
@@ -77,9 +75,6 @@ public class PipelineManager implements SecuredEntityManager {
     private PipelineRunDao pipelineRunDao;
 
     @Autowired
-    private RunLogDao runLogDao;
-
-    @Autowired
     private DataStorageRuleDao dataStorageRuleDao;
 
     @Autowired
@@ -98,16 +93,7 @@ public class PipelineManager implements SecuredEntityManager {
     private MetadataManager metadataManager;
 
     @Autowired
-    private RestartRunManager restartRunManager;
-
-    @Autowired
-    private RunStatusManager runStatusManager;
-
-    @Autowired
     private RunScheduleManager runScheduleManager;
-
-    @Autowired
-    private NotificationManager notificationManager;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PipelineManager.class);
 
@@ -246,12 +232,7 @@ public class PipelineManager implements SecuredEntityManager {
                 LOGGER.error(e.getMessage(), e);
             }
         }
-        runLogDao.deleteLogsForPipeline(id);
-        notificationManager.removeNotificationTimestampsByPipelineId(id);
-        restartRunManager.deleteRestartedRunsForPipeline(id);
-        runStatusManager.deleteRunStatusForPipeline(id);
         runScheduleManager.deleteSchedulesForRunByPipeline(id);
-        pipelineRunDao.deleteRunSidsByPipelineId(id);
         resetPipelineIdForRuns(id);
         dataStorageRuleDao.deleteRulesByPipeline(id);
         pipelineDao.deletePipeline(id);

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/RestartRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/RestartRunManager.java
@@ -57,13 +57,4 @@ public class RestartRunManager {
     public List<RestartRun> loadRestartedRunsForInitialRun(Long initialRunId) {
         return restartRunDao.loadAllRestartedRunsForInitialRun(initialRunId);
     }
-
-    /**
-     * Deletes all restart info for runs associated with pipelineId
-     * @param pipelineId
-     */
-    @Transactional(propagation = Propagation.REQUIRED)
-    public void deleteRestartedRunsForPipeline(final Long pipelineId) {
-        restartRunDao.deleteRestartedRunsForPipeline(pipelineId);
-    }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/RunScheduleManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/RunScheduleManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -182,7 +182,6 @@ public class RunScheduleManager {
                 .stream()
                 .flatMap(run -> loadAllSchedulesBySchedulableId(run.getId(), ScheduleType.PIPELINE_RUN).stream())
                 .forEach(scheduler::unscheduleRunSchedule);
-        runScheduleDao.deleteRunSchedulesForRunByPipeline(pipelineId);
     }
 
     private void checkNewRunScheduleRequirements(final Long schedulableId, final PipelineRunScheduleVO runScheduleVO,

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/RunStatusManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/RunStatusManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,10 +59,5 @@ public class RunStatusManager {
     @Transactional(propagation = Propagation.REQUIRED)
     public void deleteRunStatus(final Long runId) {
         runStatusDao.deleteRunStatus(runId);
-    }
-
-    @Transactional(propagation = Propagation.REQUIRED)
-    public void deleteRunStatusForPipeline(final Long pipelineId) {
-        runStatusDao.deleteRunStatusForPipeline(pipelineId);
     }
 }

--- a/api/src/main/resources/dao/filter-dao.xml
+++ b/api/src/main/resources/dao/filter-dao.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+  ~ Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -71,10 +71,9 @@
                         r.tags,
                         r.sensitive,
                         r.kube_service_enabled,
-                        pipelines.pipeline_name
+                        r.pipeline_name
                     FROM
                         pipeline.pipeline_run r
-                    LEFT JOIN pipeline.pipeline pipelines ON (pipelines.pipeline_id = r.pipeline_id)
                     WHERE @WHERE@
                     ORDER BY r.run_id DESC
                     LIMIT :LIMIT OFFSET :OFFSET
@@ -88,7 +87,6 @@
                         count(*) as count
                     FROM
                         pipeline.pipeline_run r
-                    LEFT JOIN pipeline.pipeline pipelines ON (pipelines.pipeline_id = r.pipeline_id)
                     WHERE @WHERE@
                 ]]>
             </value>

--- a/api/src/main/resources/dao/monitoring-notification-dao.xml
+++ b/api/src/main/resources/dao/monitoring-notification-dao.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+  ~ Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -126,17 +126,6 @@
                     FROM
                         pipeline.notification_timestamp
                     WHERE run_id = ?
-                ]]>
-            </value>
-        </property>
-        <property name="deleteNotificationTimestampsByPipelineIdQuery">
-            <value>
-                <![CDATA[
-                    DELETE
-                    FROM
-                        pipeline.notification_timestamp nt
-                    USING pipeline.pipeline_run pr
-                    WHERE pr.run_id = nt.run_id AND pr.pipeline_id = ?
                 ]]>
             </value>
         </property>

--- a/api/src/main/resources/dao/pipeline-restart-run-dao.xml
+++ b/api/src/main/resources/dao/pipeline-restart-run-dao.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+  ~ Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -135,18 +135,6 @@
                     JOIN pipeline.restart_run AS r
                     ON (rrrr.top_parent_run_id = r.restarted_run_id OR rrrr.top_restarted_run_id = r.restarted_run_id)
                     ORDER BY r.parent_run_id;
-                ]]>
-            </value>
-        </property>
-        <property name="deleteRestartedRunsByPipelineQuery">
-            <value>
-                <![CDATA[
-                    DELETE FROM
-                        pipeline.restart_run
-                    USING
-                        pipeline.pipeline_run AS run
-                    WHERE
-                        run.run_id = restart_run.restarted_run_id AND run.pipeline_id = ?
                 ]]>
             </value>
         </property>

--- a/api/src/main/resources/dao/pipeline-run-dao.xml
+++ b/api/src/main/resources/dao/pipeline-run-dao.xml
@@ -1782,14 +1782,5 @@
                 ]]>
             </value>
         </property>
-        <property name="deleteRunSidsByPipelineIdQuery">
-            <value>
-                <![CDATA[
-                    DELETE FROM pipeline.run_user ru
-                    USING pipeline.pipeline_run pr, pipeline.pipeline p
-                    WHERE pr.run_id = ru.run_id AND p.pipeline_id = pr.pipeline_id AND p.pipeline_id = ?
-                ]]>
-            </value>
-        </property>
     </bean>
 </beans>

--- a/api/src/main/resources/dao/pipeline-run-log-dao.xml
+++ b/api/src/main/resources/dao/pipeline-run-log-dao.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+  ~ Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -159,18 +159,6 @@
                     WHERE
                         run_id = ? AND instance = ?
                     LIMIT 1
-                ]]>
-            </value>
-        </property>
-        <property name="deleteLogsByPipelineQuery">
-            <value>
-                <![CDATA[
-                    DELETE FROM
-                        pipeline.pipeline_run_log as log
-                    USING
-                        pipeline.pipeline_run AS run
-                    WHERE
-                        run.run_id = log.run_id AND run.pipeline_id = ?
                 ]]>
             </value>
         </property>

--- a/api/src/main/resources/dao/run-schedule-dao.xml
+++ b/api/src/main/resources/dao/run-schedule-dao.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
@@ -110,17 +125,6 @@
             <value>
                 <![CDATA[
                     DELETE FROM pipeline.run_schedule WHERE schedulable_id = :SCHEDULABLE_ID AND type = :TYPE
-                ]]>
-            </value>
-        </property>
-        <property name="deleteRunSchedulesForRunByPipelineIdQuery">
-            <value>
-                <![CDATA[
-                    DELETE FROM pipeline.run_schedule s
-                    USING
-                        pipeline.pipeline_run r
-                    WHERE
-                        s.type = 'PIPELINE_RUN' AND s.schedulable_id = r.run_id AND r.pipeline_id = ?
                 ]]>
             </value>
         </property>

--- a/api/src/main/resources/dao/run-status-dao.xml
+++ b/api/src/main/resources/dao/run-status-dao.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+  ~ Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -72,18 +72,6 @@
                         pipeline.run_status_change
                     WHERE
                         run_id = ?
-                ]]>
-            </value>
-        </property>
-        <property name="deleteRunStatusForPipelineQuery">
-            <value>
-                <![CDATA[
-                    DELETE FROM
-                        pipeline.run_status_change
-                    USING
-                        pipeline.pipeline_run AS run
-                    WHERE
-                        run.run_id = run_status_change.run_id AND run.pipeline_id = ?
                 ]]>
             </value>
         </property>

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
@@ -45,7 +45,6 @@ import com.epam.pipeline.manager.filter.FilterOperandType;
 import com.epam.pipeline.manager.filter.WrongFilterException;
 import com.epam.pipeline.test.jdbc.AbstractJdbcTest;
 import com.epam.pipeline.util.TestUtils;
-import org.apache.commons.collections4.CollectionUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -813,20 +812,6 @@ public class PipelineRunDaoTest extends AbstractJdbcTest {
         final List<PipelineRun> runs = pipelineRunDao.loadRunsByStatuses(
                 Arrays.asList(TaskStatus.PAUSING, TaskStatus.RESUMING));
         assertEquals(2, runs.size());
-    }
-
-    @Test
-    public void shouldDeleteSidsFromRunByPipelineId() {
-        final RunSid runSid = new RunSid();
-        runSid.setName(GROUP_NAME);
-        runSid.setIsPrincipal(false);
-        final Pipeline pipeline = getPipeline();
-        final PipelineRun run = createRunWithRunSids(pipeline.getId(), null, Collections.singletonList(runSid));
-
-        pipelineRunDao.deleteRunSidsByPipelineId(pipeline.getId());
-
-        final PipelineRun loadedRun = pipelineRunDao.loadPipelineRun(run.getId());
-        assertTrue(CollectionUtils.isEmpty(loadedRun.getRunSids()));
     }
 
     @Test

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/RestartRunDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/RestartRunDaoTest.java
@@ -33,7 +33,6 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 @Transactional
 public class RestartRunDaoTest extends AbstractJdbcTest {
@@ -149,16 +148,6 @@ public class RestartRunDaoTest extends AbstractJdbcTest {
         assertNotNull(runs);
         assertEquals(1, runs2.size());
         assertEquals(runs2.get(0).getParentRunId(), restartRun4.getParentRunId());
-    }
-
-    @Test
-    public void testDeleteRestartedRunsByPipeline() {
-        restartRunDao.createPipelineRestartRun(restartRun1);
-        restartRunDao.createPipelineRestartRun(restartRun2);
-
-        restartRunDao.deleteRestartedRunsForPipeline(testPipeline.getId());
-        List<RestartRun> loadRestartRun = restartRunDao.loadAllRestartedRuns();
-        assertTrue(loadRestartRun.isEmpty());
     }
 
     private PipelineRun createPipelineRun(Long runId, Long pipelineId, Long parentRunId) {

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/RunScheduleDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/RunScheduleDaoTest.java
@@ -29,7 +29,6 @@ import com.epam.pipeline.entity.region.AbstractCloudRegion;
 import com.epam.pipeline.entity.utils.DateUtils;
 import com.epam.pipeline.manager.ObjectCreatorUtils;
 import com.epam.pipeline.manager.configuration.RunConfigurationManager;
-import com.epam.pipeline.manager.pipeline.PipelineManager;
 import com.epam.pipeline.test.jdbc.AbstractJdbcTest;
 import org.junit.Before;
 import org.junit.Test;
@@ -69,9 +68,6 @@ public class RunScheduleDaoTest extends AbstractJdbcTest {
 
     @Autowired
     private PipelineDao pipelineDao;
-
-    @Autowired
-    private PipelineManager pipelineManager;
 
     @Autowired
     private RunConfigurationDao configurationDao;
@@ -167,14 +163,6 @@ public class RunScheduleDaoTest extends AbstractJdbcTest {
         final List<RunSchedule> runSchedules = runScheduleDao.loadAllRunSchedules();
         assertEquals(1, runSchedules.size());
         assertEquals(runSchedules.get(0).getId(), testRunSchedule2.getId());
-    }
-
-    @Test
-    public void testScheduleRemovalAfterRunIsRemoved() {
-        runScheduleDao.createRunSchedules(Arrays.asList(testRunSchedule, testUpdatedRunSchedule, testRunSchedule2));
-        assertFalse(runScheduleDao.loadAllRunSchedules().isEmpty());
-        pipelineManager.delete(testPipeline.getId(), true);
-        assertTrue(runScheduleDao.loadAllRunSchedules().isEmpty());
     }
 
     @Test

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/RunStatusDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/RunStatusDaoTest.java
@@ -101,13 +101,6 @@ public class RunStatusDaoTest extends AbstractJdbcTest {
         assertTrue(runStatusDao.loadRunStatus(testRun.getId()).isEmpty());
     }
 
-    @Test
-    public void shouldDeleteStatusesByPipelineId() {
-        createStatus();
-        runStatusDao.deleteRunStatusForPipeline(testPipeline.getId());
-        assertTrue(runStatusDao.loadRunStatus(testRun.getId()).isEmpty());
-    }
-
     private RunStatus createStatus() {
         RunStatus runStatus = RunStatus.builder()
                 .runId(testRun.getId())

--- a/api/src/test/java/com/epam/pipeline/manager/notification/NotificationManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/notification/NotificationManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,6 @@ import com.epam.pipeline.entity.region.CloudProvider;
 import com.epam.pipeline.manager.execution.EnvVarsBuilder;
 import com.epam.pipeline.manager.execution.EnvVarsBuilderTest;
 import com.epam.pipeline.manager.execution.SystemParams;
-import com.epam.pipeline.manager.pipeline.PipelineManager;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -125,9 +124,6 @@ public class NotificationManagerTest extends AbstractManagerTest {
 
     @Autowired
     private PipelineRunDao pipelineRunDao;
-
-    @Autowired
-    private PipelineManager pipelineManager;
 
     @MockBean
     private KubernetesManager kubernetesManager;
@@ -470,23 +466,6 @@ public class NotificationManagerTest extends AbstractManagerTest {
 
         messages = monitoringNotificationDao.loadAllNotifications();
         Assert.assertEquals(0, messages.size());
-    }
-
-    @Test
-    public void testRemoveNotificationTimestampWhenDelete() {
-        Pipeline pipeline = createPipeline(testOwner);
-        PipelineRun run1 = createTestPipelineRun(pipeline.getId());
-        notificationManager.notifyHighResourceConsumingRuns(Collections.singletonList(
-                new ImmutablePair<>(run1, Collections.singletonMap(ELKUsageMetric.MEM, TEST_MEMORY_RATE))),
-                HIGH_CONSUMED_RESOURCES);
-
-        Assert.assertTrue(notificationManager.loadLastNotificationTimestamp(run1.getId(),
-                HIGH_CONSUMED_RESOURCES).isPresent());
-
-        pipelineManager.delete(pipeline.getId(), true);
-
-        Assert.assertFalse(notificationManager.loadLastNotificationTimestamp(run1.getId(),
-                HIGH_CONSUMED_RESOURCES).isPresent());
     }
 
     @Test

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/RunScheduleManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/RunScheduleManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -253,18 +253,14 @@ public class RunScheduleManagerTest extends AbstractManagerTest {
 
     @Test
     @WithMockUser(username = USER_OWNER)
-    public void testDeleteRunSchedulesForPipeline() {
+    public void shouldUnscheduleRunSchedulesForPipeline() {
         runScheduleManager.createSchedules(RUN_ID, ScheduleType.PIPELINE_RUN,
                 Arrays.asList(testRunScheduleVO, testRunScheduleVO2));
         Mockito.verify(runScheduler, Mockito.times(2)).scheduleRunSchedule(any());
 
         runScheduleManager.deleteSchedulesForRunByPipeline(testPipeline.getId());
 
-        final List<RunSchedule> loadRunSchedule = runScheduleManager
-                .loadAllSchedulesBySchedulableId(RUN_ID, ScheduleType.PIPELINE_RUN);
-        assertEquals(0, loadRunSchedule.size());
         Mockito.verify(runScheduler, Mockito.times(2)).unscheduleRunSchedule(any());
-
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
The current PR provides fixes for issue #1771 

The following entities shall not be deleted when parent pipeline deleted:
- `NotificationTimestamp`
- `RunSid`
- `RestartRun`
- `RunLog`
- `RunSchedule`