### PR TITLE
fixes for runPipelineWithSensitiveLimitMounts trst and waitForLog method

### DIFF
--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/LaunchLimitMountsTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/LaunchLimitMountsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/LaunchLimitMountsTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/LaunchLimitMountsTest.java
@@ -37,6 +37,7 @@ import java.util.stream.IntStream;
 import static com.codeborne.selenide.Condition.disabled;
 import static com.codeborne.selenide.Condition.enabled;
 import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Condition.matchText;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Selenide.open;
 import static com.epam.pipeline.autotests.ao.LogAO.configurationParameter;
@@ -284,8 +285,8 @@ public class LaunchLimitMountsTest
                 .waitForTask(mountDataStoragesTask)
                 .click(taskWithName(mountDataStoragesTask))
                 .ensure(log(), containsMessages("Found 2 available storage(s). Checking mount options."))
-                .ensure(log(), containsMessages(format("Run is launched with mount limits (%s,%s) Only 2 storages will be mounted",
-                        sensitiveStorageID, storageID)))
+                .ensure(log(), matchText(format("Run is launched with mount limits \\((%s,%s|%s,%s)\\) Only 2 storages will be mounted",
+                        sensitiveStorageID, storageID, storageID, sensitiveStorageID)))
                 .ensure(log(), containsMessages(mountStorageMessage(storage1)))
                 .ensure(log(), containsMessages(mountStorageMessage(storageSensitive)))
                 .ssh(shell -> shell

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/LogAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/LogAO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/LogAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/LogAO.java
@@ -290,7 +290,7 @@ public class LogAO implements AccessObject<LogAO> {
     public LogAO waitForLog(final String message) {
         for (int i = 0; i < 70; i++) {
             refresh();
-            if ($(log()).is(matchText(message))) {
+            if ($(log()).shouldBe(visible).is(matchText(message))) {
                 break;
             }
             sleep(20, SECONDS);


### PR DESCRIPTION
This PR provides fixes for runPipelineWithSensitiveLimitMounts trst and waitForLog method