### PR TITLE
Gui tests improvements from 17/03/21

### DIFF
--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/GlobalSearchTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/GlobalSearchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -748,7 +748,9 @@ public class GlobalSearchTest extends AbstractSeveralPipelineRunningTest impleme
         search()
                 .search(pipeline)
                 .enter()
-                .validateSearchResults(0, "")
+                .sleep(2, SECONDS)
+                .ensure(RUNS, enabled)
+                .validateCountSearchResults(4)
                 .search(configuration)
                 .enter()
                 .validateSearchResults(0, "")

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/RunsTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/RunsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@ import com.epam.pipeline.autotests.utils.Utils;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import java.util.Arrays;
 
 import static com.codeborne.selenide.CollectionCondition.size;
 import static com.codeborne.selenide.CollectionCondition.sizeGreaterThanOrEqual;
@@ -104,8 +106,8 @@ public class RunsTest extends AbstractSeveralPipelineRunningTest implements Auth
                 .completedRuns()
                 .validateColumnName("Run", "Parent run", "Pipeline", "Docker image",
                         "Started", "Completed", "Elapsed", "Owner")
-                .validateAllRunsHaveButton("RERUN")
                 .validateAllRunsHaveButton("Log")
+                .validateRunsHaveButton(Arrays.asList(pipelineRunID, secondToolRunID), "RERUN")
                 .validateAllRunsHaveCost()
                 .validateRowsCount(sizeGreaterThanOrEqual(3));
     }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/RunsMenuAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/RunsMenuAO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -197,6 +197,16 @@ public class RunsMenuAO implements AccessObject<RunsMenuAO> {
 
     public RunsMenuAO validateAllRunsHaveButton(String button) {
         allRuns().forEach(row -> row.$(byText(button)).shouldBe(visible));
+        return this;
+    }
+
+    public RunsMenuAO validateRunsHaveButton(final List<String> runIds, final String button) {
+        runIds.forEach(id -> $("tbody")
+                .find(withText(id))
+                .closest(".ant-table-row")
+                .find(byText(button))
+                .shouldBe(visible)
+        );
         return this;
     }
 


### PR DESCRIPTION
The PR provides the e2e fixes according to #1771 changes:
* `EPMCMBIBPC-103` - validate `RERUN` button just for runs with existing pipelines
* `EPMCMBIBPC-2676` - validate a deleted pipeline run in the global search