### PR TITLE
Improve data storage object tags management

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/tag/DataStorageTagProviderManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/tag/DataStorageTagProviderManager.java
@@ -1,0 +1,209 @@
+package com.epam.pipeline.manager.datastorage.tag;
+
+import com.epam.pipeline.common.MessageConstants;
+import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
+import com.epam.pipeline.entity.datastorage.DataStorageFile;
+import com.epam.pipeline.entity.datastorage.tag.DataStorageObject;
+import com.epam.pipeline.entity.datastorage.tag.DataStorageTag;
+import com.epam.pipeline.entity.datastorage.tag.DataStorageTagCopyBatchRequest;
+import com.epam.pipeline.entity.datastorage.tag.DataStorageTagCopyRequest;
+import com.epam.pipeline.manager.datastorage.StorageProviderManager;
+import com.epam.pipeline.manager.datastorage.providers.ProviderUtils;
+import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.epam.pipeline.manager.preference.SystemPreferences;
+import com.epam.pipeline.manager.security.AuthManager;
+import com.epam.pipeline.utils.StreamUtils;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class DataStorageTagProviderManager {
+    
+    private static final int DEFAULT_OPERATIONS_BULK_SIZE = 1000;
+
+    private final StorageProviderManager storageProviderManager;
+    private final DataStorageTagManager tagManager;
+    private final DataStorageTagBatchManager tagBatchManager;
+    private final PreferenceManager preferenceManager;
+    private final AuthManager authManager;
+    private final MessageHelper messageHelper;
+
+    public void createFileTags(final AbstractDataStorage storage,
+                               final String path,
+                               final String version) {
+        final String authorizedUser = authManager.getAuthorizedUser();
+        final String relativePath = storage.resolveRootPath(path);
+        final Map<String, String> defaultTags = Collections.singletonMap(ProviderUtils.OWNER_TAG_KEY, authorizedUser);
+        tagManager.insert(storage.getRootId(), new DataStorageObject(relativePath, null), defaultTags);
+        if (storage.isVersioningEnabled()) {
+            tagManager.insert(storage.getRootId(), new DataStorageObject(relativePath, version), defaultTags);
+        }
+    }
+
+    public Map<String, String> loadFileTags(final AbstractDataStorage storage,
+                                            final String path,
+                                            final String version) {
+        final String relativePath = storage.resolveRootPath(path);
+        final DataStorageObject object = new DataStorageObject(relativePath, version);
+        return mapFrom(tagManager.load(storage.getRootId(), object));
+    }
+
+    public Map<String, String> updateFileTags(final AbstractDataStorage storage,
+                                              final String path,
+                                              final String version,
+                                              final Map<String, String> tagsToAdd,
+                                              final Boolean rewrite) {
+        final String relativePath = storage.resolveRootPath(path);
+        final Function<DataStorageObject, List<DataStorageTag>> updateTags = rewrite
+                ? object -> tagManager.insert(storage.getRootId(), object, tagsToAdd)
+                : object -> tagManager.upsert(storage.getRootId(), object, tagsToAdd);
+        if (storage.isVersioningEnabled()) {
+            storageProviderManager.findFile(storage, path)
+                    .map(DataStorageFile::getVersion)
+                    .map(latestVersion ->
+                            StringUtils.isBlank(version)
+                                    ? new DataStorageObject(relativePath, latestVersion)
+                                    : latestVersion.equals(version)
+                                    ? new DataStorageObject(relativePath)
+                                    : null)
+                    .ifPresent(updateTags::apply);
+        }
+        return mapFrom(updateTags.apply(new DataStorageObject(relativePath, version)));
+    }
+
+    public void moveFileTags(final AbstractDataStorage storage,
+                             final String oldPath,
+                             final String newPath,
+                             final String newVersion) {
+        final String oldRelativePath = storage.resolveRootPath(oldPath);
+        final String newRelativePath = storage.resolveRootPath(newPath);
+        final Map<String, String> tagMap = mapFrom(tagManager.load(storage.getRootId(),
+                new DataStorageObject(oldRelativePath)));
+        tagManager.upsert(storage.getRootId(), new DataStorageObject(newRelativePath), tagMap);
+        if (storage.isVersioningEnabled()) {
+            tagManager.upsert(storage.getRootId(), new DataStorageObject(newRelativePath, newVersion), tagMap);
+        } else {
+            tagManager.delete(storage.getRootId(), new DataStorageObject(oldRelativePath));
+        }
+    }
+
+    public void moveFolderTags(final AbstractDataStorage storage,
+                               final String oldPath,
+                               final String newPath) {
+        final String oldRelativePath = storage.resolveRootPath(oldPath);
+        final String newRelativePath = storage.resolveRootPath(newPath);
+        tagManager.copyFolder(storage.getRootId(), oldRelativePath, newRelativePath);
+        if (storage.isVersioningEnabled()) {
+            StreamUtils.chunked(storageProviderManager.listFiles(storage, newPath + storage.getDelimiter()),
+                    getOperationsBulkSize())
+                    .forEach(chunk -> tagBatchManager.copy(storage.getId(), new DataStorageTagCopyBatchRequest(
+                            chunk.stream()
+                                    .map(file -> new DataStorageTagCopyRequest(
+                                            DataStorageTagCopyRequest.object(file.getPath(), null),
+                                            DataStorageTagCopyRequest.object(file.getPath(), file.getVersion())))
+                                    .collect(Collectors.toList()))));
+        } else {
+            tagManager.deleteAllInFolder(storage.getRootId(), oldRelativePath);
+        }
+    }
+
+    public void restoreFileTags(final AbstractDataStorage storage,
+                                final String path,
+                                final String version) {
+        final String relativePath = storage.resolveRootPath(path);
+        storageProviderManager.findFile(storage, path)
+                .map(DataStorageFile::getVersion)
+                .ifPresent(latestVersion -> {
+                    tagManager.copy(storage.getRootId(),
+                            new DataStorageObject(relativePath, version),
+                            new DataStorageObject(relativePath));
+                    tagManager.copy(storage.getRootId(),
+                            new DataStorageObject(relativePath, version),
+                            new DataStorageObject(relativePath, latestVersion));
+                });
+        tagManager.delete(storage.getRootId(), new DataStorageObject(relativePath, version));
+    }
+
+    public void deleteFileTags(final AbstractDataStorage storage,
+                               final String path,
+                               final String version,
+                               final Set<String> tags) {
+        final String relativePath = storage.resolveRootPath(path);
+        final DataStorageObject object = new DataStorageObject(relativePath, version);
+        final List<DataStorageTag> existingTags = tagManager.load(storage.getRootId(), object);
+        tags.forEach(tag -> Assert.isTrue(existingTags.stream().anyMatch(it -> it.getKey().equals(tag)),
+                messageHelper.getMessage(MessageConstants.ERROR_DATASTORAGE_FILE_TAG_NOT_EXIST, tag)));
+        if (storage.isVersioningEnabled()) {
+            storageProviderManager.findFile(storage, path)
+                    .map(DataStorageFile::getVersion)
+                    .map(latestVersion ->
+                            StringUtils.isBlank(version)
+                                    ? new DataStorageObject(relativePath, latestVersion)
+                                    : latestVersion.equals(version)
+                                    ? new DataStorageObject(relativePath)
+                                    : null)
+                    .ifPresent(obj -> tagManager.delete(storage.getRootId(), obj, tags));
+        }
+        tagManager.delete(storage.getRootId(), object, tags);
+    }
+
+    public void deleteFileTags(final AbstractDataStorage storage,
+                               final String path,
+                               final String version,
+                               final Boolean totally) {
+        final String relativePath = storage.resolveRootPath(path);
+        if (storage.isVersioningEnabled()) {
+            if (version != null) {
+                final Optional<String> latestVersion = storageProviderManager.findFile(storage, path)
+                        .map(DataStorageFile::getVersion);
+                if (latestVersion.isPresent()) {
+                    tagManager.copy(storage.getRootId(),
+                            new DataStorageObject(relativePath, latestVersion.get()),
+                            new DataStorageObject(relativePath));
+                    tagManager.delete(storage.getRootId(), new DataStorageObject(relativePath, version));
+                } else {
+                    tagManager.delete(storage.getRootId(), new DataStorageObject(relativePath, version));
+                    tagManager.delete(storage.getRootId(), new DataStorageObject(relativePath));
+                }
+            } else if (totally) {
+                tagManager.deleteAll(storage.getRootId(), relativePath);
+            }
+        } else {
+            tagManager.deleteAll(storage.getRootId(), relativePath);
+        }
+    }
+
+    public void deleteFolderTags(final AbstractDataStorage storage,
+                                 final String path,
+                                 final Boolean totally) {
+        if (!storage.isVersioningEnabled() || totally) {
+            tagManager.deleteAllInFolder(storage.getRootId(), storage.resolveRootPath(path));
+        }
+    }
+
+    public void deleteStorageTags(final AbstractDataStorage storage) {
+        deleteFolderTags(storage, "", true);
+    }
+
+    private Integer getOperationsBulkSize() {
+        return Optional.of(SystemPreferences.DATA_STORAGE_OPERATIONS_BULK_SIZE)
+                .map(preferenceManager::getPreference)
+                .orElse(DEFAULT_OPERATIONS_BULK_SIZE);
+    }
+
+    private Map<String, String> mapFrom(final List<DataStorageTag> tags) {
+        return tags.stream().collect(Collectors.toMap(DataStorageTag::getKey, DataStorageTag::getValue));
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -143,6 +143,8 @@ public class SystemPreferences {
                                new TypeReference<DataStorageTemplate>() {},
                                DATA_STORAGE_GROUP,
                                isNullOrValidJson(new TypeReference<DataStorageTemplate>() {}));
+    public static final IntPreference DATA_STORAGE_OPERATIONS_BULK_SIZE = new IntPreference(
+            "storage.operations.bulk.size", 1000, DATA_STORAGE_GROUP, isGreaterThan(0));
 
     /**
      * Black list for mount points, accept notation like: '/dir/*', '/dir/**'

--- a/api/src/test/java/com/epam/pipeline/test/acl/AclTestBeans.java
+++ b/api/src/test/java/com/epam/pipeline/test/acl/AclTestBeans.java
@@ -58,6 +58,7 @@ import com.epam.pipeline.manager.datastorage.StorageProviderManager;
 import com.epam.pipeline.manager.datastorage.lustre.LustreFSManager;
 import com.epam.pipeline.manager.datastorage.tag.DataStorageTagBatchManager;
 import com.epam.pipeline.manager.datastorage.tag.DataStorageTagManager;
+import com.epam.pipeline.manager.datastorage.tag.DataStorageTagProviderManager;
 import com.epam.pipeline.manager.docker.DockerClientFactory;
 import com.epam.pipeline.manager.docker.DockerContainerOperationManager;
 import com.epam.pipeline.manager.docker.DockerRegistryManager;
@@ -268,10 +269,13 @@ public class AclTestBeans {
     protected DataStorageRuleManager mockDataStorageRuleManager;
 
     @MockBean
+    protected DataStorageTagBatchManager mockDataStorageTagBatchManager;
+
+    @MockBean
     protected DataStorageTagManager mockDataStorageTagManager;
 
     @MockBean
-    protected DataStorageTagBatchManager mockDataStorageTagBatchManager;
+    protected DataStorageTagProviderManager mockDataStorageTagProviderManager;
 
     @MockBean
     protected ToolScanScheduler mockToolScanScheduler;

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/utils/ChunkedIterator.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/utils/ChunkedIterator.java
@@ -1,0 +1,32 @@
+package com.epam.pipeline.utils;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class ChunkedIterator<T> implements Iterator<List<T>> {
+
+    private final Iterator<T> iterator;
+    private final int chunkSize;
+    private final List<T> chunk;
+
+    public ChunkedIterator(final Iterator<T> iterator, final int chunkSize) {
+        this.iterator = iterator;
+        this.chunkSize = chunkSize;
+        this.chunk = new ArrayList<>(chunkSize);
+    }
+    
+    @Override
+    public boolean hasNext() {
+        return iterator.hasNext();
+    }
+
+    @Override
+    public List<T> next() {
+        chunk.clear();
+        while (iterator.hasNext() && chunk.size() < chunkSize) {
+            chunk.add(iterator.next());
+        }
+        return chunk;
+    }
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/utils/IteratorUtils.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/utils/IteratorUtils.java
@@ -1,0 +1,17 @@
+package com.epam.pipeline.utils;
+
+import java.util.Iterator;
+import java.util.List;
+
+public final class IteratorUtils {
+
+    private IteratorUtils() {}
+
+    public static <T> Iterator<List<T>> windowed(final Iterator<List<T>> iterator, final int windowSize) {
+        return new WindowIterator<>(iterator, windowSize);
+    }
+
+    public static <T> Iterator<List<T>> chunked(final Iterator<T> iterator, final int chunkSize) {
+        return new ChunkedIterator<>(iterator, chunkSize);
+    }
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/utils/StreamUtils.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/utils/StreamUtils.java
@@ -1,0 +1,26 @@
+package com.epam.pipeline.utils;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public final class StreamUtils {
+
+    private StreamUtils() {}
+
+    public static <T> Stream<T> from(final Iterator<T> iterator) {
+        final Spliterator<T> spliterator = Spliterators.spliteratorUnknownSize(iterator, 0);
+        return StreamSupport.stream(spliterator, false);
+    }
+
+    public static <T> Stream<List<T>> windowed(final Stream<List<T>> stream, final int windowSize) {
+        return from(IteratorUtils.windowed(stream.iterator(), windowSize));
+    }
+
+    public static <T> Stream<List<T>> chunked(final Stream<T> stream, final int chunkSize) {
+        return from(IteratorUtils.chunked(stream.iterator(), chunkSize));
+    }
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/utils/WindowIterator.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/utils/WindowIterator.java
@@ -1,0 +1,34 @@
+package com.epam.pipeline.utils;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class WindowIterator<T> implements Iterator<List<T>> {
+
+    private static final double DEFAULT_WINDOW_SIZE_MULTIPLIER = 1.1;
+    
+    private final Iterator<List<T>> iterator;
+    private final int windowSize;
+    private final List<T> window;
+
+    public WindowIterator(final Iterator<List<T>> iterator, final int windowSize) {
+        this.iterator = iterator;
+        this.windowSize = windowSize;
+        this.window = new ArrayList<>((int) (windowSize * DEFAULT_WINDOW_SIZE_MULTIPLIER));
+    }
+
+    @Override
+    public boolean hasNext() {
+        return iterator.hasNext();
+    }
+
+    @Override
+    public List<T> next() {
+        window.clear();
+        while (iterator.hasNext() && window.size() < windowSize) {
+            window.addAll(iterator.next());
+        }
+        return window;
+    }
+}

--- a/core/src/main/java/com/epam/pipeline/utils/ChunkedIterator.java
+++ b/core/src/main/java/com/epam/pipeline/utils/ChunkedIterator.java
@@ -1,4 +1,4 @@
-package com.epam.pipeline.elasticsearchagent.utils;
+package com.epam.pipeline.utils;
 
 import java.util.ArrayList;
 import java.util.Iterator;

--- a/core/src/main/java/com/epam/pipeline/utils/IteratorUtils.java
+++ b/core/src/main/java/com/epam/pipeline/utils/IteratorUtils.java
@@ -1,24 +1,14 @@
-package com.epam.pipeline.elasticsearchagent.utils;
+package com.epam.pipeline.utils;
 
 import java.util.Iterator;
 import java.util.List;
 
 public final class IteratorUtils {
 
-    private static final int DEFAULT_CHUNK_SIZE = 100;
-
     private IteratorUtils() {}
-
-    public static <T> Iterator<List<T>> windowed(final Iterator<List<T>> iterator) {
-        return windowed(iterator, DEFAULT_CHUNK_SIZE);
-    }
 
     public static <T> Iterator<List<T>> windowed(final Iterator<List<T>> iterator, final int windowSize) {
         return new WindowIterator<>(iterator, windowSize);
-    }
-
-    public static <T> Iterator<List<T>> chunked(final Iterator<T> iterator) {
-        return chunked(iterator, DEFAULT_CHUNK_SIZE);
     }
 
     public static <T> Iterator<List<T>> chunked(final Iterator<T> iterator, final int chunkSize) {

--- a/core/src/main/java/com/epam/pipeline/utils/StreamUtils.java
+++ b/core/src/main/java/com/epam/pipeline/utils/StreamUtils.java
@@ -1,4 +1,4 @@
-package com.epam.pipeline.elasticsearchagent.utils;
+package com.epam.pipeline.utils;
 
 import java.util.Iterator;
 import java.util.List;
@@ -9,8 +9,6 @@ import java.util.stream.StreamSupport;
 
 public final class StreamUtils {
 
-    private static final int DEFAULT_CHUNK_SIZE = 100;
-
     private StreamUtils() {}
 
     public static <T> Stream<T> from(final Iterator<T> iterator) {
@@ -18,16 +16,8 @@ public final class StreamUtils {
         return StreamSupport.stream(spliterator, false);
     }
 
-    public static <T> Stream<List<T>> windowed(final Stream<List<T>> stream) {
-        return windowed(stream, DEFAULT_CHUNK_SIZE);
-    }
-
     public static <T> Stream<List<T>> windowed(final Stream<List<T>> stream, final int windowSize) {
         return from(IteratorUtils.windowed(stream.iterator(), windowSize));
-    }
-
-    public static <T> Stream<List<T>> chunked(final Stream<T> stream) {
-        return chunked(stream, DEFAULT_CHUNK_SIZE);
     }
 
     public static <T> Stream<List<T>> chunked(final Stream<T> stream, final int chunkSize) {

--- a/core/src/main/java/com/epam/pipeline/utils/WindowIterator.java
+++ b/core/src/main/java/com/epam/pipeline/utils/WindowIterator.java
@@ -1,4 +1,4 @@
-package com.epam.pipeline.elasticsearchagent.utils;
+package com.epam.pipeline.utils;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class WindowIterator<T> implements Iterator<List<T>> {
 
-    private static final double DEFAULT_WINDOW_SIZE_MULTIPLIER = 1.5;
+    private static final double DEFAULT_WINDOW_SIZE_MULTIPLIER = 1.1;
     
     private final Iterator<List<T>> iterator;
     private final int windowSize;

--- a/deploy/docker/cp-search/config/application.properties
+++ b/deploy/docker/cp-search/config/application.properties
@@ -49,12 +49,14 @@ sync.s3-file.index.mapping=file://${CP_SEARCH_MAPPINGS_LOCATION}/storage_file.js
 sync.s3-file.index.name=s3-file
 sync.s3-file.enable.tags=false
 sync.s3-file.bulk.insert.size=1000
+sync.s3-file.bulk.load.tags.size=100
 
 #NFS Files Settings
 sync.nfs-file.disable=${CP_SEARCH_DISABLE_NFS_FILE:false}
 sync.nfs-file.index.mapping=file://${CP_SEARCH_MAPPINGS_LOCATION}/storage_file.json
 sync.nfs-file.index.name=nfs-file
 sync.nfs-file.bulk.insert.size=1000
+sync.nfs-file.bulk.load.tags.size=100
 sync.nfs-file.root.mount.point=${CP_SEARCH_MOUNT_ROOT:}
 
 #GS Files Settings
@@ -62,6 +64,7 @@ sync.gs-file.disable=${CP_SEARCH_DISABLE_GS_FILE:false}
 sync.gs-file.index.name=gs-file
 sync.gs-file.index.mapping=file://${CP_SEARCH_MAPPINGS_LOCATION}/storage_file.json
 sync.gs-file.bulk.insert.size=1000
+sync.gs-file.bulk.load.tags.size=100
 
 #GS Storage Settings
 sync.gs-storage.disable=${CP_SEARCH_DISABLE_GS_STORAGE:false}
@@ -88,6 +91,7 @@ sync.az-blob.disable=${CP_SEARCH_DISABLE_AZ_BLOB_FILE:false}
 sync.az-blob.index.mapping=file://${CP_SEARCH_MAPPINGS_LOCATION}/storage_file.json
 sync.az-blob.index.name=az-blob
 sync.az-blob.bulk.insert.size=1000
+sync.az-blob.bulk.load.tags.size=100
 
 #Tool Settings
 sync.tool.disable=${CP_SEARCH_DISABLE_TOOL:false}
@@ -123,3 +127,7 @@ sync.metadata-entity.index.name=metadata-entity
 sync.run-configuration.disable=${CP_SEARCH_DISABLE_CONFIGURATION:false}
 sync.run-configuration.index.mapping=file://${CP_SEARCH_MAPPINGS_LOCATION}/run_configuration.json
 sync.run-configuration.index.name=run-configuration
+
+#Data Storage Tags Transfer Settings
+sync.native.tags.transfer.disable=${CP_SEARCH_DISABLE_NATIVE_TAGS_TRANSFER:true}
+sync.native.tags.transfer.bulk.insert.size=1000

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/app/AzureFileSyncConfiguration.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/app/AzureFileSyncConfiguration.java
@@ -42,6 +42,9 @@ public class AzureFileSyncConfiguration {
 
     @Value("${sync.az-blob.bulk.insert.size:1000}")
     private Integer bulkInsertSize;
+    
+    @Value("${sync.az-blob.bulk.load.tags.size:100}")
+    private Integer bulkLoadTagsSize;
 
     @Value("${sync.az-blob.index.name}")
     private String indexName;
@@ -60,7 +63,8 @@ public class AzureFileSyncConfiguration {
             final @Qualifier("azFileManager") ObjectStorageFileManager azFileManager) {
         return new ObjectStorageIndexImpl(apiClient, esClient, indexService,
                 azFileManager, indexPrefix + indexName,
-                indexSettingsPath, bulkInsertSize, DataStorageType.AZ,
+                indexSettingsPath, bulkInsertSize, bulkLoadTagsSize,
+                DataStorageType.AZ,
                 SearchDocumentType.AZ_BLOB_FILE);
     }
 }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/app/GSFileSyncConfiguration.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/app/GSFileSyncConfiguration.java
@@ -42,6 +42,9 @@ public class GSFileSyncConfiguration {
     @Value("${sync.gs-file.bulk.insert.size:1000}")
     private Integer bulkInsertSize;
 
+    @Value("${sync.gs-file.bulk.load.tags.size:100}")
+    private Integer bulkLoadTagsSize;
+
     @Bean
     public ObjectStorageFileManager gsFileManager() {
         return new GsBucketFileManager();
@@ -56,7 +59,8 @@ public class GSFileSyncConfiguration {
             final @Qualifier("gsFileManager") ObjectStorageFileManager gsFileManager) {
         return new ObjectStorageIndexImpl(apiClient, esClient, indexService,
                 gsFileManager, indexPrefix + indexName,
-                indexSettingsPath, bulkInsertSize, DataStorageType.GS,
+                indexSettingsPath, bulkInsertSize, bulkLoadTagsSize,
+                DataStorageType.GS,
                 SearchDocumentType.GS_FILE);
     }
 

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/app/S3FileSyncConfiguration.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/app/S3FileSyncConfiguration.java
@@ -42,6 +42,8 @@ public class S3FileSyncConfiguration {
     private String indexSettingsPath;
     @Value("${sync.s3-file.bulk.insert.size:1000}")
     private Integer bulkInsertSize;
+    @Value("${sync.s3-file.bulk.load.tags.size:100}")
+    private Integer bulkLoadTagsSize;
 
     @Bean
     public ObjectStorageFileManager s3FileManager() {
@@ -57,7 +59,8 @@ public class S3FileSyncConfiguration {
             final @Qualifier("s3FileManager") ObjectStorageFileManager s3FileManager) {
         return new ObjectStorageIndexImpl(apiClient, esClient, indexService,
                 s3FileManager, indexPrefix + indexName,
-                indexSettingsPath, bulkInsertSize, DataStorageType.S3,
+                indexSettingsPath, bulkInsertSize, bulkLoadTagsSize,
+                DataStorageType.S3,
                 SearchDocumentType.S3_FILE);
     }
 

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/AzureBlobManager.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/AzureBlobManager.java
@@ -18,7 +18,7 @@ package com.epam.pipeline.elasticsearchagent.service.impl;
 
 import com.epam.pipeline.elasticsearchagent.service.ObjectStorageFileManager;
 import com.epam.pipeline.elasticsearchagent.utils.ESConstants;
-import com.epam.pipeline.elasticsearchagent.utils.StreamUtils;
+import com.epam.pipeline.utils.StreamUtils;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.DataStorageException;
 import com.epam.pipeline.entity.datastorage.DataStorageFile;

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/GsBucketFileManager.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/GsBucketFileManager.java
@@ -17,7 +17,7 @@ package com.epam.pipeline.elasticsearchagent.service.impl;
 
 import com.epam.pipeline.elasticsearchagent.service.ObjectStorageFileManager;
 import com.epam.pipeline.elasticsearchagent.utils.ESConstants;
-import com.epam.pipeline.elasticsearchagent.utils.StreamUtils;
+import com.epam.pipeline.utils.StreamUtils;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.DataStorageFile;
 import com.epam.pipeline.entity.datastorage.DataStorageType;

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/ObjectStorageIndexImpl.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/ObjectStorageIndexImpl.java
@@ -21,7 +21,7 @@ import com.epam.pipeline.elasticsearchagent.service.ElasticsearchServiceClient;
 import com.epam.pipeline.elasticsearchagent.service.ObjectStorageFileManager;
 import com.epam.pipeline.elasticsearchagent.service.ObjectStorageIndex;
 import com.epam.pipeline.elasticsearchagent.service.impl.converter.storage.StorageFileMapper;
-import com.epam.pipeline.elasticsearchagent.utils.StreamUtils;
+import com.epam.pipeline.utils.StreamUtils;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.DataStorageAction;
 import com.epam.pipeline.entity.datastorage.DataStorageFile;
@@ -59,6 +59,7 @@ public class ObjectStorageIndexImpl implements ObjectStorageIndex {
     private final String indexPrefix;
     private final String indexMappingFile;
     private final int bulkInsertSize;
+    private final int bulkLoadTagsSize;
     @Getter
     private final DataStorageType storageType;
     @Getter
@@ -90,7 +91,7 @@ public class ObjectStorageIndexImpl implements ObjectStorageIndex {
             elasticIndexService.createIndexIfNotExist(indexName, indexMappingFile);
             final TemporaryCredentials credentials = getTemporaryCredentials(dataStorage);
             try (IndexRequestContainer requestContainer = getRequestContainer(indexName, bulkInsertSize)) {
-                StreamUtils.chunked(fileManager.files(dataStorage, credentials))
+                StreamUtils.chunked(fileManager.files(dataStorage, credentials), bulkLoadTagsSize)
                         .flatMap(files -> filesWithIncorporatedTags(dataStorage, files))
                         .map(file -> createIndexRequest(file, dataStorage, permissionsContainer, indexName, 
                                 credentials))

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/S3FileManager.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/S3FileManager.java
@@ -30,7 +30,7 @@ import com.amazonaws.services.s3.model.Tag;
 import com.amazonaws.services.s3.model.VersionListing;
 import com.epam.pipeline.elasticsearchagent.service.ObjectStorageFileManager;
 import com.epam.pipeline.elasticsearchagent.utils.ESConstants;
-import com.epam.pipeline.elasticsearchagent.utils.StreamUtils;
+import com.epam.pipeline.utils.StreamUtils;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.DataStorageFile;
 import com.epam.pipeline.entity.datastorage.DataStorageType;

--- a/elasticsearch-agent/src/main/resources/application.properties
+++ b/elasticsearch-agent/src/main/resources/application.properties
@@ -54,6 +54,7 @@ sync.az-blob-storage.index.mapping=classpath:/templates/storage_file.json
 sync.az-blob.index.mapping=classpath:/templates/storage_file.json
 sync.az-blob.index.name=az-blob
 sync.az-blob.bulk.insert.size=1000
+sync.az-blob.bulk.load.tags.size=100
 
 #S3 Files Settings
 #sync.s3-file.disable=true
@@ -61,12 +62,14 @@ sync.s3-file.index.mapping=classpath:/templates/storage_file.json
 sync.s3-file.index.name=s3-file
 sync.s3-file.enable.tags=false
 sync.s3-file.bulk.insert.size=1000
+sync.s3-file.bulk.load.tags.size=100
 
 #GS Files Settings
 #sync.gs-file.disable=true
 sync.gs-file.index.name=gs-file
 sync.gs-file.index.mapping=classpath:/templates/storage_file.json
 sync.gs-file.bulk.insert.size=1000
+sync.gs-file.bulk.load.tags.size=100
 
 #GS Storage Settings
 #sync.gs-storage.disable=true
@@ -78,6 +81,7 @@ sync.gs-storage.index.name=gs-storage
 sync.nfs-file.index.mapping=classpath:/templates/storage_file.json
 sync.nfs-file.index.name=nfs-file
 sync.nfs-file.bulk.insert.size=1000
+sync.nfs-file.bulk.load.tags.size=100
 sync.nfs-file.root.mount.point=
 
 #S3 Storage Settings
@@ -127,6 +131,7 @@ sync.run-configuration.index.name=run-configuration
 
 #Data Storage Tags Transfer Settings
 sync.native.tags.transfer.disable=true
+sync.native.tags.transfer.bulk.insert.size=1000
 
 #High availability
 kube.master.pod.check.url=http://localhost:4040

--- a/elasticsearch-agent/src/test/java/com/epam/pipeline/elasticsearchagent/service/impl/ObjectStorageIndexTest.java
+++ b/elasticsearch-agent/src/test/java/com/epam/pipeline/elasticsearchagent/service/impl/ObjectStorageIndexTest.java
@@ -69,6 +69,7 @@ public class ObjectStorageIndexTest {
             TEST_NAME,
             TEST_NAME,
             1000,
+            1000,
             DataStorageType.GS,
             SearchDocumentType.GS_FILE);
 


### PR DESCRIPTION
Relates to #1717 and depends on #1863.

The pull request brings several improvements to the original pull request #1798:
 - It extracts data storage object tags management code from `DataStorageManager` to `DataStorageTagProviderManager`.
 - It allows to configure bulk tag operation sizes for both `api` and `elasticsearch-agent` modules.
 - It gets rid of extra requests to s3 in pipe cli while uploading files.

The following system preference `storage.operations.bulk.size` can be used to change the default bulk size for data storage operations in `api` module. By default it is 1000.

The following application properties can be specified for `elasticsearch-agent` module to configure different bulk operation sizes. Default sizes are shown.

```properties
sync.s3-file.bulk.load.tags.size=100
sync.nfs-file.bulk.load.tags.size=100
sync.gs-file.bulk.load.tags.size=100
sync.az-blob.bulk.load.tags.size=100
sync.native.tags.transfer.bulk.insert.size=1000
```