### PR TITLE
Use encoded repository path in GitLab get files request

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/git/GitLabApi.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/GitLabApi.java
@@ -122,7 +122,7 @@ public interface GitLabApi {
      */
     @GET("api/v3/projects/{project}/repository/files/{file_path}")
     Call<GitFile> getFiles(@Path(PROJECT) String idOrName,
-                           @Path(FILE_PATH) String filePath,
+                           @Path(value = FILE_PATH, encoded = true) String filePath,
                            @Query(REF) String reference);
 
     /**

--- a/api/src/main/java/com/epam/pipeline/manager/git/GitlabClient.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/GitlabClient.java
@@ -99,8 +99,8 @@ public class GitlabClient {
     private static final String PUBLIC_VISIBILITY = "public";
     public static final String NEW_LINE = "\n";
     public static final long MAINTAINER = 40L;
-    private static final String DOT_CHAR = ".";
-    private static final String DOT_CHAR_URL_ENCODING_REPLACEMENT = "%2E";
+    public static final String DOT_CHAR = ".";
+    public static final String DOT_CHAR_URL_ENCODING_REPLACEMENT = "%2E";
 
     static {
         DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
@@ -340,8 +340,12 @@ public class GitlabClient {
         if (StringUtils.isBlank(projectId)) {
             projectId = makeProjectId(namespace, projectName);
         }
-        GitFile gitFile = execute(gitLabApi.getFiles(projectId, path, revision));
-        return Base64.getDecoder().decode(gitFile.getContent());
+        try {
+            GitFile gitFile = execute(gitLabApi.getFiles(projectId, encodePath(path), revision));
+            return Base64.getDecoder().decode(gitFile.getContent());
+        } catch (IOException e) {
+            throw new GitClientException("Error receiving file content!", e);
+        }
     }
 
     public byte[] getTruncatedFileContents(final String path, final String revision,

--- a/api/src/test/java/com/epam/pipeline/manager/git/GitManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/git/GitManagerTest.java
@@ -59,6 +59,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -659,7 +660,8 @@ public class GitManagerTest extends AbstractManagerTest {
 
     private String encodeUrlPath(final String filePath) {
         try {
-            return URLEncoder.encode(filePath, "UTF8");
+            return URLEncoder.encode(filePath, StandardCharsets.UTF_8.toString())
+                    .replace(GitlabClient.DOT_CHAR, GitlabClient.DOT_CHAR_URL_ENCODING_REPLACEMENT);
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeIOException(e.getMessage());
         }


### PR DESCRIPTION
Resolves issue #1872.

Original issue is [a bug in GitLab](https://gitlab.com/gitlab-org/gitlab-foss/-/issues/34963) which was fixed in the newer GitLab version. As a workaround for a currently used GitLab version a repository path encoding was introduced.
