### PR TITLE
Index prefixed data storage objects

### DIFF
--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/datastorage/AbstractDataStorage.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/datastorage/AbstractDataStorage.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.Getter;
 import lombok.Setter;
-import org.springframework.util.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * An abstract entity, that represents a Data Storage, that is used to store and access data from different sources.
@@ -130,4 +130,16 @@ public abstract class AbstractDataStorage extends AbstractSecuredEntity {
      * @return
      */
     public abstract boolean isPolicySupported();
+
+    public String resolveRootPath(final String path) {
+        final String storagePath = StringUtils.strip(StringUtils.removeStart(getPath(), getRoot()), getDelimiter());
+        final String relativePath = StringUtils.strip(path, getDelimiter());
+        if (StringUtils.isBlank(storagePath)) {
+            return relativePath;
+        }
+        if (StringUtils.isBlank(relativePath)) {
+            return storagePath;
+        }
+        return storagePath + getDelimiter() + relativePath;
+    }
 }

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/datastorage/AbstractDataStorage.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/datastorage/AbstractDataStorage.java
@@ -45,6 +45,7 @@ public abstract class AbstractDataStorage extends AbstractSecuredEntity {
     private String description;
     private String path;
     private String root;
+    private String prefix;
     private DataStorageType type;
     private Long parentFolderId;
     private Folder parent;
@@ -131,15 +132,21 @@ public abstract class AbstractDataStorage extends AbstractSecuredEntity {
      */
     public abstract boolean isPolicySupported();
 
-    public String resolveRootPath(final String path) {
-        final String storagePath = StringUtils.strip(StringUtils.removeStart(getPath(), getRoot()), getDelimiter());
-        final String relativePath = StringUtils.strip(path, getDelimiter());
-        if (StringUtils.isBlank(storagePath)) {
-            return relativePath;
+    public String resolveAbsolutePath(final String relativePath) {
+        final String storageAbsolutePrefix = getPrefix();
+        final String strippedRelativePath = StringUtils.strip(relativePath, getDelimiter());
+        if (StringUtils.isBlank(storageAbsolutePrefix)) {
+            return strippedRelativePath;
         }
-        if (StringUtils.isBlank(relativePath)) {
-            return storagePath;
+        if (StringUtils.isBlank(strippedRelativePath)) {
+            return storageAbsolutePrefix;
         }
-        return storagePath + getDelimiter() + relativePath;
+        return storageAbsolutePrefix + getDelimiter() + strippedRelativePath;
+    }
+
+    public String resolveRelativePath(final String absolutePath) {
+        final String storageAbsolutePrefix = getPrefix();
+        final String strippedAbsolutePath = StringUtils.strip(absolutePath, getDelimiter());
+        return StringUtils.strip(StringUtils.removeStart(strippedAbsolutePath, storageAbsolutePrefix), getDelimiter());
     }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/datastorage/AbstractDataStorage.java
+++ b/core/src/main/java/com/epam/pipeline/entity/datastorage/AbstractDataStorage.java
@@ -121,15 +121,25 @@ public abstract class AbstractDataStorage extends AbstractSecuredEntity {
         return getPath().split(getDelimiter())[0];
     }
 
-    public String resolveRootPath(final String path) {
-        final String storagePath = StringUtils.strip(StringUtils.removeStart(getPath(), getRoot()), getDelimiter());
-        final String relativePath = StringUtils.strip(path, getDelimiter());
-        if (StringUtils.isBlank(storagePath)) {
-            return relativePath;
+    public String getPrefix() {
+        return StringUtils.strip(StringUtils.removeStart(getPath(), getRoot()), getDelimiter());
+    }
+
+    public String resolveAbsolutePath(final String relativePath) {
+        final String storageAbsolutePrefix = getPrefix();
+        final String strippedRelativePath = StringUtils.strip(relativePath, getDelimiter());
+        if (StringUtils.isBlank(storageAbsolutePrefix)) {
+            return strippedRelativePath;
         }
-        if (StringUtils.isBlank(relativePath)) {
-            return storagePath;
+        if (StringUtils.isBlank(strippedRelativePath)) {
+            return storageAbsolutePrefix;
         }
-        return storagePath + getDelimiter() + relativePath;
+        return storageAbsolutePrefix + getDelimiter() + strippedRelativePath;
+    }
+
+    public String resolveRelativePath(final String absolutePath) {
+        final String storageAbsolutePrefix = getPrefix();
+        final String strippedAbsolutePath = StringUtils.strip(absolutePath, getDelimiter());
+        return StringUtils.strip(StringUtils.removeStart(strippedAbsolutePath, storageAbsolutePrefix), getDelimiter());
     }
 }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/ObjectStorageFileManager.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/ObjectStorageFileManager.java
@@ -16,7 +16,6 @@
 
 package com.epam.pipeline.elasticsearchagent.service;
 
-import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.DataStorageFile;
 import com.epam.pipeline.entity.datastorage.DataStorageType;
 import com.epam.pipeline.entity.datastorage.TemporaryCredentials;
@@ -30,10 +29,12 @@ public interface ObjectStorageFileManager {
     
     DataStorageType getType();
 
-    Stream<DataStorageFile> files(AbstractDataStorage storage,
+    Stream<DataStorageFile> files(String storage,
+                                  String path,
                                   TemporaryCredentials credentials);
 
-    Stream<DataStorageFile> versionsWithNativeTags(AbstractDataStorage storage,
+    Stream<DataStorageFile> versionsWithNativeTags(String storage,
+                                                   String path,
                                                    TemporaryCredentials credentials);
 
 }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/AzureBlobManager.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/AzureBlobManager.java
@@ -69,7 +69,8 @@ public class AzureBlobManager implements ObjectStorageFileManager {
     @Override
     public Stream<DataStorageFile> files(final AbstractDataStorage storage,
                                          final TemporaryCredentials credentials) {
-        return StreamUtils.from(new AzureFlatSegmentIterator(buildContainerUrl(storage, credentials), ""))
+        return StreamUtils.from(new AzureFlatSegmentIterator(buildContainerUrl(storage, credentials), 
+                storage.resolveRootPath(StringUtils.EMPTY)))
                 .map(response -> Optional.of(response.body())
                         .map(ListBlobsFlatSegmentResponse::segment)
                         .map(BlobFlatListSegment::blobItems)
@@ -92,7 +93,7 @@ public class AzureBlobManager implements ObjectStorageFileManager {
         final ServiceURL serviceURL = new ServiceURL(
                 url(String.format(BLOB_URL_FORMAT, credentials.getAccessKey(), credentials.getToken())),
                 StorageURL.createPipeline(creds, new PipelineOptions()));
-        return serviceURL.createContainerURL(storage.getPath());
+        return serviceURL.createContainerURL(storage.getRoot());
     }
 
     private DataStorageFile convertToStorageFile(final BlobItem blob) {

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/CloudPipelineAPIClient.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/CloudPipelineAPIClient.java
@@ -44,6 +44,7 @@ import com.epam.pipeline.vo.EntityPermissionVO;
 import com.epam.pipeline.vo.EntityVO;
 import com.epam.pipeline.vo.data.storage.DataStorageTagInsertBatchRequest;
 import com.epam.pipeline.vo.data.storage.DataStorageTagLoadBatchRequest;
+import org.apache.commons.collections4.ListUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -77,7 +78,7 @@ public class CloudPipelineAPIClient {
     }
 
     public List<DataStorageTag> loadDataStorageTags(final Long id, final DataStorageTagLoadBatchRequest request) {
-        return QueryUtils.execute(cloudPipelineAPI.loadDataStorageObjectTags(id, request));
+        return ListUtils.emptyIfNull(QueryUtils.execute(cloudPipelineAPI.loadDataStorageObjectTags(id, request)));
     }
 
     public Map<String, Map<String, String>> loadDataStorageTagsMap(final Long id,

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/DataStorageNativeTagsTransferSynchronizer.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/DataStorageNativeTagsTransferSynchronizer.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
@@ -59,7 +60,9 @@ public class DataStorageNativeTagsTransferSynchronizer implements ElasticsearchS
                         final boolean isVersioningEnabled = storage.isVersioningEnabled();
                         Optional.ofNullable(storage.getType()).map(fileManagers::get)
                                 .map(fileManager -> fileManager
-                                        .versionsWithNativeTags(storage, getTemporaryCredentials(storage))
+                                        .versionsWithNativeTags(storage.getRoot(),
+                                                Optional.ofNullable(storage.getPrefix()).orElse(StringUtils.EMPTY),
+                                                getTemporaryCredentials(storage))
                                         .map(chunk -> isVersioningEnabled ? versionedTags(chunk) : tags(chunk))
                                         .map(stream -> stream.collect(Collectors.toList()))
                                         .filter(CollectionUtils::isNotEmpty))

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/GsBucketFileManager.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/GsBucketFileManager.java
@@ -66,8 +66,8 @@ public class GsBucketFileManager implements ObjectStorageFileManager {
     public Stream<DataStorageFile> files(final AbstractDataStorage storage,
                                          final TemporaryCredentials credentials) {
         final Storage googleStorage = getGoogleStorage(credentials);
-        final String bucketName = storage.getPath();
-        final Iterator<Blob> iterator = googleStorage.list(bucketName)
+        final Iterator<Blob> iterator = googleStorage.list(storage.getRoot(), 
+                Storage.BlobListOption.prefix(storage.resolveRootPath(StringUtils.EMPTY)))
                 .iterateAll()
                 .iterator();
         return StreamUtils.from(iterator)
@@ -80,8 +80,9 @@ public class GsBucketFileManager implements ObjectStorageFileManager {
     public Stream<DataStorageFile> versionsWithNativeTags(final AbstractDataStorage storage,
                                                           final TemporaryCredentials credentials) {
         final Storage googleStorage = getGoogleStorage(credentials);
-        final String bucketName = storage.getPath();
-        final Iterator<Blob> iterator = googleStorage.list(bucketName, Storage.BlobListOption.versions(true))
+        final Iterator<Blob> iterator = googleStorage.list(storage.getRoot(), 
+                Storage.BlobListOption.versions(true),
+                Storage.BlobListOption.prefix(storage.resolveRootPath(StringUtils.EMPTY)))
                 .iterateAll()
                 .iterator();
         return StreamUtils.from(iterator)

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/GsBucketFileManager.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/GsBucketFileManager.java
@@ -18,7 +18,6 @@ package com.epam.pipeline.elasticsearchagent.service.impl;
 import com.epam.pipeline.elasticsearchagent.service.ObjectStorageFileManager;
 import com.epam.pipeline.elasticsearchagent.utils.ESConstants;
 import com.epam.pipeline.utils.StreamUtils;
-import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.DataStorageFile;
 import com.epam.pipeline.entity.datastorage.DataStorageType;
 import com.epam.pipeline.entity.datastorage.TemporaryCredentials;
@@ -63,11 +62,12 @@ public class GsBucketFileManager implements ObjectStorageFileManager {
     }
 
     @Override
-    public Stream<DataStorageFile> files(final AbstractDataStorage storage,
+    public Stream<DataStorageFile> files(final String storage,
+                                         final String path,
                                          final TemporaryCredentials credentials) {
         final Storage googleStorage = getGoogleStorage(credentials);
-        final Iterator<Blob> iterator = googleStorage.list(storage.getRoot(), 
-                Storage.BlobListOption.prefix(storage.resolveRootPath(StringUtils.EMPTY)))
+        final Iterator<Blob> iterator = googleStorage.list(storage, 
+                Storage.BlobListOption.prefix(path))
                 .iterateAll()
                 .iterator();
         return StreamUtils.from(iterator)
@@ -77,12 +77,13 @@ public class GsBucketFileManager implements ObjectStorageFileManager {
     }
 
     @Override
-    public Stream<DataStorageFile> versionsWithNativeTags(final AbstractDataStorage storage,
+    public Stream<DataStorageFile> versionsWithNativeTags(final String storage,
+                                                          final String path,
                                                           final TemporaryCredentials credentials) {
         final Storage googleStorage = getGoogleStorage(credentials);
-        final Iterator<Blob> iterator = googleStorage.list(storage.getRoot(), 
-                Storage.BlobListOption.versions(true),
-                Storage.BlobListOption.prefix(storage.resolveRootPath(StringUtils.EMPTY)))
+        final Iterator<Blob> iterator = googleStorage.list(storage,
+                Storage.BlobListOption.prefix(path),
+                Storage.BlobListOption.versions(true))
                 .iterateAll()
                 .iterator();
         return StreamUtils.from(iterator)

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/ObjectStorageIndexImpl.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/ObjectStorageIndexImpl.java
@@ -94,10 +94,10 @@ public class ObjectStorageIndexImpl implements ObjectStorageIndex {
                 final Stream<DataStorageFile> files = fileManager
                         .files(dataStorage.getRoot(),
                                 Optional.ofNullable(dataStorage.getPrefix()).orElse(StringUtils.EMPTY),
-                                credentials)
-                        .peek(file -> file.setPath(dataStorage.resolveRelativePath(file.getPath())));
+                                credentials);
                 StreamUtils.chunked(files, bulkLoadTagsSize)
                         .flatMap(filesChunk -> filesWithIncorporatedTags(dataStorage, filesChunk))
+                        .peek(file -> file.setPath(dataStorage.resolveRelativePath(file.getPath())))
                         .map(file -> createIndexRequest(file, dataStorage, permissionsContainer, indexName, 
                                 credentials))
                         .forEach(requestContainer::add);

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/S3FileManager.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/S3FileManager.java
@@ -69,7 +69,8 @@ public class S3FileManager implements ObjectStorageFileManager {
     public Stream<DataStorageFile> files(final AbstractDataStorage storage,
                                          final TemporaryCredentials credentials) {
         final AmazonS3 client = getS3Client(credentials);
-        return StreamUtils.from(new S3PageIterator(client, storage.getPath(), ""))
+        return StreamUtils.from(new S3PageIterator(client, storage.getRoot(), 
+                storage.resolveRootPath(StringUtils.EMPTY)))
                 .flatMap(List::stream);
     }
 
@@ -77,7 +78,8 @@ public class S3FileManager implements ObjectStorageFileManager {
     public Stream<DataStorageFile> versionsWithNativeTags(final AbstractDataStorage storage,
                                                           final TemporaryCredentials credentials) {
         final AmazonS3 client = getS3Client(credentials);
-        return StreamUtils.from(new S3VersionPageIterator(client, storage.getPath(), ""))
+        return StreamUtils.from(new S3VersionPageIterator(client, storage.getRoot(), 
+                storage.resolveRootPath(StringUtils.EMPTY)))
                 .flatMap(List::stream)
                 .filter(file -> !file.getDeleteMarker())
                 .peek(file -> file.setTags(getNativeTags(client, storage, file)));

--- a/elasticsearch-agent/src/test/java/com/epam/pipeline/elasticsearchagent/service/impl/ObjectStorageIndexTest.java
+++ b/elasticsearch-agent/src/test/java/com/epam/pipeline/elasticsearchagent/service/impl/ObjectStorageIndexTest.java
@@ -94,7 +94,7 @@ public class ObjectStorageIndexTest {
     private void setUpReturnValues(final List<DataStorageFile> files) {
         Mockito.doAnswer(i -> files.stream())
                .when(fileManager)
-               .files(dataStorage, temporaryCredentials);
+               .files(any(), any(), temporaryCredentials);
     }
 
     private void verifyNumberOfInsertions(final int numberOfInvocation) {


### PR DESCRIPTION
Resolves issue #1852 and relates to #1717.

The pull request brings support for prefixed data storage objects indexing.

Additionally it fixes a possible NPE in `CloudPipelineAPIClient` and refactors `AbstractDataStorage` classes a bit.