### PR TITLE
Handle google data storage file version deletion properly

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/ProviderUtils.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/ProviderUtils.java
@@ -29,6 +29,7 @@ public final class ProviderUtils {
     public static final String DELIMITER = "/";
     public static final String FOLDER_TOKEN_FILE = ".DS_Store";
     public static final String OWNER_TAG_KEY = "CP_OWNER";
+    public static final String SYNTHETIC_DELETION_MARKER_SUFFIX = "_d";
 
     private ProviderUtils() {
         //no op
@@ -108,5 +109,17 @@ public final class ProviderUtils {
 
     public static String removePrefix(final String path, final String prefix) {
         return path.startsWith(prefix) ? path.replaceFirst(prefix, StringUtils.EMPTY) : path;
+    }
+
+    public static boolean isSyntheticDeletionMarker(final String version) {
+        return StringUtils.endsWith(version, ProviderUtils.SYNTHETIC_DELETION_MARKER_SUFFIX);
+    }
+
+    public static String getSyntheticDeletionMarkerFromVersion(final String version) {
+        return version + ProviderUtils.SYNTHETIC_DELETION_MARKER_SUFFIX;
+    }
+
+    public static String getVersionFromSyntheticDeletionMarker(final String version) {
+        return StringUtils.removeEnd(version, ProviderUtils.SYNTHETIC_DELETION_MARKER_SUFFIX);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/tag/DataStorageTagProviderManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/tag/DataStorageTagProviderManager.java
@@ -4,6 +4,7 @@ import com.epam.pipeline.common.MessageConstants;
 import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.DataStorageFile;
+import com.epam.pipeline.entity.datastorage.DataStorageType;
 import com.epam.pipeline.entity.datastorage.tag.DataStorageObject;
 import com.epam.pipeline.entity.datastorage.tag.DataStorageTag;
 import com.epam.pipeline.entity.datastorage.tag.DataStorageTagCopyBatchRequest;
@@ -163,6 +164,10 @@ public class DataStorageTagProviderManager {
                                final String path,
                                final String version,
                                final Boolean totally) {
+        if (storage.getType() == DataStorageType.GS && ProviderUtils.isSyntheticDeletionMarker(version)) {
+            restoreFileTags(storage, path, ProviderUtils.getVersionFromSyntheticDeletionMarker(version));
+            return;
+        }
         final String absolutePath = storage.resolveAbsolutePath(path);
         if (storage.isVersioningEnabled()) {
             if (version != null) {


### PR DESCRIPTION
Relates to #1717.

The pull request repairs two google data storage file version deletion scenarios:
- data storage file delete marker deletion using GUI
- data storage file non latest version deletion using CLI
