### PR TITLE
Add retries support for requests to api from search

### DIFF
--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineApiBuilder.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineApiBuilder.java
@@ -18,7 +18,7 @@ package com.epam.pipeline.client.pipeline;
 
 import com.epam.pipeline.client.TokenInterceptor;
 import com.epam.pipeline.config.JsonMapper;
-import com.epam.pipeline.utils.QueryUtils;
+import com.epam.pipeline.utils.URLUtils;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import java.security.GeneralSecurityException;
 import java.text.SimpleDateFormat;
@@ -49,7 +49,7 @@ public class CloudPipelineApiBuilder {
 
     public CloudPipelineAPI buildClient() {
         return new Retrofit.Builder()
-                .baseUrl(QueryUtils.normalizeUrl(apiHost))
+                .baseUrl(URLUtils.normalizeUrl(apiHost))
                 .addConverterFactory(CONVERTER)
                 .client(buildHttpClient())
                 .build()

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineApiExecutor.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineApiExecutor.java
@@ -1,0 +1,13 @@
+package com.epam.pipeline.client.pipeline;
+
+import com.epam.pipeline.rest.Result;
+import retrofit2.Call;
+
+public interface CloudPipelineApiExecutor {
+    
+    <T> T execute(final Call<Result<T>> call);
+
+    String getStringResponse(final Call<byte[]> call);
+
+    byte[] getByteResponse(final Call<byte[]> call);
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/RetryingCloudPipelineApiExecutor.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/RetryingCloudPipelineApiExecutor.java
@@ -1,0 +1,143 @@
+package com.epam.pipeline.client.pipeline;
+
+import com.epam.pipeline.exception.PipelineResponseApiException;
+import com.epam.pipeline.exception.PipelineResponseException;
+import com.epam.pipeline.exception.PipelineResponseHttpException;
+import com.epam.pipeline.exception.PipelineResponseIOException;
+import com.epam.pipeline.rest.Result;
+import com.epam.pipeline.rest.ResultStatus;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import retrofit2.Call;
+import retrofit2.Response;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.time.Duration;
+import java.util.Objects;
+
+@Slf4j
+@RequiredArgsConstructor
+public class RetryingCloudPipelineApiExecutor implements CloudPipelineApiExecutor {
+
+    private static final int DEFAULT_RETRY_ATTEMPTS = 3;
+    private static final Duration DEFAULT_RETRY_DELAY = Duration.ofSeconds(5);
+
+    private final int attempts;
+    private final Duration delay;
+
+    public RetryingCloudPipelineApiExecutor() {
+        this(DEFAULT_RETRY_ATTEMPTS, DEFAULT_RETRY_DELAY);
+    }
+    
+    public static RetryingCloudPipelineApiExecutor basic() {
+        return new RetryingCloudPipelineApiExecutor();
+    }
+
+    @Override
+    public <T> T execute(final Call<Result<T>> call) {
+        return execute(call, this::internalExecute);
+    }
+
+    @SneakyThrows
+    private <T, R> R execute(final Call<T> call,
+                             final Caller<T, R> caller) {
+        if (attempts < 1) {
+            throw new IllegalArgumentException("The number of retry attempts should be at least 1.");
+        }
+        int attempt = 0;
+        Exception lastException = null;
+        while (attempt < attempts) {
+            attempt += 1;
+            try {
+                return caller.apply(attempt > 1 ? call.clone() : call);
+            } catch (PipelineResponseException e) {
+                log.error("Cloud Pipeline API call {}/{} has failed due to API error. " +
+                        "It won't be retried.", attempt, attempts, e);
+                throw e;
+            } catch (Exception e) {
+                log.error("Cloud Pipeline API call {}/{} has failed due to IO error. " +
+                        "It will be retried in {} s.", attempt, attempts, delay.getSeconds(), e);
+                lastException = e;
+                Thread.sleep(delay.toMillis());
+            }
+        }
+        throw new PipelineResponseIOException(lastException);
+    }
+
+    private <T> T internalExecute(final Call<Result<T>> call) throws IOException {
+        final Response<Result<T>> response = call.execute();
+        if (!response.isSuccessful()) {
+            throw new PipelineResponseHttpException(String.format("Unexpected response http code: %d, %s",
+                    response.code(), response.errorBody() != null ? response.errorBody().string() : StringUtils.EMPTY));
+        }
+        if (response.body() == null) {
+            throw new PipelineResponseApiException("Empty response body");
+        }
+        if (response.body().getStatus() != ResultStatus.OK) {
+            throw new PipelineResponseApiException(String.format("Unexpected response api status: %s, %s",
+                    response.body().getStatus(), response.body().getMessage()));
+        }
+        return response.body().getPayload();
+    }
+    
+    @Override
+    public String getStringResponse(final Call<byte[]> call) {
+        return execute(call, this::internalGetStringResponse);
+    }
+
+    private String internalGetStringResponse(final Call<byte[]> call) throws IOException {
+        try {
+            final Response<byte[]> response = call.execute();
+            validateResponseStatus(response);
+            return getFileContent(response);
+        } catch (JsonMappingException e) {
+            // case with empty output
+            return null;
+        }
+    }
+    
+    @Override
+    public byte[] getByteResponse(final Call<byte[]> call) {
+        return execute(call, this::internalGetByteResponse);
+    }
+
+    private byte[] internalGetByteResponse(final Call<byte[]> call) throws IOException {
+        try {
+            final Response<byte[]> response = call.execute();
+            validateResponseStatus(response);
+            return response.body();
+        } catch (JsonMappingException e) {
+            // case with empty output
+            return null;
+        }
+    }
+
+    private static void validateResponseStatus(final Response<byte[]> response) throws IOException {
+        if (!response.isSuccessful()) {
+            throw new PipelineResponseException(String.format("Unexpected status code: %d, %s", response.code(),
+                    response.errorBody() != null ? response.errorBody().string() : ""));
+        }
+    }
+
+    private static String getFileContent(final Response<byte[]> response) throws IOException {
+        final InputStream in = new ByteArrayInputStream(Objects.requireNonNull(response.body()));
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(in))) {
+            return IOUtils.toString(br);
+        }
+    }
+
+    @FunctionalInterface
+    public interface Caller<T, R> {
+
+        R apply(Call<T> t) throws IOException;
+    }
+
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/exception/PipelineResponseApiException.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/exception/PipelineResponseApiException.java
@@ -1,0 +1,16 @@
+package com.epam.pipeline.exception;
+
+public class PipelineResponseApiException extends PipelineResponseException {
+
+    public PipelineResponseApiException(final String message) {
+        super(message);
+    }
+
+    public PipelineResponseApiException(final Throwable cause) {
+        super(cause);
+    }
+
+    public PipelineResponseApiException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/exception/PipelineResponseHttpException.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/exception/PipelineResponseHttpException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,17 @@
 
 package com.epam.pipeline.exception;
 
-public class PipelineResponseException extends RuntimeException {
+public class PipelineResponseHttpException extends PipelineResponseException {
 
-    public PipelineResponseException(final String message) {
+    public PipelineResponseHttpException(final String message) {
         super(message);
     }
 
-    public PipelineResponseException(final Throwable cause) {
+    public PipelineResponseHttpException(final Throwable cause) {
         super(cause);
     }
 
-    public PipelineResponseException(final String message, final Throwable cause) {
+    public PipelineResponseHttpException(final String message, final Throwable cause) {
         super(message, cause);
     }
 }

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/exception/PipelineResponseIOException.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/exception/PipelineResponseIOException.java
@@ -1,0 +1,16 @@
+package com.epam.pipeline.exception;
+
+public class PipelineResponseIOException extends PipelineResponseException {
+
+    public PipelineResponseIOException(final String message) {
+        super(message);
+    }
+
+    public PipelineResponseIOException(final Throwable cause) {
+        super(cause);
+    }
+
+    public PipelineResponseIOException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/utils/QueryUtils.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/utils/QueryUtils.java
@@ -29,17 +29,14 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.springframework.util.Assert;
 import retrofit2.Call;
 import retrofit2.Response;
 
+/**
+ * @deprecated Use {@link com.epam.pipeline.client.pipeline.RetryingCloudPipelineApiExecutor} instead.
+ */
+@Deprecated
 public interface QueryUtils {
-
-    static String normalizeUrl(String url) {
-        Assert.state(StringUtils.isNotBlank(url), "Url shall be specified");
-        return url.endsWith("/") ? url : url + "/";
-    }
 
     static <T> T execute(Call<Result<T>> call) {
         try {

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/utils/URLUtils.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/utils/URLUtils.java
@@ -16,10 +16,18 @@
 
 package com.epam.pipeline.utils;
 
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.util.Assert;
+
 public final class URLUtils {
 
     private URLUtils() {
         //no op
+    }
+
+    public static String normalizeUrl(String url) {
+        Assert.state(StringUtils.isNotBlank(url), "Url shall be specified");
+        return url.endsWith("/") ? url : url + "/";
     }
 
     public static String getUrlWithoutTrailingSlash(String url) {

--- a/deploy/docker/cp-search/config/application.properties
+++ b/deploy/docker/cp-search/config/application.properties
@@ -18,6 +18,8 @@ database.initial.pool.size=${CP_SEARCH_DB_INITIAL_POOL_SIZE:2}
 #Cloud Pipeline API settings
 cloud.pipeline.host=https://${CP_API_SRV_INTERNAL_HOST:cp-api-srv.default.svc.cluster.local}:${CP_API_SRV_INTERNAL_PORT:31080}/pipeline/restapi/
 cloud.pipeline.token=${CP_API_JWT_ADMIN}
+cloud.pipeline.retry.attempts=${CP_SEARCH_API_RETRY_ATTEMPTS:3}
+cloud.pipeline.retry.delay=${CP_SEARCH_API_RETRY_DELAY:5000}
 
 #Common sync settings
 sync.index.common.prefix=cp-

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/app/AppConfiguration.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/app/AppConfiguration.java
@@ -15,6 +15,8 @@
  */
 package com.epam.pipeline.elasticsearchagent.app;
 
+import com.epam.pipeline.client.pipeline.CloudPipelineApiExecutor;
+import com.epam.pipeline.client.pipeline.RetryingCloudPipelineApiExecutor;
 import net.javacrumbs.shedlock.core.LockProvider;
 import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
 import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
@@ -23,6 +25,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -44,5 +47,12 @@ public class AppConfiguration {
     @Bean(name = "lockProvider")
     public LockProvider lockProvider(DataSource dataSource) {
         return new JdbcTemplateLockProvider(dataSource);
+    }
+    
+    @Bean
+    public CloudPipelineApiExecutor cloudPipelineApiExecutor(
+            @Value("${cloud.pipeline.retry.attempts:3}") int retryAttempts,
+            @Value("${cloud.pipeline.retry.delay:5000}") int retryDelay) {
+        return new RetryingCloudPipelineApiExecutor(retryAttempts, Duration.ofMillis(retryDelay));
     }
 }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/CloudPipelineAPIClient.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/CloudPipelineAPIClient.java
@@ -17,6 +17,7 @@ package com.epam.pipeline.elasticsearchagent.service.impl;
 
 import com.epam.pipeline.client.pipeline.CloudPipelineAPI;
 import com.epam.pipeline.client.pipeline.CloudPipelineApiBuilder;
+import com.epam.pipeline.client.pipeline.CloudPipelineApiExecutor;
 import com.epam.pipeline.elasticsearchagent.model.PipelineRunWithLog;
 import com.epam.pipeline.entity.configuration.RunConfiguration;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
@@ -39,7 +40,6 @@ import com.epam.pipeline.entity.pipeline.ToolGroup;
 import com.epam.pipeline.entity.region.AbstractCloudRegion;
 import com.epam.pipeline.entity.security.acl.AclClass;
 import com.epam.pipeline.entity.user.PipelineUser;
-import com.epam.pipeline.utils.QueryUtils;
 import com.epam.pipeline.vo.EntityPermissionVO;
 import com.epam.pipeline.vo.EntityVO;
 import com.epam.pipeline.vo.data.storage.DataStorageTagInsertBatchRequest;
@@ -57,28 +57,31 @@ import java.util.stream.Collectors;
 public class CloudPipelineAPIClient {
 
     private final CloudPipelineAPI cloudPipelineAPI;
+    private final CloudPipelineApiExecutor executor;
 
     public CloudPipelineAPIClient(@Value("${cloud.pipeline.host}") String cloudPipelineHostUrl,
-                                  @Value("${cloud.pipeline.token}") String cloudPipelineToken) {
+                                  @Value("${cloud.pipeline.token}") String cloudPipelineToken,
+                                  CloudPipelineApiExecutor cloudPipelineApiExecutor) {
         this.cloudPipelineAPI =
                 new CloudPipelineApiBuilder(0, 0, cloudPipelineHostUrl, cloudPipelineToken)
                         .buildClient();
+        this.executor = cloudPipelineApiExecutor;
     }
 
     public List<AbstractDataStorage> loadAllDataStorages() {
-        return QueryUtils.execute(cloudPipelineAPI.loadAllDataStorages());
+        return executor.execute(cloudPipelineAPI.loadAllDataStorages());
     }
 
     public AbstractDataStorage loadDataStorage(final Long id) {
-        return QueryUtils.execute(cloudPipelineAPI.loadDataStorage(id));
+        return executor.execute(cloudPipelineAPI.loadDataStorage(id));
     }
 
     public void insertDataStorageTags(final Long id, final DataStorageTagInsertBatchRequest request) {
-        QueryUtils.execute(cloudPipelineAPI.insertDataStorageTags(id, request));
+        executor.execute(cloudPipelineAPI.insertDataStorageTags(id, request));
     }
 
     public List<DataStorageTag> loadDataStorageTags(final Long id, final DataStorageTagLoadBatchRequest request) {
-        return ListUtils.emptyIfNull(QueryUtils.execute(cloudPipelineAPI.loadDataStorageObjectTags(id, request)));
+        return ListUtils.emptyIfNull(executor.execute(cloudPipelineAPI.loadDataStorageObjectTags(id, request)));
     }
 
     public Map<String, Map<String, String>> loadDataStorageTagsMap(final Long id,
@@ -93,100 +96,99 @@ public class CloudPipelineAPIClient {
 
         runWithLog.setPipelineRun(loadPipelineRun(pipelineRunId));
 
-        List<RunLog> runLogs = QueryUtils.execute(cloudPipelineAPI.loadLogs(pipelineRunId));
+        List<RunLog> runLogs = executor.execute(cloudPipelineAPI.loadLogs(pipelineRunId));
         runWithLog.setRunLogs(runLogs);
 
         return runWithLog;
     }
 
     public PipelineRun loadPipelineRun(final Long pipelineRunId) {
-        return QueryUtils.execute(cloudPipelineAPI.loadPipelineRun(pipelineRunId));
+        return executor.execute(cloudPipelineAPI.loadPipelineRun(pipelineRunId));
     }
 
     public TemporaryCredentials generateTemporaryCredentials(final List<DataStorageAction> actions) {
-        return QueryUtils.execute(cloudPipelineAPI.generateTemporaryCredentials(actions));
+        return executor.execute(cloudPipelineAPI.generateTemporaryCredentials(actions));
     }
 
     public Map<String, PipelineUser> loadAllUsers() {
-        return QueryUtils.execute(cloudPipelineAPI.loadAllUsers()).stream()
+        return executor.execute(cloudPipelineAPI.loadAllUsers()).stream()
                 .collect(Collectors.toMap(PipelineUser::getUserName, Function.identity()));
     }
 
     public PipelineUser loadUserByName(final String userName) {
-        return QueryUtils.execute(cloudPipelineAPI.loadUserByName(userName));
+        return executor.execute(cloudPipelineAPI.loadUserByName(userName));
     }
 
     public List<? extends AbstractCloudRegion> loadAllRegions() {
-        return QueryUtils.execute(cloudPipelineAPI.loadAllRegions());
+        return executor.execute(cloudPipelineAPI.loadAllRegions());
     }
 
     public AbstractCloudRegion loadRegion(final Long regionId) {
-        return QueryUtils.execute(cloudPipelineAPI.loadRegion(regionId));
+        return executor.execute(cloudPipelineAPI.loadRegion(regionId));
     }
 
     public Tool loadTool(final String toolId) {
-        return QueryUtils.execute(cloudPipelineAPI.loadTool(null, toolId));
+        return executor.execute(cloudPipelineAPI.loadTool(null, toolId));
     }
 
     public Folder loadPipelineFolder(final Long folderId) {
-        return QueryUtils.execute(cloudPipelineAPI.findFolder(String.valueOf(folderId)));
+        return executor.execute(cloudPipelineAPI.findFolder(String.valueOf(folderId)));
     }
 
     public List<MetadataEntry> loadMetadataEntry(List<EntityVO> entities) {
-        return QueryUtils.execute(cloudPipelineAPI.loadFolderMetadata(entities));
+        return executor.execute(cloudPipelineAPI.loadFolderMetadata(entities));
     }
 
     public ToolGroup loadToolGroup(final String toolGroupId) {
-        return QueryUtils.execute(cloudPipelineAPI.loadToolGroup(toolGroupId));
+        return executor.execute(cloudPipelineAPI.loadToolGroup(toolGroupId));
     }
 
     public ToolDescription loadToolDescription(final Long toolId) {
-        return QueryUtils.execute(cloudPipelineAPI.loadToolAttributes(toolId));
+        return executor.execute(cloudPipelineAPI.loadToolAttributes(toolId));
     }
 
     public DockerRegistry loadDockerRegistry(final Long dockerRegistryId) {
-        return QueryUtils.execute(cloudPipelineAPI.loadDockerRegistry(dockerRegistryId));
+        return executor.execute(cloudPipelineAPI.loadDockerRegistry(dockerRegistryId));
     }
 
     public Issue loadIssue(final Long issueId) {
-        return QueryUtils.execute(cloudPipelineAPI.loadIssue(issueId));
+        return executor.execute(cloudPipelineAPI.loadIssue(issueId));
     }
 
     public MetadataEntity loadMetadataEntity(final Long metadataEntityId) {
-        return QueryUtils.execute(cloudPipelineAPI.loadMetadeataEntity(metadataEntityId));
+        return executor.execute(cloudPipelineAPI.loadMetadeataEntity(metadataEntityId));
     }
 
     public RunConfiguration loadRunConfiguration(final Long runConfigurationId) {
-        return QueryUtils.execute(cloudPipelineAPI.loadRunConfiguration(runConfigurationId));
+        return executor.execute(cloudPipelineAPI.loadRunConfiguration(runConfigurationId));
     }
 
     public Pipeline loadPipeline(final String identifier) {
-        return QueryUtils.execute(cloudPipelineAPI.loadPipeline(identifier));
+        return executor.execute(cloudPipelineAPI.loadPipeline(identifier));
     }
 
     public EntityPermissionVO loadPermissionsForEntity(final Long id, final AclClass entityClass) {
-        return QueryUtils.execute(cloudPipelineAPI.loadEntityPermissions(id, entityClass));
+        return executor.execute(cloudPipelineAPI.loadEntityPermissions(id, entityClass));
     }
 
     public List<Revision> loadPipelineVersions(final Long id) {
-        return QueryUtils.execute(cloudPipelineAPI.loadPipelineVersions(id));
+        return executor.execute(cloudPipelineAPI.loadPipelineVersions(id));
     }
 
     public String getPipelineFile(final Long id, final String version, final String path) {
-        return QueryUtils.executeFileContent(cloudPipelineAPI.loadFileContent(id, version, path));
+        return executor.getStringResponse(cloudPipelineAPI.loadFileContent(id, version, path));
     }
 
     public byte[] getTruncatedPipelineFile(final Long id, final String version, final String path,
                                            final int byteLimit) {
-        return QueryUtils.getByteResponse(cloudPipelineAPI
-                .loadTruncatedFileContent(id, version, path, byteLimit));
+        return executor.getByteResponse(cloudPipelineAPI.loadTruncatedFileContent(id, version, path, byteLimit));
     }
 
     public List<GitRepositoryEntry> loadRepositoryContents(final Long id, final String version, final String path) {
-        return QueryUtils.execute(cloudPipelineAPI.loadRepositoryContent(id, version, path));
+        return executor.execute(cloudPipelineAPI.loadRepositoryContent(id, version, path));
     }
 
     public Pipeline loadPipelineByRepositoryUrl(final String repositoryUrl) {
-        return QueryUtils.execute(cloudPipelineAPI.loadPipelineByUrl(repositoryUrl));
+        return executor.execute(cloudPipelineAPI.loadPipelineByUrl(repositoryUrl));
     }
 }

--- a/elasticsearch-agent/src/main/resources/application.properties
+++ b/elasticsearch-agent/src/main/resources/application.properties
@@ -18,6 +18,8 @@ database.initial.pool.size=2
 #Cloud Pipeline API settings
 cloud.pipeline.host=
 cloud.pipeline.token=
+cloud.pipeline.retry.attempts=3
+cloud.pipeline.retry.delay=5000
 
 #Common sync settings
 sync.index.common.prefix=cp-


### PR DESCRIPTION
Resolves #1890 and relates to #1717.

The pull request brings common approach for API request retries which is used in search but can be reused in any other service. **Notice** that only IO errors during requests will be retried.

Two additional application properties were added to search which specify how many retries are allowed and what delay in ms shall be used between retries. Default values are shown below.

```
cloud.pipeline.retry.attempts=3
cloud.pipeline.retry.delay=5000
```

For data storage tags transferring the higher values are recommended to avoid possible API redeployments.