### PR TITLE
Issue #1838: Faceted Filter search results (API)

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/search/SearchDocument.java
+++ b/api/src/main/java/com/epam/pipeline/entity/search/SearchDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,14 @@
 
 package com.epam.pipeline.entity.search;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 @Builder
@@ -37,6 +39,13 @@ public class SearchDocument {
     private SearchDocumentType type;
     private List<HightLight> highlights;
     private float score;
+    private String owner;
+    private Map<String, String> attributes;
+
+    @JsonAnyGetter
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
 
     @Data
     @Builder

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -678,6 +678,10 @@ public class SystemPreferences {
     public static final StringPreference SEARCH_ELASTIC_DENIED_GROUPS_FIELD = new StringPreference(
             "search.elastic.denied.groups.field", null, SEARCH_GROUP, pass);
 
+    public static final ObjectPreference<Set<String>> SEARCH_ELASTIC_INDEX_METADATA_FIELDS = new ObjectPreference<>(
+            "search.elastic.index.metadata.fields", null, new TypeReference<Set<String>>() {},
+            SEARCH_GROUP, pass);
+
     // Grid engine autoscaling
     public static final IntPreference GE_AUTOSCALING_SCALE_UP_TIMEOUT =
             new IntPreference("ge.autoscaling.scale.up.timeout", 30,

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchSourceFields.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchSourceFields.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.search;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Getter
+@RequiredArgsConstructor
+public enum SearchSourceFields {
+    ID("id"),
+    PARENT_ID("parentId"),
+    NAME("name"),
+    DESCRIPTION("description"),
+    OWNER("ownerUserName"),
+    PATH("path"),
+    TEXT("text"),
+    START_DATE("startDate"),
+    END_DATE("endDate"),
+    IMAGE("image"),
+    SIZE("size"),
+    LAST_MODIFIED("lastModified");
+
+    private final String fieldName;
+
+    public static Set<String> getAdditionalFields() {
+        return Stream.of(PATH, TEXT, START_DATE, END_DATE, IMAGE, SIZE, LAST_MODIFIED)
+                .map(SearchSourceFields::getFieldName)
+                .collect(Collectors.toSet());
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/test/creator/search/SearchCreatorUtils.java
+++ b/api/src/test/java/com/epam/pipeline/test/creator/search/SearchCreatorUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,6 +62,7 @@ public final class SearchCreatorUtils {
 
     private static SearchDocument getSearchDocument() {
         return new SearchDocument(TEST_STRING, TEST_STRING, TEST_STRING, TEST_STRING, TEST_STRING, SEARCH_DOCUMENT_TYPE,
-                Collections.singletonList(new SearchDocument.HightLight(TEST_STRING, TEST_STRING_LIST)), TEST_INT);
+                Collections.singletonList(new SearchDocument.HightLight(TEST_STRING, TEST_STRING_LIST)), TEST_INT,
+                TEST_STRING, null);
     }
 }


### PR DESCRIPTION
The current PR provides implementation for https://github.com/epam/cloud-pipeline/issues/1838#issuecomment-811058164

-  a new system preference add  `search.elastic.index.metadata.fields`. This preference indicates the metadata keys that shall be searched for all entities.
- a new common field `owner` (owner user name) added to search result object
- a new fields added to search result object: 
  - run: `startDate`, `endDate`
  - storage: `path`
  - tool: `image`
  - storage file: `path`, `size`, `lastModified`
  - issue: `text`
- the metadata key-value pair returns at the root of the search result object