### PR TITLE
Support dns hosts management in sge autoscaler

### DIFF
--- a/workflows/pipe-common/scripts/autoscale_sge.py
+++ b/workflows/pipe-common/scripts/autoscale_sge.py
@@ -678,7 +678,7 @@ class GridEngineScaleUpHandler:
         raise ScalingError(error_msg)
 
     def _add_worker_to_master_hosts(self, pod):
-        self.executor.execute('add_to_hosts "%s" && wait_for_host_resolving "%s" "%s"' % (pod.name, pod.name, pod.ip))
+        self.executor.execute('add_to_hosts "%s" "%s"' % (pod.name, pod.ip))
 
     def _await_worker_initialization(self, run_id):
         Logger.info('Waiting for additional worker with run_id=%s to initialize.' % run_id)

--- a/workflows/pipe-common/scripts/autoscale_sge.py
+++ b/workflows/pipe-common/scripts/autoscale_sge.py
@@ -678,7 +678,7 @@ class GridEngineScaleUpHandler:
         raise ScalingError(error_msg)
 
     def _add_worker_to_master_hosts(self, pod):
-        self.executor.execute('add_to_hosts "%s" "%s"' % (pod.name, pod.ip))
+        self.executor.execute('add_to_hosts "%s" && wait_for_host_resolving "%s" "%s"' % (pod.name, pod.name, pod.ip))
 
     def _await_worker_initialization(self, run_id):
         Logger.info('Waiting for additional worker with run_id=%s to initialize.' % run_id)

--- a/workflows/pipe-common/shell/add_to_hosts
+++ b/workflows/pipe-common/shell/add_to_hosts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,13 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Adds a new record to /etc/hosts file as well as default hostfile using file system locking.
-# It prevents possible race condition during host files modification.
+# Adds a new host record to default hostfile in a concurrent safe way.
+# Additionally adds a new host record to /etc/hosts if host ip is provided as a second argument.
 # 
 # Usage examples:
 #
 # add_to_hosts "pipeline-12345" \
-#              "127.0.0.2"
+#              "127.0.0.1"
+#
+# add_to_hosts "pipeline-12345"
 
 # Required args
 WORKER_HOST="$1"
@@ -29,7 +31,11 @@ WORKER_IP="$2"
 LOCK_FILE="/var/run/hosts-modification.lock"
 DEFAULT_HOSTFILE="${DEFAULT_HOSTFILE:-/common/hostfile}"
 
-COMMAND="echo -e '$WORKER_IP\t$WORKER_HOST' >> '/etc/hosts';
-         echo -e '$WORKER_HOST' >> '$DEFAULT_HOSTFILE'"
+if [[ -z "$WORKER_IP" ]]; then
+    COMMAND="echo -e '$WORKER_HOST' >> '$DEFAULT_HOSTFILE'"
+else
+    COMMAND="echo -e '$WORKER_HOST' >> '$DEFAULT_HOSTFILE';
+             echo -e '$WORKER_IP\t$WORKER_HOST' >> '/etc/hosts'"
+fi
 
 flock -w 10 "$LOCK_FILE" bash -c "$COMMAND"

--- a/workflows/pipe-common/shell/add_to_hosts
+++ b/workflows/pipe-common/shell/add_to_hosts
@@ -14,8 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Adds a new host record to default hostfile in a concurrent safe way.
-# Additionally adds a new host record to /etc/hosts if host ip is provided as a second argument.
+# Adds a new host records to default hostfile and /etc/hosts in a concurrent safe way.
+#
+# If CP_CAP_AUTOSCALE_DNS_HOSTS run parameter is enabled then /etc/hosts file is not modified
+# and the script will wait until host entry is resolvable.
+#
+# If second argument is omitted then /etc/hosts file is not modified.
 # 
 # Usage examples:
 #
@@ -31,11 +35,16 @@ WORKER_IP="$2"
 LOCK_FILE="/var/run/hosts-modification.lock"
 DEFAULT_HOSTFILE="${DEFAULT_HOSTFILE:-/common/hostfile}"
 
-if [[ -z "$WORKER_IP" ]]; then
-    COMMAND="echo -e '$WORKER_HOST' >> '$DEFAULT_HOSTFILE'"
-else
-    COMMAND="echo -e '$WORKER_HOST' >> '$DEFAULT_HOSTFILE';
-             echo -e '$WORKER_IP\t$WORKER_HOST' >> '/etc/hosts'"
+COMMAND="echo -e '$WORKER_HOST' >> '$DEFAULT_HOSTFILE'"
+
+if [[ "$CP_CAP_AUTOSCALE_DNS_HOSTS" == "true" ]]; then
+    wait_for_host_resolving "$WORKER_HOST" "$WORKER_IP"
+    host_resolving_exit_code=$?
+    if [[ "$host_resolving_exit_code" != "0" ]]; then
+        exit "$host_resolving_exit_code"
+    fi
+elif [[ "$WORKER_IP" ]]; then
+    COMMAND="$COMMAND; echo -e '$WORKER_IP\t$WORKER_HOST' >> '/etc/hosts'"
 fi
 
 flock -w 10 "$LOCK_FILE" bash -c "$COMMAND"

--- a/workflows/pipe-common/shell/remove_from_hosts
+++ b/workflows/pipe-common/shell/remove_from_hosts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Removes host record from /etc/hosts file as well as default hostfile using file system locking.
-# It prevents possible race condition during host files modification.
+# Removes a host record from default hostfile and /etc/hosts in a concurrent safe way.
 #
 # Usage examples:
 #
@@ -27,7 +26,15 @@ WORKER_HOST="$1"
 LOCK_FILE="/var/run/hosts-modification.lock"
 DEFAULT_HOSTFILE="${DEFAULT_HOSTFILE:-/common/hostfile}"
 
-COMMAND="sed '/\t$WORKER_HOST$/d' /etc/hosts > /etc/hosts_modified; cp /etc/hosts_modified /etc/hosts; rm /etc/hosts_modified;
-         sed '/^$WORKER_HOST$/d' '$DEFAULT_HOSTFILE' > '${DEFAULT_HOSTFILE}_modified'; cp '${DEFAULT_HOSTFILE}_modified' '$DEFAULT_HOSTFILE'; rm '${DEFAULT_HOSTFILE}_modified'"
+COMMAND="if grep $'^$WORKER_HOST$' '$DEFAULT_HOSTFILE' > /dev/null; then
+             sed '/^$WORKER_HOST$/d' '$DEFAULT_HOSTFILE' > '${DEFAULT_HOSTFILE}_modified';
+             cp '${DEFAULT_HOSTFILE}_modified' '$DEFAULT_HOSTFILE';
+             rm '${DEFAULT_HOSTFILE}_modified';
+         fi;
+         if grep $'\t$WORKER_HOST$' /etc/hosts > /dev/null; then
+             sed '/\t$WORKER_HOST$/d' /etc/hosts > /etc/hosts_modified;
+             cp /etc/hosts_modified /etc/hosts;
+             rm /etc/hosts_modified;
+         fi"
 
 flock -w 10 "$LOCK_FILE" bash -c "$COMMAND"

--- a/workflows/pipe-common/shell/remove_from_hosts
+++ b/workflows/pipe-common/shell/remove_from_hosts
@@ -16,6 +16,8 @@
 
 # Removes a host record from default hostfile and /etc/hosts in a concurrent safe way.
 #
+# If CP_CAP_AUTOSCALE_DNS_HOSTS run parameter is enabled then /etc/hosts file is not modified.
+#
 # Usage examples:
 #
 # remove_from_hosts "pipeline-12345"
@@ -30,11 +32,15 @@ COMMAND="if grep $'^$WORKER_HOST$' '$DEFAULT_HOSTFILE' > /dev/null; then
              sed '/^$WORKER_HOST$/d' '$DEFAULT_HOSTFILE' > '${DEFAULT_HOSTFILE}_modified';
              cp '${DEFAULT_HOSTFILE}_modified' '$DEFAULT_HOSTFILE';
              rm '${DEFAULT_HOSTFILE}_modified';
-         fi;
-         if grep $'\t$WORKER_HOST$' /etc/hosts > /dev/null; then
-             sed '/\t$WORKER_HOST$/d' /etc/hosts > /etc/hosts_modified;
-             cp /etc/hosts_modified /etc/hosts;
-             rm /etc/hosts_modified;
          fi"
+
+if [[ "$CP_CAP_AUTOSCALE_DNS_HOSTS" != "true" ]]; then
+    COMMAND="$COMMAND;
+             if grep $'\t$WORKER_HOST$' /etc/hosts > /dev/null; then
+                 sed '/\t$WORKER_HOST$/d' /etc/hosts > /etc/hosts_modified;
+                 cp /etc/hosts_modified /etc/hosts;
+                 rm /etc/hosts_modified;
+             fi"
+fi
 
 flock -w 10 "$LOCK_FILE" bash -c "$COMMAND"

--- a/workflows/pipe-common/shell/wait_for_host_resolving
+++ b/workflows/pipe-common/shell/wait_for_host_resolving
@@ -30,25 +30,26 @@
 WORKER_HOST="$1"
 WORKER_IP="$2"
 
-CP_CAP_AUTOSCALE_HOSTS_RESOLVING_ATTEMPTS="${CP_CAP_AUTOSCALE_HOSTS_RESOLVING_ATTEMPTS:-12}"
-CP_CAP_AUTOSCALE_HOSTS_RESOLVING_DELAY="${CP_CAP_AUTOSCALE_HOSTS_RESOLVING_DELAY:-5}"
+CP_CAP_AUTOSCALE_DNS_HOSTS_RESOLVE_ATTEMPTS="${CP_CAP_AUTOSCALE_DNS_HOSTS_RESOLVE_ATTEMPTS:-12}"
+CP_CAP_AUTOSCALE_DNS_HOSTS_RESOLVE_DELAY="${CP_CAP_AUTOSCALE_DNS_HOSTS_RESOLVE_DELAY:-5}"
 
-for host_resolving_attempt in $(seq 1 "$CP_CAP_AUTOSCALE_HOSTS_RESOLVING_ATTEMPTS"); do
+for host_resolving_attempt in $(seq 1 "$CP_CAP_AUTOSCALE_DNS_HOSTS_RESOLVE_ATTEMPTS"); do
     if [[ -z "$WORKER_IP" ]]; then
         getent hosts "$WORKER_HOST" | grep "\s\+$WORKER_HOST\$" > /dev/null
     else
         getent hosts "$WORKER_HOST" | grep "^$WORKER_IP\s\+$WORKER_HOST\$" > /dev/null
     fi
     host_resolving_exit_code=$?
-    if [[ $host_resolving_exit_code -eq 0 ]]; then
+    if [[ "$host_resolving_exit_code" == "0" ]]; then
         break
     fi
-    echo "Host resolving has failed after $host_resolving_attempt/$CP_CAP_AUTOSCALE_HOSTS_RESOLVING_ATTEMPTS attempts. Trying again in $CP_CAP_AUTOSCALE_HOSTS_RESOLVING_DELAY seconds."
-    sleep "$CP_CAP_AUTOSCALE_HOSTS_RESOLVING_DELAY"
+    echo "Host resolving has failed after $host_resolving_attempt/$CP_CAP_AUTOSCALE_DNS_HOSTS_RESOLVE_ATTEMPTS attempts. Trying again in $CP_CAP_AUTOSCALE_DNS_HOSTS_RESOLVE_DELAY seconds."
+    sleep "$CP_CAP_AUTOSCALE_DNS_HOSTS_RESOLVE_DELAY"
 done
 
-if [[ $host_resolving_exit_code -ne 0 ]]
+if [[ "$host_resolving_exit_code" != "0" ]]
 then
     echo "Host resolving has failed. Exiting..."
-    exit 1
 fi
+
+exit "$host_resolving_exit_code"

--- a/workflows/pipe-common/shell/wait_for_host_resolving
+++ b/workflows/pipe-common/shell/wait_for_host_resolving
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Waits until the given host resolves to some ip address.
+# Optionally waits until the host resolves to an ip address provided as a second argument.
+# Can be used for waiting for a remote dns server to configure the required host record.
+# Notice that the resolving also considers local /etc/hosts.
+#
+# Usage examples:
+#
+# wait_for_host_resolving "pipeline-12345" \
+#                         "127.0.0.1"
+#
+# wait_for_host_resolving "pipeline-12345"
+
+# Required args
+WORKER_HOST="$1"
+WORKER_IP="$2"
+
+CP_CAP_AUTOSCALE_HOSTS_RESOLVING_ATTEMPTS="${CP_CAP_AUTOSCALE_HOSTS_RESOLVING_ATTEMPTS:-12}"
+CP_CAP_AUTOSCALE_HOSTS_RESOLVING_DELAY="${CP_CAP_AUTOSCALE_HOSTS_RESOLVING_DELAY:-5}"
+
+for host_resolving_attempt in $(seq 1 "$CP_CAP_AUTOSCALE_HOSTS_RESOLVING_ATTEMPTS"); do
+    if [[ -z "$WORKER_IP" ]]; then
+        getent hosts "$WORKER_HOST" | grep "\s\+$WORKER_HOST\$" > /dev/null
+    else
+        getent hosts "$WORKER_HOST" | grep "^$WORKER_IP\s\+$WORKER_HOST\$" > /dev/null
+    fi
+    host_resolving_exit_code=$?
+    if [[ $host_resolving_exit_code -eq 0 ]]; then
+        break
+    fi
+    echo "Host resolving has failed after $host_resolving_attempt/$CP_CAP_AUTOSCALE_HOSTS_RESOLVING_ATTEMPTS attempts. Trying again in $CP_CAP_AUTOSCALE_HOSTS_RESOLVING_DELAY seconds."
+    sleep "$CP_CAP_AUTOSCALE_HOSTS_RESOLVING_DELAY"
+done
+
+if [[ $host_resolving_exit_code -ne 0 ]]
+then
+    echo "Host resolving has failed. Exiting..."
+    exit 1
+fi


### PR DESCRIPTION
Relates to #1900 and depends on #1911.

The pull request brings support for dns hosts management to sge autoscaler.

By default sge autoscaler as well as `add_to_hosts` and `remove_from_hosts` utilities act as before. To enable dns hosts management boolean run parameter `CP_CAP_AUTOSCALE_DNS_HOSTS` should be enabled.
