### PR TITLE
Node requests performance

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/cluster/ClusterApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/cluster/ClusterApiService.java
@@ -29,6 +29,7 @@ import com.epam.pipeline.entity.cluster.MasterNode;
 import com.epam.pipeline.entity.cluster.NodeDisk;
 import com.epam.pipeline.entity.cluster.NodeInstance;
 import com.epam.pipeline.entity.cluster.monitoring.MonitoringStats;
+import com.epam.pipeline.entity.pipeline.run.RunInfo;
 import com.epam.pipeline.manager.cluster.InstanceOfferManager;
 import com.epam.pipeline.manager.cluster.MonitoringReportType;
 import com.epam.pipeline.manager.cluster.NodeDiskManager;
@@ -69,6 +70,12 @@ public class ClusterApiService {
     @AclMask
     public NodeInstance getNode(final String name) {
         return nodesManager.getNode(name);
+    }
+
+    @PreAuthorize(NODE_READ)
+    @AclMask
+    public RunInfo loadRunIdForNode(final String name) {
+        return nodesManager.loadRunIdForNode(name);
     }
 
     @PreAuthorize(NODE_READ)

--- a/api/src/main/java/com/epam/pipeline/acl/cluster/ClusterApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/cluster/ClusterApiService.java
@@ -73,7 +73,6 @@ public class ClusterApiService {
     }
 
     @PreAuthorize(NODE_READ)
-    @AclMask
     public RunInfo loadRunIdForNode(final String name) {
         return nodesManager.loadRunIdForNode(name);
     }

--- a/api/src/main/java/com/epam/pipeline/controller/cluster/ClusterController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/cluster/ClusterController.java
@@ -29,6 +29,7 @@ import com.epam.pipeline.entity.cluster.NodeDisk;
 import com.epam.pipeline.entity.cluster.NodeInstance;
 import com.epam.pipeline.entity.cluster.monitoring.MonitoringStats;
 import com.epam.pipeline.acl.cluster.ClusterApiService;
+import com.epam.pipeline.entity.pipeline.run.RunInfo;
 import com.epam.pipeline.manager.cluster.MonitoringReportType;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -137,6 +138,20 @@ public class ClusterController extends AbstractRestController {
             })
     public Result<NodeInstance> loadNode(@PathVariable(value = NAME) final String name) {
         return Result.success(clusterApiService.getNode(name));
+    }
+
+    @RequestMapping(value = "/cluster/node/{name}/run", method = RequestMethod.GET)
+    @ResponseBody
+    @ApiOperation(
+            value = "Returns run id associated with nodename.",
+            notes = "Returns run id associated with nodename.",
+            produces = MediaType.APPLICATION_JSON_VALUE
+        )
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public Result<RunInfo> loadRunIdForNode(@PathVariable(value = NAME) final String name) {
+        return Result.success(clusterApiService.loadRunIdForNode(name));
     }
 
     @RequestMapping(value = "/cluster/node/{name}/load", method = RequestMethod.POST)

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
@@ -122,6 +122,7 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     private String loadAllRunsByStatusQuery;
     private String loadAllRunsByIdsQuery;
     private String loadRunByPodIPQuery;
+    private String loadRunsByNodeNameQuery;
 
     // We put Propagation.REQUIRED here because this method can be called from non-transaction context
     // (see PipelineRunManager, it performs internal call for launchPipeline)
@@ -426,6 +427,11 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
                 .query(loadRunByPodIPQuery, params, PipelineRunParameters.getRowMapper()))
                 .stream()
                 .findFirst();
+    }
+
+    public List<PipelineRun> loadRunsByNodeName(final String nodeName) {
+        return ListUtils.emptyIfNull(getJdbcTemplate()
+                .query(loadRunsByNodeNameQuery, PipelineRunParameters.getRowMapper(), nodeName));
     }
 
     private MapSqlParameterSource getPagingParameters(PagingRunFilterVO filter) {
@@ -1219,5 +1225,10 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setLoadRunByPodIPQuery(final String loadRunByPodIPQuery) {
         this.loadRunByPodIPQuery = loadRunByPodIPQuery;
+    }
+
+    @Required
+    public void setLoadRunsByNodeNameQuery(final String loadRunsByNodeNameQuery) {
+        this.loadRunsByNodeNameQuery = loadRunsByNodeNameQuery;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/execution/PipelineExecutor.java
+++ b/api/src/main/java/com/epam/pipeline/manager/execution/PipelineExecutor.java
@@ -21,6 +21,7 @@ import com.epam.pipeline.entity.cluster.container.ContainerMemoryResourcePolicy;
 import com.epam.pipeline.entity.cluster.container.ImagePullPolicy;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.manager.cluster.KubernetesConstants;
+import com.epam.pipeline.manager.cluster.KubernetesManager;
 import com.epam.pipeline.manager.cluster.container.ContainerMemoryResourceService;
 import com.epam.pipeline.manager.cluster.container.ContainerResources;
 import com.epam.pipeline.manager.preference.PreferenceManager;
@@ -40,7 +41,6 @@ import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.SecurityContext;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.internal.PodOperationsImpl;
 import io.fabric8.kubernetes.client.utils.HttpClientUtils;
@@ -84,17 +84,20 @@ public class PipelineExecutor {
     private final PreferenceManager preferenceManager;
     private final String kubeNamespace;
     private final AuthManager authManager;
+    private final KubernetesManager kubernetesManager;
     private final Map<ContainerMemoryResourcePolicy, ContainerMemoryResourceService> memoryRequestServices;
 
     public PipelineExecutor(final PreferenceManager preferenceManager,
                             final AuthManager authManager,
                             final List<ContainerMemoryResourceService> memoryRequestServices,
-                            @Value("${kube.namespace}") final String kubeNamespace) {
+                            @Value("${kube.namespace}") final String kubeNamespace,
+                            final KubernetesManager kubernetesManager) {
         this.preferenceManager = preferenceManager;
         this.kubeNamespace = kubeNamespace;
         this.authManager = authManager;
         this.memoryRequestServices = CommonUtils.groupByKey(memoryRequestServices,
                 ContainerMemoryResourceService::policy);
+        this.kubernetesManager = kubernetesManager;
     }
 
     public void launchRootPod(String command, PipelineRun run, List<EnvVar> envVars, List<String> endpoints,
@@ -106,7 +109,7 @@ public class PipelineExecutor {
     public void launchRootPod(String command, PipelineRun run, List<EnvVar> envVars, List<String> endpoints,
             String pipelineId, String nodeIdLabel, String secretName, String clusterId,
                               ImagePullPolicy imagePullPolicy) {
-        try (KubernetesClient client = new DefaultKubernetesClient()) {
+        try (KubernetesClient client = kubernetesManager.getKubernetesClient()) {
             Map<String, String> labels = new HashMap<>();
             labels.put("spawned_by", "pipeline-api");
             labels.put("pipeline_id", pipelineId);

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunCRUDService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunCRUDService.java
@@ -71,4 +71,8 @@ public class PipelineRunCRUDService {
         Assert.notNull(pipelineRun, messageHelper.getMessage(MessageConstants.ERROR_RUN_PIPELINES_NOT_FOUND, id));
         return pipelineRun;
     }
+
+    public List<PipelineRun> loadRunsForNodeName(final String nodeName) {
+        return pipelineRunDao.loadRunsByNodeName(nodeName);
+    }
 }

--- a/api/src/main/resources/dao/pipeline-run-dao.xml
+++ b/api/src/main/resources/dao/pipeline-run-dao.xml
@@ -1782,5 +1782,67 @@
                 ]]>
             </value>
         </property>
+        <property name="loadRunsByNodeNameQuery">
+            <value>
+                <![CDATA[
+                    SELECT
+                        run_id,
+                        pipeline_id,
+                        version,
+                        start_date,
+                        end_date,
+                        parameters,
+                        status,
+                        terminating,
+                        pod_id,
+                        node_type,
+                        node_disk,
+                        node_ip,
+                        node_id,
+                        node_name,
+                        node_image,
+                        node_cloud_region,
+                        docker_image,
+                        actual_docker_image,
+                        cmd_template,
+                        actual_cmd,
+                        timeout,
+                        owner,
+                        service_url,
+                        pod_ip,
+                        commit_status,
+                        last_change_commit_time,
+                        config_name,
+                        node_count,
+                        parent_id,
+                        entities_ids,
+                        is_spot,
+                        configuration_id,
+                        pod_status,
+                        prolonged_at_time,
+                        last_notification_time,
+                        last_idle_notification_time,
+                        exec_preferences,
+                        pretty_url,
+                        price_per_hour,
+                        compute_price_per_hour,
+                        disk_price_per_hour,
+                        state_reason,
+                        non_pause,
+                        node_real_disk,
+                        node_cloud_provider,
+                        tags,
+                        sensitive,
+                        kube_service_enabled,
+                        pipeline_name
+                    FROM
+                        pipeline.pipeline_run
+                    WHERE
+                        node_name = ?
+                    ORDER BY
+                        start_date DESC
+                ]]>
+            </value>
+        </property>
     </bean>
 </beans>

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
@@ -69,6 +69,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.epam.pipeline.utils.PasswordGenerator.generateRandomString;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
@@ -124,6 +125,7 @@ public class PipelineRunDaoTest extends AbstractJdbcTest {
     private static final String ACTUAL_DOCKER_IMAGE = "actualDockerImage";
     private static final String TEST_PIPELINE_NAME = "Test";
     private static final String TEST_NEW_PIPELINE_NAME = "AnotherName";
+    private static final String NODE_NAME = "node-12323";
 
     @Autowired
     private PipelineRunDao pipelineRunDao;
@@ -915,6 +917,16 @@ public class PipelineRunDaoTest extends AbstractJdbcTest {
         assertNotNull(result);
         assertThat(result.getPipelineName(), is(TEST_PIPELINE_NAME));
         assertNull(result.getPipelineId());
+    }
+
+    @Test
+    public void shoudlFindRunByNodeName() {
+        final PipelineRun run = buildPipelineRun(null, null);
+        run.getInstance().setNodeName(NODE_NAME);
+        pipelineRunDao.createPipelineRun(run);
+        final List<PipelineRun> loaded = pipelineRunDao.loadRunsByNodeName(NODE_NAME);
+        assertThat(loaded.size(), equalTo(1));
+        assertThat(loaded.get(0).getId(), equalTo(run.getId()));
     }
 
     private PipelineRun createTestPipelineRun() {

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/run/RunInfo.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/run/RunInfo.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.pipeline.run;
+
+import lombok.Value;
+
+/**
+ * Provides minimal run description
+ */
+@Value
+public class RunInfo {
+
+    Long runId;
+}

--- a/scripts/autoscaling/fsautoscale.sh
+++ b/scripts/autoscaling/fsautoscale.sh
@@ -99,8 +99,8 @@ function get_current_run_id() {
   _API="$1"
   _API_TOKEN="$2"
   _NODE="$3"
-  call_api "$_API" "$_API_TOKEN" "cluster/node/$_NODE/load" "GET" |
-    jq -r ".payload.labels.runid" |
+  call_api "$_API" "$_API_TOKEN" "cluster/node/$_NODE/run" "GET" |
+    jq -r ".payload.runId" |
     grep -v "^null$"
 }
 

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/k8s/KubernetesDeploymentMonitorImpl.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/k8s/KubernetesDeploymentMonitorImpl.java
@@ -18,6 +18,8 @@
 package com.epam.pipeline.vmmonitor.service.k8s;
 
 import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
@@ -38,6 +40,7 @@ public class KubernetesDeploymentMonitorImpl implements KubernetesDeploymentMoni
 
     private static final String NAMESPACE_DELIMITER = "@";
     private static final String DELIMITER = ",";
+    private static final int CONNECTION_TIMEOUT_MS = 2 * 1000;
 
     private final KubernetesNotifier kubernetesNotifier;
     private final List<String> monitoredDeployments;
@@ -64,7 +67,8 @@ public class KubernetesDeploymentMonitorImpl implements KubernetesDeploymentMoni
     }
 
     private void checkDeploymentStatus(final String deploymentName) {
-        try (KubernetesClient client = new DefaultKubernetesClient()) {
+        final Config config = new ConfigBuilder().withConnectionTimeout(CONNECTION_TIMEOUT_MS).build();
+        try (KubernetesClient client = new DefaultKubernetesClient(config)) {
             final String namespace = getDeploymentNamespace(deploymentName);
             final Deployment deployment = client.apps().deployments()
                     .inNamespace(namespace)


### PR DESCRIPTION
This PR provides the following fixes for #1897:
- Improve performance of `/node/{}/load` method
- Add a new method `/node/{}/run` to get run id for a node
- `fsautoscaler` and `oom-reporter` use new API method to fetch current run_id