### PR TITLE
Issue #1914 Use `searchAfter` for search paging

### DIFF
--- a/api/src/main/java/com/epam/pipeline/controller/vo/search/ElasticSearchRequest.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/search/ElasticSearchRequest.java
@@ -34,6 +34,5 @@ public class ElasticSearchRequest {
     private boolean aggregate = false;
     private boolean highlight = false;
     private List<SearchDocumentType> filterTypes;
-    private List<ScrollingParameter> paginationRules;
-    private boolean isScrollingBackward;
+    private ScrollingParameter scrollingParameter;
 }

--- a/api/src/main/java/com/epam/pipeline/controller/vo/search/ElasticSearchRequest.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/search/ElasticSearchRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 @NoArgsConstructor
@@ -34,5 +35,6 @@ public class ElasticSearchRequest {
     private boolean aggregate = false;
     private boolean highlight = false;
     private List<SearchDocumentType> filterTypes;
+    private Map<String, Object> searchAfter;
 
 }

--- a/api/src/main/java/com/epam/pipeline/controller/vo/search/ElasticSearchRequest.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/search/ElasticSearchRequest.java
@@ -35,5 +35,5 @@ public class ElasticSearchRequest {
     private boolean highlight = false;
     private List<SearchDocumentType> filterTypes;
     private List<ScrollingParameter> paginationRules;
-    private boolean isScrollingForward = true;
+    private boolean isScrollingBackward;
 }

--- a/api/src/main/java/com/epam/pipeline/controller/vo/search/ElasticSearchRequest.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/search/ElasticSearchRequest.java
@@ -34,5 +34,5 @@ public class ElasticSearchRequest {
     private boolean aggregate = false;
     private boolean highlight = false;
     private List<SearchDocumentType> filterTypes;
-    private ScrollingParameter scrollingParameter;
+    private ScrollingParameters scrollingParameters;
 }

--- a/api/src/main/java/com/epam/pipeline/controller/vo/search/ElasticSearchRequest.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/search/ElasticSearchRequest.java
@@ -22,7 +22,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
-import java.util.Map;
 
 @Data
 @NoArgsConstructor
@@ -35,6 +34,6 @@ public class ElasticSearchRequest {
     private boolean aggregate = false;
     private boolean highlight = false;
     private List<SearchDocumentType> filterTypes;
-    private Map<String, Object> searchAfter;
-
+    private List<ScrollingParameter> paginationRules;
+    private boolean isScrollingForward = true;
 }

--- a/api/src/main/java/com/epam/pipeline/controller/vo/search/FacetedSearchRequest.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/search/FacetedSearchRequest.java
@@ -33,4 +33,5 @@ public class FacetedSearchRequest {
     private Integer pageSize;
     private Integer offset;
     private boolean highlight = false;
+    private Map<String, Object> searchAfter;
 }

--- a/api/src/main/java/com/epam/pipeline/controller/vo/search/FacetedSearchRequest.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/search/FacetedSearchRequest.java
@@ -34,5 +34,5 @@ public class FacetedSearchRequest {
     private Integer offset;
     private boolean highlight = false;
     private List<ScrollingParameter> scrollingParameters;
-    private boolean isScrollingForward = true;
+    private boolean isScrollingBackward;
 }

--- a/api/src/main/java/com/epam/pipeline/controller/vo/search/FacetedSearchRequest.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/search/FacetedSearchRequest.java
@@ -33,6 +33,5 @@ public class FacetedSearchRequest {
     private Integer pageSize;
     private Integer offset;
     private boolean highlight = false;
-    private List<ScrollingParameter> scrollingParameters;
-    private boolean isScrollingBackward;
+    private ScrollingParameter scrollingParameter;
 }

--- a/api/src/main/java/com/epam/pipeline/controller/vo/search/FacetedSearchRequest.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/search/FacetedSearchRequest.java
@@ -33,5 +33,5 @@ public class FacetedSearchRequest {
     private Integer pageSize;
     private Integer offset;
     private boolean highlight = false;
-    private ScrollingParameter scrollingParameter;
+    private ScrollingParameters scrollingParameters;
 }

--- a/api/src/main/java/com/epam/pipeline/controller/vo/search/ScrollingParameter.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/search/ScrollingParameter.java
@@ -21,6 +21,7 @@ import lombok.Data;
 @Data
 public class ScrollingParameter {
 
-    private String field;
-    private Object tieBreaker;
+    private String docId;
+    private float docScore;
+    private boolean isScrollingBackward;
 }

--- a/api/src/main/java/com/epam/pipeline/controller/vo/search/ScrollingParameter.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/search/ScrollingParameter.java
@@ -16,23 +16,11 @@
 
 package com.epam.pipeline.controller.vo.search;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.NoArgsConstructor;
-
-import java.util.List;
-import java.util.Map;
 
 @Data
-@NoArgsConstructor
-@AllArgsConstructor
-public class FacetedSearchRequest {
-    private String query;
-    private Map<String, List<String>> filters;
-    private List<String> facets;
-    private Integer pageSize;
-    private Integer offset;
-    private boolean highlight = false;
-    private List<ScrollingParameter> scrollingParameters;
-    private boolean isScrollingForward = true;
+public class ScrollingParameter {
+
+    private String field;
+    private Object tieBreaker;
 }

--- a/api/src/main/java/com/epam/pipeline/controller/vo/search/ScrollingParameters.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/search/ScrollingParameters.java
@@ -19,7 +19,7 @@ package com.epam.pipeline.controller.vo.search;
 import lombok.Data;
 
 @Data
-public class ScrollingParameter {
+public class ScrollingParameters {
 
     private String docId;
     private float docScore;

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchManager.java
@@ -60,7 +60,7 @@ public class SearchManager {
             final SearchResponse searchResult = globalSearchElasticHelper.buildClient().search(
                     requestBuilder.buildRequest(searchRequest, typeFieldName, TYPE_AGGREGATION, metadataSourceFields));
             return resultConverter.buildResult(searchResult, TYPE_AGGREGATION, typeFieldName, getAclFilterFields(),
-                    metadataSourceFields);
+                    metadataSourceFields, searchRequest.isScrollingForward());
         } catch (IOException e) {
             log.error(e.getMessage(), e);
             throw new SearchException(e.getMessage(), e);
@@ -89,7 +89,7 @@ public class SearchManager {
             final SearchResponse response = globalSearchElasticHelper.buildClient()
                     .search(requestBuilder.buildFacetedRequest(searchRequest, typeFieldName, metadataSourceFields));
             return resultConverter.buildFacetedResult(response, typeFieldName, getAclFilterFields(),
-                    metadataSourceFields);
+                    metadataSourceFields, searchRequest.isScrollingForward());
         } catch (IOException e) {
             log.error(e.getMessage(), e);
             throw new SearchException(e.getMessage(), e);

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchManager.java
@@ -60,7 +60,7 @@ public class SearchManager {
             final SearchResponse searchResult = globalSearchElasticHelper.buildClient().search(
                     requestBuilder.buildRequest(searchRequest, typeFieldName, TYPE_AGGREGATION, metadataSourceFields));
             return resultConverter.buildResult(searchResult, TYPE_AGGREGATION, typeFieldName, getAclFilterFields(),
-                    metadataSourceFields, searchRequest.isScrollingForward());
+                    metadataSourceFields, searchRequest.isScrollingBackward());
         } catch (IOException e) {
             log.error(e.getMessage(), e);
             throw new SearchException(e.getMessage(), e);
@@ -89,7 +89,7 @@ public class SearchManager {
             final SearchResponse response = globalSearchElasticHelper.buildClient()
                     .search(requestBuilder.buildFacetedRequest(searchRequest, typeFieldName, metadataSourceFields));
             return resultConverter.buildFacetedResult(response, typeFieldName, getAclFilterFields(),
-                    metadataSourceFields, searchRequest.isScrollingForward());
+                    metadataSourceFields, searchRequest.isScrollingBackward());
         } catch (IOException e) {
             log.error(e.getMessage(), e);
             throw new SearchException(e.getMessage(), e);

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchManager.java
@@ -28,7 +28,6 @@ import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.manager.utils.GlobalSearchElasticHelper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.SetUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.elasticsearch.action.search.SearchResponse;
@@ -38,6 +37,7 @@ import org.springframework.util.Assert;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 @Service
@@ -60,7 +60,7 @@ public class SearchManager {
             final SearchResponse searchResult = globalSearchElasticHelper.buildClient().search(
                     requestBuilder.buildRequest(searchRequest, typeFieldName, TYPE_AGGREGATION, metadataSourceFields));
             return resultConverter.buildResult(searchResult, TYPE_AGGREGATION, typeFieldName, getAclFilterFields(),
-                    metadataSourceFields, searchRequest.isScrollingBackward());
+                    metadataSourceFields, searchRequest.getScrollingParameter());
         } catch (IOException e) {
             log.error(e.getMessage(), e);
             throw new SearchException(e.getMessage(), e);
@@ -80,7 +80,7 @@ public class SearchManager {
 
     public FacetedSearchResult facetedSearch(final FacetedSearchRequest searchRequest) {
         Assert.notNull(searchRequest.getPageSize(), "Page Size is required");
-        if (CollectionUtils.isEmpty(searchRequest.getScrollingParameters())) {
+        if (Objects.isNull(searchRequest.getScrollingParameter())) {
             Assert.notNull(searchRequest.getOffset(), "Offset is required");
         }
         try {
@@ -89,7 +89,7 @@ public class SearchManager {
             final SearchResponse response = globalSearchElasticHelper.buildClient()
                     .search(requestBuilder.buildFacetedRequest(searchRequest, typeFieldName, metadataSourceFields));
             return resultConverter.buildFacetedResult(response, typeFieldName, getAclFilterFields(),
-                    metadataSourceFields, searchRequest.isScrollingBackward());
+                    metadataSourceFields, searchRequest.getScrollingParameter());
         } catch (IOException e) {
             log.error(e.getMessage(), e);
             throw new SearchException(e.getMessage(), e);

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchManager.java
@@ -28,6 +28,7 @@ import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.manager.utils.GlobalSearchElasticHelper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.collections4.SetUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.elasticsearch.action.search.SearchResponse;
@@ -79,7 +80,9 @@ public class SearchManager {
 
     public FacetedSearchResult facetedSearch(final FacetedSearchRequest searchRequest) {
         Assert.notNull(searchRequest.getPageSize(), "Page Size is required");
-        Assert.notNull(searchRequest.getOffset(), "Offset is required");
+        if (MapUtils.isEmpty(searchRequest.getSearchAfter())) {
+            Assert.notNull(searchRequest.getOffset(), "Offset is required");
+        }
         try {
             final String typeFieldName = getTypeFieldName();
             final Set<String> metadataSourceFields = getMetadataSourceFields();

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchManager.java
@@ -28,7 +28,7 @@ import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.manager.utils.GlobalSearchElasticHelper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.SetUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.elasticsearch.action.search.SearchResponse;
@@ -80,7 +80,7 @@ public class SearchManager {
 
     public FacetedSearchResult facetedSearch(final FacetedSearchRequest searchRequest) {
         Assert.notNull(searchRequest.getPageSize(), "Page Size is required");
-        if (MapUtils.isEmpty(searchRequest.getSearchAfter())) {
+        if (CollectionUtils.isEmpty(searchRequest.getScrollingParameters())) {
             Assert.notNull(searchRequest.getOffset(), "Offset is required");
         }
         try {

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchManager.java
@@ -60,7 +60,7 @@ public class SearchManager {
             final SearchResponse searchResult = globalSearchElasticHelper.buildClient().search(
                     requestBuilder.buildRequest(searchRequest, typeFieldName, TYPE_AGGREGATION, metadataSourceFields));
             return resultConverter.buildResult(searchResult, TYPE_AGGREGATION, typeFieldName, getAclFilterFields(),
-                    metadataSourceFields, searchRequest.getScrollingParameter());
+                    metadataSourceFields, searchRequest.getScrollingParameters());
         } catch (IOException e) {
             log.error(e.getMessage(), e);
             throw new SearchException(e.getMessage(), e);
@@ -80,7 +80,7 @@ public class SearchManager {
 
     public FacetedSearchResult facetedSearch(final FacetedSearchRequest searchRequest) {
         Assert.notNull(searchRequest.getPageSize(), "Page Size is required");
-        if (Objects.isNull(searchRequest.getScrollingParameter())) {
+        if (Objects.isNull(searchRequest.getScrollingParameters())) {
             Assert.notNull(searchRequest.getOffset(), "Offset is required");
         }
         try {
@@ -89,7 +89,7 @@ public class SearchManager {
             final SearchResponse response = globalSearchElasticHelper.buildClient()
                     .search(requestBuilder.buildFacetedRequest(searchRequest, typeFieldName, metadataSourceFields));
             return resultConverter.buildFacetedResult(response, typeFieldName, getAclFilterFields(),
-                    metadataSourceFields, searchRequest.getScrollingParameter());
+                    metadataSourceFields, searchRequest.getScrollingParameters());
         } catch (IOException e) {
             log.error(e.getMessage(), e);
             throw new SearchException(e.getMessage(), e);

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchRequestBuilder.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchRequestBuilder.java
@@ -18,7 +18,7 @@ package com.epam.pipeline.manager.search;
 
 import com.epam.pipeline.controller.vo.search.ElasticSearchRequest;
 import com.epam.pipeline.controller.vo.search.FacetedSearchRequest;
-import com.epam.pipeline.controller.vo.search.ScrollingParameter;
+import com.epam.pipeline.controller.vo.search.ScrollingParameters;
 import com.epam.pipeline.entity.datastorage.DataStorageType;
 import com.epam.pipeline.entity.search.SearchDocumentType;
 import com.epam.pipeline.entity.user.DefaultRoles;
@@ -90,11 +90,11 @@ public class SearchRequestBuilder {
                 .query(query)
                 .fetchSource(buildSourceFields(typeFieldName, metadataSourceFields), Strings.EMPTY_ARRAY)
                 .size(searchRequest.getPageSize());
-        if (Objects.isNull(searchRequest.getScrollingParameter())) {
+        if (Objects.isNull(searchRequest.getScrollingParameters())) {
             searchSource.from(searchRequest.getOffset());
             applyDefaultSorting(searchSource);
         } else {
-            applyScrollingParameter(searchSource, searchRequest.getScrollingParameter());
+            applyScrollingParameters(searchSource, searchRequest.getScrollingParameters());
         }
         if (searchRequest.isHighlight()) {
             addHighlighterToSource(searchSource);
@@ -144,11 +144,11 @@ public class SearchRequestBuilder {
                 .fetchSource(buildSourceFields(typeFieldName, metadataSourceFields), Strings.EMPTY_ARRAY)
                 .size(facetedSearchRequest.getPageSize());
 
-        if (Objects.isNull(facetedSearchRequest.getScrollingParameter())) {
+        if (Objects.isNull(facetedSearchRequest.getScrollingParameters())) {
             searchSource.from(facetedSearchRequest.getOffset());
             applyDefaultSorting(searchSource);
         } else {
-            applyScrollingParameter(searchSource, facetedSearchRequest.getScrollingParameter());
+            applyScrollingParameters(searchSource, facetedSearchRequest.getScrollingParameters());
         }
 
         if (facetedSearchRequest.isHighlight()) {
@@ -163,10 +163,10 @@ public class SearchRequestBuilder {
                 .source(searchSource);
     }
 
-    private void applyScrollingParameter(final SearchSourceBuilder searchSource,
-                                         final ScrollingParameter scrollingParameter) {
-        applySorting(searchSource, scrollingParameter.isScrollingBackward());
-        searchSource.searchAfter(Arrays.asList(scrollingParameter.getDocScore(), scrollingParameter.getDocId())
+    private void applyScrollingParameters(final SearchSourceBuilder searchSource,
+                                          final ScrollingParameters scrollingParameters) {
+        applySorting(searchSource, scrollingParameters.isScrollingBackward());
+        searchSource.searchAfter(Arrays.asList(scrollingParameters.getDocScore(), scrollingParameters.getDocId())
                                      .toArray(new Object[0]));
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchRequestBuilder.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchRequestBuilder.java
@@ -94,7 +94,7 @@ public class SearchRequestBuilder {
             applyDefaultSortingOrder(searchSource);
         } else {
             applyScrollingParameters(searchSource, searchRequest.getPaginationRules(),
-                                     searchRequest.isScrollingForward());
+                                     searchRequest.isScrollingBackward());
         }
         if (searchRequest.isHighlight()) {
             addHighlighterToSource(searchSource);
@@ -149,7 +149,7 @@ public class SearchRequestBuilder {
             applyDefaultSortingOrder(searchSource);
         } else {
             applyScrollingParameters(searchSource, facetedSearchRequest.getScrollingParameters(),
-                                     facetedSearchRequest.isScrollingForward());
+                                     facetedSearchRequest.isScrollingBackward());
         }
 
         if (facetedSearchRequest.isHighlight()) {
@@ -166,11 +166,11 @@ public class SearchRequestBuilder {
 
     private void applyScrollingParameters(final SearchSourceBuilder searchSource,
                                           final List<ScrollingParameter> scrollingParameters,
-                                          final boolean isScrollingForward) {
+                                          final boolean isScrollingBackward) {
         final List<Object> values = new ArrayList<>();
         scrollingParameters.forEach(parameter -> {
             searchSource.sort(SortBuilders.fieldSort(parameter.getField())
-                                  .order(isScrollingForward ? SortOrder.DESC : SortOrder.ASC));
+                                  .order(isScrollingBackward ? SortOrder.ASC : SortOrder.DESC));
             values.add(parameter.getTieBreaker());
         });
         searchSource.searchAfter(values.toArray(new Object[0]));

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchRequestBuilder.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchRequestBuilder.java
@@ -92,7 +92,7 @@ public class SearchRequestBuilder {
                 .size(searchRequest.getPageSize());
         if (Objects.isNull(searchRequest.getScrollingParameter())) {
             searchSource.from(searchRequest.getOffset());
-            applyDefaultSortingOrder(searchSource);
+            applyDefaultSorting(searchSource);
         } else {
             applyScrollingParameter(searchSource, searchRequest.getScrollingParameter());
         }
@@ -146,7 +146,7 @@ public class SearchRequestBuilder {
 
         if (Objects.isNull(facetedSearchRequest.getScrollingParameter())) {
             searchSource.from(facetedSearchRequest.getOffset());
-            applyDefaultSortingOrder(searchSource);
+            applyDefaultSorting(searchSource);
         } else {
             applyScrollingParameter(searchSource, facetedSearchRequest.getScrollingParameter());
         }
@@ -165,16 +165,19 @@ public class SearchRequestBuilder {
 
     private void applyScrollingParameter(final SearchSourceBuilder searchSource,
                                          final ScrollingParameter scrollingParameter) {
-        final SortOrder order = scrollingParameter.isScrollingBackward() ? SortOrder.ASC : SortOrder.DESC;
-        searchSource.sort(SortBuilders.fieldSort(ES_DOC_SCORE_FIELD).order(order));
-        searchSource.sort(SortBuilders.fieldSort(ES_DOC_ID_FIELD).order(order));
+        applySorting(searchSource, scrollingParameter.isScrollingBackward());
         searchSource.searchAfter(Arrays.asList(scrollingParameter.getDocScore(), scrollingParameter.getDocId())
                                      .toArray(new Object[0]));
     }
 
-    private void applyDefaultSortingOrder(final SearchSourceBuilder searchSource) {
-        searchSource.sort(SortBuilders.scoreSort());
-        searchSource.sort(SortBuilders.fieldSort(ES_DOC_ID_FIELD).order(SortOrder.DESC));
+    private void applyDefaultSorting(final SearchSourceBuilder searchSource) {
+        applySorting(searchSource, false);
+    }
+
+    private void applySorting(final SearchSourceBuilder searchSource, final boolean isScrollingBackward) {
+        final SortOrder order = isScrollingBackward ? SortOrder.ASC : SortOrder.DESC;
+        searchSource.sort(SortBuilders.fieldSort(ES_DOC_SCORE_FIELD).order(order));
+        searchSource.sort(SortBuilders.fieldSort(ES_DOC_ID_FIELD).order(order));
     }
 
     private String[] buildSourceFields(final String typeFieldName, final Set<String> metadataSourceFields) {

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchResultConverter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchResultConverter.java
@@ -16,6 +16,7 @@
 
 package com.epam.pipeline.manager.search;
 
+import com.epam.pipeline.controller.vo.search.ScrollingParameter;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.StorageUsage;
 import com.epam.pipeline.entity.search.FacetedSearchResult;
@@ -60,12 +61,12 @@ public class SearchResultConverter {
                                     final String typeFieldName,
                                     final Set<String> aclFilterFields,
                                     final Set<String> metadataSourceFields,
-                                    final boolean isScrollingBackward) {
+                                    final ScrollingParameter scrollingParameter) {
         return SearchResult.builder()
                 .searchSucceeded(!searchResult.isTimedOut())
                 .totalHits(searchResult.getHits().getTotalHits())
                 .documents(buildDocuments(searchResult, typeFieldName, aclFilterFields, metadataSourceFields,
-                                          isScrollingBackward))
+                                          scrollingParameter))
                 .aggregates(buildAggregates(searchResult.getAggregations(), aggregation))
                 .build();
     }
@@ -86,11 +87,11 @@ public class SearchResultConverter {
     public FacetedSearchResult buildFacetedResult(final SearchResponse response, final String typeFieldName,
                                                   final Set<String> aclFilterFields,
                                                   final Set<String> metadataSourceFields,
-                                                  final boolean isScrollingBackward) {
+                                                  final ScrollingParameter scrollingParameter) {
         return FacetedSearchResult.builder()
                 .totalHits(response.getHits().getTotalHits())
                 .documents(buildDocuments(response, typeFieldName, aclFilterFields, metadataSourceFields,
-                                          isScrollingBackward))
+                                          scrollingParameter))
                 .facets(buildFacets(response.getAggregations()))
                 .build();
     }
@@ -98,10 +99,10 @@ public class SearchResultConverter {
     private List<SearchDocument> buildDocuments(final SearchResponse searchResult, final String typeFieldName,
                                                 final Set<String> aclFilterFields,
                                                 final Set<String> metadataSourceFields,
-                                                final boolean isScrollingBackward) {
+                                                final ScrollingParameter scrollingParameter) {
         final List<SearchDocument> documents =
             buildDocuments(searchResult.getHits(), typeFieldName, aclFilterFields, metadataSourceFields);
-        if (isScrollingBackward) {
+        if (Objects.nonNull(scrollingParameter) && scrollingParameter.isScrollingBackward()) {
             Collections.reverse(documents);
         }
         return documents;

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchResultConverter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchResultConverter.java
@@ -59,13 +59,27 @@ public class SearchResultConverter {
                                     final String aggregation,
                                     final String typeFieldName,
                                     final Set<String> aclFilterFields,
-                                    final Set<String> metadataSourceFields) {
+                                    final Set<String> metadataSourceFields,
+                                    final boolean isScrollingForward) {
         return SearchResult.builder()
                 .searchSucceeded(!searchResult.isTimedOut())
                 .totalHits(searchResult.getHits().getTotalHits())
-                .documents(buildDocuments(searchResult.getHits(), typeFieldName, aclFilterFields, metadataSourceFields))
+                .documents(buildDocuments(searchResult, typeFieldName, aclFilterFields, metadataSourceFields,
+                                          isScrollingForward))
                 .aggregates(buildAggregates(searchResult.getAggregations(), aggregation))
                 .build();
+    }
+
+    private List<SearchDocument> buildDocuments(final SearchResponse searchResult, final String typeFieldName,
+                                                final Set<String> aclFilterFields,
+                                                final Set<String> metadataSourceFields,
+                                                final boolean isScrollingForward) {
+        final List<SearchDocument> documents =
+            buildDocuments(searchResult.getHits(), typeFieldName, aclFilterFields, metadataSourceFields);
+        if (!isScrollingForward) {
+            Collections.reverse(documents);
+        }
+        return documents;
     }
 
     public StorageUsage buildStorageUsageResponse(final SearchResponse searchResponse,
@@ -83,10 +97,12 @@ public class SearchResultConverter {
 
     public FacetedSearchResult buildFacetedResult(final SearchResponse response, final String typeFieldName,
                                                   final Set<String> aclFilterFields,
-                                                  final Set<String> metadataSourceFields) {
+                                                  final Set<String> metadataSourceFields,
+                                                  final boolean isScrollingForward) {
         return FacetedSearchResult.builder()
                 .totalHits(response.getHits().getTotalHits())
-                .documents(buildDocuments(response.getHits(), typeFieldName, aclFilterFields, metadataSourceFields))
+                .documents(buildDocuments(response, typeFieldName, aclFilterFields, metadataSourceFields,
+                                          isScrollingForward))
                 .facets(buildFacets(response.getAggregations()))
                 .build();
     }

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchResultConverter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchResultConverter.java
@@ -16,7 +16,7 @@
 
 package com.epam.pipeline.manager.search;
 
-import com.epam.pipeline.controller.vo.search.ScrollingParameter;
+import com.epam.pipeline.controller.vo.search.ScrollingParameters;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.StorageUsage;
 import com.epam.pipeline.entity.search.FacetedSearchResult;
@@ -61,12 +61,12 @@ public class SearchResultConverter {
                                     final String typeFieldName,
                                     final Set<String> aclFilterFields,
                                     final Set<String> metadataSourceFields,
-                                    final ScrollingParameter scrollingParameter) {
+                                    final ScrollingParameters scrollingParameters) {
         return SearchResult.builder()
                 .searchSucceeded(!searchResult.isTimedOut())
                 .totalHits(searchResult.getHits().getTotalHits())
                 .documents(buildDocuments(searchResult, typeFieldName, aclFilterFields, metadataSourceFields,
-                                          scrollingParameter))
+                                          scrollingParameters))
                 .aggregates(buildAggregates(searchResult.getAggregations(), aggregation))
                 .build();
     }
@@ -87,11 +87,11 @@ public class SearchResultConverter {
     public FacetedSearchResult buildFacetedResult(final SearchResponse response, final String typeFieldName,
                                                   final Set<String> aclFilterFields,
                                                   final Set<String> metadataSourceFields,
-                                                  final ScrollingParameter scrollingParameter) {
+                                                  final ScrollingParameters scrollingParameters) {
         return FacetedSearchResult.builder()
                 .totalHits(response.getHits().getTotalHits())
                 .documents(buildDocuments(response, typeFieldName, aclFilterFields, metadataSourceFields,
-                                          scrollingParameter))
+                                          scrollingParameters))
                 .facets(buildFacets(response.getAggregations()))
                 .build();
     }
@@ -99,10 +99,10 @@ public class SearchResultConverter {
     private List<SearchDocument> buildDocuments(final SearchResponse searchResult, final String typeFieldName,
                                                 final Set<String> aclFilterFields,
                                                 final Set<String> metadataSourceFields,
-                                                final ScrollingParameter scrollingParameter) {
+                                                final ScrollingParameters scrollingParameters) {
         final List<SearchDocument> documents =
             buildDocuments(searchResult.getHits(), typeFieldName, aclFilterFields, metadataSourceFields);
-        if (Objects.nonNull(scrollingParameter) && scrollingParameter.isScrollingBackward()) {
+        if (Objects.nonNull(scrollingParameters) && scrollingParameters.isScrollingBackward()) {
             Collections.reverse(documents);
         }
         return documents;

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchResultConverter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchResultConverter.java
@@ -60,26 +60,14 @@ public class SearchResultConverter {
                                     final String typeFieldName,
                                     final Set<String> aclFilterFields,
                                     final Set<String> metadataSourceFields,
-                                    final boolean isScrollingForward) {
+                                    final boolean isScrollingBackward) {
         return SearchResult.builder()
                 .searchSucceeded(!searchResult.isTimedOut())
                 .totalHits(searchResult.getHits().getTotalHits())
                 .documents(buildDocuments(searchResult, typeFieldName, aclFilterFields, metadataSourceFields,
-                                          isScrollingForward))
+                                          isScrollingBackward))
                 .aggregates(buildAggregates(searchResult.getAggregations(), aggregation))
                 .build();
-    }
-
-    private List<SearchDocument> buildDocuments(final SearchResponse searchResult, final String typeFieldName,
-                                                final Set<String> aclFilterFields,
-                                                final Set<String> metadataSourceFields,
-                                                final boolean isScrollingForward) {
-        final List<SearchDocument> documents =
-            buildDocuments(searchResult.getHits(), typeFieldName, aclFilterFields, metadataSourceFields);
-        if (!isScrollingForward) {
-            Collections.reverse(documents);
-        }
-        return documents;
     }
 
     public StorageUsage buildStorageUsageResponse(final SearchResponse searchResponse,
@@ -98,13 +86,25 @@ public class SearchResultConverter {
     public FacetedSearchResult buildFacetedResult(final SearchResponse response, final String typeFieldName,
                                                   final Set<String> aclFilterFields,
                                                   final Set<String> metadataSourceFields,
-                                                  final boolean isScrollingForward) {
+                                                  final boolean isScrollingBackward) {
         return FacetedSearchResult.builder()
                 .totalHits(response.getHits().getTotalHits())
                 .documents(buildDocuments(response, typeFieldName, aclFilterFields, metadataSourceFields,
-                                          isScrollingForward))
+                                          isScrollingBackward))
                 .facets(buildFacets(response.getAggregations()))
                 .build();
+    }
+
+    private List<SearchDocument> buildDocuments(final SearchResponse searchResult, final String typeFieldName,
+                                                final Set<String> aclFilterFields,
+                                                final Set<String> metadataSourceFields,
+                                                final boolean isScrollingBackward) {
+        final List<SearchDocument> documents =
+            buildDocuments(searchResult.getHits(), typeFieldName, aclFilterFields, metadataSourceFields);
+        if (isScrollingBackward) {
+            Collections.reverse(documents);
+        }
+        return documents;
     }
 
     private Map<SearchDocumentType, Long> buildAggregates(final Aggregations aggregations,


### PR DESCRIPTION
This PR is related to issue #1914
It allows using a different approach for pagination over search results.
In addition to classic paging with `from` +` pageSize`, which is limited by ES `index.max_result_window` index setting, it allows to scroll as deep, as the user wants, but navigation is available in the` previous-next` manner.
Scrolling setup is specified via `docId`,` docScore`, `isScrollingBackward` fields of the nested into search request `scrollingParameters` object, containing information regarding the last/first object at the current page. 
If no such details specified, `from` value is going to be consumed.