### PR TITLE
Upsert rather than insert data storage object native tags

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/datastorage/tag/DataStorageTagBatchApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/datastorage/tag/DataStorageTagBatchApiService.java
@@ -6,6 +6,7 @@ import com.epam.pipeline.entity.datastorage.tag.DataStorageTagDeleteAllBatchRequ
 import com.epam.pipeline.entity.datastorage.tag.DataStorageTagDeleteBatchRequest;
 import com.epam.pipeline.entity.datastorage.tag.DataStorageTagInsertBatchRequest;
 import com.epam.pipeline.entity.datastorage.tag.DataStorageTagLoadBatchRequest;
+import com.epam.pipeline.entity.datastorage.tag.DataStorageTagUpsertBatchRequest;
 import com.epam.pipeline.manager.datastorage.tag.DataStorageTagBatchManager;
 import com.epam.pipeline.security.acl.AclExpressions;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,12 @@ public class DataStorageTagBatchApiService {
     public List<DataStorageTag> insert(final Long id,
                                        final DataStorageTagInsertBatchRequest request) {
         return dataStorageTagBatchManager.insert(id, request);
+    }
+
+    @PreAuthorize(AclExpressions.STORAGE_ID_WRITE)
+    public List<DataStorageTag> upsert(final Long id, final DataStorageTagUpsertBatchRequest request) {
+        return dataStorageTagBatchManager.upsert(id, request);
+
     }
 
     @PreAuthorize(AclExpressions.STORAGE_ID_WRITE)

--- a/api/src/main/java/com/epam/pipeline/controller/datastorage/tag/DataStorageTagBatchController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/datastorage/tag/DataStorageTagBatchController.java
@@ -9,6 +9,7 @@ import com.epam.pipeline.entity.datastorage.tag.DataStorageTagDeleteAllBatchRequ
 import com.epam.pipeline.entity.datastorage.tag.DataStorageTagDeleteBatchRequest;
 import com.epam.pipeline.entity.datastorage.tag.DataStorageTagInsertBatchRequest;
 import com.epam.pipeline.entity.datastorage.tag.DataStorageTagLoadBatchRequest;
+import com.epam.pipeline.entity.datastorage.tag.DataStorageTagUpsertBatchRequest;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
@@ -46,6 +47,21 @@ public class DataStorageTagBatchController extends AbstractRestController {
     public Result insert(@PathVariable(value = ID) final Long id,
                          @RequestBody final DataStorageTagInsertBatchRequest request) {
         dataStorageTagBatchApiService.insert(id, request);
+        return Result.success();
+    }
+
+    @RequestMapping(value = "/datastorage/{id}/tags/batch/upsert", method = RequestMethod.PUT)
+    @ResponseBody
+    @ApiOperation(
+            value = "Upserts data storage object tags overriding already existing ones.",
+            notes = "Upserts data storage object tags overriding already existing ones.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public Result upsert(@PathVariable(value = ID) final Long id,
+                         @RequestBody final DataStorageTagUpsertBatchRequest request) {
+        dataStorageTagBatchApiService.upsert(id, request);
         return Result.success();
     }
 

--- a/api/src/main/java/com/epam/pipeline/entity/datastorage/tag/DataStorageTagUpsertBatchRequest.java
+++ b/api/src/main/java/com/epam/pipeline/entity/datastorage/tag/DataStorageTagUpsertBatchRequest.java
@@ -1,0 +1,11 @@
+package com.epam.pipeline.entity.datastorage.tag;
+
+import lombok.Value;
+
+import java.util.List;
+
+@Value
+public class DataStorageTagUpsertBatchRequest {
+    
+    List<DataStorageTagUpsertRequest> requests;
+}

--- a/api/src/main/java/com/epam/pipeline/entity/datastorage/tag/DataStorageTagUpsertRequest.java
+++ b/api/src/main/java/com/epam/pipeline/entity/datastorage/tag/DataStorageTagUpsertRequest.java
@@ -1,0 +1,12 @@
+package com.epam.pipeline.entity.datastorage.tag;
+
+import lombok.Value;
+
+@Value
+public class DataStorageTagUpsertRequest {
+    
+    String path;
+    String version;
+    String key;
+    String value;
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
@@ -51,6 +51,7 @@ import com.epam.pipeline.vo.FilterNodesVO;
 import com.epam.pipeline.vo.RunStatusVO;
 import com.epam.pipeline.vo.data.storage.DataStorageTagInsertBatchRequest;
 import com.epam.pipeline.vo.data.storage.DataStorageTagLoadBatchRequest;
+import com.epam.pipeline.vo.data.storage.DataStorageTagUpsertBatchRequest;
 import com.epam.pipeline.vo.notification.NotificationMessageVO;
 import okhttp3.MultipartBody;
 import retrofit2.Call;
@@ -153,6 +154,10 @@ public interface CloudPipelineAPI {
     @PUT("datastorage/{id}/tags/batch/insert")
     Call<Result<Object>> insertDataStorageTags(@Path(ID) Long storageId,
                                                @Body DataStorageTagInsertBatchRequest request);
+
+    @PUT("datastorage/{id}/tags/batch/upsert")
+    Call<Result<Object>> upsertDataStorageTags(@Path(ID) Long id,
+                                               @Body DataStorageTagUpsertBatchRequest request);
 
     @POST("datastorage/{id}/tags/batch/load")
     Call<Result<List<DataStorageTag>>> loadDataStorageObjectTags(@Path(ID) Long storageId,

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/vo/data/storage/DataStorageTagUpsertBatchRequest.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/vo/data/storage/DataStorageTagUpsertBatchRequest.java
@@ -1,0 +1,11 @@
+package com.epam.pipeline.vo.data.storage;
+
+import lombok.Value;
+
+import java.util.List;
+
+@Value
+public class DataStorageTagUpsertBatchRequest {
+    
+    List<DataStorageTagUpsertRequest> requests;
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/vo/data/storage/DataStorageTagUpsertRequest.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/vo/data/storage/DataStorageTagUpsertRequest.java
@@ -1,0 +1,12 @@
+package com.epam.pipeline.vo.data.storage;
+
+import lombok.Value;
+
+@Value
+public class DataStorageTagUpsertRequest {
+    
+    String path;
+    String version;
+    String key;
+    String value;
+}

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/CloudPipelineAPIClient.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/CloudPipelineAPIClient.java
@@ -44,6 +44,7 @@ import com.epam.pipeline.vo.EntityPermissionVO;
 import com.epam.pipeline.vo.EntityVO;
 import com.epam.pipeline.vo.data.storage.DataStorageTagInsertBatchRequest;
 import com.epam.pipeline.vo.data.storage.DataStorageTagLoadBatchRequest;
+import com.epam.pipeline.vo.data.storage.DataStorageTagUpsertBatchRequest;
 import org.apache.commons.collections4.ListUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -75,6 +76,10 @@ public class CloudPipelineAPIClient {
 
     public void insertDataStorageTags(final Long id, final DataStorageTagInsertBatchRequest request) {
         QueryUtils.execute(cloudPipelineAPI.insertDataStorageTags(id, request));
+    }
+
+    public void upsertDataStorageTags(final Long id, final DataStorageTagUpsertBatchRequest request) {
+        QueryUtils.execute(cloudPipelineAPI.upsertDataStorageTags(id, request));
     }
 
     public List<DataStorageTag> loadDataStorageTags(final Long id, final DataStorageTagLoadBatchRequest request) {


### PR DESCRIPTION
Resolves #1918 and relates to #1717.

The pull request prevents existing data storage object tags from being deleted during data storage object native tags transferring.
