### PR TITLE
Allow to skip node reassignment for a run - fix for tests

### DIFF
--- a/e2e/cli/autoscaling/test_node_reassign.py
+++ b/e2e/cli/autoscaling/test_node_reassign.py
@@ -33,6 +33,7 @@ class TestNodeReassign(object):
     second_run_id = None
     state = FailureIndicator()
     test_case = 'TC-SCALING-2'
+    instance_type = get_reassign_node_type()
 
     @classmethod
     def setup_class(cls):
@@ -43,7 +44,7 @@ class TestNodeReassign(object):
         logging.info("Pipeline {} with ID {} created.".format(pipeline_name, cls.pipeline_id))
 
         try:
-            run_id = run_pipe(pipeline_name, "-id", "16")[0]
+            run_id = run_pipe(pipeline_name, "-id", "16", "-it", cls.instance_type)[0]
             cls.first_run_id = run_id
             logging.info("Pipeline run with ID {}.".format(cls.first_run_id))
             wait_for_node_up(run_id, MAX_REP_COUNT)
@@ -59,7 +60,7 @@ class TestNodeReassign(object):
             logging.info("Pipeline {} stopped.".format(cls.first_run_id))
             wait_for_end_of_job(node_name, MAX_REP_COUNT)
 
-            run_id = run_pipe(pipeline_name, "-id", "16")[0]
+            run_id = run_pipe_with_reassign(pipeline_name, "-id", "16", "-it", cls.instance_type)[0]
             cls.second_run_id = run_id
             logging.info("Pipeline {} launched".format(run_id))
             node_state = wait_for_node_up(run_id, MAX_REP_COUNT)

--- a/e2e/cli/autoscaling/test_node_reassign.py
+++ b/e2e/cli/autoscaling/test_node_reassign.py
@@ -33,7 +33,7 @@ class TestNodeReassign(object):
     second_run_id = None
     state = FailureIndicator()
     test_case = 'TC-SCALING-2'
-    instance_type = get_reassign_node_type()
+    instance_type = get_reassign_node_type('CP_TEST_REASSIGN_INSTANCE_TYPE')
 
     @classmethod
     def setup_class(cls):

--- a/e2e/cli/autoscaling/test_stop_pipe_before_labeling.py
+++ b/e2e/cli/autoscaling/test_stop_pipe_before_labeling.py
@@ -33,7 +33,7 @@ class TestStopPipelineBeforeLabeling(object):
     new_run_id = None
     state = FailureIndicator()
     test_case = "TC-SCALING-10"
-    instance_type = get_reassign_node_type()
+    instance_type = get_reassign_node_type('CP_TEST_STOP_BEFORE_LABEL_INSTANCE_TYPE')
 
     @classmethod
     def setup_class(cls):

--- a/e2e/cli/autoscaling/test_stop_pipe_before_labeling.py
+++ b/e2e/cli/autoscaling/test_stop_pipe_before_labeling.py
@@ -33,6 +33,7 @@ class TestStopPipelineBeforeLabeling(object):
     new_run_id = None
     state = FailureIndicator()
     test_case = "TC-SCALING-10"
+    instance_type = get_reassign_node_type()
 
     @classmethod
     def setup_class(cls):
@@ -44,7 +45,7 @@ class TestStopPipelineBeforeLabeling(object):
         logging.info("Pipeline {} with ID {} created.".format(pipeline_name, cls.pipeline_id))
 
         try:
-            run_id = run_pipe(pipeline_name, "-id", "21")[0]
+            run_id = run_pipe(pipeline_name, "-id", "21", "-it", cls.instance_type)[0]
             cls.run_id = run_id
             logging.info("Pipeline run with ID {}.".format(cls.run_id))
             wait_for_required_status("SCHEDULED", run_id, MAX_REP_COUNT)
@@ -88,7 +89,7 @@ class TestStopPipelineBeforeLabeling(object):
     @pytest.mark.run(order=2)
     def test_node_should_reassign(self):
         try:
-            run_id = run_pipe(self.pipeline_name, "-id", "21")[0]
+            run_id = run_pipe_with_reassign(self.pipeline_name, "-id", "21", "-it", self.instance_type)[0]
             self.new_run_id = run_id
             logging.info("Pipeline run with ID {}.".format(run_id))
             node_state = wait_for_node_up(run_id, MAX_REP_COUNT)

--- a/e2e/cli/utils/pipeline_utils.py
+++ b/e2e/cli/utils/pipeline_utils.py
@@ -210,9 +210,9 @@ def pipe_run(pipeline_name, disable_reassign, *args):
     return run_id, status
 
 
-def get_reassign_node_type():
+def get_reassign_node_type(envvar_name):
     default_instance_type = os.environ.get('CP_TEST_INSTANCE_TYPE')
-    return os.environ.get('CP_TEST_REASSIGN_INSTANCE_TYPE', default_instance_type)
+    return os.environ.get(envvar_name, default_instance_type)
 
 
 def stop_pipe(run_id):

--- a/e2e/cli/utils/pipeline_utils.py
+++ b/e2e/cli/utils/pipeline_utils.py
@@ -165,6 +165,14 @@ def run_tool(*args):
 
 
 def run_pipe(pipeline_name, *args):
+    return pipe_run(pipeline_name, True, *args)
+
+
+def run_pipe_with_reassign(pipeline_name, *args):
+    return pipe_run(pipeline_name, False, *args)
+
+
+def pipe_run(pipeline_name, disable_reassign, *args):
     command = ['pipe', 'run', '--pipeline', pipeline_name, '-y']
 
     instance_type = os.environ.get('CP_TEST_INSTANCE_TYPE')
@@ -180,7 +188,6 @@ def run_pipe(pipeline_name, *args):
     for arg in args:
         command.append(arg)
 
-    disable_reassign = _str_to_bool(os.environ.get('CP_TEST_DISABLE_NODE_REASSIGN', 'True'))
     if disable_reassign:
         command.append("--CP_CREATE_NEW_NODE")
         command.append("true")
@@ -201,6 +208,11 @@ def run_pipe(pipeline_name, *args):
     if not run_id:
         raise RuntimeError('RunID was not found')
     return run_id, status
+
+
+def get_reassign_node_type():
+    default_instance_type = os.environ.get('CP_TEST_INSTANCE_TYPE')
+    return os.environ.get('CP_TEST_REASSIGN_INSTANCE_TYPE', default_instance_type)
 
 
 def stop_pipe(run_id):
@@ -512,7 +524,3 @@ def get_log_filename():
     if 'RESULTS_DIR' in os.environ:
         return '%s/tests.log' % os.environ['RESULTS_DIR']
     return 'tests.log'
-
-
-def _str_to_bool(input_value):
-    return input_value.lower() in ("true", "t")

--- a/e2e/cli/utils/pipeline_utils.py
+++ b/e2e/cli/utils/pipeline_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -167,18 +167,23 @@ def run_tool(*args):
 def run_pipe(pipeline_name, *args):
     command = ['pipe', 'run', '--pipeline', pipeline_name, '-y']
 
-    instance_type = os.environ['CP_TEST_INSTANCE_TYPE']
+    instance_type = os.environ.get('CP_TEST_INSTANCE_TYPE')
     if instance_type and "-it" not in args:
         command.append("-it")
         command.append(instance_type)
 
-    price_type = os.environ['CP_TEST_PRICE_TYPE']
+    price_type = os.environ.get('CP_TEST_PRICE_TYPE')
     if price_type and "-pt" not in args:
         command.append("-pt")
         command.append(price_type)
 
     for arg in args:
         command.append(arg)
+
+    disable_reassign = _str_to_bool(os.environ.get('CP_TEST_DISABLE_NODE_REASSIGN', 'True'))
+    if disable_reassign:
+        command.append('--CP_CREATE_NEW_NODE true')
+
     process = subprocess.Popen(command, stdout=subprocess.PIPE)
     process.wait()
     line = process.stdout.readline()
@@ -506,3 +511,7 @@ def get_log_filename():
     if 'RESULTS_DIR' in os.environ:
         return '%s/tests.log' % os.environ['RESULTS_DIR']
     return 'tests.log'
+
+
+def _str_to_bool(input_value):
+    return input_value.lower() in ("true", "t")

--- a/e2e/cli/utils/pipeline_utils.py
+++ b/e2e/cli/utils/pipeline_utils.py
@@ -182,7 +182,8 @@ def run_pipe(pipeline_name, *args):
 
     disable_reassign = _str_to_bool(os.environ.get('CP_TEST_DISABLE_NODE_REASSIGN', 'True'))
     if disable_reassign:
-        command.append('--CP_CREATE_NEW_NODE true')
+        command.append("--CP_CREATE_NEW_NODE")
+        command.append("true")
 
     process = subprocess.Popen(command, stdout=subprocess.PIPE)
     process.wait()


### PR DESCRIPTION
The current PR provides fixes for autoscaler tests according to issue #1865 