### PR TITLE
Test cases for checking "Hot node pools" main functionality

### DIFF
--- a/docs/testcases/UI/Cluster_nodes/Hot_node_pools/841_persistent_cluster_nodes/841_1_pool_creation.md
+++ b/docs/testcases/UI/Cluster_nodes/Hot_node_pools/841_persistent_cluster_nodes/841_1_pool_creation.md
@@ -1,0 +1,71 @@
+# Hot node pool creation
+
+**Prerequisites**:
+
+- admin user
+
+**Preparations**:
+
+1. Login as admin user from the prerequisites
+2. Open the **Settings** page
+3. Open the **CLOUD REGIONS** tab
+4. Saved the selected region name (_default region_)
+5. Open the **PREFERENCES** tab
+6. Find the preference `cluster.reassign.disk.delta`
+7. Set the value `100` for the preference from step 4
+8. Save changes
+
+**Actions**:
+
+1. Login as admin user from the prerequisites
+2. Open the **Cluster state** page
+3. Click the **HOT NODE POOLS** tab
+4. Click the "**+ Create**" button
+5. Specify valid _Pool name_
+6. Specify the "_Starts on_" day - the current day of the week then specify the "_Starts on_" time `00:00`
+7. Specify the "_Ends on_" day - the next day of the week then specify the "_Ends on_" time `23:59`
+8. Specify the _Nodes count_ - `2`
+9. Select the _Region_ - the same one as was saved at step 4 of the preparations
+10. Select `spot` type for the _Price type_
+11. Select any _Instance type_
+12. Specify the _Disk_ size between `100` and `150` (e.g. `120`)
+13. Click the "**+ Add docker image**" button
+14. In the appeared field, select any tool from the `Default registry` and `library` group (e.g. `ubuntu`)
+15. Select the _Condition_ - `Matches all filters ("and")`
+16. Click the "**+ Filter**" button
+17. Select the _Property_ in the appeared popup - `Run owner`
+18. Select the _Owner_ - the admin user name from the prerequisites
+19. Click the **CREATE** button
+20. Click the just-created node pool item
+21. Click the **Refresh** button every minute until two nodes appear in the node list
+22. Save node names
+23. Click the **CLUSTER** tab
+24. Click the **HOT NODE POOLS** tab
+
+***
+
+**Expected result**:
+
+After step 19, the new item appears in the pools list. This item contains:
+
+- the name equals to the specified at step 5
+- labels: `2 NODES`, `<instance_type>` equals to the selected at step 11, `SPOT`, `<disk_size> GB` equals to the disk size specified at step 12
+- label with the tool name selected at step 14
+- label with the schedule in format: `<day_starts_on>, 00:00 - <day_ends_on>, 23:59` with the values of week days specified at steps 6-7
+- buttons: **Edit** and **Remove**
+
+After step 20, the nodes page appears that contains at least header with the pool name specified at step 5
+
+After step 21:
+
+- the header becomes `<pool_name> nodes (2 nodes, 2 nodes with associated RunId)` where `<pool_name>` is the pool name specified at step 5
+- two nodes appear. Each appeared node has:  
+    - the label with the pool name specified at step 5
+    - the label starts from `RUN ID P-`
+
+After step 23, the full node cluster appears. There are two nodes that have:
+
+- the label with the pool name specified at step 5
+- the label starts from `RUN ID P-`
+
+After step 24, at the panel of the pool created at step 19, there is the label `0/2`

--- a/docs/testcases/UI/Cluster_nodes/Hot_node_pools/841_persistent_cluster_nodes/841_2_pool_usage.md
+++ b/docs/testcases/UI/Cluster_nodes/Hot_node_pools/841_persistent_cluster_nodes/841_2_pool_usage.md
@@ -1,0 +1,54 @@
+# Checking hot node pool usage
+
+**Preparations**:
+
+Perform [_841\_1_](841_1_pool_creation.md) case
+
+**Actions**:
+
+1. Login as admin user from the prerequisites of [_841\_1_](841_1_pool_creation.md) case
+2. Open the **Tools** page
+3. Find and open the tool from step 14 of [_841\_1_](841_1_pool_creation.md) case
+4. Click **v** button near the **Run** button
+5. Click **Custom settings** in the list
+6. Expand the **Exec environment** section
+7. Set the _Node type_ the same as at step 11 of [_841\_1_](841_1_pool_creation.md) case
+8. Set the _Cloud Region_ the same as at step 9 of [_841\_1_](841_1_pool_creation.md) case
+9. Set the _Disk_ size equals the value set at step 12 of [_841\_1_](841_1_pool_creation.md) case minus `80`
+10. Expand the **Advanced** section
+11. Set `spot` type for the _Price type_
+12. Click the **Launch** button
+13. In the appeared popup, click the **Launch** button
+14. At the **Runs** page, click the just-launched run
+15. Expand the **Instance** section
+16. Wait until the **IP** label appears
+17. Click the hyperlink near the **IP** label
+18. Open the **Cluster state** page
+19. Click the **HOT NODE POOLS** tab
+20. Click the node pool created at step 19 of [_841\_1_](841_1_pool_creation.md) case
+
+**After**:
+
+- stop the run launched at step 13
+
+***
+
+**Expected result**:
+
+After step 16:
+
+- "_Running for_" value at the Run logs page is less than 30 sec
+- Disk size (displayed in **Instance** section) equals the value specified at step 12 of [_841\_1_](841_1_pool_creation.md) case
+
+After step 17:
+
+- the node name is one from saved names at step 22 of [_841\_1_](841_1_pool_creation.md) case
+- the node header contains the label with the pool name specified at step 5 of [_841\_1_](841_1_pool_creation.md) case
+- the _Run ID_ label contains the run ID launched at step 13 and doesn't contain text construction `P-`
+
+After step 19, at the panel of the pool created at step 19 of [_841\_1_](841_1_pool_creation.md) case, there is the label `1/2`
+
+After step 20:
+
+- one node has the label starts from `RUN ID P-`
+- and second node has the label with the run ID launched at step 13

--- a/docs/testcases/UI/Cluster_nodes/Hot_node_pools/841_persistent_cluster_nodes/841_3_pool_disk_delta.md
+++ b/docs/testcases/UI/Cluster_nodes/Hot_node_pools/841_persistent_cluster_nodes/841_3_pool_disk_delta.md
@@ -1,0 +1,39 @@
+# Checking disk delta for a node from the pool
+
+**Preparations**:
+
+1. Perform [_841\_1_](841_1_pool_creation.md) case
+2. Open the **Settings** page
+3. Open the **PREFERENCES** tab
+4. Find the preference `cluster.reassign.disk.delta`
+5. Set the value `50` for the preference from step 4
+6. Save changes
+
+**Actions**:
+
+1. Login as admin user from the prerequisites of [_841\_1_](841_1_pool_creation.md) case
+2. Repeat steps 2-16 of [_841\_2_](841_2_pool_usage.md) case
+3. Stop the run launched at step 2
+4. Click the **RERUN** button
+5. Expand the **Exec environment** section
+6. Set the _Disk_ size equals the value set at step 12 of [_841\_1_](841_1_pool_creation.md) case minus `50`
+7. Repeat steps 12-16 of [_841\_2_](841_2_pool_usage.md) case
+8. Stop the run launched at step 7
+
+**After**:
+
+- return the value `100` for the preference `cluster.reassign.disk.delta`
+
+***
+
+**Expected result**:
+
+After step 2:
+
+- disk size (displayed in **Instance** section) does not equal the value specified at step 12 of [_841\_1_](841_1_pool_creation.md) case
+- the node name (near the **IP** label) doesn't equal to any from saved names at step 22 of [_841\_1_](841_1_pool_creation.md) case
+
+After step 7:
+
+- disk size (displayed in **Instance** section) equals the value specified at step 12 of [_841\_1_](841_1_pool_creation.md) case
+- the node name (near the **IP** label) is one from saved names at step 22 of [_841\_1_](841_1_pool_creation.md) case

--- a/docs/testcases/UI/Cluster_nodes/Hot_node_pools/841_persistent_cluster_nodes/841_4_pool_filters.md
+++ b/docs/testcases/UI/Cluster_nodes/Hot_node_pools/841_persistent_cluster_nodes/841_4_pool_filters.md
@@ -1,0 +1,47 @@
+# Checking filters for hot node pool
+
+**Preparations**:
+
+1. Perform [_841\_1_](841_1_pool_creation.md) case
+2. Login as admin user from the prerequisites of [_841\_1_](841_1_pool_creation.md) case
+3. Open the **Library** page
+4. Create a new `DEFAULT` pipeline
+
+**Actions**:
+
+1. Open the **Cluster state** page
+2. Click the **HOT NODE POOLS** tab
+3. Click the **Edit** button for the pool node created at step 19 of [_841\_1_](841_1_pool_creation.md) case
+4. Click the "**+ Add filter**" button
+5. Click the **Select property** dropdown list and select `Pipeline` item in the list
+6. Click the **Select pipeline** dropdown list and select the name of the pipeline created at step 4 of the preparations
+7. Click the **SAVE** button
+8. Repeat steps 2-16 of [_841\_2_](841_2_pool_usage.md) case
+9. Stop the run launched at step 9
+10. Open the **Library** page
+11. Open the pipeline created at step 4 of the preparations
+12. Click the **RUN** button
+13. Repeat steps 6-11 of [_841\_2_](841_2_pool_usage.md) case
+14. Click the **Docker image** field
+15. Select the same tool as at step 14 of [_841\_1_](841_1_pool_creation.md) case
+16. Click the **OK** button
+17. Repeat steps 12-16 of [_841\_2_](841_2_pool_usage.md) case
+
+After:
+
+- open the configuration of the pool node created at step 19 of [_841\_1_](841_1_pool_creation.md) case and delete the filter added at steps 4-7
+- delete the pipeline created at step 4 of the preparations
+
+***
+
+**Expected result**:
+
+After step 8:
+
+- disk size (displayed in **Instance** section) does not equal the value specified at step 12 of [_841\_1_](841_1_pool_creation.md) case
+- the node name (near the **IP** label) doesn't equal to any from saved names at step 22 of [_841\_1_](841_1_pool_creation.md) case
+
+After step 17:
+
+- disk size (displayed in **Instance** section) equals the value specified at step 12 of [_841\_1_](841_1_pool_creation.md) case
+- the node name (near the **IP** label) is one from saved names at step 22 of [_841\_1_](841_1_pool_creation.md) case

--- a/docs/testcases/UI/Cluster_nodes/Hot_node_pools/841_persistent_cluster_nodes/841_5_pool_usage_non_admin.md
+++ b/docs/testcases/UI/Cluster_nodes/Hot_node_pools/841_persistent_cluster_nodes/841_5_pool_usage_non_admin.md
@@ -1,0 +1,48 @@
+# Checking hot node pool usage by non-admin user
+
+**Prerequisites**:
+
+- non-admin user with the ability to run tools from `Default registry/library`
+
+**Preparations**:
+
+Perform [_841\_1_](841_1_pool_creation.md) case
+
+**Actions**:
+
+1. Login as non-admin user from the prerequisites
+2. Repeat steps 2-16 of [_841\_2_](841_2_pool_usage.md) case
+3. Stop the run launched at step 2
+4. Logout
+5. Login as admin user from the prerequisites of [_841\_1_](841_1_pool_creation.md) case
+6. Open the **Cluster state** page
+7. Click the **HOT NODE POOLS** tab
+8. Click the **Edit** button for the pool node created at step 19 of [_841\_1_](841_1_pool_creation.md) case
+9. Click the "**+ Add filter**" button
+10. Click the **Select property** dropdown list and select `Run owner` item in the list
+11. Click the **Select owner** dropdown list and select the name of the non-admin user from the prerequisites
+12. Click the **Condition** dropdown list and select `Matches any filter ("or")` item in the list
+13. Click the **SAVE** button
+14. Logout
+15. Login as non-admin user from the prerequisites
+16. Repeat steps 2-16 of [_841\_2_](841_2_pool_usage.md) case
+17. Stop the run launched at step 16
+
+**After**:
+
+- stop the run launched at step 13
+- open the configuration of the pool node created at step 19 of [_841\_1_](841_1_pool_creation.md) case and delete the filter added at steps 9-13
+
+***
+
+**Expected result**:
+
+After step 2:
+
+- disk size (displayed in **Instance** section) does not equal the value specified at step 12 of [_841\_1_](841_1_pool_creation.md) case
+- the node name (near the **IP** label) doesn't equal to any from saved names at step 22 of [_841\_1_](841_1_pool_creation.md) case
+
+After step 16:
+
+- disk size (displayed in **Instance** section) equals the value specified at step 12 of [_841\_1_](841_1_pool_creation.md) case
+- the node name (near the **IP** label) is one from saved names at step 22 of [_841\_1_](841_1_pool_creation.md) case

--- a/docs/testcases/UI/Cluster_nodes/Hot_node_pools/841_persistent_cluster_nodes/841_6_pool_autoscaled.md
+++ b/docs/testcases/UI/Cluster_nodes/Hot_node_pools/841_persistent_cluster_nodes/841_6_pool_autoscaled.md
@@ -1,0 +1,55 @@
+# Checking the autoscaling of the hot node pool
+
+**Preparations**:
+
+Perform [_841\_1_](841_1_pool_creation.md) case
+
+**Actions**:
+
+1. Open the **Cluster state** page
+2. Click the **HOT NODE POOLS** tab
+3. Click the **Edit** button for the pool node created at step 19 of [_841\_1_](841_1_pool_creation.md) case
+4. Enabled the **Autoscaled** checkbox
+5. Set the value `4` for the **Max Size** field
+6. Set the value `70` for the **Scale Up Threshold** field
+7. Set the value `30` for the **Scale Down Threshold** field
+8. Set the value `3` for the **Scale Step** field
+9. Click the **SAVE** button
+10. Repeat steps 2-13 of [_841\_2_](841_2_pool_usage.md) case
+11. Repeat steps 2-13 of [_841\_2_](841_2_pool_usage.md) case
+12. Open the **Cluster state** page
+13. Click the **HOT NODE POOLS** tab
+14. Click the node pool created at step 19 of [_841\_1_](841_1_pool_creation.md) case
+15. Wait until four nodes will be in the list
+16. Repeat step 13
+17. Repeat steps 2-13 of [_841\_2_](841_2_pool_usage.md) case
+18. Repeat steps 2-13 of [_841\_2_](841_2_pool_usage.md) case
+19. Repeat steps 12-13
+20. Open the **Runs** page
+21. Stop runs launched at steps 10, 11, 17, 18
+22. Repeat steps 12-13
+23. Click the **Refresh** button
+
+**After**:
+
+- open the **HOT NODE POOLS** tab and delete the pool node created at [_841\_1_](841_1_pool_creation.md) case
+
+***
+
+**Expected result**:
+
+After step 4, the following fields appear:
+
+- **Min Size**
+- **Max Size**
+- **Scale Up Threshold**
+- **Scale Down Threshold**
+- **Scale Step**
+
+After step 9, at the panel of the pool created at step 19 of [_841\_1_](841_1_pool_creation.md) case, the label appears `AUTOSCALED (2-4 NODES)`
+
+After steps 13, 23: at the panel of the pool created at step 19 of [_841\_1_](841_1_pool_creation.md) case, there is the label `2/2`
+
+After step 16, at the panel of the pool created at step 19 of [_841\_1_](841_1_pool_creation.md) case, there is the label `2/4`
+
+After step 16, at the panel of the pool created at step 19 of [_841\_1_](841_1_pool_creation.md) case, there is the label `4/4`

--- a/docs/testcases/UI/Cluster_nodes/Hot_node_pools/841_persistent_cluster_nodes/841_6_pool_autoscaled.md
+++ b/docs/testcases/UI/Cluster_nodes/Hot_node_pools/841_persistent_cluster_nodes/841_6_pool_autoscaled.md
@@ -20,15 +20,16 @@ Perform [_841\_1_](841_1_pool_creation.md) case
 12. Open the **Cluster state** page
 13. Click the **HOT NODE POOLS** tab
 14. Click the node pool created at step 19 of [_841\_1_](841_1_pool_creation.md) case
-15. Wait until four nodes will be in the list
+15. Click the **Refresh** button every minute until four nodes will be in the node list
 16. Repeat step 13
 17. Repeat steps 2-13 of [_841\_2_](841_2_pool_usage.md) case
 18. Repeat steps 2-13 of [_841\_2_](841_2_pool_usage.md) case
 19. Repeat steps 12-13
 20. Open the **Runs** page
 21. Stop runs launched at steps 10, 11, 17, 18
-22. Repeat steps 12-13
-23. Click the **Refresh** button
+22. Repeat steps 12-14
+23. Click the **Refresh** button every minute until two nodes will stay in the node list
+24. Repeat step 13
 
 **After**:
 
@@ -48,7 +49,7 @@ After step 4, the following fields appear:
 
 After step 9, at the panel of the pool created at step 19 of [_841\_1_](841_1_pool_creation.md) case, the label appears `AUTOSCALED (2-4 NODES)`
 
-After steps 13, 23: at the panel of the pool created at step 19 of [_841\_1_](841_1_pool_creation.md) case, there is the label `2/2`
+After steps 13, 24: at the panel of the pool created at step 19 of [_841\_1_](841_1_pool_creation.md) case, there is the label `2/2`
 
 After step 16, at the panel of the pool created at step 19 of [_841\_1_](841_1_pool_creation.md) case, there is the label `2/4`
 


### PR DESCRIPTION
This PR adds test cases to check "Hot node pools" main functionality:
- creation of the pool
- assigning nodes from the pool
- filters usage
- assigning nodes from the pool for non-admin jobs
- autoscaled regimen of the pool