### PR TITLE
Support background pipe tunnel polling for a regular user on MacOS

### DIFF
--- a/pipe-cli/src/utilities/platform_utilities.py
+++ b/pipe-cli/src/utilities/platform_utilities.py
@@ -20,3 +20,10 @@ def is_wsl():
         if platform_version:
             return 'microsoft' in platform_version.lower()
     return False
+
+
+def is_mac():
+    """
+    Checks if the execution environment is Mac.
+    """
+    return platform.system() == 'Darwin'


### PR DESCRIPTION
Resolves issue #1950.

The pull request brings support for pipe tunnel to regular users on MacOS. From now on background pipe tunnel polling will be performed using `lsof` utility rather than `psutil` package on MacOS.
