### PR TITLE
Allow general users to run a job on behalf of the other account

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,10 +97,11 @@ public class RunApiService {
         return runVO.getUseRunId() == null ? runManager.runCmd(runVO) : runManager.runPod(runVO);
     }
 
-    @PreAuthorize("hasRole('ADMIN') OR "
-            + "hasPermission(#runVO.pipelineId, 'com.epam.pipeline.entity.pipeline.Pipeline', 'EXECUTE')")
+    @PreAuthorize("(hasRole('ADMIN') OR "
+            + "hasPermission(#runVO.pipelineId, 'com.epam.pipeline.entity.pipeline.Pipeline', 'EXECUTE'))"
+            + " AND @grantPermissionManager.hasPipelinePermissionToRunAs(#runVO, 'EXECUTE')")
     @AclMask
-    public PipelineRun runPipeline(PipelineStart runVO) {
+    public PipelineRun runPipeline(final PipelineStart runVO) {
         return runManager.runPipeline(runVO);
     }
 

--- a/api/src/main/java/com/epam/pipeline/acl/user/UserApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/user/UserApiService.java
@@ -216,7 +216,7 @@ public class UserApiService {
      * @return the list of the runners
      */
     @PreAuthorize(ADMIN_ONLY)
-    public List<RunnerSid> addRunners(final Long id, final List<RunnerSid> runners) {
+    public List<RunnerSid> updateRunners(final Long id, final List<RunnerSid> runners) {
         return userRunnersManager.saveRunners(id, runners);
     }
 

--- a/api/src/main/java/com/epam/pipeline/acl/user/UserApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/user/UserApiService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,9 @@ import com.epam.pipeline.entity.user.CustomControl;
 import com.epam.pipeline.entity.user.GroupStatus;
 import com.epam.pipeline.entity.user.PipelineUser;
 import com.epam.pipeline.entity.user.PipelineUserEvent;
+import com.epam.pipeline.entity.user.RunnerSid;
 import com.epam.pipeline.manager.user.UserManager;
+import com.epam.pipeline.manager.user.UserRunnersManager;
 import com.epam.pipeline.manager.user.UsersFileImportManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -46,6 +48,9 @@ public class UserApiService {
 
     @Autowired
     private UsersFileImportManager usersFileImportManager;
+
+    @Autowired
+    private UserRunnersManager userRunnersManager;
 
     /**
      * Registers a new user
@@ -201,5 +206,27 @@ public class UserApiService {
                                                       final List<String> systemDictionariesToCreate,
                                                       final MultipartFile file) {
         return usersFileImportManager.importUsersFromFile(createUser, createGroup, systemDictionariesToCreate, file);
+    }
+
+    /**
+     * Adds runners to user (service account).
+     * @param id the user ID
+     * @param runners the list of the {@link RunnerSid} objects which correspond to users/roles that may
+     *                launch pipelines as specified user
+     * @return the list of the runners
+     */
+    @PreAuthorize(ADMIN_ONLY)
+    public List<RunnerSid> addRunners(final Long id, final List<RunnerSid> runners) {
+        return userRunnersManager.saveRunners(id, runners);
+    }
+
+    /**
+     * Returns runners for specified user
+     * @param id the user ID
+     * @return the list of the runners
+     */
+    @PreAuthorize(ADMIN_ONLY + OR_USER_READER)
+    public List<RunnerSid> getRunners(final Long id) {
+        return userRunnersManager.getRunners(id);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -162,6 +162,8 @@ public final class MessageConstants {
     public static final String ERROR_RUN_CLOUD_REGION_NOT_ALLOWED = "error.run.cloud.region.not.allowed";
     public static final String INFO_LOG_PAUSE_COMPLETED = "info.log.pause.completed";
     public static final String ERROR_STOP_START_INSTANCE_TERMINATED = "error.stop.start.instance.reason.terminated";
+    public static final String ERROR_RUN_ALLOWED_SID_NOT_FOUND = "error.run.allowed.sid.not.found";
+    public static final String ERROR_RUN_ALLOWED_SID_NAME_NOT_FOUND = "error.run.allowed.sid.name.not.found";
 
     //Run schedule
     public static final String CRON_EXPRESSION_IS_NOT_PROVIDED = "cron.expression.is.not.provided";

--- a/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
@@ -409,12 +409,13 @@ public class UserController extends AbstractRestController {
     @PostMapping("/users/{id}/runners")
     @ResponseBody
     @ApiOperation(
-            value = "Adds runners to user",
-            notes = "Adds runners to user",
+            value = "Updates runners to user",
+            notes = "Updates runners to user",
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
-    public Result<List<RunnerSid>> addRunners(@PathVariable final Long id, @RequestBody final List<RunnerSid> runners) {
-        return Result.success(userApiService.addRunners(id, runners));
+    public Result<List<RunnerSid>> updateRunners(@PathVariable final Long id,
+                                                 @RequestBody final List<RunnerSid> runners) {
+        return Result.success(userApiService.updateRunners(id, runners));
     }
 
     @GetMapping("/users/{id}/runners")

--- a/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
@@ -27,6 +27,7 @@ import com.epam.pipeline.entity.user.CustomControl;
 import com.epam.pipeline.entity.user.GroupStatus;
 import com.epam.pipeline.entity.user.PipelineUser;
 import com.epam.pipeline.entity.user.PipelineUserEvent;
+import com.epam.pipeline.entity.user.RunnerSid;
 import com.epam.pipeline.manager.security.AuthManager;
 import com.epam.pipeline.acl.user.UserApiService;
 import io.swagger.annotations.Api;
@@ -403,5 +404,27 @@ public class UserController extends AbstractRestController {
             final HttpServletRequest request) throws FileUploadException {
         final MultipartFile file = consumeMultipartFile(request);
         return Result.success(userApiService.importUsersFromCsv(createUser, createGroup, createMetadata, file));
+    }
+
+    @PostMapping("/users/{id}/runners")
+    @ResponseBody
+    @ApiOperation(
+            value = "Adds runners to user",
+            notes = "Adds runners to user",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<List<RunnerSid>> addRunners(@PathVariable final Long id, @RequestBody final List<RunnerSid> runners) {
+        return Result.success(userApiService.addRunners(id, runners));
+    }
+
+    @GetMapping("/users/{id}/runners")
+    @ResponseBody
+    @ApiOperation(
+            value = "Loads runners for user",
+            notes = "Loads runners for user",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<List<RunnerSid>> getRunners(@PathVariable final Long id) {
+        return Result.success(userApiService.getRunners(id));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -101,6 +101,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -1480,27 +1481,16 @@ public class PipelineRunManager {
                 : formatRegistryPath(parsedImage.getKey(), parsedImage.getValue());
     }
 
-    private List<RunSid> buildRunSids(final List<RunSid> runSids, final String currentUser,
+    private List<RunSid> buildRunSids(final List<RunSid> runSidsFromVO, final String currentUser,
                                       final RunAccessType allowedAccessType) {
-        final boolean runSharedWithCurrentUser = ListUtils.emptyIfNull(runSids).stream()
-                .anyMatch(runSid -> Objects.nonNull(runSid.getIsPrincipal())
-                        && runSid.getIsPrincipal()
-                        && currentUser.equalsIgnoreCase(runSid.getName())
-                        && Objects.equals(runSid.getAccessType(), allowedAccessType));
-
-        if (runSharedWithCurrentUser) {
-            return runSids;
-        }
+        final Set<RunSid> runSids = new HashSet<>(ListUtils.emptyIfNull(runSidsFromVO));
 
         final RunSid runSid = new RunSid();
         runSid.setName(currentUser.toUpperCase());
         runSid.setIsPrincipal(true);
         runSid.setAccessType(allowedAccessType);
-
-        if (CollectionUtils.isEmpty(runSids)) {
-            return Collections.singletonList(runSid);
-        }
         runSids.add(runSid);
-        return runSids;
+
+        return new ArrayList<>(runSids);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/security/AuthManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/AuthManager.java
@@ -57,6 +57,11 @@ public class AuthManager {
         return SecurityContextHolder.getContext().getAuthentication();
     }
 
+    public void setAuthentication(final Authentication authentication) {
+        SecurityContextHolder.setContext(SecurityContextHolder.createEmptyContext());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
     /**
      * @return user name of currently logged in user
      */

--- a/api/src/main/java/com/epam/pipeline/manager/security/CheckPermissionHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/CheckPermissionHelper.java
@@ -51,7 +51,7 @@ public class CheckPermissionHelper {
     private final UserRunnersManager userRunnersManager;
 
     public void setContext(final String userName) {
-        authManager.setAuthentication(getAuthentication(userName));
+        authManager.setAuthentication(getAuthentication(userName.toUpperCase()));
     }
 
     public boolean isAllowed(final String permissionName, final AbstractSecuredEntity entity) {

--- a/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -831,6 +831,17 @@ public class GrantPermissionManager {
         }
         Assert.notNull(securedEntity, "Pipeline ID or docker image must be provided");
         return permissionsHelper.isAllowed(permissionName, securedEntity);
+    }
+
+    public boolean hasPipelinePermissionToRunAs(final PipelineStart startVO, final String permissionName) {
+        final String userName = startVO.getRunAs();
+        if (StringUtils.isBlank(userName)) {
+            return true;
+        }
+        final AbstractSecuredEntity pipeline = entityManager.load(AclClass.PIPELINE, startVO.getPipelineId());
+        Assert.notNull(pipeline, "Pipeline must be provided");
+        return permissionsHelper.isAllowed(permissionName, pipeline, userName)
+                && permissionsHelper.hasCurrentUserAsRunner(userName);
     }
 
     /**

--- a/api/src/main/java/com/epam/pipeline/manager/user/UserRunnersManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/UserRunnersManager.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.user;
+
+import com.epam.pipeline.common.MessageConstants;
+import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.entity.user.RunnerSid;
+import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.entity.user.Role;
+import com.epam.pipeline.repository.user.PipelineUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.ListUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+public class UserRunnersManager {
+    private final PipelineUserRepository pipelineUserRepository;
+    private final MessageHelper messageHelper;
+
+    public List<RunnerSid> getRunners(final Long id) {
+        return getUserOrThrow(id).getAllowedRunners();
+    }
+
+    public boolean hasUserAsRunner(final PipelineUser user, final String runAsUser) {
+        return ListUtils.emptyIfNull(getUserByNameOrThrow(runAsUser).getAllowedRunners()).stream()
+                .anyMatch(aclSidEntity -> isRunnerAllowed(aclSidEntity, user));
+    }
+
+    @Transactional
+    public List<RunnerSid> saveRunners(final Long id, final List<RunnerSid> runners) {
+        final PipelineUser user = getUserOrThrow(id);
+        user.setAllowedRunners(ListUtils.emptyIfNull(runners));
+        pipelineUserRepository.save(user);
+        return runners;
+    }
+
+    private PipelineUser getUserOrThrow(final Long id) {
+        return Optional.of(pipelineUserRepository.findOne(id)).orElseThrow(() -> new IllegalArgumentException(
+                messageHelper.getMessage(MessageConstants.ERROR_USER_ID_NOT_FOUND, id)));
+    }
+
+    private PipelineUser getUserByNameOrThrow(final String userName) {
+        return pipelineUserRepository.findByUserName(userName).orElseThrow(() -> new IllegalArgumentException(
+                messageHelper.getMessage(MessageConstants.ERROR_USER_NAME_NOT_FOUND, userName)));
+    }
+
+    private boolean isRunnerAllowed(final RunnerSid runnersAclSid, final PipelineUser user) {
+        return isRunnerAllowedForUser(runnersAclSid, user.getUserName())
+                || isRunnerAllowedForRoles(runnersAclSid, user.getRoles());
+    }
+
+    private boolean isRunnerAllowedForUser(final RunnerSid runnerSid, final String userName) {
+        return runnerSid.isPrincipal() && runnerSid.getName().equalsIgnoreCase(userName);
+    }
+
+    private boolean isRunnerAllowedForRoles(final RunnerSid runnersAclSid, final List<Role> roles) {
+        return !runnersAclSid.isPrincipal()
+                && ListUtils.emptyIfNull(roles).stream()
+                .anyMatch(role -> role.getName().equalsIgnoreCase(runnersAclSid.getName()));
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/user/UserRunnersManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/UserRunnersManager.java
@@ -24,12 +24,12 @@ import com.epam.pipeline.entity.user.Role;
 import com.epam.pipeline.repository.user.PipelineUserRepository;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.lang.StringUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
 import java.util.List;
-import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
@@ -68,8 +68,9 @@ public class UserRunnersManager {
     }
 
     private PipelineUser getUserOrThrow(final Long id) {
-        return Optional.of(pipelineUserRepository.findOne(id)).orElseThrow(() -> new IllegalArgumentException(
-                messageHelper.getMessage(MessageConstants.ERROR_USER_ID_NOT_FOUND, id)));
+        final PipelineUser user = pipelineUserRepository.findOne(id);
+        Assert.notNull(user, messageHelper.getMessage(MessageConstants.ERROR_USER_ID_NOT_FOUND, id));
+        return user;
     }
 
     private PipelineUser getUserByNameOrThrow(final String userName) {
@@ -93,7 +94,7 @@ public class UserRunnersManager {
     }
 
     private void validateRunner(final RunnerSid runnerSid) {
-        Assert.notNull(runnerSid.getName(), messageHelper.getMessage(
+        Assert.state(StringUtils.isNotBlank(runnerSid.getName()), messageHelper.getMessage(
                 MessageConstants.ERROR_RUN_ALLOWED_SID_NAME_NOT_FOUND));
     }
 }

--- a/api/src/main/resources/db/migration/v2021.05.07_17.00__issue_1948_pipeline_sid.sql
+++ b/api/src/main/resources/db/migration/v2021.05.07_17.00__issue_1948_pipeline_sid.sql
@@ -1,0 +1,5 @@
+CREATE TABLE pipeline.pipeline_user_allowed_runners (
+    pipeline_user_id integer not null,
+    principal boolean not null,
+    name text not null
+);

--- a/api/src/main/resources/db/migration/v2021.05.07_17.00__issue_1948_pipeline_sid.sql
+++ b/api/src/main/resources/db/migration/v2021.05.07_17.00__issue_1948_pipeline_sid.sql
@@ -1,5 +1,6 @@
 CREATE TABLE pipeline.pipeline_user_allowed_runners (
     pipeline_user_id integer not null,
     principal boolean not null,
-    name text not null
+    name text not null,
+    access_type text not null
 );

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -116,6 +116,8 @@ error.run.stats.xls.template.empty.path=Empty path to XLS report template specif
 error.run.cloud.region.not.allowed=User doesn''t have sufficient permissions to run instance in ''{0}'' cloud region.
 info.log.pause.completed=[INFO] Pause run script completed successfully
 error.stop.start.instance.reason.terminated="Cannot {} instance: instance terminated"
+error.run.allowed.sid.not.found="Cannot find allowed user or group for runner ''{0}''"
+error.run.allowed.sid.name.not.found="User or role shall be specified"
 
 #Run schedule
 cron.expression.is.not.provided=Cron expression for {0} id ''{1}'' is not provided.

--- a/api/src/test/java/com/epam/pipeline/app/TestApplication.java
+++ b/api/src/test/java/com/epam/pipeline/app/TestApplication.java
@@ -26,6 +26,7 @@ import com.epam.pipeline.manager.cluster.InstanceOfferScheduler;
 import com.epam.pipeline.manager.cluster.performancemonitoring.ESMonitoringManager;
 import com.epam.pipeline.manager.ontology.OntologyManager;
 import com.epam.pipeline.manager.scheduling.AutowiringSpringBeanJobFactory;
+import com.epam.pipeline.manager.user.UserRunnersManager;
 import com.epam.pipeline.security.jwt.JwtTokenGenerator;
 import com.epam.pipeline.security.jwt.JwtTokenVerifier;
 import org.springframework.boot.SpringApplication;
@@ -118,6 +119,9 @@ public class TestApplication {
 
     @MockBean
     public CloudProfileCredentialsManager cloudProfileCredentialsManager;
+
+    @MockBean
+    public UserRunnersManager mockUserRunnersManager;
 
     @Bean
     public EmbeddedServletContainerCustomizer containerCustomizer() throws FileNotFoundException {

--- a/api/src/test/java/com/epam/pipeline/manager/contextual/ContextualPreferenceManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/contextual/ContextualPreferenceManagerTest.java
@@ -66,13 +66,13 @@ public class ContextualPreferenceManagerTest {
     private static final String USER_NAME = "userName";
     private static final PipelineUser USER = new PipelineUser(1L, null, Arrays.asList(ROLE_1, ROLE_2),
             Collections.emptyList(), false, false, null, null, null,
-            Collections.emptyMap(), Collections.emptyList(), null);
+            Collections.emptyMap(), Collections.emptyList(), null, Collections.emptyList());
     private static final PipelineUser USER_WITHOUT_ROLES = new PipelineUser(USER.getId(), null, null,
             Collections.emptyList(), false, false, null, null, null,
-            Collections.emptyMap(), Collections.emptyList(), null);
+            Collections.emptyMap(), Collections.emptyList(), null, Collections.emptyList());
     private static final PipelineUser USER_WITHOUT_ID = new PipelineUser(null, USER_NAME, Collections.emptyList(),
             Collections.emptyList(), false, false, null, null, null,
-            Collections.emptyMap(), Collections.emptyList(), null);
+            Collections.emptyMap(), Collections.emptyList(), null, Collections.emptyList());
 
     private final ContextualPreferenceExternalResource toolResource =
             new ContextualPreferenceExternalResource(LEVEL, TOOL_ID);

--- a/api/src/test/java/com/epam/pipeline/manager/user/UserRunnersManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/user/UserRunnersManagerTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.user;
+
+import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.entity.user.Role;
+import com.epam.pipeline.entity.user.RunnerSid;
+import com.epam.pipeline.repository.user.PipelineUserRepository;
+import com.epam.pipeline.test.creator.user.UserCreatorUtils;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static com.epam.pipeline.test.creator.CommonCreatorConstants.TEST_STRING;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static com.epam.pipeline.test.creator.CommonCreatorConstants.ID;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class UserRunnersManagerTest {
+    private static final String USER_NAME = "user";
+    private static final String ROLE_NAME = "role";
+
+    private final PipelineUserRepository pipelineUserRepository = mock(PipelineUserRepository.class);
+    private final MessageHelper messageHelper = mock(MessageHelper.class);
+    private final UserRunnersManager manager = new UserRunnersManager(pipelineUserRepository, messageHelper);
+
+    private final RunnerSid userRunnerSid = RunnerSid.builder().name(USER_NAME).principal(true).build();
+
+    @Test
+    public void shouldGetRunners() {
+        when(pipelineUserRepository.findOne(ID)).thenReturn(pipelineUser());
+
+        final List<RunnerSid> runners = manager.getRunners(ID);
+
+        assertThat(runners).hasSize(1).contains(userRunnerSid);
+    }
+
+    @Test
+    public void shouldSaveRunners() {
+        when(pipelineUserRepository.findOne(ID)).thenReturn(UserCreatorUtils.getPipelineUser());
+
+        final List<RunnerSid> runners = manager.saveRunners(ID, Collections.singletonList(userRunnerSid));
+
+        verify(pipelineUserRepository).save((PipelineUser) any());
+        assertThat(runners).hasSize(1).contains(userRunnerSid);
+    }
+
+    @Test
+    public void shouldReturnTrueIfUserRunnerPresents() {
+        when(pipelineUserRepository.findByUserName(TEST_STRING)).thenReturn(Optional.of(pipelineUser()));
+        final PipelineUser currentUser = UserCreatorUtils.getPipelineUser(USER_NAME);
+
+        assertThat(manager.hasUserAsRunner(currentUser, TEST_STRING)).isTrue();
+    }
+
+    @Test
+    public void shouldReturnFalseIfUserRunnerNotPresents() {
+        when(pipelineUserRepository.findByUserName(TEST_STRING))
+                .thenReturn(Optional.of(UserCreatorUtils.getPipelineUser()));
+        final PipelineUser currentUser = UserCreatorUtils.getPipelineUser(USER_NAME);
+
+        assertThat(manager.hasUserAsRunner(currentUser, TEST_STRING)).isFalse();
+    }
+
+    @Test
+    public void shouldReturnTrueIfRunnerPresentsInRoles() {
+        final PipelineUser runAsUser = UserCreatorUtils.getPipelineUser();
+        runAsUser.setAllowedRunners(Collections.singletonList(
+                RunnerSid.builder().name(ROLE_NAME).principal(false).build()));
+        when(pipelineUserRepository.findByUserName(TEST_STRING))
+                .thenReturn(Optional.of(runAsUser));
+        final PipelineUser currentUser = UserCreatorUtils.getPipelineUser(USER_NAME);
+        currentUser.setRoles(Collections.singletonList(new Role(ROLE_NAME)));
+
+        assertThat(manager.hasUserAsRunner(currentUser, TEST_STRING)).isTrue();
+    }
+
+    private PipelineUser pipelineUser() {
+        final PipelineUser pipelineUser = UserCreatorUtils.getPipelineUser();
+        pipelineUser.setAllowedRunners(Collections.singletonList(userRunnerSid));
+        return pipelineUser;
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/repository/user/PipelineUserRepositoryTest.java
+++ b/api/src/test/java/com/epam/pipeline/repository/user/PipelineUserRepositoryTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.repository.user;
+
+import com.epam.pipeline.dao.user.UserDao;
+import com.epam.pipeline.entity.user.RunnerSid;
+import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.test.repository.AbstractJpaTest;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static com.epam.pipeline.test.creator.user.UserCreatorUtils.getPipelineUser;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class PipelineUserRepositoryTest extends AbstractJpaTest {
+    private static final String USER_NAME = "user";
+    private static final String ROLE_NAME = "role";
+    private static final String SERVICE_ACCOUNT = "service";
+
+    @Autowired
+    private TestEntityManager entityManager;
+    @Autowired
+    private UserDao userDao;
+    @Autowired
+    private PipelineUserRepository pipelineUserRepository;
+
+    @Test
+    @Transactional
+    public void shouldLoadRunnersForUser() {
+        final PipelineUser serviceAccount = userDao.createUser(getPipelineUser(SERVICE_ACCOUNT),
+                Collections.emptyList());
+
+        final RunnerSid userSid = aclSidEntity(USER_NAME, true);
+        final RunnerSid roleSid = aclSidEntity(ROLE_NAME, false);
+
+        serviceAccount.setAllowedRunners(Arrays.asList(userSid, roleSid));
+        pipelineUserRepository.save(serviceAccount);
+
+        entityManager.flush();
+
+        final List<RunnerSid> allowedRunners = pipelineUserRepository.findOne(serviceAccount.getId())
+                .getAllowedRunners();
+        assertThat(allowedRunners.size(), is(2));
+        allowedRunners.forEach(this::assertSid);
+    }
+
+    private void assertSid(final RunnerSid runnerSid) {
+        if (runnerSid.isPrincipal()) {
+            assertUserSid(runnerSid);
+            return;
+        }
+        assertRoleSid(runnerSid);
+    }
+
+    private void assertUserSid(final RunnerSid loaded) {
+        assertThat(loaded, notNullValue());
+        assertThat(loaded.getName(), is(USER_NAME));
+        assertTrue(loaded.isPrincipal());
+    }
+
+    private void assertRoleSid(final RunnerSid loaded) {
+        assertThat(loaded, notNullValue());
+        assertThat(loaded.getName(), is(ROLE_NAME));
+        assertFalse(loaded.isPrincipal());
+    }
+
+    private RunnerSid aclSidEntity(final String sidName, final boolean principal) {
+        final RunnerSid aclSidEntity = new RunnerSid();
+        aclSidEntity.setName(sidName);
+        aclSidEntity.setPrincipal(principal);
+        return aclSidEntity;
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/repository/user/PipelineUserRepositoryTest.java
+++ b/api/src/test/java/com/epam/pipeline/repository/user/PipelineUserRepositoryTest.java
@@ -17,6 +17,7 @@
 package com.epam.pipeline.repository.user;
 
 import com.epam.pipeline.dao.user.UserDao;
+import com.epam.pipeline.entity.pipeline.run.parameter.RunAccessType;
 import com.epam.pipeline.entity.user.RunnerSid;
 import com.epam.pipeline.entity.user.PipelineUser;
 import com.epam.pipeline.test.repository.AbstractJpaTest;
@@ -79,12 +80,14 @@ public class PipelineUserRepositoryTest extends AbstractJpaTest {
     private void assertUserSid(final RunnerSid loaded) {
         assertThat(loaded, notNullValue());
         assertThat(loaded.getName(), is(USER_NAME));
+        assertThat(loaded.getAccessType(), is(RunAccessType.SSH));
         assertTrue(loaded.isPrincipal());
     }
 
     private void assertRoleSid(final RunnerSid loaded) {
         assertThat(loaded, notNullValue());
         assertThat(loaded.getName(), is(ROLE_NAME));
+        assertThat(loaded.getAccessType(), is(RunAccessType.SSH));
         assertFalse(loaded.isPrincipal());
     }
 
@@ -92,6 +95,7 @@ public class PipelineUserRepositoryTest extends AbstractJpaTest {
         final RunnerSid aclSidEntity = new RunnerSid();
         aclSidEntity.setName(sidName);
         aclSidEntity.setPrincipal(principal);
+        aclSidEntity.setAccessType(RunAccessType.SSH);
         return aclSidEntity;
     }
 }

--- a/api/src/test/java/com/epam/pipeline/test/acl/AclTestBeans.java
+++ b/api/src/test/java/com/epam/pipeline/test/acl/AclTestBeans.java
@@ -120,6 +120,7 @@ import com.epam.pipeline.manager.security.GrantPermissionManager;
 import com.epam.pipeline.manager.security.PermissionsService;
 import com.epam.pipeline.manager.user.RoleManager;
 import com.epam.pipeline.manager.user.UserManager;
+import com.epam.pipeline.manager.user.UserRunnersManager;
 import com.epam.pipeline.manager.user.UsersFileImportManager;
 import com.epam.pipeline.manager.utils.JsonService;
 import com.epam.pipeline.manager.utils.UtilsManager;
@@ -509,6 +510,9 @@ public class AclTestBeans {
 
     @MockBean
     protected PipelineRunKubernetesManager pipelineRunKubernetesManager;
+
+    @MockBean
+    protected UserRunnersManager mockUserRunnersManager;
 
     @Bean
     public GrantPermissionManager grantPermissionManager() {

--- a/api/src/test/java/com/epam/pipeline/test/aspect/AspectTestBeans.java
+++ b/api/src/test/java/com/epam/pipeline/test/aspect/AspectTestBeans.java
@@ -70,6 +70,7 @@ import com.epam.pipeline.manager.cluster.PodMonitor;
 import com.epam.pipeline.manager.contextual.handler.ContextualPreferenceHandler;
 import com.epam.pipeline.manager.docker.scan.ToolScanScheduler;
 import com.epam.pipeline.manager.scheduling.RunScheduler;
+import com.epam.pipeline.manager.user.UserRunnersManager;
 import com.epam.pipeline.mapper.AbstractDataStorageMapper;
 import com.epam.pipeline.mapper.AbstractEntityPermissionMapper;
 import com.epam.pipeline.mapper.AbstractRunConfigurationMapper;
@@ -357,4 +358,7 @@ public class AspectTestBeans {
 
     @MockBean
     protected RunStatusDao mockRunStatusDao;
+
+    @MockBean
+    protected UserRunnersManager mockUserRunnersManager;
 }

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/run/PipelineStart.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/run/PipelineStart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ public class PipelineStart {
     private ExecutionEnvironment executionEnvironment;
     private String prettyUrl;
     private boolean nonPause;
+    private String runAs;
 
     @JsonDeserialize(using = PipelineConfValuesMapDeserializer.class)
     private Map<String, PipeConfValueVO> params;

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/run/parameter/RunSid.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/run/parameter/RunSid.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,14 @@
 
 package com.epam.pipeline.entity.pipeline.run.parameter;
 
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Objects;
 
 @Getter
 @Setter
-@EqualsAndHashCode
 public class RunSid {
 
     private Long runId;
@@ -30,4 +31,22 @@ public class RunSid {
     private Boolean isPrincipal;
     private RunAccessType accessType;
 
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final RunSid runSid = (RunSid) o;
+        return StringUtils.equalsIgnoreCase(name, runSid.getName())
+                && Objects.equals(accessType, runSid.getAccessType())
+                && Objects.equals(isPrincipal, runSid.getIsPrincipal());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name.toUpperCase(), isPrincipal, accessType);
+    }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/user/PipelineUser.java
+++ b/core/src/main/java/com/epam/pipeline/entity/user/PipelineUser.java
@@ -31,6 +31,7 @@ import org.springframework.util.StringUtils;
 import javax.persistence.AttributeConverter;
 import javax.persistence.Column;
 import javax.persistence.Convert;
+import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -109,6 +110,9 @@ public class PipelineUser implements StorageContainer {
     private List<CloudProfileCredentialsEntity> cloudProfiles;
 
     private Long defaultProfileId;
+
+    @ElementCollection
+    private List<RunnerSid> allowedRunners;
 
     public PipelineUser() {
         this.admin = false;

--- a/core/src/main/java/com/epam/pipeline/entity/user/RunnerSid.java
+++ b/core/src/main/java/com/epam/pipeline/entity/user/RunnerSid.java
@@ -14,14 +14,24 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.repository.user;
+package com.epam.pipeline.entity.user;
 
-import com.epam.pipeline.entity.user.PipelineUser;
-import org.springframework.data.repository.CrudRepository;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-import java.util.Optional;
+import javax.persistence.Embeddable;
 
-public interface PipelineUserRepository extends CrudRepository<PipelineUser, Long> {
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class RunnerSid {
 
-    Optional<PipelineUser> findByUserName(String userName);
+    private String name;
+    private boolean principal;
 }

--- a/core/src/main/java/com/epam/pipeline/entity/user/RunnerSid.java
+++ b/core/src/main/java/com/epam/pipeline/entity/user/RunnerSid.java
@@ -16,6 +16,7 @@
 
 package com.epam.pipeline.entity.user;
 
+import com.epam.pipeline.entity.pipeline.run.parameter.RunAccessType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,6 +24,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.Embeddable;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 
 @Embeddable
 @Getter
@@ -33,5 +36,8 @@ import javax.persistence.Embeddable;
 public class RunnerSid {
 
     private String name;
-    private boolean principal;
+    private boolean principal = true;
+
+    @Enumerated(EnumType.STRING)
+    private RunAccessType accessType = RunAccessType.ENDPOINT;
 }

--- a/pipe-cli/src/api/pipeline.py
+++ b/pipe-cli/src/api/pipeline.py
@@ -104,7 +104,8 @@ class Pipeline(API):
                         instance_disk=None, instance_type=None,
                         docker_image=None, cmd_template=None,
                         timeout=None, config_name=None, instance_count=None,
-                        price_type=None, region_id=None, parent_node=None, non_pause=None, friendly_url=None):
+                        price_type=None, region_id=None, parent_node=None, non_pause=None, friendly_url=None,
+                        run_as_user=None):
         api = cls.instance()
         params = {}
         for parameter in parameters:
@@ -136,6 +137,8 @@ class Pipeline(API):
             payload['nonPause'] = non_pause
         if friendly_url:
             payload['prettyUrl'] = friendly_url
+        if run_as_user:
+            payload['runAs'] = run_as_user
         data = json.dumps(payload)
         response_data = api.call('run', data)
         return PipelineRunModel.load(response_data['payload'])

--- a/pipe-cli/src/utilities/pipeline_run_operations.py
+++ b/pipe-cli/src/utilities/pipeline_run_operations.py
@@ -56,7 +56,7 @@ class PipelineRunOperations(object):
     @classmethod
     def run(cls, pipeline, config, parameters, yes, run_params, instance_disk, instance_type, docker_image,
             cmd_template, timeout, quiet, instance_count, cores, sync, price_type=None, region_id=None,
-            parent_node=None, non_pause=None, friendly_url=None):
+            parent_node=None, non_pause=None, friendly_url=None, run_as_user=None):
         # All pipeline run parameters can be specified as options, e.g. --read1 /path/to/reads.fastq
         # In this case - runs_params_dict will contain keys-values for each option, e.g. {'--read1': '/path/to/reads.fastq'}
         # So they can be addressed with run_params_dict['--read1']
@@ -188,7 +188,8 @@ class PipelineRunOperations(object):
                                                                       region_id=region_id,
                                                                       parent_node=parent_node,
                                                                       non_pause=non_pause,
-                                                                      friendly_url=friendly_url)
+                                                                      friendly_url=friendly_url,
+                                                                      run_as_user=run_as_user)
                         pipeline_run_id = pipeline_run_model.identifier
                         if not quiet:
                             click.echo('"{}" pipeline run scheduled with RunId: {}'.format(


### PR DESCRIPTION
This PR provides implementation for issue #1948 

A new field `runAs` added to the pipeline run object (`POST /run` method). This value is the user name, which is going to be the `OWNER` of the job.

Also, a new API methods were added:
- `POST users/{id}/runners` with request body:
```
[{
    "name": "<user or role/group name>",
    "principal": true/false,
    "accessType": "ENDPOINT"/"SSH"
}]
```
that saves users or roles, who are allowed to launch pipelines on behalf of the specified user
- `GET users/{id}/runners` that load users/roles, who are allowed to launch pipelines on behalf of the specified user

 