### PR TITLE
issue 1805 GitReader service, ability to work with files with spaces in a name

### DIFF
--- a/git-reader/gitreader/src/git_manager.py
+++ b/git-reader/gitreader/src/git_manager.py
@@ -114,7 +114,7 @@ class GitManager(object):
             return 0, result
         git_ls_tree_result = git_ls_tree_result.split("\n")
         for line in git_ls_tree_result[offset:offset + page_size]:
-            git_ls_tree_line = line.split()
+            git_ls_tree_line = line.split(maxsplit=4)
             name = os.path.basename(git_ls_tree_line[4])
             result.append(GitObject(
                             git_id=git_ls_tree_line[4],


### PR DESCRIPTION
This PR related to ability of Git Reader service to work with files that contains spaces in a path