### PR TITLE
Seamless authentication in AWS - fix for empty policy

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSUtils.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSUtils.java
@@ -33,6 +33,7 @@ import org.apache.commons.lang3.StringUtils;
 public final class AWSUtils {
 
     private static final String EMPTY_KEY_ARN = "NONE";
+    private static final String EMPTY_JSON = "{}";
 
     private AWSUtils() {
         //no op
@@ -69,7 +70,7 @@ public final class AWSUtils {
     }
 
     public static String getPolicy(final String policy) {
-        return StringUtils.isBlank(policy) ? null : policy;
+        return StringUtils.isBlank(policy) || EMPTY_JSON.equals(policy) ? null : policy;
     }
 
     public static TemporaryCredentials generate(final Integer duration, final String policy, final String role,

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSUtils.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSUtils.java
@@ -68,18 +68,22 @@ public final class AWSUtils {
         return storage.getTempCredentialsRole();
     }
 
+    public static String getPolicy(final String policy) {
+        return StringUtils.isBlank(policy) ? null : policy;
+    }
+
     public static TemporaryCredentials generate(final Integer duration, final String policy, final String role,
                                                 final String profile, final String regionCode) {
         final String sessionName = "SessionID-" + PasswordGenerator.generateRandomString(10);
 
         final AssumeRoleRequest assumeRoleRequest = new AssumeRoleRequest()
                 .withDurationSeconds(duration)
-                .withPolicy(policy)
+                .withPolicy(getPolicy(policy))
                 .withRoleSessionName(sessionName)
                 .withRoleArn(role);
 
         final AssumeRoleResult assumeRoleResult = AWSSecurityTokenServiceClientBuilder.standard()
-                .withCredentials(AWSUtils.getCredentialsProvider(profile))
+                .withCredentials(getCredentialsProvider(profile))
                 .build()
                 .assumeRole(assumeRoleRequest);
         final Credentials resultingCredentials = assumeRoleResult.getCredentials();

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/credentials/aws/AWSProfileCredentialsManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/credentials/aws/AWSProfileCredentialsManager.java
@@ -56,6 +56,7 @@ public class AWSProfileCredentialsManager implements CloudProfileCredentialsMana
     public AWSProfileCredentials create(final AWSProfileCredentials credentials) {
         validateProfileCredentials(credentials);
         final AWSProfileCredentialsEntity entity = mapper.toAWSEntity(credentials);
+        entity.setPolicy(buildPolicy(credentials.getPolicy()));
         entity.setId(null);
         return mapper.toAWSDto(repository.save(entity));
     }
@@ -67,7 +68,7 @@ public class AWSProfileCredentialsManager implements CloudProfileCredentialsMana
         final AWSProfileCredentialsEntity entity = findEntity(id);
         entity.setAssumedRole(credentials.getAssumedRole());
         entity.setProfileName(credentials.getProfileName());
-        entity.setPolicy(credentials.getPolicy());
+        entity.setPolicy(buildPolicy(credentials.getPolicy()));
         repository.save(entity);
         return mapper.toAWSDto(entity);
     }
@@ -102,5 +103,9 @@ public class AWSProfileCredentialsManager implements CloudProfileCredentialsMana
             return null;
         }
         return region.getRegionCode();
+    }
+
+    private String buildPolicy(final String rawPolicy) {
+        return StringUtils.isBlank(rawPolicy) ? null : rawPolicy;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/credentials/aws/AWSProfileCredentialsManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/credentials/aws/AWSProfileCredentialsManager.java
@@ -56,7 +56,7 @@ public class AWSProfileCredentialsManager implements CloudProfileCredentialsMana
     public AWSProfileCredentials create(final AWSProfileCredentials credentials) {
         validateProfileCredentials(credentials);
         final AWSProfileCredentialsEntity entity = mapper.toAWSEntity(credentials);
-        entity.setPolicy(buildPolicy(credentials.getPolicy()));
+        entity.setPolicy(AWSUtils.getPolicy(credentials.getPolicy()));
         entity.setId(null);
         return mapper.toAWSDto(repository.save(entity));
     }
@@ -68,7 +68,7 @@ public class AWSProfileCredentialsManager implements CloudProfileCredentialsMana
         final AWSProfileCredentialsEntity entity = findEntity(id);
         entity.setAssumedRole(credentials.getAssumedRole());
         entity.setProfileName(credentials.getProfileName());
-        entity.setPolicy(buildPolicy(credentials.getPolicy()));
+        entity.setPolicy(AWSUtils.getPolicy(credentials.getPolicy()));
         repository.save(entity);
         return mapper.toAWSDto(entity);
     }
@@ -103,9 +103,5 @@ public class AWSProfileCredentialsManager implements CloudProfileCredentialsMana
             return null;
         }
         return region.getRegionCode();
-    }
-
-    private String buildPolicy(final String rawPolicy) {
-        return StringUtils.isBlank(rawPolicy) ? null : rawPolicy;
     }
 }


### PR DESCRIPTION
#### Background
`GET /cloud/credentials/generate/{id}` method fails in case if policy is empty string

This PR (connected with issue #1713) provides fix for this situation
