### PR TITLE
issue 1805 encode file path with UriUtils instead of URLEncoder

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/git/GitlabClient.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/GitlabClient.java
@@ -46,6 +46,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.Assert;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.util.UriUtils;
 import retrofit2.Call;
 import retrofit2.HttpException;
 import retrofit2.Response;
@@ -55,7 +56,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -599,7 +599,7 @@ public class GitlabClient {
     }
 
     private String encodePath(final String path) throws UnsupportedEncodingException {
-        return URLEncoder.encode(path, StandardCharsets.UTF_8.toString()).replace(DOT_CHAR,
+        return UriUtils.encodePathSegment(path, StandardCharsets.UTF_8.toString()).replace(DOT_CHAR,
                                                                                   DOT_CHAR_URL_ENCODING_REPLACEMENT);
     }
 }


### PR DESCRIPTION
When encode file path with URLEncoder it will replace ` ` with + sign instead of `%20` in this case gitlab will throw 404 error on file content request
This PR uses `UriUtils` to encode path as pathSegment