### PR TITLE
Versioned Storages - fix for git operations

### DIFF
--- a/fs-browser/README.md
+++ b/fs-browser/README.md
@@ -263,8 +263,10 @@ Response example:
 }
 ```
 
-- `POST /vs/<id>/conflicts` - registers changes after conflicts resolving for specified file in `path` request
-parameter. If file has no conflicts an error will be occurred. Performs `git add` operation.
+- `POST /vs/<id>/conflicts` - registers changes after conflicts resolving. If `path` request parameter specified 
+performs `git add` operation. If specified file has no conflicts an error will be occurred. If `path` is not 
+specified and HEAD detached this method performs `git checkout HEAD` operation to set HEAD after refresh. 
+This method shall be called after all conflicts resolving caused by the `fetch` operation.
 
 Request example:
 ```
@@ -290,9 +292,9 @@ Response example:
 {    
     "payload": {
        "files": [
-          { "file": "relative/file_name1"; "status": "modified"},
-          { "file": "relative/file_name2"; "status": "created"},
-          { "file": "relative/file_name3"; "status": "deleted"}
+          { "file": "relative/file_name1"; "status": "modified", "binary": false, "new_size": 1, "old_size": 2 },
+          { "file": "relative/file_name2"; "status": "created",  "binary": true, "new_size": 1, "old_size": null },
+          { "file": "relative/file_name3"; "status": "deleted", "binary": true, "new_size": null, "old_size": 2 }
        ],
        "merge_in_progress": false,
        "unsaved": false
@@ -449,3 +451,7 @@ Request example:
 curl -X POST http://127.0.0.1:8080/vs/1/merge/abort
 ```
 
+- `POST /vs/<vs_id>/checkout/path?path=<file path>&remote=<true/false>` - provides ability to accepts 
+`theirs` or `ours` changes. This method checkouts specified file. This file shall contain conflicts. 
+If `remote` flag (default: false) specified the remote (or `theirs`) changes shall be accepted. 
+Otherwise local (or `ours`).

--- a/fs-browser/fsbrowser/src/git/git_diff_helper.py
+++ b/fs-browser/fsbrowser/src/git/git_diff_helper.py
@@ -84,6 +84,17 @@ class GitDiffHelper:
         git_file_diff.old_name = self._get_delta_path(delta.old_file)
         return git_file_diff
 
+    def build_status_diff(self, diff_patch, git_file):
+        if not diff_patch:
+            self.logger.log("Diff not found")
+            return None
+        delta = diff_patch.delta
+
+        git_file.binary = delta.is_binary
+        git_file.new_size = self._get_delta_size(delta.new_file)
+        git_file.old_size = self._get_delta_size(delta.old_file)
+        return git_file
+
     def _get_repo_diff(self, file_status, file_path):
         if self._is_created(file_status):
             # build in-memory index

--- a/fs-browser/fsbrowser/src/git/git_task.py
+++ b/fs-browser/fsbrowser/src/git/git_task.py
@@ -56,9 +56,6 @@ class GitTask(Task):
     def pull(self, git_client, full_repo_path, is_head_detached):
         try:
             self.pulling()
-            if is_head_detached:
-                git_client.revert(full_repo_path)
-
             self._check_pull_possibility(git_client, full_repo_path)
 
             status_files = git_client.status(full_repo_path)
@@ -69,14 +66,15 @@ class GitTask(Task):
             if status_files:
                 git_client.unstash(full_repo_path)
 
-            if is_head_detached:
-                git_client.set_head(full_repo_path)
-
             stash_conflicts = self._conflicts_in_status(git_client, full_repo_path)
             conflicts = list(set(stash_conflicts + self._build_pull_conflicts(pull_conflicts)))
             if conflicts:
                 self._conflicts_failure(conflicts)
                 return
+
+            if is_head_detached:
+                git_client.set_head(full_repo_path)
+
             self.success()
         except Exception as e:
             self.logger.log(traceback.format_exc())

--- a/fs-browser/fsbrowser/src/model/git_file.py
+++ b/fs-browser/fsbrowser/src/model/git_file.py
@@ -21,6 +21,9 @@ class GitFile:
         self.path = path
         self.state = None
         self.state_code = None
+        self.binary = None
+        self.new_size = None
+        self.old_size = None
 
     def is_modified(self):
         return self.state_code & pygit2.GIT_STATUS_INDEX_MODIFIED or self.state_code & pygit2.GIT_STATUS_WT_MODIFIED
@@ -82,5 +85,8 @@ class GitFile:
     def to_json(self):
         return {
             "status": self.state,
-            "path": self.path
+            "path": self.path,
+            "binary": self.binary,
+            "new_size": self.new_size,
+            "old_size": self.old_size
         }


### PR DESCRIPTION
The current PR provides implementation for issue https://github.com/epam/cloud-pipeline/issues/1805#issuecomment-851282962 

The following changes were added:
- a new fsbrowser API method `POST /vs/<vs_id>/checkout/path?path=<file path>&remote=<true/false>` added. This method provides ability to accepts `theirs` or `ours` changes. This method checkouts specified file. This file shall contain conflicts. If `remote` flag (default: false) specified the remote or `theirs` changes shall be accepted. Otherwise local or `ours`.
- method `POST /vs/<vs_id>/conflicts?path=<file path>` was updated. The `path` request parameter is no longer required. If `path` is not specified and HEAD detached this method performs `git checkout HEAD` operation to set HEAD after refresh. This method shall be called after all conflicts resolving caused by the `fetch` operation.
- method `GET /vs/<vs_id>/files` fixed for binary files
- method `GET /vs/<vs_id>/status` returns the following structure now:
```
{    
    "payload": {
       "files": [
          { "file": "relative/file_name1"; "status": "modified", "binary": false, "new_size": 1, "old_size": 2 },
          { "file": "relative/file_name2"; "status": "created",  "binary": true, "new_size": 1, "old_size": null },
          { "file": "relative/file_name3"; "status": "deleted", "binary": true, "new_size": null, "old_size": 2 }
       ],
       "merge_in_progress": false,
       "unsaved": false
    },
    "status":"OK"
}
```