### PR TITLE
issue #1965: Updates for metadata entity filters

### DIFF
--- a/api/src/main/java/com/epam/pipeline/dao/metadata/MetadataEntityDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/metadata/MetadataEntityDao.java
@@ -67,7 +67,7 @@ public class MetadataEntityDao extends NamedParameterJdbcDaoSupport {
     private static final String AND = " AND ";
     private static final String OR = " OR ";
     private static final int BATCH_SIZE = 1000;
-    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.BASIC_ISO_DATE;
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
 
     @Autowired
     private DaoHelper daoHelper;
@@ -370,9 +370,9 @@ public class MetadataEntityDao extends NamedParameterJdbcDaoSupport {
             clause.append(AND);
             MetadataField field = MetadataEntityParameters.getFieldNames().get(filter.getKey().toUpperCase());
             if (field != null) {
-                clause.append(addFilterClause(filter, "%s::text LIKE '%%%s%%'", field.getDbName()));
+                clause.append(addFilterClause(filter, "%s::text ILIKE '%%%s%%'", field.getDbName()));
             } else {
-                clause.append(addFilterClause(filter, "e.data #>> '{%s,value}' LIKE '%%%s%%'", filter.getKey()));
+                clause.append(addFilterClause(filter, "e.data #>> '{%s,value}' ILIKE '%%%s%%'", filter.getKey()));
             }
         });
     }

--- a/api/src/main/java/com/epam/pipeline/entity/metadata/MetadataFilter.java
+++ b/api/src/main/java/com/epam/pipeline/entity/metadata/MetadataFilter.java
@@ -16,7 +16,7 @@
 
 package com.epam.pipeline.entity.metadata;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -57,9 +57,9 @@ public class MetadataFilter {
     @ApiModelProperty(notes = "list string to perform substring insensitive search in external ids")
     private List<String> externalIdQueries;
     @ApiModelProperty(notes = "Start created date to filter for metadata")
-    private LocalDate startDateFrom;
+    private LocalDateTime startDateFrom;
     @ApiModelProperty(notes = "End created date to filter for metadata")
-    private LocalDate endDateTo;
+    private LocalDateTime endDateTo;
 
     @Getter
     @Setter

--- a/api/src/test/java/com/epam/pipeline/dao/metadata/MetadataEntityDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/metadata/MetadataEntityDaoTest.java
@@ -35,7 +35,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Collection;
@@ -424,15 +424,15 @@ public class MetadataEntityDaoTest extends AbstractJdbcTest {
     public void testDateFilter() {
         MetadataClass metadataClass1 = createMetadataClass(CLASS_NAME_1);
         Folder folder1 = createFolder();
-        LocalDate date1 = LocalDate.now();
-        LocalDate date2 = LocalDate.now().minusDays(1);
+        LocalDateTime date1 = LocalDateTime.now();
+        LocalDateTime date2 = LocalDateTime.now().minusDays(1);
         MetadataEntity folder1Sample1 = ObjectCreatorUtils.createMetadataEntity(folder1, metadataClass1,
                 TEST_ENTITY_NAME_1, EXTERNAL_ID_1, new HashMap<>(),
-                Date.from(date1.atStartOfDay(ZoneId.systemDefault()).toInstant()));
+                Date.from(date1.atZone(ZoneId.systemDefault()).toInstant()));
         metadataEntityDao.createMetadataEntity(folder1Sample1);
         MetadataEntity folder1Sample2 = ObjectCreatorUtils.createMetadataEntity(folder1, metadataClass1,
                 TEST_ENTITY_NAME_1, EXTERNAL_ID_2, new HashMap<>(),
-                Date.from(date2.atStartOfDay(ZoneId.systemDefault()).toInstant()));
+                Date.from(date2.atZone(ZoneId.systemDefault()).toInstant()));
         metadataEntityDao.createMetadataEntity(folder1Sample2);
 
         MetadataFilter filterByDate = createFilter(folder1.getId(), metadataClass1.getName(),
@@ -664,8 +664,8 @@ public class MetadataEntityDaoTest extends AbstractJdbcTest {
     private MetadataFilter createFilter(Long folderId, String className,
                                         List<String> searchQueries, List<MetadataFilter.FilterQuery> filters,
                                         List<MetadataFilter.OrderBy> sorting, boolean recursive,
-                                        List<String> externalIds, LocalDate startDateFrom,
-                                        LocalDate endDateTo) {
+                                        List<String> externalIds, LocalDateTime startDateFrom,
+                                        LocalDateTime endDateTo) {
         MetadataFilter filter = new MetadataFilter();
         filter.setFolderId(folderId);
         filter.setMetadataClass(className);


### PR DESCRIPTION
This PR is related to issue #1965:

- filter date fields were changed from `LocalDate` to `LocalDateTime`
- filter was made case insensitive  