### PR TITLE
Add missing sticky bit to munge directory during debian slurm installation

### DIFF
--- a/workflows/pipe-common/shell/slurm_setup_master
+++ b/workflows/pipe-common/shell/slurm_setup_master
@@ -133,6 +133,9 @@ if [ "$LINUX_DISTRIBUTION" = "debian" ]; then
     _SLURM_CONFIG_LOCATION=/etc/slurm-llnl/
     mkdir -p /var/run/munge
     chown munge: /var/run/munge
+    mkdir -p /run/munge
+    chown munge: /run/munge
+    chmod +t /run/munge
 elif [ "$LINUX_DISTRIBUTION" = "redhat" ]; then
 
     if [ -z $CP_SLURM_PACKAGE_URL ]; then

--- a/workflows/pipe-common/shell/slurm_setup_worker
+++ b/workflows/pipe-common/shell/slurm_setup_worker
@@ -86,6 +86,9 @@ if [ "$LINUX_DISTRIBUTION" = "debian" ]; then
     apt install -y munge slurm-wlm
     mkdir -p /var/run/munge
     chown munge: /var/run/munge
+    mkdir -p /run/munge
+    chown munge: /run/munge
+    chmod +t /run/munge
     export _SLURM_CONFIG_LOCATION=/etc/slurm-llnl/
 elif [ "$LINUX_DISTRIBUTION" = "redhat" ]; then
     export _SLURM_CONFIG_LOCATION=/etc/slurm/


### PR DESCRIPTION
Resolves #2020.

The pull request adds missing sticky bit configuration to `/run/munge` during debian slurm installation.

Checked to be working on SLURM clusters of m5.large instances using `centos:7`, `ubuntu:18.04`, `debian:9` and `debian:10` tools with the following command.

```bash
srun -n4 -l /bin/hostname
```
