### PR TITLE
Fixing bug when git reader was registered with wrong url 

### DIFF
--- a/deploy/contents/install/app/configure-utils.sh
+++ b/deploy/contents/install/app/configure-utils.sh
@@ -959,7 +959,7 @@ function api_setup_base_preferences {
 }
 
 function api_register_git_reader {
-      api_set_preference "git.reader.service.host" "${CP_GITLAB_READER_INTERNAL_HOST:-http://cp-gitlab-reader.default.svc.cluster.local}:${CP_GITLAB_READER_INTERNAL_PORT:-35800}" "false"
+      api_set_preference "git.reader.service.host" "http://${CP_GITLAB_READER_INTERNAL_HOST:-cp-gitlab-reader.default.svc.cluster.local}:${CP_GITLAB_READER_INTERNAL_PORT:-35800}" "false"
 }
 
 function api_register_search {


### PR DESCRIPTION
This PR just changes git.reader.service.host property value resolving in `pipectl`