### PR TITLE
Issue #1832 Load privileges from contextual preferences

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -451,6 +451,9 @@ public class SystemPreferences {
     public static final ObjectPreference<List<DockerMount>> DOCKER_IN_DOCKER_MOUNTS = new ObjectPreference<>(
             "launch.dind.mounts", null, new TypeReference<List<DockerMount>>() {},
             LAUNCH_GROUP, isNullOrValidJson(new TypeReference<List<DockerMount>>() {}));
+    public static final StringPreference WINDOWS_USER_GROUPS = new StringPreference(
+        "launch.win.user.groups", "Users", LAUNCH_GROUP, PreferenceValidators.isNotBlank);
+
     /**
      * Specifies a comma-separated list of environment variables that should be inherited by DIND containers
      * from run container.

--- a/workflows/pipe-common/pipeline/api/api.py
+++ b/workflows/pipe-common/pipeline/api/api.py
@@ -217,6 +217,8 @@ class PipelineAPI:
     LOAD_PROFILE_CREDENTIALS = 'cloud/credentials/generate/%d'
     LOAD_PROFILES = 'cloud/credentials'
     LOAD_CURRENT_USER = 'whoami'
+    GET_TOOLS_FOR_RUNS = '/runs?runIds=%s'
+    CONTEXTUAL_PREFERENCE = '/contextual/preference'
     # Pipeline API default header
 
     RESPONSE_STATUS_OK = 'OK'
@@ -931,3 +933,29 @@ class PipelineAPI:
             return self.execute_request(url, method='get')
         except Exception as e:
             raise RuntimeError("Failed to load current user. Error message: {}".format(str(e.message)))
+
+    def load_tool_for_run(self, run_id):
+        try:
+            url = str(self.api_url) + self.GET_TOOLS_FOR_RUNS % str(run_id)
+            result = self.execute_request(url)
+            if result and 'tool' in result[0] and result[0]['tool']:
+                return result[0]['tool']
+            else:
+                raise RuntimeError("No tool details found for runId={} or such run doesn't exist!".format(str(run_id)))
+        except Exception as e:
+            raise RuntimeError("Failed to load a tool for run. Error message: {}".format(str(e.message)))
+
+    def load_contextual_preference(self, resource_level, resource_id, preferences):
+        try:
+            preference_request = {
+                'preferences': preferences,
+                'resource': {
+                    'level': resource_level,
+                    'resourceId': resource_id
+                }
+            }
+            url = str(self.api_url) + self.CONTEXTUAL_PREFERENCE
+            result = self.execute_request(url, method='post', data=json.dumps(preference_request))
+            return result['value']
+        except Exception as e:
+            raise RuntimeError("Failed to load contextual preferences. Error message: {}".format(str(e.message)))


### PR DESCRIPTION
This PR is related to issue #1832 

It changes the way user privileges retrieved for Windows-based runs: previously it was passed through run parameter `OWNER_GROUPS` with _Administrators_ as a default value. From now it will be processed from contextual preferences.

1.  New preference `launch.win.user.groups` is introduced (defaults to _Users_)
2.  `launch.py` is modified: groups are loaded using new preference