### PR TITLE
`pipe` CLI shall respect `-e` and `-f` combination

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -51,6 +51,10 @@ RETRIES_OPTION_DESCRIPTION = 'Number of retries to connect to specified pipeline
 TRACE_OPTION_DESCRIPTION = 'Enables error stack traces displaying'
 SYNC_FLAG_DESCRIPTION = 'Perform operation in a sync mode. When set - terminal will be blocked' \
                         ' until the expected status of the operation won\'t be returned'
+STORAGE_VERIFY_DESTINATION_OPTION_DESCRIPTION = 'Enables additional destination path check: if destination already ' \
+                                                'exists an error will be occurred. Cannot be used in combination' \
+                                                ' with --force (-f) option: if --force (-f) specified ' \
+                                                '--verify-destination (-vd) will be ignored.'
 
 
 def silent_print_api_version():
@@ -927,15 +931,18 @@ def storage_remove_item(path, yes, version, hard_delete, recursive, exclude, inc
 @click.option('-n', '--threads', type=int, required=False,
               help='The number of threads that will work to perform operation. Allowed for folders only. '
                    'Use to move a huge number of small files. Not supported for Windows OS. Progress bar is disabled')
+@click.option('-vd', '--verify-destination', is_flag=True, required=False,
+              help=STORAGE_VERIFY_DESTINATION_OPTION_DESCRIPTION)
 @click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token(quiet_flag_property_name='quiet')
 def storage_move_item(source, destination, recursive, force, exclude, include, quiet, skip_existing, tags, file_list,
-                      symlinks, threads):
+                      symlinks, threads, verify_destination):
     """ Moves a file or a folder from one datastorage to another one
     or between the local filesystem and a datastorage (in both directions)
     """
     DataStorageOperations.cp(source, destination, recursive, force, exclude, include, quiet, tags, file_list,
-                             symlinks, threads, clean=True, skip_existing=skip_existing)
+                             symlinks, threads, clean=True, skip_existing=skip_existing,
+                             verify_destination=verify_destination)
 
 
 @storage.command('cp')
@@ -966,15 +973,18 @@ def storage_move_item(source, destination, recursive, force, exclude, include, q
 @click.option('-n', '--threads', type=int, required=False,
               help='The number of threads that will work to perform operation. Allowed for folders only. '
                    'Use to copy a huge number of small files. Not supported for Windows OS. Progress bar is disabled')
+@click.option('-vd', '--verify-destination', is_flag=True, required=False,
+              help=STORAGE_VERIFY_DESTINATION_OPTION_DESCRIPTION)
 @click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @Config.validate_access_token(quiet_flag_property_name='quiet')
 def storage_copy_item(source, destination, recursive, force, exclude, include, quiet, skip_existing, tags, file_list,
-                      symlinks, threads):
+                      symlinks, threads, verify_destination):
     """ Copies files from one datastorage to another one
     or between the local filesystem and a datastorage (in both directions)
     """
     DataStorageOperations.cp(source, destination, recursive, force,
-                             exclude, include, quiet, tags, file_list, symlinks, threads, skip_existing=skip_existing)
+                             exclude, include, quiet, tags, file_list, symlinks, threads, skip_existing=skip_existing,
+                             verify_destination=verify_destination)
 
 
 @storage.command('du')

--- a/pipe-cli/src/utilities/datastorage_operations.py
+++ b/pipe-cli/src/utilities/datastorage_operations.py
@@ -73,9 +73,6 @@ class DataStorageOperations(object):
                 click.echo('-n (--threads) is not supported for Windows OS', err=True)
                 sys.exit(1)
             relative = os.path.basename(source) if source_wrapper.is_file() else None
-            can_be_skipped = skip_existing or include or exclude
-            if not force and not destination_wrapper.is_empty(relative=relative) and not can_be_skipped:
-                cls._force_required()
 
             # append slashes to path to correctly determine file/folder type
             if not source_wrapper.is_file():
@@ -150,6 +147,10 @@ class DataStorageOperations(object):
                 if not quiet:
                     click.echo("Skipping file {} since it matches exclude patterns [{}]."
                                .format(full_path, ",".join(exclude)))
+                continue
+
+            if force and not skip_existing:
+                filtered_items.append(item)
                 continue
 
             destination_key = manager.get_destination_key(destination_wrapper, relative_path)

--- a/pipe-cli/src/utilities/datastorage_operations.py
+++ b/pipe-cli/src/utilities/datastorage_operations.py
@@ -35,6 +35,7 @@ from src.utilities.storage.mount import Mount
 from src.utilities.storage.umount import Umount
 
 ALL_ERRORS = Exception
+FOLDER_MARKER = '.DS_Store'
 
 
 class DataStorageOperations(object):
@@ -128,6 +129,11 @@ class DataStorageOperations(object):
             full_path = item[1]
             relative_path = item[2]
             size = item[3]
+
+            if relative_path.endswith(FOLDER_MARKER):
+                filtered_items.append(item)
+                continue
+
             # check that we have corresponding permission for the file before take action
             if source_wrapper.is_local() and not os.access(full_path, permission_to_check):
                 continue

--- a/pipe-cli/src/utilities/datastorage_operations.py
+++ b/pipe-cli/src/utilities/datastorage_operations.py
@@ -128,7 +128,7 @@ class DataStorageOperations(object):
         for item in items:
             full_path = item[1]
             relative_path = item[2]
-            size = item[3]
+            source_size = item[3]
 
             if relative_path.endswith(FOLDER_MARKER):
                 filtered_items.append(item)
@@ -167,7 +167,6 @@ class DataStorageOperations(object):
                 continue
             if skip_existing:
                 source_key = manager.get_source_key(source_wrapper, full_path)
-                source_size = manager.get_source_size(source_wrapper, source_key, size)
                 need_to_overwrite = not manager.skip_existing(source_key, source_size, destination_key,
                                                               destination_size, quiet)
                 if need_to_overwrite and not force:

--- a/pipe-cli/src/utilities/storage/azure.py
+++ b/pipe-cli/src/utilities/storage/azure.py
@@ -214,9 +214,6 @@ class TransferBetweenAzureBucketsManager(AzureManager, AbstractTransferManager):
     def get_source_key(self, source_wrapper, source_path):
         return source_path
 
-    def get_source_size(self, source_wrapper, source_key, source_size):
-        return source_wrapper.get_list_manager().get_file_size(source_key)
-
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False,
                  quiet=False, size=None, tags=(), lock=None):
         full_path = path
@@ -274,9 +271,6 @@ class AzureDownloadManager(AzureManager, AbstractTransferManager):
     def get_source_key(self, source_wrapper, source_path):
         return source_path or source_wrapper.path
 
-    def get_source_size(self, source_wrapper, source_key, source_size):
-        return source_wrapper.get_list_manager().get_file_size(source_key)
-
     def transfer(self, source_wrapper, destination_wrapper, path=None,
                  relative_path=None, clean=False, quiet=False, size=None, tags=None, lock=None):
         source_key = self.get_source_key(source_wrapper, path)
@@ -303,9 +297,6 @@ class AzureUploadManager(AzureManager, AbstractTransferManager):
             return os.path.join(source_wrapper.path, source_path)
         else:
             return source_wrapper.path
-
-    def get_source_size(self, source_wrapper, source_key, source_size):
-        return StorageOperations.get_local_file_size(source_key)
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False, quiet=False,
                  size=None, tags=(), lock=None):
@@ -346,9 +337,6 @@ class TransferFromHttpOrFtpToAzureManager(AzureManager, AbstractTransferManager)
 
     def get_source_key(self, source_wrapper, source_path):
         return source_path or source_wrapper.path
-
-    def get_source_size(self, source_wrapper, source_key, source_size):
-        return source_size
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False, quiet=False,
                  size=None, tags=(), lock=None):

--- a/pipe-cli/src/utilities/storage/common.py
+++ b/pipe-cli/src/utilities/storage/common.py
@@ -231,10 +231,6 @@ class AbstractTransferManager:
         pass
 
     @abstractmethod
-    def get_source_size(self, source_wrapper, source_key, source_size):
-        pass
-
-    @abstractmethod
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False,
                  quiet=False, size=None, tags=(), lock=None):
         """

--- a/pipe-cli/src/utilities/storage/common.py
+++ b/pipe-cli/src/utilities/storage/common.py
@@ -219,6 +219,22 @@ class AbstractTransferManager:
     __metaclass__ = ABCMeta
 
     @abstractmethod
+    def get_destination_key(self, destination_wrapper, relative_path):
+        pass
+
+    @abstractmethod
+    def get_source_key(self, source_wrapper, source_path):
+        pass
+
+    @abstractmethod
+    def get_destination_size(self, destination_wrapper, destination_key):
+        pass
+
+    @abstractmethod
+    def get_source_size(self, source_wrapper, source_key, source_size):
+        pass
+
+    @abstractmethod
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False,
                  quiet=False, size=None, tags=(), skip_existing=False, lock=None):
         """
@@ -240,6 +256,14 @@ class AbstractTransferManager:
         :type lock: multiprocessing.Lock
         """
         pass
+
+    @staticmethod
+    def skip_existing(source_key, source_size, destination_key, destination_size, quiet):
+        if destination_size is not None and destination_size == source_size:
+            if not quiet:
+                click.echo('Skipping file %s since it exists in the destination %s' % (source_key, destination_key))
+            return True
+        return False
 
     @staticmethod
     def create_local_folder(destination_key, lock):

--- a/pipe-cli/src/utilities/storage/common.py
+++ b/pipe-cli/src/utilities/storage/common.py
@@ -236,7 +236,7 @@ class AbstractTransferManager:
 
     @abstractmethod
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False,
-                 quiet=False, size=None, tags=(), skip_existing=False, lock=None):
+                 quiet=False, size=None, tags=(), lock=None):
         """
         Transfers data from the source storage to the destination storage.
 
@@ -251,7 +251,6 @@ class AbstractTransferManager:
         :param size: Size of the transfer source object.
         :param tags: Additional tags that will be included to the transferring object.
         Tags CP_SOURCE and CP_OWNER will be included by default.
-        :param skip_existing: Skips transfer objects that already exist in the destination storage.
         :param lock: The lock object if multithreaded transfer is requested
         :type lock: multiprocessing.Lock
         """

--- a/pipe-cli/src/utilities/storage/gs.py
+++ b/pipe-cli/src/utilities/storage/gs.py
@@ -710,9 +710,6 @@ class TransferBetweenGsBucketsManager(GsManager, AbstractTransferManager):
     def get_source_key(self, source_wrapper, source_path):
         return source_path
 
-    def get_source_size(self, source_wrapper, source_key, source_size):
-        return source_wrapper.get_list_manager().get_file_size(source_key)
-
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False, quiet=False,
                  size=None, tags=(), lock=None):
         full_path = path
@@ -774,9 +771,6 @@ class GsDownloadManager(GsManager, AbstractTransferManager):
 
     def get_source_key(self, source_wrapper, source_path):
         return source_path or source_wrapper.path
-
-    def get_source_size(self, source_wrapper, source_key, source_size):
-        return source_wrapper.get_list_manager().get_file_size(source_key)
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False, quiet=False,
                  size=None, tags=(), lock=None):
@@ -856,9 +850,6 @@ class GsUploadManager(GsManager, AbstractTransferManager):
             return os.path.join(source_wrapper.path, source_path)
         else:
             return source_wrapper.path
-
-    def get_source_size(self, source_wrapper, source_key, source_size):
-        return StorageOperations.get_local_file_size(source_key)
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False, quiet=False,
                  size=None, tags=(), lock=None):
@@ -941,9 +932,6 @@ class TransferFromHttpOrFtpToGsManager(GsManager, AbstractTransferManager):
 
     def get_source_key(self, source_wrapper, source_path):
         return source_path or source_wrapper.path
-
-    def get_source_size(self, source_wrapper, source_key, source_size):
-        return source_size
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False, quiet=False,
                  size=None, tags=(), lock=None):

--- a/pipe-cli/src/utilities/storage/local.py
+++ b/pipe-cli/src/utilities/storage/local.py
@@ -45,9 +45,6 @@ class TransferFromHttpOrFtpToLocal(AbstractTransferManager):
     def get_source_key(self, source_wrapper, source_path):
         return source_path or source_wrapper.path
 
-    def get_source_size(self, source_wrapper, source_key, source_size):
-        return source_size
-
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False,
                  quiet=False, size=None, tags=(), lock=None):
         """

--- a/pipe-cli/src/utilities/storage/local.py
+++ b/pipe-cli/src/utilities/storage/local.py
@@ -49,7 +49,7 @@ class TransferFromHttpOrFtpToLocal(AbstractTransferManager):
         return source_size
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False,
-                 quiet=False, size=None, tags=(), skip_existing=False, lock=None):
+                 quiet=False, size=None, tags=(), lock=None):
         """
         Transfers data from remote resource (only ftp(s) or http(s) protocols supported) to local file system.
         :param source_wrapper: wrapper for ftp or http resource
@@ -62,7 +62,7 @@ class TransferFromHttpOrFtpToLocal(AbstractTransferManager):
         :param quiet: True if quite mode specified
         :param size: the size of the source file
         :param tags: not needed for this kind of transfer
-        :param skip_existing: indicates --skip_existing option
+
         :param lock: The lock object if multithreaded transfer is requested
         :type lock: multiprocessing.Lock
         """

--- a/pipe-cli/src/utilities/storage/s3.py
+++ b/pipe-cli/src/utilities/storage/s3.py
@@ -172,9 +172,6 @@ class DownloadManager(StorageItemManager, AbstractTransferManager):
     def get_destination_size(self, destination_wrapper, destination_key):
         return self.get_local_file_size(destination_key)
 
-    def get_source_size(self, source_wrapper, source_key, source_size):
-        return self.get_s3_file_size(source_wrapper.bucket.path, source_key)
-
     def transfer(self, source_wrapper, destination_wrapper, path=None,
                  relative_path=None, clean=False, quiet=False, size=None, tags=None, lock=None):
         source_key = self.get_source_key(source_wrapper, path)
@@ -205,9 +202,6 @@ class UploadManager(StorageItemManager, AbstractTransferManager):
             return os.path.join(source_wrapper.path, source_path)
         else:
             return source_wrapper.path
-
-    def get_source_size(self, source_wrapper, source_key, source_size):
-        return self.get_local_file_size(source_key)
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None,
                  clean=False, quiet=False, size=None, tags=(), lock=None):
@@ -251,9 +245,6 @@ class TransferFromHttpOrFtpToS3Manager(StorageItemManager, AbstractTransferManag
     def get_source_key(self, source_wrapper, source_path):
         return source_path or source_wrapper.path
 
-    def get_source_size(self, source_wrapper, source_key, source_size):
-        return source_size
-
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None,
                  clean=False, quiet=False, size=None, tags=(), lock=None):
         if clean:
@@ -296,9 +287,6 @@ class TransferBetweenBucketsManager(StorageItemManager, AbstractTransferManager)
 
     def get_source_key(self, source_wrapper, source_path):
         return source_path
-
-    def get_source_size(self, source_wrapper, source_key, source_size):
-        return self.get_s3_file_size(source_wrapper.bucket.path, source_key)
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False,
                  quiet=False, size=None, tags=(), lock=None):

--- a/pipe-cli/src/utilities/storage/s3.py
+++ b/pipe-cli/src/utilities/storage/s3.py
@@ -160,6 +160,21 @@ class DownloadManager(StorageItemManager, AbstractTransferManager):
     def __init__(self, session, bucket, region_name=None):
         super(DownloadManager, self).__init__(session, bucket=bucket, region_name=region_name)
 
+    def get_destination_key(self, destination_wrapper, relative_path):
+        if destination_wrapper.path.endswith(os.path.sep):
+            return os.path.join(destination_wrapper.path, relative_path)
+        else:
+            return destination_wrapper.path
+
+    def get_source_key(self, source_wrapper, path):
+        return path or source_wrapper.path
+
+    def get_destination_size(self, destination_wrapper, destination_key):
+        return self.get_local_file_size(destination_key)
+
+    def get_source_size(self, source_wrapper, source_key, source_size):
+        return self.get_s3_file_size(source_wrapper.bucket.path, source_key)
+
     def transfer(self, source_wrapper, destination_wrapper, path=None,
                  relative_path=None, clean=False, quiet=False, size=None, tags=None, skip_existing=False, lock=None):
         if path:
@@ -170,13 +185,6 @@ class DownloadManager(StorageItemManager, AbstractTransferManager):
             destination_key = os.path.join(destination_wrapper.path, relative_path)
         else:
             destination_key = destination_wrapper.path
-        if skip_existing:
-            remote_size = self.get_s3_file_size(source_wrapper.bucket.path, source_key)
-            local_size = self.get_local_file_size(destination_key)
-            if local_size is not None and remote_size == local_size:
-                if not quiet:
-                    click.echo('Skipping file %s since it exists in the destination %s' % (source_key, destination_key))
-                return
         self.create_local_folder(destination_key, lock)
         if StorageItemManager.show_progress(quiet, size, lock):
             self.bucket.download_file(source_key, destination_key, Callback=ProgressPercentage(relative_path, size))
@@ -190,6 +198,21 @@ class UploadManager(StorageItemManager, AbstractTransferManager):
 
     def __init__(self, session, bucket, region_name=None):
         super(UploadManager, self).__init__(session, bucket=bucket, region_name=region_name)
+
+    def get_destination_key(self, destination_wrapper, relative_path):
+        return S3BucketOperations.normalize_s3_path(destination_wrapper, relative_path)
+
+    def get_destination_size(self, destination_wrapper, destination_key):
+        return self.get_s3_file_size(destination_wrapper.bucket.path, destination_key)
+
+    def get_source_key(self, source_wrapper, source_path):
+        if source_path:
+            return os.path.join(source_wrapper.path, source_path)
+        else:
+            return source_wrapper.path
+
+    def get_source_size(self, source_wrapper, source_key, source_size):
+        return self.get_local_file_size(source_key)
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None,
                  clean=False, quiet=False, size=None, tags=(), skip_existing=False, lock=None):
@@ -230,6 +253,21 @@ class TransferFromHttpOrFtpToS3Manager(StorageItemManager, AbstractTransferManag
     def __init__(self, session, bucket, region_name=None):
         super(TransferFromHttpOrFtpToS3Manager, self).__init__(session, bucket=bucket, region_name=region_name)
 
+    def get_destination_key(self, destination_wrapper, relative_path):
+        if destination_wrapper.path.endswith(os.path.sep):
+            return os.path.join(destination_wrapper.path, relative_path)
+        else:
+            return destination_wrapper.path
+
+    def get_destination_size(self, destination_wrapper, destination_key):
+        return self.get_s3_file_size(destination_wrapper.bucket.path, destination_key)
+
+    def get_source_key(self, source_wrapper, source_path):
+        return source_path or source_wrapper.path
+
+    def get_source_size(self, source_wrapper, source_key, source_size):
+        return source_size
+
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None,
                  clean=False, quiet=False, size=None, tags=(), skip_existing=False, lock=None):
         if clean:
@@ -243,13 +281,6 @@ class TransferFromHttpOrFtpToS3Manager(StorageItemManager, AbstractTransferManag
             destination_key = os.path.join(destination_wrapper.path, relative_path)
         else:
             destination_key = destination_wrapper.path
-        if skip_existing:
-            remote_size = size
-            s3_size = self.get_s3_file_size(destination_wrapper.bucket.path, destination_key)
-            if s3_size is not None and remote_size == s3_size:
-                if not quiet:
-                    click.echo('Skipping file %s since it exists in the destination %s' % (source_key, destination_key))
-                return
         tags += ("CP_SOURCE={}".format(source_key),)
         tags += ("CP_OWNER={}".format(self._get_user()),)
         extra_args = {
@@ -275,6 +306,18 @@ class TransferBetweenBucketsManager(StorageItemManager, AbstractTransferManager)
         self.cross_region = cross_region
         super(TransferBetweenBucketsManager, self).__init__(session, bucket=bucket, region_name=region_name,
                                                             cross_region=cross_region)
+
+    def get_destination_key(self, destination_wrapper, relative_path):
+        return S3BucketOperations.normalize_s3_path(destination_wrapper, relative_path)
+
+    def get_destination_size(self, destination_wrapper, destination_key):
+        return self.get_s3_file_size(destination_wrapper.bucket.path, destination_key)
+
+    def get_source_key(self, source_wrapper, source_path):
+        return source_path
+
+    def get_source_size(self, source_wrapper, source_key, source_size):
+        return self.get_s3_file_size(source_wrapper.bucket.path, source_key)
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False,
                  quiet=False, size=None, tags=(), skip_existing=False, lock=None):


### PR DESCRIPTION
The current PR provides fixes introduces in issue #2039 

`-f` flag is not required for copy into existing folder. If the same file exists into source and destination (and shall be copied according to `-e`/`-i`/`-s` options) an error will be occurred in case `-f` is not specified. 

WARN:
The performance may decrease if `-f` flag is not specified since we shall check all destinations 