### PR TITLE
Add support for automated Windows kube service management

### DIFF
--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -209,6 +209,7 @@ public final class MessageConstants {
     public static final String ERROR_NODE_DOWN_TIMEOUT = "error.kube.node.down.timeout";
     public static final String LOG_WAS_TRUNCATED = "log.truncated";
     public static final String ERROR_KUBE_SERVICE_CREATE = "error.kube.service.create";
+    public static final String ERROR_KUBE_ENDPOINTS_CREATE = "error.kube.endpoints.create";
     public static final String ERROR_KUBE_POD_NOT_FOUND = "error.kube.pod.not.found";
 
     // Data storage messages

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -405,6 +405,8 @@ public class SystemPreferences {
             CLUSTER_GROUP, isGreaterThan(0L));
     public static final IntPreference CLUSTER_KUBE_MASTER_PORT =
             new IntPreference("cluster.kube.master.port", 6443, CLUSTER_GROUP, isGreaterThan(0));
+    public static final IntPreference CLUSTER_KUBE_WINDOWS_SERVICE_PORT =
+            new IntPreference("cluster.kube.windows.service.port", 22, CLUSTER_GROUP, isGreaterThan(0));
     public static final ObjectPreference<Set<String>> INSTANCE_COMPUTE_FAMILY_NAMES = new ObjectPreference<>(
             "instance.compute.family.names", null, new TypeReference<Set<String>>() {}, CLUSTER_GROUP,
             isNullOrValidJson(new TypeReference<Set<String>>() {}));

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -205,6 +205,7 @@ error.kube.service.port.undefined=Kubernetes service {0} port is not defined.
 error.kube.node.down.timeout=Node {0} was not removed in requested period.
 log.truncated=< ... Some of the preceding lines were skipped due to log size limit ...>
 error.kube.service.create=Failed to create kubernetes service ''{0}''
+error.kube.endpoints.create=Failed to create kubernetes endpoints ''{0}''
 error.kube.pod.not.found=Pod with requested id ''{0}'' not found 
 
 # Data sources messages


### PR DESCRIPTION
Relates to #1832.

The pull request brings support for Windows kube service management. From now on a corresponding service will be created for each Windows node which serves a single port. The serving port can be configured by `cluster.kube.windows.service.port` system preference which defaults to 22. Once a Windows node is terminated or scaled down the corresponding service is also shut down.