### PR TITLE
Issue #2044 Implement `dts` group for pipe CLI

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1764,27 +1764,27 @@ def preferences():
 
 
 @preferences.command(name='update')
-@click.argument('registry-id', required=True)
+@click.argument('registry-name-or-id', required=True, type=str)
 @click.option('--preference', '-p', multiple=True, type=str,
               help='String, describing preference''s key and value: key=value. Multiple options supported')
 @click.option('--json-out', '-jo', required=False, is_flag=True, help='Defines if output should be JSON-formatted')
-def update_dts_preferences(registry_id, preference, json_out):
+def update_dts_preferences(registry_name_or_id, preference, json_out):
     """
     Updates preferences for the given DTS
     """
-    DtsOperationsManager().upsert_preferences(registry_id, preference, json_out)
+    DtsOperationsManager().upsert_preferences(registry_name_or_id, preference, json_out)
 
 
 @preferences.command(name='delete')
-@click.argument('registry-id', required=True)
+@click.argument('registry-name-or-id', required=True, type=str)
 @click.option('--key', '-k', multiple=True, type=str,
               help="Key of the preference, that should be removed. Multiple options supported")
 @click.option('--json-out', '-jo', required=False, is_flag=True, help='Defines if output should be JSON-formatted')
-def delete_dts_preferences(registry_id, key, json_out):
+def delete_dts_preferences(registry_name_or_id, key, json_out):
     """
     Removes preferences for specified keys from the given DTS
     """
-    DtsOperationsManager().delete_preferences(registry_id, key, json_out)
+    DtsOperationsManager().delete_preferences(registry_name_or_id, key, json_out)
 
 
 # Used to run a PyInstaller "freezed" version

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1732,8 +1732,10 @@ def dts():
 @click.option('--url', '-u', required=True, type=str)
 @click.option('--name', '-n', required=True, type=str)
 @click.option('--schedulable', '-s', required=False, is_flag=True)
-@click.option('--prefix', required=False, type=str, multiple=True)
-@click.option('--preference', required=False, type=str, multiple=True)
+@click.option('--prefix', required=False, type=str, multiple=True,
+              help='String, describing URL prefix for a DTS. Multiple options supported')
+@click.option('--preference', required=False, type=str, multiple=True,
+              help='String, describing preference''s key and value: key=value. Multiple options supported')
 @click.option('--json-out', '-jo', required=False, is_flag=True, help='Defines if output should be JSON-formatted')
 @Config.validate_access_token
 def create_dts(url, name, schedulable, prefix, preference, json_out):
@@ -1764,7 +1766,7 @@ def preferences():
 @preferences.command(name='update')
 @click.argument('registry-id', required=True)
 @click.option('--preference', '-p', multiple=True, type=str,
-              help='String describing preference''s key and value: key=value')
+              help='String, describing preference''s key and value: key=value. Multiple options supported')
 @click.option('--json-out', '-jo', required=False, is_flag=True, help='Defines if output should be JSON-formatted')
 def update_dts_preferences(registry_id, preference, json_out):
     """
@@ -1775,7 +1777,8 @@ def update_dts_preferences(registry_id, preference, json_out):
 
 @preferences.command(name='delete')
 @click.argument('registry-id', required=True)
-@click.option('--key', '-k', multiple=True, type=str, help="Key of the preference intended to be removed")
+@click.option('--key', '-k', multiple=True, type=str,
+              help="Key of the preference, that should be removed. Multiple options supported")
 @click.option('--json-out', '-jo', required=False, is_flag=True, help='Defines if output should be JSON-formatted')
 def delete_dts_preferences(registry_id, key, json_out):
     """

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -42,6 +42,7 @@ from src.utilities.ssh_operations import run_ssh, run_scp, create_tunnel, kill_t
 from src.utilities.update_cli_version import UpdateCLIVersionManager
 from src.utilities.user_operations_manager import UserOperationsManager
 from src.utilities.user_token_operations import UserTokenOperations
+from src.utilities.dts_operations_manager import DtsOperationsManager
 from src.version import __version__
 
 MAX_INSTANCE_COUNT = 1000
@@ -1718,6 +1719,69 @@ def import_users(file_path, create_user, create_group, create_metadata):
     Registers a new users, roles and metadata specified in input file
     """
     UserOperationsManager().import_users(file_path, create_user, create_group, create_metadata)
+
+
+@cli.group()
+def dts():
+    """ Data-transfer-service commands
+    """
+    pass
+
+
+@dts.command(name='create')
+@click.option('--url', '-u', required=True, type=str)
+@click.option('--name', '-n', required=True, type=str)
+@click.option('--schedulable', '-s', required=False, is_flag=True)
+@click.option('--prefix', required=False, type=str, multiple=True)
+@click.option('--preference', required=False, type=str, multiple=True)
+@click.option('--json-out', '-jo', required=False, is_flag=True, help='Defines if output should be JSON-formatted')
+@Config.validate_access_token
+def create_dts(url, name, schedulable, prefix, preference, json_out):
+    """
+    Registers a DTS
+    """
+    DtsOperationsManager().create(url, name, schedulable, prefix, preference, json_out)
+
+
+@dts.command(name='list')
+@click.argument('registry-id', required=False, type=int)
+@click.option('--json-out', '-jo', required=False, is_flag=True, help='Defines if output should be JSON-formatted')
+@Config.validate_access_token
+def list_dts(registry_id, json_out):
+    """
+    Shows details of all DTS registries or the one for ID specified
+    """
+    DtsOperationsManager().list(registry_id, json_out)
+
+
+@dts.group()
+def preferences():
+    """ Commands for DTS preferences management
+    """
+    pass
+
+
+@preferences.command(name='update')
+@click.argument('registry-id', required=True)
+@click.option('--preference', '-p', multiple=True, type=str,
+              help='String describing preference''s key and value: key=value')
+@click.option('--json-out', '-jo', required=False, is_flag=True, help='Defines if output should be JSON-formatted')
+def update_dts_preferences(registry_id, preference, json_out):
+    """
+    Updates preferences for the given DTS
+    """
+    DtsOperationsManager().upsert_preferences(registry_id, preference, json_out)
+
+
+@preferences.command(name='delete')
+@click.argument('registry-id', required=True)
+@click.option('--key', '-k', multiple=True, type=str, help="Key of the preference intended to be removed")
+@click.option('--json-out', '-jo', required=False, is_flag=True, help='Defines if output should be JSON-formatted')
+def delete_dts_preferences(registry_id, key, json_out):
+    """
+    Removes preferences for specified keys from the given DTS
+    """
+    DtsOperationsManager().delete_preferences(registry_id, key, json_out)
 
 
 # Used to run a PyInstaller "freezed" version

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1746,14 +1746,14 @@ def create_dts(url, name, schedulable, prefix, preference, json_out):
 
 
 @dts.command(name='list')
-@click.argument('registry-id', required=False, type=int)
+@click.argument('registry-name-or-id', required=False, type=str)
 @click.option('--json-out', '-jo', required=False, is_flag=True, help='Defines if output should be JSON-formatted')
 @Config.validate_access_token
-def list_dts(registry_id, json_out):
+def list_dts(registry_name_or_id, json_out):
     """
     Shows details of all DTS registries or the one for ID specified
     """
-    DtsOperationsManager().list(registry_id, json_out)
+    DtsOperationsManager().list(registry_name_or_id, json_out)
 
 
 @dts.group()

--- a/pipe-cli/src/api/dts.py
+++ b/pipe-cli/src/api/dts.py
@@ -1,0 +1,74 @@
+# Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .base import API
+from ..model.dts_model import DtsModel
+
+import json
+
+
+class DTS(API):
+
+    def __init__(self):
+        super(DTS, self).__init__()
+
+    @classmethod
+    def create(cls, url, name, schedulable, prefixes, preferences):
+        api = cls.instance()
+        if not prefixes:
+            prefixes = []
+        if not preferences:
+            preferences = {}
+        dts = {
+            'url': url,
+            'name': name,
+            'schedulable': schedulable,
+            'prefixes': prefixes,
+            'preferences': preferences
+        }
+        response = api.call('/dts', json.dumps(dts), http_method='post')
+        return DtsModel().load(response['payload'])
+
+    @classmethod
+    def load_all(cls):
+        api = cls.instance()
+        response = api.call('/dts', None)
+        registries = []
+        for registry_json in response['payload']:
+            registries.append(DtsModel().load(registry_json))
+        return registries
+
+    @classmethod
+    def load(cls, registry_id):
+        api = cls.instance()
+        response = api.call('/dts/{}'.format(registry_id), None)
+        return DtsModel().load(response['payload'])
+
+    @classmethod
+    def update_preferences(cls, registry_id, preferences):
+        api = cls.instance()
+        data = {
+            'preferencesToUpdate': preferences
+        }
+        response = api.call('/dts/{}/preferences'.format(registry_id), json.dumps(data), http_method='put')
+        return DtsModel().load(response['payload'])
+
+    @classmethod
+    def delete_preferences(cls, registry_id, preferences_keys):
+        api = cls.instance()
+        data = {
+            'preferenceKeysToRemove': preferences_keys
+        }
+        response = api.call('/dts/{}/preferences'.format(registry_id), json.dumps(data), http_method='delete')
+        return DtsModel().load(response['payload'])

--- a/pipe-cli/src/model/dts_model.py
+++ b/pipe-cli/src/model/dts_model.py
@@ -1,0 +1,49 @@
+# Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from ..utilities import date_utilities
+
+
+class DtsModel(object):
+
+    def __init__(self):
+        self.id = None
+        self.name = None
+        self.url = None
+        self.created_date = None
+        self.schedulable = False
+        self.prefixes = []
+        self.preferences = {}
+
+    @classmethod
+    def load(cls, json):
+        dts = cls()
+        dts.id = json['id']
+        dts.name = json['name']
+        dts.url = json['url']
+        dts.created_date = date_utilities.server_date_representation(json['createdDate'])
+        dts.schedulable = json['schedulable']
+        if 'prefixes' in json:
+            dts.prefixes = json['prefixes']
+        if 'preferences' in json:
+            dts.preferences = json['preferences']
+        return dts
+
+
+class DtsEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, DtsModel):
+            return obj.__dict__
+        return json.JSONEncoder.default(self, obj)

--- a/pipe-cli/src/utilities/dts_operations_manager.py
+++ b/pipe-cli/src/utilities/dts_operations_manager.py
@@ -1,0 +1,99 @@
+# Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import click
+import json
+import sys
+from prettytable import prettytable
+
+from src.api.dts import DTS
+from src.model.dts_model import DtsEncoder
+
+
+class DtsOperationsManager:
+
+    _DTS_TABLE_HEADERS = ['Registry ID', 'Name', 'URL', 'Created date', 'Schedulable', 'Prefixes', 'Preferences']
+    _PREF_DELIMITER = "="
+
+    def __init__(self):
+        pass
+
+    def create(self, url, name, schedulable, prefixes, preferences, json_out):
+        registry = DTS.create(url, name, schedulable, prefixes, self._convert_preferences_list_to_dict(preferences))
+        self._print_registry(registry, json_out)
+
+    def list(self, registry_id, json_out):
+        if registry_id:
+            registry = DTS.load(registry_id)
+            self._print_registry(registry, json_out)
+        else:
+            registries = DTS.load_all()
+            if json_out:
+                self._print_dts_json(registries)
+            else:
+                self._print_registries_prettytable(registries)
+
+    def upsert_preferences(self, registry_id, preferences_list, json_out):
+        if not preferences_list:
+            click.echo('Preferences should not be empty!', err=True)
+            sys.exit(1)
+        updated_registry = DTS.update_preferences(registry_id, self._convert_preferences_list_to_dict(preferences_list))
+        self._print_registry(updated_registry, json_out)
+
+    def delete_preferences(self, registry_id, preferences_keys, json_out):
+        if not preferences_keys:
+            click.echo('Preferences keys to be removed should not be empty!', err=True)
+            sys.exit(1)
+        updated_registry = DTS.delete_preferences(registry_id, preferences_keys)
+        self._print_registry(updated_registry, json_out)
+
+    def _convert_preferences_list_to_dict(self, preferences_list):
+        preferences_dict = {}
+        for preference_entry in preferences_list:
+            preference_value_and_key = preference_entry.split(self._PREF_DELIMITER)
+            if len(preference_value_and_key) != 2:
+                click.echo('Error [%s]: preference should contain exactly one delimiter!' % preference_entry, err=True)
+                sys.exit(1)
+            else:
+                preferences_dict[preference_value_and_key[0]] = preference_value_and_key[1]
+        return preferences_dict
+
+    def _print_registry(self, registry, json_out):
+        if json_out:
+            self._print_dts_json(registry)
+        else:
+            self._print_registries_prettytable([registry])
+
+    def _print_dts_json(self, object):
+        click.echo(json.dumps(object, cls=DtsEncoder))
+
+    def _print_registries_prettytable(self, registries):
+        table = self._init_table()
+        for registry in registries:
+            table.add_row(self._convert_registry_to_prettytable_row(registry))
+        click.echo(table)
+
+    def _init_table(self):
+        table = prettytable.PrettyTable()
+        table.field_names = self._DTS_TABLE_HEADERS
+        table.align = "l"
+        table.header = True
+        return table
+
+    def _convert_registry_to_prettytable_row(self, registry):
+        flat_preferences = []
+        for preference in registry.preferences.items():
+            flat_preferences.append(preference[0] + self._PREF_DELIMITER + preference[1])
+        return [registry.id, registry.name, registry.url, registry.created_date, registry.schedulable,
+                '\n'.join(registry.prefixes), '\n'.join(flat_preferences)]


### PR DESCRIPTION
This PR is related to issue #2044 

It brings new `dts` group into pipe CLI, consist of the following commands:
- `create` - to register a new DTS
- `list` <registry_id> - to receive information about all of the registered DTS or a specific one

`preferences` subgroup with 2 commands:
- `update` - to update preferences for an existing DTS
- `delete` to remove certain preferences from DTS

All of the commands support output in a pretty format as a table (default behavior) or JSON-formatted (if `--json-out`/`-jo` flag is used)

Depends on PR #2046 
