### PR TITLE
GUI FIX: fix metadata autofill increment for numeric part of value

### DIFF
--- a/client/src/components/pipelines/browser/metadata-controls/auto-fill-entities.js
+++ b/client/src/components/pipelines/browser/metadata-controls/auto-fill-entities.js
@@ -251,18 +251,21 @@ function buildAutoFillAction (options) {
         value: undefined
       };
     }
+    let zeroPrefix;
     if (!Number.isNaN(Number(value))) {
+      zeroPrefix = /^0*/.exec(value);
       return {
         value,
         number: +value,
-        string: ''
+        string: zeroPrefix
       };
     }
     const exec = /^([^\d]*)([\d]+)$/.exec(`${value}`);
     if (exec && exec.length === 3) {
+      zeroPrefix = /^0*/.exec(exec[2]);
       return {
         value: exec[0],
-        string: exec[1],
+        string: zeroPrefix ? exec[1] + zeroPrefix : exec[1],
         number: +exec[2]
       };
     }


### PR DESCRIPTION
This PR implements fix for #2023  "Cells aren't filled exactly following to pattern if the value's numeric part starts with 0."