### PR TITLE
User permissions to edit own metadata

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/entity/EntityApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/entity/EntityApiService.java
@@ -37,7 +37,7 @@ public class EntityApiService {
     @Autowired
     private HierarchicalEntityManager hierarchicalEntityManager;
 
-    @PostAuthorize("hasRole('ADMIN') OR @grantPermissionManager.entityPermission(returnObject, 'READ')")
+    @PostAuthorize("hasRole('ADMIN') OR @metadataPermissionManager.entityPermission(returnObject, 'READ')")
     public AbstractSecuredEntity loadByNameOrId(AclClass entityClass, String identifier) {
         return entityManager.loadByNameOrId(entityClass, identifier);
     }

--- a/api/src/main/java/com/epam/pipeline/acl/folder/FolderApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/folder/FolderApiService.java
@@ -49,7 +49,7 @@ public class FolderApiService {
         return folderManager.update(folder);
     }
 
-    @PreAuthorize("hasRole('ADMIN') OR @grantPermissionManager.metadataPermission(#id, #aclClass, 'READ')")
+    @PreAuthorize("hasRole('ADMIN') OR @metadataPermissionManager.metadataPermission(#id, #aclClass, 'READ')")
     @AclTree
     public FolderWithMetadata getProject(final Long id, final AclClass aclClass) {
         return folderManager.getProject(id, aclClass);

--- a/api/src/main/java/com/epam/pipeline/acl/metadata/MetadataApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/metadata/MetadataApiService.java
@@ -39,61 +39,60 @@ public class MetadataApiService {
     @Autowired
     private MetadataManager metadataManager;
 
-    @PreAuthorize(AclExpressions.METADATA_OWNER)
+    @PreAuthorize(AclExpressions.METADATA_UPDATE)
     public MetadataEntry updateMetadataItemKey(MetadataVO metadataVO) {
         return metadataManager.updateMetadataItemKey(metadataVO);
     }
 
-    @PreAuthorize(AclExpressions.METADATA_OWNER)
+    @PreAuthorize(AclExpressions.METADATA_UPDATE)
     public MetadataEntry updateMetadataItemKeys(MetadataVO metadataVO) {
         return metadataManager.updateMetadataItemKeys(metadataVO);
     }
 
-    @PreAuthorize(AclExpressions.METADATA_OWNER)
+    @PreAuthorize(AclExpressions.METADATA_UPDATE)
     public MetadataEntry updateMetadataItem(MetadataVO metadataVO) {
         return metadataManager.updateMetadataItem(metadataVO);
     }
 
-    @PreAuthorize("hasRole('ADMIN') OR @grantPermissionManager.listMetadataPermissions(#entities, 'READ')")
+    @PreAuthorize("hasRole('ADMIN') OR @metadataPermissionManager.listMetadataPermission(#entities, 'READ')")
     public List<MetadataEntry> listMetadataItems(List<EntityVO> entities) {
         return metadataManager.listMetadataItems(entities);
     }
 
-    @PreAuthorize(AclExpressions.METADATA_ENTRY_OWNER)
+    @PreAuthorize(AclExpressions.METADATA_UPDATE_KEY)
     public MetadataEntry deleteMetadataItemKey(EntityVO entityVO, String key) {
         return metadataManager.deleteMetadataItemKey(entityVO, key);
     }
 
-    @PreAuthorize(AclExpressions.METADATA_ENTRY_OWNER)
+    @PreAuthorize(AclExpressions.METADATA_OWNER)
     public MetadataEntry deleteMetadataItem(EntityVO entityVO) {
         return metadataManager.deleteMetadataItem(entityVO);
     }
 
-    @PreAuthorize(AclExpressions.METADATA_OWNER)
+    @PreAuthorize(AclExpressions.METADATA_UPDATE)
     public MetadataEntry deleteMetadataItemKeys(MetadataVO metadataVO) {
         return metadataManager.deleteMetadataItemKeys(metadataVO);
     }
 
-    @PostAuthorize("hasRole('ADMIN') OR @grantPermissionManager.metadataPermission(returnObject, 'READ')")
+    @PostAuthorize("hasRole('ADMIN') OR @metadataPermissionManager.metadataPermission(returnObject, 'READ')")
     public MetadataEntry findMetadataEntityIdByName(String entityName, AclClass entityClass) {
         return metadataManager.findMetadataEntryByNameOrId(entityName, entityClass);
     }
 
-    @PreAuthorize(AclExpressions.METADATA_ENTRY_OWNER)
+    @PreAuthorize(AclExpressions.METADATA_OWNER)
     public MetadataEntry uploadMetadataFromFile(final EntityVO entityVO,
                                                 final MultipartFile file,
                                                 final boolean mergeWithExistingMetadata) {
         return metadataManager.uploadMetadataFromFile(entityVO, file, mergeWithExistingMetadata);
     }
 
-    @PostFilter("hasRole('ADMIN') OR " + "@grantPermissionManager.metadataPermission(" +
-            "filterObject.entity.entityId, filterObject.entity.entityClass, 'READ')")
+    @PostFilter(AclExpressions.METADATA_FILTER)
     public List<MetadataEntryWithIssuesCount> loadEntitiesMetadataFromFolder(Long parentFolderId) {
         return metadataManager.loadEntitiesMetadataFromFolder(parentFolderId);
     }
 
-    @PostFilter("hasRole('ADMIN') OR " + "@grantPermissionManager.metadataPermission(" +
-            "filterObject.entityId, filterObject.entityClass, 'READ')")
+    @PostFilter("hasRole('ADMIN') or " +
+            "@metadataPermissionManager.metadataPermission(filterObject.entityId, filterObject.entityClass, 'READ')")
     public List<EntityVO> searchMetadataByClassAndKeyValue(final AclClass entityClass, final String key,
                                                            final String value) {
         return metadataManager.searchMetadataByClassAndKeyValue(entityClass, key, value);

--- a/api/src/main/java/com/epam/pipeline/acl/security/AclPermissionApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/security/AclPermissionApiService.java
@@ -36,7 +36,7 @@ import org.springframework.stereotype.Service;
         return permissionManager.setPermissions(grantVO);
     }
 
-    @PreAuthorize("hasRole('ADMIN') or @grantPermissionManager.metadataPermission(#id, #aclClass, 'READ')")
+    @PreAuthorize("hasRole('ADMIN') or @metadataPermissionManager.metadataPermission(#id, #aclClass, 'READ')")
     public AclSecuredEntry getPermissions(Long id, AclClass aclClass) {
         return permissionManager.getPermissions(id, aclClass);
     }
@@ -56,7 +56,7 @@ import org.springframework.stereotype.Service;
         return permissionManager.changeOwner(id, aclClass, userName);
     }
 
-    @PreAuthorize("hasRole('ADMIN') or @grantPermissionManager.metadataPermission(#id, #aclClass, 'READ')")
+    @PreAuthorize("hasRole('ADMIN') or @metadataPermissionManager.metadataPermission(#id, #aclClass, 'READ')")
     public EntityPermissionVO loadEntityPermission(final Long id, final AclClass aclClass) {
         return permissionManager.loadEntityPermission(aclClass, id);
     }

--- a/api/src/main/java/com/epam/pipeline/manager/security/metadata/MetadataPermissionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/metadata/MetadataPermissionManager.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.security.metadata;
+
+import com.epam.pipeline.controller.vo.EntityVO;
+import com.epam.pipeline.controller.vo.MetadataVO;
+import com.epam.pipeline.entity.AbstractSecuredEntity;
+import com.epam.pipeline.entity.metadata.MetadataEntry;
+import com.epam.pipeline.entity.security.acl.AclClass;
+import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.manager.EntityManager;
+import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.epam.pipeline.manager.preference.SystemPreferences;
+import com.epam.pipeline.manager.security.CheckPermissionHelper;
+import com.epam.pipeline.manager.user.UserManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.collections4.MapUtils;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MetadataPermissionManager {
+
+    private final CheckPermissionHelper permissionHelper;
+    private final EntityManager entityManager;
+    private final UserManager userManager;
+    private final PreferenceManager preferenceManager;
+
+    /**
+     * - For basic ACL entities (FOLDER, PIPELINE, etc.) admins and
+     * users with corresponding permission granted are allowed
+     * - For ROLE entity only admins are allowed
+     * - For PIPELINE_USER admins are allowed, users are allowed to access own metadata
+     * @param entityId
+     * @param entityClass
+     * @param permission
+     * @return
+     */
+    public boolean metadataPermission(final Long entityId, final AclClass entityClass, final String permission) {
+        if (permissionHelper.isAdmin()) {
+            return true;
+        }
+        if (entityClass.isSupportsEntityManager()) {
+            final AbstractSecuredEntity securedEntity = entityManager.load(entityClass, entityId);
+            return permissionHelper.isAllowed(permission, securedEntity);
+        }
+        if (entityClass.equals(AclClass.ROLE)) {
+            return false;
+        }
+        if (entityClass.equals(AclClass.PIPELINE_USER)) {
+            return isSameUser(entityId);
+        }
+        return false;
+    }
+
+    public boolean metadataPermission(final MetadataEntry metadataEntry, final String permissionName) {
+        final EntityVO entity = metadataEntry.getEntity();
+        return metadataPermission(entity.getEntityId(), entity.getEntityClass(), permissionName);
+    }
+
+    public boolean entityPermission(AbstractSecuredEntity entity, String permissionName) {
+        return entity == null || metadataPermission(entity.getId(), entity.getAclClass(), permissionName);
+    }
+
+    /**
+     * - For basic ACL entities (FOLDER, PIPELINE, etc.) owner and admins are allowed to modify metadata
+     * - For ROLE entity only admins are allowed to modify metadata
+     * - For PIPELINE_USER admins have full access to metadata, users are allowed to modify own metadata,
+     * except for restricted keys defined by {@code SystemPreferences.MISC_METADATA_SENSITIVE_KEYS}
+     * @param metadataVO
+     * @return
+     */
+    public boolean editMetadataPermission(final MetadataVO metadataVO) {
+        return metadataPermission(metadataVO, true);
+    }
+
+    public boolean editMetadataPermission(final EntityVO entityVO, final String key) {
+        final MetadataVO metadataVO = new MetadataVO();
+        metadataVO.setData(Collections.singletonMap(key, null));
+        metadataVO.setEntity(entityVO);
+        return editMetadataPermission(metadataVO);
+    }
+
+    public boolean metadataOwnerPermission(final EntityVO entityVO) {
+        final MetadataVO metadataVO = new MetadataVO();
+        metadataVO.setEntity(entityVO);
+        return metadataPermission(metadataVO, false);
+    }
+
+    public boolean listMetadataPermission(final List<EntityVO> entities, final String permission) {
+        if (permissionHelper.isAdmin()) {
+            return true;
+        }
+        return ListUtils.emptyIfNull(entities).stream()
+                .allMatch(entity -> metadataPermission(entity.getEntityId(), entity.getEntityClass(), permission));
+    }
+
+    private boolean metadataPermission(final MetadataVO metadataVO, final boolean allowUser) {
+        if (permissionHelper.isAdmin()) {
+            return true;
+        }
+        final EntityVO entity = metadataVO.getEntity();
+        final AclClass entityClass = entity.getEntityClass();
+        if (entityClass.isSupportsEntityManager()) {
+            return permissionHelper.isOwner(
+                    entityManager.load(entityClass, entity.getEntityId()));
+        }
+        if (entityClass.equals(AclClass.ROLE)) {
+            return false;
+        }
+        if (allowUser && entityClass.equals(AclClass.PIPELINE_USER)) {
+            return isMetadataEditAllowedForUser(metadataVO);
+        }
+        return false;
+    }
+
+    private boolean isMetadataEditAllowedForUser(final MetadataVO metadataVO) {
+        final List<String> sensitiveKeys = preferenceManager.getPreference(
+                SystemPreferences.MISC_METADATA_SENSITIVE_KEYS);
+        if (MapUtils.isNotEmpty(metadataVO.getData()) && ListUtils.emptyIfNull(sensitiveKeys).stream()
+                .anyMatch(key -> metadataVO.getData().containsKey(key))) {
+            return false;
+        }
+        return isSameUser(metadataVO.getEntity().getEntityId());
+    }
+
+    private boolean isSameUser(final Long entityId) {
+        final PipelineUser user = userManager.loadUserById(entityId);
+        return permissionHelper.isOwner(user.getUserName());
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
+++ b/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
@@ -87,12 +87,18 @@ public final class AclExpressions {
         "hasRole('ADMIN') OR (@runPermissionManager.runPermission(#runId, 'EXECUTE')"
             + " AND hasPermission(#registryId, 'com.epam.pipeline.entity.pipeline.DockerRegistry', 'WRITE'))";
 
-    public static final String METADATA_OWNER =
-            "hasRole('ADMIN') OR @grantPermissionManager.hasMetadataOwnerPermission(#metadataVO.entity.entityId, "
-                    + "#metadataVO.entity.entityClass)";
+    public static final String METADATA_OWNER = ADMIN_ONLY + OR +
+            "@metadataPermissionManager.metadataOwnerPermission(#entityVO)";
 
-    public static final String METADATA_ENTRY_OWNER = "hasRole('ADMIN') OR "
-            + "@grantPermissionManager.hasMetadataOwnerPermission(#entityVO.entityId, #entityVO.entityClass)";
+    public static final String METADATA_UPDATE = ADMIN_ONLY + OR +
+            "@metadataPermissionManager.editMetadataPermission(#metadataVO)";
+
+    public static final String METADATA_UPDATE_KEY = ADMIN_ONLY + OR +
+            "@metadataPermissionManager.editMetadataPermission(#entityVO, #key)";
+
+    public static final String METADATA_FILTER = ADMIN_ONLY + OR +
+            "@metadataPermissionManager.metadataPermission(" +
+            "filterObject.entity.entityId, filterObject.entity.entityClass, 'READ')";
 
     public static final String ACL_ENTITY_OWNER =
             "hasRole('ADMIN') or @grantPermissionManager.ownerPermission(#id, #aclClass)";
@@ -107,9 +113,9 @@ public final class AclExpressions {
             "(@grantPermissionManager.issuePermission(#issueId, 'READ'))";
 
     public static final String ENTITY_READ = ADMIN_ONLY + OR +
-            "(@grantPermissionManager.metadataPermission(#entityVO.entityId, #entityVO.entityClass, 'READ'))";
+            "(@metadataPermissionManager.metadataPermission(#entityVO.entityId, #entityVO.entityClass, 'READ'))";
 
-    public static final String ISSUE_CREATE = ADMIN_ONLY + " OR (@grantPermissionManager.metadataPermission(" +
+    public static final String ISSUE_CREATE = ADMIN_ONLY + " OR (@metadataPermissionManager.metadataPermission(" +
             "#issueVO.entity.entityId, #issueVO.entity.entityClass, 'READ'))";
 
     public static final String ADMIN_OR_GENERAL_USER = "hasRole('ADMIN') OR hasRole('ROLE_USER')";

--- a/api/src/test/java/com/epam/pipeline/acl/security/AclPermissionApiServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/acl/security/AclPermissionApiServiceTest.java
@@ -252,7 +252,7 @@ public class AclPermissionApiServiceTest extends AbstractAclTest {
         doReturn(s3bucket).when(entityManager).load(AclClass.DATA_STORAGE, ID);
         doReturn(entityPermissionVO).when(spyPermissionManager)
                 .loadEntityPermission(AclClass.DATA_STORAGE, ID);
-        mockUser(SIMPLE_USER);
+        mockAuthUser(SIMPLE_USER);
 
         assertThat(aclPermissionApiService.loadEntityPermission(ID, AclClass.DATA_STORAGE))
                 .isEqualTo(entityPermissionVO);
@@ -263,7 +263,7 @@ public class AclPermissionApiServiceTest extends AbstractAclTest {
     @Ignore("with changes from issue #1936 this test shall be updated")
     public void shouldDenyLoadEntityPermissionForNotOwner() {
         doReturn(s3bucket).when(entityManager).load(AclClass.DATA_STORAGE, ID);
-        mockUser(ANOTHER_SIMPLE_USER);
+        mockAuthUser(ANOTHER_SIMPLE_USER);
 
         assertThrows(AccessDeniedException.class,
             () -> aclPermissionApiService.loadEntityPermission(ID, AclClass.DATA_STORAGE));


### PR DESCRIPTION
Related to #2067 

This PR changes permissions check for user metadata editing. User is allowed to edit his/hers own metadata except for the sensitive keys defined in `misc.metadata.sensitive.keys` system preference.