### PR TITLE
Implements fsync operation in pipe fuse

### DIFF
--- a/pipe-cli/mount/pipefuse/pipefs.py
+++ b/pipe-cli/mount/pipefuse/pipefs.py
@@ -257,8 +257,10 @@ class PipeFS(Operations):
     def release(self, path, fh):
         self.container.release(fh)
 
+    @syncronized
+    @errorlogged
     def fsync(self, path, fdatasync, fh):
-        pass
+        self.client.flush(fh, path)
 
     class FallocateFlag:
         # See http://man7.org/linux/man-pages/man2/fallocate.2.html.


### PR DESCRIPTION
Resolves issue #2070.

The pull request implements fsync operation in pipe fuse just the same way flush operation is already implemented.

In terms of libfuse [fsync and flush](https://libfuse.github.io/doxygen/structfuse__operations.html#ad4ec9c309072a92dd82ddb20efa4ab14) implementations are not equal. At the same time in case of network filesystems such as pipe fuse or [s3fs](https://github.com/s3fs-fuse/s3fs-fuse/blob/881025cc9e099a2824085133c6285d6793c09c92/src/s3fs.cpp#L2392-L2450) fsync operation still can be implemented almost exactly as flush to support basic use cases.
