### PR TITLE
Support heartbeat in data transfer service

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/dts/DtsRegistryApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/dts/DtsRegistryApiService.java
@@ -55,6 +55,11 @@ public class DtsRegistryApiService {
     }
 
     @PreAuthorize(DTS_REGISTRY_PERMISSIONS)
+    public DtsRegistry updateHeartbeat(final String registryId) {
+        return dtsRegistryManager.updateHeartbeat(registryId);
+    }
+
+    @PreAuthorize(DTS_REGISTRY_PERMISSIONS)
     public DtsRegistry delete(Long registryId) {
         return dtsRegistryManager.delete(registryId);
     }

--- a/api/src/main/java/com/epam/pipeline/acl/dts/DtsRegistryApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/dts/DtsRegistryApiService.java
@@ -50,7 +50,7 @@ public class DtsRegistryApiService {
     }
 
     @PreAuthorize(DTS_REGISTRY_PERMISSIONS)
-    public DtsRegistry update(Long registryId, DtsRegistryVO dtsRegistryVO) {
+    public DtsRegistry update(final String registryId, final DtsRegistryVO dtsRegistryVO) {
         return dtsRegistryManager.update(registryId, dtsRegistryVO);
     }
 
@@ -60,7 +60,7 @@ public class DtsRegistryApiService {
     }
 
     @PreAuthorize(DTS_REGISTRY_PERMISSIONS)
-    public DtsRegistry delete(Long registryId) {
+    public DtsRegistry delete(final String registryId) {
         return dtsRegistryManager.delete(registryId);
     }
 

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -462,6 +462,7 @@ public final class MessageConstants {
     public static final String ERROR_DTS_PREFERENCES_DOESNT_EXIST = "error.dts.preferences.not.exist";
     public static final String ERROR_DTS_PREFERENCES_UPDATE_EMPTY = "error.dts.preferences.update.empty";
     public static final String ERROR_DTS_PREFERENCES_DELETE_EMPTY = "error.dts.preferences.delete.empty";
+    public static final String INFO_DTS_MONITORING_STATUS = "info.dts.monitoring.status";
 
     //Cloud region
     public static final String ERROR_REGION_NOT_FOUND = "error.region.not.found";

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -458,11 +458,14 @@ public final class MessageConstants {
     public static final String ERROR_DTS_REGISTRY_ID_IS_EMPTY = "error.dts.registry.id.is.empty";
     public static final String ERROR_DTS_REGISTRY_NAME_IS_EMPTY = "error.dts.registry.name.is.empty";
     public static final String ERROR_DTS_REGISTRY_NAME_CONSIST_OF_NUMBERS = "error.dts.registry.name.numbers.only";
+    public static final String ERROR_DTS_REGISTRY_NAME_ALREADY_EXISTS = "error.dts.registry.name.already.exists";
     public static final String ERROR_DTS_NOT_SCHEDULABLE = "error.dts.registry.not.schedulable";
     public static final String ERROR_DTS_PREFERENCES_DOESNT_EXIST = "error.dts.preferences.not.exist";
     public static final String ERROR_DTS_PREFERENCES_UPDATE_EMPTY = "error.dts.preferences.update.empty";
     public static final String ERROR_DTS_PREFERENCES_DELETE_EMPTY = "error.dts.preferences.delete.empty";
     public static final String INFO_DTS_MONITORING_STATUS = "info.dts.monitoring.status";
+    public static final String INFO_DTS_MONITORING_STATUS_MISSING_HEARTBEAT =
+            "info.dts.monitoring.status.missing.heartbeat";
 
     //Cloud region
     public static final String ERROR_REGION_NOT_FOUND = "error.region.not.found";

--- a/api/src/main/java/com/epam/pipeline/controller/dts/DtsRegistryController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/dts/DtsRegistryController.java
@@ -98,7 +98,7 @@ public class DtsRegistryController extends AbstractRestController {
     @ApiResponses(
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
             })
-    public Result<DtsRegistry> updateDtsRegistry(@PathVariable(value = REGISTRY_ID) Long registryId,
+    public Result<DtsRegistry> updateDtsRegistry(@PathVariable(value = REGISTRY_ID) String registryId,
                                                  @RequestBody DtsRegistryVO dtsRegistryVO) {
         return Result.success(dtsRegistryApiService.update(registryId, dtsRegistryVO));
     }
@@ -125,7 +125,7 @@ public class DtsRegistryController extends AbstractRestController {
     @ApiResponses(
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
             })
-    public Result<DtsRegistry> updateDtsRegistry(@PathVariable(value = REGISTRY_ID) Long registryId) {
+    public Result<DtsRegistry> updateDtsRegistry(@PathVariable(value = REGISTRY_ID) String registryId) {
         return Result.success(dtsRegistryApiService.delete(registryId));
     }
 

--- a/api/src/main/java/com/epam/pipeline/controller/dts/DtsRegistryController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/dts/DtsRegistryController.java
@@ -103,6 +103,19 @@ public class DtsRegistryController extends AbstractRestController {
         return Result.success(dtsRegistryApiService.update(registryId, dtsRegistryVO));
     }
 
+    @PutMapping(value = "/{registryId}/heartbeat")
+    @ResponseBody
+    @ApiOperation(
+            value = "Updates Data Transfer Service registry heartbeat.",
+            notes = "Updates Data Transfer Service registry heartbeat.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public Result<DtsRegistry> updateDtsRegistryHeartbeat(final @PathVariable(value = REGISTRY_ID) String registryId) {
+        return Result.success(dtsRegistryApiService.updateHeartbeat(registryId));
+    }
+
     @DeleteMapping(value = "/{registryId}")
     @ResponseBody
     @ApiOperation(

--- a/api/src/main/java/com/epam/pipeline/dao/dts/DtsRegistryDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/dts/DtsRegistryDao.java
@@ -19,9 +19,11 @@ package com.epam.pipeline.dao.dts;
 import com.epam.pipeline.config.JsonMapper;
 import com.epam.pipeline.dao.DaoHelper;
 import com.epam.pipeline.entity.dts.DtsRegistry;
+import com.epam.pipeline.entity.dts.DtsStatus;
 import com.epam.pipeline.entity.utils.DateUtils;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,6 +36,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Array;
 import java.sql.Connection;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -61,9 +65,11 @@ public class DtsRegistryDao extends NamedParameterJdbcDaoSupport {
     private String deleteDtsRegistryQuery;
     private String upsertDtsRegistryPreferencesQuery;
     private String deleteDtsRegistryPreferencesQuery;
+    private String updateDtsRegistryHeartbeatQuery;
+    private String updateDtsRegistryStatusQuery;
 
     public List<DtsRegistry> loadAll() {
-        return getJdbcTemplate().query(loadAllDtsRegistriesQuery, DtsRegistryParameters.getRowMapper());
+        return ListUtils.emptyIfNull(getJdbcTemplate().query(loadAllDtsRegistriesQuery, DtsRegistryParameters.getRowMapper()));
     }
 
     public Optional<DtsRegistry> loadById(Long registryId) {
@@ -111,7 +117,21 @@ public class DtsRegistryDao extends NamedParameterJdbcDaoSupport {
     public void deletePreferences(final Long registryId, final List<String> preferencesKeys) {
         getNamedParameterJdbcTemplate()
             .update(buildDeletePreferencesQuery(preferencesKeys),
-                    DtsRegistryParameters.getRemovingPreferencesParameters(registryId));
+                    DtsRegistryParameters.getParameters(registryId));
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void updateHeartbeat(final Long registryId, final LocalDateTime heartbeat, final DtsStatus status) {
+        getNamedParameterJdbcTemplate()
+                .update(updateDtsRegistryHeartbeatQuery,
+                        DtsRegistryParameters.getHeartbeatParameters(registryId, heartbeat, status));
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void updateStatus(final Long registryId, final DtsStatus status) {
+        getNamedParameterJdbcTemplate()
+                .update(updateDtsRegistryStatusQuery,
+                        DtsRegistryParameters.getStatusParameters(registryId, status));
     }
 
     @Required
@@ -159,12 +179,24 @@ public class DtsRegistryDao extends NamedParameterJdbcDaoSupport {
         this.deleteDtsRegistryPreferencesQuery = deleteDtsRegistryPreferencesQuery;
     }
 
+    @Required
+    public void setUpdateDtsRegistryHeartbeatQuery(final String updateDtsRegistryHeartbeatQuery) {
+        this.updateDtsRegistryHeartbeatQuery = updateDtsRegistryHeartbeatQuery;
+    }
+
+    @Required
+    public void setUpdateDtsRegistryStatusQuery(final String updateDtsRegistryStatusQuery) {
+        this.updateDtsRegistryStatusQuery = updateDtsRegistryStatusQuery;
+    }
+
     enum DtsRegistryParameters {
         ID,
         NAME,
         SCHEDULABLE,
         CREATED_DATE,
         URL,
+        HEARTBEAT,
+        STATUS,
         PREFIXES,
         PREFERENCES,
         PREFERENCES_KEYS;
@@ -192,17 +224,25 @@ public class DtsRegistryDao extends NamedParameterJdbcDaoSupport {
 
         static MapSqlParameterSource getPreferencesParameters(final Long dtsRegistryId,
                                                               final Map<String, String> preferences) {
-            final MapSqlParameterSource params = new MapSqlParameterSource();
-            params.addValue(ID.name(), dtsRegistryId);
-            params.addValue(PREFERENCES.name(),
+            return getParameters(dtsRegistryId)
+                    .addValue(PREFERENCES.name(),
                             JsonMapper.convertDataToJsonStringForQuery(MapUtils.emptyIfNull(preferences)));
-            return params;
         }
 
-        static MapSqlParameterSource getRemovingPreferencesParameters(final Long registryId) {
-            final MapSqlParameterSource params = new MapSqlParameterSource();
-            params.addValue(ID.name(), registryId);
-            return params;
+        public static MapSqlParameterSource getHeartbeatParameters(final Long registryId, final LocalDateTime heartbeat,
+                                                                   final DtsStatus status) {
+            return getStatusParameters(registryId, status)
+                    .addValue(HEARTBEAT.name(), Timestamp.valueOf(heartbeat));
+        }
+
+        public static MapSqlParameterSource getStatusParameters(final Long registryId, final DtsStatus status) {
+            return getParameters(registryId)
+                    .addValue(STATUS.name(), status.getId());
+        }
+
+        static MapSqlParameterSource getParameters(final Long registryId) {
+            return new MapSqlParameterSource()
+                    .addValue(ID.name(), registryId);
         }
 
         static RowMapper<DtsRegistry> getRowMapper() {
@@ -213,6 +253,8 @@ public class DtsRegistryDao extends NamedParameterJdbcDaoSupport {
                 dtsRegistry.setName(rs.getString(NAME.name()));
                 dtsRegistry.setCreatedDate(new Date(rs.getTimestamp(CREATED_DATE.name()).getTime()));
                 dtsRegistry.setSchedulable(rs.getBoolean(SCHEDULABLE.name()));
+                dtsRegistry.setHeartbeat(rs.getTimestamp(HEARTBEAT.name()).toLocalDateTime());
+                dtsRegistry.setStatus(DtsStatus.findById(rs.getLong(STATUS.name())).orElse(DtsStatus.OFFLINE));
                 Array prefixesSqlArray = rs.getArray(PREFIXES.name());
                 List<String> prefixesList = Arrays.asList((String[]) prefixesSqlArray.getArray());
                 dtsRegistry.setPrefixes(prefixesList);

--- a/api/src/main/java/com/epam/pipeline/dao/dts/DtsRegistryDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/dts/DtsRegistryDao.java
@@ -216,6 +216,7 @@ public class DtsRegistryDao extends NamedParameterJdbcDaoSupport {
             Array prefixesArray = mapListToSqlArray(dtsRegistry.getPrefixes(), connection);
             params.addValue(PREFIXES.name(), prefixesArray);
             if (extended) {
+                params.addValue(STATUS.name(), dtsRegistry.getStatus().getId());
                 params.addValue(PREFERENCES.name(), JsonMapper
                     .convertDataToJsonStringForQuery(MapUtils.emptyIfNull(dtsRegistry.getPreferences())));
             }
@@ -253,7 +254,9 @@ public class DtsRegistryDao extends NamedParameterJdbcDaoSupport {
                 dtsRegistry.setName(rs.getString(NAME.name()));
                 dtsRegistry.setCreatedDate(new Date(rs.getTimestamp(CREATED_DATE.name()).getTime()));
                 dtsRegistry.setSchedulable(rs.getBoolean(SCHEDULABLE.name()));
-                dtsRegistry.setHeartbeat(rs.getTimestamp(HEARTBEAT.name()).toLocalDateTime());
+                Optional.ofNullable(rs.getTimestamp(HEARTBEAT.name()))
+                        .map(Timestamp::toLocalDateTime)
+                        .ifPresent(dtsRegistry::setHeartbeat);
                 dtsRegistry.setStatus(DtsStatus.findById(rs.getLong(STATUS.name())).orElse(DtsStatus.OFFLINE));
                 Array prefixesSqlArray = rs.getArray(PREFIXES.name());
                 List<String> prefixesList = Arrays.asList((String[]) prefixesSqlArray.getArray());

--- a/api/src/main/java/com/epam/pipeline/dao/dts/DtsRegistryDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/dts/DtsRegistryDao.java
@@ -69,7 +69,8 @@ public class DtsRegistryDao extends NamedParameterJdbcDaoSupport {
     private String updateDtsRegistryStatusQuery;
 
     public List<DtsRegistry> loadAll() {
-        return ListUtils.emptyIfNull(getJdbcTemplate().query(loadAllDtsRegistriesQuery, DtsRegistryParameters.getRowMapper()));
+        return ListUtils.emptyIfNull(getJdbcTemplate().query(loadAllDtsRegistriesQuery,
+                DtsRegistryParameters.getRowMapper()));
     }
 
     public Optional<DtsRegistry> loadById(Long registryId) {

--- a/api/src/main/java/com/epam/pipeline/entity/dts/DtsRegistry.java
+++ b/api/src/main/java/com/epam/pipeline/entity/dts/DtsRegistry.java
@@ -23,6 +23,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -36,4 +37,6 @@ public class DtsRegistry extends BaseEntity {
     private List<String> prefixes;
     private Map<String, String> preferences;
     private boolean schedulable = false;
+    private LocalDateTime heartbeat;
+    private DtsStatus status;
 }

--- a/api/src/main/java/com/epam/pipeline/entity/dts/DtsStatus.java
+++ b/api/src/main/java/com/epam/pipeline/entity/dts/DtsStatus.java
@@ -1,0 +1,22 @@
+package com.epam.pipeline.entity.dts;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+@Getter
+@RequiredArgsConstructor
+public enum DtsStatus {
+    OFFLINE(0),
+    ONLINE(1);
+
+    private final long id;
+
+    public static Optional<DtsStatus> findById(Long id) {
+        return Arrays.stream(values())
+                .filter(value -> value.id == id)
+                .findFirst();
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/dts/DtsMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/dts/DtsMonitoringManager.java
@@ -1,0 +1,59 @@
+package com.epam.pipeline.manager.dts;
+
+import com.epam.pipeline.common.MessageConstants;
+import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.entity.dts.DtsRegistry;
+import com.epam.pipeline.entity.dts.DtsStatus;
+import com.epam.pipeline.entity.utils.DateUtils;
+import com.epam.pipeline.manager.preference.AbstractSystemPreference;
+import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.epam.pipeline.manager.preference.SystemPreferences;
+import com.epam.pipeline.manager.scheduling.AbstractSchedulingManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DtsMonitoringManager extends AbstractSchedulingManager {
+
+    private static final Duration FALLBACK_OFFLINE_TIMEOUT = Duration.ofMinutes(5);
+
+    private final DtsRegistryManager registryManager;
+    private final PreferenceManager preferenceManager;
+    private final MessageHelper messageHelper;
+
+    @PostConstruct
+    public void init() {
+        scheduleFixedDelaySecured(this::monitor, SystemPreferences.DTS_MONITORING_PERIOD_SECONDS,
+                TimeUnit.SECONDS, "DTS Monitoring");
+    }
+
+    private void monitor() {
+        final LocalDateTime offlineThreshold = DateUtils.nowUTC().minus(getOfflineTimeout());
+        for (final DtsRegistry registry : registryManager.loadAll()) {
+            final LocalDateTime heartbeat = Optional.ofNullable(registry.getHeartbeat()).orElse(LocalDateTime.MIN);
+            if (heartbeat.isBefore(offlineThreshold)) {
+                registry.setStatus(DtsStatus.OFFLINE);
+                registryManager.updateStatus(registry.getId(), registry.getStatus());
+            }
+            log.debug(messageHelper.getMessage(MessageConstants.INFO_DTS_MONITORING_STATUS,
+                    registry.getName(), registry.getId(), registry.getStatus(), registry.getHeartbeat()));
+        }
+    }
+
+    private Duration getOfflineTimeout() {
+        return Optional.of(SystemPreferences.DTS_OFFLINE_TIMEOUT_SECONDS)
+                .map(AbstractSystemPreference::getKey)
+                .map(preferenceManager::getIntPreference)
+                .map(Duration::ofSeconds)
+                .orElse(FALLBACK_OFFLINE_TIMEOUT);
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/dts/DtsMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/dts/DtsMonitoringManager.java
@@ -36,7 +36,7 @@ public class DtsMonitoringManager extends AbstractSchedulingManager {
                 TimeUnit.SECONDS, "Data Transfer Service Monitoring");
     }
 
-    private void monitor() {
+    public void monitor() {
         final LocalDateTime offlineThreshold = DateUtils.nowUTC().minus(getOfflineTimeout());
         for (final DtsRegistry registry : registryManager.loadAll()) {
             final LocalDateTime heartbeat = Optional.ofNullable(registry.getHeartbeat()).orElse(LocalDateTime.MIN);

--- a/api/src/main/java/com/epam/pipeline/manager/dts/DtsMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/dts/DtsMonitoringManager.java
@@ -33,7 +33,7 @@ public class DtsMonitoringManager extends AbstractSchedulingManager {
     @PostConstruct
     public void init() {
         scheduleFixedDelaySecured(this::monitor, SystemPreferences.DTS_MONITORING_PERIOD_SECONDS,
-                TimeUnit.SECONDS, "DTS Monitoring");
+                TimeUnit.SECONDS, "Data Transfer Service Monitoring");
     }
 
     private void monitor() {
@@ -44,8 +44,13 @@ public class DtsMonitoringManager extends AbstractSchedulingManager {
                 registry.setStatus(DtsStatus.OFFLINE);
                 registryManager.updateStatus(registry.getId(), registry.getStatus());
             }
-            log.debug(messageHelper.getMessage(MessageConstants.INFO_DTS_MONITORING_STATUS,
-                    registry.getName(), registry.getId(), registry.getStatus(), registry.getHeartbeat()));
+            if (heartbeat.isAfter(LocalDateTime.MIN)) {
+                log.debug(messageHelper.getMessage(MessageConstants.INFO_DTS_MONITORING_STATUS,
+                        registry.getName(), registry.getId(), registry.getStatus(), registry.getHeartbeat()));
+            } else {
+                log.debug(messageHelper.getMessage(MessageConstants.INFO_DTS_MONITORING_STATUS_MISSING_HEARTBEAT,
+                        registry.getName(), registry.getId(), registry.getStatus()));
+            }
         }
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/dts/DtsRegistryManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/dts/DtsRegistryManager.java
@@ -98,7 +98,9 @@ public class DtsRegistryManager {
     @Transactional(propagation = Propagation.REQUIRED)
     public DtsRegistry create(DtsRegistryVO dtsRegistryVO) {
         validateDtsRegistryVO(dtsRegistryVO);
+        validateDtsRegistryDoesNotExist(dtsRegistryVO.getName());
         DtsRegistry dtsRegistry = dtsRegistryMapper.toDtsRegistry(dtsRegistryVO);
+        dtsRegistry.setStatus(DtsStatus.OFFLINE);
         return dtsRegistryDao.create(dtsRegistry);
     }
 
@@ -228,5 +230,10 @@ public class DtsRegistryManager {
 
     private void validateDtsRegistryId(Long registryId) {
         Assert.notNull(registryId, messageHelper.getMessage(MessageConstants.ERROR_DTS_REGISTRY_ID_IS_EMPTY));
+    }
+
+    private void validateDtsRegistryDoesNotExist(final String registryId) {
+        Assert.isTrue(!dtsRegistryDao.loadByName(registryId).isPresent(),
+                messageHelper.getMessage(MessageConstants.ERROR_DTS_REGISTRY_NAME_ALREADY_EXISTS, registryId));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/dts/DtsRegistryManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/dts/DtsRegistryManager.java
@@ -23,6 +23,8 @@ import com.epam.pipeline.controller.vo.dts.DtsRegistryPreferencesUpdateVO;
 import com.epam.pipeline.controller.vo.dts.DtsRegistryVO;
 import com.epam.pipeline.dao.dts.DtsRegistryDao;
 import com.epam.pipeline.entity.dts.DtsRegistry;
+import com.epam.pipeline.entity.dts.DtsStatus;
+import com.epam.pipeline.entity.utils.DateUtils;
 import com.epam.pipeline.mapper.DtsRegistryMapper;
 import lombok.AllArgsConstructor;
 import org.apache.commons.collections4.CollectionUtils;
@@ -115,6 +117,36 @@ public class DtsRegistryManager {
         DtsRegistry dtsRegistry = dtsRegistryMapper.toDtsRegistry(dtsRegistryVO);
         dtsRegistry.setId(registryId);
         dtsRegistryDao.update(dtsRegistry);
+        return dtsRegistry;
+    }
+
+    /**
+     * Updates a {@link DtsRegistry} heartbeat specified by ID. If required {@link DtsRegistry} does not exist an error will be
+     * thrown.
+     * @param registryId a {@link DtsRegistry} ID to update heartbeat
+     * @return updated {@link DtsRegistry}
+     */
+    @Transactional(propagation = Propagation.REQUIRED)
+    public DtsRegistry updateHeartbeat(final String registryId) {
+        final DtsRegistry dtsRegistry = loadByNameOrId(registryId);
+        dtsRegistry.setHeartbeat(DateUtils.nowUTC());
+        dtsRegistry.setStatus(DtsStatus.ONLINE);
+        dtsRegistryDao.updateHeartbeat(dtsRegistry.getId(), dtsRegistry.getHeartbeat(), dtsRegistry.getStatus());
+        return dtsRegistry;
+    }
+
+    /**
+     * Updates a {@link DtsRegistry} status specified by ID. If required {@link DtsRegistry} does not exist an error will be
+     * thrown.
+     * @param registryId a {@link DtsRegistry} ID to update heartbeat
+     * @param status a {@link DtsRegistry} status to set
+     * @return updated {@link DtsRegistry}
+     */
+    @Transactional(propagation = Propagation.REQUIRED)
+    public DtsRegistry updateStatus(final Long registryId, final DtsStatus status) {
+        final DtsRegistry dtsRegistry = loadById(registryId);
+        dtsRegistry.setStatus(status);
+        dtsRegistryDao.updateStatus(dtsRegistry.getId(), dtsRegistry.getStatus());
         return dtsRegistry;
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/dts/DtsRegistryManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/dts/DtsRegistryManager.java
@@ -53,6 +53,7 @@ public class DtsRegistryManager {
 
     /**
      * Loads all existing {@link DtsRegistry}s.
+     *
      * @return list of existing {@link DtsRegistry}s
      */
     public List<DtsRegistry> loadAll() {
@@ -69,6 +70,7 @@ public class DtsRegistryManager {
 
     /**
      * Loads {@link DtsRegistry} specified by ID.
+     *
      * @param registryId a {@link DtsRegistry} ID
      * @return existing {@link DtsRegistry} or error if required registry does not exist.
      */
@@ -79,6 +81,7 @@ public class DtsRegistryManager {
 
     /**
      * Loads {@link DtsRegistry} specified by name.
+     *
      * @param registryName a {@link DtsRegistry} name
      * @return existing {@link DtsRegistry} or error if required registry does not exist.
      */
@@ -92,6 +95,7 @@ public class DtsRegistryManager {
 
     /**
      * Creates a new {@link DtsRegistry}.
+     *
      * @param dtsRegistryVO a {@link DtsRegistryVO} to create
      * @return created {@link DtsRegistry}
      */
@@ -105,8 +109,10 @@ public class DtsRegistryManager {
     }
 
     /**
-     * Updates a {@link DtsRegistry} specified by ID. If required {@link DtsRegistry} does not exist an error will be
-     * thrown.
+     * Updates a {@link DtsRegistry} specified by ID.
+     *
+     * If required {@link DtsRegistry} does not exist an error will be thrown.
+     *
      * @param registryId a {@link DtsRegistry} ID to update
      * @param dtsRegistryVO a {@link DtsRegistryVO} to update
      * @return updated {@link DtsRegistry}
@@ -123,8 +129,10 @@ public class DtsRegistryManager {
     }
 
     /**
-     * Updates a {@link DtsRegistry} heartbeat specified by ID. If required {@link DtsRegistry} does not exist an error will be
-     * thrown.
+     * Updates a {@link DtsRegistry} heartbeat specified by ID.
+     *
+     * If required {@link DtsRegistry} does not exist an error will be thrown.
+     *
      * @param registryId a {@link DtsRegistry} ID to update heartbeat
      * @return updated {@link DtsRegistry}
      */
@@ -138,8 +146,10 @@ public class DtsRegistryManager {
     }
 
     /**
-     * Updates a {@link DtsRegistry} status specified by ID. If required {@link DtsRegistry} does not exist an error will be
-     * thrown.
+     * Updates a {@link DtsRegistry} status specified by ID.
+     *
+     * If required {@link DtsRegistry} does not exist an error will be thrown.
+     *
      * @param registryId a {@link DtsRegistry} ID to update heartbeat
      * @param status a {@link DtsRegistry} status to set
      * @return updated {@link DtsRegistry}
@@ -153,8 +163,10 @@ public class DtsRegistryManager {
     }
 
     /**
-     * Deletes a {@link DtsRegistry} specified by ID. If required {@link DtsRegistry} does not exist an error will be
-     * thrown.
+     * Deletes a {@link DtsRegistry} specified by ID.
+     *
+     * If required {@link DtsRegistry} does not exist an error will be thrown.
+     *
      * @param registryId a {@link DtsRegistry} ID to delete
      * @return deleted {@link DtsRegistry}
      */
@@ -168,7 +180,9 @@ public class DtsRegistryManager {
 
     /**
      * Creates new or updates existing preferences in a {@link DtsRegistry} specified by ID or name.
+     *
      * If required {@link DtsRegistry} does not exist an error will be thrown.
+     *
      * @param registryId a {@link DtsRegistry} ID or name of a registry to update
      * @param preferencesVO preferences, that need to be set for a registry
      * @return updated {@link DtsRegistry}
@@ -186,8 +200,10 @@ public class DtsRegistryManager {
 
     /**
      * Removes preferences in a {@link DtsRegistry} specified by ID or name.
+     *
      * If required {@link DtsRegistry} does not exist an error will be thrown.
      * If any key specified for removal, is not presented in a registry's preferences, an error will be thrown.
+     *
      * @param registryId a {@link DtsRegistry} ID or name of a registry to update
      * @param preferencesVO list of keys indicating which preferences need to be removed from a registry
      * @return updated {@link DtsRegistry}

--- a/api/src/main/java/com/epam/pipeline/manager/dts/DtsRegistryManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/dts/DtsRegistryManager.java
@@ -118,14 +118,13 @@ public class DtsRegistryManager {
      * @return updated {@link DtsRegistry}
      */
     @Transactional(propagation = Propagation.REQUIRED)
-    public DtsRegistry update(Long registryId, DtsRegistryVO dtsRegistryVO) {
-        validateDtsRegistryId(registryId);
+    public DtsRegistry update(final String registryId, final DtsRegistryVO dtsRegistryVO) {
+        final DtsRegistry originalDtsRegistry = loadByNameOrId(registryId);
         validateDtsRegistryVO(dtsRegistryVO);
-        loadOrThrow(registryId);
-        DtsRegistry dtsRegistry = dtsRegistryMapper.toDtsRegistry(dtsRegistryVO);
-        dtsRegistry.setId(registryId);
+        final DtsRegistry dtsRegistry = dtsRegistryMapper.toDtsRegistry(dtsRegistryVO);
+        dtsRegistry.setId(originalDtsRegistry.getId());
         dtsRegistryDao.update(dtsRegistry);
-        return dtsRegistry;
+        return loadById(dtsRegistry.getId());
     }
 
     /**
@@ -171,10 +170,9 @@ public class DtsRegistryManager {
      * @return deleted {@link DtsRegistry}
      */
     @Transactional(propagation = Propagation.REQUIRED)
-    public DtsRegistry delete(Long registryId) {
-        validateDtsRegistryId(registryId);
-        DtsRegistry dtsRegistry = loadOrThrow(registryId);
-        dtsRegistryDao.delete(registryId);
+    public DtsRegistry delete(final String registryId) {
+        final DtsRegistry dtsRegistry = loadByNameOrId(registryId);
+        dtsRegistryDao.delete(dtsRegistry.getId());
         return dtsRegistry;
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -509,6 +509,10 @@ public class SystemPreferences {
             "", DTS_GROUP, pass);
     public static final StringPreference DTS_DISTRIBUTION_URL = new StringPreference("dts.dist.url",
             "", DTS_GROUP, pass);
+    public static final IntPreference DTS_MONITORING_PERIOD_SECONDS = new IntPreference("dts.monitoring.period.seconds",
+            (int) TimeUnit.MINUTES.toSeconds(1), DTS_GROUP, isGreaterThan(10));
+    public static final IntPreference DTS_OFFLINE_TIMEOUT_SECONDS = new IntPreference("dts.offline.timeout.seconds",
+            (int) TimeUnit.MINUTES.toSeconds(5), DTS_GROUP, isGreaterThan(0));
 
     /**
      * Controls maximum number of scheduled at once runs

--- a/api/src/main/java/com/epam/pipeline/mapper/DtsRegistryMapper.java
+++ b/api/src/main/java/com/epam/pipeline/mapper/DtsRegistryMapper.java
@@ -26,5 +26,6 @@ public interface DtsRegistryMapper {
 
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "createdDate", ignore = true)
+    @Mapping(target = "status", ignore = true)
     DtsRegistry toDtsRegistry(DtsRegistryVO dtsRegistryVO);
 }

--- a/api/src/main/resources/dao/dts-registry-dao.xml
+++ b/api/src/main/resources/dao/dts-registry-dao.xml
@@ -141,5 +141,30 @@
                 ]]>
             </value>
         </property>
+        <property name="updateDtsRegistryHeartbeatQuery">
+            <value>
+                <![CDATA[
+                    UPDATE
+                        pipeline.dts_registry
+                    SET
+                        heartbeat = :HEARTBEAT,
+                        status = :STATUS
+                    WHERE
+                        id = :ID
+                ]]>
+            </value>
+        </property>
+        <property name="updateDtsRegistryStatusQuery">
+            <value>
+                <![CDATA[
+                    UPDATE
+                        pipeline.dts_registry
+                    SET
+                        status = :STATUS
+                    WHERE
+                        id = :ID
+                ]]>
+            </value>
+        </property>
     </bean>
 </beans>

--- a/api/src/main/resources/dao/dts-registry-dao.xml
+++ b/api/src/main/resources/dao/dts-registry-dao.xml
@@ -29,6 +29,7 @@
                         schedulable,
                         created_date,
                         url,
+                        status,
                         prefixes,
                         preferences)
                     VALUES (
@@ -37,6 +38,7 @@
                         :SCHEDULABLE,
                         :CREATED_DATE,
                         :URL,
+                        :STATUS,
                         :PREFIXES,
                         to_jsonb(:PREFERENCES::jsonb))
                 ]]>
@@ -51,6 +53,8 @@
                         r.schedulable,
                         r.created_date,
                         r.url,
+                        r.status,
+                        r.heartbeat,
                         r.prefixes,
                         r.preferences
                     FROM
@@ -68,6 +72,8 @@
                         r.schedulable,
                         r.created_date,
                         r.url,
+                        r.status,
+                        r.heartbeat,
                         r.prefixes,
                         r.preferences
                     FROM
@@ -85,6 +91,8 @@
                         r.schedulable,
                         r.created_date,
                         r.url,
+                        r.status,
+                        r.heartbeat,
                         r.prefixes,
                         r.preferences
                     FROM

--- a/api/src/main/resources/db/migration/v2021.07.19_18.00__issue_2044_dts_heartbeat.sql
+++ b/api/src/main/resources/db/migration/v2021.07.19_18.00__issue_2044_dts_heartbeat.sql
@@ -1,0 +1,2 @@
+ALTER TABLE pipeline.dts_registry ADD heartbeat TIMESTAMP WITH TIME ZONE NULL;
+ALTER TABLE pipeline.dts_registry ADD status BIGINT NOT NULL DEFAULT 0;

--- a/api/src/main/resources/db/migration/v2021.07.19_18.00__issue_2044_dts_heartbeat.sql
+++ b/api/src/main/resources/db/migration/v2021.07.19_18.00__issue_2044_dts_heartbeat.sql
@@ -1,2 +1,11 @@
 ALTER TABLE pipeline.dts_registry ADD heartbeat TIMESTAMP WITH TIME ZONE NULL;
 ALTER TABLE pipeline.dts_registry ADD status BIGINT NOT NULL DEFAULT 0;
+DELETE FROM pipeline.dts_registry r1
+    USING (
+        SELECT MIN(id) as id, name
+        FROM pipeline.dts_registry
+        GROUP BY name HAVING COUNT(*) > 1
+    ) r2
+    WHERE r1.name = r2.name
+    AND r1.id <> r2.id;
+ALTER TABLE pipeline.dts_registry ADD CONSTRAINT dts_registry_name_unique UNIQUE (name);

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -431,6 +431,7 @@ error.dts.registry.not.schedulable= DTS ''{0}' does not support jobs scheduling.
 error.dts.preferences.not.exist=DTS id=''{0}'' does not have following preferences: [ {1} ].
 error.dts.preferences.update.empty=DTS preferences to be updated should be specified.
 error.dts.preferences.delete.empty=Keys to be removed from DTS preferences should be specified.
+info.dts.monitoring.status=DTS {0} ({1}) is {2} with last heartbeat at {3}.
 
 #Cloud region
 error.region.not.found=Cloud region with requested id: ''{0}'' was not found.

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -426,12 +426,14 @@ error.dts.registry.prefixes.are.empty=Prefixes are required for DTS registry.
 error.dts.registry.id.is.empty=DTS registry ID must be specified.
 error.dts.registry.name.is.empty=DTS registry NAME must be specified.
 error.dts.registry.name.numbers.only=DTS registry NAME consists of numbers only.
+error.dts.registry.name.already.exists=DTS registry with NAME ''{0}'' already exists.
 error.dts.registry.prefix.is.empty=DTS registry prefix must be specified.
 error.dts.registry.not.schedulable= DTS ''{0}' does not support jobs scheduling.
 error.dts.preferences.not.exist=DTS id=''{0}'' does not have following preferences: [ {1} ].
 error.dts.preferences.update.empty=DTS preferences to be updated should be specified.
 error.dts.preferences.delete.empty=Keys to be removed from DTS preferences should be specified.
 info.dts.monitoring.status=DTS {0} ({1}) is {2} with last heartbeat at {3}.
+info.dts.monitoring.status.missing.heartbeat=DTS {0} ({1}) is {2} without any heartbeat yet.
 
 #Cloud region
 error.region.not.found=Cloud region with requested id: ''{0}'' was not found.

--- a/api/src/test/java/com/epam/pipeline/acl/dts/DtsRegistryApiServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/acl/dts/DtsRegistryApiServiceTest.java
@@ -153,65 +153,101 @@ public class DtsRegistryApiServiceTest extends AbstractAclTest {
     @Test
     @WithMockUser(roles = ADMIN_ROLE)
     public void shouldUpdateDtsRegistryForAdmin() {
-        doReturn(dtsRegistry).when(mockDtsRegistryManager).update(ID, dtsRegistryVO);
+        doReturn(dtsRegistry).when(mockDtsRegistryManager).update(REGISTRY_ID_AS_STRING, dtsRegistryVO);
 
-        assertThat(dtsRegistryApiService.update(ID, dtsRegistryVO)).isEqualTo(dtsRegistry);
+        assertThat(dtsRegistryApiService.update(REGISTRY_ID_AS_STRING, dtsRegistryVO)).isEqualTo(dtsRegistry);
     }
 
     @Test
     @WithMockUser(roles = DTS_MANAGER)
     public void shouldUpdateDtsRegistryForManager() {
-        doReturn(dtsRegistry).when(mockDtsRegistryManager).update(ID, dtsRegistryVO);
+        doReturn(dtsRegistry).when(mockDtsRegistryManager).update(REGISTRY_ID_AS_STRING, dtsRegistryVO);
 
-        assertThat(dtsRegistryApiService.update(ID, dtsRegistryVO)).isEqualTo(dtsRegistry);
+        assertThat(dtsRegistryApiService.update(REGISTRY_ID_AS_STRING, dtsRegistryVO)).isEqualTo(dtsRegistry);
     }
 
     @Test
     @WithMockUser
     public void shouldDenyUpdateDtsRegistryForUser() {
-        doReturn(dtsRegistry).when(mockDtsRegistryManager).update(ID, dtsRegistryVO);
+        doReturn(dtsRegistry).when(mockDtsRegistryManager).update(REGISTRY_ID_AS_STRING, dtsRegistryVO);
 
-        assertThrows(AccessDeniedException.class, () -> dtsRegistryApiService.update(ID, dtsRegistryVO));
+        assertThrows(AccessDeniedException.class,
+            () -> dtsRegistryApiService.update(REGISTRY_ID_AS_STRING, dtsRegistryVO));
     }
 
     @Test
     @WithMockUser(roles = SIMPLE_USER)
     public void shouldDenyUpdateDtsRegistryWithoutUserRole() {
-        doReturn(dtsRegistry).when(mockDtsRegistryManager).update(ID, dtsRegistryVO);
+        doReturn(dtsRegistry).when(mockDtsRegistryManager).update(REGISTRY_ID_AS_STRING, dtsRegistryVO);
 
-        assertThrows(AccessDeniedException.class, () -> dtsRegistryApiService.update(ID, dtsRegistryVO));
+        assertThrows(AccessDeniedException.class,
+            () -> dtsRegistryApiService.update(REGISTRY_ID_AS_STRING, dtsRegistryVO));
+    }
+
+    @Test
+    @WithMockUser(roles = ADMIN_ROLE)
+    public void shouldUpdateDtsRegistryHeartbeatForAdmin() {
+        doReturn(dtsRegistry).when(mockDtsRegistryManager).updateHeartbeat(REGISTRY_ID_AS_STRING);
+
+        assertThat(dtsRegistryApiService.updateHeartbeat(REGISTRY_ID_AS_STRING)).isEqualTo(dtsRegistry);
+    }
+
+    @Test
+    @WithMockUser(roles = DTS_MANAGER)
+    public void shouldUpdateDtsRegistryHeartbeatForManager() {
+        doReturn(dtsRegistry).when(mockDtsRegistryManager).updateHeartbeat(REGISTRY_ID_AS_STRING);
+
+        assertThat(dtsRegistryApiService.updateHeartbeat(REGISTRY_ID_AS_STRING)).isEqualTo(dtsRegistry);
+    }
+
+    @Test
+    @WithMockUser
+    public void shouldDenyUpdateDtsRegistryHeartbeatForUser() {
+        doReturn(dtsRegistry).when(mockDtsRegistryManager).updateHeartbeat(REGISTRY_ID_AS_STRING);
+
+        assertThrows(AccessDeniedException.class,
+            () -> dtsRegistryApiService.updateHeartbeat(REGISTRY_ID_AS_STRING));
+    }
+
+    @Test
+    @WithMockUser(roles = SIMPLE_USER)
+    public void shouldDenyUpdateDtsRegistryHeartbeatWithoutUserRole() {
+        doReturn(dtsRegistry).when(mockDtsRegistryManager).updateHeartbeat(REGISTRY_ID_AS_STRING);
+
+        assertThrows(AccessDeniedException.class,
+            () -> dtsRegistryApiService.updateHeartbeat(REGISTRY_ID_AS_STRING));
     }
 
     @Test
     @WithMockUser(roles = ADMIN_ROLE)
     public void shouldDeleteDtsRegistryForAdmin() {
-        doReturn(dtsRegistry).when(mockDtsRegistryManager).delete(ID);
+        doReturn(dtsRegistry).when(mockDtsRegistryManager).delete(REGISTRY_ID_AS_STRING);
 
-        assertThat(dtsRegistryApiService.delete(ID)).isEqualTo(dtsRegistry);
+        assertThat(dtsRegistryApiService.delete(REGISTRY_ID_AS_STRING)).isEqualTo(dtsRegistry);
     }
 
     @Test
     @WithMockUser(roles = DTS_MANAGER)
     public void shouldDeleteDtsRegistryForManager() {
-        doReturn(dtsRegistry).when(mockDtsRegistryManager).delete(ID);
+        doReturn(dtsRegistry).when(mockDtsRegistryManager).delete(REGISTRY_ID_AS_STRING);
 
-        assertThat(dtsRegistryApiService.delete(ID)).isEqualTo(dtsRegistry);
+        assertThat(dtsRegistryApiService.delete(REGISTRY_ID_AS_STRING)).isEqualTo(dtsRegistry);
     }
 
     @Test
     @WithMockUser
     public void shouldDenyDeleteDtsRegistryForUser() {
-        doReturn(dtsRegistry).when(mockDtsRegistryManager).delete(ID);
+        doReturn(dtsRegistry).when(mockDtsRegistryManager).delete(REGISTRY_ID_AS_STRING);
 
-        assertThrows(AccessDeniedException.class, () -> dtsRegistryApiService.delete(ID));
+        assertThrows(AccessDeniedException.class, () -> dtsRegistryApiService.delete(REGISTRY_ID_AS_STRING));
     }
 
     @Test
     @WithMockUser(roles = SIMPLE_USER)
     public void shouldDenyDeleteDtsRegistryWithoutUserRole() {
-        doReturn(dtsRegistry).when(mockDtsRegistryManager).delete(ID);
+        doReturn(dtsRegistry).when(mockDtsRegistryManager).delete(REGISTRY_ID_AS_STRING);
 
-        assertThrows(AccessDeniedException.class, () -> dtsRegistryApiService.delete(ID));
+        assertThrows(AccessDeniedException.class, () -> dtsRegistryApiService.delete(REGISTRY_ID_AS_STRING));
     }
 
     @Test

--- a/api/src/test/java/com/epam/pipeline/controller/dts/DtsRegistryControllerTest.java
+++ b/api/src/test/java/com/epam/pipeline/controller/dts/DtsRegistryControllerTest.java
@@ -47,6 +47,7 @@ public class DtsRegistryControllerTest extends AbstractControllerTest {
     private static final String DTS_URL = SERVLET_PATH + "/dts";
     private static final String ID_URL = DTS_URL + "/%d";
     private static final String DTS_PREFERENCES_URL = ID_URL + "/preferences";
+    private static final String DTS_HEARTBEAT_URL = ID_URL + "/heartbeat";
     private static final String ADMIN = "ADMIN";
     private static final String REGISTRY_ID_AS_STRING = Long.toString(ID);
 
@@ -112,11 +113,11 @@ public class DtsRegistryControllerTest extends AbstractControllerTest {
     @WithMockUser
     public void shouldUpdateDtsRegistry() throws Exception {
         final String content = getObjectMapper().writeValueAsString(dtsRegistryVO);
-        doReturn(dtsRegistry).when(mockDtsRegistryApiService).update(ID, dtsRegistryVO);
+        doReturn(dtsRegistry).when(mockDtsRegistryApiService).update(REGISTRY_ID_AS_STRING, dtsRegistryVO);
 
         final MvcResult mvcResult = performRequest(put(String.format(ID_URL, ID)).content(content));
 
-        verify(mockDtsRegistryApiService).update(ID, dtsRegistryVO);
+        verify(mockDtsRegistryApiService).update(REGISTRY_ID_AS_STRING, dtsRegistryVO);
         assertResponse(mvcResult, dtsRegistry, DtsCreatorUtils.DTS_REGISTRY_TYPE);
     }
 
@@ -127,12 +128,28 @@ public class DtsRegistryControllerTest extends AbstractControllerTest {
 
     @Test
     @WithMockUser
+    public void shouldUpdateDtsRegistryHeartbeat() throws Exception {
+        doReturn(dtsRegistry).when(mockDtsRegistryApiService).updateHeartbeat(REGISTRY_ID_AS_STRING);
+
+        final MvcResult mvcResult = performRequest(put(String.format(DTS_HEARTBEAT_URL, ID)));
+
+        verify(mockDtsRegistryApiService).updateHeartbeat(REGISTRY_ID_AS_STRING);
+        assertResponse(mvcResult, dtsRegistry, DtsCreatorUtils.DTS_REGISTRY_TYPE);
+    }
+
+    @Test
+    public void shouldFailUpdateDtsRegistryHeartbeat() {
+        performUnauthorizedRequest(put(String.format(DTS_HEARTBEAT_URL, ID)));
+    }
+
+    @Test
+    @WithMockUser
     public void shouldDeleteDtsRegistry() {
-        doReturn(dtsRegistry).when(mockDtsRegistryApiService).delete(ID);
+        doReturn(dtsRegistry).when(mockDtsRegistryApiService).delete(REGISTRY_ID_AS_STRING);
 
         final MvcResult mvcResult = performRequest(delete(String.format(ID_URL, ID)));
 
-        verify(mockDtsRegistryApiService).delete(ID);
+        verify(mockDtsRegistryApiService).delete(REGISTRY_ID_AS_STRING);
         assertResponse(mvcResult, dtsRegistry, DtsCreatorUtils.DTS_REGISTRY_TYPE);
     }
 

--- a/api/src/test/java/com/epam/pipeline/manager/dts/DtsMonitoringManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/dts/DtsMonitoringManagerTest.java
@@ -1,0 +1,83 @@
+package com.epam.pipeline.manager.dts;
+
+import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.entity.dts.DtsRegistry;
+import com.epam.pipeline.entity.dts.DtsStatus;
+import com.epam.pipeline.entity.utils.DateUtils;
+import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.epam.pipeline.manager.preference.SystemPreferences;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Collections;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class DtsMonitoringManagerTest {
+
+    private static final Long ID = 1L;
+    private static final Duration OFFLINE_TIMEOUT = Duration.ofMinutes(5);
+    private static final LocalDateTime RECENT_HEARTBEAT = DateUtils.nowUTC().minus(Duration.ofMinutes(1));
+    private static final LocalDateTime OLD_HEARTBEAT = DateUtils.nowUTC().minus(Duration.ofHours(1));
+    private static final LocalDateTime NO_HEARTBEAT = null;
+    private final DtsRegistryManager dtsRegistryManager = mock(DtsRegistryManager.class);
+    private final PreferenceManager preferenceManager = mock(PreferenceManager.class);
+    private final MessageHelper messageHelper = mock(MessageHelper.class);
+    private final DtsMonitoringManager manager = new DtsMonitoringManager(dtsRegistryManager, preferenceManager,
+            messageHelper);
+
+    @Before
+    public void setUp() {
+        doReturn((int) OFFLINE_TIMEOUT.getSeconds())
+                .when(preferenceManager)
+                .getIntPreference(SystemPreferences.DTS_OFFLINE_TIMEOUT_SECONDS.getKey());
+    }
+
+    @Test
+    public void monitorShouldNotFailIfThereAreNoDtsRegistered() {
+        doReturn(Collections.emptyList()).when(dtsRegistryManager).loadAll();
+
+        manager.monitor();
+    }
+
+    @Test
+    public void monitorShouldNotUpdateStatusOfDtsWithRecentHeartbeat() {
+        doReturn(Collections.singletonList(dts(RECENT_HEARTBEAT))).when(dtsRegistryManager).loadAll();
+
+        manager.monitor();
+
+        verify(dtsRegistryManager, times(0)).updateStatus(eq(ID), any());
+    }
+
+    @Test
+    public void monitorShouldSetOfflineStatusForDtsWithOldHeartbeat() {
+        doReturn(Collections.singletonList(dts(OLD_HEARTBEAT))).when(dtsRegistryManager).loadAll();
+
+        manager.monitor();
+
+        verify(dtsRegistryManager).updateStatus(ID, DtsStatus.OFFLINE);
+    }
+
+    @Test
+    public void monitorShouldSetOfflineStatusForDtsWithNoHeartbeat() {
+        doReturn(Collections.singletonList(dts(NO_HEARTBEAT))).when(dtsRegistryManager).loadAll();
+
+        manager.monitor();
+
+        verify(dtsRegistryManager).updateStatus(ID, DtsStatus.OFFLINE);
+    }
+
+    private DtsRegistry dts(final LocalDateTime heartbeat) {
+        final DtsRegistry dts = new DtsRegistry();
+        dts.setId(ID);
+        dts.setHeartbeat(heartbeat);
+        return dts;
+    }
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
@@ -251,6 +251,6 @@ public interface CloudPipelineAPI {
     Call<Result<DtsRegistry>> deleteDtsPreferences(@Path(ID) String dtsNameOrId,
                                                    @Body DtsRegistryPreferencesRemovalVO removalVO);
 
-    @PUT("dts/{id}/preferences")
+    @PUT("dts/{id}/heartbeat")
     Call<Result<DtsRegistry>> updateDtsHeartbeat(@Path(ID) final String dtsId);
 }

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
@@ -250,4 +250,7 @@ public interface CloudPipelineAPI {
     @HTTP(method = "DELETE", path = "dts/{id}/preferences", hasBody = true)
     Call<Result<DtsRegistry>> deleteDtsPreferences(@Path(ID) String dtsNameOrId,
                                                    @Body DtsRegistryPreferencesRemovalVO removalVO);
+
+    @PUT("dts/{id}/preferences")
+    Call<Result<DtsRegistry>> updateDtsHeartbeat(@Path(ID) final String dtsId);
 }

--- a/data-transfer-service/src/main/java/com/epam/pipeline/dts/common/service/CloudPipelineAPIClient.java
+++ b/data-transfer-service/src/main/java/com/epam/pipeline/dts/common/service/CloudPipelineAPIClient.java
@@ -98,4 +98,8 @@ public class CloudPipelineAPIClient {
         return pipelineApiExecutor.execute(
             cloudPipelineAPI.deleteDtsPreferences(dtsId, new DtsRegistryPreferencesRemovalVO(preferencesToRemove)));
     }
+
+    public DtsRegistry updateDtsRegistryHeartbeat(final String dtsId) {
+        return pipelineApiExecutor.execute(cloudPipelineAPI.updateDtsHeartbeat(dtsId));
+    }
 }

--- a/data-transfer-service/src/main/java/com/epam/pipeline/dts/common/service/IdentificationService.java
+++ b/data-transfer-service/src/main/java/com/epam/pipeline/dts/common/service/IdentificationService.java
@@ -1,0 +1,5 @@
+package com.epam.pipeline.dts.common.service;
+
+public interface IdentificationService {
+    String getId();
+}

--- a/data-transfer-service/src/main/java/com/epam/pipeline/dts/common/service/impl/SimpleIdentificationService.java
+++ b/data-transfer-service/src/main/java/com/epam/pipeline/dts/common/service/impl/SimpleIdentificationService.java
@@ -1,0 +1,15 @@
+package com.epam.pipeline.dts.common.service.impl;
+
+import com.epam.pipeline.dts.common.service.IdentificationService;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class SimpleIdentificationService implements IdentificationService {
+
+    private final String id;
+
+    @Override
+    public String getId() {
+        return id;
+    }
+}

--- a/data-transfer-service/src/main/java/com/epam/pipeline/dts/configuration/CommonConfiguration.java
+++ b/data-transfer-service/src/main/java/com/epam/pipeline/dts/configuration/CommonConfiguration.java
@@ -71,8 +71,8 @@ public class CommonConfiguration {
     public CloudPipelineAPIClient apiClient(final @Value("${dts.api.url}") String apiUrl,
                                             final @Value("${dts.api.token}") String apiToken,
                                             final @Value("${dts.api.timeout.seconds}") int apiTimeoutInSeconds) {
-        return CloudPipelineAPIClient.from(new CloudPipelineApiBuilder(apiTimeoutInSeconds, apiTimeoutInSeconds, apiUrl, apiToken)
-                .buildClient());
+        return CloudPipelineAPIClient.from(new CloudPipelineApiBuilder(apiTimeoutInSeconds, apiTimeoutInSeconds,
+                apiUrl, apiToken).buildClient());
     }
 
     @Bean

--- a/data-transfer-service/src/main/java/com/epam/pipeline/dts/configuration/CommonConfiguration.java
+++ b/data-transfer-service/src/main/java/com/epam/pipeline/dts/configuration/CommonConfiguration.java
@@ -18,8 +18,11 @@ package com.epam.pipeline.dts.configuration;
 
 import com.epam.pipeline.client.pipeline.CloudPipelineApiBuilder;
 import com.epam.pipeline.dts.common.service.CloudPipelineAPIClient;
+import com.epam.pipeline.dts.common.service.IdentificationService;
 import com.epam.pipeline.dts.common.service.FileService;
 import com.epam.pipeline.dts.common.service.impl.FileServiceImpl;
+import com.epam.pipeline.dts.common.service.impl.SimpleIdentificationService;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -29,6 +32,9 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.security.concurrent.DelegatingSecurityContextExecutor;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Optional;
 import java.util.concurrent.Executor;
 
 @Configuration
@@ -69,6 +75,11 @@ public class CommonConfiguration {
                 .buildClient());
     }
 
+    @Bean
+    public IdentificationService dtsIdentificationService(final @Value("${dts.name}") String dtsName) {
+        return new SimpleIdentificationService(tryBuildDtsName(dtsName));
+    }
+
     private Executor getThreadPoolTaskExecutor(String name, int taskPoolSize) {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(taskPoolSize);
@@ -76,5 +87,28 @@ public class CommonConfiguration {
         executor.setThreadNamePrefix(name);
         executor.initialize();
         return executor;
+    }
+
+    private String tryBuildDtsName(final String preconfiguredDtsName) {
+        final String dtsName = Optional.ofNullable(preconfiguredDtsName)
+                .filter(StringUtils::isNotBlank)
+                .orElseGet(this::tryExtractHostnameFromEnvironment);
+        if (StringUtils.isBlank(dtsName)) {
+            throw new IllegalStateException("Unable to build DTS name!");
+        }
+        return dtsName;
+    }
+
+    private String tryExtractHostnameFromEnvironment() {
+        try {
+            return Optional.ofNullable(InetAddress.getLocalHost())
+                    .map(InetAddress::getCanonicalHostName)
+                    .filter(StringUtils::isNotEmpty)
+                    .map(StringUtils::strip)
+                    .map(StringUtils::lowerCase)
+                    .orElse(StringUtils.EMPTY);
+        } catch (UnknownHostException e) {
+            return StringUtils.EMPTY;
+        }
     }
 }

--- a/data-transfer-service/src/main/java/com/epam/pipeline/dts/sync/model/AutonomousSyncCronDetails.java
+++ b/data-transfer-service/src/main/java/com/epam/pipeline/dts/sync/model/AutonomousSyncCronDetails.java
@@ -16,17 +16,17 @@
 
 package com.epam.pipeline.dts.sync.model;
 
-import lombok.Getter;
+import lombok.Value;
 import org.springframework.scheduling.support.CronSequenceGenerator;
 
 import java.util.Date;
 
-@Getter
+@Value
 public class AutonomousSyncCronDetails {
 
-    private String expression;
-    private CronSequenceGenerator generator;
-    private Date lastExecution;
+    String expression;
+    CronSequenceGenerator generator;
+    Date lastExecution;
 
     public AutonomousSyncCronDetails(final String expression, final Date lastExecution) {
         this.expression = expression;

--- a/data-transfer-service/src/main/java/com/epam/pipeline/dts/sync/service/HeartbeatService.java
+++ b/data-transfer-service/src/main/java/com/epam/pipeline/dts/sync/service/HeartbeatService.java
@@ -1,0 +1,5 @@
+package com.epam.pipeline.dts.sync.service;
+
+public interface HeartbeatService {
+    void heartbeat();
+}

--- a/data-transfer-service/src/main/java/com/epam/pipeline/dts/sync/service/PreferenceService.java
+++ b/data-transfer-service/src/main/java/com/epam/pipeline/dts/sync/service/PreferenceService.java
@@ -25,5 +25,6 @@ public interface PreferenceService {
 
     Optional<List<AutonomousSyncRule>> getSyncRules();
     boolean isShutdownRequired();
+    boolean isHeartbeatEnabled();
     void clearShutdownFlag();
 }

--- a/data-transfer-service/src/main/java/com/epam/pipeline/dts/sync/service/impl/CloudPipelineApiPreferenceService.java
+++ b/data-transfer-service/src/main/java/com/epam/pipeline/dts/sync/service/impl/CloudPipelineApiPreferenceService.java
@@ -66,7 +66,8 @@ public class CloudPipelineApiPreferenceService implements PreferenceService {
 
     @Scheduled(fixedDelayString = "${dts.sync.poll:60000}")
     public void synchronizePreferences() {
-        final Map<String, String> updatedPreferences = apiClient.findDtsRegistryByNameOrId(identificationService.getId())
+        final Map<String, String> updatedPreferences = Optional.of(identificationService.getId())
+            .flatMap(apiClient::findDtsRegistryByNameOrId)
             .map(DtsRegistry::getPreferences)
             .orElse(Collections.emptyMap());
         log.warn("Following preferences received during sync iteration: {}", updatedPreferences.toString());

--- a/data-transfer-service/src/main/java/com/epam/pipeline/dts/sync/service/impl/CloudPipelineHeartbeatService.java
+++ b/data-transfer-service/src/main/java/com/epam/pipeline/dts/sync/service/impl/CloudPipelineHeartbeatService.java
@@ -3,6 +3,7 @@ package com.epam.pipeline.dts.sync.service.impl;
 import com.epam.pipeline.dts.common.service.CloudPipelineAPIClient;
 import com.epam.pipeline.dts.common.service.IdentificationService;
 import com.epam.pipeline.dts.sync.service.HeartbeatService;
+import com.epam.pipeline.dts.sync.service.PreferenceService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -15,11 +16,14 @@ public class CloudPipelineHeartbeatService implements HeartbeatService {
 
     private final CloudPipelineAPIClient api;
     private final IdentificationService identificationService;
+    private final PreferenceService preferenceService;
 
     @Override
     @Scheduled(fixedDelayString = "${dts.heartbeat.poll:60000}")
     public void heartbeat() {
-        log.debug("Sending heartbeat");
-        api.updateDtsRegistryHeartbeat(identificationService.getId());
+        if (preferenceService.isHeartbeatEnabled()) {
+            log.debug("Sending heartbeat");
+            api.updateDtsRegistryHeartbeat(identificationService.getId());
+        }
     }
 }

--- a/data-transfer-service/src/main/java/com/epam/pipeline/dts/sync/service/impl/CloudPipelineHeartbeatService.java
+++ b/data-transfer-service/src/main/java/com/epam/pipeline/dts/sync/service/impl/CloudPipelineHeartbeatService.java
@@ -1,0 +1,25 @@
+package com.epam.pipeline.dts.sync.service.impl;
+
+import com.epam.pipeline.dts.common.service.CloudPipelineAPIClient;
+import com.epam.pipeline.dts.common.service.IdentificationService;
+import com.epam.pipeline.dts.sync.service.HeartbeatService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CloudPipelineHeartbeatService implements HeartbeatService {
+
+    private final CloudPipelineAPIClient api;
+    private final IdentificationService identificationService;
+
+    @Override
+    @Scheduled(fixedDelayString = "${dts.heartbeat.poll:60000}")
+    public void heartbeat() {
+        log.debug("Sending heartbeat");
+        api.updateDtsRegistryHeartbeat(identificationService.getId());
+    }
+}

--- a/data-transfer-service/src/main/resources/application.properties
+++ b/data-transfer-service/src/main/resources/application.properties
@@ -79,5 +79,8 @@ dts.api.token=${CP_API_JWT_TOKEN:}
 dts.api.timeout.seconds=${CP_API_TIMEOUT_SECONDS:60}
 dts.sync.poll=${DTS_SYNC_POLL_TIMEOUT:30000}
 dts.heartbeat.poll=${DTS_HEARTBEAT_POLL_TIMEOUT:60000}
-dts.preference.shutdown.key=${DTS_SHUTDOWN_KEY:dts.restart.force}
 dts.autonomous.sync.cron=${DTS_AUTONOMOUS_SYNC_CRON:0 0 0 ? * *}
+
+dts.preference.shutdown.key=${DTS_PREFERENCE_SHUTDOWN_KEY:dts.restart.force}
+dts.preference.sync.rules.key=${DTS_PREFERENCE_SYNC_RULES_KEY:dts.local.sync.rules}
+dts.preference.heartbeat.enabled.key=${DTS_PREFERENCE_HEARTBEAT_ENABLED_KEY:dts.heartbeat.enabled}

--- a/data-transfer-service/src/main/resources/application.properties
+++ b/data-transfer-service/src/main/resources/application.properties
@@ -78,5 +78,6 @@ dts.api.url=${CP_API_URL:}
 dts.api.token=${CP_API_JWT_TOKEN:}
 dts.api.timeout.seconds=${CP_API_TIMEOUT_SECONDS:60}
 dts.sync.poll=${DTS_SYNC_POLL_TIMEOUT:30000}
+dts.heartbeat.poll=${DTS_HEARTBEAT_POLL_TIMEOUT:60000}
 dts.preference.shutdown.key=${DTS_SHUTDOWN_KEY:dts.restart.force}
 dts.autonomous.sync.cron=${DTS_AUTONOMOUS_SYNC_CRON:0 0 0 ? * *}

--- a/data-transfer-service/src/test/java/com/epam/pipeline/dts/sync/service/CloudPipelineHeartbeatServiceTest.java
+++ b/data-transfer-service/src/test/java/com/epam/pipeline/dts/sync/service/CloudPipelineHeartbeatServiceTest.java
@@ -1,0 +1,46 @@
+package com.epam.pipeline.dts.sync.service;
+
+import com.epam.pipeline.dts.common.service.CloudPipelineAPIClient;
+import com.epam.pipeline.dts.common.service.IdentificationService;
+import com.epam.pipeline.dts.sync.service.impl.CloudPipelineHeartbeatService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class CloudPipelineHeartbeatServiceTest {
+
+    private static final String TEST_ID = "DTS";
+
+    private final CloudPipelineAPIClient api = mock(CloudPipelineAPIClient.class);
+    private final IdentificationService identificationService = mock(IdentificationService.class);
+    private final PreferenceService preferenceService = mock(PreferenceService.class);
+    private final HeartbeatService service = new CloudPipelineHeartbeatService(api, identificationService,
+            preferenceService);
+
+    @BeforeEach
+    void setUp() {
+        doReturn(TEST_ID).when(identificationService).getId();
+    }
+
+    @Test
+    void heartbeatShouldSendRequestIfHeartbeatIsEnabled() {
+        doReturn(true).when(preferenceService).isHeartbeatEnabled();
+
+        service.heartbeat();
+
+        verify(api).updateDtsRegistryHeartbeat(TEST_ID);
+    }
+
+    @Test
+    void heartbeatShouldNotSendRequestIfHeartbeatIsDisabled() {
+        doReturn(false).when(preferenceService).isHeartbeatEnabled();
+
+        service.heartbeat();
+
+        verify(api, times(0)).updateDtsRegistryHeartbeat(TEST_ID);
+    }
+}

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1858,13 +1858,13 @@ def update_dts_preferences(registry_name_or_id, preference, json_out, trace):
 
 @preferences.command(name='delete')
 @click.argument('registry-name-or-id', required=True, type=str)
-@click.option('--key', '-k', multiple=True, type=str,
+@click.option('--preference', '-p', multiple=True, type=str,
               help="Key of the preference, that should be removed. Multiple options supported")
 @click.option('--json-out', '-jo', required=False, is_flag=True, help='Defines if output should be JSON-formatted')
 @click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
 @Config.validate_access_token
 @stacktracing
-def delete_dts_preferences(registry_name_or_id, key, json_out, trace):
+def delete_dts_preferences(registry_name_or_id, preference, json_out, trace):
     """
     Deletes preferences for the given data transfer service.
 
@@ -1872,18 +1872,18 @@ def delete_dts_preferences(registry_name_or_id, key, json_out, trace):
 
     I.   Deletes a single preference (key) from a data transfer service with some name (dtsname).
 
-        pipe dts preferences delete dtsname -k key
+        pipe dts preferences delete dtsname -p key
 
     II.  Deletes multiple preferences (key1, key2) from a data transfer service with some name (dtsname).
 
-        pipe dts preferences delete dtsname -k key1 -k key2
+        pipe dts preferences delete dtsname -p key1 -p key2
 
     III. Deletes a single preference (key) from a data transfer service with some id (123).
 
-        pipe dts preferences delete 123 -k key
+        pipe dts preferences delete 123 -p key
 
     """
-    DtsOperationsManager().delete_preferences(registry_name_or_id, key, json_out)
+    DtsOperationsManager().delete_preferences(registry_name_or_id, preference, json_out)
 
 
 # Used to run a PyInstaller "freezed" version

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1730,7 +1730,8 @@ def import_users(file_path, create_user, create_group, create_metadata):
 
 @cli.group()
 def dts():
-    """ Data-transfer-service commands
+    """
+    Data transfer service commands
     """
     pass
 
@@ -1749,7 +1750,18 @@ def dts():
 @stacktracing
 def create_dts(url, name, schedulable, prefix, preference, json_out, trace):
     """
-    Registers a DTS
+    Registers new data transfer service.
+
+    Examples:
+
+    I.  Registers data transfer service which can be used for input / output data transferring in runs.
+
+        pipe dts create -n "dtsname" -u "https://exampledtsurl/restapi" -p "/path/prefix/to/example/dts/local/paths"
+
+    II. Registers data transfer service which can be used for autonomous local data synchronisation.
+
+        pipe dts create -n "autonomousdtshostname" -u "autonomousdtshostname" -p "autonomousdtshostname"
+
     """
     DtsOperationsManager().create(url, name, schedulable, prefix, preference, json_out)
 
@@ -1762,14 +1774,54 @@ def create_dts(url, name, schedulable, prefix, preference, json_out, trace):
 @stacktracing
 def list_dts(registry_name_or_id, json_out, trace):
     """
-    Shows details of all DTS registries or the one for ID specified
+    Either shows details of a data transfer service or lists all data transfer services.
+
+    Examples:
+
+    I.  List all data transfer services.
+
+        pipe dts list
+
+    II. Show details of a single data transfer service with some name (dtsname).
+
+        pipe dts list dtsname
+
+    II. Show details of a single data transfer service with some id (123).
+
+        pipe dts list 123
+
     """
     DtsOperationsManager().list(registry_name_or_id, json_out)
 
 
+@dts.command(name='delete')
+@click.argument('registry-name-or-id', required=True, type=str)
+@click.option('--json-out', '-jo', required=False, is_flag=True, help='Defines if output should be JSON-formatted')
+@click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
+@Config.validate_access_token
+@stacktracing
+def create_dts(registry_name_or_id, json_out, trace):
+    """
+    Deletes data transfer service.
+
+    Examples:
+
+    I.  Deletes data transfer service with some name (dtsname).
+
+        pipe dts delete dtsname
+
+    II. Deletes data transfer service with some id (123).
+
+        pipe dts delete 123
+
+    """
+    DtsOperationsManager().delete(registry_name_or_id, json_out)
+
+
 @dts.group()
 def preferences():
-    """ Commands for DTS preferences management
+    """
+    Commands for data transfer service preferences management
     """
     pass
 
@@ -1784,7 +1836,22 @@ def preferences():
 @stacktracing
 def update_dts_preferences(registry_name_or_id, preference, json_out, trace):
     """
-    Updates preferences for the given DTS
+    Updates existing preferences or adds new preferences for the given data transfer service.
+
+    Examples:
+
+    I.   Adds single preference for a data transfer service with some name (dtsname).
+
+        pipe dts preferences update dtsname -p key=value
+
+    II.  Adds multiple preferences for a data transfer service with some name (dtsname).
+
+        pipe dts preferences update dtsname -p key1=value1 -p key2=value2
+
+    III. Adds a single preference for a data transfer service with some id (123).
+
+        pipe dts preferences update 123 -p key=value
+
     """
     DtsOperationsManager().upsert_preferences(registry_name_or_id, preference, json_out)
 
@@ -1799,7 +1866,22 @@ def update_dts_preferences(registry_name_or_id, preference, json_out, trace):
 @stacktracing
 def delete_dts_preferences(registry_name_or_id, key, json_out, trace):
     """
-    Removes preferences for specified keys from the given DTS
+    Deletes preferences for the given data transfer service.
+
+    Examples:
+
+    I.   Deletes a single preference (key) from a data transfer service with some name (dtsname).
+
+        pipe dts preferences delete dtsname -k key
+
+    II.  Deletes multiple preferences (key1, key2) from a data transfer service with some name (dtsname).
+
+        pipe dts preferences delete dtsname -k key1 -k key2
+
+    III. Deletes a single preference (key) from a data transfer service with some id (123).
+
+        pipe dts preferences delete 123 -k key
+
     """
     DtsOperationsManager().delete_preferences(registry_name_or_id, key, json_out)
 

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1892,5 +1892,5 @@ def delete_dts_preferences(registry_name_or_id, preference, json_out, trace):
 
 
 # Used to run a PyInstaller "freezed" version
-# if getattr(sys, 'frozen', False):
-cli(sys.argv[1:])
+if getattr(sys, 'frozen', False):
+    cli(sys.argv[1:])

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1807,7 +1807,7 @@ def list_dts(registry_name_or_id, json_out, trace):
 @click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
 @Config.validate_access_token
 @stacktracing
-def create_dts(registry_name_or_id, json_out, trace):
+def delete_dts(registry_name_or_id, json_out, trace):
     """
     Deletes data transfer service.
 

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1275,6 +1275,7 @@ def chown(user_name, entity_class, entity_name):
 @click.option('-r', '--retries', required=False, type=int, default=10, help=RETRIES_OPTION_DESCRIPTION)
 @click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
 @click.option('-rg', '--region', required=False, help='The edge region name. If not specified the default edge region '
+                                                      'will be used.')
 @click.pass_context
 @Config.validate_access_token
 @stacktracing
@@ -1311,6 +1312,7 @@ def ssh(ctx, run_id, retries, trace, region):
 @click.option('--retries', required=False, type=int, default=10, help=RETRIES_OPTION_DESCRIPTION)
 @click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
 @click.option('-rg', '--region', required=False, help='The edge region name. If not specified the default edge region '
+                                                      'will be used.')
 @Config.validate_access_token
 @stacktracing
 def scp(source, destination, recursive, quiet, retries, trace, region):

--- a/pipe-cli/src/api/dts.py
+++ b/pipe-cli/src/api/dts.py
@@ -54,6 +54,12 @@ class DTS(API):
         return DtsModel().load(response)
 
     @classmethod
+    def delete(cls, registry_id):
+        api = cls.instance()
+        response = api.retryable_call('DELETE', '/dts/{}'.format(registry_id))
+        return DtsModel().load(response)
+
+    @classmethod
     def update_preferences(cls, registry_id, preferences):
         api = cls.instance()
         preferences_update = {

--- a/pipe-cli/src/api/dts.py
+++ b/pipe-cli/src/api/dts.py
@@ -41,7 +41,7 @@ class DTS(API):
     @classmethod
     def load_all(cls):
         api = cls.instance()
-        response = api.retryable_call('GET', '/dts')
+        response = api.retryable_call('GET', '/dts') or []
         registries = []
         for registry_json in response:
             registries.append(DtsModel().load(registry_json))

--- a/pipe-cli/src/model/dts_model.py
+++ b/pipe-cli/src/model/dts_model.py
@@ -24,6 +24,8 @@ class DtsModel(object):
         self.url = None
         self.created_date = None
         self.schedulable = False
+        self.status = None
+        self.heartbeat = None
         self.prefixes = []
         self.preferences = {}
 
@@ -35,6 +37,10 @@ class DtsModel(object):
         dts.url = json['url']
         dts.created_date = date_utilities.server_date_representation(json['createdDate'])
         dts.schedulable = json['schedulable']
+        dts.status = json['status']
+        dts.heartbeat = json.get('heartbeat')
+        if dts.heartbeat:
+            dts.heartbeat = date_utilities.server_date_representation(dts.heartbeat)
         dts.prefixes = json.get('prefixes') or []
         dts.preferences = json.get('preferences') or {}
         return dts

--- a/pipe-cli/src/utilities/dts_operations_manager.py
+++ b/pipe-cli/src/utilities/dts_operations_manager.py
@@ -23,7 +23,7 @@ from src.model.dts_model import DtsEncoder
 
 class DtsOperationsManager:
 
-    _DTS_TABLE_HEADERS = ['ID', 'Name', 'Schedulable']
+    _DTS_TABLE_HEADERS = ['ID', 'Name', 'Status']
     _PREF_DELIMITER = "="
 
     def __init__(self):
@@ -41,8 +41,10 @@ class DtsOperationsManager:
             registries = DTS.load_all()
             if json_out:
                 self._print_dts_json(registries)
-            else:
+            elif registries:
                 self._print_registries_prettytable(registries)
+            else:
+                click.echo('No data transfer services are available.')
 
     def upsert_preferences(self, registry_id, preferences_list, json_out):
         if not preferences_list:
@@ -89,6 +91,8 @@ class DtsOperationsManager:
         registry_info_table.add_row(['URL:', registry.url])
         registry_info_table.add_row(['Created:', registry.created_date])
         registry_info_table.add_row(['Schedulable:', registry.schedulable])
+        registry_info_table.add_row(['Status:', registry.status])
+        registry_info_table.add_row(['Last heartbeat:', registry.heartbeat or 'No heartbeat was received yet'])
         click.echo(registry_info_table)
         self._print_list_as_table('Prefixes', registry.prefixes)
         self._print_list_as_table('Preferences', self.get_flat_preferences(registry))
@@ -129,4 +133,4 @@ class DtsOperationsManager:
         return table
 
     def _convert_registry_to_prettytable_row(self, registry):
-        return [registry.id, registry.name, registry.schedulable]
+        return [registry.id, registry.name, registry.status]

--- a/pipe-cli/src/utilities/dts_operations_manager.py
+++ b/pipe-cli/src/utilities/dts_operations_manager.py
@@ -46,6 +46,10 @@ class DtsOperationsManager:
             else:
                 click.echo('No data transfer services are available.')
 
+    def delete(self, registry_id, json_out):
+        registry = DTS.delete(registry_id)
+        self._print_registry(registry, json_out)
+
     def upsert_preferences(self, registry_id, preferences_list, json_out):
         if not preferences_list:
             click.echo('Preferences should not be empty!', err=True)

--- a/scripts/dts/README.md
+++ b/scripts/dts/README.md
@@ -3,7 +3,7 @@
 Launcher script allows deploying Data Transfer Service for local directories' synchronisation to Windows hosts.
 It handles Data Transfer Service failures and host restarts allowing to maintain continuous data synchronisation process.
 
-# Install
+## Install
 
 To install dts InstallDts.ps1 script can be used.
 Download the script and set `API`, `API_TOKEN` and `API_PUBLIC_KEY` environment variable placeholders in it.
@@ -14,7 +14,7 @@ Set-ExecutionPolicy Bypass -Scope Process -Force -Confirm:$false
 & "$HOME\Downloads\InstallDts.ps1"
 ```
 
-# Configure
+## Configure
 
 To register new dts the command below can be used. Notice that DTS name should be the same as in the _Install_ step.
 
@@ -25,10 +25,9 @@ pipe dts create --name "$DTS_NAME" \
                 --prefix "$DTS_NAME"
 ```
 
-To synchronise some local directory as well as dts logs directory every midnight the command below can be used.
+To synchronise some data directory as well as dts logs directory every minute the command below can be used.
 
 ```bash
-DTS_NAME="{PUT DTS HOST NAME HERE}"
 pipe dts preferences update "$DTS_NAME" -p 'dts.local.sync.rules=[{
                                                 "source": "c:\\local\\path\\to\\source\\directory",
                                                 "destination": "s3://data/storage/path/to/destination/directory",
@@ -43,6 +42,19 @@ pipe dts preferences update "$DTS_NAME" -p 'dts.local.sync.rules=[{
 To restart dts the command below can be used.
 
 ```bash
-DTS_NAME="{PUT DTS HOST NAME HERE}"
 pipe dts preferences update "$DTS_NAME" -p 'dts.restart.force=true'
 ```
+
+To enabled dts heartbeat the command below can be used.
+
+```bash
+pipe dts preferences update "$DTS_NAME" -p 'dts.heartbeat.enabled=true'
+```
+
+## Cron
+
+The following cron expressions can be used as a template in synchronisation rules in dts.
+
+- `0 0/1 * ? * *` - every minute (00:00, 00:01, ..., 00:00, 00:01, ...)
+- `0 0 * ? * *` - every hour (00:00, 01:00, ..., 00:00, 01:00, ...)
+- `0 30 14 ? * *` - every day at 14:30 (14:30, 14:30, ..., 14:30, 14:30, ...)


### PR DESCRIPTION
Relates to #2044.

The pull request brings support for data transfer service heartbeat.

## System preferences

Several new system preferences are introduced.

- `dts.monitoring.period.seconds` configures how often API should monitor data transfer services in seconds. By default it does it every minute.
- `dts.offline.timeout.seconds` configures a timeout in seconds after which data transfer service is considered offline if no heartbeats were sent during that period. By default timeout is five minutes.

## Observation

The following pipe cli command can be used to check status of all data transfer services.

```bash
pipe dts list

# +----+------------+---------+
# | ID | Name       | Status  |
# +----+------------+---------+
# | 1  | firstdts   | ONLINE  |
# +----+------------+---------+
# | 2  | seconddts  | OFFLINE |
# +----+------------+---------+
```

## Configuration

_Notice that heartbeat is disabled in data transfer service by default._ To enable heartbeat the following preference should be set for each individual data transfer service: `dts.heartbeat.enabled`. This can be done using the following cli command.

```bash
pipe dts preferences update dtsname -p dts.heartbeat.enabled=true
```

## Related changes

Besides the introduction of data transfer service heartbeat the following smaller changes are also covered by this pull request:
- Disable support for registering two data transfer services with the same name in api.
- Support `pipe dts delete` command in cli.
- Support `--trace` flag in all `pipe dts` commands in cli.
- Update `--help` output for all `pipe dts` commands in cli.