### PR TITLE
Issue 2084 exclude files from vs reporst and commits

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/git/gitreader/GitReaderLogsPathFilter.java
+++ b/api/src/main/java/com/epam/pipeline/entity/git/gitreader/GitReaderLogsPathFilter.java
@@ -17,11 +17,13 @@
 package com.epam.pipeline.entity.git.gitreader;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 import java.util.List;
 
 @Data
+@AllArgsConstructor
 public class GitReaderLogsPathFilter {
 
     @JsonProperty("paths")

--- a/api/src/main/java/com/epam/pipeline/manager/git/GitManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/GitManager.java
@@ -1021,6 +1021,7 @@ public class GitManager {
                         preferenceManager.getPreference(SystemPreferences.VERSION_STORAGE_IGNORED_FILES)
                 ).orElse(EMPTY).split(COMMA))
                 .filter(p -> !StringUtils.isNullOrEmpty(p))
+                .map(String::trim)
                 .map(p -> {
                     if (!p.startsWith(ROOT_PATH)) {
                         return EXCLUDE_MARK + ANY_SUB_PATH + p;

--- a/api/src/main/java/com/epam/pipeline/manager/git/GitReaderApi.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/GitReaderApi.java
@@ -28,12 +28,10 @@ import com.epam.pipeline.entity.git.gitreader.GitReaderRepositoryCommitDiff;
 import com.epam.pipeline.entity.git.gitreader.GitReaderRepositoryLogEntry;
 import retrofit2.Call;
 import retrofit2.http.Body;
-import retrofit2.http.GET;
 import retrofit2.http.POST;
 import retrofit2.http.Path;
 import retrofit2.http.Query;
 
-import java.util.List;
 
 public interface GitReaderApi {
 
@@ -50,35 +48,35 @@ public interface GitReaderApi {
      * This command provides essentially the same functionality as the git ls-tree command.
      *
      * @param name  URL-encoded path of the project
-     * @param path      (optional) - The path inside repository. Used to get contend of subdirectories
      * @param reference (optional) - The name of a repository branch or tag or if not given the default branch
      * @param page (optional) - The number of page to return
      * @param pageSize (optional) - The size of the page to return
+     * @param paths      (optional) - The paths inside repository. Used to get contend of subdirectories
      */
-    @GET("git/{project}/ls_tree")
+    @POST("git/{project}/ls_tree")
     Call<Result<GitReaderEntryListing<GitReaderObject>>> getRepositoryTree(@Path(PROJECT) String name,
-                                                                           @Query(PATH_GLOBS) List<String> path,
                                                                            @Query(REF) String reference,
                                                                            @Query(PAGE) Long page,
-                                                                           @Query(PAGE_SIZE) Integer pageSize);
+                                                                           @Query(PAGE_SIZE) Integer pageSize,
+                                                                           @Body GitReaderLogsPathFilter paths);
 
 
     /**
      * Get a list of repository files and directories in a project with additional information about last commit.
      *
      * @param name  URL-encoded path of the project
-     * @param path  Url encoded full path to new file. Ex. lib%2Fclass%2Erb
      * @param reference The name of branch, tag or commit
      * @param page (optional) - The number of page to return
      * @param pageSize (optional) - The size of the page to return
+     * @param paths  (optional) - The paths inside repository. Used to get contend of subdirectories
      */
-    @GET("git/{project}/logs_tree")
+    @POST("git/{project}/logs_tree")
     Call<Result<GitReaderEntryListing<GitReaderRepositoryLogEntry>>> getRepositoryLogsTree(
             @Path(PROJECT) String name,
-            @Query(PATH_GLOBS) List<String> path,
             @Query(REF) String reference,
             @Query(PAGE) Long page,
-            @Query(PAGE_SIZE) Integer pageSize);
+            @Query(PAGE_SIZE) Integer pageSize,
+            @Body GitReaderLogsPathFilter paths);
 
     /**
      * Get a list of repository files and directories in a project with additional information about last commit.
@@ -122,11 +120,11 @@ public interface GitReaderApi {
      *
      * @param name  URL-encoded path of the project
      * @param commit - The commit sha
-     * @param path (optional) - path to filter diff output
+     * @param paths (optional) - path globs to filter diff output
      */
-    @GET("git/{project}/diff/{commit}")
+    @POST("git/{project}/diff/{commit}")
     Call<Result<GitReaderDiffEntry>> getCommitDiff(@Path(PROJECT) String name, @Path(COMMIT) String commit,
-                                                   @Query(PATH_GLOBS) List<String> path);
+                                                   @Body GitReaderLogsPathFilter paths);
 
 
 }

--- a/api/src/main/java/com/epam/pipeline/manager/git/GitReaderApi.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/GitReaderApi.java
@@ -33,11 +33,13 @@ import retrofit2.http.POST;
 import retrofit2.http.Path;
 import retrofit2.http.Query;
 
+import java.util.List;
+
 public interface GitReaderApi {
 
     String REF = "ref";
     String PROJECT = "project";
-    String PATH = "path";
+    String PATH_GLOBS = "paths";
     String PAGE = "page";
     String PAGE_SIZE = "page_size";
     String INCLUDE_DIFF = "include_diff";
@@ -55,7 +57,7 @@ public interface GitReaderApi {
      */
     @GET("git/{project}/ls_tree")
     Call<Result<GitReaderEntryListing<GitReaderObject>>> getRepositoryTree(@Path(PROJECT) String name,
-                                                                           @Query(PATH) String path,
+                                                                           @Query(PATH_GLOBS) List<String> path,
                                                                            @Query(REF) String reference,
                                                                            @Query(PAGE) Long page,
                                                                            @Query(PAGE_SIZE) Integer pageSize);
@@ -73,7 +75,7 @@ public interface GitReaderApi {
     @GET("git/{project}/logs_tree")
     Call<Result<GitReaderEntryListing<GitReaderRepositoryLogEntry>>> getRepositoryLogsTree(
             @Path(PROJECT) String name,
-            @Query(PATH) String path,
+            @Query(PATH_GLOBS) List<String> path,
             @Query(REF) String reference,
             @Query(PAGE) Long page,
             @Query(PAGE_SIZE) Integer pageSize);
@@ -124,7 +126,7 @@ public interface GitReaderApi {
      */
     @GET("git/{project}/diff/{commit}")
     Call<Result<GitReaderDiffEntry>> getCommitDiff(@Path(PROJECT) String name, @Path(COMMIT) String commit,
-                                                   @Query(PATH) String path);
+                                                   @Query(PATH_GLOBS) List<String> path);
 
 
 }

--- a/api/src/main/java/com/epam/pipeline/manager/git/GitReaderClient.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/GitReaderClient.java
@@ -96,29 +96,28 @@ public class GitReaderClient {
 
     public GitReaderDiffEntry getRepositoryCommitDiff(final GitRepositoryUrl repo,
                                                       final String commit,
-                                                      final List<String> paths) throws GitClientException {
+                                                      final GitReaderLogsPathFilter paths) throws GitClientException {
         return callAndCheckResult(
                 gitReaderApi.getCommitDiff(getRepositoryPath(repo), commit, paths)
         ).getPayload();
     }
 
     public GitReaderEntryListing<GitReaderObject> getRepositoryTree(final GitRepositoryUrl repo,
-                                                                    final List<String> paths,
+                                                                    final GitReaderLogsPathFilter paths,
                                                                     final String ref, final Long page,
-                                                                    final Integer pageSize)
-            throws GitClientException {
+                                                                    final Integer pageSize) throws GitClientException {
         return callAndCheckResult(
-                gitReaderApi.getRepositoryTree(getRepositoryPath(repo), paths, ref, page, pageSize)
+                gitReaderApi.getRepositoryTree(getRepositoryPath(repo), ref, page, pageSize, paths)
         ).getPayload();
     }
 
     public GitReaderEntryListing<GitReaderRepositoryLogEntry> getRepositoryTreeLogs(final GitRepositoryUrl repo,
-                                                                                    final List<String> paths,
+                                                                                    final GitReaderLogsPathFilter paths,
                                                                                     final String ref, final Long page,
                                                                                     final Integer pageSize)
             throws GitClientException {
         return callAndCheckResult(
-                gitReaderApi.getRepositoryLogsTree(getRepositoryPath(repo), paths, ref, page, pageSize)
+                gitReaderApi.getRepositoryLogsTree(getRepositoryPath(repo), ref, page, pageSize, paths)
         ).getPayload();
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -153,7 +153,7 @@ public class SystemPreferences {
             "storage.version.storage.report.binary.file.exts",
             "pdf", DATA_STORAGE_GROUP, pass);
     public static final StringPreference VERSION_STORAGE_IGNORED_FILES = new StringPreference(
-            "storage.version.storage.report.ignored.files",
+            "storage.version.storage.ignored.files",
             ".gitkeep", DATA_STORAGE_GROUP, PreferenceValidators.isEmptyOrValidBatchOfPaths);
 
 

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -152,6 +152,9 @@ public class SystemPreferences {
     public static final StringPreference VERSION_STORAGE_BINARY_FILE_EXTS = new StringPreference(
             "storage.version.storage.report.binary.file.exts",
             "pdf", DATA_STORAGE_GROUP, pass);
+    public static final StringPreference VERSION_STORAGE_IGNORED_FILES = new StringPreference(
+            "storage.version.storage.report.ignored.files",
+            ".gitkeep", DATA_STORAGE_GROUP, PreferenceValidators.isEmptyOrValidBatchOfPaths);
 
 
     /**

--- a/api/src/test/java/com/epam/pipeline/manager/git/GitReaderClientTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/git/GitReaderClientTest.java
@@ -18,6 +18,7 @@ package com.epam.pipeline.manager.git;
 
 import com.epam.pipeline.entity.git.GitCommitsFilter;
 import com.epam.pipeline.entity.git.gitreader.GitReaderLogRequestFilter;
+import org.apache.commons.collections4.CollectionUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -29,11 +30,9 @@ public class GitReaderClientTest {
     @Test
     public void testMapEmptyCommitFilters() {
         GitReaderLogRequestFilter mapped = GitReaderClient.toGitReaderRequestFilter(
-                GitCommitsFilter.builder()
-                        .build()
-        );
+                GitCommitsFilter.builder().build(), Collections.emptyList());
 
-        Assert.assertNull(mapped.getPathMasks());
+        Assert.assertTrue(CollectionUtils.isEmpty(mapped.getPathMasks()));
         Assert.assertNull(mapped.getAuthors());
         Assert.assertNull(mapped.getRef());
         Assert.assertNull(mapped.getDateFrom());
@@ -45,8 +44,7 @@ public class GitReaderClientTest {
         GitReaderLogRequestFilter mapped = GitReaderClient.toGitReaderRequestFilter(
                 GitCommitsFilter.builder()
                         .extensions(Collections.singletonList("js"))
-                        .build()
-        );
+                        .build(), Collections.emptyList());
 
         Assert.assertArrayEquals(mapped.getPathMasks().toArray(), Collections.singletonList("*.js").toArray());
     }
@@ -56,8 +54,7 @@ public class GitReaderClientTest {
         GitReaderLogRequestFilter mapped = GitReaderClient.toGitReaderRequestFilter(
                 GitCommitsFilter.builder()
                         .extensions(Arrays.asList("js", "py"))
-                        .build()
-        );
+                        .build(), Collections.emptyList());
 
         Assert.assertArrayEquals(mapped.getPathMasks().toArray(), new String[]{"*.js", "*.py"});
     }
@@ -68,8 +65,7 @@ public class GitReaderClientTest {
                 GitCommitsFilter.builder()
                         .path("path/")
                         .extensions(Arrays.asList("js", "py"))
-                        .build()
-        );
+                        .build(), Collections.emptyList());
 
         Assert.assertArrayEquals(mapped.getPathMasks().toArray(), new String[]{"path/*.js", "path/*.py"});
     }
@@ -79,8 +75,7 @@ public class GitReaderClientTest {
         GitReaderLogRequestFilter mapped = GitReaderClient.toGitReaderRequestFilter(
                 GitCommitsFilter.builder()
                         .path("path/")
-                        .build()
-        );
+                        .build(), Collections.emptyList());
 
         Assert.assertArrayEquals(mapped.getPathMasks().toArray(), new String[]{"path/"});
     }

--- a/deploy/contents/install/app/configure-utils.sh
+++ b/deploy/contents/install/app/configure-utils.sh
@@ -909,6 +909,7 @@ function api_setup_base_preferences {
 
     ## Storage
     api_set_preference "storage.allow.signed.urls" "${CP_PREF_STORAGE_ALLOW_SIGNED_URLS:-"true"}" "true"
+    api_set_preference "storage.version.storage.ignored.files" ".gitkeep" "true"
 
     ## Metadata
     api_set_preference "misc.metadata.sensitive.keys" "${CP_PREF_METADATA_SENSITIVE_KEYS:-"[]"}" "true"

--- a/git-reader/gitreader/application.py
+++ b/git-reader/gitreader/application.py
@@ -67,8 +67,8 @@ def health():
 def git_list_tree(repo):
     manager = app.config['gitmanager']
     try:
-        path, page, page_size, ref = parse_url_params()
-        list_tree = manager.ls_tree(repo, path, ref, page, page_size)
+        path_masks, page, page_size, ref = parse_url_params()
+        list_tree = manager.ls_tree(repo, path_masks, ref, page, page_size)
         return jsonify(success(list_tree.to_json()))
     except Exception as e:
         manager.logger.log(traceback.format_exc())
@@ -80,9 +80,9 @@ def git_list_tree(repo):
 @swag_from('flasgger-doc/logs-tree.yml')
 def git_logs_tree(repo):
     manager = app.config['gitmanager']
-    path, page, page_size, ref = parse_url_params()
+    path_masks, page, page_size, ref = parse_url_params()
     try:
-        logs_tree = manager.logs_tree(repo, path, ref, page, page_size)
+        logs_tree = manager.logs_tree(repo, path_masks, ref, page, page_size)
         return jsonify(success(logs_tree.to_json()))
     except Exception as e:
         manager.logger.log(traceback.format_exc())
@@ -148,15 +148,15 @@ def git_diff_report(repo):
 def git_diff_by_commit(repo, commit):
     manager = app.config['gitmanager']
     try:
-        if request.args.get('path'):
-            path = request.args.get('path')
+        if request.args.getlist('paths'):
+            path_masks = request.args.getlist('paths')
         else:
-            path = "."
+            path_masks = ["."]
 
         unified_lines = 3
         if request.args.get('unified_lines'):
             unified_lines = int(request.args.get('unified_lines'))
-        commit_diff = manager.diff(repo, commit, path, unified_lines)
+        commit_diff = manager.diff(repo, commit, path_masks, unified_lines)
         return jsonify(success(commit_diff.to_json()))
     except Exception as e:
         manager.logger.log(traceback.format_exc())
@@ -182,9 +182,9 @@ def str_to_bool(input_value):
 
 
 def parse_url_params():
-    path = "."
-    if request.args.get('path'):
-        path = request.args.get('path')
+    path_masks = ["."]
+    if request.args.getlist('paths'):
+        path_masks = request.args.getlist('paths')
     page = 0
     if request.args.get('page'):
         page = int(request.args.get('page'))
@@ -194,7 +194,7 @@ def parse_url_params():
     ref = "HEAD"
     if request.args.get('ref'):
         ref = request.args.get('ref')
-    return path, page, page_size, ref
+    return path_masks, page, page_size, ref
 
 
 def main():

--- a/git-reader/gitreader/application.py
+++ b/git-reader/gitreader/application.py
@@ -61,13 +61,14 @@ def health():
     return jsonify(success({"healthy": True}))
 
 
-@app.route('/git/<path:repo>/ls_tree')
+@app.route('/git/<path:repo>/ls_tree',  methods=["POST"])
 @auth.login_required
 @swag_from('flasgger-doc/list-tree.yml')
 def git_list_tree(repo):
     manager = app.config['gitmanager']
     try:
-        path_masks, page, page_size, ref = parse_url_params()
+        path_masks = extract_path_masks()
+        page, page_size, ref = parse_url_params()
         list_tree = manager.ls_tree(repo, path_masks, ref, page, page_size)
         return jsonify(success(list_tree.to_json()))
     except Exception as e:
@@ -75,13 +76,14 @@ def git_list_tree(repo):
         return jsonify(error(e.__str__()))
 
 
-@app.route('/git/<path:repo>/logs_tree',  methods=["GET"])
+@app.route('/git/<path:repo>/logs_tree',  methods=["POST"])
 @auth.login_required
 @swag_from('flasgger-doc/logs-tree.yml')
 def git_logs_tree(repo):
     manager = app.config['gitmanager']
-    path_masks, page, page_size, ref = parse_url_params()
+    page, page_size, ref = parse_url_params()
     try:
+        path_masks = extract_path_masks()
         logs_tree = manager.logs_tree(repo, path_masks, ref, page, page_size)
         return jsonify(success(logs_tree.to_json()))
     except Exception as e:
@@ -95,7 +97,7 @@ def git_logs_tree(repo):
 def git_logs_tree_by_paths(repo):
     manager = app.config['gitmanager']
     try:
-        _, _, _, ref = parse_url_params()
+        _, _, ref = parse_url_params()
         data = load_data_from_request(request)
         if "paths" in data:
             logs_tree = manager.logs_paths(repo, ref, data['paths'])
@@ -114,7 +116,7 @@ def git_list_commits(repo):
     manager = app.config['gitmanager']
     try:
         filters = load_filters_from_request(request)
-        _, page, page_size, _ = parse_url_params()
+        page, page_size, _ = parse_url_params()
         commits = manager.list_commits(repo, filters, page, page_size)
         return jsonify(success(commits.to_json()))
     except Exception as e:
@@ -142,17 +144,13 @@ def git_diff_report(repo):
         return jsonify(error(e.__str__()))
 
 
-@app.route('/git/<path:repo>/diff/<commit>', methods=["GET"])
+@app.route('/git/<path:repo>/diff/<commit>', methods=["POST"])
 @auth.login_required
 @swag_from('flasgger-doc/diff-by-commit.yml')
 def git_diff_by_commit(repo, commit):
     manager = app.config['gitmanager']
     try:
-        if request.args.getlist('paths'):
-            path_masks = request.args.getlist('paths')
-        else:
-            path_masks = ["."]
-
+        path_masks = extract_path_masks()
         unified_lines = 3
         if request.args.get('unified_lines'):
             unified_lines = int(request.args.get('unified_lines'))
@@ -161,6 +159,15 @@ def git_diff_by_commit(repo, commit):
     except Exception as e:
         manager.logger.log(traceback.format_exc())
         return jsonify(error(e.__str__()))
+
+
+def extract_path_masks():
+    data = load_data_from_request(request)
+    if "paths" in data:
+        path_masks = data['paths']
+    else:
+        path_masks = ["."]
+    return path_masks
 
 
 def load_filters_from_request(req):
@@ -182,9 +189,6 @@ def str_to_bool(input_value):
 
 
 def parse_url_params():
-    path_masks = ["."]
-    if request.args.getlist('paths'):
-        path_masks = request.args.getlist('paths')
     page = 0
     if request.args.get('page'):
         page = int(request.args.get('page'))
@@ -194,7 +198,7 @@ def parse_url_params():
     ref = "HEAD"
     if request.args.get('ref'):
         ref = request.args.get('ref')
-    return path_masks, page, page_size, ref
+    return page, page_size, ref
 
 
 def main():

--- a/git-reader/gitreader/src/git_manager.py
+++ b/git-reader/gitreader/src/git_manager.py
@@ -35,10 +35,12 @@ class GitManager(object):
         self.logger = logger
         self.git_root = git_root
 
-    def logs_tree(self, repo_path, path, ref="HEAD", page=0, page_size=20):
+    def logs_tree(self, repo_path, paths=None, ref="HEAD", page=0, page_size=20):
+        if paths is None:
+            paths = ["."]
         repo = self.getRepo(repo_path)
         result = []
-        max_page, listing = self.list_tree(repo, path, ref, page, page_size)
+        max_page, listing = self.list_tree(repo, paths, ref, page, page_size)
         for git_object in listing:
             result.append(self.get_last_commit_by_object(repo, ref, git_object))
         return GitListing(result, page, page_size, max_page=max_page)
@@ -49,7 +51,7 @@ class GitManager(object):
             paths = []
         result = []
         for path in paths:
-            _, listing = self.list_tree(repo, path, ref, 0, 1)
+            _, listing = self.list_tree(repo, [path], ref, 0, 1)
             if len(listing) == 1:
                 result.append(self.get_last_commit_by_object(repo, ref, listing[0]))
         return GitListing(result, 0, len(result))
@@ -59,9 +61,9 @@ class GitManager(object):
         has_next, result = self.get_commits(repo, filters, page * page_size, page_size)
         return GitListing(result, page, page_size, has_next=has_next)
 
-    def ls_tree(self, repo_path, path, ref="HEAD", page=0, page_size=20):
+    def ls_tree(self, repo_path, paths, ref="HEAD", page=0, page_size=20):
         repo = self.getRepo(repo_path)
-        max_page, listing = self.list_tree(repo, path, ref, page, page_size)
+        max_page, listing = self.list_tree(repo, paths, ref, page, page_size)
         return GitListing(listing, page, page_size, max_page=max_page)
 
     def diff_report(self, repo_path, filters=None, include_diff=False, unified_lines=3):
@@ -72,9 +74,9 @@ class GitManager(object):
         else:
             return GitDiffReport(filters, [GitDiffReportEntry(x, None) for x in commits_for_report])
 
-    def diff(self, repo_path, commit, path, unified_lines=3):
+    def diff(self, repo_path, commit, paths, unified_lines=3):
         repo = self.getRepo(repo_path)
-        return GitDiffReportEntry(GitCommit(sha=commit), self.get_diff(repo, GitCommit(sha=commit), unified_lines, GitSearchFilter(path_masks=[path])))
+        return GitDiffReportEntry(GitCommit(sha=commit), self.get_diff(repo, GitCommit(sha=commit), unified_lines, GitSearchFilter(path_masks=paths)))
 
     def get_commits(self, repo, filters, skip, batch_size):
         args = ['--skip={}'.format(skip), '-{}'.format(batch_size + 1), '--format=%H||%P||%ai||%an||%ae||%ci||%cn||%ce||%s']
@@ -106,10 +108,10 @@ class GitManager(object):
             # '4b825dc642cb6eb9a060e54bf8d69288fbee4904' - the empty tree SHA and this commit
             return repo.git.diff("-U{}".format(unified_lines), EMPTY_TREE_SHA, commit.sha, "--", filters.path_masks)
 
-    def list_tree(self, repo, path, ref, page, page_size):
+    def list_tree(self, repo, paths, ref, page, page_size):
         result = []
         offset = int(page * page_size)
-        git_ls_tree_result = repo.git.ls_tree("--full-tree", ref, "-l", "--", path)
+        git_ls_tree_result = repo.git.ls_tree("--full-tree", ref, "-l", "--", paths)
         if git_ls_tree_result == "" or not git_ls_tree_result:
             return 0, result
         git_ls_tree_result = git_ls_tree_result.split("\n")


### PR DESCRIPTION
This PR adds new functionality to hide some of the files from VS reports and history (f.e. it is useful for such files like .gitkeep that we've created to store an empty directory)

new preference `storage.version.storage.ignored.files` is introduced - it can contain list of path globs to be excluded from VS history
e.g.
`.gitkeep,/root_ignored_file` - split by `,`
Note that if path glob started with `/` it is treated as an absolute path, and if it doesn't it will treated as a context path -> `.gitkeep` will be ignored for each folder but `/root_ignored_file` will be ignored only in `/`

For this changes model of Rest API for Git Reader was changed, now it accept batch of paths as a request body to be able to provide to it an excluded paths 

@rodichenko @sidoruka @mzueva additional changes for UI part is needed, since we have filtration on UI part for VS listing we need to support new preference `storage.version.storage.ignored.files` that contains file patterns to be ignored
for such need server does it like:

```
split and trim preference storage.version.storage.ignored.files
for each file_pattern adds * to the start of the file_pattern if it isn't starts with / to be able to filter such files for each directory
``` 