### PR TITLE
Issue #2115 Allow to store CLI config in the installation directory

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -149,7 +149,11 @@ def cli():
 @click.option('-c', '--codec',
               help='Encoding that shall be used',
               default=None)
-def configure(auth_token, api, timezone, proxy, proxy_ntlm, proxy_ntlm_user, proxy_ntlm_domain, proxy_ntlm_pass, codec):
+@click.option('-cs', '--config-store',
+              help='CLI configuration mode(home-dir/install-dir)',
+              default='home-dir')
+def configure(auth_token, api, timezone, proxy, proxy_ntlm, proxy_ntlm_user, proxy_ntlm_domain, proxy_ntlm_pass, codec,
+              config_store):
     """Configures CLI parameters
     """
     if proxy_ntlm and not proxy_ntlm_user:
@@ -167,7 +171,8 @@ def configure(auth_token, api, timezone, proxy, proxy_ntlm, proxy_ntlm_user, pro
                  proxy_ntlm_user,
                  proxy_ntlm_domain,
                  proxy_ntlm_pass,
-                 codec)
+                 codec,
+                 config_store)
 
 
 def echo_title(title, line=True):

--- a/pipe-cli/src/config.py
+++ b/pipe-cli/src/config.py
@@ -206,10 +206,10 @@ class Config(object):
                   'codec': codec
                   }
         config_store_mode = config_store.lower()
+        install_dir_config = cls.get_install_dir_config_path()
         if 'install-dir' == config_store_mode:
-            config_file = cls.get_install_dir_config_path()
+            config_file = install_dir_config
         elif 'home-dir' == config_store_mode:
-            install_dir_config = cls.get_install_dir_config_path()
             if os.path.exists(install_dir_config):
                 try:
                     os.remove(install_dir_config)
@@ -218,7 +218,7 @@ class Config(object):
                     sys.exit(1)
             config_file = cls.get_home_dir_config_path()
         else:
-            click.echo('Unknown storing mode for CLI config: `{}`, valid types are [install-dir, home-dir].'
+            click.echo('Unknown storing mode for CLI config: `{}`, valid types are [home-dir, install-dir].'
                        .format(config_store),
                        err=True)
             sys.exit(1)

--- a/pipe-cli/src/config.py
+++ b/pipe-cli/src/config.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -182,7 +182,7 @@ class Config(object):
 
     @classmethod
     def store(cls, access_key, api, timezone, proxy,
-              proxy_ntlm, proxy_ntlm_user, proxy_ntlm_domain, proxy_ntlm_pass, codec):
+              proxy_ntlm, proxy_ntlm_user, proxy_ntlm_domain, proxy_ntlm_pass, codec, config_store):
         check_token(access_key, timezone)
         if proxy == PROXY_TYPE_PAC and proxy_ntlm:
             raise ProxyInvalidConfig('NTLM proxy authentication cannot be used for the PAC proxy type'
@@ -205,7 +205,25 @@ class Config(object):
                   'proxy_ntlm_pass': cls.encode_password(proxy_ntlm_pass),
                   'codec': codec
                   }
-        config_file = cls.config_path()
+        config_store_mode = config_store.lower()
+        if 'install-dir' == config_store_mode:
+            config_file = cls.get_install_dir_config_path()
+        elif 'home-dir' == config_store_mode:
+            install_dir_config = cls.get_install_dir_config_path()
+            if os.path.exists(install_dir_config):
+                try:
+                    os.remove(install_dir_config)
+                except OSError:
+                    click.echo("Unable to cleanup existing config in the installation directory")
+                    sys.exit(1)
+            config_file = cls.get_home_dir_config_path()
+        else:
+            click.echo('Unknown storing mode for CLI config: `{}`, valid types are [install-dir, home-dir].'
+                       .format(config_store),
+                       err=True)
+            sys.exit(1)
+        click.echo('Config storing mode is `{}`, target path `{}`'.format(config_store_mode, config_file))
+
         # create file
         with open(config_file, 'w+'):
             os.utime(config_file, None)
@@ -226,6 +244,21 @@ class Config(object):
 
     @classmethod
     def config_path(cls):
+        config_path = cls.get_install_dir_config_path()
+        if not os.path.isfile(config_path):
+            config_path = cls.get_home_dir_config_path()
+        return config_path
+
+    @classmethod
+    def get_install_dir_config_path(cls):
+        pipe_binary_path = sys.argv[0]
+        if not os.path.isabs(pipe_binary_path):
+            pipe_binary_path = os.path.join(os.getcwd(), pipe_binary_path)
+        config_file = os.path.join(os.path.dirname(pipe_binary_path), 'config.json')
+        return config_file
+
+    @classmethod
+    def get_home_dir_config_path(cls):
         home = os.path.expanduser("~")
         config_folder = os.path.join(home, '.pipe')
         if not os.path.exists(config_folder):


### PR DESCRIPTION
This PR is related to issue #2115

It brings new flag `--config-store|-cs` with the following values **home-dir** (default) and **install-dir** for CLI configuration. It allows having a separate configuration for each of the several pipe versions installed.