### PR TITLE
Support nfs data storage items copying in api

### DIFF
--- a/api/src/main/java/com/epam/pipeline/controller/vo/data/storage/UpdateDataStorageItemActionTypes.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/data/storage/UpdateDataStorageItemActionTypes.java
@@ -16,40 +16,8 @@
 
 package com.epam.pipeline.controller.vo.data.storage;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public enum UpdateDataStorageItemActionTypes {
-    Create(0),
-    Move(1);
-
-    private long id;
-    private static Map<Long, UpdateDataStorageItemActionTypes> idMap = new HashMap<>();
-    static {
-        idMap.put(Create.id, Create);
-        idMap.put(Move.id, Move);
-    }
-    private static Map<String, UpdateDataStorageItemActionTypes> namesMap = new HashMap<>();
-    static {
-        namesMap.put(Create.name(), Create);
-        namesMap.put(Move.name(), Move);
-    }
-
-    UpdateDataStorageItemActionTypes(long id) {
-        this.id = id;
-    }
-
-    public static UpdateDataStorageItemActionTypes getById(Long id) {
-        if (id == null) {
-            return null;
-        }
-        return idMap.get(id);
-    }
-
-    public static UpdateDataStorageItemActionTypes getByName(String name) {
-        if (name == null) {
-            return null;
-        }
-        return namesMap.get(name);
-    }
+    Create,
+    Move,
+    Copy;
 }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
@@ -853,6 +853,22 @@ public class DataStorageManager implements SecuredEntityManager {
         return file;
     }
 
+    private DataStorageFolder copyDataStorageFolder(final AbstractDataStorage dataStorage,
+                                                    final String oldPath,
+                                                    final String newPath) {
+        final DataStorageFolder folder = storageProviderManager.copyFolder(dataStorage, oldPath, newPath);
+        tagProviderManager.copyFolderTags(dataStorage, oldPath, newPath);
+        return folder;
+    }
+
+    private DataStorageFile copyDataStorageFile(final AbstractDataStorage dataStorage,
+                                                final String oldPath,
+                                                final String newPath) {
+        final DataStorageFile file = storageProviderManager.copyFile(dataStorage, oldPath, newPath);
+        tagProviderManager.copyFileTags(dataStorage, oldPath, newPath, file.getVersion());
+        return file;
+    }
+
     private void deleteDataStorageFolder(final AbstractDataStorage dataStorage,
                                          final String path,
                                          final Boolean totally) throws DataStorageException {
@@ -975,39 +991,30 @@ public class DataStorageManager implements SecuredEntityManager {
     }
 
     private AbstractDataStorageItem updateDataStorageItem(final AbstractDataStorage storage,
-            UpdateDataStorageItemVO item)
-            throws DataStorageException{
-        AbstractDataStorageItem result = null;
+                                                          final UpdateDataStorageItemVO item) {
         switch (item.getType()) {
-            case Folder: result = updateFolderItem(storage, item); break;
-            case File: result = updateFileItem(storage, item); break;
-            default: break;
+            case Folder: return updateFolderItem(storage, item);
+            case File: return updateFileItem(storage, item);
+            default: return null;
         }
-        return result;
     }
 
-    private DataStorageFolder updateFolderItem(final AbstractDataStorage storage,
-            UpdateDataStorageItemVO item)
-            throws DataStorageException{
-        DataStorageFolder folder = null;
+    private DataStorageFolder updateFolderItem(final AbstractDataStorage storage, final UpdateDataStorageItemVO item) {
         switch (item.getAction()) {
-            case Create: folder = createDataStorageFolder(storage, item.getPath()); break;
-            case Move: folder = moveDataStorageFolder(storage, item.getOldPath(), item.getPath()); break;
-            default: break;
+            case Create: return createDataStorageFolder(storage, item.getPath());
+            case Move: return moveDataStorageFolder(storage, item.getOldPath(), item.getPath());
+            case Copy: return copyDataStorageFolder(storage, item.getOldPath(), item.getPath());
+            default: return null;
         }
-        return folder;
     }
 
-    private DataStorageFile updateFileItem(final AbstractDataStorage storage,
-            UpdateDataStorageItemVO item)
-            throws DataStorageException{
-        DataStorageFile file = null;
+    private DataStorageFile updateFileItem(final AbstractDataStorage storage, final UpdateDataStorageItemVO item) {
         switch (item.getAction()) {
-            case Create: file = createDataStorageFile(storage, item.getPath(), item.getContents()); break;
-            case Move: file = moveDataStorageFile(storage, item.getOldPath(), item.getPath()); break;
-            default: break;
+            case Create: return createDataStorageFile(storage, item.getPath(), item.getContents());
+            case Move: return moveDataStorageFile(storage, item.getOldPath(), item.getPath());
+            case Copy: return copyDataStorageFile(storage, item.getOldPath(), item.getPath());
+            default: return null;
         }
-        return file;
     }
 
     private void checkDataStorageVersioning(AbstractDataStorage dataStorage, String version) {

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageProviderManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageProviderManager.java
@@ -181,6 +181,16 @@ public class StorageProviderManager {
         return getStorageProvider(dataStorage).moveFolder(dataStorage, oldPath, newPath);
     }
 
+    @StorageWriteOperation
+    public DataStorageFile copyFile(AbstractDataStorage dataStorage, String oldPath, String newPath) {
+        return getStorageProvider(dataStorage).copyFile(dataStorage, oldPath, newPath);
+    }
+
+    @StorageWriteOperation
+    public DataStorageFolder copyFolder(AbstractDataStorage dataStorage, String oldPath, String newPath) {
+        return getStorageProvider(dataStorage).copyFolder(dataStorage, oldPath, newPath);
+    }
+
     public boolean checkStorage(AbstractDataStorage dataStorage) {
         return getStorageProvider(dataStorage).checkStorage(dataStorage);
     }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/StorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/StorageProvider.java
@@ -88,6 +88,10 @@ public interface StorageProvider<T extends AbstractDataStorage> {
     DataStorageFolder moveFolder(T dataStorage, String oldPath, String newPath)
             throws DataStorageException;
 
+    DataStorageFile copyFile(T dataStorage, String oldPath, String newPath);
+
+    DataStorageFolder copyFolder(T dataStorage, String oldPath, String newPath);
+
     boolean checkStorage(T dataStorage);
 
     Map<String, String> updateObjectTags(T dataStorage, String path, Map<String, String> tags,

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3StorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3StorageProvider.java
@@ -270,6 +270,17 @@ public class S3StorageProvider implements StorageProvider<S3bucketDataStorage> {
                 ProviderUtils.buildPath(dataStorage, newPath));
     }
 
+    @Override
+    public DataStorageFile copyFile(final S3bucketDataStorage dataStorage, final String oldPath, final String newPath) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DataStorageFolder copyFolder(final S3bucketDataStorage dataStorage, final String oldPath,
+                                        final String newPath) {
+        throw new UnsupportedOperationException();
+    }
+
     @Override public boolean checkStorage(S3bucketDataStorage dataStorage) {
         if (dataStorage.getRegionId() == null) {
             final AwsRegion awsRegion = cloudRegionManager.getAwsRegion(dataStorage);

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureBlobStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureBlobStorageProvider.java
@@ -213,6 +213,17 @@ public class AzureBlobStorageProvider implements StorageProvider<AzureBlobStorag
     }
 
     @Override
+    public DataStorageFile copyFile(final AzureBlobStorage dataStorage, final String oldPath, final String newPath) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DataStorageFolder copyFolder(final AzureBlobStorage dataStorage, final String oldPath,
+                                        final String newPath) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public boolean checkStorage(final AzureBlobStorage dataStorage) {
         return getAzureStorageHelper(dataStorage).checkStorage(dataStorage);
     }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageProvider.java
@@ -170,6 +170,16 @@ public class GSBucketStorageProvider implements StorageProvider<GSBucketStorage>
     }
 
     @Override
+    public DataStorageFile copyFile(final GSBucketStorage dataStorage, final String oldPath, final String newPath) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DataStorageFolder copyFolder(final GSBucketStorage dataStorage, final String oldPath, final String newPath) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public boolean checkStorage(final GSBucketStorage dataStorage) {
         return getHelper(dataStorage).checkStorageExists(dataStorage.getPath());
     }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/tag/DataStorageTagProviderManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/tag/DataStorageTagProviderManager.java
@@ -88,6 +88,27 @@ public class DataStorageTagProviderManager {
                              final String oldPath,
                              final String newPath,
                              final String newVersion) {
+        copyFileTags(storage, oldPath, newPath, newVersion);
+        if (!storage.isVersioningEnabled()) {
+            final String oldAbsolutePath = storage.resolveAbsolutePath(oldPath);
+            tagManager.delete(storage.getRootId(), new DataStorageObject(oldAbsolutePath));
+        }
+    }
+
+    public void moveFolderTags(final AbstractDataStorage storage,
+                               final String oldPath,
+                               final String newPath) {
+        copyFolderTags(storage, oldPath, newPath);
+        if (!storage.isVersioningEnabled()) {
+            final String oldAbsolutePath = storage.resolveAbsolutePath(oldPath);
+            tagManager.deleteAllInFolder(storage.getRootId(), oldAbsolutePath);
+        }
+    }
+
+    public void copyFileTags(final AbstractDataStorage storage,
+                             final String oldPath,
+                             final String newPath,
+                             final String newVersion) {
         final String oldAbsolutePath = storage.resolveAbsolutePath(oldPath);
         final String newAbsolutePath = storage.resolveAbsolutePath(newPath);
         final Map<String, String> tagMap = mapFrom(tagManager.load(storage.getRootId(),
@@ -95,12 +116,10 @@ public class DataStorageTagProviderManager {
         tagManager.upsert(storage.getRootId(), new DataStorageObject(newAbsolutePath), tagMap);
         if (storage.isVersioningEnabled()) {
             tagManager.upsert(storage.getRootId(), new DataStorageObject(newAbsolutePath, newVersion), tagMap);
-        } else {
-            tagManager.delete(storage.getRootId(), new DataStorageObject(oldAbsolutePath));
         }
     }
 
-    public void moveFolderTags(final AbstractDataStorage storage,
+    public void copyFolderTags(final AbstractDataStorage storage,
                                final String oldPath,
                                final String newPath) {
         final String oldAbsolutePath = storage.resolveAbsolutePath(oldPath);
@@ -115,8 +134,6 @@ public class DataStorageTagProviderManager {
                                             DataStorageTagCopyRequest.object(file.getPath(), null),
                                             DataStorageTagCopyRequest.object(file.getPath(), file.getVersion())))
                                     .collect(Collectors.toList()))));
-        } else {
-            tagManager.deleteAllInFolder(storage.getRootId(), oldAbsolutePath);
         }
     }
 

--- a/api/src/test/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProviderTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProviderTest.java
@@ -21,6 +21,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -43,6 +46,7 @@ import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.region.*;
 import com.epam.pipeline.manager.security.AuthManager;
 import com.epam.pipeline.mapper.region.CloudRegionMapper;
+import com.epam.pipeline.test.creator.CommonCreatorConstants;
 import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -69,6 +73,7 @@ public class NFSStorageProviderTest extends AbstractSpringTest {
     private static final String TEST_PATH = "localhost";
     private static final String TEST_STORAGE_NAME = "testStorage";
     private static final String STORAGE_NAME = "bucket";
+    private static final String TEST_PREFIX = ":/test";
 
     @Mock
     private CmdExecutor mockCmdExecutor;
@@ -234,7 +239,7 @@ public class NFSStorageProviderTest extends AbstractSpringTest {
 
     @Test
     public void testCreateFileFolderAndList() {
-        NFSDataStorage dataStorage = new NFSDataStorage(0L, TEST_STORAGE_NAME, TEST_PATH + ":/test");
+        NFSDataStorage dataStorage = new NFSDataStorage(0L, TEST_STORAGE_NAME, TEST_PATH + TEST_PREFIX);
         dataStorage.setFileShareMountId(awsFileShareMount.getId());
         nfsProvider.createStorage(dataStorage);
         String testFileName = "testFile.txt";
@@ -281,6 +286,50 @@ public class NFSStorageProviderTest extends AbstractSpringTest {
     }
 
     @Test
+    public void testCopyFile() {
+        final NFSDataStorage storage = new NFSDataStorage(0L, TEST_STORAGE_NAME, TEST_PATH + TEST_PREFIX);
+        storage.setFileShareMountId(awsFileShareMount.getId());
+        nfsProvider.createStorage(storage);
+        final Path rootPath = Paths.get(testMountPoint.toString(), TEST_PATH,  "test");
+        final Path oldPath = rootPath.resolve("oldFilePath");
+        final Path newPath = rootPath.resolve("newFilePath");
+        nfsProvider.createFile(storage, oldPath.getFileName().toString(), CommonCreatorConstants.TEST_BYTES);
+
+        nfsProvider.copyFile(storage, oldPath.getFileName().toString(), newPath.getFileName().toString());
+
+        Assert.assertTrue(Files.exists(oldPath));
+        Assert.assertTrue(Files.isRegularFile(oldPath));
+        Assert.assertTrue(Files.exists(newPath));
+        Assert.assertTrue(Files.isRegularFile(newPath));
+        Assert.assertArrayEquals(CommonCreatorConstants.TEST_BYTES,
+                nfsProvider.getFile(storage, newPath.getFileName().toString(), null, Long.MAX_VALUE).getContent());
+
+        nfsProvider.deleteFile(storage, oldPath.getFileName().toString(), null, true);
+        nfsProvider.deleteFile(storage, newPath.getFileName().toString(), null, true);
+    }
+
+    @Test
+    public void testCopyFolder() {
+        final NFSDataStorage storage = new NFSDataStorage(0L, TEST_STORAGE_NAME, TEST_PATH + TEST_PREFIX);
+        storage.setFileShareMountId(awsFileShareMount.getId());
+        nfsProvider.createStorage(storage);
+        final Path rootPath = Paths.get(testMountPoint.toString(), TEST_PATH,  "test");
+        final Path oldPath = rootPath.resolve("oldFolderPath");
+        final Path newPath = rootPath.resolve("newFolderPath");
+        nfsProvider.createFolder(storage, oldPath.getFileName().toString());
+
+        nfsProvider.copyFolder(storage, oldPath.getFileName().toString(), newPath.getFileName().toString());
+
+        Assert.assertTrue(Files.exists(oldPath));
+        Assert.assertTrue(Files.isDirectory(oldPath));
+        Assert.assertTrue(Files.exists(newPath));
+        Assert.assertTrue(Files.isDirectory(newPath));
+
+        nfsProvider.deleteFolder(storage, oldPath.getFileName().toString(), true);
+        nfsProvider.deleteFolder(storage, newPath.getFileName().toString(), true);
+    }
+
+    @Test
     public void testMoveDeleteFile() {
         String rootPath = TEST_PATH + 1;
         FileShareMount awsFileShareMount = new FileShareMount();
@@ -289,7 +338,7 @@ public class NFSStorageProviderTest extends AbstractSpringTest {
         awsFileShareMount.setRegionId(awsRegionId);
         fileShareMountManager.save(awsFileShareMount);
 
-        NFSDataStorage dataStorage = new NFSDataStorage(0L, "testStorage", rootPath + ":/test");
+        NFSDataStorage dataStorage = new NFSDataStorage(0L, TEST_STORAGE_NAME, rootPath + TEST_PREFIX);
         dataStorage.setFileShareMountId(awsFileShareMount.getId());
         nfsProvider.createStorage(dataStorage);
 
@@ -331,7 +380,7 @@ public class NFSStorageProviderTest extends AbstractSpringTest {
 
     @Test
     public void testEditFile() {
-        NFSDataStorage dataStorage = new NFSDataStorage(0L, "testStorage", TEST_PATH + ":/test");
+        NFSDataStorage dataStorage = new NFSDataStorage(0L, TEST_STORAGE_NAME, TEST_PATH + TEST_PREFIX);
         dataStorage.setFileShareMountId(awsFileShareMount.getId());
         nfsProvider.createStorage(dataStorage);
 

--- a/api/src/test/java/com/epam/pipeline/test/creator/CommonCreatorConstants.java
+++ b/api/src/test/java/com/epam/pipeline/test/creator/CommonCreatorConstants.java
@@ -56,6 +56,7 @@ public final class CommonCreatorConstants {
     public static final int EXECUTE_PERMISSION = 4;
     public static final int ALL_PERMISSIONS = 15;
     public static final String TEST_STRING = "TEST";
+    public static final byte[] TEST_BYTES = TEST_STRING.getBytes();
     public static final String TEST_NAME = "TEST_NAME";
     public static final String TEST_NAME_2 = "TEST_NAME_2";
     public static final List<String> TEST_STRING_LIST = Collections.singletonList(TEST_STRING);


### PR DESCRIPTION
The pull request brings support for nfs data storage items copying to api.

The following API method can be used to copy folders.

```
POST /datastorage/{id}/list
[
  {
    "action": "Copy",
    "oldPath": "old/folder/path",
    "path": "new/folder/path",
    "type": "Folder"
  }
]
```

And this one can be used to copy files.

```
POST /datastorage/{id}/list
[
  {
    "action": "Copy",
    "oldPath": "old/file/path",
    "path": "new/file/path",
    "type": "File"
  }
]
```