### PR TITLE
Issue #2115 Fix working with pipe on PATH

### DIFF
--- a/pipe-cli/src/config.py
+++ b/pipe-cli/src/config.py
@@ -255,15 +255,10 @@ class Config(object):
 
     @classmethod
     def get_install_dir_config_path(cls):
-        pipe_binary_path = sys.argv[0]
-        if not pipe_binary_path:
+        pipe_binary_path = sys.executable
+        if not pipe_binary_path or 'python' in os.path.basename(pipe_binary_path):
             return None
-        if pipe_binary_path != 'pipe':
-            if not os.path.isabs(pipe_binary_path):
-                pipe_binary_path = os.path.join(os.getcwd(), pipe_binary_path)
-            if not os.path.samefile(sys.executable, pipe_binary_path):
-                return None
-        return os.path.join(os.path.dirname(sys.executable), 'config.json')
+        return os.path.join(os.path.dirname(pipe_binary_path), 'config.json')
 
     @classmethod
     def get_home_dir_config_path(cls):

--- a/pipe-cli/src/config.py
+++ b/pipe-cli/src/config.py
@@ -258,12 +258,12 @@ class Config(object):
         pipe_binary_path = sys.argv[0]
         if not pipe_binary_path:
             return None
-        if not os.path.isabs(pipe_binary_path):
-            pipe_binary_path = os.path.join(os.getcwd(), pipe_binary_path)
-        if not os.path.samefile(sys.executable, pipe_binary_path):
-            return None
-        else:
-            return os.path.join(os.path.dirname(pipe_binary_path), 'config.json')
+        if pipe_binary_path != 'pipe':
+            if not os.path.isabs(pipe_binary_path):
+                pipe_binary_path = os.path.join(os.getcwd(), pipe_binary_path)
+            if not os.path.samefile(sys.executable, pipe_binary_path):
+                return None
+        return os.path.join(os.path.dirname(sys.executable), 'config.json')
 
     @classmethod
     def get_home_dir_config_path(cls):

--- a/pipe-cli/src/utilities/storage/mount.py
+++ b/pipe-cli/src/utilities/storage/mount.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ class FrozenMount(AbstractMount):
 
     def _get_mount_cmd(self, config, mountpoint, options, additional_arguments, mode):
         mount_bin = self.get_mount_executable(config)
-        mount_script = self.create_mount_script(os.path.dirname(Config.config_path()), mount_bin,
+        mount_script = self.create_mount_script(os.path.dirname(Config.get_home_dir_config_path()), mount_bin,
                                                 mountpoint, options, additional_arguments, mode)
         return ['bash', mount_script]
 
@@ -97,7 +97,7 @@ class FrozenMount(AbstractMount):
     # Otherwise (i.e. "one-folder") - packed binary is used directly
     def get_mount_executable(self, config):
         mount_packed = config.build_inner_module_path('mount')
-        config_folder = os.path.dirname(Config.config_path())
+        config_folder = os.path.dirname(Config.get_home_dir_config_path())
         mount_bin = os.path.join(mount_packed, 'pipe-fuse')
 
         if self._needs_pipe_fuse_copy():


### PR DESCRIPTION
This PR is related to issue #2115 

It fixes working with pipe CLI configured in PATH. Previously we used script name passed via shell arguments, but with this logic, the incorrect path to config is built. From now we are using an absolute path to executable instead