### PR TITLE
Gui tests improvements from 18/08/21

### DIFF
--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/AutopauseTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/AutopauseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import static com.codeborne.selenide.Condition.visible;
 import static com.epam.pipeline.autotests.ao.Primitive.AUTO_PAUSE;
 import static com.epam.pipeline.autotests.utils.PipelineSelectors.runWithId;
 import static com.epam.pipeline.autotests.utils.Utils.ON_DEMAND;
-import static java.util.concurrent.TimeUnit.SECONDS;
+import static com.epam.pipeline.autotests.utils.Utils.nameWithoutGroup;
 
 public class AutopauseTest extends AbstractSeveralPipelineRunningTest implements Tools, Authorization {
 
@@ -104,7 +104,7 @@ public class AutopauseTest extends AbstractSeveralPipelineRunningTest implements
                 .completedRuns()
                 .ensure(runWithId(run2), visible)
                 .activeRuns()
-                .resume(run1, getToolName())
+                .resume(run1, nameWithoutGroup(tool))
                 .waitUntilStopButtonAppear(run1)
                 .stopRun(run1);
     }
@@ -121,7 +121,7 @@ public class AutopauseTest extends AbstractSeveralPipelineRunningTest implements
                 .activeRuns()
                 .waitUntilResumeButtonAppear(runId)
                 .validateStatus(runId, LogAO.Status.PAUSED)
-                .resume(runId, getToolName())
+                .resume(runId, nameWithoutGroup(tool))
                 .waitUntilStopButtonAppear(runId)
                 .stopRun(runId);
     }
@@ -163,10 +163,5 @@ public class AutopauseTest extends AbstractSeveralPipelineRunningTest implements
                 .settings()
                 .switchToPreferences()
                 .switchToSystem());
-    }
-
-    private String getToolName() {
-        final String[] toolAndGroup = tool.split("/");
-        return toolAndGroup[toolAndGroup.length - 1];
     }
 }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/LaunchClusterTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/LaunchClusterTest.java
@@ -94,7 +94,7 @@ public class LaunchClusterTest extends AbstractAutoRemovingPipelineRunningTest i
         getWebDriver().navigate().refresh();
     }
 
-    @Test(enabled = false)
+    @Test
     @TestCase({"EPMCMBIBPC-975"})
     public void launchPipelineWithLaunchFlag() {
         library()
@@ -122,7 +122,7 @@ public class LaunchClusterTest extends AbstractAutoRemovingPipelineRunningTest i
                 .shouldContainRunsWithParentRun(2, getRunId());
     }
 
-    @Test(enabled = false)
+    @Test
     @TestCase({"EPMCMBIBPC-2618"})
     public void launchAutoScaledClusterTest() {
         library()
@@ -151,7 +151,7 @@ public class LaunchClusterTest extends AbstractAutoRemovingPipelineRunningTest i
                 .stopRunIfPresent(getRunId());
     }
 
-    @Test(priority = 1, enabled = false)
+    @Test(priority = 1)
     @TestCase({"EPMCMBIBPC-2620"})
     public void invalidValuesOnConfigureClusterPopUp() {
         library()
@@ -188,7 +188,7 @@ public class LaunchClusterTest extends AbstractAutoRemovingPipelineRunningTest i
                 .messageShouldAppear("Enter positive number");
     }
 
-    @Test(enabled = false)
+    @Test
     @TestCase({"EPMCMBIBPC-2628"})
     public void autoScaledClusterWithDefaultChildNodesValidationTest() {
         String childRunID1 = library()
@@ -246,7 +246,7 @@ public class LaunchClusterTest extends AbstractAutoRemovingPipelineRunningTest i
                 .validateStatus(childRunID2, LogAO.Status.STOPPED);
     }
 
-    @Test(enabled = false)
+    @Test
     @TestCase({"EPMCMBIBPC-3150"})
     public void validationOfGECluster() {
         String childRunID = library()
@@ -295,7 +295,7 @@ public class LaunchClusterTest extends AbstractAutoRemovingPipelineRunningTest i
                         .close());
     }
 
-    @Test(enabled = false)
+    @Test
     @TestCase({"EPMCMBIBPC-3151"})
     public void validationOfSlurmCluster() {
         String childRunID = library()
@@ -338,7 +338,7 @@ public class LaunchClusterTest extends AbstractAutoRemovingPipelineRunningTest i
                         .close());
     }
 
-    @Test(enabled = false)
+    @Test
     @TestCase({"EPMCMBIBPC-3152"})
     public void validationOfApacheSparkCluster() {
         tools()
@@ -373,7 +373,7 @@ public class LaunchClusterTest extends AbstractAutoRemovingPipelineRunningTest i
                 .closeTab();
     }
 
-    @Test(enabled = false)
+    @Test
     @TestCase({"EPMCMBIBPC-3155"})
     public void hybridAutoScaledClusterInstanceTypeFamily() {
         library()
@@ -438,16 +438,18 @@ public class LaunchClusterTest extends AbstractAutoRemovingPipelineRunningTest i
                         .sleep(20, SECONDS)
                         .execute("qstat")
                         .close());
-        navigationMenu()
+        final String nestedRunID = navigationMenu()
                 .runs()
                 .activeRuns()
                 .showLog(getRunId())
                 .waitForNestedRunsLink()
+                .getNestedRunID(1);
+        new LogAO()
                 .clickOnNestedRunLink()
-                .ensure(STATUS, text(String.valueOf(Integer.parseInt(getRunId()) + 1)));
+                .ensure(STATUS, text(nestedRunID));
     }
 
-    @Test(enabled = false)
+    @Test
     @TestCase({"EPMCMBIBPC-3153"})
     public void hybridAutoScaledCluster() {
         String cpu = library()
@@ -508,7 +510,7 @@ public class LaunchClusterTest extends AbstractAutoRemovingPipelineRunningTest i
                         .close());
     }
 
-    @Test(enabled = false)
+    @Test
     @TestCase({"EPMCMBIBPC-3159"})
     public void hybridAutoScaledClusterCPUDeadlockWithAdditionalRestrictions() {
         final String systemParam = "CP_CAP_AUTOSCALE_HYBRID_MAX_CORE_PER_NODE";
@@ -547,7 +549,7 @@ public class LaunchClusterTest extends AbstractAutoRemovingPipelineRunningTest i
                         "requested resources and therefore they will be rejected: 1 (50 cpu)"));
     }
 
-    @Test(enabled = false)
+    @Test
     @TestCase({"EPMCMBIBPC-3156"})
     public void autoScaledClusterWorkersPriceTypeSpot() {
         library()
@@ -574,7 +576,7 @@ public class LaunchClusterTest extends AbstractAutoRemovingPipelineRunningTest i
                         instance.ensure(PRICE_TYPE, text(spotPrice)));
     }
 
-    @Test(enabled = false)
+    @Test
     @TestCase({"EPMCMBIBPC-3160"})
     public void autoScaledClusterWorkersPriceTypeOnDemand() {
         library()
@@ -601,7 +603,7 @@ public class LaunchClusterTest extends AbstractAutoRemovingPipelineRunningTest i
                         instance.ensure(PRICE_TYPE, text(onDemandPrice)));
     }
 
-    @Test(enabled = false)
+    @Test
     @TestCase({"EPMCMBIBPC-3161"})
     public void autoScaledClusterWorkersPriceTypeMastersConfig() {
         library()

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/LaunchClusterTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/LaunchClusterTest.java
@@ -94,7 +94,7 @@ public class LaunchClusterTest extends AbstractAutoRemovingPipelineRunningTest i
         getWebDriver().navigate().refresh();
     }
 
-    @Test
+    @Test(enabled = false)
     @TestCase({"EPMCMBIBPC-975"})
     public void launchPipelineWithLaunchFlag() {
         library()
@@ -122,7 +122,7 @@ public class LaunchClusterTest extends AbstractAutoRemovingPipelineRunningTest i
                 .shouldContainRunsWithParentRun(2, getRunId());
     }
 
-    @Test
+    @Test(enabled = false)
     @TestCase({"EPMCMBIBPC-2618"})
     public void launchAutoScaledClusterTest() {
         library()
@@ -151,7 +151,7 @@ public class LaunchClusterTest extends AbstractAutoRemovingPipelineRunningTest i
                 .stopRunIfPresent(getRunId());
     }
 
-    @Test(priority = 1)
+    @Test(priority = 1, enabled = false)
     @TestCase({"EPMCMBIBPC-2620"})
     public void invalidValuesOnConfigureClusterPopUp() {
         library()
@@ -188,7 +188,7 @@ public class LaunchClusterTest extends AbstractAutoRemovingPipelineRunningTest i
                 .messageShouldAppear("Enter positive number");
     }
 
-    @Test
+    @Test(enabled = false)
     @TestCase({"EPMCMBIBPC-2628"})
     public void autoScaledClusterWithDefaultChildNodesValidationTest() {
         String childRunID1 = library()
@@ -246,7 +246,7 @@ public class LaunchClusterTest extends AbstractAutoRemovingPipelineRunningTest i
                 .validateStatus(childRunID2, LogAO.Status.STOPPED);
     }
 
-    @Test
+    @Test(enabled = false)
     @TestCase({"EPMCMBIBPC-3150"})
     public void validationOfGECluster() {
         String childRunID = library()
@@ -295,7 +295,7 @@ public class LaunchClusterTest extends AbstractAutoRemovingPipelineRunningTest i
                         .close());
     }
 
-    @Test
+    @Test(enabled = false)
     @TestCase({"EPMCMBIBPC-3151"})
     public void validationOfSlurmCluster() {
         String childRunID = library()
@@ -338,7 +338,7 @@ public class LaunchClusterTest extends AbstractAutoRemovingPipelineRunningTest i
                         .close());
     }
 
-    @Test
+    @Test(enabled = false)
     @TestCase({"EPMCMBIBPC-3152"})
     public void validationOfApacheSparkCluster() {
         tools()
@@ -373,7 +373,7 @@ public class LaunchClusterTest extends AbstractAutoRemovingPipelineRunningTest i
                 .closeTab();
     }
 
-    @Test
+    @Test(enabled = false)
     @TestCase({"EPMCMBIBPC-3155"})
     public void hybridAutoScaledClusterInstanceTypeFamily() {
         library()
@@ -435,6 +435,8 @@ public class LaunchClusterTest extends AbstractAutoRemovingPipelineRunningTest i
                         "requested resources and therefore they will be rejected: 1 (150 cpu)"))
                 .ssh(shell -> shell
                         .execute("qsub -b y -pe local 50 sleep 5m")
+                        .sleep(20, SECONDS)
+                        .execute("qstat")
                         .close());
         navigationMenu()
                 .runs()
@@ -445,7 +447,7 @@ public class LaunchClusterTest extends AbstractAutoRemovingPipelineRunningTest i
                 .ensure(STATUS, text(String.valueOf(Integer.parseInt(getRunId()) + 1)));
     }
 
-    @Test
+    @Test(enabled = false)
     @TestCase({"EPMCMBIBPC-3153"})
     public void hybridAutoScaledCluster() {
         String cpu = library()
@@ -506,7 +508,7 @@ public class LaunchClusterTest extends AbstractAutoRemovingPipelineRunningTest i
                         .close());
     }
 
-    @Test
+    @Test(enabled = false)
     @TestCase({"EPMCMBIBPC-3159"})
     public void hybridAutoScaledClusterCPUDeadlockWithAdditionalRestrictions() {
         final String systemParam = "CP_CAP_AUTOSCALE_HYBRID_MAX_CORE_PER_NODE";
@@ -545,7 +547,7 @@ public class LaunchClusterTest extends AbstractAutoRemovingPipelineRunningTest i
                         "requested resources and therefore they will be rejected: 1 (50 cpu)"));
     }
 
-    @Test
+    @Test(enabled = false)
     @TestCase({"EPMCMBIBPC-3156"})
     public void autoScaledClusterWorkersPriceTypeSpot() {
         library()
@@ -572,7 +574,7 @@ public class LaunchClusterTest extends AbstractAutoRemovingPipelineRunningTest i
                         instance.ensure(PRICE_TYPE, text(spotPrice)));
     }
 
-    @Test
+    @Test(enabled = false)
     @TestCase({"EPMCMBIBPC-3160"})
     public void autoScaledClusterWorkersPriceTypeOnDemand() {
         library()
@@ -599,7 +601,7 @@ public class LaunchClusterTest extends AbstractAutoRemovingPipelineRunningTest i
                         instance.ensure(PRICE_TYPE, text(onDemandPrice)));
     }
 
-    @Test
+    @Test(enabled = false)
     @TestCase({"EPMCMBIBPC-3161"})
     public void autoScaledClusterWorkersPriceTypeMastersConfig() {
         library()

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/LaunchClusterTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/LaunchClusterTest.java
@@ -438,13 +438,15 @@ public class LaunchClusterTest extends AbstractAutoRemovingPipelineRunningTest i
                         .sleep(20, SECONDS)
                         .execute("qstat")
                         .close());
-        navigationMenu()
+        final String nestedRunID = navigationMenu()
                 .runs()
                 .activeRuns()
                 .showLog(getRunId())
                 .waitForNestedRunsLink()
+                .getNestedRunID(1);
+        new LogAO()
                 .clickOnNestedRunLink()
-                .ensure(STATUS, text(String.valueOf(Integer.parseInt(getRunId()) + 1)));
+                .ensure(STATUS, text(nestedRunID));
     }
 
     @Test(enabled = false)

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/PauseResumeTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/PauseResumeTest.java
@@ -51,6 +51,7 @@ import static com.epam.pipeline.autotests.utils.Conditions.textMatches;
 import static com.epam.pipeline.autotests.utils.PipelineSelectors.button;
 import static com.epam.pipeline.autotests.utils.PipelineSelectors.tabWithName;
 import static com.epam.pipeline.autotests.utils.Utils.ON_DEMAND;
+import static com.epam.pipeline.autotests.utils.Utils.nameWithoutGroup;
 import static com.epam.pipeline.autotests.utils.Utils.sleep;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -109,7 +110,7 @@ public class PauseResumeTest extends AbstractSeveralPipelineRunningTest implemen
         tools()
                 .perform(registry, group, tool, ToolTab::runWithCustomSettings)
                 .setPriceType(priceType)
-                .launchTool(this, Utils.nameWithoutGroup(tool))
+                .launchTool(this, nameWithoutGroup(tool))
                 .log(getLastRunId(), log ->
                         log.waitForSshLink()
                                 .inAnotherTab(logTab -> logTab
@@ -117,7 +118,7 @@ public class PauseResumeTest extends AbstractSeveralPipelineRunningTest implemen
                                                 String.format("echo '%s' > %s", testFileContent, testFileName)))
                                 )
                                 .waitForPauseButton()
-                                .pause(getToolName())
+                                .pause(nameWithoutGroup(tool))
                                 .assertPausingFinishedSuccessfully()
                                 .instanceParameters(parameters -> {
                                     final String ipHyperlink = getParameterValueLink(ipField);
@@ -128,7 +129,7 @@ public class PauseResumeTest extends AbstractSeveralPipelineRunningTest implemen
                                                     , ipHyperlink)
                                     );
                                 })
-                                .resume(getToolName())
+                                .resume(nameWithoutGroup(tool))
                                 .assertResumingFinishedSuccessfully()
                                 .waitForSshLink()
                                 .inAnotherTab(logTab -> logTab
@@ -161,7 +162,7 @@ public class PauseResumeTest extends AbstractSeveralPipelineRunningTest implemen
                     .setLaunchOptions("15", instanceType, null)
                     .setPriceType(priceType)
                     .click(START_IDLE)
-                    .launchTool(this, Utils.nameWithoutGroup(tool));
+                    .launchTool(this, nameWithoutGroup(tool));
             loginAsAdminAndPerform(() ->
                     navigationMenu()
                             .settings()
@@ -195,16 +196,16 @@ public class PauseResumeTest extends AbstractSeveralPipelineRunningTest implemen
         tools()
                 .perform(registry, group, tool, ToolTab::runWithCustomSettings)
                 .setPriceType(priceType)
-                .launchTool(this, Utils.nameWithoutGroup(tool))
+                .launchTool(this, nameWithoutGroup(tool))
                 .activeRuns()
                 .waitUntilPauseButtonAppear(getLastRunId())
-                .pause(getLastRunId(), getToolName())
+                .pause(getLastRunId(), nameWithoutGroup(tool))
                 .waitUntilResumeButtonAppear(getLastRunId())
                 .showLog(getLastRunId())
                 .ensure(ENDPOINT, hidden)
                 .ensure(SSH_LINK, hidden);
         runsMenu()
-                .resume(getLastRunId(), getToolName())
+                .resume(getLastRunId(), nameWithoutGroup(tool))
                 .waitUntilPauseButtonAppear(getLastRunId())
                 .showLog(getLastRunId())
                 .ensure(ENDPOINT, visible)
@@ -227,7 +228,7 @@ public class PauseResumeTest extends AbstractSeveralPipelineRunningTest implemen
                 .setLaunchOptions("15", instanceType, null)
                 .setPriceType(priceType)
                 .click(START_IDLE)
-                .launchTool(this, Utils.nameWithoutGroup(tool))
+                .launchTool(this, nameWithoutGroup(tool))
                 .log(getLastRunId(), log ->
                         log.waitForSshLink()
                                 .inAnotherTab(logTab -> logTab
@@ -238,7 +239,7 @@ public class PauseResumeTest extends AbstractSeveralPipelineRunningTest implemen
                                 )
                                 .sleep(30, SECONDS)
                                 .waitForPauseButton()
-                                .pause(getToolName())
+                                .pause(nameWithoutGroup(tool))
                                 .assertPausingFinishedSuccessfully()
                                 .ensure(taskWithName(pauseTask), visible)
                                 .click(taskWithName(pauseTask))
@@ -246,7 +247,7 @@ public class PauseResumeTest extends AbstractSeveralPipelineRunningTest implemen
                                 .ensure(log(), matchText("Temporary container was successfully committed"))
                                 .ensure(log(), matchText("Docker container logs were successfully retrieved."))
                                 .ensure(log(), matchText("Docker service was successfully stopped"))
-                                .resume(getToolName())
+                                .resume(nameWithoutGroup(tool))
                                 .assertResumingFinishedSuccessfully()
                                 .inAnotherTab(logTab -> logTab
                                         .ssh(shell -> shell
@@ -264,7 +265,7 @@ public class PauseResumeTest extends AbstractSeveralPipelineRunningTest implemen
         endpoint = tools()
                 .perform(registry, group, tool, ToolTab::runWithCustomSettings)
                 .setPriceType(priceType)
-                .launchTool(this, Utils.nameWithoutGroup(tool))
+                .launchTool(this, nameWithoutGroup(tool))
                 .show(getLastRunId())
                 .waitForInitializeNode(getLastRunId())
                 .clickEndpoint()
@@ -275,7 +276,7 @@ public class PauseResumeTest extends AbstractSeveralPipelineRunningTest implemen
         runsMenu()
                 .log(getLastRunId(), log -> log
                         .waitForPauseButton()
-                        .pause(getToolName())
+                        .pause(nameWithoutGroup(tool))
                         .assertPausingFinishedSuccessfully()
                         .sleep(2, MINUTES)
                         .inAnotherTab(nodeTab ->
@@ -284,7 +285,7 @@ public class PauseResumeTest extends AbstractSeveralPipelineRunningTest implemen
                                                         .assertPageTitleIs("404 Not Found"),
                                         endpoint)
                         )
-                        .resume(getToolName())
+                        .resume(nameWithoutGroup(tool))
                         .waitForEndpointLink()
                         .sleep(C.ENDPOINT_INITIALIZATION_TIMEOUT, MILLISECONDS)
                         .inAnotherTab(nodeTab ->
@@ -298,10 +299,5 @@ public class PauseResumeTest extends AbstractSeveralPipelineRunningTest implemen
         sleep(5, SECONDS);
         refresh();
         nodePage.get();
-    }
-
-    private String getToolName() {
-        final String[] toolAndGroup = tool.split("/");
-        return toolAndGroup[toolAndGroup.length - 1];
     }
 }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/PipelineDetailsTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/PipelineDetailsTest.java
@@ -296,6 +296,7 @@ public class PipelineDetailsTest extends AbstractSeveralPipelineRunningTest impl
     private void runPipeline(String pipelineName, PipelineDetailsTest pipelineDetailsTest) {
         library()
                 .clickOnPipeline(pipelineName)
+                .sleep(2, SECONDS)
                 .firstVersion()
                 .runPipeline()
                 .launch(pipelineDetailsTest);

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/RestrictionsOnInstancePriceTypeTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/RestrictionsOnInstancePriceTypeTest.java
@@ -15,7 +15,6 @@
  */
 package com.epam.pipeline.autotests;
 
-import com.epam.pipeline.autotests.ao.Configuration;
 import com.epam.pipeline.autotests.ao.SettingsPageAO.UserManagementAO.UsersTabAO.UserEntry.EditUserPopup;
 import com.epam.pipeline.autotests.ao.ToolTab;
 import com.epam.pipeline.autotests.mixins.Authorization;

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ToolsScanTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ToolsScanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,12 @@
 package com.epam.pipeline.autotests;
 
 import com.codeborne.selenide.Condition;
-import com.epam.pipeline.autotests.ao.PipelinesLibraryAO;
-import com.epam.pipeline.autotests.ao.SettingsPageAO;
 import com.epam.pipeline.autotests.ao.ToolGroup;
 import com.epam.pipeline.autotests.mixins.Authorization;
 import com.epam.pipeline.autotests.mixins.Tools;
 import com.epam.pipeline.autotests.utils.C;
 import com.epam.pipeline.autotests.utils.TestCase;
+import com.epam.pipeline.autotests.utils.Utils;
 import org.openqa.selenium.support.Colors;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -55,9 +54,9 @@ public class ToolsScanTest extends AbstractAutoRemovingPipelineRunningTest imple
             "The latest version shall be scanned for vulnerabilities. You can try an older one.";
     private final String registry = C.DEFAULT_REGISTRY;
     private final String group = C.DEFAULT_GROUP;
-    private final String tool = "shell";
     private final String version = "latest";
-    private final String fullToolName = String.format("%s/%s", group, tool);
+    private final String fullToolName = C.TOOL_WITHOUT_DEFAULT_SETTINGS;
+    private final String tool = Utils.nameWithoutGroup(fullToolName);
 
     private String graceHours;
     private boolean policyDenyNotScanned;
@@ -159,7 +158,7 @@ public class ToolsScanTest extends AbstractAutoRemovingPipelineRunningTest imple
                                 .selectVersion(version)
                                 .validateVersionPage("VULNERABILITIES REPORT")
                                 .validateReportTableColumns()
-                                .selectComponent("kernel-headers")
+                                .selectComponent("bash")
                                 .click(versionTab("PACKAGES"))
                                 .selectEcosystem("Python.Dist")
                                 .validatePackageList(Arrays.asList("pip", "py"), true)
@@ -313,9 +312,5 @@ public class ToolsScanTest extends AbstractAutoRemovingPipelineRunningTest imple
                 .delete()
                 .messageShouldAppear("Are you sure you want to delete the tool?")
                 .delete());
-    }
-
-    private void ok() {
-        new SettingsPageAO(new PipelinesLibraryAO()).ok();
     }
 }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/VersionControlTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/VersionControlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -154,6 +154,7 @@ public class VersionControlTest extends AbstractBfxPipelineTest implements Autho
                 .selectNthFileWithName(1, file.getName())
                 .reload()
                 .selectFile(file.getName() + " (latest)")
+                .sleep(2, SECONDS)
                 .validateFileHasBackgroundColor(backgroundColorOfRestoredFile)
                 .showFilesVersions(false)
                 .validateElementIsPresent(file.getName());

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/ToolVersions.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/ToolVersions.java
@@ -313,7 +313,7 @@ public class ToolVersions extends ToolTab<ToolVersions> {
         scanComponent.find(byClassName("ant-table-row-expand-icon")).click();
         final ElementsCollection advisors = $$(".tool-scanning-info__vulnerability-row").filterBy(visible);
         advisors.forEach(a -> {
-            a.find("a").shouldHave(attribute("href")).shouldHave(text("RHSA-"));
+            a.find("a").shouldHave(attribute("href")).shouldHave(text("CVE-"));
             a.shouldHave(Condition.or("severity",
                     text(severity[0]), text(severity[1]), text(severity[2]), text(severity[3]), text(severity[4])));
         });


### PR DESCRIPTION
The PR provides updates:
- extract child run id in hybridAutoScaledClusterCPUDeadlock() 
- change scan tool to e2e-empty 
- fix VersionControlTest