### PR TITLE
GUI fix: Chosen user/role should be fully into line with entered group or role after press 'enter' key

### DIFF
--- a/client/src/components/runs/logs/forms/ShareWithForm.js
+++ b/client/src/components/runs/logs/forms/ShareWithForm.js
@@ -140,7 +140,7 @@ export default class ShareWithForm extends React.Component {
 
   findUserDataSource = () => {
     if (this.userFind && !this.userFind.pending && !this.userFind.error) {
-      return (this.userFind.value || []).map(user => user);
+      return (this.userFind.value || []).map(user => user).sort();
     }
     return [];
   };
@@ -156,10 +156,10 @@ export default class ShareWithForm extends React.Component {
     const roles = this.state.groupSearchString
       ? (
         this.props.roles
-          .filter(r => r.name.toLowerCase()
-            .indexOf(this.state.groupSearchString.toLowerCase()) >= 0
-          )
           .map(r => r.predefined ? r.name : this.splitRoleName(r.name))
+          .filter(name => name.toLowerCase()
+            .indexOf(this.state.groupSearchString.toLowerCase()) >= 0
+          ).sort()
       )
       : [];
     if (this.groupFind && !this.groupFind.pending && !this.groupFind.error) {
@@ -169,7 +169,7 @@ export default class ShareWithForm extends React.Component {
             ...roles,
             ...(this.groupFind.value || []).map(g => g)]
         )
-      ];
+      ].sort();
     }
     return [...roles];
   };


### PR DESCRIPTION
This PR implements fix for #2123 