### PR TITLE
Add support for pipe cp/mv io threads parameter

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1009,17 +1009,21 @@ def storage_remove_item(path, yes, version, hard_delete, recursive, exclude, inc
 @click.option('-n', '--threads', type=int, required=False,
               help='The number of threads that will work to perform operation. Allowed for folders only. '
                    'Use to move a huge number of small files. Not supported for Windows OS. Progress bar is disabled')
+@click.option('-nio', '--io-threads', type=int, required=False,
+              help='The number of threads to be used for a single file io operations')
 @click.option('-vd', '--verify-destination', is_flag=True, required=False,
               help=STORAGE_VERIFY_DESTINATION_OPTION_DESCRIPTION)
 @click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
+@click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
 @Config.validate_access_token(quiet_flag_property_name='quiet')
+@stacktracing
 def storage_move_item(source, destination, recursive, force, exclude, include, quiet, skip_existing, tags, file_list,
-                      symlinks, threads, verify_destination):
+                      symlinks, threads, io_threads, verify_destination):
     """ Moves a file or a folder from one datastorage to another one
     or between the local filesystem and a datastorage (in both directions)
     """
     DataStorageOperations.cp(source, destination, recursive, force, exclude, include, quiet, tags, file_list,
-                             symlinks, threads, clean=True, skip_existing=skip_existing,
+                             symlinks, threads, io_threads, clean=True, skip_existing=skip_existing,
                              verify_destination=verify_destination)
 
 
@@ -1051,17 +1055,21 @@ def storage_move_item(source, destination, recursive, force, exclude, include, q
 @click.option('-n', '--threads', type=int, required=False,
               help='The number of threads that will work to perform operation. Allowed for folders only. '
                    'Use to copy a huge number of small files. Not supported for Windows OS. Progress bar is disabled')
+@click.option('-nio', '--io-threads', type=int, required=False,
+              help='The number of threads to be used for a single file io operations')
 @click.option('-vd', '--verify-destination', is_flag=True, required=False,
               help=STORAGE_VERIFY_DESTINATION_OPTION_DESCRIPTION)
 @click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
+@click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
 @Config.validate_access_token(quiet_flag_property_name='quiet')
+@stacktracing
 def storage_copy_item(source, destination, recursive, force, exclude, include, quiet, skip_existing, tags, file_list,
-                      symlinks, threads, verify_destination):
+                      symlinks, threads, io_threads, verify_destination, trace):
     """ Copies files from one datastorage to another one
     or between the local filesystem and a datastorage (in both directions)
     """
     DataStorageOperations.cp(source, destination, recursive, force,
-                             exclude, include, quiet, tags, file_list, symlinks, threads, skip_existing=skip_existing,
+                             exclude, include, quiet, tags, file_list, symlinks, threads, io_threads, skip_existing=skip_existing,
                              verify_destination=verify_destination)
 
 

--- a/pipe-cli/src/utilities/datastorage_operations.py
+++ b/pipe-cli/src/utilities/datastorage_operations.py
@@ -41,90 +41,86 @@ FOLDER_MARKER = '.DS_Store'
 class DataStorageOperations(object):
     @classmethod
     def cp(cls, source, destination, recursive, force, exclude, include, quiet, tags, file_list, symlinks, threads,
-           clean=False, skip_existing=False, verify_destination=False):
-        try:
-            source_wrapper = DataStorageWrapper.get_wrapper(source, symlinks)
-            destination_wrapper = DataStorageWrapper.get_wrapper(destination)
-            files_to_copy = []
+           io_threads, clean=False, skip_existing=False, verify_destination=False):
+        source_wrapper = DataStorageWrapper.get_wrapper(source, symlinks)
+        destination_wrapper = DataStorageWrapper.get_wrapper(destination)
+        files_to_copy = []
 
-            if source_wrapper is None:
-                click.echo('Could not resolve path {}'.format(source), err=True)
-                sys.exit(1)
-            if not source_wrapper.exists():
-                click.echo("Source {} doesn't exist".format(source), err=True)
-                sys.exit(1)
-            if destination_wrapper is None:
-                click.echo('Could not resolve path {}'.format(destination), err=True)
-                sys.exit(1)
-            if not recursive and not source_wrapper.is_file():
-                click.echo('Flag --recursive (-r) is required to copy folders.', err=True)
-                sys.exit(1)
-            if file_list:
-                if source_wrapper.is_file():
-                    click.echo('Option --file-list (-l) allowed for folders copy only.', err=True)
-                    sys.exit(1)
-                if not os.path.exists(file_list):
-                    click.echo('Specified --file-list file does not exist.', err=True)
-                    sys.exit(1)
-                files_to_copy = cls.__get_file_to_copy(file_list, source_wrapper.path)
-            if threads and not recursive:
-                click.echo('-n (--threads) is allowed for folders only.', err=True)
-                sys.exit(1)
-            if threads and platform.system() == 'Windows':
-                click.echo('-n (--threads) is not supported for Windows OS', err=True)
-                sys.exit(1)
-            relative = os.path.basename(source) if source_wrapper.is_file() else None
-            if not force and not verify_destination and not destination_wrapper.is_empty(relative=relative):
-                click.echo('The destination already exists. Specify --force (-f) flag to overwrite data or '
-                           '--verify-destination (-vd) flag to enable existence check for each destination path.',
-                           err=True)
-                sys.exit(1)
-
-            # append slashes to path to correctly determine file/folder type
-            if not source_wrapper.is_file():
-                if not source_wrapper.is_local() and not source_wrapper.path.endswith('/'):
-                    source_wrapper.path = source_wrapper.path + '/'
-                if destination_wrapper.is_local() and not destination_wrapper.path.endswith(os.path.sep):
-                    destination_wrapper.path = destination_wrapper.path + os.path.sep
-                if not destination_wrapper.is_local() and not destination_wrapper.path.endswith('/'):
-                    destination_wrapper.path = destination_wrapper.path + '/'
-
-            # copying a file to a remote destination, we need to set folder/file flag correctly
-            if source_wrapper.is_file() and not destination_wrapper.is_local() and not destination.endswith('/'):
-                destination_wrapper.is_file_flag = True
-
-            command = 'mv' if clean else 'cp'
-            permission_to_check = os.R_OK if command == 'cp' else os.W_OK
-            manager = DataStorageWrapper.get_operation_manager(source_wrapper, destination_wrapper, command)
-            items = files_to_copy if file_list else source_wrapper.get_items()
-            items = cls._filter_items(items, manager, source_wrapper, destination_wrapper, permission_to_check,
-                                      include, exclude, force, quiet, skip_existing, verify_destination)
-            sorted_items = list()
-            transfer_results = []
-            for item in items:
-                full_path = item[1]
-                relative_path = item[2]
-                size = item[3]
-                if threads:
-                    sorted_items.append(item)
-                else:
-                    transfer_result = manager.transfer(source_wrapper, destination_wrapper, path=full_path,
-                                                       relative_path=relative_path, clean=clean, quiet=quiet, size=size,
-                                                       tags=tags)
-                    if not destination_wrapper.is_local() and transfer_result:
-                        transfer_results.append(transfer_result)
-                        transfer_results = cls._flush_transfer_results(source_wrapper, destination_wrapper,
-                                                                       transfer_results, clean=clean)
-            if threads:
-                cls._multiprocess_transfer_items(sorted_items, threads, manager, source_wrapper, destination_wrapper,
-                                                 clean, quiet, tags)
-            else:
-                if not destination_wrapper.is_local():
-                    cls._flush_transfer_results(source_wrapper, destination_wrapper,
-                                                transfer_results, clean=clean, flush_size=1)
-        except ALL_ERRORS as error:
-            click.echo('Error: %s' % str(error), err=True)
+        if source_wrapper is None:
+            click.echo('Could not resolve path {}'.format(source), err=True)
             sys.exit(1)
+        if not source_wrapper.exists():
+            click.echo("Source {} doesn't exist".format(source), err=True)
+            sys.exit(1)
+        if destination_wrapper is None:
+            click.echo('Could not resolve path {}'.format(destination), err=True)
+            sys.exit(1)
+        if not recursive and not source_wrapper.is_file():
+            click.echo('Flag --recursive (-r) is required to copy folders.', err=True)
+            sys.exit(1)
+        if file_list:
+            if source_wrapper.is_file():
+                click.echo('Option --file-list (-l) allowed for folders copy only.', err=True)
+                sys.exit(1)
+            if not os.path.exists(file_list):
+                click.echo('Specified --file-list file does not exist.', err=True)
+                sys.exit(1)
+            files_to_copy = cls.__get_file_to_copy(file_list, source_wrapper.path)
+        if threads and not recursive:
+            click.echo('-n (--threads) is allowed for folders only.', err=True)
+            sys.exit(1)
+        if threads and platform.system() == 'Windows':
+            click.echo('-n (--threads) is not supported for Windows OS', err=True)
+            sys.exit(1)
+        relative = os.path.basename(source) if source_wrapper.is_file() else None
+        if not force and not verify_destination and not destination_wrapper.is_empty(relative=relative):
+            click.echo('The destination already exists. Specify --force (-f) flag to overwrite data or '
+                       '--verify-destination (-vd) flag to enable existence check for each destination path.',
+                       err=True)
+            sys.exit(1)
+
+        # append slashes to path to correctly determine file/folder type
+        if not source_wrapper.is_file():
+            if not source_wrapper.is_local() and not source_wrapper.path.endswith('/'):
+                source_wrapper.path = source_wrapper.path + '/'
+            if destination_wrapper.is_local() and not destination_wrapper.path.endswith(os.path.sep):
+                destination_wrapper.path = destination_wrapper.path + os.path.sep
+            if not destination_wrapper.is_local() and not destination_wrapper.path.endswith('/'):
+                destination_wrapper.path = destination_wrapper.path + '/'
+
+        # copying a file to a remote destination, we need to set folder/file flag correctly
+        if source_wrapper.is_file() and not destination_wrapper.is_local() and not destination.endswith('/'):
+            destination_wrapper.is_file_flag = True
+
+        command = 'mv' if clean else 'cp'
+        permission_to_check = os.R_OK if command == 'cp' else os.W_OK
+        manager = DataStorageWrapper.get_operation_manager(source_wrapper, destination_wrapper, command)
+        items = files_to_copy if file_list else source_wrapper.get_items()
+        items = cls._filter_items(items, manager, source_wrapper, destination_wrapper, permission_to_check,
+                                  include, exclude, force, quiet, skip_existing, verify_destination)
+        sorted_items = list()
+        transfer_results = []
+        for item in items:
+            full_path = item[1]
+            relative_path = item[2]
+            size = item[3]
+            if threads:
+                sorted_items.append(item)
+            else:
+                transfer_result = manager.transfer(source_wrapper, destination_wrapper, path=full_path,
+                                                   relative_path=relative_path, clean=clean, quiet=quiet, size=size,
+                                                   tags=tags, io_threads=io_threads)
+                if not destination_wrapper.is_local() and transfer_result:
+                    transfer_results.append(transfer_result)
+                    transfer_results = cls._flush_transfer_results(source_wrapper, destination_wrapper,
+                                                                   transfer_results, clean=clean)
+        if threads:
+            cls._multiprocess_transfer_items(sorted_items, threads, manager, source_wrapper, destination_wrapper,
+                                             clean, quiet, tags, io_threads)
+        else:
+            if not destination_wrapper.is_local():
+                cls._flush_transfer_results(source_wrapper, destination_wrapper,
+                                            transfer_results, clean=clean, flush_size=1)
 
     @classmethod
     def _filter_items(cls, items, manager, source_wrapper, destination_wrapper, permission_to_check,
@@ -599,7 +595,7 @@ class DataStorageOperations(object):
 
     @classmethod
     def _multiprocess_transfer_items(cls, sorted_items, threads, manager, source_wrapper, destination_wrapper, clean,
-                                     quiet, tags):
+                                     quiet, tags, io_threads):
         size_index = 3
         sorted_items.sort(key=itemgetter(size_index), reverse=True)
         splitted_items = cls._split_items_by_process(sorted_items, threads)
@@ -615,13 +611,14 @@ class DataStorageOperations(object):
                                                     clean,
                                                     quiet,
                                                     tags,
+                                                    io_threads,
                                                     lock))
             process.start()
             workers.append(process)
         cls._handle_keyboard_interrupt(workers)
 
     @classmethod
-    def _transfer_items(cls, items, manager, source_wrapper, destination_wrapper, clean, quiet, tags, lock):
+    def _transfer_items(cls, items, manager, source_wrapper, destination_wrapper, clean, quiet, tags, io_threads, lock):
         transfer_results = []
         for item in items:
             full_path = item[1]
@@ -629,7 +626,7 @@ class DataStorageOperations(object):
             size = item[3]
             transfer_result = manager.transfer(source_wrapper, destination_wrapper, path=full_path,
                                                relative_path=relative_path, clean=clean, quiet=quiet, size=size,
-                                               tags=tags, lock=lock)
+                                               tags=tags, io_threads=io_threads, lock=lock)
             if not destination_wrapper.is_local() and transfer_result:
                 transfer_results.append(transfer_result)
                 transfer_results = cls._flush_transfer_results(source_wrapper, destination_wrapper,

--- a/pipe-cli/src/utilities/storage/common.py
+++ b/pipe-cli/src/utilities/storage/common.py
@@ -232,7 +232,7 @@ class AbstractTransferManager:
 
     @abstractmethod
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False,
-                 quiet=False, size=None, tags=(), lock=None):
+                 quiet=False, size=None, tags=(), io_threads=None, lock=None):
         """
         Transfers data from the source storage to the destination storage.
 
@@ -247,6 +247,7 @@ class AbstractTransferManager:
         :param size: Size of the transfer source object.
         :param tags: Additional tags that will be included to the transferring object.
         Tags CP_SOURCE and CP_OWNER will be included by default.
+        :param io_threads: Number of threads to be used for a single file io operations.
         :param lock: The lock object if multithreaded transfer is requested
         :type lock: multiprocessing.Lock
         """

--- a/pipe-cli/src/utilities/storage/gs.py
+++ b/pipe-cli/src/utilities/storage/gs.py
@@ -711,7 +711,7 @@ class TransferBetweenGsBucketsManager(GsManager, AbstractTransferManager):
         return source_path
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False, quiet=False,
-                 size=None, tags=(), lock=None):
+                 size=None, tags=(), io_threads=None, lock=None):
         full_path = path
         destination_path = self.get_destination_key(destination_wrapper, relative_path)
         source_client = GsBucketOperations.get_client(source_wrapper.bucket, read=True, write=clean)
@@ -773,7 +773,7 @@ class GsDownloadManager(GsManager, AbstractTransferManager):
         return source_path or source_wrapper.path
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False, quiet=False,
-                 size=None, tags=(), lock=None):
+                 size=None, tags=(), io_threads=None, lock=None):
         source_key = self.get_source_key(source_wrapper, path)
         destination_key = self.get_destination_key(destination_wrapper, relative_path)
 
@@ -783,7 +783,7 @@ class GsDownloadManager(GsManager, AbstractTransferManager):
         else:
             progress_callback = None
         self._replace_default_download_chunk_size(self._buffering)
-        transfer_config = self._get_download_config()
+        transfer_config = self._get_transfer_config(io_threads)
         if size > transfer_config.multipart_threshold:
             bucket = self.client.bucket(source_wrapper.bucket.path)
             blob = self.custom_blob(bucket, source_key, None, size)
@@ -803,7 +803,7 @@ class GsDownloadManager(GsManager, AbstractTransferManager):
         if clean:
             blob.delete()
 
-    def _get_download_config(self):
+    def _get_transfer_config(self, io_threads=None):
         transfer_config = TransferConfig(multipart_threshold=200 * MB,
                                          multipart_chunksize=200 * MB)
         if os.getenv(CP_CLI_GCP_MULTIPART_THRESHOLD):
@@ -812,6 +812,8 @@ class GsDownloadManager(GsManager, AbstractTransferManager):
             transfer_config.multipart_chunksize = int(os.getenv(CP_CLI_GCP_MULTIPART_CHUNKSIZE))
         if os.getenv(CP_CLI_GCP_MAX_CONCURRENCY):
             transfer_config.max_concurrency = int(os.getenv(CP_CLI_GCP_MAX_CONCURRENCY))
+        if io_threads is not None:
+            transfer_config.max_concurrency = max(io_threads, 1)
         return transfer_config
 
     def _download_to_file(self, blob, destination_key):
@@ -852,7 +854,7 @@ class GsUploadManager(GsManager, AbstractTransferManager):
             return source_wrapper.path
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False, quiet=False,
-                 size=None, tags=(), lock=None):
+                 size=None, tags=(), io_threads=None, lock=None):
         source_key = self.get_source_key(source_wrapper, path)
         destination_key = self.get_destination_key(destination_wrapper, relative_path)
 
@@ -860,7 +862,7 @@ class GsUploadManager(GsManager, AbstractTransferManager):
             progress_callback = ProgressPercentage(relative_path, size)
         else:
             progress_callback = None
-        transfer_config = self._get_upload_config(size)
+        transfer_config = self._get_transfer_config(size, io_threads)
         destination_tags = StorageOperations.generate_tags(tags, source_key)
         if size > transfer_config.multipart_threshold:
             upload_client = GsCompositeUploadClient(destination_wrapper.bucket.path, destination_key,
@@ -881,7 +883,7 @@ class GsUploadManager(GsManager, AbstractTransferManager):
         return UploadResult(source_key=source_key, destination_key=destination_key, destination_version=generation,
                             tags=destination_tags)
 
-    def _get_upload_config(self, size):
+    def _get_transfer_config(self, size, io_threads):
         multipart_threshold, multipart_chunksize = self._get_adjusted_parameters(size,
                                                                                  multipart_threshold=150 * MB,
                                                                                  max_parts=32)
@@ -893,6 +895,8 @@ class GsUploadManager(GsManager, AbstractTransferManager):
             transfer_config.multipart_chunksize = int(os.getenv(CP_CLI_GCP_MULTIPART_CHUNKSIZE))
         if os.getenv(CP_CLI_GCP_MAX_CONCURRENCY):
             transfer_config.max_concurrency = int(os.getenv(CP_CLI_GCP_MAX_CONCURRENCY))
+        if io_threads is not None:
+            transfer_config.max_concurrency = max(io_threads, 1)
         return transfer_config
 
     def _get_adjusted_parameters(self, size, multipart_threshold, max_parts):
@@ -934,7 +938,7 @@ class TransferFromHttpOrFtpToGsManager(GsManager, AbstractTransferManager):
         return source_path or source_wrapper.path
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False, quiet=False,
-                 size=None, tags=(), lock=None):
+                 size=None, tags=(), io_threads=None, lock=None):
         if clean:
             raise AttributeError('Cannot perform \'mv\' operation due to deletion remote files '
                                  'is not supported for ftp/http sources.')

--- a/pipe-cli/src/utilities/storage/s3.py
+++ b/pipe-cli/src/utilities/storage/s3.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from boto3.s3.transfer import TransferConfig
 from botocore.endpoint import BotocoreHTTPSession, MAX_POOL_CONNECTIONS
 
 from src.utilities.storage.s3_proxy_utils import AwsProxyConnectWithHeadersHTTPSAdapter
@@ -154,6 +155,13 @@ class StorageItemManager(object):
     def get_local_file_size(path):
         return StorageOperations.get_local_file_size(path)
 
+    def get_transfer_config(self, io_threads):
+        transfer_config = TransferConfig()
+        if io_threads is not None:
+            transfer_config.max_concurrency = max(io_threads, 1)
+            transfer_config.use_threads = transfer_config.max_concurrency > 1
+        return transfer_config
+
 
 class DownloadManager(StorageItemManager, AbstractTransferManager):
 
@@ -173,15 +181,18 @@ class DownloadManager(StorageItemManager, AbstractTransferManager):
         return self.get_local_file_size(destination_key)
 
     def transfer(self, source_wrapper, destination_wrapper, path=None,
-                 relative_path=None, clean=False, quiet=False, size=None, tags=None, lock=None):
+                 relative_path=None, clean=False, quiet=False, size=None, tags=None, io_threads=None, lock=None):
         source_key = self.get_source_key(source_wrapper, path)
         destination_key = self.get_destination_key(destination_wrapper, relative_path)
 
         self.create_local_folder(destination_key, lock)
+        transfer_config = self.get_transfer_config(io_threads)
         if StorageItemManager.show_progress(quiet, size, lock):
-            self.bucket.download_file(source_key, destination_key, Callback=ProgressPercentage(relative_path, size))
+            self.bucket.download_file(source_key, destination_key, Callback=ProgressPercentage(relative_path, size),
+                                      Config=transfer_config)
         else:
-            self.bucket.download_file(source_key, destination_key)
+            self.bucket.download_file(source_key, destination_key,
+                                      Config=transfer_config)
         if clean:
             source_wrapper.delete_item(source_key)
 
@@ -204,7 +215,7 @@ class UploadManager(StorageItemManager, AbstractTransferManager):
             return source_wrapper.path
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None,
-                 clean=False, quiet=False, size=None, tags=(), lock=None):
+                 clean=False, quiet=False, size=None, tags=(), io_threads=None, lock=None):
         source_key = self.get_source_key(source_wrapper, path)
         destination_key = self.get_destination_key(destination_wrapper, relative_path)
 
@@ -215,11 +226,12 @@ class UploadManager(StorageItemManager, AbstractTransferManager):
             'ACL': 'bucket-owner-full-control'
         }
         TransferManager.ALLOWED_UPLOAD_ARGS.append('Tagging')
+        transfer_config = self.get_transfer_config(io_threads)
         if StorageItemManager.show_progress(quiet, size, lock):
             self.bucket.upload_file(source_key, destination_key, Callback=ProgressPercentage(relative_path, size),
-                                    ExtraArgs=extra_args)
+                                    Config=transfer_config, ExtraArgs=extra_args)
         else:
-            self.bucket.upload_file(source_key, destination_key, ExtraArgs=extra_args)
+            self.bucket.upload_file(source_key, destination_key, Config=transfer_config, ExtraArgs=extra_args)
         if clean:
             source_wrapper.delete_item(source_key)
         tags = StorageOperations.parse_tags(tags)
@@ -246,7 +258,7 @@ class TransferFromHttpOrFtpToS3Manager(StorageItemManager, AbstractTransferManag
         return source_path or source_wrapper.path
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None,
-                 clean=False, quiet=False, size=None, tags=(), lock=None):
+                 clean=False, quiet=False, size=None, tags=(), io_threads=None, lock=None):
         if clean:
             raise AttributeError("Cannot perform 'mv' operation due to deletion remote files "
                                  "is not supported for ftp/http sources.")
@@ -289,7 +301,7 @@ class TransferBetweenBucketsManager(StorageItemManager, AbstractTransferManager)
         return source_path
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False,
-                 quiet=False, size=None, tags=(), lock=None):
+                 quiet=False, size=None, tags=(), io_threads=None, lock=None):
         # checked is bucket and file
         source_bucket = source_wrapper.bucket.path
         source_region = source_wrapper.bucket.region


### PR DESCRIPTION
Resolves issue #2140.

The pull request brings support for `-nio/--io-threads` parameter to `pipe cp/mv` commands which allows to configure number of threads to use for a single file io operations. Bidirectional transfers between local file system and cloud data storage are supported for all available cloud providers (AWS, GCP and Azure) on all platforms.

Notice that pipe cli transferring uses 10 io threads on AWS and GCP and 2 io threads on Azure by default.

## Examples

Transfer directory using twenty io threads

```bash
pipe storage cp --nio 20 -r local/source/directory cp://cloud/data/storage/target/directory
```

Transfer directory using a single io thread

```bash
pipe storage cp --nio 1 -r local/source/directory cp://cloud/data/storage/target/directory
```

## Related changes

Additionally the pull request brings support for `--trace` parameter to `pipe cp/mv` commands which allows to optionally print error stack traces.
