### PR TITLE
Allow hiding certain files for faceted search

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/search/StorageFileSearchMask.java
+++ b/api/src/main/java/com/epam/pipeline/entity/search/StorageFileSearchMask.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.search;
+
+import lombok.AllArgsConstructor;
+
+import java.util.List;
+
+@AllArgsConstructor
+public class StorageFileSearchMask {
+
+    private final String storageName;
+    private final List<String> hiddenFilePathGlobs;
+}

--- a/api/src/main/java/com/epam/pipeline/entity/search/StorageFileSearchMask.java
+++ b/api/src/main/java/com/epam/pipeline/entity/search/StorageFileSearchMask.java
@@ -18,11 +18,11 @@ package com.epam.pipeline.entity.search;
 
 import lombok.AllArgsConstructor;
 
-import java.util.List;
+import java.util.Set;
 
 @AllArgsConstructor
 public class StorageFileSearchMask {
 
     private final String storageName;
-    private final List<String> hiddenFilePathGlobs;
+    private final Set<String> hiddenFilePathGlobs;
 }

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -32,6 +32,7 @@ import com.epam.pipeline.entity.monitoring.IdleRunAction;
 import com.epam.pipeline.entity.monitoring.LongPausedRunAction;
 import com.epam.pipeline.entity.preference.Preference;
 import com.epam.pipeline.entity.region.CloudProvider;
+import com.epam.pipeline.entity.search.StorageFileSearchMask;
 import com.epam.pipeline.entity.search.SearchDocumentType;
 import com.epam.pipeline.entity.templates.DataStorageTemplate;
 import com.epam.pipeline.entity.utils.ControlEntry;
@@ -755,6 +756,13 @@ public class SystemPreferences {
             "search.elastic.denied.groups.field", null, SEARCH_GROUP, pass);
     public static final IntPreference SEARCH_AGGS_MAX_COUNT = new IntPreference("search.aggs.max.count",
             20, SEARCH_GROUP, pass);
+
+    public static final ObjectPreference<List<StorageFileSearchMask>> FILE_SEARCH_MASK_RULES = new ObjectPreference<>(
+        "search.storage.elements.hide.mask",
+        Collections.emptyList(),
+        new TypeReference<List<StorageFileSearchMask>>() {},
+        SEARCH_GROUP,
+        isNullOrValidJson(new TypeReference<List<StorageFileSearchMask>>() {}));
 
     // Grid engine autoscaling
     public static final IntPreference GE_AUTOSCALING_SCALE_UP_TIMEOUT =

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchRequestBuilder.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchRequestBuilder.java
@@ -75,6 +75,7 @@ public class SearchRequestBuilder {
     private static final String ES_FILE_INDEX_PATTERN = "cp-%s-file-%d";
     private static final String ES_DOC_ID_FIELD = "_id";
     private static final String ES_DOC_SCORE_FIELD = "_score";
+    private static final String SEARCH_HIDDEN = "is_hidden";
 
     private final PreferenceManager preferenceManager;
     private final AuthManager authManager;
@@ -133,7 +134,7 @@ public class SearchRequestBuilder {
 
         final QueryBuilder queryBuilder = prepareFacetedQuery(facetedSearchRequest.getQuery());
         boolQueryBuilder.must(queryBuilder);
-
+        boolQueryBuilder.mustNot(QueryBuilders.termsQuery(SEARCH_HIDDEN, Boolean.TRUE));
         MapUtils.emptyIfNull(facetedSearchRequest.getFilters())
                 .forEach((fieldName, values) -> boolQueryBuilder.must(filterToTermsQuery(fieldName, values)));
 

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
@@ -41,6 +41,7 @@ import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.RunLog;
 import com.epam.pipeline.entity.pipeline.Tool;
 import com.epam.pipeline.entity.pipeline.ToolGroup;
+import com.epam.pipeline.entity.preference.Preference;
 import com.epam.pipeline.entity.region.AbstractCloudRegion;
 import com.epam.pipeline.entity.region.AwsRegion;
 import com.epam.pipeline.entity.security.acl.AclClass;
@@ -253,4 +254,7 @@ public interface CloudPipelineAPI {
 
     @PUT("dts/{id}/heartbeat")
     Call<Result<DtsRegistry>> updateDtsHeartbeat(@Path(ID) String dtsId);
+
+    @GET("preferences/{key}")
+    Call<Result<Preference>> loadPreference(@Path(KEY) final String preferenceName);
 }

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/datastorage/DataStorageFile.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/datastorage/DataStorageFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ public class DataStorageFile extends AbstractDataStorageItem {
     private String changed;
     private String version;
     private Boolean deleteMarker;
+    private Boolean isHidden = false;
     private Map<String, AbstractDataStorageItem> versions;
 
     public DataStorageFile() {
@@ -49,6 +50,7 @@ public class DataStorageFile extends AbstractDataStorageItem {
         file.setLabels(other.getLabels());
         file.setVersion(other.getVersion());
         file.setDeleteMarker(other.getDeleteMarker());
+        file.setIsHidden(other.getIsHidden());
         return file;
     }
 

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/search/StorageFileSearchMask.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/search/StorageFileSearchMask.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.search;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class StorageFileSearchMask {
+
+    private final String storageName;
+    private final List<String> hiddenFilePathGlobs;
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/search/StorageFileSearchMask.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/search/StorageFileSearchMask.java
@@ -18,11 +18,11 @@ package com.epam.pipeline.entity.search;
 
 import lombok.Data;
 
-import java.util.List;
+import java.util.Set;
 
 @Data
 public class StorageFileSearchMask {
 
     private final String storageName;
-    private final List<String> hiddenFilePathGlobs;
+    private final Set<String> hiddenFilePathGlobs;
 }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/ObjectStorageIndexImpl.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/ObjectStorageIndexImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import com.epam.pipeline.elasticsearchagent.service.ElasticsearchServiceClient;
 import com.epam.pipeline.elasticsearchagent.service.ObjectStorageFileManager;
 import com.epam.pipeline.elasticsearchagent.service.ObjectStorageIndex;
 import com.epam.pipeline.elasticsearchagent.service.impl.converter.storage.StorageFileMapper;
+import com.epam.pipeline.entity.search.StorageFileSearchMask;
 import com.epam.pipeline.utils.StreamUtils;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.DataStorageAction;
@@ -34,11 +35,14 @@ import com.epam.pipeline.vo.data.storage.DataStorageTagLoadRequest;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.elasticsearch.action.index.IndexRequest;
+import org.springframework.util.AntPathMatcher;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -66,10 +70,12 @@ public class ObjectStorageIndexImpl implements ObjectStorageIndex {
     @Getter
     private final SearchDocumentType documentType;
     private final StorageFileMapper fileMapper = new StorageFileMapper();
+    private final Map<String, List<String>> searchMasks = new HashMap<>();
 
     @Override
     public void synchronize(final LocalDateTime lastSyncTime, final LocalDateTime syncStart) {
         log.debug("Started {} files synchronization", getStorageType());
+        updateSearchMasks();
         cloudPipelineAPIClient.loadAllDataStorages()
                 .stream()
                 .filter(dataStorage -> dataStorage.getType() == getStorageType())
@@ -96,11 +102,12 @@ public class ObjectStorageIndexImpl implements ObjectStorageIndex {
                 final Stream<DataStorageFile> files = fileManager
                         .files(dataStorage.getRoot(),
                                 Optional.ofNullable(dataStorage.getPrefix()).orElse(StringUtils.EMPTY),
-                                credentialsSupplier);
+                                credentialsSupplier)
+                        .map(file -> setHiddenFlag(dataStorage, file));
                 StreamUtils.chunked(files, bulkLoadTagsSize)
                         .flatMap(filesChunk -> filesWithIncorporatedTags(dataStorage, filesChunk))
                         .peek(file -> file.setPath(dataStorage.resolveRelativePath(file.getPath())))
-                        .map(file -> createIndexRequest(file, dataStorage, permissionsContainer, indexName, 
+                        .map(file -> createIndexRequest(file, dataStorage, permissionsContainer, indexName,
                                 credentials.getRegion()))
                         .forEach(requestContainer::add);
             }
@@ -115,6 +122,28 @@ public class ObjectStorageIndexImpl implements ObjectStorageIndex {
                 elasticsearchServiceClient.deleteIndex(indexName);
             }
         }
+    }
+
+    private void updateSearchMasks() {
+        final Map<String, List<String>> newMasks = cloudPipelineAPIClient.getStorageSearchMasks()
+            .stream()
+            .collect(Collectors.toMap(StorageFileSearchMask::getStorageName,
+                                      StorageFileSearchMask::getHiddenFilePathGlobs));
+        searchMasks.clear();
+        log.info("Updating search masks: {}", newMasks);
+        searchMasks.putAll(newMasks);
+    }
+
+    private DataStorageFile setHiddenFlag(final AbstractDataStorage dataStorage,
+                                          final DataStorageFile file) {
+        final String storageName = dataStorage.getName();
+        if (searchMasks.containsKey(storageName)) {
+            final AntPathMatcher pathMatcher = new AntPathMatcher();
+            file.setIsHidden(CollectionUtils.emptyIfNull(searchMasks.get(storageName))
+                                 .stream()
+                                 .anyMatch(mask -> pathMatcher.match(mask, file.getPath())));
+        }
+        return file;
     }
 
     private IndexRequestContainer getRequestContainer(final String indexName, final int bulkInsertSize) {

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/storage/StorageFileMapper.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/storage/StorageFileMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ public class StorageFileMapper {
                     .field("storage_id", dataStorage.getId())
                     .field("storage_name", dataStorage.getName())
                     .field("storage_region", region)
+                    .field("is_hidden", dataStorageFile.getIsHidden())
                     .field(DOC_TYPE_FIELD, type.name())
                     .array("metadata", tags.entrySet().stream()
                             .map(entry -> entry.getKey() + " " + entry.getValue())

--- a/elasticsearch-agent/src/main/resources/application.properties
+++ b/elasticsearch-agent/src/main/resources/application.properties
@@ -46,6 +46,9 @@ sync.run.index.name=pipeline-run
 sync.run.bulk.insert.size=100
 sync.run.log.lines.size=1000
 
+# Common files settings
+sync.search.files.hidden.masks.preference.key=search.storage.elements.hide.mask
+
 #Azure blob storage Settings
 #sync.az-blob-storage.disable=false
 sync.az-blob-storage.index.name=az-storage

--- a/elasticsearch-agent/src/main/resources/templates/storage_file.json
+++ b/elasticsearch-agent/src/main/resources/templates/storage_file.json
@@ -21,7 +21,8 @@
         "allowed_users": { "type": "keyword" },
         "denied_users": { "type": "keyword" },
         "allowed_groups": { "type": "keyword" },
-        "denied_groups": { "type": "keyword" }
+        "denied_groups": { "type": "keyword" },
+        "is_hidden": { "type":  "boolean" }
       }
     }
   },


### PR DESCRIPTION
This PR improves faceted search, allowing to hide some of the results by specifying the list of masks in `search.storage.elements.hide.mask` preference.

Mask object is implemented as `StorageFileSearchMask`, consists of a storage name and list of globs, describing files that need to be ignored.