### PR TITLE
Issue #2144 User impersonation

### DIFF
--- a/api/profiles/dev/application.properties
+++ b/api/profiles/dev/application.properties
@@ -13,7 +13,7 @@ spring.session.store-type=jdbc
 
 #Security
 api.security.anonymous.urls=${CP_API_SECURITY_ANONYMOUS_URLS:/restapi/route}
-api.security.impersonation.operations.root.url=${CP_API_SECURITY_IMPERSONATION_ROOT_URL:/restapi/user/impersonation/}
+api.security.impersonation.operations.root.url=${CP_API_SECURITY_IMPERSONATION_ROOT_URL:/restapi/user/impersonation}
 api.security.public.urls=${CP_API_SECURITY_PUBLIC_URLS:/launch.sh,/launch.py,/PipelineCLI.tar.gz,/pipe-common.tar.gz,/commit-run-scripts/**,/pipe,/fsbrowser.tar.gz,/pipe.zip,/pipe.tar.gz,/pipe-el6,/pipe-el6.tar.gz,/pipe-osx,/pipe-osx.tar.gz,/cloud-data-linux.tar.gz,/cloud-data-win64.zip,/fsautoscale.sh,/data-transfer-service.jar,/data-transfer-service-windows.zip,/DeployDts.ps1}
 
 #db configuration

--- a/api/profiles/dev/application.properties
+++ b/api/profiles/dev/application.properties
@@ -13,6 +13,7 @@ spring.session.store-type=jdbc
 
 #Security
 api.security.anonymous.urls=${CP_API_SECURITY_ANONYMOUS_URLS:/restapi/route}
+api.security.impersonation.operations.root.url=${CP_API_SECURITY_IMPERSONATION_ROOT_URL:/restapi/user/impersonation/}
 api.security.public.urls=${CP_API_SECURITY_PUBLIC_URLS:/launch.sh,/launch.py,/PipelineCLI.tar.gz,/pipe-common.tar.gz,/commit-run-scripts/**,/pipe,/fsbrowser.tar.gz,/pipe.zip,/pipe.tar.gz,/pipe-el6,/pipe-el6.tar.gz,/pipe-osx,/pipe-osx.tar.gz,/cloud-data-linux.tar.gz,/cloud-data-win64.zip,/fsautoscale.sh,/data-transfer-service.jar,/data-transfer-service-windows.zip,/DeployDts.ps1}
 
 #db configuration

--- a/api/profiles/release/application.properties
+++ b/api/profiles/release/application.properties
@@ -11,6 +11,7 @@ spring.http.encoding.force-response=true
 
 #Security
 api.security.anonymous.urls=${CP_API_SECURITY_ANONYMOUS_URLS:/restapi/route}
+api.security.impersonation.operations.root.url=${CP_API_SECURITY_IMPERSONATION_ROOT_URL:/restapi/user/impersonation/}
 
 #db configuration
 database.url=

--- a/api/profiles/release/application.properties
+++ b/api/profiles/release/application.properties
@@ -11,7 +11,7 @@ spring.http.encoding.force-response=true
 
 #Security
 api.security.anonymous.urls=${CP_API_SECURITY_ANONYMOUS_URLS:/restapi/route}
-api.security.impersonation.operations.root.url=${CP_API_SECURITY_IMPERSONATION_ROOT_URL:/restapi/user/impersonation/}
+api.security.impersonation.operations.root.url=${CP_API_SECURITY_IMPERSONATION_ROOT_URL:/restapi/user/impersonation}
 
 #db configuration
 database.url=

--- a/api/src/main/java/com/epam/pipeline/acl/user/UserApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/user/UserApiService.java
@@ -22,6 +22,7 @@ import com.epam.pipeline.entity.info.UserInfo;
 import com.epam.pipeline.entity.security.JwtRawToken;
 import com.epam.pipeline.entity.user.CustomControl;
 import com.epam.pipeline.entity.user.GroupStatus;
+import com.epam.pipeline.entity.user.ImpersonationStatus;
 import com.epam.pipeline.entity.user.PipelineUser;
 import com.epam.pipeline.entity.user.PipelineUserEvent;
 import com.epam.pipeline.entity.user.RunnerSid;
@@ -228,5 +229,9 @@ public class UserApiService {
     @PreAuthorize(ADMIN_ONLY + OR_USER_READER)
     public List<RunnerSid> getRunners(final Long id) {
         return userRunnersManager.getRunners(id);
+    }
+
+    public ImpersonationStatus getImpersonationStatus() {
+        return userManager.getImpersonationStatus();
     }
 }

--- a/api/src/main/java/com/epam/pipeline/app/JWTSecurityConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/JWTSecurityConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,6 +70,9 @@ public class JWTSecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Value("${api.security.anonymous.urls:/restapi/route}")
     private String[] anonymousResources;
 
+    @Value("${api.security.impersonation.operations.root.url:/restapi/user/impersonation/}")
+    private String impersonationOperationsRoot;
+
     @Value("#{'${api.security.public.urls}'.split(',')}")
     private List<String> excludeScripts;
 
@@ -110,6 +113,8 @@ public class JWTSecurityConfiguration extends WebSecurityConfigurerAdapter {
                             DefaultRoles.ROLE_ANONYMOUS_USER.getName())
                 .antMatchers(getSecuredResources())
                     .hasAnyAuthority(DefaultRoles.ROLE_ADMIN.getName(), DefaultRoles.ROLE_USER.getName())
+                .antMatchers(getImpersonationStartUrl())
+                    .hasAuthority(DefaultRoles.ROLE_ADMIN.getName())
                 .and()
                 .sessionManagement().sessionCreationPolicy(
                         disableJwtSession ? SessionCreationPolicy.NEVER : SessionCreationPolicy.IF_REQUIRED)
@@ -155,6 +160,10 @@ public class JWTSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     public String[] getAnonymousResources() {
         return anonymousResources;
+    }
+
+    public String getImpersonationStartUrl() {
+        return impersonationOperationsRoot + "start";
     }
 
     //List of urls under REST that should be redirected back after authorization

--- a/api/src/main/java/com/epam/pipeline/app/JWTSecurityConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/JWTSecurityConfiguration.java
@@ -70,8 +70,8 @@ public class JWTSecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Value("${api.security.anonymous.urls:/restapi/route}")
     private String[] anonymousResources;
 
-    @Value("${api.security.impersonation.operations.root.url:/restapi/user/impersonation/}")
-    private String impersonationOperationsRoot;
+    @Value("${api.security.impersonation.operations.root.url:/restapi/user/impersonation}")
+    private String impersonationOperationsRootUrl;
 
     @Value("#{'${api.security.public.urls}'.split(',')}")
     private List<String> excludeScripts;
@@ -111,10 +111,10 @@ public class JWTSecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .antMatchers(getAnonymousResources())
                     .hasAnyAuthority(DefaultRoles.ROLE_ADMIN.getName(), DefaultRoles.ROLE_USER.getName(), 
                             DefaultRoles.ROLE_ANONYMOUS_USER.getName())
+                .antMatchers(getImpersonationStartUrl())
+                     .hasAuthority(DefaultRoles.ROLE_ADMIN.getName())
                 .antMatchers(getSecuredResources())
                     .hasAnyAuthority(DefaultRoles.ROLE_ADMIN.getName(), DefaultRoles.ROLE_USER.getName())
-                .antMatchers(getImpersonationStartUrl())
-                    .hasAuthority(DefaultRoles.ROLE_ADMIN.getName())
                 .and()
                 .sessionManagement().sessionCreationPolicy(
                         disableJwtSession ? SessionCreationPolicy.NEVER : SessionCreationPolicy.IF_REQUIRED)
@@ -163,7 +163,7 @@ public class JWTSecurityConfiguration extends WebSecurityConfigurerAdapter {
     }
 
     public String getImpersonationStartUrl() {
-        return impersonationOperationsRoot + "start";
+        return impersonationOperationsRootUrl + "/start";
     }
 
     //List of urls under REST that should be redirected back after authorization

--- a/api/src/main/java/com/epam/pipeline/app/SAMLSecurityConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/SAMLSecurityConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package com.epam.pipeline.app;
 
 import com.epam.pipeline.entity.user.DefaultRoles;
+import com.epam.pipeline.manager.user.ImpersonationManager;
 import com.epam.pipeline.security.saml.OptionalSAMLLogoutFilter;
 import com.epam.pipeline.security.saml.SAMLContexProviderCustomSingKey;
 import com.epam.pipeline.utils.URLUtils;
@@ -88,6 +89,7 @@ import org.springframework.security.web.authentication.SimpleUrlAuthenticationFa
 import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.security.web.authentication.logout.SimpleUrlLogoutSuccessHandler;
+import org.springframework.security.web.authentication.switchuser.SwitchUserFilter;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.OrRequestMatcher;
@@ -140,6 +142,9 @@ public class SAMLSecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Value("${api.security.anonymous.urls:/restapi/route}")
     private String[] anonymousResources;
 
+    @Value("${api.security.impersonation.operations.root.url:/restapi/user/impersonation/}")
+    private String impersonationOperationsRootUrl;
+
     @Value("#{'${api.security.public.urls}'.split(',')}")
     private List<String> excludeScripts;
 
@@ -172,7 +177,9 @@ public class SAMLSecurityConfiguration extends WebSecurityConfigurerAdapter {
                     .hasAnyAuthority(DefaultRoles.ROLE_ADMIN.getName(), DefaultRoles.ROLE_USER.getName(), 
                             DefaultRoles.ROLE_ANONYMOUS_USER.getName())
                 .antMatchers(getSecuredResourcesRoot())
-                    .hasAnyAuthority(DefaultRoles.ROLE_ADMIN.getName(), DefaultRoles.ROLE_USER.getName());
+                    .hasAnyAuthority(DefaultRoles.ROLE_ADMIN.getName(), DefaultRoles.ROLE_USER.getName())
+                .antMatchers(getImpersonationStartUrl())
+                    .hasAuthority(DefaultRoles.ROLE_ADMIN.getName());
         http.logout().logoutSuccessUrl("/");
     }
 
@@ -553,5 +560,25 @@ public class SAMLSecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Override
     public AuthenticationManager authenticationManagerBean() throws Exception {
         return super.authenticationManagerBean();
+    }
+
+    @Bean
+    public SwitchUserFilter switchUserFilter(final ImpersonationManager impersonationManager) {
+        final SwitchUserFilter filter = new SwitchUserFilter();
+        filter.setUserDetailsService(impersonationManager);
+        filter.setUserDetailsChecker(impersonationManager);
+        filter.setSwitchUserUrl(getImpersonationStartUrl());
+        filter.setExitUserUrl(getImpersonationStopUrl());
+        filter.setTargetUrl("/");
+        filter.setFailureHandler((request, response, exception) -> {});
+        return filter;
+    }
+
+    public String getImpersonationStartUrl() {
+        return impersonationOperationsRootUrl + "start";
+    }
+
+    public String getImpersonationStopUrl() {
+        return impersonationOperationsRootUrl + "stop";
     }
 }

--- a/api/src/main/java/com/epam/pipeline/app/SAMLSecurityConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/SAMLSecurityConfiguration.java
@@ -142,7 +142,7 @@ public class SAMLSecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Value("${api.security.anonymous.urls:/restapi/route}")
     private String[] anonymousResources;
 
-    @Value("${api.security.impersonation.operations.root.url:/restapi/user/impersonation/}")
+    @Value("${api.security.impersonation.operations.root.url:/restapi/user/impersonation}")
     private String impersonationOperationsRootUrl;
 
     @Value("#{'${api.security.public.urls}'.split(',')}")
@@ -176,10 +176,10 @@ public class SAMLSecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .antMatchers(getAnonymousResources())
                     .hasAnyAuthority(DefaultRoles.ROLE_ADMIN.getName(), DefaultRoles.ROLE_USER.getName(), 
                             DefaultRoles.ROLE_ANONYMOUS_USER.getName())
-                .antMatchers(getSecuredResourcesRoot())
-                    .hasAnyAuthority(DefaultRoles.ROLE_ADMIN.getName(), DefaultRoles.ROLE_USER.getName())
                 .antMatchers(getImpersonationStartUrl())
-                    .hasAuthority(DefaultRoles.ROLE_ADMIN.getName());
+                    .hasAuthority(DefaultRoles.ROLE_ADMIN.getName())
+                .antMatchers(getSecuredResourcesRoot())
+                    .hasAnyAuthority(DefaultRoles.ROLE_ADMIN.getName(), DefaultRoles.ROLE_USER.getName());
         http.logout().logoutSuccessUrl("/");
     }
 
@@ -575,10 +575,10 @@ public class SAMLSecurityConfiguration extends WebSecurityConfigurerAdapter {
     }
 
     public String getImpersonationStartUrl() {
-        return impersonationOperationsRootUrl + "start";
+        return impersonationOperationsRootUrl + "/start";
     }
 
     public String getImpersonationStopUrl() {
-        return impersonationOperationsRootUrl + "stop";
+        return impersonationOperationsRootUrl + "/stop";
     }
 }

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -331,6 +331,8 @@ public final class MessageConstants {
     public static final String INFO_UPDATE_USER_SAML_INFO = "info.update.user.saml.info";
     public static final String ERROR_DEFAULT_STORAGE_CREATION = "user.storage.home.auto.fails";
     public static final String DEFAULT_STORAGE_CREATION_CORRESPONDING_EXISTS = "user.storage.home.auto.exists";
+    public static final String ERROR_SELF_IMPERSONATION_NOT_ALLOWED = "impersonation.self.not.allowed";
+    public static final String ERROR_IMPERSONATION_EMPTY_USER = "impersonation.validation.empty.user";
 
     // Security
     public static final String ERROR_PERMISSION_PARAM_REQUIRED = "permission.param.is.required";

--- a/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import com.epam.pipeline.entity.info.UserInfo;
 import com.epam.pipeline.entity.security.JwtRawToken;
 import com.epam.pipeline.entity.user.CustomControl;
 import com.epam.pipeline.entity.user.GroupStatus;
+import com.epam.pipeline.entity.user.ImpersonationStatus;
 import com.epam.pipeline.entity.user.PipelineUser;
 import com.epam.pipeline.entity.user.PipelineUserEvent;
 import com.epam.pipeline.entity.user.RunnerSid;
@@ -427,5 +428,16 @@ public class UserController extends AbstractRestController {
     @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
     public Result<List<RunnerSid>> getRunners(@PathVariable final Long id) {
         return Result.success(userApiService.getRunners(id));
+    }
+
+    @GetMapping("/user/impersonation")
+    @ResponseBody
+    @ApiOperation(
+        value = "Loads impersonation status",
+        notes = "Loads impersonation status: show original user and impersonated one if present",
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<ImpersonationStatus> getImpersonationStatus() {
+        return Result.success(userApiService.getImpersonationStatus());
     }
 }

--- a/api/src/main/java/com/epam/pipeline/entity/user/ImpersonationStatus.java
+++ b/api/src/main/java/com/epam/pipeline/entity/user/ImpersonationStatus.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ImpersonationStatus {
+
+    private final PipelineUser original;
+    private final PipelineUser impersonated;
+}

--- a/api/src/main/java/com/epam/pipeline/manager/security/AuthManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/AuthManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package com.epam.pipeline.manager.security;
 
 import com.epam.pipeline.entity.security.JwtRawToken;
 import com.epam.pipeline.entity.user.DefaultRoles;
+import com.epam.pipeline.entity.user.ImpersonationStatus;
 import com.epam.pipeline.entity.user.PipelineUser;
 import com.epam.pipeline.entity.user.Role;
 import com.epam.pipeline.security.UserContext;
@@ -32,6 +33,7 @@ import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
+import org.springframework.security.web.authentication.switchuser.SwitchUserGrantedAuthority;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.Nullable;
@@ -119,6 +121,10 @@ public class AuthManager {
      */
     public PipelineUser getCurrentUser() {
         Object principal = getPrincipal();
+        return mapToPipelineUser(principal);
+    }
+
+    private PipelineUser mapToPipelineUser(final Object principal) {
         if (principal instanceof UserContext) {
             return ((UserContext)principal).toPipelineUser();
         } else if (principal instanceof User) {
@@ -132,6 +138,19 @@ public class AuthManager {
         } else {
             return null;
         }
+    }
+
+    public ImpersonationStatus getImpersonationStatus() {
+        final PipelineUser activeUser = getCurrentUser();
+        return getAuthentication().getAuthorities().stream()
+            .filter(SwitchUserGrantedAuthority.class::isInstance)
+            .map(SwitchUserGrantedAuthority.class::cast)
+            .findAny()
+            .map(SwitchUserGrantedAuthority::getSource)
+            .map(Authentication::getPrincipal)
+            .map(this::mapToPipelineUser)
+            .map(originalUser -> new ImpersonationStatus(originalUser, activeUser))
+            .orElseGet(() -> new ImpersonationStatus(activeUser, null));
     }
 
     public UserContext getUserContext() {

--- a/api/src/main/java/com/epam/pipeline/manager/user/ImpersonationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/ImpersonationManager.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.user;
+
+import com.epam.pipeline.common.MessageConstants;
+import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.manager.security.AuthManager;
+import com.epam.pipeline.security.UserAccessService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsChecker;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+@Service
+@RequiredArgsConstructor
+public class ImpersonationManager implements UserDetailsChecker, UserDetailsService {
+
+    private final UserManager userManager;
+    private final UserAccessService userAccessService;
+    private final AuthManager authManager;
+    private final MessageHelper messageHelper;
+
+    @Override
+    public void check(final UserDetails userToImpersonate) {
+        Assert.notNull(userToImpersonate, messageHelper.getMessage(MessageConstants.ERROR_IMPERSONATION_EMPTY_USER));
+        final String impersonatedName = userToImpersonate.getUsername();
+        Assert.isTrue(!impersonatedName.equals(authManager.getAuthorizedUser()),
+                      messageHelper.getMessage(MessageConstants.ERROR_SELF_IMPERSONATION_NOT_ALLOWED,
+                                               impersonatedName));
+        final PipelineUser user = userManager.loadUserByName(impersonatedName);
+        userAccessService.validateUserBlockStatus(user);
+        userAccessService.validateUserGroupsBlockStatus(user);
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(final String username) throws UsernameNotFoundException {
+        return userManager.loadUserContext(username);
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/user/UserManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/UserManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import com.epam.pipeline.entity.security.acl.AclClass;
 import com.epam.pipeline.entity.user.CustomControl;
 import com.epam.pipeline.entity.user.DefaultRoles;
 import com.epam.pipeline.entity.user.GroupStatus;
+import com.epam.pipeline.entity.user.ImpersonationStatus;
 import com.epam.pipeline.entity.user.PipelineUser;
 import com.epam.pipeline.entity.user.PipelineUserWithStoragePath;
 import com.epam.pipeline.entity.user.Role;
@@ -140,10 +141,14 @@ public class UserManager {
                 userVO.getDefaultStorageId());
     }
 
-    public UserContext loadUserContext(String name) {
+    public UserContext loadUserContext(final String name) {
         PipelineUser pipelineUser = userDao.loadUserByName(name);
         Assert.notNull(pipelineUser, messageHelper.getMessage(MessageConstants.ERROR_USER_NAME_NOT_FOUND, name));
         return new UserContext(pipelineUser);
+    }
+
+    public ImpersonationStatus getImpersonationStatus() {
+        return authManager.getImpersonationStatus();
     }
 
     /**

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -319,6 +319,8 @@ info.update.user.block.status=Update user blocking status. User id={0}. Blocking
 info.update.user.saml.info=Update user SAML info. User: name={0} id={1}
 user.storage.home.auto.fails=User {0} created successfully, but default storage creation failed: {1}!
 user.storage.home.auto.exists=Default storage creation: [{0}] for user [{1}] clashes with existing one [id={2}], it will be skipped!
+impersonation.self.not.allowed=Self-impersonation is not allowed: user requested for impersonation and the active one are both [{0}] 
+impersonation.validation.empty.user=Empty user in impersonation validation!
 
 # Metadata
 error.metadata.not.found=Error: metadata for id ''{0}'' and class ''{1}'' not found.

--- a/api/src/test/resources/test-application.properties
+++ b/api/src/test/resources/test-application.properties
@@ -31,6 +31,7 @@ spring.jpa.properties.hibernate.dialect=com.epam.pipeline.hibernate.JsonPostgreS
 
 #Security
 api.security.anonymous.urls=/restapi/route
+api.security.impersonation.operations.root.url=/restapi/user/impersonation/
 
 #flyway configuration
 flyway.sql-migration-prefix=v

--- a/api/src/test/resources/test-application.properties
+++ b/api/src/test/resources/test-application.properties
@@ -31,7 +31,7 @@ spring.jpa.properties.hibernate.dialect=com.epam.pipeline.hibernate.JsonPostgreS
 
 #Security
 api.security.anonymous.urls=/restapi/route
-api.security.impersonation.operations.root.url=/restapi/user/impersonation/
+api.security.impersonation.operations.root.url=/restapi/user/impersonation
 
 #flyway configuration
 flyway.sql-migration-prefix=v

--- a/deploy/docker/cp-api-srv/config/application.properties
+++ b/deploy/docker/cp-api-srv/config/application.properties
@@ -10,6 +10,7 @@ spring.http.encoding.force=true
 spring.http.encoding.force-response=true
 spring.resources.static-locations=file:${CP_API_SRV_STATIC_DIR}/,classpath:/META-INF/resources/,classpath:/resources/,classpath:/static/,classpath:/public/
 api.security.anonymous.urls=${CP_API_SRV_ANONYMOUS_URLS:/restapi/route}
+api.security.impersonation.operations.root.url=${CP_API_SECURITY_IMPERSONATION_ROOT_URL:/restapi/user/impersonation/}
 api.security.public.urls=${CP_API_SECURITY_PUBLIC_URLS:/launch.sh,/launch.py,/PipelineCLI.tar.gz,/pipe-common.tar.gz,/commit-run-scripts/**,/pipe,/fsbrowser.tar.gz,/pipe.zip,/pipe.tar.gz,/pipe-el6,/pipe-el6.tar.gz,/pipe-osx,/pipe-osx.tar.gz,/cloud-data-linux.tar.gz,/cloud-data-win64.zip,/fsautoscale.sh,/data-transfer-service.jar,/data-transfer-service-windows.zip,/DeployDts.ps1}
 # supported values - jdbc, HASH_MAP
 spring.session.store-type=${CP_API_SRV_SESSION_STORE_TYPE:jdbc}

--- a/deploy/docker/cp-api-srv/config/application.properties
+++ b/deploy/docker/cp-api-srv/config/application.properties
@@ -10,7 +10,7 @@ spring.http.encoding.force=true
 spring.http.encoding.force-response=true
 spring.resources.static-locations=file:${CP_API_SRV_STATIC_DIR}/,classpath:/META-INF/resources/,classpath:/resources/,classpath:/static/,classpath:/public/
 api.security.anonymous.urls=${CP_API_SRV_ANONYMOUS_URLS:/restapi/route}
-api.security.impersonation.operations.root.url=${CP_API_SECURITY_IMPERSONATION_ROOT_URL:/restapi/user/impersonation/}
+api.security.impersonation.operations.root.url=${CP_API_SECURITY_IMPERSONATION_ROOT_URL:/restapi/user/impersonation}
 api.security.public.urls=${CP_API_SECURITY_PUBLIC_URLS:/launch.sh,/launch.py,/PipelineCLI.tar.gz,/pipe-common.tar.gz,/commit-run-scripts/**,/pipe,/fsbrowser.tar.gz,/pipe.zip,/pipe.tar.gz,/pipe-el6,/pipe-el6.tar.gz,/pipe-osx,/pipe-osx.tar.gz,/cloud-data-linux.tar.gz,/cloud-data-win64.zip,/fsautoscale.sh,/data-transfer-service.jar,/data-transfer-service-windows.zip,/DeployDts.ps1}
 # supported values - jdbc, HASH_MAP
 spring.session.store-type=${CP_API_SRV_SESSION_STORE_TYPE:jdbc}


### PR DESCRIPTION
This PR is related to issue #2144

It allows administrator to impersonate users and act on their behalf. PR brings 3 endpoints to control impersonating:
- **GET** _/restapi/user/impersonation/start?username=<target_user>_ - starts impersonation as a <target_user>
- **GET** _/restapi/user/impersonation/stop_ - stops impersonation, restores original user context
- **GET** _/restapi/user/impersonation_ - returns `ImpersonationStatus`, consists of 2 fields with `PipelineUser` type: **original**, **impersonated** (empty if no impersonation is performed). This endpoint is available for any user and returns result of security context anylysis showing if currecntly active user is impersonated one.

Impersonation is implemented with [SwitchUserFilter](https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/web/authentication/switchuser/SwitchUserFilter.html)