### PR TITLE
Add existing tunnel management flags to pipe tunnel

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1481,8 +1481,19 @@ def stop_tunnel(run_id, local_port, timeout, force, log_level, trace):
                                                         'CRITICAL, ERROR, WARNING, INFO or DEBUG')
 @click.option('-t', '--timeout', required=False, type=int, default=5 * 60,
               help='Maximum timeout for background tunnel process health check in seconds')
+@click.option('-ts', '--timeout-stop', required=False, type=int, default=60,
+              help='Maximum timeout for background tunnel process stopping in seconds')
 @click.option('-f', '--foreground', required=False, is_flag=True, default=False,
               help='Establishes tunnel in foreground mode')
+@click.option('-ke', '--keep-existing', required=False, is_flag=True, default=False,
+              help='Skips tunnel establishing if a tunnel on the same local port already exists')
+@click.option('-ks', '--keep-same', required=False, is_flag=True, default=False,
+              help='Skips tunnel establishing if a tunnel with the same configuration '
+                   'on the same local port already exists')
+@click.option('-re', '--replace-existing', required=False, is_flag=True, default=False,
+              help='Replaces existing tunnel on the same local port')
+@click.option('-rd', '--replace-different', required=False, is_flag=True, default=False,
+              help='Replaces existing tunnel on the same local port if it has different configuration')
 @click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @click.option('-r', '--retries', required=False, type=int, default=10, help=RETRIES_OPTION_DESCRIPTION)
 @click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
@@ -1492,7 +1503,9 @@ def stop_tunnel(run_id, local_port, timeout, force, log_level, trace):
 @stacktracing
 def start_tunnel(host_id, local_port, remote_port, connection_timeout,
                  ssh, ssh_path, ssh_host, ssh_keep, direct, log_file, log_level,
-                 timeout, foreground, retries, trace, region):
+                 timeout, timeout_stop, foreground,
+                 keep_existing, keep_same, replace_existing, replace_different,
+                 retries, trace, region):
     """
     Establishes tunnel connection to specified run instance port and serves it as a local port.
 
@@ -1564,7 +1577,9 @@ def start_tunnel(host_id, local_port, remote_port, connection_timeout,
     """
     create_tunnel(host_id, local_port, remote_port, connection_timeout,
                   ssh, ssh_path, ssh_host, ssh_keep, direct, log_file, log_level,
-                  timeout, foreground, retries, region)
+                  timeout, timeout_stop, foreground,
+                  keep_existing, keep_same, replace_existing, replace_different,
+                  retries, region)
 
 
 @cli.command(name='update')

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -16,6 +16,7 @@ import traceback
 from functools import update_wrapper
 
 import click
+import functools
 import requests
 import sys
 import re
@@ -1460,45 +1461,60 @@ def stop_tunnel(run_id, local_port, timeout, force, log_level, trace):
     kill_tunnels(run_id=run_id, local_port=local_port, timeout=timeout, force=force, log_level=log_level)
 
 
+def start_tunnel_arguments(start_tunnel_command):
+    @click.argument('host-id', required=True)
+    @click.option('-lp', '--local-port', required=True, type=int, help='Local port to establish connection from')
+    @click.option('-rp', '--remote-port', required=True, type=int, help='Remote port to establish connection to')
+    @click.option('-ct', '--connection-timeout', required=False, type=float, default=0,
+                  help='Socket connection timeout in seconds')
+    @click.option('-s', '--ssh', required=False, is_flag=True, default=False,
+                  help='Configures passwordless ssh to specified run instance')
+    @click.option('-sp', '--ssh-path', required=False, type=str,
+                  help='Path to .ssh directory for passwordless ssh configuration on Linux')
+    @click.option('-sh', '--ssh-host', required=False, type=str,
+                  help='Host name for passwordless ssh configuration')
+    @click.option('-sk', '--ssh-keep', required=False, is_flag=True, default=False,
+                  help='Keeps passwordless ssh configuration after tunnel stopping')
+    @click.option('-d', '--direct', required=False, is_flag=True, default=False,
+                  help='Configures direct tunnel connection without proxy')
+    @click.option('-l', '--log-file', required=False, help='Logs file for tunnel in background mode')
+    @click.option('-v', '--log-level', required=False, help='Logs level for tunnel: '
+                                                            'CRITICAL, ERROR, WARNING, INFO or DEBUG')
+    @click.option('-t', '--timeout', required=False, type=int, default=5 * 60,
+                  help='Maximum timeout for background tunnel process health check in seconds')
+    @click.option('-ts', '--timeout-stop', required=False, type=int, default=60,
+                  help='Maximum timeout for background tunnel process stopping in seconds')
+    @click.option('-f', '--foreground', required=False, is_flag=True, default=False,
+                  help='Establishes tunnel in foreground mode')
+    @click.option('-ke', '--keep-existing', required=False, is_flag=True, default=False,
+                  help='Skips tunnel establishing if a tunnel on the same local port already exists')
+    @click.option('-ks', '--keep-same', required=False, is_flag=True, default=False,
+                  help='Skips tunnel establishing if a tunnel with the same configuration '
+                       'on the same local port already exists')
+    @click.option('-re', '--replace-existing', required=False, is_flag=True, default=False,
+                  help='Replaces existing tunnel on the same local port')
+    @click.option('-rd', '--replace-different', required=False, is_flag=True, default=False,
+                  help='Replaces existing tunnel on the same local port if it has different configuration')
+    @click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False,
+                  help=USER_OPTION_DESCRIPTION)
+    @click.option('-r', '--retries', required=False, type=int, default=10, help=RETRIES_OPTION_DESCRIPTION)
+    @click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
+    @click.option('-rg', '--region', required=False,
+                  help='The edge region name. If not specified the default edge region '
+                       'will be used.')
+    def _start_tunnel_command_decorator(*args, **kwargs):
+        return start_tunnel_command(*args, **kwargs)
+    return functools.update_wrapper(_start_tunnel_command_decorator, start_tunnel_command)
+
+
 @tunnel.command(name='start')
-@click.argument('host-id', required=True)
-@click.option('-lp', '--local-port', required=True, type=int, help='Local port to establish connection from')
-@click.option('-rp', '--remote-port', required=True, type=int, help='Remote port to establish connection to')
-@click.option('-ct', '--connection-timeout', required=False, type=float, default=0,
-              help='Socket connection timeout in seconds')
-@click.option('-s', '--ssh', required=False, is_flag=True, default=False,
-              help='Configures passwordless ssh to specified run instance')
-@click.option('-sp', '--ssh-path', required=False, type=str,
-              help='Path to .ssh directory for passwordless ssh configuration on Linux')
-@click.option('-sh', '--ssh-host', required=False, type=str,
-              help='Host name for passwordless ssh configuration')
-@click.option('-sk', '--ssh-keep', required=False, is_flag=True, default=False,
-              help='Keeps passwordless ssh configuration after tunnel stopping')
-@click.option('-d', '--direct', required=False, is_flag=True, default=False,
-              help='Configures direct tunnel connection without proxy')
-@click.option('-l', '--log-file', required=False, help='Logs file for tunnel in background mode')
-@click.option('-v', '--log-level', required=False, help='Logs level for tunnel: '
-                                                        'CRITICAL, ERROR, WARNING, INFO or DEBUG')
-@click.option('-t', '--timeout', required=False, type=int, default=5 * 60,
-              help='Maximum timeout for background tunnel process health check in seconds')
-@click.option('-ts', '--timeout-stop', required=False, type=int, default=60,
-              help='Maximum timeout for background tunnel process stopping in seconds')
-@click.option('-f', '--foreground', required=False, is_flag=True, default=False,
-              help='Establishes tunnel in foreground mode')
-@click.option('-ke', '--keep-existing', required=False, is_flag=True, default=False,
-              help='Skips tunnel establishing if a tunnel on the same local port already exists')
-@click.option('-ks', '--keep-same', required=False, is_flag=True, default=False,
-              help='Skips tunnel establishing if a tunnel with the same configuration '
-                   'on the same local port already exists')
-@click.option('-re', '--replace-existing', required=False, is_flag=True, default=False,
-              help='Replaces existing tunnel on the same local port')
-@click.option('-rd', '--replace-different', required=False, is_flag=True, default=False,
-              help='Replaces existing tunnel on the same local port if it has different configuration')
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@click.option('-r', '--retries', required=False, type=int, default=10, help=RETRIES_OPTION_DESCRIPTION)
-@click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
-@click.option('-rg', '--region', required=False, help='The edge region name. If not specified the default edge region '
-                                                      'will be used.')
+@start_tunnel_arguments
+def return_tunnel_args(*args, **kwargs):
+    return kwargs
+
+
+@tunnel.command(name='start')
+@start_tunnel_arguments
 @Config.validate_access_token
 @stacktracing
 def start_tunnel(host_id, local_port, remote_port, connection_timeout,
@@ -1575,11 +1591,14 @@ def start_tunnel(host_id, local_port, remote_port, connection_timeout,
         CP_CLI_TUNNEL_TARGET_HOST - tunnel target host
         CP_CLI_TUNNEL_SERVER_ADDRESS - tunnel server address
     """
+    def _parse_tunnel_args(args):
+        with return_tunnel_args.make_context('start', args) as ctx:
+            return return_tunnel_args.invoke(ctx)
     create_tunnel(host_id, local_port, remote_port, connection_timeout,
                   ssh, ssh_path, ssh_host, ssh_keep, direct, log_file, log_level,
                   timeout, timeout_stop, foreground,
                   keep_existing, keep_same, replace_existing, replace_different,
-                  retries, region)
+                  retries, region, _parse_tunnel_args)
 
 
 @cli.command(name='update')

--- a/pipe-cli/src/utilities/ssh_operations.py
+++ b/pipe-cli/src/utilities/ssh_operations.py
@@ -1049,7 +1049,9 @@ def get_current_pids():
 def kill_process(proc, timeout, force=False):
     import psutil
     import signal
-    if force or is_windows():
+    if is_windows():
+        send_signal_to_process(proc, signal.SIGTERM, timeout)
+    elif force:
         send_signal_to_process(proc, signal.SIGKILL, timeout)
     else:
         try:


### PR DESCRIPTION
Resolves #2149.

The pull request brings support for pipe tunnel existence checks. From now on before establishing a tunnel pipe will check for an existing tunnel on the same local port. If such a tunnel already exists then several new pipe tunnel flags (see #2149) will be used depending on the existing tunnel configuration.

The following command will keep the existing tunnel if it has just the same configuration and it will restart it in case its configuration is anyhow different.

```
pipe tunnel start 12345 -lp 8080 -rp 8080 --keep-same --replace-different
```