### PR TITLE
issue 2142 possibility to search entity with only metadata key and ac…

### DIFF
--- a/api/src/main/java/com/epam/pipeline/controller/metadata/MetadataController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/metadata/MetadataController.java
@@ -210,15 +210,15 @@ public class MetadataController extends AbstractRestController {
     @GetMapping(value = "/metadata/search")
     @ResponseBody
     @ApiOperation(
-            value = "Loads metadata by entity class and key-value pair.",
-            notes = "Loads metadata by entity class and key-value pair.",
+            value = "Loads metadata by entity class and key-value pair. Value is not required.",
+            notes = "Loads metadata by entity class and key-value pair. Value is not required.",
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiResponses(
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
             })
     public Result<List<EntityVO>> searchMetadataByClassAndKeyValue(@RequestParam final AclClass entityClass,
                                                                    @RequestParam final String key,
-                                                                   @RequestParam final String value) {
+                                                                   @RequestParam(required = false) final String value) {
         return Result.success(metadataApiService.searchMetadataByClassAndKeyValue(entityClass, key, value));
     }
 

--- a/api/src/main/java/com/epam/pipeline/dao/metadata/MetadataDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/metadata/MetadataDao.java
@@ -65,6 +65,7 @@ public class MetadataDao extends NamedParameterJdbcDaoSupport {
     private String deleteMetadataItemKeyQuery;
     private String loadMetadataItemsWithIssuesQuery;
     private String searchMetadataByClassAndKeyValueQuery;
+    private String searchMetadataByClassAndKeyQuery;
     private String loadUniqueValuesFromEntitiesAttributes;
     private String createMetadataDictionary;
     private String loadMetadataKeysQuery;
@@ -142,6 +143,14 @@ public class MetadataDao extends NamedParameterJdbcDaoSupport {
                         MetadataParameters.getParametersWithArrays(entities),
                         MetadataParameters.getRowMapperWithIssues());
         return items.isEmpty() ? null : items;
+    }
+
+    public List<EntityVO> searchMetadataByClassAndKey(final AclClass entityClass, final String key) {
+        MapSqlParameterSource parameters = new MapSqlParameterSource();
+        parameters.addValue(MetadataParameters.ENTITY_CLASS.name(), entityClass.name());
+        parameters.addValue(KEY, key);
+        return getNamedParameterJdbcTemplate().query(searchMetadataByClassAndKeyQuery,
+                parameters, MetadataParameters.getEntityVORowMapper());
     }
 
     public List<EntityVO> searchMetadataByClassAndKeyValue(final AclClass entityClass,
@@ -242,6 +251,11 @@ public class MetadataDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setLoadMetadataKeysQuery(final String loadMetadataKeysQuery) {
         this.loadMetadataKeysQuery = loadMetadataKeysQuery;
+    }
+
+    @Required
+    public void setSearchMetadataByClassAndKeyQuery(String searchMetadataByClassAndKeyQuery) {
+        this.searchMetadataByClassAndKeyQuery = searchMetadataByClassAndKeyQuery;
     }
 
     public enum MetadataParameters {

--- a/api/src/main/java/com/epam/pipeline/manager/metadata/MetadataManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/metadata/MetadataManager.java
@@ -295,8 +295,12 @@ public class MetadataManager {
 
     public List<EntityVO> searchMetadataByClassAndKeyValue(final AclClass entityClass, final String key,
                                                            final String value) {
-        Map<String, PipeConfValue> indicator = Collections.singletonMap(key, new PipeConfValue(null, value));
-        return metadataDao.searchMetadataByClassAndKeyValue(entityClass, indicator);
+        if (value == null) {
+            return metadataDao.searchMetadataByClassAndKey(entityClass, key);
+        } else {
+            final Map<String, PipeConfValue> indicator = Collections.singletonMap(key, new PipeConfValue(null, value));
+            return metadataDao.searchMetadataByClassAndKeyValue(entityClass, indicator);
+        }
     }
 
     @Transactional(propagation = Propagation.REQUIRED)

--- a/api/src/main/resources/dao/metadata-dao.xml
+++ b/api/src/main/resources/dao/metadata-dao.xml
@@ -189,6 +189,21 @@
                 ]]>
             </value>
         </property>
+        <property name="searchMetadataByClassAndKeyQuery">
+            <value>
+                <![CDATA[
+                    SELECT
+                        m.entity_id,
+                        m.entity_class
+                    FROM
+                        pipeline.metadata m
+                    WHERE
+                        m.entity_class = :ENTITY_CLASS
+                    AND
+                        m.data ?? :KEY
+                ]]>
+            </value>
+        </property>
         <property name="loadUniqueValuesFromEntitiesAttributes">
             <value>
                 <![CDATA[

--- a/api/src/test/java/com/epam/pipeline/dao/metadata/MetadataDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/metadata/MetadataDaoTest.java
@@ -213,6 +213,28 @@ public class MetadataDaoTest extends AbstractJdbcTest {
     }
 
     @Test
+    public void testShouldSearchMetadataByClassAndKey() {
+        EntityVO entityVO = new EntityVO(ID_1, CLASS_1);
+        Map<String, PipeConfValue> data = new HashMap<>();
+        data.put(DATA_KEY_1, new PipeConfValue(null, DATA_VALUE_1));
+        MetadataEntry metadataToSave = new MetadataEntry();
+        metadataToSave.setEntity(entityVO);
+        metadataToSave.setData(data);
+        metadataDao.registerMetadataItem(metadataToSave);
+
+        EntityVO entityVO2 = new EntityVO(ID_2, CLASS_1);
+        metadataToSave.setEntity(entityVO2);
+        data.get(DATA_KEY_1).setValue(DATA_VALUE_2);
+        metadataToSave.setData(data);
+        metadataDao.registerMetadataItem(metadataToSave);
+
+        List<EntityVO> loadedEntities = metadataDao.searchMetadataByClassAndKey(CLASS_1, DATA_KEY_1);
+        Assert.assertEquals(2, loadedEntities.size());
+        Assert.assertEquals(entityVO, loadedEntities.get(0));
+        Assert.assertEquals(entityVO2, loadedEntities.get(1));
+    }
+
+    @Test
     public void testLoadUniqueAttributes() {
         createMetadataForEntity(ID_1, CLASS_1, DATA_KEY_1, DATA_TYPE_1, DATA_VALUE_1);
         createMetadataForEntity(ID_2, CLASS_1, DATA_KEY_1, DATA_TYPE_1, DATA_VALUE_1);

--- a/api/src/test/java/com/epam/pipeline/manager/metadata/MetadataManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/metadata/MetadataManagerTest.java
@@ -192,6 +192,30 @@ public class MetadataManagerTest extends AbstractSpringTest {
                    CoreMatchers.is(Collections.singletonList(VALUE_2)));
     }
 
+    @Test
+    @Transactional
+    public void testThatEntityCouldBeSearchedByClassAndKeyOnly() {
+        Mockito.doReturn(new PipelineUser(TEST_USER)).when(userManager).loadUserById(Mockito.anyLong());
+
+        final EntityVO entityVO = new EntityVO(USER_ENTITY_ID, AclClass.PIPELINE_USER);
+        final Map<String, PipeConfValue> data = new HashMap<>();
+        data.put(KEY_1, new PipeConfValue(TYPE, VALUE_1));
+        final MetadataVO metadataVO = new MetadataVO();
+        metadataVO.setEntity(entityVO);
+        metadataVO.setData(data);
+        metadataManager.updateMetadataItem(metadataVO);
+
+        List<EntityVO> result = metadataManager.searchMetadataByClassAndKeyValue(
+                AclClass.PIPELINE_USER, KEY_1, VALUE_2);
+
+        Assert.assertTrue(result.isEmpty());
+
+        result = metadataManager.searchMetadataByClassAndKeyValue(
+                AclClass.PIPELINE_USER, KEY_1, null);
+
+        Assert.assertFalse(result.isEmpty());
+    }
+
     @Test(expected = MetadataReadingException.class)
     public void metadataFileShouldFailWithoutHeader() throws IOException {
         String exampleContent = simpleContent("\t", false);

--- a/api/src/test/java/com/epam/pipeline/test/aspect/AspectTestBeans.java
+++ b/api/src/test/java/com/epam/pipeline/test/aspect/AspectTestBeans.java
@@ -73,6 +73,7 @@ import com.epam.pipeline.manager.notification.ContextualNotificationManager;
 import com.epam.pipeline.manager.notification.ContextualNotificationRegistrationManager;
 import com.epam.pipeline.manager.notification.ContextualNotificationSettingsManager;
 import com.epam.pipeline.manager.scheduling.RunScheduler;
+import com.epam.pipeline.manager.user.ImpersonationManager;
 import com.epam.pipeline.manager.user.UserRunnersManager;
 import com.epam.pipeline.mapper.AbstractDataStorageMapper;
 import com.epam.pipeline.mapper.AbstractEntityPermissionMapper;
@@ -116,6 +117,9 @@ public class AspectTestBeans {
 
     @MockBean(name = "flywayInitializer")
     protected FlywayMigrationInitializer mockFlywayMigrationInitializer;
+
+    @MockBean
+    protected ImpersonationManager impersonationManager;
 
     @MockBean
     protected JwtTokenGenerator mockJwtTokenGenerator;


### PR DESCRIPTION
relates to #2142  and adds possibility to search with `metadata/search` not only with key and value, but also just with key attribute 

If client sends as before `AclClass` `key` `value` - server works as before
if client sends only `AclClass` `key` (`value` is not required parameter now) - server works with new logic and loads all entities that have metadata with such `key`