### PR TITLE
Issue 2155 NFS observer implementation

### DIFF
--- a/deploy/docker/cp-api-srv/init-api
+++ b/deploy/docker/cp-api-srv/init-api
@@ -301,7 +301,7 @@ if [ -z "$CP_CAP_NFS_MNT_OBSERVER_DISABLED" ]; then
   inotify_watchers=${CP_CAP_NFS_MNT_OBSERVER_API_WATCHERS:-131071}
   sysctl -w fs.inotify.max_user_watches=$inotify_watchers && \
   sysctl -w fs.inotify.max_queued_events=$((inotify_watchers*2)) && \
-  nohup python $WATCHER_HOME/watch_mount_shares.py 1>/dev/null 2>$WATCHER_LOG_HOME/.nohup.nfswatcher.log &
+  nohup python -u $WATCHER_HOME/watch_mount_shares.py 1>/dev/null 2>$WATCHER_LOG_HOME/.nohup.nfswatcher.log &
 fi
 
 # Workaround the container hanging when being terminated

--- a/deploy/docker/cp-api-srv/init-api
+++ b/deploy/docker/cp-api-srv/init-api
@@ -126,6 +126,15 @@ function sign_and_publish_pipe_win_distribution() {
     rm -rf pipe
 }
 
+function extract_nfs_observing_script {
+    local jar_path="$1"
+    local output_dir="$2"
+    unzip -p "$jar_path" BOOT-INF/classes/static/pipe-common.tar.gz >pipe-common.tar.gz
+    tar -xf pipe-common.tar.gz scripts/watch_mount_shares.py --strip-components=1 &&\
+    mv watch_mount_shares.py $output_dir && \
+    rm -rf pipe-common.tar.gz
+}
+
 # Validate SSO and SSL certificates
 if [ -z "$CP_API_SRV_CERT_DIR" ]; then
     export CP_API_SRV_CERT_DIR="/opt/api/pki"
@@ -284,6 +293,16 @@ if [ "$CP_CLOUD_PLATFORM" == "az" ] && [ -f /root/.cloud/azureProfile.json ] && 
   cp /root/.cloud/* /root/.azure/
 fi
 
+if [ -z "$CP_CAP_NFS_MNT_OBSERVER_DISABLED" ]; then
+  WATCHER_HOME="$CP_API_HOME/nfs-watcher"
+  WATCHER_LOG_HOME="/var/log/nfs-watcher"
+  mkdir -p "$WATCHER_LOG_HOME" "$WATCHER_HOME"
+  extract_nfs_observing_script "$CP_API_HOME/pipeline.jar" "$WATCHER_HOME"
+  inotify_watchers=${CP_CAP_NFS_MNT_OBSERVER_API_WATCHERS:-131071}
+  sysctl -w fs.inotify.max_user_watches=$inotify_watchers && \
+  sysctl -w fs.inotify.max_queued_events=$((inotify_watchers*2)) && \
+  nohup python $WATCHER_HOME/watch_mount_shares.py 1>/dev/null 2>$WATCHER_LOG_HOME/.nohup.nfswatcher.log &
+fi
 
 # Workaround the container hanging when being terminated
 function sig_handler {

--- a/deploy/docker/cp-dav/Dockerfile
+++ b/deploy/docker/cp-dav/Dockerfile
@@ -90,6 +90,7 @@ ENV SYNC_HOME=/opt/sync
 ENV SYNC_LOG_DIR=/var/log/dav/sync
 COPY sync/crontab /tmp/sync
 COPY sync/sync-nfs.sh ${SYNC_HOME}/
+COPY sync/nfs-watcher.sh ${SYNC_HOME}/
 # "nfs-roles-management" shall be copied to the docker build folder from "(repo-root)/scripts/nfs-roles-management"
 # E.g.: cp cp ../../../scripts/nfs-roles-management ./ -r && docker build ...
 COPY nfs-roles-management ${SYNC_HOME}/nfs-roles-management

--- a/deploy/docker/cp-dav/init
+++ b/deploy/docker/cp-dav/init
@@ -81,3 +81,21 @@ umask ${CP_DAV_UMASK:-0002}
 
 # Start Apache in the foreground
 ${APACHE_HOME}/bin/apachectl -DFOREGROUND
+
+if [ -z "$CP_CAP_NFS_MNT_OBSERVER_DISABLED" ]; then
+  export PIPE_COMMON_DISTRIBUTION_URL="${PIPE_COMMON_DISTRIBUTION_URL:-https://${CP_API_SRV_INTERNAL_HOST}:${CP_API_SRV_INTERNAL_PORT}/pipeline/pipe-common.tar.gz}"
+  download_file "${PIPE_COMMON_DISTRIBUTION_URL}"
+  if [ $? -eq 0 ]; then
+        echo "'pipe-common' package was downloaded successfully."
+        tar -xf pipe-common.tar.gz scripts/watch_mount_shares.py --strip-components=1 &&\
+        mv watch_mount_shares.py $SYNC_HOME && \
+        rm -rf pipe-common.tar.gz
+
+        inotify_watchers=${CP_CAP_NFS_MNT_OBSERVER_DAV_WATCHERS:-131071}
+        sysctl -w fs.inotify.max_user_watches=$inotify_watchers && \
+        sysctl -w fs.inotify.max_queued_events=$((inotify_watchers*2)) && \
+        nohup python $SYNC_HOME/watch_mount_shares.py 1>/dev/null 2>$SYNC_LOG_DIR/.nohup.nfswatcher.log &
+  else
+    echo "Unable to retrieve 'pipe-common' package"
+  fi
+fi

--- a/deploy/docker/cp-dav/init
+++ b/deploy/docker/cp-dav/init
@@ -62,6 +62,24 @@ fi
 mkdir -p "$CP_DAV_SERVE_DIR" "$CP_DAV_MOUNT_POINT" "$APACHE_LOG_DIR" "$SYNC_LOG_DIR"
 mkdir -p $(dirname $APACHE_DAV_LOCK_DB)
 
+# Unpack and configure NFS observer script
+if [ -z "$CP_CAP_NFS_MNT_OBSERVER_DISABLED" ]; then
+  export PIPE_COMMON_DISTRIBUTION_URL="${PIPE_COMMON_DISTRIBUTION_URL:-https://${CP_API_SRV_INTERNAL_HOST}:${CP_API_SRV_INTERNAL_PORT}/pipeline/pipe-common.tar.gz}"
+  download_file "${PIPE_COMMON_DISTRIBUTION_URL}"
+  if [ $? -eq 0 ]; then
+        echo "'pipe-common' package was downloaded successfully."
+        inotify_watchers=${CP_CAP_NFS_MNT_OBSERVER_DAV_WATCHERS:-131071}
+        tar -xf pipe-common.tar.gz scripts/watch_mount_shares.py --strip-components=1 &&\
+        mv watch_mount_shares.py $SYNC_HOME/ && \
+        rm -rf pipe-common.tar.gz && \
+        sysctl -w fs.inotify.max_user_watches=$inotify_watchers && \
+        sysctl -w fs.inotify.max_queued_events=$((inotify_watchers*2)) && \
+        echo "* * * * * root flock -w 1 /var/run/nfs-watcher.lock bash \${SYNC_HOME}/nfs-watcher.sh" >> /tmp/sync
+  else
+    echo "Unable to retrieve 'pipe-common' package"
+  fi
+fi
+
 # Persist environment for a cron job
 env > $SYNC_HOME/env.sh
 envsubst < /tmp/sync > /etc/cron.d/sync
@@ -81,21 +99,3 @@ umask ${CP_DAV_UMASK:-0002}
 
 # Start Apache in the foreground
 ${APACHE_HOME}/bin/apachectl -DFOREGROUND
-
-if [ -z "$CP_CAP_NFS_MNT_OBSERVER_DISABLED" ]; then
-  export PIPE_COMMON_DISTRIBUTION_URL="${PIPE_COMMON_DISTRIBUTION_URL:-https://${CP_API_SRV_INTERNAL_HOST}:${CP_API_SRV_INTERNAL_PORT}/pipeline/pipe-common.tar.gz}"
-  download_file "${PIPE_COMMON_DISTRIBUTION_URL}"
-  if [ $? -eq 0 ]; then
-        echo "'pipe-common' package was downloaded successfully."
-        tar -xf pipe-common.tar.gz scripts/watch_mount_shares.py --strip-components=1 &&\
-        mv watch_mount_shares.py $SYNC_HOME && \
-        rm -rf pipe-common.tar.gz
-
-        inotify_watchers=${CP_CAP_NFS_MNT_OBSERVER_DAV_WATCHERS:-131071}
-        sysctl -w fs.inotify.max_user_watches=$inotify_watchers && \
-        sysctl -w fs.inotify.max_queued_events=$((inotify_watchers*2)) && \
-        nohup python $SYNC_HOME/watch_mount_shares.py 1>/dev/null 2>$SYNC_LOG_DIR/.nohup.nfswatcher.log &
-  else
-    echo "Unable to retrieve 'pipe-common' package"
-  fi
-fi

--- a/deploy/docker/cp-dav/sync/nfs-watcher.sh
+++ b/deploy/docker/cp-dav/sync/nfs-watcher.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+watcher_script_path="$SYNC_HOME/watch_mount_shares.py"
+ps -C python --no-headers -o args | grep "$watcher_script_path"
+if [ $? -ne 0 ]; then
+    echo "No active observer process found, starting a new one..."
+    nohup python "$watcher_script_path" 1>/dev/null 2>$SYNC_LOG_DIR/.nohup.nfswatcher.log &
+fi
+rm -rf /var/run/nfs-watcher.lock

--- a/deploy/docker/cp-dav/sync/nfs-watcher.sh
+++ b/deploy/docker/cp-dav/sync/nfs-watcher.sh
@@ -18,6 +18,6 @@ watcher_script_path="$SYNC_HOME/watch_mount_shares.py"
 ps -C python --no-headers -o args | grep "$watcher_script_path"
 if [ $? -ne 0 ]; then
     echo "No active observer process found, starting a new one..."
-    nohup python "$watcher_script_path" 1>/dev/null 2>$SYNC_LOG_DIR/.nohup.nfswatcher.log &
+    nohup python -u "$watcher_script_path" 1>/dev/null 2>$SYNC_LOG_DIR/.nohup.nfswatcher.log &
 fi
 rm -rf /var/run/nfs-watcher.lock

--- a/scripts/pipeline-launch/launch.sh
+++ b/scripts/pipeline-launch/launch.sh
@@ -1735,6 +1735,24 @@ fi
 
 ######################################################
 
+######################################################
+# Enable NFS observer
+######################################################
+
+echo "Setup NFS events observer"
+echo "-"
+
+if [ "$CP_CAP_NFS_MNT_OBSERVER_DISABLED" == "true" ]; then
+    echo "NFS events observer is not requested"
+else
+    inotify_watchers=${CP_CAP_NFS_MNT_OBSERVER_RUN_WATCHERS:-65535}
+    sysctl -w fs.inotify.max_user_watches=$inotify_watchers
+    sysctl -w fs.inotify.max_queued_events=$((inotify_watchers*2))
+    nohup $CP_PYTHON2_PATH $COMMON_REPO_DIR/scripts/watch_mount_shares.py > $LOG_DIR/.nohup.nfswatcher.log 2>&1 &
+fi
+
+######################################################
+
 
 ######################################################
 echo Executing task

--- a/scripts/pipeline-launch/launch.sh
+++ b/scripts/pipeline-launch/launch.sh
@@ -1748,7 +1748,7 @@ else
     inotify_watchers=${CP_CAP_NFS_MNT_OBSERVER_RUN_WATCHERS:-65535}
     sysctl -w fs.inotify.max_user_watches=$inotify_watchers
     sysctl -w fs.inotify.max_queued_events=$((inotify_watchers*2))
-    nohup $CP_PYTHON2_PATH $COMMON_REPO_DIR/scripts/watch_mount_shares.py > $LOG_DIR/.nohup.nfswatcher.log 2>&1 &
+    nohup $CP_PYTHON2_PATH -u $COMMON_REPO_DIR/scripts/watch_mount_shares.py 1>/dev/null 2> $LOG_DIR/.nohup.nfswatcher.log &
 fi
 
 ######################################################

--- a/workflows/pipe-common/scripts/watch_mount_shares.py
+++ b/workflows/pipe-common/scripts/watch_mount_shares.py
@@ -1,0 +1,267 @@
+import datetime
+import errno
+import os
+import re
+import subprocess
+import time
+from watchdog.observers.inotify import InotifyObserver
+from watchdog.events import FileSystemEventHandler, FileMovedEvent
+from watchdog.observers.api import ObservedWatch
+
+NEWLINE = '\n'
+
+COMMA = ','
+EVENTS_LIMIT = int(os.getenv('CP_CAP_NFS_OBSERVER_EVENTS_LIMIT', 3))
+TARGET_FS_TYPES = os.getenv('CP_CAP_NFS_OBSERVER_TARGET_FS_TYPES', 'nfs4,lustre').split(COMMA)
+MNT_LISTING_COMMAND = 'df -t {} --output=fstype,source,target'
+DT_FORMAT = '%Y-%m-%d %H:%M:%S:%f'
+
+CREATE_EVENT = 'c'
+MODIFY_EVENT = 'm'
+MOVED_FROM_EVENT = 'mf'
+MOVED_TO_EVENT = 'mt'
+DELETE_EVENT = 'd'
+
+
+def log(message):
+    print('[{}] {}'.format(current_utc_time_str(), message))
+
+
+def mkdir(path):
+    try:
+        os.makedirs(path)
+    except OSError as e:
+        if e.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        else:
+            raise
+
+
+def execute_cmd_command_and_get_stdout_stderr(command, silent=False, executable=None):
+    if executable:
+        p = subprocess.Popen(command, shell=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE, executable=executable)
+    else:
+        p = subprocess.Popen(command, shell=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+    stdout, stderr = p.communicate()
+    if not silent and stderr:
+        print(stderr)
+    if not silent and stdout:
+        print(stdout)
+    return p.wait(), stdout, stderr
+
+
+def execute_command(command, max_attempts=1):
+    attempts = 0
+    success = False
+    stdout = None
+    stderr = None
+    while attempts < max_attempts and not success:
+        attempts += 1
+        exit_code, stdout, stderr = execute_cmd_command_and_get_stdout_stderr(command, silent=True)
+        success = exit_code == 0
+    if not success:
+        log('Execution of [{}] failed due to the reason: {}'.format(command, stderr))
+    return stdout, success
+
+
+def current_utc_time():
+    return datetime.datetime.utcnow()
+
+
+def current_utc_time_millis():
+    return int((current_utc_time() - datetime.datetime(1970, 1, 1)).total_seconds() * 1000)
+
+
+def current_utc_time_str():
+    return current_utc_time().strftime(DT_FORMAT)
+
+
+class Event:
+
+    def __init__(self, path, event_type):
+        self.timestamp = current_utc_time_millis()
+        self.path = path
+        self.event_type = event_type[:1]
+
+
+class S3DumpingEventHandler(FileSystemEventHandler):
+
+    def __init__(self):
+        super(FileSystemEventHandler, self).__init__()
+        self._active_events = dict()
+        self._target_path_mapping = dict()
+        self._activity_logging_local_dir = self._configure_logging_local_dir()
+        self._activity_logging_bucket_dir = self._configure_logging_bucket_dir()
+
+    @staticmethod
+    def _configure_logging_bucket_dir():
+        bucket_dir = os.path.join(os.getenv('CP_CAP_NFS_MNT_OBSERVER_TARGET_BUCKET'),
+                                  S3DumpingEventHandler._get_service_name())
+        log('Destination bucket location is [{}]'.format(bucket_dir))
+        return bucket_dir
+
+    @staticmethod
+    def _get_service_name():
+        service_name = os.getenv('RUN_ID')
+        if not service_name:
+            if os.getenv('CP_API_HOME'):
+                service_name = 'api'
+            elif os.getenv('CP_DAV_MOUNT_POINT'):
+                service_name = 'dav'
+            else:
+                service_name = 'unknown'
+        return service_name
+
+    @staticmethod
+    def _configure_logging_local_dir():
+        local_logging_dir = os.path.join(os.getenv('RUN_DIR', '/tmp'), 'fs_watcher')
+        log('Local storage directory is [{}]'.format(local_logging_dir))
+        mkdir(local_logging_dir)
+        return local_logging_dir
+
+    def _convert_event_to_str(self, event):
+        for mnt_src, mnt_dest in self._target_path_mapping.items():
+            path = event.path
+            if path.startswith(mnt_dest):
+                return COMMA.join([str(event.timestamp),
+                                   event.event_type,
+                                   mnt_src,
+                                   path[len(mnt_dest) + 1:]])
+
+    def _insert_event(self, file_path, event_type):
+        if file_path not in self._active_events:
+            event_descriptor = Event(file_path, event_type)
+        else:
+            last_event = self._active_events[file_path]
+            last_event_type = last_event.event_type
+            if last_event_type == CREATE_EVENT:
+                if event_type == DELETE_EVENT or event_type == MOVED_FROM_EVENT:
+                    del self._active_events[file_path]
+                return
+            else:
+                event_descriptor = Event(file_path, event_type)
+        self._active_events[file_path] = event_descriptor
+
+    def update_target_mounts_mappings(self, new_mappings):
+        self._target_path_mapping.update(new_mappings)
+
+    def dispatch(self, event):
+        if len(self._active_events) > EVENTS_LIMIT:
+            self.dump_to_storage()
+        if not event.is_directory:
+            if type(event) is FileMovedEvent:
+                self._insert_event(event.src_path, MOVED_FROM_EVENT)
+                self._insert_event(event.dest_path, MOVED_TO_EVENT)
+            # TODO check if filtering could be applied at observer creation
+            elif event.event_type != 'closed':
+                self._insert_event(event.src_path, event.event_type)
+
+    def dump_to_storage(self):
+        if len(self._active_events) == 0:
+            return
+        filename = 'events-' + current_utc_time_str().replace(' ', '_')
+        local_file = os.path.join(self._activity_logging_local_dir, filename)
+        log('Saving events to {} '.format(local_file))
+        with open(local_file, 'w') as outfile:
+            # TODO sorting might be skipped in case events will be sorted in the consuming service
+            sorted_events = sorted(self._active_events.values(), key=lambda e: e.timestamp)
+            outfile.write(NEWLINE.join(map(self._convert_event_to_str, sorted_events)))
+        bucket_file = os.path.join(self._activity_logging_bucket_dir, filename)
+        log('Dumping events to {} '.format(bucket_file))
+        _, result = execute_command('pipe storage cp \'{}\' \'{}\''.format(local_file, bucket_file))
+        if result:
+            log('Cleaning activity list')
+            self._active_events.clear()
+
+
+class NFSMountWatcher:
+
+    def __init__(self):
+        self._target_path_mapping = dict()
+        self._event_handler = S3DumpingEventHandler()
+        self._event_observer = InotifyObserver()
+        self._update_target_mount_points()
+
+    def _update_target_mount_points(self):
+        log('Checking active mounts...')
+        latest_mounts_mapping = self._get_target_mount_points()
+        log('Found [{}] active mounts'.format(len(latest_mounts_mapping)))
+        self._remove_unmounted_watchers(latest_mounts_mapping)
+        for mnt_src, mnt_dest in latest_mounts_mapping.items():
+            if mnt_src not in self._target_path_mapping:
+                self._add_new_mount_watcher(mnt_dest, mnt_src)
+            else:
+                self._update_existing_mount_watcher(mnt_dest, mnt_src)
+        self._event_handler.update_target_mounts_mappings(self._target_path_mapping)
+
+    def _update_existing_mount_watcher(self, mnt_dest, mnt_src):
+        active_watching_mount = self._target_path_mapping[mnt_src]
+        if active_watching_mount != mnt_dest:
+            log('Updating observer: [{}] mount-point changed from [{}] to [{}]'.format(mnt_src,
+                                                                                         active_watching_mount,
+                                                                                         mnt_dest))
+            if self.try_to_remove_path_from_observer(active_watching_mount) \
+                    and self.try_to_add_path_to_observer(mnt_dest):
+                self._target_path_mapping[mnt_src] = mnt_dest
+
+    def _add_new_mount_watcher(self, mnt_dest, mnt_src):
+        log('Assigning [{}] to the observer'.format(mnt_dest))
+        if self.try_to_add_path_to_observer(mnt_dest):
+            self._target_path_mapping[mnt_src] = mnt_dest
+
+    def _remove_unmounted_watchers(self, latest_mounts_mapping):
+        for mnt_src, mnt_dest in self._target_path_mapping.items():
+            if mnt_src not in latest_mounts_mapping:
+                log('Removing observer from [{}]'.format(mnt_dest))
+                if self.try_to_remove_path_from_observer(mnt_dest):
+                    self._target_path_mapping.pop(mnt_src)
+
+    def try_to_remove_path_from_observer(self, mnt_dest):
+        try:
+            self._event_observer.unschedule(ObservedWatch(mnt_dest, True))
+            return True
+        except OSError as e:
+            log('Unable to assign [{}], an error occurred: {}'.format(mnt_dest, e.message))
+            return False
+
+    def try_to_add_path_to_observer(self, mnt_dest):
+        try:
+            self._event_observer.schedule(self._event_handler, mnt_dest, recursive=True)
+            return True
+        except OSError as e:
+            log('Unable to assign [{}], an error occurred: {}'.format(mnt_dest, e.message))
+            return False
+
+    @staticmethod
+    def _get_target_mount_points():
+        mount_points = dict()
+        for fs_type in TARGET_FS_TYPES:
+            out, res = execute_command(MNT_LISTING_COMMAND.format(fs_type))
+            if not res:
+                log('Unable to retrieve [{}] mounts'.format(fs_type))
+                continue
+            out = out.split(NEWLINE)
+            for index in range(1, len(out)):
+                line = out[index]
+                if line.strip():
+                    mount_point_description = re.split('\\s+', line)
+                    mount_source = mount_point_description[1]
+                    mount_point = mount_point_description[2]
+                    mount_points[mount_source] = mount_point
+        return mount_points
+
+    def start(self):
+        log('Start monitoring shares state...')
+        self._event_observer.start()
+        try:
+            while True:
+                time.sleep(10)
+                self._update_target_mount_points()
+        finally:
+            self._event_observer.stop()
+            self._event_observer.join()
+            self._event_handler.dump_to_storage()
+
+
+if __name__ == '__main__':
+    NFSMountWatcher().start()

--- a/workflows/pipe-common/scripts/watch_mount_shares.py
+++ b/workflows/pipe-common/scripts/watch_mount_shares.py
@@ -267,10 +267,13 @@ class NFSMountWatcher:
             self._event_observer.unschedule(ObservedWatch(mnt_dest, True))
             return True
         except OSError as e:
-            log('Unable to assign [{}], an error occurred: {}'.format(mnt_dest, e.message))
+            log('Unable to drop observation on [{}], an error occurred: {}'.format(mnt_dest, e.message))
             return False
 
     def try_to_add_path_to_observer(self, mnt_dest):
+        if not os.path.exists(mnt_dest):
+            log('Target path [{}] doesn\'t exist, skipping...'.format(mnt_dest))
+            return False
         try:
             self._event_observer.schedule(self._event_handler, mnt_dest, recursive=True)
             return True

--- a/workflows/pipe-common/setup.py
+++ b/workflows/pipe-common/setup.py
@@ -59,6 +59,6 @@ setup(name='pipeline',
             'paramiko==2.6.0',
             'psutil==5.8.0',
             'pywin32==300; platform_system == "Windows"',
-            'watchdog==0.10.7'
+            'watchdog==0.10.4'
       ],
       zip_safe=False)

--- a/workflows/pipe-common/setup.py
+++ b/workflows/pipe-common/setup.py
@@ -58,6 +58,7 @@ setup(name='pipeline',
             'urllib3==1.25.9',
             'paramiko==2.6.0',
             'psutil==5.8.0',
-            'pywin32==300; platform_system == "Windows"'
+            'pywin32==300; platform_system == "Windows"',
+            'watchdog==0.10.7'
       ],
       zip_safe=False)


### PR DESCRIPTION
This PR is related to issue #2155 

It brings some 'observer' service implementation, which performs tracking on all mounted NFS (or specific paths passed given in `CP_CAP_NFS_OBSERVER_TARGET_PATHS` env var) - filesystem events, which might change disk consumptions are being saved and dumped to the certain object storage.

PR contains the script itself, along with changes to `launch.sh` and init scripts, performing installation and configuration of that observer in the runs, __api__ and __dav__` instances.