### PR TITLE
Issue 2155 NFS events synchronization

### DIFF
--- a/deploy/docker/cp-search/config/application.properties
+++ b/deploy/docker/cp-search/config/application.properties
@@ -82,6 +82,9 @@ sync.s3-storage.index.name=s3-storage
 sync.nfs-storage.disable=${CP_SEARCH_DISABLE_NFS_STORAGE:false}
 sync.nfs-storage.index.mapping=file://${CP_SEARCH_MAPPINGS_LOCATION}/data_storage.json
 sync.nfs-storage.index.name=nfs-storage
+sync.nfs-file.observer.sync.disable=${CP_SEARCH_DISABLE_NFS_OBSERVER_SYNC:false}
+sync.nfs-file.observer.sync.target.bucket=${CP_SEARCH_NFS_OBSERVER_EVENTS_BUCKET}
+sync.nfs-file.observer.sync.files.chunk=${CP_SEARCH_NFS_OBSERVER_EVENTS_FILES_CHUNK_SIZE:10}
 
 #Azure blob storage Settings
 sync.az-blob-storage.disable=${CP_SEARCH_DISABLE_AZ_BLOB_STORAGE:false}

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/model/nfsobserver/NFSObserverEvent.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/model/nfsobserver/NFSObserverEvent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.elasticsearchagent.model.nfsobserver;
+
+import lombok.Value;
+
+@Value
+public class NFSObserverEvent {
+    private final Long timestamp;
+    private final NFSObserverEventType eventType;
+    private final String storage;
+    private final String filePath;
+
+}

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/model/nfsobserver/NFSObserverEventType.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/model/nfsobserver/NFSObserverEventType.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.elasticsearchagent.model.nfsobserver;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@AllArgsConstructor
+@Getter
+public enum NFSObserverEventType {
+    CREATED("c"),
+    MODIFIED("m"),
+    MOVED_FROM("mf"),
+    MOVED_TO("mt"),
+    DELETED("d");
+
+    private final String eventCode;
+
+    private static final Map<String, NFSObserverEventType> CODES = Stream.of(NFSObserverEventType.values())
+        .collect(Collectors.toMap(NFSObserverEventType::getEventCode, Function.identity()));
+
+    public static NFSObserverEventType fromCode(final String code) {
+        final NFSObserverEventType event = CODES.get(code);
+        if (event == null) {
+            throw new IllegalArgumentException("Unsupported event code.");
+        }
+        return event;
+    }
+}

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/BulkRequestCreator.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/BulkRequestCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,12 @@
  */
 package com.epam.pipeline.elasticsearchagent.service;
 
+import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
-import org.elasticsearch.action.index.IndexRequest;
 
 import java.util.List;
 
 @FunctionalInterface
 public interface BulkRequestCreator {
-    BulkResponse sendRequest(List<IndexRequest> requests);
+    BulkResponse sendRequest(List<? extends DocWriteRequest> requests);
 }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/ElasticsearchServiceClient.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/ElasticsearchServiceClient.java
@@ -17,8 +17,8 @@ package com.epam.pipeline.elasticsearchagent.service;
 
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
-import org.elasticsearch.action.delete.DeleteRequest;
-import org.elasticsearch.action.delete.DeleteResponse;
+import org.elasticsearch.action.search.MultiSearchRequest;
+import org.elasticsearch.action.search.MultiSearchResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 
@@ -33,5 +33,5 @@ public interface ElasticsearchServiceClient {
     void createIndexAlias(String indexName, String indexAlias);
     String getIndexNameByAlias(String alias);
     SearchResponse search(SearchRequest request);
-    DeleteResponse deleteDocument(DeleteRequest request);
+    MultiSearchResponse search(MultiSearchRequest request);
 }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/ElasticsearchServiceClient.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/ElasticsearchServiceClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ package com.epam.pipeline.elasticsearchagent.service;
 
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 
@@ -31,4 +33,5 @@ public interface ElasticsearchServiceClient {
     void createIndexAlias(String indexName, String indexAlias);
     String getIndexNameByAlias(String alias);
     SearchResponse search(SearchRequest request);
+    DeleteResponse deleteDocument(DeleteRequest request);
 }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/ObjectStorageFileManager.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/ObjectStorageFileManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,4 +45,9 @@ public interface ObjectStorageFileManager {
         throw new UnsupportedOperationException();
     }
 
+    default void deleteFile(String storage,
+                            String path,
+                            Supplier<TemporaryCredentials> credentialsSupplier) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/ObjectStorageFileManager.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/ObjectStorageFileManager.java
@@ -20,6 +20,7 @@ import com.epam.pipeline.entity.datastorage.DataStorageFile;
 import com.epam.pipeline.entity.datastorage.DataStorageType;
 import com.epam.pipeline.entity.datastorage.TemporaryCredentials;
 
+import java.io.InputStream;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -37,5 +38,11 @@ public interface ObjectStorageFileManager {
     Stream<DataStorageFile> versionsWithNativeTags(String storage,
                                                    String path,
                                                    Supplier<TemporaryCredentials> credentialsSupplier);
+
+    default InputStream readFileContent(String storage,
+                                        String path,
+                                        Supplier<TemporaryCredentials> credentialsSupplier) {
+        throw new UnsupportedOperationException();
+    }
 
 }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/ElasticsearchServiceClientImpl.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/ElasticsearchServiceClientImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,8 @@ import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
 import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
-import org.elasticsearch.action.delete.DeleteRequest;
-import org.elasticsearch.action.delete.DeleteResponse;
+import org.elasticsearch.action.search.MultiSearchRequest;
+import org.elasticsearch.action.search.MultiSearchResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.RequestOptions;
@@ -187,11 +187,11 @@ public class ElasticsearchServiceClientImpl implements ElasticsearchServiceClien
     }
 
     @Override
-    public DeleteResponse deleteDocument(final DeleteRequest deleteRequest) {
+    public MultiSearchResponse search(final MultiSearchRequest request) {
         try {
-            return client.delete(deleteRequest, RequestOptions.DEFAULT);
+            return client.msearch(request, RequestOptions.DEFAULT);
         } catch (IOException e) {
-            throw new ElasticsearchException("Failed to delete docs for a query:" + e.getMessage(), e);
+            throw new ElasticsearchException("Failed to find results for multi-search query:" + e.getMessage(), e);
         }
     }
 }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/ElasticsearchServiceClientImpl.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/ElasticsearchServiceClientImpl.java
@@ -28,6 +28,8 @@ import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
 import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.RequestOptions;
@@ -181,6 +183,15 @@ public class ElasticsearchServiceClientImpl implements ElasticsearchServiceClien
             return client.search(request, RequestOptions.DEFAULT);
         } catch (IOException e) {
             throw new ElasticsearchException("Failed to find results for search query:" + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public DeleteResponse deleteDocument(final DeleteRequest deleteRequest) {
+        try {
+            return client.delete(deleteRequest, RequestOptions.DEFAULT);
+        } catch (IOException e) {
+            throw new ElasticsearchException("Failed to delete docs for a query:" + e.getMessage(), e);
         }
     }
 }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/IndexRequestContainer.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/IndexRequestContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@ package com.epam.pipeline.elasticsearchagent.service.impl;
 import com.epam.pipeline.elasticsearchagent.service.BulkRequestCreator;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
+import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
-import org.elasticsearch.action.index.IndexRequest;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,7 +27,7 @@ import java.util.List;
 
 @Slf4j
 public class IndexRequestContainer implements AutoCloseable {
-    private List<IndexRequest> requests;
+    private List<DocWriteRequest> requests;
     private BulkRequestCreator bulkRequestCreator;
     private Integer bulkSize;
 
@@ -37,7 +37,7 @@ public class IndexRequestContainer implements AutoCloseable {
         this.bulkSize = bulkSize;
     }
 
-    public void add(final IndexRequest request) {
+    public void add(final DocWriteRequest request) {
         requests.add(request);
         if (requests.size() == bulkSize) {
             flush();

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/NFSObserverEventSynchronizer.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/NFSObserverEventSynchronizer.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.elasticsearchagent.service.impl;
+
+import static com.epam.pipeline.utils.PasswordGenerator.generateRandomString;
+
+import com.epam.pipeline.elasticsearchagent.exception.ElasticClientException;
+import com.epam.pipeline.elasticsearchagent.model.PermissionsContainer;
+import com.epam.pipeline.elasticsearchagent.model.nfsobserver.NFSObserverEvent;
+import com.epam.pipeline.elasticsearchagent.model.nfsobserver.NFSObserverEventType;
+import com.epam.pipeline.elasticsearchagent.service.ElasticsearchServiceClient;
+import com.epam.pipeline.elasticsearchagent.service.ObjectStorageFileManager;
+import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
+import com.epam.pipeline.entity.datastorage.DataStorageAction;
+import com.epam.pipeline.entity.datastorage.DataStorageFile;
+import com.epam.pipeline.entity.datastorage.DataStorageType;
+import com.epam.pipeline.entity.datastorage.TemporaryCredentials;
+import com.epam.pipeline.vo.EntityPermissionVO;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.lucene.codecs.lucene50.Lucene50PostingsFormat;
+import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Service
+@Slf4j
+@ConditionalOnProperty(value = "sync.nfs-file.observer.sync.disable", matchIfMissing = true, havingValue = "false")
+public class NFSObserverEventSynchronizer extends NFSSynchronizer {
+
+    public static final String BACKSLASH = "/";
+    public static final String COMMA = ",";
+
+    private final String eventsBucketName;
+    private final String eventsBucketFolderPath;
+    private final ObjectStorageFileManager eventBucketFileManager;
+
+    public NFSObserverEventSynchronizer(final @Value("${sync.nfs-file.index.mapping}") String indexSettingsPath,
+                                        final @Value("${sync.nfs-file.root.mount.point}") String rootMountPoint,
+                                        final @Value("${sync.index.common.prefix}") String indexPrefix,
+                                        final @Value("${sync.nfs-file.index.name}") String indexName,
+                                        final @Value("${sync.nfs-file.bulk.insert.size}") Integer bulkInsertSize,
+                                        final @Value("${sync.nfs-file.bulk.load.tags.size}") Integer bulkLoadTagsSize,
+                                        final @Value("${sync.nfs-file.observer.sync.target.bucket}")
+                                            String eventsBucketUriStr,
+                                        final CloudPipelineAPIClient cloudPipelineAPIClient,
+                                        final ElasticsearchServiceClient elasticsearchServiceClient,
+                                        final ElasticIndexService elasticIndexService,
+                                        final List<ObjectStorageFileManager> objectStorageFileManagers) {
+        super(indexSettingsPath, rootMountPoint, indexPrefix, indexName, bulkInsertSize, bulkLoadTagsSize,
+              cloudPipelineAPIClient, elasticsearchServiceClient, elasticIndexService);
+
+
+        final URI eventsBucketUri = URI.create(eventsBucketUriStr);
+        final String bucketScheme = eventsBucketUri.getScheme();
+        this.eventsBucketName = eventsBucketUri.getAuthority();
+        this.eventsBucketFolderPath = Optional.ofNullable(eventsBucketUri.getPath())
+            .map(path -> StringUtils.removeEnd(path, BACKSLASH))
+            .map(path -> StringUtils.removeStart(path, BACKSLASH))
+            .orElse(StringUtils.EMPTY);
+        this.eventBucketFileManager = objectStorageFileManagers.stream()
+            .filter(manager -> manager.getType().getId().equalsIgnoreCase(bucketScheme))
+            .findAny()
+            .orElseThrow(() -> new IllegalArgumentException("Can't find a file manger for scheme " + bucketScheme));
+    }
+
+    @Override
+    public void synchronize(final LocalDateTime lastSyncTime, final LocalDateTime syncStart) {
+        final Map<String, AbstractDataStorage> storagePathMapping = getCloudPipelineAPIClient().loadAllDataStorages()
+            .stream()
+            .collect(Collectors.toMap(AbstractDataStorage::getPath, Function.identity()));
+        final AbstractDataStorage eventsStorage = storagePathMapping.get(eventsBucketName);
+        storagePathMapping.values().removeIf(dataStorage -> dataStorage.getType() != DataStorageType.NFS);
+
+        final Supplier<TemporaryCredentials> listingCredentialsSupplier = getListingCredentialsSupplier(eventsStorage);
+        final Map<String, List<DataStorageFile>> filesByRun =
+            eventBucketFileManager.files(eventsBucketName, eventsBucketFolderPath, listingCredentialsSupplier)
+                .collect(Collectors.groupingBy(this::getProducerName));
+
+        filesByRun.forEach((producer, fileList) -> {
+            final Supplier<TemporaryCredentials> readingCredentialsSupplier =
+                getReadingCredentialsSupplier(eventsStorage);
+            loadAllEventsFromFiles(fileList, readingCredentialsSupplier)
+                .filter(event -> storagePathMapping.get(event.getStorage()) != null)
+                .collect(Collectors.groupingBy(NFSObserverEvent::getStorage))
+                .values()
+                .stream()
+                .map(this::mergeEvents)
+                .flatMap(Collection::stream)
+                .forEach(event -> processEvent(storagePathMapping, event));
+        });
+
+    }
+
+    private void processEvent(final Map<String, AbstractDataStorage> storagePathMapping,
+                              final NFSObserverEvent event) {
+        final AbstractDataStorage dataStorage = storagePathMapping.get(event.getStorage());
+        if (dataStorage == null) {
+            log.info("No storage with root [{}] is registered in the system, skipping", event.getStorage());
+            return;
+        }
+        final Optional<SearchHit> existingDocument = searchExistingDocument(event, dataStorage);
+        final String storageName = getStorageName(dataStorage.getPath());
+        final Path mountFolder = Paths.get(getRootMountPoint(), getMountDirName(dataStorage.getPath()), storageName);
+        final Path absoluteFilePath = mountFolder.resolve(event.getFilePath());
+        final boolean fileExists = absoluteFilePath.toFile().exists();
+
+        if (fileExists) {
+            final DataStorageFile storageFile = convertToStorageFile(absoluteFilePath, mountFolder);
+            final PermissionsContainer permissionsContainer = getPermissionContainer(dataStorage);
+            final IndexRequest request;
+            if (!existingDocument.isPresent()) {
+                final String newIndex = createIndexForStorageIfNotExists(dataStorage);
+                request = createIndexRequest(storageFile, newIndex, dataStorage, permissionsContainer);
+            } else {
+                request = existingDocument
+                    .map(document -> updateIndexRequest(dataStorage, storageFile, permissionsContainer, document))
+                    .get();
+            }
+            getElasticsearchServiceClient().sendRequests(request.index(), Collections.singletonList(request));
+        } else if (existingDocument.isPresent()) {
+            existingDocument
+                .map(hit -> new DeleteRequest(hit.getIndex(), Lucene50PostingsFormat.DOC_EXTENSION, hit.getId()))
+                .ifPresent(getElasticsearchServiceClient()::deleteDocument);
+        }
+    }
+
+    private IndexRequest updateIndexRequest(final AbstractDataStorage dataStorage, final DataStorageFile file,
+                                            final PermissionsContainer container, final SearchHit hit) {
+        final IndexRequest updateRequest = createIndexRequest(file, hit.getIndex(), dataStorage, container);
+        updateRequest.id(hit.getId());
+        return updateRequest;
+    }
+
+    private Optional<SearchHit> searchExistingDocument(NFSObserverEvent event, AbstractDataStorage dataStorage) {
+        return Optional.of(getElasticsearchServiceClient().search(buildSearchRequest(event, dataStorage)))
+            .map(SearchResponse::getHits)
+            .filter(hits -> hits.getTotalHits() == 1)
+            .map(hits -> hits.getAt(0));
+    }
+
+    private SearchRequest buildSearchRequest(final NFSObserverEvent event, final AbstractDataStorage dataStorage) {
+        final SearchSourceBuilder source = new SearchSourceBuilder()
+            .query(QueryBuilders.boolQuery()
+                       .must(QueryBuilders.termQuery("path", event.getFilePath()))
+                       .must(QueryBuilders.termQuery("storage_id", dataStorage.getId())))
+            .size(1);
+        return new SearchRequest("*")
+            .indicesOptions(IndicesOptions.lenientExpandOpen())
+            .source(source);
+    }
+
+    private PermissionsContainer getPermissionContainer(final AbstractDataStorage dataStorage) {
+        final EntityPermissionVO entityPermission = getCloudPipelineAPIClient()
+            .loadPermissionsForEntity(dataStorage.getId(), dataStorage.getAclClass());
+
+        final PermissionsContainer permissionsContainer = new PermissionsContainer();
+        if (entityPermission != null) {
+            permissionsContainer.add(entityPermission.getPermissions(), dataStorage.getOwner());
+        }
+        return permissionsContainer;
+    }
+
+    private String createIndexForStorageIfNotExists(final AbstractDataStorage dataStorage) {
+        final String alias = getIndexPrefix() + getIndexName() + String.format("-%d", dataStorage.getId());
+        final String indexName = generateRandomString(5).toLowerCase() + "-" + alias;
+        return Optional.ofNullable(getElasticsearchServiceClient().getIndexNameByAlias(alias))
+            .orElseGet(() -> {
+                try {
+                    getElasticIndexService().createIndexIfNotExist(indexName, getIndexSettingsPath());
+                    return indexName;
+                } catch (ElasticClientException e) {
+                    log.error(e.getMessage(), e);
+                    if (getElasticsearchServiceClient().isIndexExists(indexName)) {
+                        getElasticsearchServiceClient().deleteIndex(indexName);
+                    }
+                    return null;
+                }
+            });
+    }
+
+    private Collection<NFSObserverEvent> mergeEvents(final List<NFSObserverEvent> events) {
+        return events.stream()
+            .sorted(Comparator.comparing(NFSObserverEvent::getTimestamp))
+            .collect(Collectors.toMap(NFSObserverEvent::getFilePath,
+                                      Function.identity(),
+                                      this::mergeEventsPair))
+            .values();
+    }
+
+    private NFSObserverEvent mergeEventsPair(final NFSObserverEvent currentEvent, final NFSObserverEvent newEvent) {
+        if (currentEvent == null) {
+            return newEvent;
+        }
+        if (currentEvent.getEventType() == NFSObserverEventType.CREATED) {
+            final NFSObserverEventType newEventType = newEvent.getEventType();
+            if (newEventType == NFSObserverEventType.MOVED_FROM || newEventType == NFSObserverEventType.DELETED) {
+                return null;
+            }
+            return currentEvent;
+        }
+        return newEvent;
+    }
+
+    private Stream<NFSObserverEvent> loadAllEventsFromFiles(
+        final List<DataStorageFile> fileList, final Supplier<TemporaryCredentials> readingCredentialsSupplier) {
+        return fileList.stream()
+            .map(file -> readAllEventsFromFile(file, readingCredentialsSupplier))
+            .flatMap(Collection::stream);
+    }
+
+    private List<NFSObserverEvent> readAllEventsFromFile(
+        final DataStorageFile file, final Supplier<TemporaryCredentials> readingCredentialsSupplier) {
+        try (InputStream inputStream = eventBucketFileManager.readFileContent(eventsBucketName,
+                                                                              file.getPath(),
+                                                                              readingCredentialsSupplier)) {
+            return IOUtils.readLines(inputStream, StandardCharsets.UTF_8).stream()
+                .map(this::mapStringToEvent)
+                .collect(Collectors.toList());
+        } catch (IOException ex) {
+            return new ArrayList<>();
+        }
+    }
+
+    private NFSObserverEvent mapStringToEvent(final String line) {
+        final String[] eventDetails = line.split(COMMA);
+        return new NFSObserverEvent(Long.parseLong(eventDetails[0]),
+                                    NFSObserverEventType.fromCode(eventDetails[1]),
+                                    eventDetails[2],
+                                    eventDetails[3]);
+    }
+
+    private String getProducerName(final DataStorageFile file) {
+        return file.getPath().substring(eventsBucketFolderPath.length() + 1).split(BACKSLASH)[0];
+    }
+
+    private Supplier<TemporaryCredentials> getListingCredentialsSupplier(final AbstractDataStorage eventsStorage) {
+        return () -> getTemporaryCredentials(eventsStorage, true, false);
+    }
+
+    private Supplier<TemporaryCredentials> getReadingCredentialsSupplier(final AbstractDataStorage eventsStorage) {
+        return () -> getTemporaryCredentials(eventsStorage, false, true);
+    }
+
+    private TemporaryCredentials getTemporaryCredentials(final AbstractDataStorage dataStorage,
+                                                         final boolean list,
+                                                         final boolean read) {
+        log.debug("Retrieving {} data storage {} temporary credentials...", DataStorageType.S3, dataStorage.getPath());
+        final DataStorageAction action = new DataStorageAction();
+        action.setBucketName(dataStorage.getPath());
+        action.setId(dataStorage.getId());
+        action.setRead(read);
+        action.setList(list);
+        return getCloudPipelineAPIClient().generateTemporaryCredentials(Collections.singletonList(action));
+    }
+}

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/NFSSynchronizer.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/NFSSynchronizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,8 @@ import com.epam.pipeline.entity.search.SearchDocumentType;
 import com.epam.pipeline.vo.EntityPermissionVO;
 import com.epam.pipeline.vo.data.storage.DataStorageTagLoadBatchRequest;
 import com.epam.pipeline.vo.data.storage.DataStorageTagLoadRequest;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.elasticsearch.action.index.IndexRequest;
@@ -54,6 +56,7 @@ import static com.epam.pipeline.utils.PasswordGenerator.generateRandomString;
 @Service
 @Slf4j
 @ConditionalOnProperty(value = "sync.nfs-file.disable", matchIfMissing = true, havingValue = "false")
+@Getter(value = AccessLevel.PROTECTED)
 public class NFSSynchronizer implements ElasticsearchSynchronizer {
     private static final Pattern NFS_ROOT_PATTERN = Pattern.compile("(.+:\\/?).*[^\\/]+");
     private static final Pattern NFS_PATTERN_WITH_HOME_DIR = Pattern.compile("(.+:)[^\\/]+");
@@ -150,7 +153,7 @@ public class NFSSynchronizer implements ElasticsearchSynchronizer {
         }
     }
 
-    private DataStorageFile convertToStorageFile(final Path path, final Path mountFolder) {
+    protected DataStorageFile convertToStorageFile(final Path path, final Path mountFolder) {
         final DataStorageFile file = new DataStorageFile();
         file.setPath(getRelativePath(mountFolder, path));
         file.setName(file.getPath());
@@ -181,11 +184,11 @@ public class NFSSynchronizer implements ElasticsearchSynchronizer {
         }
     }
 
-    private String getStorageName(final String path) {
+    protected String getStorageName(final String path) {
         return path.replace(getNfsRootPath(path), "");
     }
 
-    private String getMountDirName(final String nfsPath) {
+    protected String getMountDirName(final String nfsPath) {
         String rootPath = getNfsRootPath(nfsPath);
         int index = rootPath.indexOf(':');
         if (index > 0) {
@@ -225,10 +228,10 @@ public class NFSSynchronizer implements ElasticsearchSynchronizer {
                 .peek(file -> file.setTags(tags.get(file.getPath())));
     }
 
-    private IndexRequest createIndexRequest(final DataStorageFile file,
-                                            final String indexName,
-                                            final AbstractDataStorage dataStorage,
-                                            final PermissionsContainer permissionsContainer) {
+    protected IndexRequest createIndexRequest(final DataStorageFile file,
+                                              final String indexName,
+                                              final AbstractDataStorage dataStorage,
+                                              final PermissionsContainer permissionsContainer) {
         return new IndexRequest(indexName, DOC_MAPPING_TYPE)
                 .source(fileMapper.fileToDocument(file, dataStorage, null, permissionsContainer,
                         SearchDocumentType.NFS_FILE));

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/S3FileManager.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/S3FileManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -99,6 +99,14 @@ public class S3FileManager implements ObjectStorageFileManager {
         final AmazonS3 client = getS3Client(credentialsSupplier);
         final S3Object object = client.getObject(new GetObjectRequest(storage, path));
         return object.getObjectContent();
+    }
+
+    @Override
+    public void deleteFile(final String storage,
+                           final String path,
+                           final Supplier<TemporaryCredentials> credentialsSupplier) {
+        final AmazonS3 client = getS3Client(credentialsSupplier);
+        client.deleteObject(storage, path);
     }
 
     private AmazonS3 getS3Client(final Supplier<TemporaryCredentials> credentialsSupplier) {

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/S3FileManager.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/S3FileManager.java
@@ -20,11 +20,13 @@ import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.BasicSessionCredentials;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.GetObjectTaggingRequest;
 import com.amazonaws.services.s3.model.GetObjectTaggingResult;
 import com.amazonaws.services.s3.model.ListObjectsV2Request;
 import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.ListVersionsRequest;
+import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.services.s3.model.S3VersionSummary;
 import com.amazonaws.services.s3.model.Tag;
@@ -41,6 +43,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 
+import java.io.InputStream;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -87,6 +90,15 @@ public class S3FileManager implements ObjectStorageFileManager {
                 .flatMap(List::stream)
                 .filter(file -> !file.getDeleteMarker())
                 .peek(file -> file.setTags(getNativeTags(client, storage, file)));
+    }
+
+    @Override
+    public InputStream readFileContent(final String storage,
+                                       final String path,
+                                       final Supplier<TemporaryCredentials> credentialsSupplier) {
+        final AmazonS3 client = getS3Client(credentialsSupplier);
+        final S3Object object = client.getObject(new GetObjectRequest(storage, path));
+        return object.getObjectContent();
     }
 
     private AmazonS3 getS3Client(final Supplier<TemporaryCredentials> credentialsSupplier) {

--- a/elasticsearch-agent/src/main/resources/application.properties
+++ b/elasticsearch-agent/src/main/resources/application.properties
@@ -90,6 +90,7 @@ sync.nfs-file.bulk.load.tags.size=100
 sync.nfs-file.root.mount.point=
 #sync.nfs-file.observer.sync.disable=false
 sync.nfs-file.observer.sync.target.bucket=
+sync.nfs-file.observer.sync.files.chunk=10
 
 #S3 Storage Settings
 #sync.s3-storage.disable=true

--- a/elasticsearch-agent/src/main/resources/application.properties
+++ b/elasticsearch-agent/src/main/resources/application.properties
@@ -88,6 +88,8 @@ sync.nfs-file.index.name=nfs-file
 sync.nfs-file.bulk.insert.size=1000
 sync.nfs-file.bulk.load.tags.size=100
 sync.nfs-file.root.mount.point=
+#sync.nfs-file.observer.sync.disable=false
+sync.nfs-file.observer.sync.target.bucket=
 
 #S3 Storage Settings
 #sync.s3-storage.disable=true


### PR DESCRIPTION
This PR is related to issue #2155

It brings a new service into `elasticsearch-agent`, which performs more frequent (compared to common NFS) synchronization based on events, gathered by "observer" introduced in #2158.

It pulls files from a configurable bucket in chunks, extracts, and merges events. After that, it checks the corresponding NFS state and creates/updates/removes required documents in ES.
