### PR TITLE
Issue 2155 Search service NFS mount

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/datastorage/FileShareMountApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/datastorage/FileShareMountApiService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,4 +39,8 @@ public class FileShareMountApiService {
         fileShareMountManager.delete(id);
     }
 
+    @PreAuthorize(AclExpressions.ADMIN_ONLY)
+    public FileShareMount load(final Long id) {
+        return fileShareMountManager.load(id);
+    }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/datastorage/FileShareMountController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/datastorage/FileShareMountController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,4 +63,16 @@ public class FileShareMountController extends AbstractRestController {
         fileShareMountApiService.delete(id);
     }
 
+    @GetMapping(value = "/{id}")
+    @ResponseBody
+    @ApiOperation(
+            value = "Load file share mount.",
+            notes = "Load file share mount details.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public Result<FileShareMount> load(final @PathVariable Long id) {
+        return Result.success(fileShareMountApiService.load(id));
+    }
 }

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
@@ -24,6 +24,7 @@ import com.epam.pipeline.entity.configuration.RunConfiguration;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.DataStorageAction;
 import com.epam.pipeline.entity.datastorage.DataStorageTag;
+import com.epam.pipeline.entity.datastorage.FileShareMount;
 import com.epam.pipeline.entity.datastorage.TemporaryCredentials;
 import com.epam.pipeline.entity.docker.ToolDescription;
 import com.epam.pipeline.entity.dts.submission.DtsRegistry;
@@ -257,4 +258,7 @@ public interface CloudPipelineAPI {
 
     @GET("preferences/{key}")
     Call<Result<Preference>> loadPreference(@Path(KEY) final String preferenceName);
+
+    @GET("/filesharemount/{id}")
+    Call<Result<FileShareMount>> loadShareMount(@Path(ID) final Long id);
 }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/CloudPipelineAPIClient.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/CloudPipelineAPIClient.java
@@ -23,6 +23,7 @@ import com.epam.pipeline.entity.configuration.RunConfiguration;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.DataStorageAction;
 import com.epam.pipeline.entity.datastorage.DataStorageTag;
+import com.epam.pipeline.entity.datastorage.FileShareMount;
 import com.epam.pipeline.entity.datastorage.TemporaryCredentials;
 import com.epam.pipeline.entity.docker.ToolDescription;
 import com.epam.pipeline.entity.git.GitRepositoryEntry;
@@ -215,5 +216,9 @@ public class CloudPipelineAPIClient {
         } catch (IOException e) {
             return Collections.emptyList();
         }
+    }
+
+    public FileShareMount loadFileShareMount(final Long id) {
+        return executor.execute(cloudPipelineAPI.loadShareMount(id));
     }
 }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/NFSObserverEventSynchronizer.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/NFSObserverEventSynchronizer.java
@@ -55,7 +55,6 @@ import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -100,9 +99,10 @@ public class NFSObserverEventSynchronizer extends NFSSynchronizer {
                                         final CloudPipelineAPIClient cloudPipelineAPIClient,
                                         final ElasticsearchServiceClient elasticsearchServiceClient,
                                         final ElasticIndexService elasticIndexService,
-                                        final List<ObjectStorageFileManager> objectStorageFileManagers) {
+                                        final List<ObjectStorageFileManager> objectStorageFileManagers,
+                                        final NFSStorageMounter nfsMounter) {
         super(indexSettingsPath, rootMountPoint, indexPrefix, indexName, bulkInsertSize, bulkLoadTagsSize,
-              cloudPipelineAPIClient, elasticsearchServiceClient, elasticIndexService);
+              cloudPipelineAPIClient, elasticsearchServiceClient, elasticIndexService, nfsMounter);
 
         this.eventsFileChunkSize = eventsFileChunkSize;
         final URI eventsBucketURI = URI.create(eventsBucketUriStr);
@@ -185,8 +185,13 @@ public class NFSObserverEventSynchronizer extends NFSSynchronizer {
                                       final Collection<NFSObserverEvent> events) {
         final Map<String, SearchHit> searchHitMap = findIndexedFiles(dataStorage, events);
         final String indexForNewFiles = createIndexForStorageIfNotExists(dataStorage);
+        final Path mountFolder = mountStorageToRootIfNecessary(dataStorage);
+        if (mountFolder == null) {
+            log.warn("Unable to retrieve mount for [{}], skipping...", dataStorage.getName());
+            return;
+        }
         final Stream<DataStorageFile> fileUpdates = events.stream()
-            .map(event -> mapUpdateEventToFile(requestContainer, dataStorage, searchHitMap, event))
+            .map(event -> mapUpdateEventToFile(requestContainer, mountFolder, searchHitMap, event))
             .filter(Objects::nonNull);
         final PermissionsContainer permissionsContainer = getPermissionContainer(dataStorage);
         processFilesTagsInChunks(dataStorage, fileUpdates)
@@ -205,14 +210,11 @@ public class NFSObserverEventSynchronizer extends NFSSynchronizer {
     }
 
     private DataStorageFile mapUpdateEventToFile(final IndexRequestContainer requestContainer,
-                                                 final AbstractDataStorage dataStorage,
+                                                 final Path mountFolder,
                                                  final Map<String, SearchHit> searchHitMap,
                                                  final NFSObserverEvent event) {
-        final String storageName = getStorageName(dataStorage.getPath());
-        final Path mountFolder = Paths.get(getRootMountPoint(), getMountDirName(dataStorage.getPath()), storageName);
         Assert.isTrue(mountFolder.toFile().exists(),
-                      String.format("Mount folder [%s] doesn't exist - stop chunk synchronization...",
-                                    mountFolder.toString()));
+                      String.format("Mount folder [%s] doesn't exist - stop chunk synchronization...", mountFolder));
         final Path absoluteFilePath = mountFolder.resolve(event.getFilePath());
         final boolean fileExists = absoluteFilePath.toFile().exists();
 

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/NFSStorageMounter.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/NFSStorageMounter.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.elasticsearchagent.service.impl;
+
+import com.epam.pipeline.cmd.CmdExecutionException;
+import com.epam.pipeline.cmd.CmdExecutor;
+import com.epam.pipeline.cmd.PlainCmdExecutor;
+import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
+import com.epam.pipeline.entity.datastorage.FileShareMount;
+import com.epam.pipeline.entity.datastorage.MountType;
+import com.epam.pipeline.entity.datastorage.NFSDataStorage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class NFSStorageMounter {
+
+    private static final String NFS_MOUNT_CMD_PATTERN = "sudo mount -t %s %s %s %s";
+    private static final String LUSTRE_MGS_NID_REGEX = "([^:]+(:\\d+)?@\\w+)";
+    private static final Pattern NFS_LUSTRE_ROOT_PATTERN = Pattern.compile(String.format("^%1$s(:%1$s)*(:\\/)[^\\/]+",
+                                                                                         LUSTRE_MGS_NID_REGEX));
+    private static final String PATH_SEPARATOR = "/";
+    private static final String NFS_HOST_DELIMITER = ":/";
+    private static final String OPTIONS_FLAG = "-o ";
+
+    private final CloudPipelineAPIClient cloudPipelineAPIClient;
+    private final CmdExecutor cmdExecutor = new PlainCmdExecutor();
+
+    public synchronized boolean tryToMountStorage(final NFSDataStorage storage, final File mountFolder) {
+        Assert.isTrue(mountFolder.mkdirs(), "Could not mount NFS: unable to create a directory!");
+        final String mountCommand = buildMountCommand(storage, mountFolder);
+        try {
+            cmdExecutor.executeCommand(mountCommand);
+            return true;
+        } catch (CmdExecutionException executionException) {
+            log.error("Could not mount NFS using [{}]: {} ", mountCommand, executionException.getMessage());
+            tryRemoveFolder(storage, mountFolder);
+            return false;
+        }
+    }
+
+    private void tryRemoveFolder(final NFSDataStorage storage, final File mountFolder) {
+        try {
+            deleteFolderIfEmpty(mountFolder);
+        } catch (IOException cleanupException) {
+            log.error(String.format("Unable to remove mount point folder [%s] after [%s] mount failure.",
+                                    mountFolder.getAbsoluteFile(), storage.getPath()));
+        }
+    }
+
+    private String buildMountCommand(final NFSDataStorage storage, final File mountFolder) {
+        final FileShareMount fileShareMount = cloudPipelineAPIClient.loadFileShareMount(storage.getFileShareMountId());
+        final String protocol = fileShareMount.getMountType().getProtocol();
+        return String.format(NFS_MOUNT_CMD_PATTERN,
+                             protocol,
+                             buildMountOptions(storage),
+                             formatNfsPath(storage.getPath(), protocol),
+                             mountFolder.getAbsolutePath());
+    }
+
+    private String buildMountOptions(final AbstractDataStorage dataStorage) {
+        return Optional.ofNullable(dataStorage.getMountOptions())
+            .map(StringUtils::trimToEmpty)
+            .filter(StringUtils::isNotEmpty)
+            .map(options -> OPTIONS_FLAG + options)
+            .orElse(StringUtils.EMPTY);
+    }
+
+    private void deleteFolderIfEmpty(final File folder) throws IOException {
+        final String[] files = folder.list();
+        if (ArrayUtils.isEmpty(files)) {
+            FileUtils.deleteDirectory(folder);
+        }
+    }
+
+    private String formatNfsPath(final String path, final String protocol) {
+        if (protocol.equalsIgnoreCase(MountType.LUSTRE.getProtocol())) {
+            if (!NFS_LUSTRE_ROOT_PATTERN.matcher(path).find()) {
+                throw new IllegalArgumentException("Invalid Lustre path format!");
+            } else if (path.endsWith(PATH_SEPARATOR)) {
+                return StringUtils.chop(path);
+            }
+        }
+        if (protocol.equalsIgnoreCase(MountType.NFS.getProtocol()) && !path.contains(NFS_HOST_DELIMITER)) {
+            return path.replaceFirst(PATH_SEPARATOR, NFS_HOST_DELIMITER);
+        }
+        return path;
+    }
+}


### PR DESCRIPTION
This PR is related to issue #2155

Previously, NFS storage required should be mounted into `elasticsearch-agent` service manually before synchronization startup.
From now the approach is changed to the one, similar to `api`: trying to attach required storage at its synchronization.
- file share details loading endpoint created in the controller
- mounting logic implemented in `elasticsearch-agent`