### PR TITLE
E2E tests: impersonate mode

### DIFF
--- a/e2e/gui/default.conf
+++ b/e2e/gui/default.conf
@@ -63,3 +63,6 @@ e2e.ui.pipe.operation.system=
 e2e.ui.pipe.installation.content=
 e2e.ui.pipe.config.content.path=
 e2e.ui.impersonate.auth=
+e2e.ui.extension.path=
+e2e.ui.invalid.extension.path=
+e2e.ui.anonym.extension.path=

--- a/e2e/gui/default.conf
+++ b/e2e/gui/default.conf
@@ -62,3 +62,4 @@ e2e.ui.launch.system.parameters.path=
 e2e.ui.pipe.operation.system=
 e2e.ui.pipe.installation.content=
 e2e.ui.pipe.config.content.path=
+e2e.ui.impersonate.auth=

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/AbstractBfxPipelineTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/AbstractBfxPipelineTest.java
@@ -48,29 +48,7 @@ public abstract class AbstractBfxPipelineTest implements ITest {
         Configuration.startMaximized = true;
         System.setProperty("webdriver.chrome.driver", "/usr/local/bin/chromedriver");
 
-        if ("true".equals(C.AUTH_TOKEN)) {
-            Selenide.open(C.ROOT_ADDRESS);
-            Cookie cookie = new Cookie("HttpAuthorization", C.PASSWORD);
-            WebDriverRunner.getWebDriver().manage().addCookie(cookie);
-        }
-        Selenide.open(C.ROOT_ADDRESS);
-
-        Robot robot;
-        try {
-            robot = new Robot();
-        } catch (AWTException e) {
-            throw new RuntimeException("Something wrong with robot", e);
-        }
-        robot.keyPress(122);
-        robot.keyRelease(122);
-
-        if ("false".equals(C.AUTH_TOKEN)) {
-            new AuthenticationPageAO()
-                    .login(C.LOGIN)
-                    .password(C.PASSWORD)
-                    .signIn();
-        }
-        sleep(3, SECONDS);
+        login(C.ROOT_ADDRESS);
 
         //reset mouse
         $(byId("navigation-button-logo")).shouldBe(visible).click();
@@ -87,6 +65,11 @@ public abstract class AbstractBfxPipelineTest implements ITest {
         } else {
             this.methodName = method.getName();
         }
+    }
+
+    public void restartBrowser(final String address) {
+        Selenide.close();
+        login(address);
     }
 
     @Override
@@ -128,5 +111,31 @@ public abstract class AbstractBfxPipelineTest implements ITest {
                 break;
         }
         return status;
+    }
+
+    private void login(final String address) {
+        if ("true".equals(C.AUTH_TOKEN)) {
+            Selenide.open(address);
+            Cookie cookie = new Cookie("HttpAuthorization", C.PASSWORD);
+            WebDriverRunner.getWebDriver().manage().addCookie(cookie);
+        }
+        Selenide.open(address);
+
+        Robot robot;
+        try {
+            robot = new Robot();
+        } catch (AWTException e) {
+            throw new RuntimeException("Something wrong with robot", e);
+        }
+        robot.keyPress(122);
+        robot.keyRelease(122);
+
+        if ("false".equals(C.AUTH_TOKEN)) {
+            new AuthenticationPageAO()
+                    .login(C.LOGIN)
+                    .password(C.PASSWORD)
+                    .signIn();
+        }
+        sleep(3, SECONDS);
     }
 }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/AbstractBfxPipelineTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/AbstractBfxPipelineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,9 @@ import com.epam.pipeline.autotests.ao.AuthenticationPageAO;
 import com.epam.pipeline.autotests.utils.C;
 import com.epam.pipeline.autotests.utils.TestCase;
 import org.openqa.selenium.Cookie;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.testng.ITest;
 import org.testng.ITestResult;
 import org.testng.annotations.AfterMethod;
@@ -29,6 +32,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 
 import java.awt.*;
+import java.io.File;
 import java.lang.reflect.Method;
 
 import static com.codeborne.selenide.Condition.visible;
@@ -70,6 +74,14 @@ public abstract class AbstractBfxPipelineTest implements ITest {
     public void restartBrowser(final String address) {
         Selenide.close();
         login(address);
+    }
+
+    public void addExtension(final String extensionPath) {
+        final ChromeOptions options = new ChromeOptions();
+        options.addArguments("--no-sandbox");
+        options.addExtensions(new File(extensionPath));
+        WebDriver webDriver = new ChromeDriver(options);
+        WebDriverRunner.setWebDriver(webDriver);
     }
 
     @Override
@@ -115,6 +127,9 @@ public abstract class AbstractBfxPipelineTest implements ITest {
 
     private void login(final String address) {
         if ("true".equals(C.AUTH_TOKEN)) {
+            if ("true".equalsIgnoreCase(C.IMPERSONATE_AUTH)) {
+                addExtension(C.EXTENSION_PATH);
+            }
             Selenide.open(address);
             Cookie cookie = new Cookie("HttpAuthorization", C.PASSWORD);
             WebDriverRunner.getWebDriver().manage().addCookie(cookie);

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/DetachedConfigurationsTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/DetachedConfigurationsTest.java
@@ -141,6 +141,7 @@ public class DetachedConfigurationsTest
             .editConfiguration(pipelineCustomProfile, profile ->
                 profile.expandTabs(execEnvironmentTab, advancedTab, parametersTab)
                     .setValue(DISK, customDisk)
+                    .selectValue(INSTANCE_TYPE, defaultInstanceType)
                     .setCommand(command)
                     .clickAddStringParameter()
                     .setName(stringParameterName)
@@ -244,8 +245,6 @@ public class DetachedConfigurationsTest
                         .also(confirmConfigurationChange())
                 )
                 .ensure(DISK, value(defaultDisk))
-                .sleep(2, SECONDS)
-                .selectValue(INSTANCE_TYPE, defaultInstanceType)
                 .resetChanges()
         );
     }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/DetachedConfigurationsTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/DetachedConfigurationsTest.java
@@ -154,6 +154,7 @@ public class DetachedConfigurationsTest
             .editConfiguration(pipelineDefaultProfile, profile ->
                 profile.expandTab(EXEC_ENVIRONMENT)
                     .setValue(DISK, defaultDisk)
+                    .selectValue(INSTANCE_TYPE, defaultInstanceType)
                     .click(SAVE)
             )
             .sleep(5, SECONDS)
@@ -243,6 +244,8 @@ public class DetachedConfigurationsTest
                         .also(confirmConfigurationChange())
                 )
                 .ensure(DISK, value(defaultDisk))
+                .sleep(2, SECONDS)
+                .selectValue(INSTANCE_TYPE, defaultInstanceType)
                 .resetChanges()
         );
     }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/NotificationsTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/NotificationsTest.java
@@ -101,7 +101,9 @@ public class NotificationsTest extends AbstractBfxPipelineTest implements Author
                 .clickCombobox()
                 .selectSeverity(severity)
                 .setActive()
-                .create();
+                .create()
+                .searchForTableEntry(warningActiveNotification)
+                .ensureSeverityIconIs(severity.name());
         if(!impersonateMode()) {
             refresh();
             validateActiveNotification(warningActiveNotification, warningActiveNotificationBodyText, severity);

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/NotificationsTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/NotificationsTest.java
@@ -126,18 +126,19 @@ public class NotificationsTest extends AbstractBfxPipelineTest implements Author
     @Test(dependsOnMethods = {"validateCreateInactiveInfoNotification"})
     @TestCase(value = {"EPMCMBIBPC-1209"})
     public void validateActivateNotification() {
-        if(!impersonateMode()) {
-            changeStateOf(infoNotification);
-
-            refresh();
-            new NotificationAO(infoNotification)
-                    .ensureSeverityIs("Info")
-                    .ensureTitleIs(infoNotification)
-                    .ensureBodyIs(infoNotificationBodyText)
-                    .ensureVisible(CLOSE, DATE);
-            closeNotification(infoNotification);
-            changeStateOf(infoNotification);
+        if (impersonateMode()) {
+            return;
         }
+        changeStateOf(infoNotification);
+
+        refresh();
+        new NotificationAO(infoNotification)
+                .ensureSeverityIs("Info")
+                .ensureTitleIs(infoNotification)
+                .ensureBodyIs(infoNotificationBodyText)
+                .ensureVisible(CLOSE, DATE);
+        closeNotification(infoNotification);
+        changeStateOf(infoNotification);
     }
 
     @Test(dependsOnMethods = {"validateSystemEventsMenu"})
@@ -150,33 +151,34 @@ public class NotificationsTest extends AbstractBfxPipelineTest implements Author
     @Test(dependsOnMethods = {"validateCreateInactiveNotificationsWithDifferentSeverity"})
     @TestCase(value = {"EPMCMBIBPC-1213"})
     public void validateDisplaySeveralActiveNotifications() {
-        if(!impersonateMode()) {
-            changeStateOf(infoNotification);
-            changeStateOf(warningNotification);
-            changeStateOf(criticalNotification);
-
-            refresh();
-            validateActiveNotification(infoNotification, infoNotificationBodyText, INFO);
-            validateActiveNotification(warningNotification, warningNotificationBodyText, WARNING);
-            validateActiveNotification(criticalNotification, criticalNotificationBodyText, CRITICAL);
-
-            closeNotification(infoNotification);
-            closeNotification(warningNotification);
-            closeNotification(criticalNotification);
+        if (impersonateMode()) {
+            return;
         }
+        changeStateOf(infoNotification);
+        changeStateOf(warningNotification);
+        changeStateOf(criticalNotification);
+
+        refresh();
+        validateActiveNotification(infoNotification, infoNotificationBodyText, INFO);
+        validateActiveNotification(warningNotification, warningNotificationBodyText, WARNING);
+        validateActiveNotification(criticalNotification, criticalNotificationBodyText, CRITICAL);
+
+        closeNotification(infoNotification);
+        closeNotification(warningNotification);
+        closeNotification(criticalNotification);
     }
 
     @Test(dependsOnMethods = {"validateDisplaySeveralActiveNotifications"})
     @TestCase(value = {"EPMCMBIBPC-1219"})
     public void validateEditActiveNotification() {
-            navigationMenu()
-                    .settings()
-                    .switchToSystemEvents()
-                    .searchForTableEntry(infoNotification)
-                    .edit()
-                    .titleTo(infoEditedTitle)
-                    .bodyTo(infoEditedBodyText)
-                    .save();
+        navigationMenu()
+                .settings()
+                .switchToSystemEvents()
+                .searchForTableEntry(infoNotification)
+                .edit()
+                .titleTo(infoEditedTitle)
+                .bodyTo(infoEditedBodyText)
+                .save();
         if(!impersonateMode()) {
             refresh();
             validateActiveNotification(infoEditedTitle, infoEditedBodyText, INFO);
@@ -214,16 +216,17 @@ public class NotificationsTest extends AbstractBfxPipelineTest implements Author
     @Test(dependsOnMethods = {"validateDeleteActiveNotification"})
     @TestCase(value = {"EPMCMBIBPC-1217"})
     public void validateSeveralInactiveNotifications() {
-        if(!impersonateMode()) {
-            changeStateOf(infoEditedTitle);
-            changeStateOf(warningActiveNotification);
-            changeStateOf(criticalNotification);
-
-            refresh();
-            ensureNotificationIsAbsent(infoEditedTitle);
-            ensureNotificationIsAbsent(warningActiveNotification);
-            ensureNotificationIsAbsent(criticalNotification);
+        if (impersonateMode()) {
+            return;
         }
+        changeStateOf(infoEditedTitle);
+        changeStateOf(warningActiveNotification);
+        changeStateOf(criticalNotification);
+
+        refresh();
+        ensureNotificationIsAbsent(infoEditedTitle);
+        ensureNotificationIsAbsent(warningActiveNotification);
+        ensureNotificationIsAbsent(criticalNotification);
     }
 
     @Test(dependsOnMethods = {"validateSeveralInactiveNotifications"})
@@ -313,7 +316,7 @@ public class NotificationsTest extends AbstractBfxPipelineTest implements Author
     }
 
     private String capitalCase(Primitive severity) {
-        return severity.name().substring(0,1) + severity.name().substring(1).toLowerCase();
+        return severity.name().charAt(0) + severity.name().substring(1).toLowerCase();
     }
 
     private void closeNotification(final String notificationName) {

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/NotificationsTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/NotificationsTest.java
@@ -77,7 +77,7 @@ public class NotificationsTest extends AbstractBfxPipelineTest implements Author
         loginAs(admin)
                 .settings()
                 .switchToSystemEvents()
-                .ensureTableHasTextIfNeeded("No data")
+                .ensureTableHasNoDateText()
                 .ensureVisible(REFRESH, ADD);
     }
 

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/NotificationsTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/NotificationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package com.epam.pipeline.autotests;
 
 import com.epam.pipeline.autotests.ao.NotificationAO;
 import com.epam.pipeline.autotests.ao.Primitive;
-import com.epam.pipeline.autotests.ao.SettingsPageAO;
 import com.epam.pipeline.autotests.mixins.Authorization;
 import com.epam.pipeline.autotests.utils.C;
 import com.epam.pipeline.autotests.utils.TestCase;
@@ -25,8 +24,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.List;
 
 import static com.epam.pipeline.autotests.ao.Primitive.ADD;
@@ -41,16 +39,16 @@ import static java.lang.String.format;
 
 public class NotificationsTest extends AbstractBfxPipelineTest implements Authorization {
 
-    private final String currentDate = new SimpleDateFormat("yyyy-MM-dd").format(new Date());
-    private final String infoNotification = "info_notification-" + currentDate;
+    private final String currentDate = LocalDate.now().toString();
+    private final String infoNotification = format("info_notification-%s", currentDate);
     private final String infoNotificationBodyText = "info_notification_body_text";
     private final String infoEditedTitle = "info_edited";
     private final String infoEditedBodyText = "info_edited_body_text";
-    private final String warningNotification = "warning_notification-" + currentDate;
+    private final String warningNotification = format("warning_notification-%s", currentDate);
     private final String warningNotificationBodyText = "warning_notification_body_text";
-    private final String warningActiveNotification = "warning_active-" + currentDate;
+    private final String warningActiveNotification = format("warning_active-%s", currentDate);
     private final String warningActiveNotificationBodyText = "warning_active_body_text";
-    private final String criticalNotification = "critical_notification-" + currentDate;
+    private final String criticalNotification = format("critical_notification-%s", currentDate);
     private final String criticalNotificationBodyText = "critical_notification_body_text";
     private final String deletionMessageFormat = "Are you sure you want to delete notification '%s'?";
     private List<String> initialEntries;

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/PauseResumeTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/PauseResumeTest.java
@@ -156,6 +156,9 @@ public class PauseResumeTest extends AbstractSeveralPipelineRunningTest implemen
     @Test
     @TestCase({"EPMCMBIBPC-2627"})
     public void dockerExtraMultiValidation() {
+        if (impersonateMode() && "true".equalsIgnoreCase(C.AUTH_TOKEN)) {
+            return;
+        }
         try {
             tools()
                     .perform(registry, group, tool, ToolTab::runWithCustomSettings)

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/PauseResumeTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/PauseResumeTest.java
@@ -270,8 +270,7 @@ public class PauseResumeTest extends AbstractSeveralPipelineRunningTest implemen
                 .waitForInitializeNode(getLastRunId())
                 .clickEndpoint()
                 .getEndpoint();
-        Utils.restartBrowser(C.ROOT_ADDRESS);
-        loginAs(admin);
+        restartBrowser(C.ROOT_ADDRESS);
 
         runsMenu()
                 .log(getLastRunId(), log -> log

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/PipelineConfigurationTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/PipelineConfigurationTest.java
@@ -16,6 +16,7 @@
 package com.epam.pipeline.autotests;
 
 import com.epam.pipeline.autotests.ao.AbstractPipelineTabAO;
+import com.epam.pipeline.autotests.ao.ConfirmationPopupAO;
 import com.epam.pipeline.autotests.ao.PipelineCodeTabAO;
 import com.epam.pipeline.autotests.ao.PipelineConfigurationTabAO;
 import com.epam.pipeline.autotests.ao.PipelineRunFormAO;
@@ -259,6 +260,7 @@ public class PipelineConfigurationTest extends AbstractSeveralPipelineRunningTes
                                .clear(NAME).setValue(NAME, "conf")
                                .clear(DISK).setValue(DISK, "23")
                                .clear(TIMEOUT).setValue(TIMEOUT, "2")
+                               .selectValue(INSTANCE_TYPE, C.DEFAULT_INSTANCE)
                                .sleep(2, SECONDS)
                                .click(SAVE)
                 )
@@ -356,7 +358,7 @@ public class PipelineConfigurationTest extends AbstractSeveralPipelineRunningTes
         );
         onPipelinePage()
                 .onTab(PipelineConfigurationTabAO.class)
-                .deleteConfiguration(configurationName, popup -> popup.cancel())
+                .deleteConfiguration(configurationName, ConfirmationPopupAO::cancel)
                 .ensure(profileWithName(configurationName), exist.because(deletionWasCancelled))
                 .deleteConfiguration(configurationName, popup -> popup.ensureTitleIs(expectedTitle).ok())
                 .ensure(profileWithName(configurationName), not(exist).because(deletionWasConfirmed))
@@ -372,9 +374,5 @@ public class PipelineConfigurationTest extends AbstractSeveralPipelineRunningTes
 
     private static PipelineRunFormAO onLaunchPage() {
         return new PipelineRunFormAO();
-    }
-
-    private String withActualRunId(final String message) {
-        return message.replaceAll("run_id", getLastRunId());
     }
 }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/RestrictionsOnInstancePriceTypeTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/RestrictionsOnInstancePriceTypeTest.java
@@ -82,7 +82,7 @@ public class RestrictionsOnInstancePriceTypeTest extends AbstractBfxPipelineTest
     private final String secondConfiguration = "restrictionTestConfiguration" + Utils.randomSuffix();
     private final String customDisk = "22";
     private final String configurationName = "customConfig";
-    private final String testRole = C.ROLE_USER;
+    private final String testGroup = C.ROLE_USER;
     private final String instanceTypesMask = "Allowed instance types mask";
     private final String toolInstanceTypesMask = "Allowed tool instance types mask";
     private final String onDemandPrice = "On demand";
@@ -106,7 +106,7 @@ public class RestrictionsOnInstancePriceTypeTest extends AbstractBfxPipelineTest
         loginAs(admin);
         setMaskForUser(user.login, instanceTypesMask, "");
         setMaskForUser(user.login, toolInstanceTypesMask, "");
-        setMaskForRole(testRole, instanceTypesMask, "");
+        setMaskForGroup(testGroup, instanceTypesMask, "");
         setClusterAllowedStringPreference(clusterAllowedInstanceTypes, defaultClusterAllowedInstanceTypes);
         setClusterAllowedStringPreference(clusterAllowedInstanceTypesDocker, defaultClusterAllowedInstanceTypes);
         setClusterAllowedStringPreference(clusterAllowedPriceTypes, defaultClusterAllowedPriceTypes);
@@ -116,8 +116,8 @@ public class RestrictionsOnInstancePriceTypeTest extends AbstractBfxPipelineTest
         navigationMenu()
                 .settings()
                 .switchToUserManagement()
-                .switchToRoles()
-                .editRole(testRole)
+                .switchToGroups()
+                .editGroup(testGroup)
                 .clearAllowedPriceTypeField()
                 .ok();
         tools()
@@ -245,13 +245,13 @@ public class RestrictionsOnInstancePriceTypeTest extends AbstractBfxPipelineTest
     public void validationOfInstanceTypesRestrictionsForUserGroup() {
         try {
             loginAs(admin);
-            setMaskForRole(testRole, instanceTypesMask, format("%s.*", instanceFamilyName));
+            setMaskForGroup(testGroup, instanceTypesMask, format("%s.*", instanceFamilyName));
             logout();
             validationOfInstanceTypesRestrictions();
         } finally {
             logout();
             loginAs(admin);
-            setMaskForRole(testRole, instanceTypesMask, "");
+            setMaskForGroup(testGroup, instanceTypesMask, "");
         }
     }
 
@@ -279,7 +279,7 @@ public class RestrictionsOnInstancePriceTypeTest extends AbstractBfxPipelineTest
     public void validationOfToolsInstanceTypesRestrictionsForUserGroup() {
         try {
             loginAs(admin);
-            setMaskForRole(testRole, toolInstanceTypesMask, format("%s.*", instanceFamilyName));
+            setMaskForGroup(testGroup, toolInstanceTypesMask, format("%s.*", instanceFamilyName));
             logout();
             loginAs(user);
             tools()
@@ -289,7 +289,7 @@ public class RestrictionsOnInstancePriceTypeTest extends AbstractBfxPipelineTest
         } finally {
             logout();
             loginAs(admin);
-            setMaskForRole(testRole, toolInstanceTypesMask, "");
+            setMaskForGroup(testGroup, toolInstanceTypesMask, "");
         }
     }
 
@@ -348,7 +348,7 @@ public class RestrictionsOnInstancePriceTypeTest extends AbstractBfxPipelineTest
                                     .setValue(DISK, customDisk)
                                     .sleep(3, SECONDS)
                                     .click(SAVE))
-                                    .sleep(2, SECONDS);
+                    .sleep(2, SECONDS);
             setClusterAllowedStringPreference(clusterAllowedInstanceTypes, format("%s.*", instanceFamilyName));
             logout();
             loginAs(user);
@@ -422,7 +422,7 @@ public class RestrictionsOnInstancePriceTypeTest extends AbstractBfxPipelineTest
             String[] masks = clusterAllowedMasks.split(",");
             loginAs(admin);
             setClusterAllowedStringPreference(clusterAllowedInstanceTypes, format("%s*", masks[0]));
-            setMaskForRole(testRole, instanceTypesMask, format("%s*", masks[1]));
+            setMaskForGroup(testGroup, instanceTypesMask, format("%s*", masks[1]));
             setMaskForUser(user.login, instanceTypesMask, format("%s*", masks[2]));
             setMaskForUser(user.login, toolInstanceTypesMask, format("%s*", masks[3]));
             logout();
@@ -459,7 +459,7 @@ public class RestrictionsOnInstancePriceTypeTest extends AbstractBfxPipelineTest
             logout();
             loginAs(admin);
             setClusterAllowedStringPreference(clusterAllowedInstanceTypes, defaultClusterAllowedInstanceTypes);
-            setMaskForRole(testRole, instanceTypesMask, "");
+            setMaskForGroup(testGroup, instanceTypesMask, "");
             setMaskForUser(user.login, instanceTypesMask, "");
             setMaskForUser(user.login, toolInstanceTypesMask, "");
         }
@@ -537,8 +537,8 @@ public class RestrictionsOnInstancePriceTypeTest extends AbstractBfxPipelineTest
             navigationMenu()
                     .settings()
                     .switchToUserManagement()
-                    .switchToRoles()
-                    .editRole(testRole)
+                    .switchToGroups()
+                    .editGroup(testGroup)
                     .setAllowedPriceType(onDemandPrice)
                     .ok();
             logout();
@@ -550,8 +550,8 @@ public class RestrictionsOnInstancePriceTypeTest extends AbstractBfxPipelineTest
             navigationMenu()
                     .settings()
                     .switchToUserManagement()
-                    .switchToRoles()
-                    .editRole(testRole)
+                    .switchToGroups()
+                    .editGroup(testGroup)
                     .clearAllowedPriceTypeField()
                     .ok();
         }
@@ -668,12 +668,12 @@ public class RestrictionsOnInstancePriceTypeTest extends AbstractBfxPipelineTest
                 .ok();
     }
 
-    private void setMaskForRole(String role, String mask, String value) {
+    private void setMaskForGroup(String group, String mask, String value) {
         navigationMenu()
                 .settings()
                 .switchToUserManagement()
-                .switchToRoles()
-                .editRole(role)
+                .switchToGroups()
+                .editGroup(group)
                 .addAllowedLaunchOptions(mask, value)
                 .ok();
     }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/RoleBasedAccessControlTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/RoleBasedAccessControlTest.java
@@ -227,9 +227,6 @@ public class RoleBasedAccessControlTest extends AbstractSeveralPipelineRunningTe
     @Test
     @TestCase({"EPMCMBIBPC-3016"})
     public void blockUnblockUser() {
-        if (impersonateMode()) {
-            return;
-        }
         try {
             loginAs(user);
             tools()
@@ -247,8 +244,6 @@ public class RoleBasedAccessControlTest extends AbstractSeveralPipelineRunningTe
                     .blockUser(user.login.toUpperCase())
                     .ok();
             logout();
-            loginAs(user);
-            validateWhileErrorPageMessage();
             loginAs(user);
             validateWhileErrorPageMessage();
         } finally {
@@ -356,17 +351,24 @@ public class RoleBasedAccessControlTest extends AbstractSeveralPipelineRunningTe
 
     private void validateWhileErrorPageMessage() {
         if ("true".equals(C.AUTH_TOKEN)) {
+            if (impersonateMode()) {
+                navigationMenu()
+                        .settings()
+                        .switchToMyProfile()
+                        .validateUserName(admin.login);
+                return;
+            }
             validateErrorPage(singletonList("User is blocked!"));
             Selenide.clearBrowserCookies();
             sleep(1, SECONDS);
-            return;
+        } else {
+            validateErrorPage(Arrays.asList(
+                    "Please contact", "Support team", "to request the access",
+                    format("login back to the %s", C.PLATFORM_NAME),
+                    "if you already own an account")
+            );
+            loginBack();
         }
-        validateErrorPage(Arrays.asList(
-                "Please contact", "Support team", "to request the access",
-                format("login back to the %s", C.PLATFORM_NAME),
-                "if you already own an account")
-        );
-        loginBack();
     }
 
     private void loginWithToken(final String token) {

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/RoleBasedAccessControlTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/RoleBasedAccessControlTest.java
@@ -95,6 +95,8 @@ public class RoleBasedAccessControlTest extends AbstractSeveralPipelineRunningTe
     @AfterClass(alwaysRun = true)
     public void loginToDeleteEntities() {
         loginAs(admin);
+        library()
+                .removeStorageIfExists(format("%s-home", testUser));
     }
 
     @Test
@@ -130,15 +132,17 @@ public class RoleBasedAccessControlTest extends AbstractSeveralPipelineRunningTe
     @TestCase({"EPMCMBIBPC-3019"})
     public void addTheUser() {
         loginAs(admin);
-        storageUserHomeAutoState = navigationMenu()
-                .settings()
-                .switchToPreferences()
-                .getCheckboxPreferenceState("storage.user.home.auto");
-        navigationMenu()
-                .settings()
-                .switchToPreferences()
-                .setCheckboxPreference("storage.user.home.auto", false, true)
-                .saveIfNeeded();
+        if(!impersonateMode()) {
+            storageUserHomeAutoState = navigationMenu()
+                    .settings()
+                    .switchToPreferences()
+                    .getCheckboxPreferenceState("storage.user.home.auto");
+            navigationMenu()
+                    .settings()
+                    .switchToPreferences()
+                    .setCheckboxPreference("storage.user.home.auto", false, true)
+                    .saveIfNeeded();
+        }
         navigationMenu()
                 .settings()
                 .switchToUserManagement()

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/RoleBasedAccessControlTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/RoleBasedAccessControlTest.java
@@ -350,25 +350,25 @@ public class RoleBasedAccessControlTest extends AbstractSeveralPipelineRunningTe
     }
 
     private void validateWhileErrorPageMessage() {
+        if (impersonateMode()) {
+            navigationMenu()
+                    .settings()
+                    .switchToMyProfile()
+                    .validateUserName(admin.login);
+            return;
+        }
         if ("true".equals(C.AUTH_TOKEN)) {
-            if (impersonateMode()) {
-                navigationMenu()
-                        .settings()
-                        .switchToMyProfile()
-                        .validateUserName(admin.login);
-                return;
-            }
             validateErrorPage(singletonList("User is blocked!"));
             Selenide.clearBrowserCookies();
             sleep(1, SECONDS);
-        } else {
-            validateErrorPage(Arrays.asList(
-                    "Please contact", "Support team", "to request the access",
-                    format("login back to the %s", C.PLATFORM_NAME),
-                    "if you already own an account")
-            );
-            loginBack();
+            return;
         }
+        validateErrorPage(Arrays.asList(
+                "Please contact", "Support team", "to request the access",
+                format("login back to the %s", C.PLATFORM_NAME),
+                "if you already own an account")
+        );
+        loginBack();
     }
 
     private void loginWithToken(final String token) {

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/RoleBasedAccessControlTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/RoleBasedAccessControlTest.java
@@ -304,6 +304,17 @@ public class RoleBasedAccessControlTest extends AbstractSeveralPipelineRunningTe
         loginAs(admin);
     }
 
+    @Test
+    @TestCase({"2144"})
+    public void allowToImpersonateAdministratorAsGeneralUser() {
+        logoutIfNeeded();
+        loginAs(admin);
+        impersonateAs(user.login);
+        checkUserName(user);
+        stopImpersonation();
+        checkUserName(admin);
+    }
+
     private void validateWhileErrorPageMessage() {
         if ("true".equals(C.AUTH_TOKEN)) {
             validateErrorPage(singletonList("User is blocked!"));
@@ -326,5 +337,12 @@ public class RoleBasedAccessControlTest extends AbstractSeveralPipelineRunningTe
         }
         final Account userWithToken = new Account(user.login, token);
         loginAs(userWithToken);
+    }
+
+    private void checkUserName(Account user) {
+        navigationMenu()
+                .settings()
+                .switchToMyProfile()
+                .validateUserName(user.login);
     }
 }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/RoleBasedAccessControlTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/RoleBasedAccessControlTest.java
@@ -153,7 +153,7 @@ public class RoleBasedAccessControlTest extends AbstractSeveralPipelineRunningTe
                 .switchToUserManagement()
                 .switchToUsers()
                 .checkUserExist(testUser)
-                .checkUserRoles(testUser, C.ROLE_USER, "ROLE_PIPELINE_MANAGER",
+                .checkUserRoles(testUser, "ROLE_USER", "ROLE_PIPELINE_MANAGER",
                         "ROLE_FOLDER_MANAGER", "ROLE_CONFIGURATION_MANAGER");
     }
 

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/RoleBasedAccessControlTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/RoleBasedAccessControlTest.java
@@ -16,6 +16,7 @@
 package com.epam.pipeline.autotests;
 
 import com.codeborne.selenide.Selenide;
+import com.epam.pipeline.autotests.ao.AuthenticationPageAO;
 import com.epam.pipeline.autotests.ao.ShellAO;
 import com.epam.pipeline.autotests.ao.ToolTab;
 import com.epam.pipeline.autotests.mixins.Authorization;
@@ -107,9 +108,14 @@ public class RoleBasedAccessControlTest extends AbstractSeveralPipelineRunningTe
     @Test
     @TestCase(value = "EPMCMBIBPC-3015")
     public void failedAuthentication() {
-        Utils.restartBrowser(C.ROOT_ADDRESS);
-        final Account wrongAccount = new Account(C.LOGIN, format("123%s", C.PASSWORD));
-        loginAs(wrongAccount);
+        Selenide.close();
+        Selenide.open(C.ROOT_ADDRESS);
+        if ("false".equals(C.AUTH_TOKEN)) {
+            new AuthenticationPageAO()
+                    .login(C.LOGIN)
+                    .password(format("123%s", C.PASSWORD))
+                    .signIn();
+        }
         if ("true".equals(C.AUTH_TOKEN)) {
             validateErrorPage(singletonList("type=Unauthorized, status=401"));
             Selenide.clearBrowserCookies();
@@ -117,7 +123,7 @@ public class RoleBasedAccessControlTest extends AbstractSeveralPipelineRunningTe
         } else {
             validateErrorPage(singletonList("Incorrect user name or password"));
         }
-        loginAs(admin);
+        restartBrowser(C.ROOT_ADDRESS);
     }
 
     @Test
@@ -286,7 +292,7 @@ public class RoleBasedAccessControlTest extends AbstractSeveralPipelineRunningTe
                 .waitEndpoint()
                 .attr("href");
         logout();
-        Utils.restartBrowser(endpoint);
+        restartBrowser(endpoint);
         new ShellAO().assertPageContains("type=Unauthorized, status=401").close();
         open(C.ROOT_ADDRESS);
         loginAs(admin);
@@ -303,7 +309,7 @@ public class RoleBasedAccessControlTest extends AbstractSeveralPipelineRunningTe
         open(endpoint);
         screenshot("Endpoint_page");
         new ShellAO().assertPageContains(C.ANONYMOUS_NAME);
-        Utils.restartBrowser(C.ROOT_ADDRESS);
+        restartBrowser(C.ROOT_ADDRESS);
         loginAs(admin);
     }
 

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/RoleBasedAccessControlTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/RoleBasedAccessControlTest.java
@@ -262,7 +262,7 @@ public class RoleBasedAccessControlTest extends AbstractSeveralPipelineRunningTe
         runsMenu()
                 .activeRuns()
                 .shouldContainRun("pipeline", getLastRunId())
-                .validatePipelineOwner(getLastRunId(), user.login.toLowerCase());
+                .validatePipelineOwner(getLastRunId(), user.login);
     }
 
     @Test

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/RoleBasedAccessControlTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/RoleBasedAccessControlTest.java
@@ -209,6 +209,9 @@ public class RoleBasedAccessControlTest extends AbstractSeveralPipelineRunningTe
     @Test
     @TestCase({"EPMCMBIBPC-3016"})
     public void blockUnblockUser() {
+        if (impersonateMode()) {
+            return;
+        }
         try {
             loginAs(user);
             tools()

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/RunPipelineTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/RunPipelineTest.java
@@ -15,6 +15,7 @@
  */
 package com.epam.pipeline.autotests;
 
+import com.codeborne.selenide.Condition;
 import com.epam.pipeline.autotests.ao.LogAO;
 import com.epam.pipeline.autotests.ao.NodePage;
 import com.epam.pipeline.autotests.ao.Template;
@@ -261,7 +262,9 @@ public class RunPipelineTest extends AbstractSeveralPipelineRunningTest implemen
     @Test(priority = 2, dependsOnMethods = "runShouldNotAppearInActiveRuns")
     @TestCase({"EPMCMBIBPC-280", "EPMCMBIBPC-301"})
     public void nodePageShouldBeValid() {
-        final By nonMasterNode = Combiners.select(not(master()), node(), "any non-master node");
+        final By nonMasterNode = Combiners.select(
+                Condition.and("node neither master nor windows", not(master()), not(windows())),
+                node(), "any non-master node");
         clusterMenu()
             .click(nonMasterNode, NodePage::new)
             .ensure(button("Refresh"), visible, enabled)

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/RunToolsInSandBoxTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/RunToolsInSandBoxTest.java
@@ -134,7 +134,7 @@ public class RunToolsInSandBoxTest
         logout();
 
         // in order to avoid caching issue
-        Utils.restartBrowser(C.ROOT_ADDRESS);
+        restartBrowser(C.ROOT_ADDRESS);
 
         loginAs(user)
                 .runs()

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/SharingRunsTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/SharingRunsTest.java
@@ -96,7 +96,7 @@ public class SharingRunsTest extends AbstractSinglePipelineRunningTest implement
                     .shareWithUser(user.login, false)
                     .validateShareLink(user.login);
             logout();
-            Utils.restartBrowser(C.ROOT_ADDRESS);
+            restartBrowser(C.ROOT_ADDRESS);
             loginAs(user);
             sleep(timeout, SECONDS);
             open(endpointsLink);
@@ -111,7 +111,7 @@ public class SharingRunsTest extends AbstractSinglePipelineRunningTest implement
                     .removeShareUserGroup(user.login)
                     .ensure(SHARE_WITH, text("Not shared (click to configure)"));
             logout();
-            Utils.restartBrowser(C.ROOT_ADDRESS);
+            restartBrowser(C.ROOT_ADDRESS);
             loginAs(user);
             sleep(timeout, SECONDS);
             open(endpointsLink, "", user.login, user.password);
@@ -134,7 +134,7 @@ public class SharingRunsTest extends AbstractSinglePipelineRunningTest implement
                             .validateShareLink(userGroup.toLowerCase())
                     );
             logout();
-            Utils.restartBrowser(C.ROOT_ADDRESS);
+            restartBrowser(C.ROOT_ADDRESS);
             loginAs(user);
             sleep(timeout, SECONDS);
             open(endpointsLink);
@@ -149,7 +149,7 @@ public class SharingRunsTest extends AbstractSinglePipelineRunningTest implement
                     .removeShareUserGroup(userGroup)
                     .ensure(SHARE_WITH, text("Not shared (click to configure)"));
             logout();
-            Utils.restartBrowser(C.ROOT_ADDRESS);
+            restartBrowser(C.ROOT_ADDRESS);
             loginAs(user);
             sleep(timeout, SECONDS);
             open(endpointsLink, "", user.login, user.password);
@@ -171,7 +171,7 @@ public class SharingRunsTest extends AbstractSinglePipelineRunningTest implement
                     .shareWithUser(user.login, false)
                     .validateShareLink(user.login);
             logout();
-            Utils.restartBrowser(C.ROOT_ADDRESS);
+            restartBrowser(C.ROOT_ADDRESS);
             sleep(timeout, SECONDS);
             loginAs(user);
             final String[] name = endpointsName.split("/");
@@ -193,7 +193,7 @@ public class SharingRunsTest extends AbstractSinglePipelineRunningTest implement
                     .removeShareUserGroup(user.login)
                     .ensure(SHARE_WITH, text("Not shared (click to configure)"));
             logout();
-            Utils.restartBrowser(C.ROOT_ADDRESS);
+            restartBrowser(C.ROOT_ADDRESS);
             loginAs(user);
             sleep(timeout, SECONDS);
             home()
@@ -229,7 +229,7 @@ public class SharingRunsTest extends AbstractSinglePipelineRunningTest implement
                             .assertPageContains("123")
                             .close());
             logout();
-            Utils.restartBrowser(C.ROOT_ADDRESS);
+            restartBrowser(C.ROOT_ADDRESS);
             sleep(timeout, SECONDS);
             loginAs(user);
             final String[] name = endpointsName.split("/");
@@ -246,13 +246,12 @@ public class SharingRunsTest extends AbstractSinglePipelineRunningTest implement
                     .assertPageContains("123")
                     .closeTab();
             logout();
-            Utils.restartBrowser(C.ROOT_ADDRESS);
-            loginAs(admin);
+            restartBrowser(C.ROOT_ADDRESS);
             runsMenu()
                     .showLog(runID)
                     .setEnableSShConnection(user.login);
             logout();
-            Utils.restartBrowser(C.ROOT_ADDRESS);
+            restartBrowser(C.ROOT_ADDRESS);
             sleep(timeout, SECONDS);
             loginAs(user);
             home()

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/SystemLoggingTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/SystemLoggingTest.java
@@ -117,7 +117,7 @@ public class SystemLoggingTest extends AbstractSeveralPipelineRunningTest implem
                     .ok();
             logout();
             loginAs(userWithoutCompletedRuns);
-            if ("false".equals(C.AUTH_TOKEN)) {
+            if ("false".equals(C.AUTH_TOKEN) && !impersonateMode()) {
                 validateErrorPage(Collections.singletonList(format("%s was not able to authorize you", C.PLATFORM_NAME)));
                 loginBack();
             } else {
@@ -192,8 +192,8 @@ public class SystemLoggingTest extends AbstractSeveralPipelineRunningTest implem
                 .switchToSystemLogs()
                 .filterByUser(admin.login)
                 .filterByMessage(format("id=%s", userId))
-                .validateRow(format("Assing role. RoleId=2 UserIds=%s", userId), admin.login, TYPE)
-                .validateRow(format("Unassing role. RoleId=2 UserIds=%s", userId), admin.login, TYPE);
+                .validateRow(format("Assing role. RoleId=[0-9]+ UserIds=%s", userId), admin.login, TYPE)
+                .validateRow(format("Unassing role. RoleId=[0-9]+ UserIds=%s", userId), admin.login, TYPE);
     }
 
     @Test
@@ -258,10 +258,10 @@ public class SystemLoggingTest extends AbstractSeveralPipelineRunningTest implem
                 .filterByUser(user.login.toUpperCase())
                 .filterByService("edge")
                 .validateRow(format(
-                        ".*\\[SECURITY\\] Application: /pipeline-%s-%s-0/; User: %s; Status: Successfully authenticated",
+                        ".*[SECURITY] Application: /pipeline-%s-%s-0/; User: %s; Status: Successfully authenticated",
                         getLastRunId(), endpoint, user.login), user.login, TYPE)
                 .validateRow(format(
-                        ".*\\[SECURITY\\] Application: SSH-/ssh/pipeline/%s; User: %s; Status: Successfully authenticated",
+                        ".*[SECURITY] Application: SSH-/ssh/pipeline/%s; User: %s; Status: Successfully authenticated",
                         getLastRunId(), user.login), user.login, TYPE);
     }
 

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/SystemLoggingTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/SystemLoggingTest.java
@@ -92,7 +92,6 @@ public class SystemLoggingTest extends AbstractSeveralPipelineRunningTest implem
             }
             adminInfo = getInfo(systemLogsAO, format("Successfully authenticate user: %s", admin.login),
                     stopAction, admin);
-            System.out.println(adminInfo.text());
             userInfo = getInfo(systemLogsAO, format("Successfully authenticate user: %s", user.login), startAction,
                     user);
         } catch (NoSuchElementException e) {

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/SystemLoggingTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/SystemLoggingTest.java
@@ -117,20 +117,21 @@ public class SystemLoggingTest extends AbstractSeveralPipelineRunningTest implem
                     .ok();
             logout();
             loginAs(userWithoutCompletedRuns);
-            if (!impersonateMode()) {
+            if (impersonateMode()) {
+                navigationMenu()
+                        .settings()
+                        .switchToMyProfile()
+                        .validateUserName(admin.login);
+            } else {
                 if ("false".equals(C.AUTH_TOKEN)) {
-                    validateErrorPage(Collections.singletonList(format("%s was not able to authorize you", C.PLATFORM_NAME)));
+                    validateErrorPage(Collections.singletonList(format("%s was not able to authorize you",
+                            C.PLATFORM_NAME)));
                     loginBack();
                     return;
                 }
                 validateErrorPage(Collections.singletonList("User is blocked!"));
                 Selenide.clearBrowserCookies();
                 sleep(1, SECONDS);
-            } else {
-                navigationMenu()
-                        .settings()
-                        .switchToMyProfile()
-                        .validateUserName(admin.login);
             }
             loginAs(admin);
             navigationMenu()
@@ -265,10 +266,10 @@ public class SystemLoggingTest extends AbstractSeveralPipelineRunningTest implem
                 .filterByUser(user.login.toUpperCase())
                 .filterByService("edge")
                 .validateRow(format(
-                        ".*\\[SECURITY\\] Application: /pipeline-%s-%s-0/; User: %s; Status: Successfully authenticated.",
+                        ".*\\[SECURITY\\] Application: /pipeline-%s-%s-0/; User: %s; Status: Successfully authenticated",
                         getLastRunId(), endpoint, user.login), user.login, TYPE)
                 .validateRow(format(
-                        ".*\\[SECURITY\\] Application: SSH-/ssh/pipeline/%s; User: %s; Status: Successfully authenticated.",
+                        ".*\\[SECURITY\\] Application: SSH-/ssh/pipeline/%s; User: %s; Status: Successfully authenticated",
                         getLastRunId(), user.login), user.login, TYPE);
     }
 

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/SystemLoggingTest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/SystemLoggingTest.java
@@ -117,13 +117,20 @@ public class SystemLoggingTest extends AbstractSeveralPipelineRunningTest implem
                     .ok();
             logout();
             loginAs(userWithoutCompletedRuns);
-            if ("false".equals(C.AUTH_TOKEN) && !impersonateMode()) {
-                validateErrorPage(Collections.singletonList(format("%s was not able to authorize you", C.PLATFORM_NAME)));
-                loginBack();
-            } else {
+            if (!impersonateMode()) {
+                if ("false".equals(C.AUTH_TOKEN)) {
+                    validateErrorPage(Collections.singletonList(format("%s was not able to authorize you", C.PLATFORM_NAME)));
+                    loginBack();
+                    return;
+                }
                 validateErrorPage(Collections.singletonList("User is blocked!"));
                 Selenide.clearBrowserCookies();
                 sleep(1, SECONDS);
+            } else {
+                navigationMenu()
+                        .settings()
+                        .switchToMyProfile()
+                        .validateUserName(admin.login);
             }
             loginAs(admin);
             navigationMenu()
@@ -258,10 +265,10 @@ public class SystemLoggingTest extends AbstractSeveralPipelineRunningTest implem
                 .filterByUser(user.login.toUpperCase())
                 .filterByService("edge")
                 .validateRow(format(
-                        ".*[SECURITY] Application: /pipeline-%s-%s-0/; User: %s; Status: Successfully authenticated",
+                        ".*\\[SECURITY\\] Application: /pipeline-%s-%s-0/; User: %s; Status: Successfully authenticated.",
                         getLastRunId(), endpoint, user.login), user.login, TYPE)
                 .validateRow(format(
-                        ".*[SECURITY] Application: SSH-/ssh/pipeline/%s; User: %s; Status: Successfully authenticated",
+                        ".*\\[SECURITY\\] Application: SSH-/ssh/pipeline/%s; User: %s; Status: Successfully authenticated.",
                         getLastRunId(), user.login), user.login, TYPE);
     }
 

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/AccessObject.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/AccessObject.java
@@ -271,7 +271,7 @@ public interface AccessObject<ELEMENT_TYPE extends AccessObject> {
         while (selenideElement.is(collapsedTab) && attempt < maxAttempts) {
             selenideElement.click();
             sleep(1, SECONDS);
-            attempt += 1;
+            attempt++;
         }
         selenideElement.shouldBe(expandedTab);
         return (ELEMENT_TYPE) this;

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/AccessObject.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/AccessObject.java
@@ -266,8 +266,12 @@ public interface AccessObject<ELEMENT_TYPE extends AccessObject> {
     default ELEMENT_TYPE expandTab(final Primitive element) {
         final SelenideElement selenideElement = get(element);
         selenideElement.should(exist);
-        if (selenideElement.is(collapsedTab)) {
+        int attempt = 0;
+        int maxAttempts = 5;
+        while (selenideElement.is(collapsedTab) && attempt < maxAttempts) {
             selenideElement.click();
+            sleep(1, SECONDS);
+            attempt += 1;
         }
         selenideElement.shouldBe(expandedTab);
         return (ELEMENT_TYPE) this;

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/ClusterMenuAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/ClusterMenuAO.java
@@ -73,6 +73,16 @@ public class ClusterMenuAO implements AccessObject<ClusterMenuAO> {
         };
     }
 
+    public static Condition windows() {
+        return new Condition("windows node") {
+            @Override
+            public boolean apply(final WebElement element) {
+                return contains(nodeLabel("WINDOWS"))
+                        .test(element);
+            }
+        };
+    }
+
     public enum HeaderColumn {
         DATE("cluster__cluster-node-row-created"),
         NAME("cluster__cluster-node-row-name"),

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/NavigationHomeAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/NavigationHomeAO.java
@@ -16,6 +16,7 @@
 package com.epam.pipeline.autotests.ao;
 
 import com.codeborne.selenide.SelenideElement;
+import com.epam.pipeline.autotests.mixins.Authorization;
 import com.epam.pipeline.autotests.utils.Utils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/NavigationHomeAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/NavigationHomeAO.java
@@ -16,7 +16,6 @@
 package com.epam.pipeline.autotests.ao;
 
 import com.codeborne.selenide.SelenideElement;
-import com.epam.pipeline.autotests.mixins.Authorization;
 import com.epam.pipeline.autotests.utils.Utils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/PipelineRunFormAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/PipelineRunFormAO.java
@@ -111,8 +111,9 @@ public class PipelineRunFormAO implements AccessObject<PipelineRunFormAO> {
                 .find(className("ant-select-selection"))
                 .shouldBe(visible)
                 .click();
-
+        $(byClassName("ant-select-dropdown-hidden")).shouldNotBe(exist);
         $(byClassName("ant-select-dropdown-menu"))
+                .shouldBe(enabled)
                 .findAll(byClassName("ant-select-dropdown-menu-item"))
                 .find(text(type))
                 .click();

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/PipelineRunFormAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/PipelineRunFormAO.java
@@ -101,6 +101,7 @@ public class PipelineRunFormAO implements AccessObject<PipelineRunFormAO> {
 
     public PipelineRunFormAO setLaunchOptions(String disk, String type, String timeOut) {
         return setDisk(disk)
+                .sleep(1, SECONDS)
                 .setTypeValue(type)
                 .setTimeOut(timeOut);
     }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/Primitive.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/Primitive.java
@@ -287,5 +287,7 @@ public enum Primitive {
     DO_NOT_MOUNT_STORAGES,
     LAUNCH_COMMANDS,
     CONFIGURE,
-    GENERATE_URL
+    GENERATE_URL,
+    IMPERSONATE,
+    MY_PROFILE
 }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/SettingsPageAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/SettingsPageAO.java
@@ -31,11 +31,11 @@ import org.openqa.selenium.WebElement;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -256,13 +256,10 @@ public class SettingsPageAO extends PopupAO<SettingsPageAO, PipelinesLibraryAO> 
 
         public void deleteTestEntries(final List<String> initEntries) {
             sleep(2, SECONDS);
-            List<SelenideElement> entries = getAllEntries();
-            if (entries.isEmpty()) {
-                return;
-            }
-            entries.stream()
-                    .filter(e -> !initEntries.contains(e.find(byClassName("notification-title-column")).text()))
-                    .forEach(this::removeEntry);
+            Optional.ofNullable(getAllEntries())
+                    .ifPresent(entries -> entries.stream()
+                            .filter(e -> !initEntries.contains(e.find(byClassName("notification-title-column")).text()))
+                            .forEach(this::removeEntry));
         }
 
         private void removeEntry(SelenideElement entry) {

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/SettingsPageAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/SettingsPageAO.java
@@ -254,16 +254,15 @@ public class SettingsPageAO extends PopupAO<SettingsPageAO, PipelinesLibraryAO> 
                     .collect(toList());
         }
 
-        public SystemEventsAO deleteTestEntries(List<String> initEntries) {
+        public void deleteTestEntries(final List<String> initEntries) {
             sleep(2, SECONDS);
             List<SelenideElement> entries = getAllEntries();
-            if (!entries.isEmpty()) {
-                entries.stream()
-                       .filter(e -> !initEntries.contains(e.find(byClassName("notification-title-column")).text()))
-                       .collect(toList())
-                       .forEach(this::removeEntry);
+            if (entries.isEmpty()) {
+                return;
             }
-            return this;
+            entries.stream()
+                    .filter(e -> !initEntries.contains(e.find(byClassName("notification-title-column")).text()))
+                    .forEach(this::removeEntry);
         }
 
         private void removeEntry(SelenideElement entry) {

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/SettingsPageAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/SettingsPageAO.java
@@ -1575,7 +1575,7 @@ public class SettingsPageAO extends PopupAO<SettingsPageAO, PipelinesLibraryAO> 
         }
 
         public SystemLogsAO filterByService(final String service) {
-            selectValue(combobox("Service"), service);
+            selectValue(combobox("Service"), service).enter();
             return this;
         }
 

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/SettingsPageAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/SettingsPageAO.java
@@ -206,9 +206,10 @@ public class SettingsPageAO extends PopupAO<SettingsPageAO, PipelinesLibraryAO> 
         }
 
         public SystemEventsAO ensureTableHasNoDateText() {
-            if(getAllEntries() == null) {
-                ensure(TABLE, matchesText("No data"));
+            if (getAllEntries() != null) {
+                return this;
             }
+            ensure(TABLE, matchesText("No data"));
             return this;
         }
 

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/SettingsPageAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/SettingsPageAO.java
@@ -72,6 +72,7 @@ public class SettingsPageAO extends PopupAO<SettingsPageAO, PipelinesLibraryAO> 
             entry(SYSTEM_LOGS_TAB, context().find(byXpath("//*[contains(@class, 'ant-menu-item') and contains(., 'System Logs')]"))),
             entry(EMAIL_NOTIFICATIONS_TAB, context().find(byXpath("//*[contains(@class, 'ant-menu-item') and contains(., 'Email notifications')]"))),
             entry(CLOUD_REGIONS_TAB, context().find(byXpath("//*[contains(@class, 'ant-menu-item') and contains(., 'Cloud regions')]"))),
+            entry(MY_PROFILE, context().find(byXpath("//*[contains(@class, 'ant-menu-item') and contains(., 'My Profile')]"))),
             entry(OK, context().find(byId("settings-form-ok-button")))
     );
 
@@ -108,6 +109,11 @@ public class SettingsPageAO extends PopupAO<SettingsPageAO, PipelinesLibraryAO> 
     public SystemLogsAO switchToSystemLogs() {
         click(SYSTEM_LOGS_TAB);
         return new SystemLogsAO();
+    }
+
+    public MyProfileAO switchToMyProfile() {
+        click(MY_PROFILE);
+        return new MyProfileAO();
     }
 
     @Override
@@ -666,7 +672,8 @@ public class SettingsPageAO extends PopupAO<SettingsPageAO, PipelinesLibraryAO> 
                             entry(DELETE, context().$(byId("delete-user-button"))),
                             entry(PRICE_TYPE, context().find(byXpath(
                                     format("//div/b[text()='%s']/following::div/input", "Allowed price types")))),
-                            entry(CONFIGURE, context().$(byXpath(".//span[.='Can run as this user:']/following-sibling::a")))
+                            entry(CONFIGURE, context().$(byXpath(".//span[.='Can run as this user:']/following-sibling::a"))),
+                            entry(IMPERSONATE, context().$(button("IMPERSONATE")))
                     );
 
                     public EditUserPopup(UsersTabAO parentAO) {
@@ -783,6 +790,11 @@ public class SettingsPageAO extends PopupAO<SettingsPageAO, PipelinesLibraryAO> 
                                 .click();
                         new LogAO.ShareWith().click(OK);
                         return this;
+                    }
+
+                    public NavigationHomeAO impersonate() {
+                        click(IMPERSONATE);
+                        return new NavigationHomeAO();
                     }
                 }
             }
@@ -1589,6 +1601,21 @@ public class SettingsPageAO extends PopupAO<SettingsPageAO, PipelinesLibraryAO> 
             if ($(filterBy(name)).find(byClassName("ant-select-selection__clear")).isDisplayed()) {
                 $(filterBy(name)).find(byClassName("ant-select-selection__clear")).shouldBe(visible).click();
             }
+        }
+    }
+
+    public class MyProfileAO implements AccessObject<MyProfileAO> {
+        private final Map<Primitive,SelenideElement> elements = initialiseElements(
+                entry(USER_NAME, $(byClassName("ser-profile__header")))
+        );
+
+        public MyProfileAO validateUserName(String user) {
+            return ensure(USER_NAME, text(user));
+        }
+
+        @Override
+        public Map<Primitive, SelenideElement> elements() {
+            return elements;
         }
     }
 

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/SettingsPageAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/SettingsPageAO.java
@@ -1627,6 +1627,7 @@ public class SettingsPageAO extends PopupAO<SettingsPageAO, PipelinesLibraryAO> 
         public void validateTimeOrder(final SelenideElement info1, final SelenideElement info2) {
             LocalDateTime td1 = Utils.validateDateTimeString(info1.findAll("td").get(0).getText());
             LocalDateTime td2 = Utils.validateDateTimeString(info2.findAll("td").get(0).getText());
+            screenshot(format("SystemLogsValidateTimeOrder-%s", Utils.randomSuffix()));
             assertTrue(td1.isAfter(td2) || td1.isEqual(td2));
         }
 

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/SettingsPageAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/SettingsPageAO.java
@@ -205,9 +205,9 @@ public class SettingsPageAO extends PopupAO<SettingsPageAO, PipelinesLibraryAO> 
             return this;
         }
 
-        public SystemEventsAO ensureTableHasTextIfNeeded(String text) {
-            if(!impersonateMode()) {
-                ensure(TABLE, matchesText(text));
+        public SystemEventsAO ensureTableHasNoDateText() {
+            if(getAllEntries() == null) {
+                ensure(TABLE, matchesText("No data"));
             }
             return this;
         }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/SettingsPageAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/SettingsPageAO.java
@@ -1575,7 +1575,8 @@ public class SettingsPageAO extends PopupAO<SettingsPageAO, PipelinesLibraryAO> 
         }
 
         public SystemLogsAO filterByService(final String service) {
-            selectValue(combobox("Service"), service).enter();
+            selectValue(combobox("Service"), service);
+            click(byText("Service"));
             return this;
         }
 

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/SettingsPageAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/SettingsPageAO.java
@@ -241,17 +241,17 @@ public class SettingsPageAO extends PopupAO<SettingsPageAO, PipelinesLibraryAO> 
         }
 
         private List<SelenideElement> getAllEntries() {
-            return new ArrayList<>(context().find(byClassName("ant-table-content"))
-                    .findAll(byXpath(".//tr[contains(@class, 'ant-table-row-level-0')]")));
+            return context().find(byClassName("ant-table-content"))
+                    .findAll(byXpath(".//tr[contains(@class, 'ant-table-row-level-0')]"));
         }
 
         public List<String> getAllEntriesNames() {
             sleep(2, SECONDS);
-            return new ArrayList<>(context().find(byClassName("ant-table-content"))
+            return context().find(byClassName("ant-table-content"))
                     .findAll(byXpath(".//tr[contains(@class, 'ant-table-row-level-0')]"))
                     .stream()
                     .map(e -> e.find(byClassName("notification-title-column")).text())
-                    .collect(toList()));
+                    .collect(toList());
         }
 
         public SystemEventsAO deleteTestEntries(List<String> initEntries) {

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/SettingsPageAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/SettingsPageAO.java
@@ -910,6 +910,18 @@ public class SettingsPageAO extends PopupAO<SettingsPageAO, PipelinesLibraryAO> 
                 return this;
             }
 
+            public EditGroupPopup editGroup(final String group) {
+                sleep(1, SECONDS);
+                searchGroupBySubstring(group);
+                context().$$(byText(group))
+                        .filterBy(visible)
+                        .first()
+                        .closest(".ant-table-row-level-0")
+                        .find(byClassName("ant-btn-sm"))
+                        .click();
+                return new EditGroupPopup(this);
+            }
+
             public class CreateGroupPopup extends PopupAO<CreateGroupPopup, GroupsTabAO> implements AccessObject<CreateGroupPopup> {
                 private final GroupsTabAO parentAO;
 
@@ -948,6 +960,57 @@ public class SettingsPageAO extends PopupAO<SettingsPageAO, PipelinesLibraryAO> 
                 public GroupsTabAO cancel() {
                     click(CANCEL);
                     return parentAO;
+                }
+            }
+
+            public class EditGroupPopup extends PopupAO<EditGroupPopup, GroupsTabAO>
+                    implements AccessObject<EditGroupPopup> {
+                private final GroupsTabAO parentAO;
+                public final Map<Primitive, SelenideElement> elements = initialiseElements(
+                        entry(OK, context().find(By.id("close-edit-user-form"))),
+                        entry(PRICE_TYPE, context().find(byXpath(
+                                format("//div/b[text()='%s']/following::div/input", "Allowed price types"))))
+                );
+
+                public EditGroupPopup(final GroupsTabAO parentAO) {
+                    super(parentAO);
+                    this.parentAO = parentAO;
+                }
+
+                @Override
+                public Map<Primitive, SelenideElement> elements() {
+                    return elements;
+                }
+
+                @Override
+                public GroupsTabAO ok() {
+                    click(OK);
+                    return parentAO;
+                }
+
+                public EditGroupPopup addAllowedLaunchOptions(String option, String mask) {
+                    SettingsPageAO.this.addAllowedLaunchOptions(option, mask);
+                    return this;
+                }
+
+                public EditGroupPopup setAllowedPriceType(final String priceType) {
+                    click(PRICE_TYPE);
+                    context().find(byClassName("ant-select-dropdown")).find(byText(priceType))
+                            .shouldBe(visible)
+                            .click();
+                    click(byText("Allowed price types"));
+                    return this;
+                }
+
+                public EditGroupPopup clearAllowedPriceTypeField() {
+                    ensureVisible(PRICE_TYPE);
+                    SelenideElement type = context().$(byClassName("ant-select-selection__choice__remove"));
+                    while (type.isDisplayed()) {
+                        type.click();
+                        sleep(1, SECONDS);
+                    }
+                    click(byText("Allowed price types"));
+                    return this;
                 }
             }
         }
@@ -1020,31 +1083,6 @@ public class SettingsPageAO extends PopupAO<SettingsPageAO, PipelinesLibraryAO> 
                 public RolesTabAO ok() {
                     click(OK);
                     return parentAO;
-                }
-
-                public EditRolePopup addAllowedLaunchOptions(String option, String mask) {
-                    SettingsPageAO.this.addAllowedLaunchOptions(option, mask);
-                    return this;
-                }
-
-                public EditRolePopup setAllowedPriceType(final String priceType) {
-                    click(PRICE_TYPE);
-                    context().find(byClassName("ant-select-dropdown")).find(byText(priceType))
-                            .shouldBe(visible)
-                            .click();
-                    click(byText("Allowed price types"));
-                    return this;
-                }
-
-                public EditRolePopup clearAllowedPriceTypeField() {
-                    ensureVisible(PRICE_TYPE);
-                    SelenideElement type = context().$(byClassName("ant-select-selection__choice__remove"));
-                    while (type.isDisplayed()) {
-                        type.click();
-                        sleep(1, SECONDS);
-                    }
-                    click(byText("Allowed price types"));
-                    return this;
                 }
             }
         }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/StorageContentAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/StorageContentAO.java
@@ -653,6 +653,7 @@ public class StorageContentAO implements AccessObject<StorageContentAO> {
         }
 
         public StorageContentAO removeAllSelected() {
+            StorageContentAO.this.ensureVisible(CLEAR_SELECTION);
             StorageContentAO.this.click(REMOVE_ALL);
 
             $$(byClassName("ant-modal-content"))

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/mixins/Authorization.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/mixins/Authorization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static com.codeborne.selenide.Condition.appear;
+import static com.codeborne.selenide.Condition.empty;
 import static com.codeborne.selenide.Condition.enabled;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Selectors.byCssSelector;
@@ -36,6 +37,7 @@ import static com.codeborne.selenide.Selenide.$$;
 import static com.codeborne.selenide.Selenide.open;
 import static com.codeborne.selenide.Selenide.sleep;
 import static java.lang.String.format;
+import static org.openqa.selenium.By.tagName;
 
 public interface Authorization extends Navigation {
     Account admin = new Account(C.LOGIN, C.PASSWORD);
@@ -159,6 +161,10 @@ public interface Authorization extends Navigation {
 
     default boolean impersonateMode() {
         return "true".equalsIgnoreCase(C.IMPERSONATE_AUTH);
+    }
+
+    default void checkFailedAuthentication() {
+        $(tagName("body")).shouldBe(empty);
     }
 
     class Account {

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/mixins/Authorization.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/mixins/Authorization.java
@@ -54,6 +54,13 @@ public interface Authorization extends Navigation {
     }
 
     default NavigationMenuAO loginAs(Account account) {
+        if (impersonateMode()) {
+            if (C.LOGIN.equalsIgnoreCase(account.login)) {
+                return new NavigationMenuAO();
+            }
+            impersonateAs(account.login);
+            return new NavigationMenuAO();
+        }
         sleep(LOGIN_DELAY);
         if ("false".equals(C.AUTH_TOKEN)) {
             return new AuthenticationPageAO()
@@ -68,6 +75,12 @@ public interface Authorization extends Navigation {
     }
 
     default void logout() {
+        if (impersonateMode()) {
+            if (checkImpersonation()) {
+                stopImpersonation();
+            }
+            return;
+        }
         sleep(LOGIN_DELAY);
         new NavigationMenuAO().logout();
     }
@@ -142,6 +155,10 @@ public interface Authorization extends Navigation {
 
     default void loginBack() {
         $$(byCssSelector("a")).find(text(format("login back to the %s", C.PLATFORM_NAME))).shouldBe(enabled).click();
+    }
+
+    default boolean impersonateMode() {
+        return "true".equalsIgnoreCase(C.IMPERSONATE_AUTH);
     }
 
     class Account {

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/mixins/Navigation.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/mixins/Navigation.java
@@ -28,6 +28,8 @@ import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selectors.byId;
 import static com.codeborne.selenide.Selenide.$;
 import static com.epam.pipeline.autotests.utils.Conditions.selectedMenuItem;
+import static com.epam.pipeline.autotests.utils.Utils.sleep;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public interface Navigation {
 
@@ -88,6 +90,12 @@ public interface Navigation {
     }
 
     default boolean checkImpersonation() {
+        int attempt = 0;
+        int maxAttempts = 5;
+        while (!$(byId("navigation-button-stop-impersonation")).isDisplayed() || attempt < maxAttempts) {
+            sleep(1, SECONDS);
+            attempt += 1;
+        }
         return $(byId("navigation-button-stop-impersonation")).isDisplayed();
     }
 }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/mixins/Navigation.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/mixins/Navigation.java
@@ -86,6 +86,4 @@ public interface Navigation {
                 .edit()
                 .impersonate();
     }
-
-
 }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/mixins/Navigation.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/mixins/Navigation.java
@@ -86,4 +86,8 @@ public interface Navigation {
                 .edit()
                 .impersonate();
     }
+
+    default boolean checkImpersonation() {
+        return $(byId("navigation-button-stop-impersonation")).isEnabled();
+    }
 }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/mixins/Navigation.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/mixins/Navigation.java
@@ -86,4 +86,8 @@ public interface Navigation {
                 .edit()
                 .impersonate();
     }
+
+    default boolean checkImpersonation() {
+        return $(byId("navigation-button-stop-impersonation")).isDisplayed();
+    }
 }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/mixins/Navigation.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/mixins/Navigation.java
@@ -69,4 +69,23 @@ public interface Navigation {
         $(runsPageSelector).shouldBe(selectedMenuItem);
         return new RunsMenuAO();
     }
+
+    default NavigationHomeAO stopImpersonation() {
+        final By stopImpersonateSelector = byId("navigation-button-stop-impersonation");
+        $(stopImpersonateSelector).shouldBe(visible).click();
+        $(stopImpersonateSelector).shouldNotBe(visible);
+        return new NavigationHomeAO();
+    }
+
+    default NavigationHomeAO impersonateAs(String user) {
+        return navigationMenu()
+                .settings()
+                .switchToUserManagement()
+                .switchToUsers()
+                .searchUserEntry(user.toUpperCase())
+                .edit()
+                .impersonate();
+    }
+
+
 }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/mixins/Navigation.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/mixins/Navigation.java
@@ -28,6 +28,8 @@ import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selectors.byId;
 import static com.codeborne.selenide.Selenide.$;
 import static com.epam.pipeline.autotests.utils.Conditions.selectedMenuItem;
+import static com.epam.pipeline.autotests.utils.Utils.sleep;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public interface Navigation {
 
@@ -88,6 +90,12 @@ public interface Navigation {
     }
 
     default boolean checkImpersonation() {
+        int attempt = 0;
+        int maxAttempts = 5;
+        while (!$(byId("navigation-button-stop-impersonation")).isDisplayed() && attempt < maxAttempts) {
+            sleep(1, SECONDS);
+            attempt += 1;
+        }
         return $(byId("navigation-button-stop-impersonation")).isDisplayed();
     }
 }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/utils/C.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/utils/C.java
@@ -100,6 +100,9 @@ public class C {
         PIPE_INSTALLATION_CONTENT = conf.getProperty("e2e.ui.pipe.installation.content");
         PIPE_CONFIG_CONTENT_PATH = conf.getProperty("e2e.ui.pipe.config.content.path");
         IMPERSONATE_AUTH = conf.getProperty("e2e.ui.impersonate.auth");
+        EXTENSION_PATH = conf.getProperty("e2e.ui.extension.path");
+        INVALID_EXTENSION_PATH = conf.getProperty("e2e.ui.invalid.extension.path");
+        ANONYM_EXTENSION_PATH = conf.getProperty("e2e.ui.anonym.extension.path");
     }
 
     public static final int DEFAULT_TIMEOUT;
@@ -182,4 +185,7 @@ public class C {
     public static final String PIPE_CONFIG_CONTENT_PATH;
 
     public static final String IMPERSONATE_AUTH;
+    public static final String EXTENSION_PATH;
+    public static final String INVALID_EXTENSION_PATH;
+    public static final String ANONYM_EXTENSION_PATH;
 }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/utils/C.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/utils/C.java
@@ -99,6 +99,7 @@ public class C {
         PIPE_OPERATION_SYSTEM = conf.getProperty("e2e.ui.pipe.operation.system");
         PIPE_INSTALLATION_CONTENT = conf.getProperty("e2e.ui.pipe.installation.content");
         PIPE_CONFIG_CONTENT_PATH = conf.getProperty("e2e.ui.pipe.config.content.path");
+        IMPERSONATE_AUTH = conf.getProperty("e2e.ui.impersonate.auth");
     }
 
     public static final int DEFAULT_TIMEOUT;
@@ -179,4 +180,6 @@ public class C {
     public static final String PIPE_OPERATION_SYSTEM;
     public static final String PIPE_INSTALLATION_CONTENT;
     public static final String PIPE_CONFIG_CONTENT_PATH;
+
+    public static final String IMPERSONATE_AUTH;
 }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/utils/Utils.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/utils/Utils.java
@@ -381,11 +381,6 @@ public class Utils {
         return format("ui-tests-%s-%d", testCase, Utils.randomSuffix());
     }
 
-    public static void restartBrowser(final String address) {
-        Selenide.close();
-        Selenide.open(address);
-    }
-
     public static void assertStringContainsList(final String str, final String... subStrings) {
          Arrays.stream(subStrings).forEach(substr -> assertTrue(str.contains(substr),
                  format("'%s' doesn't exist in string", substr)));

--- a/e2e/gui/testng.xml
+++ b/e2e/gui/testng.xml
@@ -2,102 +2,9 @@
 
 <suite name="UITests" verbose="1" parallel="classes" thread-count="1">
 
-    <test name="StoragePaginationTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.StoragePaginationTest"/>
-        </classes>
-    </test>
-
-    <test name="DetachedConfigurationsTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.DetachedConfigurationsTest"/>
-        </classes>
-    </test>
-
-    <test name="RunPipelineTest" >
-        <classes>
-            <class name="com.epam.pipeline.autotests.RunPipelineTest" />
-        </classes>
-    </test>
-
-    <test name="ClusterNodeTest" >
-        <classes>
-            <class name="com.epam.pipeline.autotests.ClusterNodeTest" />
-        </classes>
-    </test>
-
-    <test name="GlobalSearchTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.GlobalSearchTest">
-                <methods>
-                    <include name="folderSearch"/>
-                    <include name="folderSearchByEnterKey"/>
-                    <include name="identicalNamesSearch"/>
-                    <include name="issueSearch"/>
-                    <include name="negativeFolderSearch"/>
-                    <include name="searchAfterDeleting"/>
-                    <include name="searchResultCancel"/>
-                </methods>
-            </class>
-        </classes>
-    </test>
-
-    <test name="PlatformPreferencesTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.PlatformPreferencesTest"/>
-        </classes>
-    </test>
-
-    <test name="PipeCLITest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.PipeCLITest"/>
-        </classes>
-    </test>
-
-    <test name="DataStoragesFeaturesTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.DataStoragesFeaturesTest"/>
-        </classes>
-    </test>
-
-    <test name="RunAsTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.RunAsTest"/>
-        </classes>
-    </test>
-
     <test name="RunToolsInSandBoxTest">
         <classes>
-            <class name="com.epam.pipeline.autotests.RunToolsInSandBoxTest">
-                <methods>
-                    <exclude name="validationOfDinDLaunchAndFunctionality"/>
-                    <exclude name="validationOfSingularityLaunchAndFunctionality"/>
-                </methods>
-            </class>
-        </classes>
-    </test>
-
-    <test name="SystemLoggingTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.SystemLoggingTest"/>
-        </classes>
-    </test>
-
-    <test name="StorageSynchronizationTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.StorageSynchronizationTest"/>
-        </classes>
-    </test>
-
-    <test name="PipelineConfigurationTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.PipelineConfigurationTest"/>
-        </classes>
-    </test>
-
-    <test name="RoleBasedAccessControlTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.RoleBasedAccessControlTest"/>
+            <class name="com.epam.pipeline.autotests.RunToolsInSandBoxTest"/>
         </classes>
     </test>
 
@@ -107,92 +14,15 @@
         </classes>
     </test>
 
-    <test name="ObjectMetadataFileTest">
+    <test name="StorageRulesTest">
         <classes>
-            <class name="com.epam.pipeline.autotests.ObjectMetadataFileTest"/>
+            <class name="com.epam.pipeline.autotests.StorageRulesTest"/>
         </classes>
     </test>
 
-    <test name="RunsTest">
+    <test name="NfsDataStorageTest">
         <classes>
-            <class name="com.epam.pipeline.autotests.RunsTest"/>
-        </classes>
-    </test>
-
-    <test name="DataStoragesTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.DataStoragesTest"/>
-        </classes>
-    </test>
-
-    <test name="PipelineDetailsTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.PipelineDetailsTest"/>
-        </classes>
-    </test>
-
-    <test name="PipelineEditingRepositoryTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.PipelineEditingRepositoryTest"/>
-        </classes>
-    </test>
-
-    <test name="ToolsParametersTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.ToolsParametersTest"/>
-        </classes>
-    </test>
-
-    <test name="RoleModelTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.RoleModelTest">
-                <methods>
-                    <exclude name="readOnlyUserIsNotAbleToEditFileInPipeline"/>
-                    <exclude name="checkFolderPermissionsForReadOnlyUserAndCheckInnerDeniedPipelinePermissions"/>
-                    <exclude name="editAndExecutePipeline"/>
-                    <exclude name="tryToNavigateToAnotherBucketByNavigationBar"/>
-                    <exclude name="checkBucketEditingByNonAdminUser"/>
-                    <exclude name="checkClusterNodesByNonAdminUser"/>
-                    <exclude name="checkPipelinePermissionsForGroup"/>
-                    <exclude name="setPipelinePermissionsAndCheckItForGroup"/>
-                    <exclude name="setToolPermissionsAndCheckItForGroup"/>
-                    <exclude name="validateSearchWithinEditUser"/>
-                    <exclude name="validateSearchForNoUser"/>
-                </methods>
-            </class>
-        </classes>
-    </test>
-
-    <test name="ToolsTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.ToolsTest">
-                <methods>
-                    <include name="toolExecutionParameters"/>
-                    <include name="toolDefaultCommandAddition"/>
-                    <include name="toolDefaultSettingsRun"/>
-                    <include name="toolCustomSettingsRun"/>
-                    <include name="toolCustomSettingsRunWithoutDefaults"/>
-                </methods>
-            </class>
-        </classes>
-    </test>
-
-    <test name="SshPermissionTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.SshPermissionTest"/>
-        </classes>
-    </test>
-
-
-    <test name="PipelineEditingTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.PipelineEditingTest"/>
-        </classes>
-    </test>
-
-    <test name="LaunchParametersRoleModelTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.LaunchParametersRoleModelTest"/>
+            <class name="com.epam.pipeline.autotests.NfsDataStorageTest"/>
         </classes>
     </test>
 
@@ -202,9 +32,75 @@
         </classes>
     </test>
 
+    <test name="PipelineEditingTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.PipelineEditingTest"/>
+        </classes>
+    </test>
+
+    <test name="PipelineEditingRepositoryTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.PipelineEditingRepositoryTest"/>
+        </classes>
+    </test>
+
+    <test name="ToolsTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.ToolsTest"/>
+        </classes>
+    </test>
+
+    <!--<test name="RegistryAdditionDeletionTest">-->
+    <!--<classes>-->
+    <!--<class name="com.epam.pipeline.autotests.RegistryAdditionDeletionTest"/>-->
+    <!--</classes>-->
+    <!--</test>-->
+
+    <test name="DataStoragesTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.DataStoragesTest"/>
+        </classes>
+    </test>
+
+    <test name="StoragePaginationTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.StoragePaginationTest"/>
+        </classes>
+    </test>
+
+    <test name="RoleModelTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.RoleModelTest"/>
+        </classes>
+    </test>
+
+    <!--<test name="RegistryTest">-->
+    <!--<classes>-->
+    <!--<class name="com.epam.pipeline.autotests.RegistryTest"/>-->
+    <!--</classes>-->
+    <!--</test>-->
+
     <test name="SshShellTest">
         <classes>
             <class name="com.epam.pipeline.autotests.SshShellTest"/>
+        </classes>
+    </test>
+
+    <test name="SshPermissionTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.SshPermissionTest"/>
+        </classes>
+    </test>
+
+    <test name="DockerCommitTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.DockerCommitTest"/>
+        </classes>
+    </test>
+
+    <test name="PipelineDockerCommitTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.PipelineDockerCommitTest"/>
         </classes>
     </test>
 
@@ -232,6 +128,18 @@
         </classes>
     </test>
 
+    <test name="LaunchClusterTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.LaunchClusterTest"/>
+        </classes>
+    </test>
+
+    <test name="RunPipelineWithOutputParameterTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.RunPipelineWithOutputParameterTest"/>
+        </classes>
+    </test>
+
     <test name="RunPipelineWithSeveralOutputParametersTest">
         <classes>
             <class name="com.epam.pipeline.autotests.RunPipelineWithSeveralOutputParametersTest"/>
@@ -241,6 +149,12 @@
     <test name="LaunchParametersNavigationTest">
         <classes>
             <class name="com.epam.pipeline.autotests.LaunchParametersNavigationTest"/>
+        </classes>
+    </test>
+
+    <test name="LaunchParametersRoleModelTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.LaunchParametersRoleModelTest"/>
         </classes>
     </test>
 
@@ -310,6 +224,18 @@
         </classes>
     </test>
 
+    <test name="Launch_InputDataValidationTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.Launch_InputDataValidationTest"/>
+        </classes>
+    </test>
+    <!--Disabled. Reason - CP doesn't support new EPAM GitLab 12-->
+    <!--<test name="RemotePipelineRepositoryTest">-->
+    <!--<classes>-->
+    <!--<class name="com.epam.pipeline.autotests.RemotePipelineRepositoryTest"/>-->
+    <!--</classes>-->
+    <!--</test>-->
+
     <test name="ObjectMetadataFolderTest">
         <classes>
             <class name="com.epam.pipeline.autotests.ObjectMetadataFolderTest"/>
@@ -328,9 +254,33 @@
         </classes>
     </test>
 
+    <test name="ObjectMetadataFileTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.ObjectMetadataFileTest"/>
+        </classes>
+    </test>
+
     <test name="ObjectMetadataToolTest">
         <classes>
             <class name="com.epam.pipeline.autotests.ObjectMetadataToolTest"/>
+        </classes>
+    </test>
+
+    <test name="SamplesMetadataTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.SamplesMetadataTest"/>
+        </classes>
+    </test>
+
+    <test name="VersionControlTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.VersionControlTest"/>
+        </classes>
+    </test>
+
+    <test name="PipelineConfigurationTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.PipelineConfigurationTest"/>
         </classes>
     </test>
 
@@ -340,9 +290,71 @@
         </classes>
     </test>
 
+    <test name="DetachedConfigurationsTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.DetachedConfigurationsTest"/>
+        </classes>
+    </test>
+
+    <test name="PauseResumeTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.PauseResumeTest"/>
+        </classes>
+    </test>
+
+    <test name="AutopauseTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.AutopauseTest"/>
+        </classes>
+    </test>
+
+    <!-- SLOW TESTS BELOW -->
+
+    <test name="ClusterNodeTest" >
+        <classes>
+            <class name="com.epam.pipeline.autotests.ClusterNodeTest" />
+        </classes>
+    </test>
+
     <test name="Launch_PipelineRunTimeoutTest" >
         <classes>
             <class name="com.epam.pipeline.autotests.Launch_PipelineRunTimeoutTest" />
+        </classes>
+    </test>
+
+    <test name="RunPipelineTest" >
+        <classes>
+            <class name="com.epam.pipeline.autotests.RunPipelineTest" />
+        </classes>
+    </test>
+
+    <test name="PipelineDetailsTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.PipelineDetailsTest"/>
+        </classes>
+    </test>
+
+    <test name="Launch_OutputParameterTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.Launch_OutputParameterTest"/>
+        </classes>
+    </test>
+
+    <test name="Launch_JsonOutputFileTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.Launch_JsonOutputFileTest"/>
+        </classes>
+    </test>
+
+    <test name="ToolsParametersTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.ToolsParametersTest"/>
+        </classes>
+    </test>
+
+    <test name="PipelineFromTemplateTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.PipelineFromTemplateTest"/>
         </classes>
     </test>
 
@@ -352,22 +364,117 @@
         </classes>
     </test>
 
-    <test name="LaunchClusterTest">
+    <test name="ToolsScanTest">
         <classes>
-            <class name="com.epam.pipeline.autotests.LaunchClusterTest">
-                <methods>
-                    <include name="autoScaledClusterWithDefaultChildNodesValidationTest"/>
-                    <include name="invalidValuesOnConfigureClusterPopUp"/>
-                    <include name="launchAutoScaledClusterTest"/>
-                    <include name="launchPipelineWithLaunchFlag"/>
-                </methods>
-            </class>
+            <class name="com.epam.pipeline.autotests.ToolsScanTest"/>
         </classes>
     </test>
 
-    <test name="PauseResumeTest">
+    <test name="GlobalSearchTest">
         <classes>
-            <class name="com.epam.pipeline.autotests.PauseResumeTest"/>
+            <class name="com.epam.pipeline.autotests.GlobalSearchTest"/>
+        </classes>
+    </test>
+
+    <test name="SystemLoggingTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.SystemLoggingTest"/>
+        </classes>
+    </test>
+
+    <test name="RoleBasedAccessControlTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.RoleBasedAccessControlTest"/>
+        </classes>
+    </test>
+
+    <test name="RunsTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.RunsTest"/>
+        </classes>
+    </test>
+
+    <test name="Launch_LimitMountsTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.LaunchLimitMountsTest"/>
+        </classes>
+    </test>
+
+    <test name="PipelinesAndStoragesRepositories">
+        <classes>
+            <class name="com.epam.pipeline.autotests.PipelinesAndStoragesRepositories"/>
+        </classes>
+    </test>
+
+    <test name="SharingRunsTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.SharingRunsTest"/>
+        </classes>
+    </test>
+
+    <test name="ParallelLoadTests" enabled="false">
+        <classes>
+            <class name="com.epam.pipeline.autotests.ParallelLoadTests"/>
+        </classes>
+    </test>
+
+    <test name="DataStoragesCLITest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.DataStoragesCLITest"/>
+        </classes>
+    </test>
+
+    <test name="CustomNodeImagesForRunsTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.CustomNodeImagesForRunsTest"/>
+        </classes>
+    </test>
+
+    <test name="SampleProcessingModuleTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.SampleProcessingModuleTest"/>
+        </classes>
+    </test>
+
+    <test name="PipelineLibraryTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.PipelineLibraryTest"/>
+        </classes>
+    </test>
+
+    <test name="StorageSynchronizationTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.StorageSynchronizationTest"/>
+        </classes>
+    </test>
+
+    <test name="RunAsTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.RunAsTest"/>
+        </classes>
+    </test>
+
+    <test name="PlatformPreferencesTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.PlatformPreferencesTest"/>
+        </classes>
+    </test>
+
+    <test name="PipeCLITest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.PipeCLITest"/>
+        </classes>
+    </test>
+
+    <test name="DataStoragesFeaturesTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.DataStoragesFeaturesTest"/>
+        </classes>
+    </test>
+
+    <test name="RestrictionsOnInstancePriceTypeTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.RestrictionsOnInstancePriceTypeTest"/>
         </classes>
     </test>
 </suite>

--- a/e2e/gui/testng.xml
+++ b/e2e/gui/testng.xml
@@ -51,9 +51,9 @@
     </test>
 
     <!--<test name="RegistryAdditionDeletionTest">-->
-    <!--<classes>-->
-    <!--<class name="com.epam.pipeline.autotests.RegistryAdditionDeletionTest"/>-->
-    <!--</classes>-->
+        <!--<classes>-->
+            <!--<class name="com.epam.pipeline.autotests.RegistryAdditionDeletionTest"/>-->
+        <!--</classes>-->
     <!--</test>-->
 
     <test name="DataStoragesTest">
@@ -75,9 +75,9 @@
     </test>
 
     <!--<test name="RegistryTest">-->
-    <!--<classes>-->
-    <!--<class name="com.epam.pipeline.autotests.RegistryTest"/>-->
-    <!--</classes>-->
+        <!--<classes>-->
+            <!--<class name="com.epam.pipeline.autotests.RegistryTest"/>-->
+        <!--</classes>-->
     <!--</test>-->
 
     <test name="SshShellTest">
@@ -231,9 +231,9 @@
     </test>
     <!--Disabled. Reason - CP doesn't support new EPAM GitLab 12-->
     <!--<test name="RemotePipelineRepositoryTest">-->
-    <!--<classes>-->
-    <!--<class name="com.epam.pipeline.autotests.RemotePipelineRepositoryTest"/>-->
-    <!--</classes>-->
+        <!--<classes>-->
+            <!--<class name="com.epam.pipeline.autotests.RemotePipelineRepositoryTest"/>-->
+        <!--</classes>-->
     <!--</test>-->
 
     <test name="ObjectMetadataFolderTest">

--- a/e2e/gui/testng.xml
+++ b/e2e/gui/testng.xml
@@ -2,9 +2,102 @@
 
 <suite name="UITests" verbose="1" parallel="classes" thread-count="1">
 
+    <test name="StoragePaginationTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.StoragePaginationTest"/>
+        </classes>
+    </test>
+
+    <test name="DetachedConfigurationsTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.DetachedConfigurationsTest"/>
+        </classes>
+    </test>
+
+    <test name="RunPipelineTest" >
+        <classes>
+            <class name="com.epam.pipeline.autotests.RunPipelineTest" />
+        </classes>
+    </test>
+
+    <test name="ClusterNodeTest" >
+        <classes>
+            <class name="com.epam.pipeline.autotests.ClusterNodeTest" />
+        </classes>
+    </test>
+
+    <test name="GlobalSearchTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.GlobalSearchTest">
+                <methods>
+                    <include name="folderSearch"/>
+                    <include name="folderSearchByEnterKey"/>
+                    <include name="identicalNamesSearch"/>
+                    <include name="issueSearch"/>
+                    <include name="negativeFolderSearch"/>
+                    <include name="searchAfterDeleting"/>
+                    <include name="searchResultCancel"/>
+                </methods>
+            </class>
+        </classes>
+    </test>
+
+    <test name="PlatformPreferencesTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.PlatformPreferencesTest"/>
+        </classes>
+    </test>
+
+    <test name="PipeCLITest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.PipeCLITest"/>
+        </classes>
+    </test>
+
+    <test name="DataStoragesFeaturesTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.DataStoragesFeaturesTest"/>
+        </classes>
+    </test>
+
+    <test name="RunAsTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.RunAsTest"/>
+        </classes>
+    </test>
+
     <test name="RunToolsInSandBoxTest">
         <classes>
-            <class name="com.epam.pipeline.autotests.RunToolsInSandBoxTest"/>
+            <class name="com.epam.pipeline.autotests.RunToolsInSandBoxTest">
+                <methods>
+                    <exclude name="validationOfDinDLaunchAndFunctionality"/>
+                    <exclude name="validationOfSingularityLaunchAndFunctionality"/>
+                </methods>
+            </class>
+        </classes>
+    </test>
+
+    <test name="SystemLoggingTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.SystemLoggingTest"/>
+        </classes>
+    </test>
+
+    <test name="StorageSynchronizationTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.StorageSynchronizationTest"/>
+        </classes>
+    </test>
+
+    <test name="PipelineConfigurationTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.PipelineConfigurationTest"/>
+        </classes>
+    </test>
+
+    <test name="RoleBasedAccessControlTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.RoleBasedAccessControlTest"/>
         </classes>
     </test>
 
@@ -14,27 +107,27 @@
         </classes>
     </test>
 
-    <test name="StorageRulesTest">
+    <test name="ObjectMetadataFileTest">
         <classes>
-            <class name="com.epam.pipeline.autotests.StorageRulesTest"/>
+            <class name="com.epam.pipeline.autotests.ObjectMetadataFileTest"/>
         </classes>
     </test>
 
-    <test name="NfsDataStorageTest">
+    <test name="RunsTest">
         <classes>
-            <class name="com.epam.pipeline.autotests.NfsDataStorageTest"/>
+            <class name="com.epam.pipeline.autotests.RunsTest"/>
         </classes>
     </test>
 
-    <test name="PipelineReleaseTest">
+    <test name="DataStoragesTest">
         <classes>
-            <class name="com.epam.pipeline.autotests.PipelineReleaseTest"/>
+            <class name="com.epam.pipeline.autotests.DataStoragesTest"/>
         </classes>
     </test>
 
-    <test name="PipelineEditingTest">
+    <test name="PipelineDetailsTest">
         <classes>
-            <class name="com.epam.pipeline.autotests.PipelineEditingTest"/>
+            <class name="com.epam.pipeline.autotests.PipelineDetailsTest"/>
         </classes>
     </test>
 
@@ -44,45 +137,43 @@
         </classes>
     </test>
 
-    <test name="ToolsTest">
+    <test name="ToolsParametersTest">
         <classes>
-            <class name="com.epam.pipeline.autotests.ToolsTest"/>
-        </classes>
-    </test>
-
-    <!--<test name="RegistryAdditionDeletionTest">-->
-        <!--<classes>-->
-            <!--<class name="com.epam.pipeline.autotests.RegistryAdditionDeletionTest"/>-->
-        <!--</classes>-->
-    <!--</test>-->
-
-    <test name="DataStoragesTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.DataStoragesTest"/>
-        </classes>
-    </test>
-
-    <test name="StoragePaginationTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.StoragePaginationTest"/>
+            <class name="com.epam.pipeline.autotests.ToolsParametersTest"/>
         </classes>
     </test>
 
     <test name="RoleModelTest">
         <classes>
-            <class name="com.epam.pipeline.autotests.RoleModelTest"/>
+            <class name="com.epam.pipeline.autotests.RoleModelTest">
+                <methods>
+                    <exclude name="readOnlyUserIsNotAbleToEditFileInPipeline"/>
+                    <exclude name="checkFolderPermissionsForReadOnlyUserAndCheckInnerDeniedPipelinePermissions"/>
+                    <exclude name="editAndExecutePipeline"/>
+                    <exclude name="tryToNavigateToAnotherBucketByNavigationBar"/>
+                    <exclude name="checkBucketEditingByNonAdminUser"/>
+                    <exclude name="checkClusterNodesByNonAdminUser"/>
+                    <exclude name="checkPipelinePermissionsForGroup"/>
+                    <exclude name="setPipelinePermissionsAndCheckItForGroup"/>
+                    <exclude name="setToolPermissionsAndCheckItForGroup"/>
+                    <exclude name="validateSearchWithinEditUser"/>
+                    <exclude name="validateSearchForNoUser"/>
+                </methods>
+            </class>
         </classes>
     </test>
 
-    <!--<test name="RegistryTest">-->
-        <!--<classes>-->
-            <!--<class name="com.epam.pipeline.autotests.RegistryTest"/>-->
-        <!--</classes>-->
-    <!--</test>-->
-
-    <test name="SshShellTest">
+    <test name="ToolsTest">
         <classes>
-            <class name="com.epam.pipeline.autotests.SshShellTest"/>
+            <class name="com.epam.pipeline.autotests.ToolsTest">
+                <methods>
+                    <include name="toolExecutionParameters"/>
+                    <include name="toolDefaultCommandAddition"/>
+                    <include name="toolDefaultSettingsRun"/>
+                    <include name="toolCustomSettingsRun"/>
+                    <include name="toolCustomSettingsRunWithoutDefaults"/>
+                </methods>
+            </class>
         </classes>
     </test>
 
@@ -92,15 +183,28 @@
         </classes>
     </test>
 
-    <test name="DockerCommitTest">
+
+    <test name="PipelineEditingTest">
         <classes>
-            <class name="com.epam.pipeline.autotests.DockerCommitTest"/>
+            <class name="com.epam.pipeline.autotests.PipelineEditingTest"/>
         </classes>
     </test>
 
-    <test name="PipelineDockerCommitTest">
+    <test name="LaunchParametersRoleModelTest">
         <classes>
-            <class name="com.epam.pipeline.autotests.PipelineDockerCommitTest"/>
+            <class name="com.epam.pipeline.autotests.LaunchParametersRoleModelTest"/>
+        </classes>
+    </test>
+
+    <test name="PipelineReleaseTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.PipelineReleaseTest"/>
+        </classes>
+    </test>
+
+    <test name="SshShellTest">
+        <classes>
+            <class name="com.epam.pipeline.autotests.SshShellTest"/>
         </classes>
     </test>
 
@@ -128,18 +232,6 @@
         </classes>
     </test>
 
-    <test name="LaunchClusterTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.LaunchClusterTest"/>
-        </classes>
-    </test>
-
-    <test name="RunPipelineWithOutputParameterTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.RunPipelineWithOutputParameterTest"/>
-        </classes>
-    </test>
-
     <test name="RunPipelineWithSeveralOutputParametersTest">
         <classes>
             <class name="com.epam.pipeline.autotests.RunPipelineWithSeveralOutputParametersTest"/>
@@ -149,12 +241,6 @@
     <test name="LaunchParametersNavigationTest">
         <classes>
             <class name="com.epam.pipeline.autotests.LaunchParametersNavigationTest"/>
-        </classes>
-    </test>
-
-    <test name="LaunchParametersRoleModelTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.LaunchParametersRoleModelTest"/>
         </classes>
     </test>
 
@@ -224,18 +310,6 @@
         </classes>
     </test>
 
-    <test name="Launch_InputDataValidationTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.Launch_InputDataValidationTest"/>
-        </classes>
-    </test>
-<!--Disabled. Reason - CP doesn't support new EPAM GitLab 12-->
-    <!--<test name="RemotePipelineRepositoryTest">-->
-        <!--<classes>-->
-            <!--<class name="com.epam.pipeline.autotests.RemotePipelineRepositoryTest"/>-->
-        <!--</classes>-->
-    <!--</test>-->
-
     <test name="ObjectMetadataFolderTest">
         <classes>
             <class name="com.epam.pipeline.autotests.ObjectMetadataFolderTest"/>
@@ -254,33 +328,9 @@
         </classes>
     </test>
 
-    <test name="ObjectMetadataFileTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.ObjectMetadataFileTest"/>
-        </classes>
-    </test>
-
     <test name="ObjectMetadataToolTest">
         <classes>
             <class name="com.epam.pipeline.autotests.ObjectMetadataToolTest"/>
-        </classes>
-    </test>
-
-    <test name="SamplesMetadataTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.SamplesMetadataTest"/>
-        </classes>
-    </test>
-
-    <test name="VersionControlTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.VersionControlTest"/>
-        </classes>
-    </test>
-
-    <test name="PipelineConfigurationTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.PipelineConfigurationTest"/>
         </classes>
     </test>
 
@@ -290,71 +340,9 @@
         </classes>
     </test>
 
-    <test name="DetachedConfigurationsTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.DetachedConfigurationsTest"/>
-        </classes>
-    </test>
-
-    <test name="PauseResumeTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.PauseResumeTest"/>
-        </classes>
-    </test>
-
-    <test name="AutopauseTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.AutopauseTest"/>
-        </classes>
-    </test>
-
-    <!-- SLOW TESTS BELOW -->
-
-    <test name="ClusterNodeTest" >
-        <classes>
-            <class name="com.epam.pipeline.autotests.ClusterNodeTest" />
-        </classes>
-    </test>
-
     <test name="Launch_PipelineRunTimeoutTest" >
         <classes>
             <class name="com.epam.pipeline.autotests.Launch_PipelineRunTimeoutTest" />
-        </classes>
-    </test>
-
-    <test name="RunPipelineTest" >
-        <classes>
-            <class name="com.epam.pipeline.autotests.RunPipelineTest" />
-        </classes>
-    </test>
-
-    <test name="PipelineDetailsTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.PipelineDetailsTest"/>
-        </classes>
-    </test>
-
-    <test name="Launch_OutputParameterTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.Launch_OutputParameterTest"/>
-        </classes>
-    </test>
-
-    <test name="Launch_JsonOutputFileTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.Launch_JsonOutputFileTest"/>
-        </classes>
-    </test>
-
-    <test name="ToolsParametersTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.ToolsParametersTest"/>
-        </classes>
-    </test>
-
-    <test name="PipelineFromTemplateTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.PipelineFromTemplateTest"/>
         </classes>
     </test>
 
@@ -364,117 +352,22 @@
         </classes>
     </test>
 
-    <test name="ToolsScanTest">
+    <test name="LaunchClusterTest">
         <classes>
-            <class name="com.epam.pipeline.autotests.ToolsScanTest"/>
+            <class name="com.epam.pipeline.autotests.LaunchClusterTest">
+                <methods>
+                    <include name="autoScaledClusterWithDefaultChildNodesValidationTest"/>
+                    <include name="invalidValuesOnConfigureClusterPopUp"/>
+                    <include name="launchAutoScaledClusterTest"/>
+                    <include name="launchPipelineWithLaunchFlag"/>
+                </methods>
+            </class>
         </classes>
     </test>
 
-    <test name="GlobalSearchTest">
+    <test name="PauseResumeTest">
         <classes>
-            <class name="com.epam.pipeline.autotests.GlobalSearchTest"/>
-        </classes>
-    </test>
-
-    <test name="SystemLoggingTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.SystemLoggingTest"/>
-        </classes>
-    </test>
-
-    <test name="RoleBasedAccessControlTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.RoleBasedAccessControlTest"/>
-        </classes>
-    </test>
-
-    <test name="RunsTest">
-    <classes>
-        <class name="com.epam.pipeline.autotests.RunsTest"/>
-    </classes>
-    </test>
-
-    <test name="Launch_LimitMountsTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.LaunchLimitMountsTest"/>
-        </classes>
-    </test>
-
-    <test name="PipelinesAndStoragesRepositories">
-        <classes>
-            <class name="com.epam.pipeline.autotests.PipelinesAndStoragesRepositories"/>
-        </classes>
-    </test>
-
-    <test name="SharingRunsTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.SharingRunsTest"/>
-        </classes>
-    </test>
-
-    <test name="ParallelLoadTests" enabled="false">
-        <classes>
-            <class name="com.epam.pipeline.autotests.ParallelLoadTests"/>
-        </classes>
-    </test>
-
-    <test name="DataStoragesCLITest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.DataStoragesCLITest"/>
-        </classes>
-    </test>
-
-    <test name="CustomNodeImagesForRunsTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.CustomNodeImagesForRunsTest"/>
-        </classes>
-    </test>
-
-    <test name="SampleProcessingModuleTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.SampleProcessingModuleTest"/>
-        </classes>
-    </test>
-
-    <test name="PipelineLibraryTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.PipelineLibraryTest"/>
-        </classes>
-    </test>
-
-    <test name="StorageSynchronizationTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.StorageSynchronizationTest"/>
-        </classes>
-    </test>
-
-    <test name="RunAsTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.RunAsTest"/>
-        </classes>
-    </test>
-
-    <test name="PlatformPreferencesTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.PlatformPreferencesTest"/>
-        </classes>
-    </test>
-
-    <test name="PipeCLITest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.PipeCLITest"/>
-        </classes>
-    </test>
-
-    <test name="DataStoragesFeaturesTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.DataStoragesFeaturesTest"/>
-        </classes>
-    </test>
-
-    <test name="RestrictionsOnInstancePriceTypeTest">
-        <classes>
-            <class name="com.epam.pipeline.autotests.RestrictionsOnInstancePriceTypeTest"/>
+            <class name="com.epam.pipeline.autotests.PauseResumeTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
Resolves issue #2145 

The pull request allows running automated tests without Cloud Pipeline service interruption. This is achieved with the `impersonate` mode and chrome auth extensions for 'first' login. The tests have also been adapted for the `impersonate` mode.