### PR TITLE
Add NICE DCV endpoints to Windows runs

### DIFF
--- a/deploy/docker/cp-tools/base/windows/Dockerfile
+++ b/deploy/docker/cp-tools/base/windows/Dockerfile
@@ -16,18 +16,19 @@ ARG BASE_IMAGE="python:3.8.9-windowsservercore"
 
 FROM $BASE_IMAGE
 
-ENV NOMACHINE_HOME="c:/opt/nomachine"
+ENV CP_DESKTOP_DIR="c:/opt/desktop"
 
-RUN New-Item -ItemType directory -Path ${env:NOMACHINE_HOME}
+RUN New-Item -ItemType directory -Path ${env:CP_DESKTOP_DIR}
 
-RUN Invoke-WebRequest "https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/nomachine/scramble.exe" -OutFile ${env:NOMACHINE_HOME}/scramble.exe
+RUN Invoke-WebRequest "https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/nomachine/scramble.exe" -OutFile ${env:CP_DESKTOP_DIR}/scramble.exe
 
-COPY requirements.txt $NOMACHINE_HOME/requirements.txt
-RUN pip install -r ${env:NOMACHINE_HOME}/requirements.txt
+COPY requirements.txt $CP_DESKTOP_DIR/requirements.txt
+RUN pip install -r ${env:CP_DESKTOP_DIR}/requirements.txt
 
 COPY init.ps1 c:/init.ps1
-COPY serve_nxs.py \
+COPY serve_desktop.py \
      template.nxs \
-     $NOMACHINE_HOME/
+     template.dcv \
+     $CP_DESKTOP_DIR/
 
 CMD powershell -Command c:\init.ps1

--- a/deploy/docker/cp-tools/base/windows/init.ps1
+++ b/deploy/docker/cp-tools/base/windows/init.ps1
@@ -32,8 +32,8 @@ Start-Job {
 
 Start-Job {
     & ${env:PIPE_DIR}\pipe tunnel start --direct `
-                                        -lp "${env:CP_NM_NOMACHINE_PORT}" `
-                                        -rp "${env:CP_NM_NOMACHINE_PORT}" `
+                                        -lp "${env:CP_NOMACHINE_DESKTOP_PORT}" `
+                                        -rp "${env:CP_NOMACHINE_DESKTOP_PORT}" `
                                         --trace `
                                         -l ${env:CP_DESKTOP_DIR}\proxy_nxs.log `
                                         "${env:NODE_IP}"

--- a/deploy/docker/cp-tools/base/windows/init.ps1
+++ b/deploy/docker/cp-tools/base/windows/init.ps1
@@ -13,16 +13,39 @@
 # limitations under the License.
 
 Start-Job {
-    python ${env:NOMACHINE_HOME}\serve_nxs.py --local-port "${env:CP_NM_LOCAL_PORT}" `
-                                              --nomachine-port "${env:CP_NM_NOMACHINE_PORT}" `
-                                              --proxy "${env:CP_NM_PROXY_HOST}" `
-                                              --proxy-port "${env:CP_NM_PROXY_PORT}" `
-                                              --template-path ${env:NOMACHINE_HOME}\template.nxs `
-                                              *>> ${env:NOMACHINE_HOME}\serve_nxs.log
+    python ${env:CP_DESKTOP_DIR}\serve_desktop.py --serving-port "${env:CP_NOMACHINE_SERVING_PORT}" `
+                                                  --desktop-port "${env:CP_NOMACHINE_DESKTOP_PORT}" `
+                                                  --proxy-host "${env:CP_DESKTOP_PROXY_HOST}" `
+                                                  --proxy-port "${env:CP_DESKTOP_PROXY_PORT}" `
+                                                  --template-path ${env:CP_DESKTOP_DIR}\template.nxs `
+                                                  *>> ${env:CP_DESKTOP_DIR}\serve_nxs.log
 }
 
 Start-Job {
-    & ${env:PIPE_DIR}\pipe tunnel start --direct -lp 4000 -rp 4000 --trace -l ${env:NOMACHINE_HOME}\proxy.log $env:NODE_IP
+    python ${env:CP_DESKTOP_DIR}\serve_desktop.py --serving-port "${env:CP_NICE_DCV_SERVING_PORT}" `
+                                                  --desktop-port "${env:CP_NICE_DCV_DESKTOP_PORT}" `
+                                                  --proxy-host "${env:CP_DESKTOP_PROXY_HOST}" `
+                                                  --proxy-port "${env:CP_DESKTOP_PROXY_PORT}" `
+                                                  --template-path ${env:CP_DESKTOP_DIR}\template.dcv `
+                                                  *>> ${env:CP_DESKTOP_DIR}\serve_nice_dcv.log
+}
+
+Start-Job {
+    & ${env:PIPE_DIR}\pipe tunnel start --direct `
+                                        -lp "${env:CP_NM_NOMACHINE_PORT}" `
+                                        -rp "${env:CP_NM_NOMACHINE_PORT}" `
+                                        --trace `
+                                        -l ${env:CP_DESKTOP_DIR}\proxy_nxs.log `
+                                        "${env:NODE_IP}"
+}
+
+Start-Job {
+    & ${env:PIPE_DIR}\pipe tunnel start --direct `
+                                        -lp "${env:CP_NICE_DCV_DESKTOP_PORT}" `
+                                        -rp "${env:CP_NICE_DCV_DESKTOP_PORT}" `
+                                        --trace `
+                                        -l ${env:CP_DESKTOP_DIR}\proxy_nice_dcv.log `
+                                        "${env:NODE_IP}"
 }
 
 while (1) {

--- a/deploy/docker/cp-tools/base/windows/template.dcv
+++ b/deploy/docker/cp-tools/base/windows/template.dcv
@@ -1,0 +1,12 @@
+[version]
+format=1.0
+
+[connect]
+proxytype=HTTP
+proxyhost={CP_PROXY}
+proxyport={CP_PROXY_PORT}
+host={CP_HOST}
+port={CP_HOST_PORT}
+sessionid=console
+user={CP_USERNAME}
+password={CP_PASSWORD}

--- a/scripts/autoscaling/init_multicloud.ps1
+++ b/scripts/autoscaling/init_multicloud.ps1
@@ -147,7 +147,7 @@ function InstallPythonIfRequired($PythonDir) {
 function InstallChromeIfRequired {
     if (-not(Test-Path "C:\Program Files\Google\Chrome\Application\chrome.exe")) {
         Write-Host "Installing chrome..."
-        Invoke-WebRequest "https://cloud-pipeline-oss-builds.s3.amazonaws.com/tools/chrome/ChromeSetup.exe" -Outfile $workingDir\ChromeSetup.exe
+        Invoke-WebRequest "https://cloud-pipeline-oss-builds.s3.amazonaws.com/tools/chrome/ChromeSetup.exe" -Outfile "$workingDir\ChromeSetup.exe"
         & $workingDir\ChromeSetup.exe /silent /install
         WaitForProcess -ProcessName "ChromeSetup"
     }
@@ -156,9 +156,19 @@ function InstallChromeIfRequired {
 function InstallDokanyIfRequired($DokanyDir) {
     if (-not (Test-Path "$DokanyDir")) {
         Write-Host "Installing Dokany..."
-        Invoke-WebRequest -Uri "https://cloud-pipeline-oss-builds.s3.amazonaws.com/tools/dokany/DokanSetup.exe" -OutFile "$workingDir\DokanSetup.exe"
+        Invoke-WebRequest "https://cloud-pipeline-oss-builds.s3.amazonaws.com/tools/dokany/DokanSetup.exe" -OutFile "$workingDir\DokanSetup.exe"
         & "$workingDir\DokanSetup.exe" /quiet /silent /verysilent
         WaitForProcess -ProcessName "DokanSetup"
+    }
+}
+
+function InstallNiceDcvIfRequired {
+    $niceDcvInstalled = Get-Service -Name "DCV Server" `
+        | Measure-Object `
+        | ForEach-Object { $_.Count -gt 0 }
+    if (-not ($niceDcvInstalled)) {
+        Invoke-WebRequest "https://d1uj6qtbmh3dt5.cloudfront.net/2021.2/Servers/nice-dcv-server-x64-Release-2021.2-11048.msi" -outfile "$workingDir\nice-dcv-server-x64-Release-2021.2-11048.msi"
+        Start-Process -FilePath "$workingDir\nice-dcv-server-x64-Release-2021.2-11048.msi" -ArgumentList "ADDLOCAL=ALL /quiet /norestart /l*v $workingDir\nice_dcv_install.log" -Wait -PassThru
     }
 }
 
@@ -490,6 +500,9 @@ InstallChromeIfRequired
 
 Write-Host "Installing Dokany if required..."
 InstallDokanyIfRequired -DokanyDir $dokanyDir
+
+Write-Host "Installing NICE DCV if required..."
+InstallNiceDcvIfRequired
 
 Write-Host "Opening host ports..."
 OpenPortIfRequired -Port 4000

--- a/scripts/pipeline-launch/launch.py
+++ b/scripts/pipeline-launch/launch.py
@@ -251,6 +251,11 @@ try:
                          f'from scripts.configure_nomachine_win import configure_nomachine_win; '
                          f'configure_nomachine_win(\'{nomachine_server_parameters}\')\\"')
 
+    logger.info('Configuring nice dcv server...')
+    node_ssh.execute(f'{python_dir}\\python.exe -c \\"'
+                     f'from scripts.configure_nice_dcv_win import configure_nice_dcv_win; '
+                     f'configure_nice_dcv_win(\'{_escape_backslashes(run_dir)}\', \'{owner}\')\\"')
+
     logger.info('Downloading seamless logon image...')
     _download_file(logon_image_url, logon_image_path)
 

--- a/workflows/pipe-common/pipeline/utils/reg.py
+++ b/workflows/pipe-common/pipeline/utils/reg.py
@@ -38,5 +38,9 @@ def set_local_machine_dword_value(path, name, value):
     set_value(winreg.HKEY_LOCAL_MACHINE, path, winreg.REG_DWORD, name, value)
 
 
+def set_user_str_value(path, name, value, sid):
+    set_value(winreg.HKEY_USERS, '{}\\{}'.format(sid, path), winreg.REG_SZ, name, value)
+
+
 def set_user_dword_value(path, name, value, sid):
     set_value(winreg.HKEY_USERS, '{}\\{}'.format(sid, path), winreg.REG_DWORD, name, value)

--- a/workflows/pipe-common/scripts/configure_nice_dcv_win.py
+++ b/workflows/pipe-common/scripts/configure_nice_dcv_win.py
@@ -1,0 +1,40 @@
+# Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os.path
+import subprocess
+
+from pipeline.utils.reg import set_user_str_value
+
+
+_nice_dcv_path = 'C:\\Program Files\\NICE\\DCV\\Server'
+_nice_dcv_cli_path = _nice_dcv_path + '\\bin\\dcv.exe'
+_nice_dcv_reg_path = 'Software\\GSettings\\com\\nicesoftware\\dcv'
+_nice_dcv_security_reg_path = _nice_dcv_reg_path + '\\security'
+
+
+def configure_nice_dcv_win(run_dir, user):
+    set_user_str_value(_nice_dcv_security_reg_path, 'authentication', 'none', 'S-1-5-18')
+    subprocess.check_call(['powershell', '-c', 'restart-service "DCV Server"'])
+    nice_dcv_permissions_path = os.path.join(run_dir, 'nice_dcv_permissions.txt')
+    with open(nice_dcv_permissions_path, 'w') as f:
+        f.write("[permissions]\n%any% allow builtin\n")
+    subprocess.check_call([_nice_dcv_cli_path, 'close-session', 'console'])
+    subprocess.check_call([_nice_dcv_cli_path, 'create-session',
+                           '--type', 'console',
+                           '--name', 'console',
+                           '--owner', user,
+                           '--permissions-file', nice_dcv_permissions_path,
+                           '--max-concurrent-clients', '1',
+                           'console'])


### PR DESCRIPTION
Resolves #2167.

The pull request brings support for two NICE DCV endpoints to Windows runs in Cloud Pipeline. User can download NICE DCV connection file by clicking the first endpoint and open NICE DCV web session by clicking the second endpoint. NoMachine endpoint behaviour hasn't been changed by the pull request and should work as before.

The following three endpoints should be configured for all Windows-based tools:
- **NICE DCV web** on **8443** port with **ssl backend** and **CP_EDGE_INSTANCE_IP** additional nginx configuration, 
- **NICE DCV desktop** on **8081** port,
- **NoMachine desktop** on **8080** port.

Notice that several existing required run parameters were renamed:
- `CP_NM_LOCAL_PORT` -> `CP_NOMACHINE_SERVING_PORT`
- `CP_NM_NOMACHINE_PORT` -> `CP_NOMACHINE_DESKTOP_PORT` 
- `CP_NM_PROXY_HOST` -> `CP_DESKTOP_PROXY_HOST`
- `CP_NM_PROXY_PORT` -> `CP_DESKTOP_PROXY_PORT`

As a result the following set of parameters is required for both NoMachine and NICE DCV connections to work properly.

```
CP_DESKTOP_PROXY_HOST=*edge host*
CP_DESKTOP_PROXY_PORT=*edge port*
CP_NICE_DCV_DESKTOP_PORT=8443
CP_NICE_DCV_SERVING_PORT=8081
CP_NOMACHINE_DESKTOP_PORT=4000
CP_NOMACHINE_SERVING_PORT=8080
```
