### PR TITLE
Add proper support for a2 instance types in Google cloud

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -788,6 +788,8 @@ public class SystemPreferences {
     public static final ObjectPreference<Map<String, GCPResourceMapping>> GCP_SKU_MAPPING = new ObjectPreference<>(
             "gcp.sku.mapping", null, new TypeReference<Map<String, GCPResourceMapping>>() {}, GCP_GROUP,
             isNullOrValidJson(new TypeReference<Map<String, GCPResourceMapping>>() {}));
+    public static final StringPreference GCP_DEFAULT_GPU_TYPE = new StringPreference(
+            "gcp.default.gpu.type", "a100", GCP_GROUP, PreferenceValidators.isNotBlank);
 
     // Billing Reports
     public static final StringPreference BILLING_USER_NAME_ATTRIBUTE = new StringPreference(

--- a/deploy/contents/install/cloud-configs/gcp/preferences/gcp.sku.mapping.json
+++ b/deploy/contents/install/cloud-configs/gcp/preferences/gcp.sku.mapping.json
@@ -39,6 +39,14 @@
     "prefix": "Memory-optimized Instance Ram",
     "group": "RAM"
   },
+  "cpu_ondemand_highgpu": {
+    "prefix": "A2 Instance Core",
+    "group": "CPU"
+  },
+  "ram_ondemand_highgpu": {
+    "prefix": "A2 Instance Ram",
+    "group": "RAM"
+  },
   "cpu_ondemand_micro": {
     "prefix": "Micro Instance",
     "group": "F1Micro"
@@ -77,6 +85,10 @@
   },
   "gpu_ondemand_k80": {
     "prefix": "Nvidia Tesla K80 GPU running",
+    "group": "GPU"
+  },
+  "gpu_ondemand_a100": {
+    "prefix": "Nvidia Tesla A100 GPU running",
     "group": "GPU"
   },
   "cpu_preemptible_standard": {
@@ -119,6 +131,14 @@
     "prefix": "Preemptible Memory-optimized Instance Ram",
     "group": "RAM"
   },
+  "cpu_preemptible_highgpu": {
+    "prefix": "Preemptible A2 Instance Core",
+    "group": "CPU"
+  },
+  "ram_preemptible_highgpu": {
+    "prefix": "Preemptible A2 Instance Ram",
+    "group": "RAM"
+  },
   "cpu_preemptible_micro": {
     "prefix": "Preemptible Micro Instance",
     "group": "F1Micro"
@@ -157,6 +177,10 @@
   },
   "gpu_preemptible_k80": {
     "prefix": "Nvidia Tesla K80 GPU attached to preemptible",
+    "group": "GPU"
+  },
+  "gpu_preemptible_a100": {
+    "prefix": "Nvidia Tesla A100 GPU attached to preemptible",
     "group": "GPU"
   },
   "disk_ondemand": {


### PR DESCRIPTION
Resolves #2172.

The pull request brings proper support for a2 instance types in Google cloud. From now on correct number of GPUs will be reported for a2 instance types as well as correct price per hour and billing reports.

Notice that the following items have to be added to `gcp.sku.mapping` system preference in order to report all costs correctly.

```json
{
  "cpu_ondemand_highgpu": {
    "prefix": "A2 Instance Core",
    "group": "CPU"
  },
  "ram_ondemand_highgpu": {
    "prefix": "A2 Instance Ram",
    "group": "RAM"
  },
  "gpu_ondemand_a100": {
    "prefix": "Nvidia Tesla A100 GPU running",
    "group": "GPU"
  },
  "cpu_preemptible_highgpu": {
    "prefix": "Preemptible A2 Instance Core",
    "group": "CPU"
  },
  "ram_preemptible_highgpu": {
    "prefix": "Preemptible A2 Instance Ram",
    "group": "RAM"
  },
  "gpu_preemptible_a100": {
    "prefix": "Nvidia Tesla A100 GPU attached to preemptible",
    "group": "GPU"
  }
}
```

New `gcp.default.gpu.type` system preference was added in order to specify default GPU type of gcp instance types with default GPUs. Defaults to `a100`.
