### PR TITLE
Impersonate users in pipe run command for admins

### DIFF
--- a/pipe-cli/src/api/user.py
+++ b/pipe-cli/src/api/user.py
@@ -96,3 +96,9 @@ class User(API):
             raise RuntimeError(response_data['message'])
         else:
             return []
+
+    @classmethod
+    def whoami(cls):
+        api = cls.instance()
+        query = '/whoami'
+        return api.retryable_call('GET', query) or {}


### PR DESCRIPTION
Relates to #1948.

The pull request changes the way `-u/--user` parameter of `pipe run` command is used for admins.

From now on if an admin launches a run with `user` parameter then a new access key will be generated for that user and used to perform a run launch. As a result no `ORIGINAL_OWNER` run parameter won't be set.

The original _run as_ behaviour is not changed for regular users. Therefore if a regular user launches a run with `user` parameter then the run will be launched on behalf of a different user and `ORIGINAL_OWNER` run parameter will be set.

## Related changes

Additionally the pull request brings support for `--trace` parameter to `pipe run/stop` commands which allows to optionally print error stack traces.