### PR TITLE
Issue #2182 NFS quotas: change `MOUNT_DISABLED` handling

### DIFF
--- a/api/profiles/dev/application.properties
+++ b/api/profiles/dev/application.properties
@@ -155,9 +155,7 @@ data.storage.nfs.options.wsize=1048576
 
 data.storage.nfs.quota.poll=60000
 data.storage.nfs.quota.metadata.key=fs_notifications
-data.storage.nfs.quota.action.email=EMAIL
-data.storage.nfs.quota.action.readonly=READONLY
-data.storage.nfs.quota.action.disabled=DISABLE_MOUNT
+data.storage.nfs.quota.default.restrictive.status=READ_ONLY
 
 # Enables logging filter using CommonsRequestLoggingFilter
 logging.level.org.springframework.web.filter.CommonsRequestLoggingFilter=DEBUG

--- a/api/profiles/release/application.properties
+++ b/api/profiles/release/application.properties
@@ -100,9 +100,7 @@ data.storage.nfs.options.wsize=1048576
 
 data.storage.nfs.quota.poll=${CP_API_NFS_QUOTA_POLL:60000}
 data.storage.nfs.quota.metadata.key=${CP_API_NFS_QUOTA_METADATA_KEY:fs_notifications}
-data.storage.nfs.quota.action.email=${CP_API_NFS_QUOTA_ACTION_MAIL:EMAIL}
-data.storage.nfs.quota.action.readonly=${CP_API_NFS_QUOTA_ACTION_READ_ONLY:READONLY}
-data.storage.nfs.quota.action.disabled=${CP_API_NFS_QUOTA_ACTION_MOUNT_DISABLE:DISABLE_MOUNT}
+data.storage.nfs.quota.default.restrictive.status=${CP_API_NFS_QUOTA_DEFAULT_RESTRICTION:READ_ONLY}
 
 #Firecloud
 firecloud.auth.client.id=

--- a/api/src/main/java/com/epam/pipeline/acl/datastorage/DataStorageApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/datastorage/DataStorageApiService.java
@@ -91,9 +91,8 @@ public class DataStorageApiService {
         return dataStorageManager.getDataStorages();
     }
 
-    @PostFilter("hasRole('ADMIN')"
-                + " OR @grantPermissionManager.storageWithSharePermission(filterObject, 'READ')"
-                + " OR @grantPermissionManager.storageWithSharePermission(filterObject, 'WRITE')")
+    @PostFilter("hasRole('ADMIN') OR (hasPermission(filterObject.storage, 'READ') OR "
+            + "hasPermission(filterObject.storage, 'WRITE'))")
     @AclMaskDelegateList
     public List<DataStorageWithShareMount> getAvailableStoragesWithShareMount(final Long fromRegionId) {
         return dataStorageManager.getDataStoragesWithShareMountObject(fromRegionId);

--- a/api/src/main/java/com/epam/pipeline/entity/datastorage/nfs/NFSQuotaNotificationEntry.java
+++ b/api/src/main/java/com/epam/pipeline/entity/datastorage/nfs/NFSQuotaNotificationEntry.java
@@ -16,6 +16,7 @@
 
 package com.epam.pipeline.entity.datastorage.nfs;
 
+import com.epam.pipeline.entity.datastorage.StorageQuotaAction;
 import lombok.Data;
 
 import java.util.Set;
@@ -25,5 +26,5 @@ public class NFSQuotaNotificationEntry {
 
     private final Double value;
     private final String type;
-    private final Set<String> actions;
+    private final Set<StorageQuotaAction> actions;
 }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSQuotasMonitor.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSQuotasMonitor.java
@@ -126,10 +126,10 @@ public class NFSQuotasMonitor {
     private NFSStorageMountStatus mapNotificationToStatus(final Long storageId,
                                                           final NFSQuotaNotificationEntry notification) {
         final Set<StorageQuotaAction> actions = notification.getActions();
-        if (actions.contains(StorageQuotaAction.DISABLE)) {
-            return NFSStorageMountStatus.MOUNT_DISABLED;
-        } else if (actions.contains(StorageQuotaAction.READ_ONLY)) {
+        if (actions.contains(StorageQuotaAction.READ_ONLY)) {
             return NFSStorageMountStatus.READ_ONLY;
+        } else if (actions.contains(StorageQuotaAction.DISABLE)) {
+            return NFSStorageMountStatus.MOUNT_DISABLED;
         } else {
             log.warn(messageHelper.getMessage(MessageConstants.STORAGE_QUOTA_UNKNOWN_RESTRICTION, actions, storageId));
             return defaultRestrictiveStatus;

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSQuotasMonitor.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSQuotasMonitor.java
@@ -25,6 +25,7 @@ import com.epam.pipeline.entity.datastorage.FileShareMount;
 import com.epam.pipeline.entity.datastorage.LustreFS;
 import com.epam.pipeline.entity.datastorage.MountType;
 import com.epam.pipeline.entity.datastorage.NFSStorageMountStatus;
+import com.epam.pipeline.entity.datastorage.StorageQuotaAction;
 import com.epam.pipeline.entity.datastorage.StorageUsage;
 import com.epam.pipeline.entity.datastorage.nfs.NFSQuotaNotificationEntry;
 import com.epam.pipeline.entity.datastorage.nfs.NFSDataStorage;
@@ -67,10 +68,8 @@ public class NFSQuotasMonitor {
     private final FileShareMountManager fileShareMountManager;
     private final LustreFSManager lustreManager;
     private final MessageHelper messageHelper;
-    private final String emailNotificationAction;
-    private final String readOnlyAction;
-    private final String disableMountAction;
     private final String notificationsKey;
+    private final NFSStorageMountStatus defaultRestrictiveStatus;
 
     public NFSQuotasMonitor(final DataStorageManager dataStorageManager,
                             final SearchManager searchManager,
@@ -78,24 +77,18 @@ public class NFSQuotasMonitor {
                             final FileShareMountManager fileShareMountManager,
                             final LustreFSManager lustreManager,
                             final MessageHelper messageHelper,
-                            final @Value("${data.storage.nfs.quota.action.email:EMAIL}")
-                                        String emailNotificationAction,
-                            final @Value("${data.storage.nfs.quota.action.readonly:READONLY}")
-                                        String readOnlyAction,
-                            final @Value("${data.storage.nfs.quota.action.disabled:DISABLE_MOUNT}")
-                                        String disableMountAction,
                             final @Value("${data.storage.nfs.quota.metadata.key:fs_notifications}")
-                                        String notificationsKey) {
+                                        String notificationsKey,
+                            final @Value("${data.storage.nfs.quota.default.restrictive.status:READ_ONLY}")
+                                NFSStorageMountStatus defaultRestrictiveStatus) {
         this.dataStorageManager = dataStorageManager;
         this.searchManager = searchManager;
         this.metadataManager = metadataManager;
         this.fileShareMountManager = fileShareMountManager;
         this.lustreManager = lustreManager;
         this.messageHelper = messageHelper;
-        this.emailNotificationAction = emailNotificationAction;
-        this.readOnlyAction = readOnlyAction;
-        this.disableMountAction = disableMountAction;
         this.notificationsKey = notificationsKey;
+        this.defaultRestrictiveStatus = defaultRestrictiveStatus;
     }
 
     @Scheduled(fixedDelayString = "${data.storage.nfs.quota.poll:60000}")
@@ -124,7 +117,7 @@ public class NFSQuotasMonitor {
             .filter(Objects::nonNull)
             .sorted(Comparator.comparing(NFSQuotaNotificationEntry::getValue).reversed())
             .filter(this::hasRestrictingActions)
-            .filter(notification -> excessLimit(storage, notification))
+            .filter(notification -> exceedsLimit(storage, notification))
             .map(notification -> mapNotificationToStatus(storage.getId(), notification))
             .findFirst()
             .orElse(NFSStorageMountStatus.ACTIVE);
@@ -132,45 +125,45 @@ public class NFSQuotasMonitor {
 
     private NFSStorageMountStatus mapNotificationToStatus(final Long storageId,
                                                           final NFSQuotaNotificationEntry notification) {
-        final Set<String> actions = notification.getActions();
-        if (actions.contains(disableMountAction)) {
+        final Set<StorageQuotaAction> actions = notification.getActions();
+        if (actions.contains(StorageQuotaAction.DISABLE)) {
             return NFSStorageMountStatus.MOUNT_DISABLED;
-        } else if (actions.contains(readOnlyAction)) {
+        } else if (actions.contains(StorageQuotaAction.READ_ONLY)) {
             return NFSStorageMountStatus.READ_ONLY;
         } else {
             log.warn(messageHelper.getMessage(MessageConstants.STORAGE_QUOTA_UNKNOWN_RESTRICTION, actions, storageId));
-            return NFSStorageMountStatus.READ_ONLY;
+            return defaultRestrictiveStatus;
         }
     }
 
     private boolean hasRestrictingActions(final NFSQuotaNotificationEntry notification) {
-        final Set<String> actions = notification.getActions();
+        final Set<StorageQuotaAction> actions = notification.getActions();
         return CollectionUtils.size(actions) > 1
-               || (CollectionUtils.size(actions) == 1 && !actions.contains(emailNotificationAction));
+               || (CollectionUtils.size(actions) == 1 && !actions.contains(StorageQuotaAction.EMAIL));
     }
 
-    private boolean excessLimit(final NFSDataStorage storage, final NFSQuotaNotificationEntry notification) {
+    private boolean exceedsLimit(final NFSDataStorage storage, final NFSQuotaNotificationEntry notification) {
         final Double originalLimit = notification.getValue();
         final StorageUsage storageUsage = searchManager.getStorageUsage(storage, null, true);
         final String notificationType = notification.getType();
         switch (notificationType) {
             case SIZE_QUOTA_GB:
-                return excessAbsoluteLimit(originalLimit, storageUsage);
+                return exceedsAbsoluteLimit(originalLimit, storageUsage);
             case SIZE_QUOTA_PERCENTS:
-                return excessPercentageLimit(storage, originalLimit, storageUsage);
+                return exceedsPercentageLimit(storage, originalLimit, storageUsage);
             default:
                 log.warn(messageHelper.getMessage(MessageConstants.STORAGE_QUOTA_UNKNOWN_TYPE, notificationType));
                 return false;
         }
     }
 
-    private boolean excessAbsoluteLimit(final Double originalLimit, final StorageUsage storageUsage) {
+    private boolean exceedsAbsoluteLimit(final Double originalLimit, final StorageUsage storageUsage) {
         final long limitBytes = (long) (originalLimit * GB_TO_BYTES);
         return storageUsage.getSize() > limitBytes;
     }
 
-    private boolean excessPercentageLimit(final NFSDataStorage storage, final Double originalLimit,
-                                          final StorageUsage storageUsage) {
+    private boolean exceedsPercentageLimit(final NFSDataStorage storage, final Double originalLimit,
+                                           final StorageUsage storageUsage) {
         final FileShareMount shareMount = fileShareMountManager.load(storage.getFileShareMountId());
         final MountType shareType = shareMount.getMountType();
         switch (shareType) {

--- a/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionManager.java
@@ -445,18 +445,6 @@ public class GrantPermissionManager {
         return user.equalsIgnoreCase(owner) || isAdmin(getSids());
     }
 
-    public boolean storageWithSharePermission(final DataStorageWithShareMount storageWithShare,
-                                              final String permissionName) {
-        final AbstractDataStorage storage = storageWithShare.getStorage();
-        final boolean disabled = Optional.of(storage)
-            .filter(NFSDataStorage.class::isInstance)
-            .map(NFSDataStorage.class::cast)
-            .map(NFSDataStorage::getMountStatus)
-            .filter(NFSStorageMountStatus.MOUNT_DISABLED::equals)
-            .isPresent();
-        return !disabled && storagePermission(storage.getId(), permissionName);
-    }
-
     public boolean storagePermission(final AbstractDataStorage storage, final String permissionName) {
         return storagePermission(storage.getId(), permissionName);
     }

--- a/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionManager.java
@@ -32,7 +32,6 @@ import com.epam.pipeline.entity.configuration.AbstractRunConfigurationEntry;
 import com.epam.pipeline.entity.configuration.RunConfiguration;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.DataStorageAction;
-import com.epam.pipeline.entity.datastorage.DataStorageWithShareMount;
 import com.epam.pipeline.entity.datastorage.NFSStorageMountStatus;
 import com.epam.pipeline.entity.datastorage.PathDescription;
 import com.epam.pipeline.entity.datastorage.nfs.NFSDataStorage;

--- a/api/src/test/java/com/epam/pipeline/acl/datastorage/DataStorageApiServiceCommonTest.java
+++ b/api/src/test/java/com/epam/pipeline/acl/datastorage/DataStorageApiServiceCommonTest.java
@@ -24,7 +24,6 @@ import com.epam.pipeline.entity.datastorage.DataStorageConvertRequest;
 import com.epam.pipeline.entity.datastorage.DataStorageConvertRequestAction;
 import com.epam.pipeline.entity.datastorage.DataStorageConvertRequestType;
 import com.epam.pipeline.entity.datastorage.DataStorageWithShareMount;
-import com.epam.pipeline.entity.datastorage.FileShareMount;
 import com.epam.pipeline.entity.datastorage.NFSStorageMountStatus;
 import com.epam.pipeline.entity.datastorage.StorageMountPath;
 import com.epam.pipeline.entity.datastorage.StorageUsage;
@@ -163,24 +162,6 @@ public class DataStorageApiServiceCommonTest extends AbstractDataStorageAclTest 
         final List<AbstractDataStorage> returnedDataStorages = dataStorageApiService.getDataStorages();
         assertThat(returnedDataStorages).hasSize(1).contains(nfsDataStorage);
         assertThat(returnedDataStorages.get(0).getMask()).isEqualTo(ALL_PERMISSIONS);
-    }
-
-    @Test
-    @WithMockUser(username = SIMPLE_USER)
-    public void shouldNotReturnDataStoragesWhenPermissionIsGrantedAndMountStatusDisabled() {
-        final NFSDataStorage nfsDataStorage =
-            DatastorageCreatorUtils.getNfsDataStorage(NFSStorageMountStatus.MOUNT_DISABLED, OWNER_USER);
-        initAclEntity(nfsDataStorage, Arrays.asList(new UserPermission(SIMPLE_USER, AclPermission.READ.getMask()),
-                                                    new UserPermission(SIMPLE_USER, AclPermission.WRITE.getMask())));
-        initUserAndEntityMocks(SIMPLE_USER, nfsDataStorage, context);
-        final DataStorageWithShareMount storageWithShareMount =
-            new DataStorageWithShareMount(nfsDataStorage, new FileShareMount());
-        doReturn(mutableListOf(storageWithShareMount)).when(mockDataStorageManager)
-            .getDataStoragesWithShareMountObject(eq(ID));
-
-        final List<DataStorageWithShareMount> returnedDataStorages =
-            dataStorageApiService.getAvailableStoragesWithShareMount(ID);
-        assertThat(returnedDataStorages).isEmpty();
     }
 
     @Test

--- a/deploy/docker/cp-api-srv/config/application.properties
+++ b/deploy/docker/cp-api-srv/config/application.properties
@@ -165,6 +165,4 @@ edge.internal.port=${CP_EDGE_INTERNAL_PORT:31081}
 
 data.storage.nfs.quota.poll=${CP_API_NFS_QUOTA_POLL:60000}
 data.storage.nfs.quota.metadata.key=${CP_API_NFS_QUOTA_METADATA_KEY:fs_notifications}
-data.storage.nfs.quota.action.email=${CP_API_NFS_QUOTA_ACTION_MAIL:EMAIL}
-data.storage.nfs.quota.action.readonly=${CP_API_NFS_QUOTA_ACTION_READ_ONLY:READONLY}
-data.storage.nfs.quota.action.disabled=${CP_API_NFS_QUOTA_ACTION_MOUNT_DISABLE:DISABLE_MOUNT}
+data.storage.nfs.quota.default.restrictive.status=${CP_API_NFS_QUOTA_DEFAULT_RESTRICTION:READ_ONLY}

--- a/workflows/pipe-common/scripts/mount_storage.py
+++ b/workflows/pipe-common/scripts/mount_storage.py
@@ -50,6 +50,7 @@ S3_PROVIDER = 'S3'
 READ_ONLY_MOUNT_OPT = 'ro'
 MOUNT_LIMITS_NONE = 'none'
 SENSITIVE_POLICY_PREFERENCE = 'storage.mounts.nfs.sensitive.policy'
+STORAGE_MOUNT_STATUS_DISABLED = 'MOUNT_DISABLED'
 
 
 class PermissionHelper:
@@ -81,6 +82,8 @@ class PermissionHelper:
 
     @classmethod
     def is_storage_writable(cls, storage):
+        if storage.mount_status == STORAGE_MOUNT_STATUS_DISABLED:
+            return False
         write_permission_granted = cls.is_permission_set(storage, WRITE_MASK)
         if not cls.is_run_sensitive():
             return write_permission_granted

--- a/workflows/pipe-common/scripts/watch_mount_shares.py
+++ b/workflows/pipe-common/scripts/watch_mount_shares.py
@@ -370,7 +370,11 @@ class NFSMountWatcher:
             return default
         matching_storage = NFSMountWatcher._find_matching_storage(available_storages_dict, mount_details)
         if matching_storage:
-            return matching_storage.mount_status
+            status = matching_storage.mount_status
+            if status == MOUNT_STATUS_DISABLED:
+                return MOUNT_STATUS_READ_ONLY
+            else:
+                return status
         else:
             return DEFAULT_MOUNT_STATUS
 


### PR DESCRIPTION
Thi PR is related to issue #2182 

It brings the following changes:
1. Modify the handling of `MOUNT_DISABLED` status in runs - storage becomes read-only
2. Storage with disabled status is not filtered from `/datastorage/availableWithMounts` endpoint
3. Restore some fixes on comments from PR #2171: fix naming and use an enum for actions.
