### PR TITLE
Issue #2182 NFS quotas: email notification

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/datastorage/nfs/NFSQuotaNotificationEntry.java
+++ b/api/src/main/java/com/epam/pipeline/entity/datastorage/nfs/NFSQuotaNotificationEntry.java
@@ -17,6 +17,7 @@
 package com.epam.pipeline.entity.datastorage.nfs;
 
 import com.epam.pipeline.entity.datastorage.StorageQuotaAction;
+import com.epam.pipeline.entity.datastorage.StorageQuotaType;
 import lombok.Data;
 
 import java.util.Set;
@@ -25,10 +26,10 @@ import java.util.Set;
 public class NFSQuotaNotificationEntry {
 
     private final Double value;
-    private final String type;
+    private final StorageQuotaType type;
     private final Set<StorageQuotaAction> actions;
 
     public String toThreshold() {
-        return String.format("%.0f %s", value, type);
+        return String.format("%.0f %s", value, type.getThresholdLabel());
     }
 }

--- a/api/src/main/java/com/epam/pipeline/entity/datastorage/nfs/NFSQuotaNotificationEntry.java
+++ b/api/src/main/java/com/epam/pipeline/entity/datastorage/nfs/NFSQuotaNotificationEntry.java
@@ -27,4 +27,8 @@ public class NFSQuotaNotificationEntry {
     private final Double value;
     private final String type;
     private final Set<StorageQuotaAction> actions;
+
+    public String toThreshold() {
+        return String.format("%.0f %s", value, type);
+    }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSQuotasMonitor.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSQuotasMonitor.java
@@ -26,6 +26,7 @@ import com.epam.pipeline.entity.datastorage.LustreFS;
 import com.epam.pipeline.entity.datastorage.MountType;
 import com.epam.pipeline.entity.datastorage.NFSStorageMountStatus;
 import com.epam.pipeline.entity.datastorage.StorageQuotaAction;
+import com.epam.pipeline.entity.datastorage.StorageQuotaType;
 import com.epam.pipeline.entity.datastorage.StorageUsage;
 import com.epam.pipeline.entity.datastorage.nfs.NFSQuotaNotificationEntry;
 import com.epam.pipeline.entity.datastorage.nfs.NFSDataStorage;
@@ -60,8 +61,6 @@ import java.util.stream.Collectors;
 public class NFSQuotasMonitor {
 
     private static final int GB_TO_BYTES = 1024 * 1024 * 1024;
-    private static final String SIZE_QUOTA_GB = "GB";
-    private static final String SIZE_QUOTA_PERCENTS = "PERCENT";
     private static final int PERCENTS_MULTIPLIER = 100;
 
     private final DataStorageManager dataStorageManager;
@@ -157,11 +156,11 @@ public class NFSQuotasMonitor {
     private boolean exceedsLimit(final NFSDataStorage storage, final NFSQuotaNotificationEntry notification) {
         final Double originalLimit = notification.getValue();
         final StorageUsage storageUsage = searchManager.getStorageUsage(storage, null, true);
-        final String notificationType = notification.getType();
+        final StorageQuotaType notificationType = notification.getType();
         switch (notificationType) {
-            case SIZE_QUOTA_GB:
+            case GIGABYTES:
                 return exceedsAbsoluteLimit(originalLimit, storageUsage);
-            case SIZE_QUOTA_PERCENTS:
+            case PERCENTS:
                 return exceedsPercentageLimit(storage, originalLimit, storageUsage);
             default:
                 log.warn(messageHelper.getMessage(MessageConstants.STORAGE_QUOTA_UNKNOWN_TYPE, notificationType));

--- a/api/src/main/java/com/epam/pipeline/manager/notification/NotificationService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/notification/NotificationService.java
@@ -2,6 +2,10 @@ package com.epam.pipeline.manager.notification;
 
 import com.epam.pipeline.entity.AbstractSecuredEntity;
 import com.epam.pipeline.entity.cluster.monitoring.ELKUsageMetric;
+import com.epam.pipeline.entity.datastorage.NFSStorageMountStatus;
+import com.epam.pipeline.entity.datastorage.nfs.NFSDataStorage;
+import com.epam.pipeline.entity.datastorage.nfs.NFSQuotaNotificationEntry;
+import com.epam.pipeline.entity.datastorage.nfs.NFSQuotaNotificationRecipient;
 import com.epam.pipeline.entity.issue.Issue;
 import com.epam.pipeline.entity.issue.IssueComment;
 import com.epam.pipeline.entity.notification.NotificationSettings;
@@ -52,5 +56,12 @@ public interface NotificationService {
 
     default List<PipelineRun> notifyLongPausedRunsBeforeStop(List<PipelineRun> pausedRuns) {
         return Collections.emptyList();
+    }
+
+    default void notifyOnStorageQuotaExceeding(final NFSDataStorage storage,
+                                               final NFSStorageMountStatus newStatus,
+                                               final NFSQuotaNotificationEntry exceededQuota,
+                                               final List<NFSQuotaNotificationRecipient> recipients) {
+
     }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/datastorage/StorageQuotaType.java
+++ b/core/src/main/java/com/epam/pipeline/entity/datastorage/StorageQuotaType.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.datastorage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@RequiredArgsConstructor
+@Getter
+public enum StorageQuotaType {
+    GIGABYTES("GB", "Gb"), PERCENTS("PERCENT", "%");
+
+    private final String sourceString;
+    private final String thresholdLabel;
+
+    private static final Map<String, StorageQuotaType> idMap = Stream.of(StorageQuotaType.values())
+        .collect(Collectors.toMap(StorageQuotaType::getSourceString, Function.identity()));
+
+    @JsonCreator
+    public static StorageQuotaType fromString(final String string) {
+        return idMap.getOrDefault(string, null);
+    }
+}

--- a/core/src/main/java/com/epam/pipeline/entity/notification/NotificationType.java
+++ b/core/src/main/java/com/epam/pipeline/entity/notification/NotificationType.java
@@ -38,7 +38,9 @@ public enum NotificationType {
     LONG_PAUSED(11, -1L, -1L, Collections.emptyList(), true,
             NotificationGroup.LONG_PAUSED),
     LONG_PAUSED_STOPPED(12, -1L, -1L, Collections.emptyList(), true,
-            NotificationGroup.LONG_PAUSED);
+            NotificationGroup.LONG_PAUSED),
+    STORAGE_QUOTA_EXCEEDING(13, -1L, -1L, Collections.emptyList(), true,
+                NotificationGroup.RESOURCE_CONSUMING);
 
     private static final Map<Long, NotificationType> BY_ID;
 

--- a/deploy/contents/install/email-templates/configs/STORAGE_QUOTA_EXCEEDING.json
+++ b/deploy/contents/install/email-templates/configs/STORAGE_QUOTA_EXCEEDING.json
@@ -1,0 +1,6 @@
+{
+  "keepInformedAdmins":false,
+  "keepInformedOwner":false,
+  "enabled":true,
+  "subject":"Storage `#$templateParameters[\"storageName\"]` exceeds a quota"
+}

--- a/deploy/contents/install/email-templates/contents/STORAGE_QUOTA_EXCEEDING.html
+++ b/deploy/contents/install/email-templates/contents/STORAGE_QUOTA_EXCEEDING.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <style>
+        table,
+        td {
+            border: 1px solid black;
+            border-collapse: collapse;
+            padding: 5px;
+        }
+    </style>
+</head>
+
+<body>
+<p>Dear user,</p>
+<p>*** This is a system generated email, do not reply to this email ***</p>
+<p>Please be informed, that a data storage <a href="https://$CP_API_SRV_EXTERNAL_HOST:$CP_API_SRV_EXTERNAL_PORT/pipeline/#/storage/${CP_DOLLAR}templateParameters.get("storageId")">${CP_DOLLAR}templateParameters.get("storageName")</a> has reached a ${CP_DOLLAR}templateParameters.get("threshold") volume consumption threshold.</p>
+<p>Previous data storage state is <b>${CP_DOLLAR}templateParameters.get("previousMountStatus")</b></p>
+<p>New data storage state is <b>${CP_DOLLAR}templateParameters.get("newMountStatus")</b></p>
+<br />
+<p>Best regards,</p>
+<p>$CP_PREF_UI_PIPELINE_DEPLOYMENT_NAME Platform</p>
+</body>
+
+</html>


### PR DESCRIPTION
This PR is related to issue #2182

It brings:
1. Email notification mechanism used for `EMAIL` quota action. Default template containing information on storage (id, name, old status, new status) and triggering quota is provided
2. Fix the comparison when mixed quotas are configured for notifications - if both `GB` and `%` quotas are specified compare their corresponding absolute values