### PR TITLE
Issue #2182 Improve status monitoring in observer

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/datastorage/DataStorageApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/datastorage/DataStorageApiService.java
@@ -91,8 +91,9 @@ public class DataStorageApiService {
         return dataStorageManager.getDataStorages();
     }
 
-    @PostFilter("hasRole('ADMIN') OR (hasPermission(filterObject.storage, 'READ') OR "
-            + "hasPermission(filterObject.storage, 'WRITE'))")
+    @PostFilter("hasRole('ADMIN')"
+                + " OR @grantPermissionManager.storageWithSharePermission(filterObject, 'READ')"
+                + " OR @grantPermissionManager.storageWithSharePermission(filterObject, 'WRITE')")
     @AclMaskDelegateList
     public List<DataStorageWithShareMount> getAvailableStoragesWithShareMount(final Long fromRegionId) {
         return dataStorageManager.getDataStoragesWithShareMountObject(fromRegionId);

--- a/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionManager.java
@@ -32,6 +32,7 @@ import com.epam.pipeline.entity.configuration.AbstractRunConfigurationEntry;
 import com.epam.pipeline.entity.configuration.RunConfiguration;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.DataStorageAction;
+import com.epam.pipeline.entity.datastorage.DataStorageWithShareMount;
 import com.epam.pipeline.entity.datastorage.NFSStorageMountStatus;
 import com.epam.pipeline.entity.datastorage.PathDescription;
 import com.epam.pipeline.entity.datastorage.nfs.NFSDataStorage;
@@ -442,6 +443,21 @@ public class GrantPermissionManager {
             return false;
         }
         return user.equalsIgnoreCase(owner) || isAdmin(getSids());
+    }
+
+    public boolean storageWithSharePermission(final DataStorageWithShareMount storageWithShare,
+                                              final String permissionName) {
+        final AbstractDataStorage storage = storageWithShare.getStorage();
+        final boolean accessGranted = storagePermission(storage.getId(), permissionName);
+        if (accessGranted) {
+            Optional.of(storage)
+                .filter(NFSDataStorage.class::isInstance)
+                .map(NFSDataStorage.class::cast)
+                .map(NFSDataStorage::getMountStatus)
+                .filter(NFSStorageMountStatus.MOUNT_DISABLED::equals)
+                .ifPresent(status -> storage.setMask(AclPermission.READ.getMask()));
+        }
+        return accessGranted;
     }
 
     public boolean storagePermission(final AbstractDataStorage storage, final String permissionName) {

--- a/api/src/test/java/com/epam/pipeline/acl/datastorage/DataStorageApiServiceCommonTest.java
+++ b/api/src/test/java/com/epam/pipeline/acl/datastorage/DataStorageApiServiceCommonTest.java
@@ -24,6 +24,7 @@ import com.epam.pipeline.entity.datastorage.DataStorageConvertRequest;
 import com.epam.pipeline.entity.datastorage.DataStorageConvertRequestAction;
 import com.epam.pipeline.entity.datastorage.DataStorageConvertRequestType;
 import com.epam.pipeline.entity.datastorage.DataStorageWithShareMount;
+import com.epam.pipeline.entity.datastorage.FileShareMount;
 import com.epam.pipeline.entity.datastorage.NFSStorageMountStatus;
 import com.epam.pipeline.entity.datastorage.StorageMountPath;
 import com.epam.pipeline.entity.datastorage.StorageUsage;
@@ -162,6 +163,43 @@ public class DataStorageApiServiceCommonTest extends AbstractDataStorageAclTest 
         final List<AbstractDataStorage> returnedDataStorages = dataStorageApiService.getDataStorages();
         assertThat(returnedDataStorages).hasSize(1).contains(nfsDataStorage);
         assertThat(returnedDataStorages.get(0).getMask()).isEqualTo(ALL_PERMISSIONS);
+    }
+
+    @Test
+    @WithMockUser(roles = ADMIN_ROLE)
+    public void shouldNotModifyMaskForDataStorageWithShareWhenAdminAndMountStatusDisabled() {
+        final NFSDataStorage nfsDataStorage =
+            DatastorageCreatorUtils.getNfsDataStorage(NFSStorageMountStatus.MOUNT_DISABLED, OWNER_USER);
+        final DataStorageWithShareMount storageWithShareMount =
+            new DataStorageWithShareMount(nfsDataStorage, new FileShareMount());
+        doReturn(mutableListOf(storageWithShareMount)).when(mockDataStorageManager)
+            .getDataStoragesWithShareMountObject(eq(ID));
+
+        final List<DataStorageWithShareMount> returnedDataStorages =
+            dataStorageApiService.getAvailableStoragesWithShareMount(ID);
+        assertThat(returnedDataStorages).hasSize(1);
+        assertThat(returnedDataStorages.get(0).getStorage().getMask()).isEqualTo(ALL_PERMISSIONS);
+    }
+
+    @Test
+    @WithMockUser(username = SIMPLE_USER)
+    public void shouldReturnReadOnlyDataStorageWithShareWhenPermissionIsGrantedAndMountStatusReadOnly() {
+        initializeNfsStorageForUser(NFSStorageMountStatus.READ_ONLY);
+
+        final List<DataStorageWithShareMount> returnedDataStorages =
+            dataStorageApiService.getAvailableStoragesWithShareMount(ID);
+        assertThat(returnedDataStorages).hasSize(1);
+        assertThat(returnedDataStorages.get(0).getStorage().getMask()).isEqualTo(READ_PERMISSION);
+    }
+
+    @Test
+    @WithMockUser(username = SIMPLE_USER)
+    public void shouldReturnReadOnlyDataStorageWithShareWhenPermissionIsGrantedAndMountStatusDisabled() {
+        initializeNfsStorageForUser(NFSStorageMountStatus.MOUNT_DISABLED);
+        final List<DataStorageWithShareMount> returnedDataStorages =
+            dataStorageApiService.getAvailableStoragesWithShareMount(ID);
+        assertThat(returnedDataStorages).hasSize(1);
+        assertThat(returnedDataStorages.get(0).getStorage().getMask()).isEqualTo(READ_PERMISSION);
     }
 
     @Test
@@ -736,5 +774,17 @@ public class DataStorageApiServiceCommonTest extends AbstractDataStorageAclTest 
 
         assertThrows(AccessDeniedException.class, () ->
                 dataStorageApiService.generateCredentials(dataStorageActionList));
+    }
+
+    private void initializeNfsStorageForUser(NFSStorageMountStatus mountDisabled) {
+        final NFSDataStorage nfsDataStorage =
+            DatastorageCreatorUtils.getNfsDataStorage(mountDisabled, OWNER_USER);
+        initAclEntity(nfsDataStorage, Arrays.asList(new UserPermission(SIMPLE_USER, AclPermission.READ.getMask()),
+                                                    new UserPermission(SIMPLE_USER, AclPermission.WRITE.getMask())));
+        initUserAndEntityMocks(SIMPLE_USER, nfsDataStorage, context);
+        final DataStorageWithShareMount storageWithShareMount =
+            new DataStorageWithShareMount(nfsDataStorage, new FileShareMount());
+        doReturn(mutableListOf(storageWithShareMount)).when(mockDataStorageManager)
+            .getDataStoragesWithShareMountObject(eq(ID));
     }
 }

--- a/workflows/pipe-common/scripts/mount_storage.py
+++ b/workflows/pipe-common/scripts/mount_storage.py
@@ -50,7 +50,6 @@ S3_PROVIDER = 'S3'
 READ_ONLY_MOUNT_OPT = 'ro'
 MOUNT_LIMITS_NONE = 'none'
 SENSITIVE_POLICY_PREFERENCE = 'storage.mounts.nfs.sensitive.policy'
-STORAGE_MOUNT_STATUS_DISABLED = 'MOUNT_DISABLED'
 
 
 class PermissionHelper:
@@ -82,8 +81,6 @@ class PermissionHelper:
 
     @classmethod
     def is_storage_writable(cls, storage):
-        if storage.mount_status == STORAGE_MOUNT_STATUS_DISABLED:
-            return False
         write_permission_granted = cls.is_permission_set(storage, WRITE_MASK)
         if not cls.is_run_sensitive():
             return write_permission_granted


### PR DESCRIPTION
This PR is related to issue #2182

It brings improvements to the NFS observer, which allows elevating permission to RW regarding the mode at the run startup. It became easy to implement since `MOUNT_DISABLED` status means 'RO mode' and not 'do not mount' inside the run.

Also, it reverts the approach of mask modification - it seems more robust to make it at the server side to avoid extra ROLE_ADMIN checks inside the run when resolving status.
