### PR TITLE
Issue #2155 Observer bucket default value

### DIFF
--- a/deploy/docker/cp-search/config/application.properties
+++ b/deploy/docker/cp-search/config/application.properties
@@ -83,7 +83,7 @@ sync.nfs-storage.disable=${CP_SEARCH_DISABLE_NFS_STORAGE:false}
 sync.nfs-storage.index.mapping=file://${CP_SEARCH_MAPPINGS_LOCATION}/data_storage.json
 sync.nfs-storage.index.name=nfs-storage
 sync.nfs-file.observer.sync.disable=${CP_SEARCH_DISABLE_NFS_OBSERVER_SYNC:false}
-sync.nfs-file.observer.sync.target.bucket=${CP_SEARCH_NFS_OBSERVER_EVENTS_BUCKET}
+sync.nfs-file.observer.sync.target.bucket=${CP_SEARCH_NFS_OBSERVER_EVENTS_BUCKET:}
 sync.nfs-file.observer.sync.files.chunk=${CP_SEARCH_NFS_OBSERVER_EVENTS_FILES_CHUNK_SIZE:10}
 
 #Azure blob storage Settings


### PR DESCRIPTION
This PR is related to issue #2155

Let's use an empty value as a default one for the event bucket in the `elasticsearch-agent`. 
This way service startup won't fail in case `NFSObserverEventSynchronizer` is disabled (`CP_SEARCH_DISABLE_NFS_OBSERVER_SYNC` set to `true`) and no value is specified as a bucket.
