### PR TITLE
Issue #2183: Autoscaled cluster costs

### DIFF
--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
@@ -57,6 +57,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
@@ -127,6 +128,9 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     private String loadAllRunsByIdsQuery;
     private String loadRunByPodIPQuery;
     private String loadRunsByNodeNameQuery;
+    private String updateClusterPriceQuery;
+    private String loadRunsByParentRunsIdsQuery;
+    private String loadRunningMasterRunsQuery;
 
     // We put Propagation.REQUIRED here because this method can be called from non-transaction context
     // (see PipelineRunManager, it performs internal call for launchPipeline)
@@ -431,6 +435,40 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     public List<PipelineRun> loadRunsByNodeName(final String nodeName) {
         return addServiceUrls(ListUtils.emptyIfNull(getJdbcTemplate()
                 .query(loadRunsByNodeNameQuery, PipelineRunParameters.getRowMapper(), nodeName)));
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void batchUpdateClusterPrices(final Collection<PipelineRun> runs) {
+        if (CollectionUtils.isEmpty(runs)) {
+            return;
+        }
+
+        final MapSqlParameterSource[] params = runs.stream()
+                .map(run -> {
+                    final MapSqlParameterSource param = new MapSqlParameterSource();
+                    param.addValue(PipelineRunParameters.RUN_ID.name(), run.getId());
+                    param.addValue(PipelineRunParameters.CLUSTER_PRICE.name(), run.getClusterPrice());
+                    return param;
+                }).toArray(MapSqlParameterSource[]::new);
+
+        getNamedParameterJdbcTemplate().batchUpdate(updateClusterPriceQuery, params);
+    }
+
+    public List<PipelineRun> loadRunsByParentRuns(final Collection<Long> parentIds) {
+        if (CollectionUtils.isEmpty(parentIds)) {
+            return Collections.emptyList();
+        }
+
+        final MapSqlParameterSource params = new MapSqlParameterSource();
+        params.addValue(LIST_PARAMETER, parentIds);
+
+        return getNamedParameterJdbcTemplate()
+                .query(loadRunsByParentRunsIdsQuery, params, PipelineRunParameters.getRowMapper());
+    }
+
+    public List<PipelineRun> loadRunningMasters() {
+        return getJdbcTemplate()
+                .query(loadRunningMasterRunsQuery, PipelineRunParameters.getExtendedRowMapper());
     }
 
     private MapSqlParameterSource getPagingParameters(PagingRunFilterVO filter) {
@@ -750,7 +788,8 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
         ACCESS_TYPE,
         TAGS,
         SENSITIVE,
-        KUBE_SERVICE_ENABLED;
+        KUBE_SERVICE_ENABLED,
+        CLUSTER_PRICE;
 
         public static final RunAccessType DEFAULT_ACCESS_TYPE = RunAccessType.ENDPOINT;
 
@@ -793,6 +832,7 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
             params.addValue(PRICE_PER_HOUR.name(), run.getPricePerHour());
             params.addValue(COMPUTE_PRICE_PER_HOUR.name(), run.getComputePricePerHour());
             params.addValue(DISK_PRICE_PER_HOUR.name(), run.getDiskPricePerHour());
+            params.addValue(CLUSTER_PRICE.name(), run.getClusterPrice());
             params.addValue(STATE_REASON.name(), run.getStateReasonMessage());
             params.addValue(NON_PAUSE.name(), run.isNonPause());
             params.addValue(TAGS.name(), JsonMapper.convertDataToJsonStringForQuery(run.getTags()));
@@ -937,6 +977,7 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
             run.setPricePerHour(rs.getBigDecimal(PRICE_PER_HOUR.name()));
             run.setComputePricePerHour(rs.getBigDecimal(COMPUTE_PRICE_PER_HOUR.name()));
             run.setDiskPricePerHour(rs.getBigDecimal(DISK_PRICE_PER_HOUR.name()));
+            run.setClusterPrice(rs.getBigDecimal(CLUSTER_PRICE.name()));
             String stateReasonMessage = rs.getString(STATE_REASON.name());
             if (!rs.wasNull()) {
                 run.setStateReasonMessage(stateReasonMessage);
@@ -1247,5 +1288,20 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setLoadRunsByNodeNameQuery(final String loadRunsByNodeNameQuery) {
         this.loadRunsByNodeNameQuery = loadRunsByNodeNameQuery;
+    }
+
+    @Required
+    public void setUpdateClusterPriceQuery(final String updateClusterPriceQuery) {
+        this.updateClusterPriceQuery = updateClusterPriceQuery;
+    }
+
+    @Required
+    public void setLoadRunsByParentRunsIdsQuery(final String loadRunsByParentRunsIdsQuery) {
+        this.loadRunsByParentRunsIdsQuery = loadRunsByParentRunsIdsQuery;
+    }
+
+    @Required
+    public void setLoadRunningMasterRunsQuery(final String loadRunningMasterRunsQuery) {
+        this.loadRunningMasterRunsQuery = loadRunningMasterRunsQuery;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/costs/ClusterCostsMonitoringService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/costs/ClusterCostsMonitoringService.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster.costs;
+
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.utils.DateUtils;
+import com.epam.pipeline.manager.pipeline.PipelineRunCRUDService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.ListUtils;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ClusterCostsMonitoringService {
+
+    private final PipelineRunCRUDService pipelineRunCRUDService;
+
+    @Scheduled(fixedDelayString = "${cluster.costs.monitor.delay:30000}")
+    public void monitor() {
+        log.debug("Started cluster costs monitoring");
+        final Map<Long, PipelineRun> masters = ListUtils.emptyIfNull(pipelineRunCRUDService
+                .loadRunningMasters()).stream()
+                .filter(PipelineRun::isMasterRun)
+                .collect(Collectors.toMap(PipelineRun::getId, Function.identity()));
+        log.debug("Found '{}' running master runs", masters.size());
+
+        final Map<Long, List<PipelineRun>> workersByParent = pipelineRunCRUDService
+                .loadRunsByParentRuns(masters.keySet());
+
+        workersByParent.forEach((parentId, workers) -> estimateClusterPrice(parentId, workers, masters));
+        pipelineRunCRUDService.updateClusterPrices(masters.values());
+        log.debug("Finished cluster costs monitoring");
+    }
+
+    private void estimateClusterPrice(final Long parentId, final List<PipelineRun> workers,
+                                      final Map<Long, PipelineRun> masters) {
+        final BigDecimal workersPrice = estimateWorkersPrice(workers);
+
+        final PipelineRun master = masters.get(parentId);
+        final BigDecimal masterPrice = estimatePriceForRun(master);
+
+        master.setClusterPrice(masterPrice.add(workersPrice));
+    }
+
+    private BigDecimal estimateWorkersPrice(final List<PipelineRun> workers) {
+        return workers.stream()
+                .map(this::estimatePriceForRun)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    private BigDecimal estimatePriceForRun(final PipelineRun run) {
+        if (Objects.isNull(run.getPricePerHour())) {
+            return BigDecimal.ZERO;
+        }
+        final BigDecimal pricePerMinute = run.getPricePerHour().divide(BigDecimal.valueOf(60), RoundingMode.HALF_UP);
+        return pricePerMinute.multiply(durationInMinutes(run));
+    }
+
+    private BigDecimal durationInMinutes(final PipelineRun run) {
+        if (Objects.isNull(run.getStartDate())) {
+            return BigDecimal.ZERO;
+        }
+
+        final Date pipelineEnd = Objects.isNull(run.getEndDate()) ? DateUtils.now() : run.getEndDate();
+        final long runDurationMs = pipelineEnd.getTime() - run.getStartDate().getTime();
+        return new BigDecimal(TimeUnit.MINUTES.convert(runDurationMs, TimeUnit.MILLISECONDS));
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/costs/ClusterCostsMonitoringService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/costs/ClusterCostsMonitoringService.java
@@ -27,7 +27,7 @@ import javax.annotation.PostConstruct;
 @RequiredArgsConstructor
 public class ClusterCostsMonitoringService extends AbstractSchedulingManager {
 
-   private final ClusterCostsMonitoringServiceCore core;
+    private final ClusterCostsMonitoringServiceCore core;
 
     @PostConstruct
     public void init() {

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/costs/ClusterCostsMonitoringService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/costs/ClusterCostsMonitoringService.java
@@ -16,80 +16,22 @@
 
 package com.epam.pipeline.manager.cluster.costs;
 
-import com.epam.pipeline.entity.pipeline.PipelineRun;
-import com.epam.pipeline.entity.utils.DateUtils;
-import com.epam.pipeline.manager.pipeline.PipelineRunCRUDService;
+import com.epam.pipeline.manager.preference.SystemPreferences;
+import com.epam.pipeline.manager.scheduling.AbstractSchedulingManager;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.collections4.ListUtils;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import java.util.stream.Collectors;
+import javax.annotation.PostConstruct;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
-public class ClusterCostsMonitoringService {
+public class ClusterCostsMonitoringService extends AbstractSchedulingManager {
 
-    private final PipelineRunCRUDService pipelineRunCRUDService;
+   private final ClusterCostsMonitoringServiceCore core;
 
-    @Scheduled(fixedDelayString = "${cluster.costs.monitor.delay:30000}")
-    public void monitor() {
-        log.debug("Started cluster costs monitoring");
-        final Map<Long, PipelineRun> masters = ListUtils.emptyIfNull(pipelineRunCRUDService
-                .loadRunningMasters()).stream()
-                .filter(PipelineRun::isMasterRun)
-                .collect(Collectors.toMap(PipelineRun::getId, Function.identity()));
-        log.debug("Found '{}' running master runs", masters.size());
-
-        final Map<Long, List<PipelineRun>> workersByParent = pipelineRunCRUDService
-                .loadRunsByParentRuns(masters.keySet());
-
-        workersByParent.forEach((parentId, workers) -> estimateClusterPrice(parentId, workers, masters));
-        pipelineRunCRUDService.updateClusterPrices(masters.values());
-        log.debug("Finished cluster costs monitoring");
-    }
-
-    private void estimateClusterPrice(final Long parentId, final List<PipelineRun> workers,
-                                      final Map<Long, PipelineRun> masters) {
-        final BigDecimal workersPrice = estimateWorkersPrice(workers);
-
-        final PipelineRun master = masters.get(parentId);
-        final BigDecimal masterPrice = estimatePriceForRun(master);
-
-        master.setClusterPrice(masterPrice.add(workersPrice));
-    }
-
-    private BigDecimal estimateWorkersPrice(final List<PipelineRun> workers) {
-        return workers.stream()
-                .map(this::estimatePriceForRun)
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
-    }
-
-    private BigDecimal estimatePriceForRun(final PipelineRun run) {
-        if (Objects.isNull(run.getPricePerHour())) {
-            return BigDecimal.ZERO;
-        }
-        final BigDecimal pricePerMinute = run.getPricePerHour().divide(BigDecimal.valueOf(60), RoundingMode.HALF_UP);
-        return pricePerMinute.multiply(durationInMinutes(run));
-    }
-
-    private BigDecimal durationInMinutes(final PipelineRun run) {
-        if (Objects.isNull(run.getStartDate())) {
-            return BigDecimal.ZERO;
-        }
-
-        final Date pipelineEnd = Objects.isNull(run.getEndDate()) ? DateUtils.now() : run.getEndDate();
-        final long runDurationMs = pipelineEnd.getTime() - run.getStartDate().getTime();
-        return new BigDecimal(TimeUnit.MINUTES.convert(runDurationMs, TimeUnit.MILLISECONDS));
+    @PostConstruct
+    public void init() {
+        scheduleFixedDelaySecured(core::monitor, SystemPreferences.SYSTEM_CLUSTER_PRICE_MONITOR_DELAY,
+                "ClusterPriceMonitor");
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/costs/ClusterCostsMonitoringServiceCore.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/costs/ClusterCostsMonitoringServiceCore.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster.costs;
+
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.utils.DateUtils;
+import com.epam.pipeline.manager.pipeline.PipelineRunCRUDService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.core.SchedulerLock;
+import org.apache.commons.collections4.ListUtils;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ClusterCostsMonitoringServiceCore {
+
+    private final PipelineRunCRUDService pipelineRunCRUDService;
+
+    @SchedulerLock(name = "ClusterCostsMonitoringService_monitor", lockAtMostForString = "PT10M")
+    public void monitor() {
+        log.debug("Started cluster costs monitoring");
+        final Map<Long, PipelineRun> masters = ListUtils.emptyIfNull(pipelineRunCRUDService
+                .loadRunningMasters()).stream()
+                .filter(PipelineRun::isMasterRun)
+                .collect(Collectors.toMap(PipelineRun::getId, Function.identity()));
+        log.debug("Found '{}' running master runs", masters.size());
+
+        final Map<Long, List<PipelineRun>> workersByParent = pipelineRunCRUDService
+                .loadRunsByParentRuns(masters.keySet());
+
+        workersByParent.forEach((parentId, workers) -> estimateClusterPrice(parentId, workers, masters));
+        pipelineRunCRUDService.updateClusterPrices(masters.values());
+        log.debug("Finished cluster costs monitoring");
+    }
+
+    private void estimateClusterPrice(final Long parentId, final List<PipelineRun> workers,
+                                      final Map<Long, PipelineRun> masters) {
+        final BigDecimal workersPrice = estimateWorkersPrice(workers);
+
+        final PipelineRun master = masters.get(parentId);
+        final BigDecimal masterPrice = estimatePriceForRun(master);
+
+        master.setClusterPrice(masterPrice.add(workersPrice));
+    }
+
+    private BigDecimal estimateWorkersPrice(final List<PipelineRun> workers) {
+        return workers.stream()
+                .map(this::estimatePriceForRun)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    private BigDecimal estimatePriceForRun(final PipelineRun run) {
+        if (Objects.isNull(run.getPricePerHour())) {
+            return BigDecimal.ZERO;
+        }
+        final BigDecimal pricePerMinute = run.getPricePerHour().divide(BigDecimal.valueOf(60), RoundingMode.HALF_UP);
+        return pricePerMinute.multiply(durationInMinutes(run));
+    }
+
+    private BigDecimal durationInMinutes(final PipelineRun run) {
+        if (Objects.isNull(run.getStartDate())) {
+            return BigDecimal.ZERO;
+        }
+
+        final Date pipelineEnd = Objects.isNull(run.getEndDate()) ? DateUtils.now() : run.getEndDate();
+        final long runDurationMs = pipelineEnd.getTime() - run.getStartDate().getTime();
+        return new BigDecimal(TimeUnit.MINUTES.convert(runDurationMs, TimeUnit.MILLISECONDS));
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunCRUDService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunCRUDService.java
@@ -27,8 +27,12 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 //TODO: Move all CRUD and DB persistence methods from PipelineRunManager to this class
 @Service
@@ -74,5 +78,21 @@ public class PipelineRunCRUDService {
 
     public List<PipelineRun> loadRunsForNodeName(final String nodeName) {
         return pipelineRunDao.loadRunsByNodeName(nodeName);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void updateClusterPrices(final Collection<PipelineRun> runs) {
+        pipelineRunDao.batchUpdateClusterPrices(CollectionUtils.emptyIfNull(runs).stream()
+                .filter(run -> Objects.nonNull(run.getClusterPrice()))
+                .collect(Collectors.toList()));
+    }
+
+    public Map<Long, List<PipelineRun>> loadRunsByParentRuns(final Collection<Long> parents) {
+        return CollectionUtils.emptyIfNull(pipelineRunDao.loadRunsByParentRuns(parents)).stream()
+                .collect(Collectors.groupingBy(PipelineRun::getParentRunId));
+    }
+
+    public List<PipelineRun> loadRunningMasters() {
+        return pipelineRunDao.loadRunningMasters();
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -681,6 +681,8 @@ public class SystemPreferences {
      */
     public static final StringPreference SYSTEM_NOTIFICATIONS_EXCLUDE_INSTANCE_TYPES = new StringPreference(
             "system.notifications.exclude.instance.types", null, SYSTEM_GROUP, pass);
+    public static final IntPreference SYSTEM_CLUSTER_PRICE_MONITOR_DELAY = new IntPreference(
+            "system.cluster.price.monitor.delay", 30000, SYSTEM_GROUP, pass);
 
     // FireCloud Integration
     public static final ObjectPreference<List<String>> FIRECLOUD_SCOPES = new ObjectPreference<>(

--- a/api/src/main/resources/dao/filter-dao.xml
+++ b/api/src/main/resources/dao/filter-dao.xml
@@ -72,7 +72,8 @@
                         r.tags,
                         r.sensitive,
                         r.kube_service_enabled,
-                        r.pipeline_name
+                        r.pipeline_name,
+                        r.cluster_price
                     FROM
                         pipeline.pipeline_run r
                     WHERE @WHERE@

--- a/api/src/main/resources/dao/pipeline-run-dao.xml
+++ b/api/src/main/resources/dao/pipeline-run-dao.xml
@@ -181,6 +181,7 @@
                         r.tags,
                         r.sensitive,
                         r.kube_service_enabled,
+                        r.cluster_price,
                         r.pipeline_name,
                         CASE
                             WHEN EXISTS (
@@ -273,7 +274,8 @@
                         tags,
                         sensitive,
                         kube_service_enabled,
-                        pipeline_name
+                        pipeline_name,
+                        cluster_price
                     FROM
                         pipeline.pipeline_run
                     WHERE
@@ -336,7 +338,8 @@
                         tags,
                         sensitive,
                         kube_service_enabled,
-                        pipeline_name
+                        pipeline_name,
+                        cluster_price
                     FROM
                         pipeline.pipeline_run
                     WHERE
@@ -399,7 +402,8 @@
                         tags,
                         sensitive,
                         kube_service_enabled,
-                        pipeline_name
+                        pipeline_name,
+                        cluster_price
                     FROM
                         pipeline.pipeline_run
                     WHERE
@@ -604,7 +608,8 @@
                       r.kube_service_enabled,
                       TRUE as initialization_finished,
                       FALSE as queued,
-                      r.pipeline_name
+                      r.pipeline_name,
+                      r.cluster_price
                     FROM
                       pipeline.pipeline_run r
                     WHERE
@@ -668,7 +673,8 @@
                       r.kube_service_enabled,
                       TRUE as initialization_finished,
                       FALSE as queued,
-                      r.pipeline_name
+                      r.pipeline_name,
+                      r.cluster_price
                     FROM
                       pipeline.pipeline_run r
                     WHERE
@@ -731,6 +737,7 @@
                       r.sensitive,
                       r.kube_service_enabled,
                       r.pipeline_name,
+                      r.cluster_price,
                       CASE
                         WHEN EXISTS (
                             SELECT 1 FROM pipeline.pipeline_run_service_url su
@@ -794,6 +801,7 @@
                       active_run.sensitive,
                       active_run.kube_service_enabled,
                       active_run.pipeline_name,
+                      active_run.cluster_price,
                       CASE
                         WHEN EXISTS (
                             SELECT 1 FROM pipeline.pipeline_run_service_url su
@@ -1003,7 +1011,8 @@
                         r.tags,
                         r.sensitive,
                         r.kube_service_enabled,
-                        r.pipeline_name
+                        r.pipeline_name,
+                        r.cluster_price
                     FROM
                         pipeline.pipeline_run r
                     WHERE
@@ -1064,7 +1073,8 @@
                         r.tags,
                         r.sensitive,
                         r.kube_service_enabled,
-                        r.pipeline_name
+                        r.pipeline_name,
+                        r.cluster_price
                     FROM
                         pipeline.pipeline_run r
                     WHERE
@@ -1126,6 +1136,7 @@
                         r.sensitive,
                         r.kube_service_enabled,
                         r.pipeline_name,
+                        r.cluster_price,
                         CASE
                             WHEN EXISTS (
                                 SELECT 1 FROM pipeline.pipeline_run_log init_tasks
@@ -1213,6 +1224,7 @@
                         runs.tags,
                         runs.sensitive,
                         runs.kube_service_enabled,
+                        runs.cluster_price,
                         CASE
                             WHEN EXISTS (
                                 SELECT 1 FROM pipeline.pipeline_run_log init_tasks
@@ -1289,7 +1301,8 @@
                             p.tags,
                             p.sensitive,
                             p.kube_service_enabled,
-                            p.pipeline_name
+                            p.pipeline_name,
+                            p.cluster_price
                         FROM (SELECT *
                             FROM pipeline.pipeline_run r
                             WHERE parent_id ISNULL @WHERE@
@@ -1346,7 +1359,8 @@
                             c.tags,
                             c.sensitive,
                             c.kube_service_enabled,
-                            c.pipeline_name
+                            c.pipeline_name,
+                            c.cluster_price
                         FROM
                             pipeline.pipeline_run c
                         INNER JOIN runs ON runs.run_id = c.parent_id
@@ -1401,6 +1415,7 @@
                         runs.tags,
                         runs.sensitive,
                         runs.kube_service_enabled,
+                        runs.cluster_price,
                         CASE
                             WHEN EXISTS (
                                 SELECT 1 FROM pipeline.pipeline_run_log init_tasks
@@ -1550,7 +1565,8 @@
                         tags,
                         sensitive,
                         kube_service_enabled,
-                        pipeline_name
+                        pipeline_name,
+                        cluster_price
                     FROM
                         pipeline.pipeline_run r
                     INNER JOIN (SELECT DISTINCT ON (run_id) run_id, status
@@ -1627,7 +1643,8 @@
                         tags,
                         sensitive,
                         kube_service_enabled,
-                        pipeline_name
+                        pipeline_name,
+                        cluster_price
                     FROM
                         pipeline.pipeline_run
                     WHERE
@@ -1690,7 +1707,8 @@
                         tags,
                         sensitive,
                         kube_service_enabled,
-                        pipeline_name
+                        pipeline_name,
+                        cluster_price
                     FROM
                         pipeline.pipeline_run
                     WHERE
@@ -1753,7 +1771,8 @@
                         tags,
                         sensitive,
                         kube_service_enabled,
-                        pipeline_name
+                        pipeline_name,
+                        cluster_price
                     FROM
                         pipeline.pipeline_run
                     WHERE
@@ -1816,13 +1835,152 @@
                         tags,
                         sensitive,
                         kube_service_enabled,
-                        pipeline_name
+                        pipeline_name,
+                        cluster_price
                     FROM
                         pipeline.pipeline_run
                     WHERE
                         node_name = ?
                     ORDER BY
                         start_date DESC
+                ]]>
+            </value>
+        </property>
+        <property name="updateClusterPriceQuery">
+            <value>
+                <![CDATA[
+                    UPDATE pipeline.pipeline_run SET
+                        cluster_price = :CLUSTER_PRICE
+                    WHERE
+                        run_id = :RUN_ID
+                ]]>
+            </value>
+        </property>
+        <property name="loadRunsByParentRunsIdsQuery">
+            <value>
+                <![CDATA[
+                    SELECT
+                        run_id,
+                        pipeline_id,
+                        version,
+                        start_date,
+                        end_date,
+                        parameters,
+                        status,
+                        terminating,
+                        pod_id,
+                        node_type,
+                        node_disk,
+                        node_ip,
+                        node_id,
+                        node_name,
+                        node_image,
+                        node_cloud_region,
+                        node_platform,
+                        docker_image,
+                        actual_docker_image,
+                        platform,
+                        cmd_template,
+                        actual_cmd,
+                        timeout,
+                        owner,
+                        pod_ip,
+                        commit_status,
+                        last_change_commit_time,
+                        config_name,
+                        node_count,
+                        parent_id,
+                        entities_ids,
+                        is_spot,
+                        configuration_id,
+                        pod_status,
+                        prolonged_at_time,
+                        last_notification_time,
+                        last_idle_notification_time,
+                        exec_preferences,
+                        pretty_url,
+                        price_per_hour,
+                        compute_price_per_hour,
+                        disk_price_per_hour,
+                        state_reason,
+                        non_pause,
+                        node_real_disk,
+                        node_cloud_provider,
+                        tags,
+                        sensitive,
+                        kube_service_enabled,
+                        pipeline_name,
+                        cluster_price
+                    FROM
+                        pipeline.pipeline_run
+                    WHERE
+                        parent_id IN (:list)
+                    ORDER BY
+                        start_date
+                ]]>
+            </value>
+        </property>
+        <property name="loadRunningMasterRunsQuery">
+            <value>
+                <![CDATA[
+                      SELECT
+                      r.run_id,
+                      r.pipeline_id,
+                      r.version,
+                      r.start_date,
+                      r.end_date,
+                      r.parameters,
+                      r.status,
+                      r.terminating,
+                      r.pod_id,
+                      r.node_type,
+                      r.node_disk,
+                      r.node_ip,
+                      r.node_id,
+                      r.node_name,
+                      r.node_image,
+                      r.node_cloud_region,
+                      r.node_platform,
+                      r.docker_image,
+                      r.actual_docker_image,
+                      r.platform,
+                      r.cmd_template,
+                      r.actual_cmd,
+                      r.timeout,
+                      r.owner,
+                      r.pod_ip,
+                      r.commit_status,
+                      r.last_change_commit_time,
+                      r.config_name,
+                      r.node_count,
+                      r.parent_id,
+                      r.entities_ids,
+                      r.is_spot,
+                      r.configuration_id,
+                      r.pod_status,
+                      r.prolonged_at_time,
+                      r.last_notification_time,
+                      r.last_idle_notification_time,
+                      r.exec_preferences,
+                      r.pretty_url,
+                      r.price_per_hour,
+                      r.compute_price_per_hour,
+                      r.disk_price_per_hour,
+                      r.state_reason,
+                      r.non_pause,
+                      r.node_real_disk,
+                      r.node_cloud_provider,
+                      r.tags,
+                      r.sensitive,
+                      r.kube_service_enabled,
+                      TRUE as initialization_finished,
+                      FALSE as queued,
+                      r.pipeline_name,
+                      r.cluster_price
+                    FROM
+                      pipeline.pipeline_run r
+                    WHERE
+                      r.status = 2 AND r.node_count NOTNULL AND r.node_count > 0
                 ]]>
             </value>
         </property>

--- a/api/src/main/resources/db/migration/v2021.10.07_12.00__issue_2183_cluster_price.sql
+++ b/api/src/main/resources/db/migration/v2021.10.07_12.00__issue_2183_cluster_price.sql
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ALTER TABLE pipeline.pipeline_run ADD cluster_price numeric(100, 2);

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
@@ -131,6 +131,11 @@ public class PipelineRunDaoTest extends AbstractJdbcTest {
     private static final String TEST_PLATFORM = "linux";
     private static final String TEST_REGION = "region";
 
+    private static final BigDecimal INITIAL_CLUSTER_PRICE_1 = BigDecimal.valueOf(1.9511111);
+    private static final BigDecimal INITIAL_CLUSTER_PRICE_2 = BigDecimal.valueOf(123456.5666);
+    private static final BigDecimal EXPECTED_CLUSTER_PRICE_1 = BigDecimal.valueOf(1.95);
+    private static final BigDecimal EXPECTED_CLUSTER_PRICE_2 = BigDecimal.valueOf(123456.57);
+
     @Autowired
     private PipelineRunDao pipelineRunDao;
 
@@ -957,6 +962,71 @@ public class PipelineRunDaoTest extends AbstractJdbcTest {
         assertTrue(loadedRun.getServiceUrl().containsValue(TEST_SERVICE_URL));
     }
 
+    @Test
+    public void shouldUpdateClusterPrices() {
+        final PipelineRun run1 =  runningRun();
+        final PipelineRun run2 =  runningRun();
+        pipelineRunDao.createPipelineRun(run1);
+        pipelineRunDao.createPipelineRun(run2);
+
+        run1.setClusterPrice(INITIAL_CLUSTER_PRICE_1);
+        run2.setClusterPrice(INITIAL_CLUSTER_PRICE_2);
+
+        pipelineRunDao.batchUpdateClusterPrices(Arrays.asList(run1, run2));
+
+        assertThat(pipelineRunDao.loadPipelineRun(run1.getId()).getClusterPrice(), equalTo(EXPECTED_CLUSTER_PRICE_1));
+        assertThat(pipelineRunDao.loadPipelineRun(run2.getId()).getClusterPrice(), equalTo(EXPECTED_CLUSTER_PRICE_2));
+    }
+
+    @Test
+    public void shouldLoadRunningMasters() {
+        final PipelineRun runningRun1 = runningRun();
+        runningRun1.setNodeCount(1);
+        final PipelineRun runningRun2 = runningRun();
+        final PipelineRun pausedRun1 = pausedRun();
+        pausedRun1.setNodeCount(4);
+        pipelineRunDao.createPipelineRun(runningRun1);
+        pipelineRunDao.createPipelineRun(runningRun2);
+        pipelineRunDao.createPipelineRun(pausedRun1);
+
+        final List<PipelineRun> actualRuns = pipelineRunDao.loadRunningMasters();
+        assertThat(actualRuns.size(), equalTo(1));
+
+        final PipelineRun actualRun = actualRuns.get(0);
+        assertThat(actualRun.getId(), equalTo(runningRun1.getId()));
+        assertTrue(actualRun.isMasterRun());
+        assertThat(actualRun.getStatus(), equalTo(TaskStatus.RUNNING));
+    }
+
+    @Test
+    public void shouldLoadWorkers() {
+        final PipelineRun masterRun = runningRun();
+        pipelineRunDao.createPipelineRun(masterRun);
+        final PipelineRun anotherMaster = runningRun();
+        pipelineRunDao.createPipelineRun(anotherMaster);
+
+        final PipelineRun worker1 = runningRun();
+        worker1.setParentRunId(masterRun.getId());
+        final PipelineRun worker2 = pausedRun();
+        worker2.setParentRunId(masterRun.getId());
+        final PipelineRun anotherWorker = runningRun();
+        anotherWorker.setParentRunId(anotherMaster.getId());
+        pipelineRunDao.createPipelineRun(worker1);
+        pipelineRunDao.createPipelineRun(worker2);
+        pipelineRunDao.createPipelineRun(anotherWorker);
+
+        List<PipelineRun> actualRuns = pipelineRunDao.loadRunsByParentRuns(
+                Collections.singletonList(masterRun.getId()));
+        assertThat(actualRuns.size(), equalTo(2));
+        assertThat(actualRuns.stream().map(PipelineRun::getId).collect(Collectors.toSet()),
+                hasItems(worker1.getId(), worker2.getId()));
+
+        actualRuns = pipelineRunDao.loadRunsByParentRuns(Arrays.asList(masterRun.getId(), anotherMaster.getId()));
+        assertThat(actualRuns.size(), equalTo(3));
+        assertThat(actualRuns.stream().map(PipelineRun::getId).collect(Collectors.toSet()),
+                hasItems(worker1.getId(), worker2.getId(), anotherWorker.getId()));
+    }
+
     private PipelineRun createTestPipelineRun() {
         return createTestPipelineRun(testPipeline.getId());
     }
@@ -1172,5 +1242,17 @@ public class PipelineRunDaoTest extends AbstractJdbcTest {
         pipelineRunServiceUrl.setPipelineRunId(runId);
         pipelineRunServiceUrlRepository.save(pipelineRunServiceUrl);
         return pipelineRunServiceUrl;
+    }
+
+    private PipelineRun runningRun() {
+        return TestUtils.createPipelineRun(testPipeline.getId(), null, TaskStatus.RUNNING,
+                USER, null, null, true, null, null, "pod-id",
+                cloudRegion.getId());
+    }
+
+    private PipelineRun pausedRun() {
+        return TestUtils.createPipelineRun(testPipeline.getId(), null, TaskStatus.PAUSED,
+                USER, null, null, true, null, null, "pod-id",
+                cloudRegion.getId());
     }
 }

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/costs/ClusterCostsMonitoringServiceCoreTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/costs/ClusterCostsMonitoringServiceCoreTest.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ClusterCostsMonitoringServiceTest {
+public class ClusterCostsMonitoringServiceCoreTest {
     private static final Long MASTER_ID_1 = 1L;
     private static final Long WORKER_ID_11 = 2L;
     private static final Long WORKER_ID_12 = 3L;
@@ -56,8 +56,8 @@ public class ClusterCostsMonitoringServiceTest {
     private static final double EXPECTED_PRICE_2 = 1.7;
 
     private final PipelineRunCRUDService pipelineRunCRUDService = mock(PipelineRunCRUDService.class);
-    private final ClusterCostsMonitoringService clusterCostsMonitoringService =
-            new ClusterCostsMonitoringService(pipelineRunCRUDService);
+    private final ClusterCostsMonitoringServiceCore clusterCostsMonitoringService =
+            new ClusterCostsMonitoringServiceCore(pipelineRunCRUDService);
 
     @Test
     public void shouldUpdateClusterPrices() {

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/costs/ClusterCostsMonitoringServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/costs/ClusterCostsMonitoringServiceTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.epam.pipeline.manager.cluster.costs;
+
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.utils.DateUtils;
+import com.epam.pipeline.manager.pipeline.PipelineRunCRUDService;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ClusterCostsMonitoringServiceTest {
+    private static final Long MASTER_ID_1 = 1L;
+    private static final Long WORKER_ID_11 = 2L;
+    private static final Long WORKER_ID_12 = 3L;
+    private static final Long MASTER_ID_2 = 4L;
+    private static final Long WORKER_ID_21 = 5L;
+    private static final double PRICE_1 = 1.95;
+    private static final double PRICE_2 = 20.25;
+    private static final int MASTER_1_DURATION = 5;
+    private static final int MASTER_2_DURATION = 3;
+    private static final int WORKER_21_DURATION = 2;
+    private static final double EXPECTED_PRICE_1 = 0.24;
+    private static final double EXPECTED_PRICE_2 = 1.7;
+
+    private final PipelineRunCRUDService pipelineRunCRUDService = mock(PipelineRunCRUDService.class);
+    private final ClusterCostsMonitoringService clusterCostsMonitoringService =
+            new ClusterCostsMonitoringService(pipelineRunCRUDService);
+
+    @Test
+    public void shouldUpdateClusterPrices() {
+        final PipelineRun master1 = masterRun(MASTER_ID_1, 2, PRICE_1, buildDate(MASTER_1_DURATION));
+        final PipelineRun master2 = masterRun(MASTER_ID_2, 1, PRICE_2, buildDate(MASTER_2_DURATION));
+        when(pipelineRunCRUDService.loadRunningMasters()).thenReturn(Arrays.asList(master1, master2));
+
+        final PipelineRun worker11 = workerRun(WORKER_ID_11, MASTER_ID_1, PRICE_1); // not start time
+        final PipelineRun worker12 = workerRun(WORKER_ID_12, MASTER_ID_1, PRICE_1); // 3 min duration
+        worker12.setStartDate(buildDate(5));
+        worker12.setEndDate(buildDate(2));
+
+        // started 2 min ago and not completed
+        final PipelineRun worker21 = workerRun(WORKER_ID_21, MASTER_ID_2, PRICE_2);
+        worker21.setStartDate(buildDate(WORKER_21_DURATION));
+
+        when(pipelineRunCRUDService.loadRunsByParentRuns(any())).thenReturn(new HashMap<Long, List<PipelineRun>>() {
+            {
+                put(MASTER_ID_1, Arrays.asList(worker11, worker12));
+                put(MASTER_ID_2, Collections.singletonList(worker21));
+            }
+        });
+
+        clusterCostsMonitoringService.monitor();
+
+        final ArgumentCaptor<Collection<PipelineRun>> runsCaptor = ArgumentCaptor.forClass((Class) Collection.class);
+        verify(pipelineRunCRUDService).updateClusterPrices(runsCaptor.capture());
+        assertThat(runsCaptor.getValue().size(), is(2));
+        final Map<Long, PipelineRun> actualMastersById = runsCaptor.getValue().stream()
+                .collect(Collectors.toMap(PipelineRun::getId, Function.identity()));
+        final PipelineRun actualMaster1 = actualMastersById.get(MASTER_ID_1);
+        final PipelineRun actualMaster2 = actualMastersById.get(MASTER_ID_2);
+        assertThat(actualMaster1, notNullValue());
+        assertThat(actualMaster2, notNullValue());
+        assertThat(actualMaster1.getClusterPrice().doubleValue(), is(EXPECTED_PRICE_1));
+        assertThat(actualMaster2.getClusterPrice().doubleValue(), is(EXPECTED_PRICE_2));
+    }
+
+    private PipelineRun masterRun(final Long id, final int nodeCount, final double price, final Date startDate) {
+        final PipelineRun pipelineRun = new PipelineRun();
+        pipelineRun.setId(id);
+        pipelineRun.setNodeCount(nodeCount);
+        pipelineRun.setPricePerHour(BigDecimal.valueOf(price));
+        pipelineRun.setStartDate(startDate);
+        return pipelineRun;
+    }
+
+    private PipelineRun workerRun(final Long id, final Long parentRunId, final double price) {
+        final PipelineRun pipelineRun = new PipelineRun();
+        pipelineRun.setId(id);
+        pipelineRun.setParentRunId(parentRunId);
+        pipelineRun.setPricePerHour(BigDecimal.valueOf(price));
+        return pipelineRun;
+    }
+
+    private Date buildDate(final int minutesFromNow) {
+        final Calendar calendar = Calendar.getInstance();
+        calendar.setTime(DateUtils.now());
+        calendar.add(Calendar.MINUTE, -minutesFromNow);
+        return calendar.getTime();
+    }
+}

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,7 +104,7 @@ public class PipelineRun extends AbstractSecuredEntity {
     private ExecutionPreferences executionPreferences = ExecutionPreferences.getDefault();
     private String prettyUrl;
     /**
-     * Pipeline run overall instance price per hour. 
+     * Pipeline run overall instance price per hour.
      */
     private BigDecimal pricePerHour;
     /**
@@ -128,6 +128,10 @@ public class PipelineRun extends AbstractSecuredEntity {
     private AclClass aclClass = AclClass.PIPELINE;
     private Map<String, String> tags;
     private boolean kubeServiceEnabled;
+    /**
+     * Pipeline run total cluster price estimation. This value shall be calculated for master runs only.
+     */
+    private BigDecimal clusterPrice;
 
     public PipelineRun() {
         this.terminating = false;
@@ -143,12 +147,19 @@ public class PipelineRun extends AbstractSecuredEntity {
     }
 
     public boolean isClusterRun() {
-                //master node of autoscale cluster
+        return isMasterRun() || isWorkerRun();
+    }
+
+    public boolean isMasterRun() {
+        //master node of autoscale cluster
         return this.hasBooleanParameter(GE_AUTOSCALING)
                 // master node
-                || this.getNodeCount() != null && this.getNodeCount() != 0
-                // worker node
-                || this.getParentRunId() != null;
+                || this.getNodeCount() != null && this.getNodeCount() != 0;
+    }
+
+    public boolean isWorkerRun() {
+        // worker node
+        return this.getParentRunId() != null;
     }
 
     private boolean hasBooleanParameter(String parameterName) {


### PR DESCRIPTION
The current PR provides implementation for issue #2183 

The following changes were added:
- a new system preference `system.cluster.price.monitor.delay` added (Default: 30 000 ms). This value determines how often the cluster costs monitoring service will start
- a new field `workersPrice` added to pipeline run output object. This value indicates the total price for all cluster workers.