### PR TITLE
Support manager node users and groups sharing within a cluster

### DIFF
--- a/deploy/contents/install/preferences/launch.system.parameters.json
+++ b/deploy/contents/install/preferences/launch.system.parameters.json
@@ -355,5 +355,12 @@
         "description": "Disables BROWSE button for the job",
         "defaultValue": "false",
         "passToWorkers": true
+    },
+    {
+        "name": "CP_CAP_SHARE_USERS",
+        "type": "boolean",
+        "description": "Enables cluster users sharing.",
+        "defaultValue": "true",
+        "passToWorkers": true
     }
 ]

--- a/scripts/pipeline-launch/launch.py
+++ b/scripts/pipeline-launch/launch.py
@@ -362,7 +362,7 @@ try:
 except BaseException as e:
     if _extract_boolean_parameter('CP_CAP_ZOMBIE'):
         traceback.print_exc()
-        stacktrace = traceback.format_stack()
+        stacktrace = traceback.format_exc()
         try:
             logger.error('Switching to zombie mode because the error occurred: {} {}'.format(e, stacktrace))
         except:

--- a/scripts/pipeline-launch/launch.sh
+++ b/scripts/pipeline-launch/launch.sh
@@ -1380,6 +1380,27 @@ echo "------"
 echo
 ######################################################
 
+
+
+######################################################
+# Setup cluster users sharing if required
+######################################################
+
+echo "Setup cluster users sharing"
+echo "-"
+
+if check_cp_cap CP_CAP_SHARE_USERS; then
+    "$CP_PYTHON2_PATH" "$COMMON_REPO_DIR/scripts/configure_shared_users.py"
+else
+    echo "Cluster users sharing is not requested"
+fi
+
+echo "------"
+echo
+######################################################
+
+
+
 CP_DATA_LOCALIZATION_ENABLED=${CP_DATA_LOCALIZATION_ENABLED:-"true"}
 if [ "$CP_DATA_LOCALIZATION_ENABLED" == "true" ]; then
       if [ "$RESUMED_RUN" == true ]; then

--- a/workflows/pipe-common/pipeline/common/common.py
+++ b/workflows/pipe-common/pipeline/common/common.py
@@ -16,6 +16,21 @@ import platform
 import subprocess
 
 
+class CmdError(RuntimeError):
+    pass
+
+
+def execute(command, logger=None):
+    exit_code, out, err = execute_cmd_command_and_get_stdout_stderr(command, silent=True)
+    if out:
+        logger.info(out)
+    if err:
+        logger.warning(err)
+    if exit_code:
+        raise CmdError('Command has finished with exit code ' + str(exit_code))
+    return out, err
+
+
 def execute_cmd_command_and_get_stdout_stderr(command, silent=False, executable=None):
     stdout, stderr = _get_stdout_and_stderr()
     p = subprocess.Popen(command, shell=True, stdout=stdout, stderr=stderr, executable=executable)

--- a/workflows/pipe-common/pipeline/utils/package.py
+++ b/workflows/pipe-common/pipeline/utils/package.py
@@ -1,0 +1,36 @@
+# Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pipeline.common.common import execute
+
+
+def is_rpm_based(logger=None):
+    try:
+        execute('/usr/bin/rpm -q -f /usr/bin/rpm >/dev/null 2>&1', logger=logger)
+        return True
+    except:
+        return False
+
+
+def install_package(rpm, nonrpm, logger=None):
+    if is_rpm_based(logger=logger):
+        try:
+            execute('rpm -q "{package}"'.format(package=rpm), logger=logger)
+        except:
+            execute('yum install -y "{package}"'.format(package=rpm), logger=logger)
+    else:
+        try:
+            execute('dpkg -l | grep -q "{package}"'.format(package=nonrpm), logger=logger)
+        except:
+            execute('apt-get install -y "{package}"'.format(package=nonrpm), logger=logger)

--- a/workflows/pipe-common/pipeline/utils/path.py
+++ b/workflows/pipe-common/pipeline/utils/path.py
@@ -17,7 +17,7 @@ import errno
 import os
 
 
-def _mkdir(path):
+def mkdir(path):
     try:
         os.makedirs(path)
     except OSError as e:
@@ -29,7 +29,7 @@ def _mkdir(path):
 
 def _add_to_powershell_profile(path, profile_path):
     profile_dir_path = os.path.dirname(profile_path)
-    _mkdir(profile_dir_path)
+    mkdir(profile_dir_path)
     with open(profile_path, 'a') as f:
         f.write('$env:PATH = "$env:PATH;{path}"\n'.format(path=path))
 
@@ -38,7 +38,7 @@ def _add_to_batch_profile(path, profile_path):
     from .reg import set_local_machine_str_value
     set_local_machine_str_value('Software\\Microsoft\\Command Processor', 'AutoRun', profile_path)
     profile_dir_path = os.path.dirname(profile_path)
-    _mkdir(profile_dir_path)
+    mkdir(profile_dir_path)
     if os.path.exists(profile_path):
         with open(profile_path, 'a') as f:
             f.write('set PATH=%PATH%;{path}\n'.format(path=path))

--- a/workflows/pipe-common/pipeline/utils/ssh.py
+++ b/workflows/pipe-common/pipeline/utils/ssh.py
@@ -67,7 +67,7 @@ class HostSSH(CloudPipelineSSH):
                 logger.info(stripped_line)
             for line in stderr:
                 stripped_line = line.strip('\n')
-                logger.warn(stripped_line)
+                logger.warning(stripped_line)
         if exit_code != 0:
             raise SSHError('Command has finished with exit code ' + str(exit_code))
         client.close()

--- a/workflows/pipe-common/scripts/configure_shared_users.py
+++ b/workflows/pipe-common/scripts/configure_shared_users.py
@@ -89,7 +89,7 @@ def configure_shared_users():
         logger.success('Shared users and groups management was successfully configured.')
     except BaseException as e:
         traceback.print_exc()
-        stacktrace = traceback.format_stack()
+        stacktrace = traceback.format_exc()
         logger.error('Shared users and groups management configuration has failed: {} {}'.format(e, stacktrace))
         raise
 

--- a/workflows/pipe-common/scripts/configure_shared_users.py
+++ b/workflows/pipe-common/scripts/configure_shared_users.py
@@ -1,0 +1,74 @@
+# Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import traceback
+
+from pipeline.api import PipelineAPI
+from pipeline.common.common import execute
+from pipeline.log.logger import LocalLogger, RunLogger, TaskLogger, LevelLogger
+from pipeline.utils.package import install_package
+from pipeline.utils.path import mkdir
+
+_MANAGER_CLUSTER_ROLE = 'master'
+_ETC_DIRECTORY = '/etc'
+_ETC_DIRECTORY_SHARED = '/etc-shared'
+_ETC_FILE_PATHS = ['passwd', 'shadow', 'group', 'gshadow']
+
+if __name__ == '__main__':
+    api_url = os.environ['API']
+    api_token = os.environ['API_TOKEN']
+    run_id = os.environ['RUN_ID']
+    cluster_role = os.getenv('cluster_role', _MANAGER_CLUSTER_ROLE)
+    logging_directory = os.getenv('CP_CAP_SHARE_USERS_LOGDIR', os.getenv('LOG_DIR', '/var/log'))
+    logging_level = os.getenv('CP_CAP_SHARE_USERS_LOGGING_LEVEL', 'ERROR')
+    logging_level_local = os.getenv('CP_CAP_SHARE_USERS_LOGGING_LEVEL_LOCAL', 'DEBUG')
+    logging_format = os.getenv('CP_CAP_SHARE_USERS_LOGGING_FORMAT', '%(asctime)s:%(levelname)s: %(message)s')
+
+    logging.basicConfig(level=logging_level_local, format=logging_format,
+                        filename=os.path.join(logging_directory, 'configure_shared_users.log'))
+
+    api = PipelineAPI(api_url=api_url, log_dir=logging_directory)
+    logger = RunLogger(api=api, run_id=run_id)
+    logger = TaskLogger(task='InitializeSharedUsers', inner=logger)
+    logger = LevelLogger(level=logging_level, inner=logger)
+    logger = LocalLogger(inner=logger)
+
+    try:
+        if cluster_role != _MANAGER_CLUSTER_ROLE:
+            logger.info('Configuring shared users and groups management...')
+
+            logger.info('Installing sshfs...')
+            install_package(rpm='fuse-sshfs', nonrpm='sshfs', logger=logger)
+
+            logger.info('Mounting etc directory from manager node...')
+            mkdir(_ETC_DIRECTORY_SHARED)
+            execute('sshfs -o ro,allow_other root@lizardfs-master:{etc_directory} {etc_directory_shared}'
+                    .format(etc_directory=_ETC_DIRECTORY, etc_directory_shared=_ETC_DIRECTORY_SHARED),
+                    logger=logger)
+
+            logger.info('Mounting users and groups from manager node etc directory...')
+            for etc_file_path in _ETC_FILE_PATHS:
+                file_path = os.path.join(_ETC_DIRECTORY, etc_file_path)
+                file_path_shared = os.path.join(_ETC_DIRECTORY_SHARED, etc_file_path)
+                execute('mount -o ro,bind,allow_other {file_path_shared} {file_path}'
+                        .format(file_path=file_path, file_path_shared=file_path_shared),
+                        logger=logger)
+
+            logger.success('Shared users and groups management was successfully configured.')
+    except BaseException as e:
+        traceback.print_exc()
+        stacktrace = traceback.format_stack()
+        logger.error('Shared users and groups management configuration has failed: {} {}'.format(e, stacktrace))


### PR DESCRIPTION
Resolves #2195.

The pull request brings support for cluster-wide manager node users and groups sharing.

The following list of run parameters can be used to configure cluster users and groups sharing:
- `CP_CAP_SHARE_USERS` enables cluster users and groups sharing. Defaults to `false`.
- `CP_CAP_SHARE_USERS_LOGGING_LEVEL` configures logging level in a GUI log. Defaults to `ERROR`. 
- `CP_CAP_SHARE_USERS_LOGGING_LEVEL_LOCAL` configures logging level in a local log file. Defaults to `DEBUG`.

Local log file can be found here `$LOG_DIR/configure_shared_users.log` or `/runs/pipeline-12345/logs/configure_shared_users.log`.