### PR TITLE
Issue #2182 improve watcher stability

### DIFF
--- a/workflows/pipe-common/scripts/watch_mount_shares.py
+++ b/workflows/pipe-common/scripts/watch_mount_shares.py
@@ -171,7 +171,7 @@ class CloudBucketDumpingEventHandler(FileSystemEventHandler):
 
     @staticmethod
     def _configure_logging_bucket_dir():
-        bucket_dir = os.path.join(os.getenv('CP_CAP_NFS_MNT_OBSERVER_TARGET_BUCKET'),
+        bucket_dir = os.path.join(os.getenv('CP_CAP_NFS_MNT_OBSERVER_TARGET_BUCKET', ''),
                                   CloudBucketDumpingEventHandler._get_service_name())
         logging.info(format_message('Destination bucket location is [{}]'.format(bucket_dir)))
         return bucket_dir


### PR DESCRIPTION
This PR is related to issues #2182 and #2155

- Regarding general functionality - an empty value is used as a target bucket in case the specific env var is not given. It prevents the observer startup failure, but dumping will not be performed 
- During storage status resolving - check if write access is granted for `ACTIVE` storage to allow rights elevation