### PR TITLE
Support local user accounts creation for shared runs

### DIFF
--- a/deploy/contents/install/preferences/launch.system.parameters.json
+++ b/deploy/contents/install/preferences/launch.system.parameters.json
@@ -362,5 +362,12 @@
         "description": "Enables cluster users sharing.",
         "defaultValue": "true",
         "passToWorkers": true
+    },
+    {
+        "name": "CP_CAP_SYNC_USERS",
+        "type": "boolean",
+        "description": "Enables users synchronization.",
+        "defaultValue": "true",
+        "passToWorkers": false
     }
 ]

--- a/scripts/pipeline-launch/launch.sh
+++ b/scripts/pipeline-launch/launch.sh
@@ -1401,6 +1401,25 @@ echo
 
 
 
+######################################################
+# Setup users synchronization if required
+######################################################
+
+echo "Setup users synchronization"
+echo "-"
+
+if check_cp_cap CP_CAP_SYNC_USERS; then
+    nohup "$CP_PYTHON2_PATH" "$COMMON_REPO_DIR/scripts/sync_users.py" &
+else
+    echo "Users synchronization is not requested"
+fi
+
+echo "------"
+echo
+######################################################
+
+
+
 CP_DATA_LOCALIZATION_ENABLED=${CP_DATA_LOCALIZATION_ENABLED:-"true"}
 if [ "$CP_DATA_LOCALIZATION_ENABLED" == "true" ]; then
       if [ "$RESUMED_RUN" == true ]; then

--- a/workflows/pipe-common/pipeline/api/api.py
+++ b/workflows/pipe-common/pipeline/api/api.py
@@ -217,6 +217,8 @@ class PipelineAPI:
     LOAD_PROFILE_CREDENTIALS = 'cloud/credentials/generate/%d'
     LOAD_PROFILES = 'cloud/credentials'
     LOAD_CURRENT_USER = 'whoami'
+    LOAD_ROLES = 'role/loadAll?loadUsers={}'
+    LOAD_ROLE = 'role/{}'
     # Pipeline API default header
 
     RESPONSE_STATUS_OK = 'OK'
@@ -931,3 +933,16 @@ class PipelineAPI:
             return self.execute_request(url, method='get')
         except Exception as e:
             raise RuntimeError("Failed to load current user. Error message: {}".format(str(e.message)))
+
+    def load_roles(self, load_users=False):
+        try:
+            return self.execute_request(str(self.api_url) + self.LOAD_ROLES.format(load_users)) or []
+        except Exception as e:
+            raise RuntimeError("Failed to load roles.", "Error message: {}".format(str(e.message)))
+
+    def load_role(self, role_id):
+        try:
+            return self.execute_request(str(self.api_url) + self.LOAD_ROLE.format(role_id))
+        except Exception as e:
+            raise RuntimeError("Failed to load role by ID '{}'.", "Error message: {}".format(str(role_id),
+                                                                                             str(e.message)))

--- a/workflows/pipe-common/pipeline/utils/account.py
+++ b/workflows/pipe-common/pipeline/utils/account.py
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import platform
+
+from pipeline.common.common import execute
+from pipeline.utils.path import mkdir
 
 _USER_ALREADY_EXISTS_WIN_ERROR = 2224
 _USER_ALREADY_IN_GROUP_WIN_ERROR = 1378
@@ -50,12 +54,28 @@ def _add_win_user_to_group(username, domain, group, skip_existing=False):
             raise
 
 
-def create_user(username, password, groups, skip_existing=False):
+def _create_lin_user(username, password, home_dir=None, skip_existing=False, logger=None):
+    try:
+        execute('id -u {username}'.format(username=username))
+        if not skip_existing:
+            raise RuntimeError('User {} already exists.'.format(username))
+    except:
+        if home_dir:
+            mkdir(os.path.dirname(home_dir))
+            home_dir_arg = '-d "{home_dir}" '.format(home_dir=home_dir)
+        else:
+            home_dir_arg = ''
+        execute(('useradd -m -s /bin/bash ' + home_dir_arg + '"{username}"; '
+                'echo "{password}" | passwd --stdin "{username}"')
+                .format(username=username, password=password),
+                logger=logger)
+
+
+def create_user(username, password, groups='', home_dir=None, skip_existing=False, logger=None):
     current_platform = platform.system()
     if current_platform == 'Windows':
         _create_win_user(username, password, skip_existing=skip_existing)
         for group in groups.split(','):
             _add_win_user_to_group(username, platform.node(), group, skip_existing=skip_existing)
     else:
-        raise RuntimeError('Creating user is not supported on {platform} platform.'
-                           .format(platform=current_platform))
+        _create_lin_user(username, password, home_dir=home_dir, skip_existing=skip_existing, logger=logger)

--- a/workflows/pipe-common/pipeline/utils/account.py
+++ b/workflows/pipe-common/pipeline/utils/account.py
@@ -65,8 +65,7 @@ def _create_lin_user(username, password, home_dir=None, skip_existing=False, log
             home_dir_arg = '-d "{home_dir}" '.format(home_dir=home_dir)
         else:
             home_dir_arg = ''
-        execute(('useradd -m -s /bin/bash ' + home_dir_arg + '"{username}"; '
-                'echo "{password}" | passwd --stdin "{username}"')
+        execute(('useradd -m -s /bin/bash ' + home_dir_arg + ' -p $(openssl passwd -1 "{password}") "{username}"')
                 .format(username=username, password=password),
                 logger=logger)
 

--- a/workflows/pipe-common/scripts/sync_users.py
+++ b/workflows/pipe-common/scripts/sync_users.py
@@ -1,0 +1,107 @@
+# Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import traceback
+import time
+from functools import reduce
+
+from pipeline.api import PipelineAPI
+from pipeline.log.logger import LocalLogger, RunLogger, TaskLogger, LevelLogger
+from pipeline.utils.account import create_user
+
+
+def _get_run_shared_users_and_groups(api, run_id):
+    run = api.load_run(run_id) or {}
+    run_sids = run.get('runSids', [])
+    return reduce(
+        lambda (us, gs), sid: (us + [sid['name']], gs) if sid['isPrincipal'] else (us, gs + [sid['name']]),
+        run_sids,
+        ([], []))
+
+
+def _get_group_users(api, run_groups):
+    groups = (api.load_roles() or []) if run_groups else []
+    for group in groups:
+        group_id = group.get('id')
+        group_name = group.get('name')
+        if not group_id or group_name not in run_groups:
+            continue
+        group_users = (api.load_role(group_id) or {}).get('users', [])
+        for group_user in group_users:
+            yield group_user['userName']
+
+
+def _get_local_users():
+    with open('/etc/passwd', 'r') as f:
+        lines = f.readlines()
+    for line in lines:
+        stripped_line = line.strip()
+        if stripped_line:
+            yield stripped_line.split(':')[0]
+
+
+if __name__ == '__main__':
+    api_url = os.environ['API']
+    api_token = os.environ['API_TOKEN']
+    run_id = os.environ['RUN_ID']
+    shared_dir = os.getenv('SHARED_ROOT', '/common')
+    shared_home_dir = os.getenv('CP_CAP_SYNC_USERS_HOME_DIR', os.path.join(shared_dir, 'home'))
+    sync_timeout = int(os.getenv('CP_CAP_SYNC_USERS_TIMEOUT_SECONDS', '60'))
+    logging_directory = os.getenv('CP_CAP_SYNC_USERS_LOG_DIR', os.getenv('LOG_DIR', '/var/log'))
+    logging_level = os.getenv('CP_CAP_SYNC_USERS_LOGGING_LEVEL', 'ERROR')
+    logging_level_local = os.getenv('CP_CAP_SYNC_USERS_LOGGING_LEVEL_LOCAL', 'DEBUG')
+    logging_format = os.getenv('CP_CAP_SYNC_USERS_LOGGING_FORMAT', '%(asctime)s:%(levelname)s: %(message)s')
+
+    logging.basicConfig(level=logging_level_local, format=logging_format,
+                        filename=os.path.join(logging_directory, 'sync_users.log'))
+
+    api = PipelineAPI(api_url=api_url, log_dir=logging_directory)
+    logger = RunLogger(api=api, run_id=run_id)
+    logger = TaskLogger(task='UsersSynchronization', inner=logger)
+    logger = LevelLogger(level=logging_level, inner=logger)
+    logger = LocalLogger(inner=logger)
+
+    while True:
+        try:
+            time.sleep(sync_timeout)
+            logger.info('Starting users synchronization...')
+
+            logger.info('Loading shared users and groups...')
+            run_users, run_groups = _get_run_shared_users_and_groups(api, run_id)
+            shared_users = set()
+            shared_users.update(run_users)
+            shared_users.update(_get_group_users(api, run_groups))
+            logger.info('Loaded {} shared users.'.format(len(shared_users)))
+            logger.debug('Loaded shared users: {}'.format(shared_users))
+
+            logger.info('Loading existing users...')
+            local_users = set(_get_local_users())
+
+            users_to_create = shared_users - local_users
+            logger.info('Creating {} users...'.format(len(users_to_create)))
+            logger.debug('Creating users {}...'.format(users_to_create))
+            for user in users_to_create:
+                user_home_dir = os.path.join(shared_home_dir, user)
+                create_user(user, user, home_dir=user_home_dir, skip_existing=True, logger=logger)
+
+            logger.info('Finishing users synchronization...')
+        except KeyboardInterrupt:
+            logging.warning('Interrupted.')
+            break
+        except BaseException as e:
+            traceback.print_exc()
+            stacktrace = traceback.format_stack()
+            logger.error('Users synchronization has failed: {} {}'.format(e, stacktrace))

--- a/workflows/pipe-common/scripts/sync_users.py
+++ b/workflows/pipe-common/scripts/sync_users.py
@@ -53,9 +53,8 @@ def _get_local_users():
             yield stripped_line.split(':')[0]
 
 
-if __name__ == '__main__':
+def sync_users():
     api_url = os.environ['API']
-    api_token = os.environ['API_TOKEN']
     run_id = os.environ['RUN_ID']
     shared_dir = os.getenv('SHARED_ROOT', '/common')
     shared_home_dir = os.getenv('CP_CAP_SYNC_USERS_HOME_DIR', os.path.join(shared_dir, 'home'))
@@ -87,8 +86,10 @@ if __name__ == '__main__':
             logger.info('Loaded {} shared users.'.format(len(shared_users)))
             logger.debug('Loaded shared users: {}'.format(shared_users))
 
-            logger.info('Loading existing users...')
+            logger.info('Loading local users...')
             local_users = set(_get_local_users())
+            logger.info('Loaded {} local users.'.format(len(local_users)))
+            logger.debug('Loaded local users: {}'.format(local_users))
 
             users_to_create = shared_users - local_users
             logger.info('Creating {} users...'.format(len(users_to_create)))
@@ -103,5 +104,10 @@ if __name__ == '__main__':
             break
         except BaseException as e:
             traceback.print_exc()
-            stacktrace = traceback.format_stack()
+            stacktrace = traceback.format_exc()
             logger.error('Users synchronization has failed: {} {}'.format(e, stacktrace))
+            raise
+
+
+if __name__ == '__main__':
+    sync_users()


### PR DESCRIPTION
Resolves #2197 and depends on #2201.

The pull request brings support shared user local accounts synchronisation. 

The following list of run parameters can be used to configure cluster users and groups sharing:
- `CP_CAP_SYNC_USERS` enables users synchronisation. Defaults to `false`.
- `CP_CAP_SYNC_USERS_HOME_DIR` configures root directory for user account home directories. Defaults to `$SHARED_ROOT/home` or `/common/home`.
- `CP_CAP_SYNC_USERS_TIMEOUT_SECONDS` configures timeout between two continuous synchronisations in seconds. Defaults to `60` seconds.
- `CP_CAP_SYNC_USERS_LOGGING_LEVEL` configures logging level in a GUI log. Defaults to `ERROR`. 
- `CP_CAP_SYNC_USERS_LOGGING_LEVEL_LOCAL` configures logging level in a local log file. Defaults to `DEBUG`.

Local log file can be found here `$LOG_DIR/sync_users.log` or `/runs/pipeline-12345/logs/sync_users.log`.