### PR TITLE
Support ssh connection modes in edge

### DIFF
--- a/deploy/contents/install/preferences/launch.system.parameters.json
+++ b/deploy/contents/install/preferences/launch.system.parameters.json
@@ -369,5 +369,12 @@
         "description": "Enables users synchronization.",
         "defaultValue": "true",
         "passToWorkers": false
+    },
+    {
+        "name": "CP_CAP_SSH_MODE",
+        "type": "string",
+        "description": "SSH connection mode. Allowed values are: user, owner, owner-sshpass and root.",
+        "defaultValue": "root",
+        "passToWorkers": true
     }
 ]

--- a/deploy/docker/cp-edge/wetty/app.js
+++ b/deploy/docker/cp-edge/wetty/app.js
@@ -209,7 +209,7 @@ io.on('connection', function(socket) {
                 if (pipe_details.platform == 'windows') {
                     run_ssh_mode = 'owner-sshpass';
                 } else {
-                    run_ssh_mode = get_boolean_preference('system.ssh.default.root.user.enabled', auth_key) ? 'root' : 'user';
+                    run_ssh_mode = get_boolean_preference('system.ssh.default.root.user.enabled', auth_key) ? 'root' : 'owner';
                 }
             }
             switch (run_ssh_mode) {

--- a/deploy/docker/cp-edge/wetty/app.js
+++ b/deploy/docker/cp-edge/wetty/app.js
@@ -237,13 +237,6 @@ io.on('connection', function(socket) {
                     rows: 30,
                     env: { [ENV_TAG_RUNID_NAME]: pipeline_id }
             });
-        } else if (match[1] == "container") {
-            console.log((new Date()) + ' Trying to exec kubectl exec for pod: ' + pipe_details.pod_id);
-            term = pty.spawn('kubectl', ['exec', '-it', pipe_details.pod_id, '/bin/bash'], {
-                    name: 'xterm-256color',
-                    cols: 80,
-                    rows: 30
-            });
         } else {
             socket.disconnect();
             return;

--- a/deploy/docker/cp-edge/wetty/app.js
+++ b/deploy/docker/cp-edge/wetty/app.js
@@ -104,7 +104,7 @@ function get_owner_user_name(owner) {
     return owner.split("@")[0];
 }
 
-function get_run_sshpass(run_details) {
+function get_run_sshpass(run_details, auth_key) {
     parent_run_id = run_details.parameters['parent-id'];
     run_shared_users_enabled = get_boolean(run_details.parameters['CP_CAP_SHARE_USERS']);
     if (run_shared_users_enabled && parent_run_id) {
@@ -224,11 +224,11 @@ io.on('connection', function(socket) {
                     break
                 case 'owner-sshpass':
                     sshuser = owner_user_name;
-                    sshpass = get_run_sshpass(pipe_details);
+                    sshpass = get_run_sshpass(pipe_details, auth_key);
                     break
                 default:
                     sshuser = 'root';
-                    sshpass = get_run_sshpass(pipe_details);
+                    sshpass = get_run_sshpass(pipe_details, auth_key);
                     break
             }
             term = pty.spawn('sshpass', ['-p', sshpass, 'ssh', sshuser + '@' + sshhost, '-p', sshport, '-o', 'StrictHostKeyChecking=no', '-o', 'GlobalKnownHostsFile=/dev/null', '-o', 'UserKnownHostsFile=/dev/null', '-q'], {


### PR DESCRIPTION
Resolves #2198 and depends on #2203.

The pull request brings support for several ssh connection modes which can be configured for a single run / a static cluster / an autoscaled cluster. See the #2198 to find out how to configure ssh connection modes.

## Related changes

Additionally the pull request resolves #994 by removing support for direct SSH connections to run pods.
