### PR TITLE
Issue #2182 API NFS events observation

### DIFF
--- a/api/profiles/dev/application.properties
+++ b/api/profiles/dev/application.properties
@@ -158,6 +158,10 @@ data.storage.nfs.quota.metadata.key=fs_notifications
 data.storage.nfs.quota.default.restrictive.status=READ_ONLY
 data.storage.nfs.quota.triggers.evict.cron=0 0 9 ? * *
 
+data.storage.nfs.events.disable.sync=${CP_API_DISABLE_STORAGE_EVENTS_SYNC:false}
+data.storage.nfs.events.sync.bucket=${CP_CAP_NFS_MNT_OBSERVER_TARGET_BUCKET:}
+data.storage.nfs.events.dump.timeout=${CP_API_STORAGE_EVENTS_DUMPING_TIMEOUT:30000}
+
 # Enables logging filter using CommonsRequestLoggingFilter
 logging.level.org.springframework.web.filter.CommonsRequestLoggingFilter=DEBUG
 

--- a/api/profiles/release/application.properties
+++ b/api/profiles/release/application.properties
@@ -103,6 +103,10 @@ data.storage.nfs.quota.metadata.key=${CP_API_NFS_QUOTA_METADATA_KEY:fs_notificat
 data.storage.nfs.quota.default.restrictive.status=${CP_API_NFS_QUOTA_DEFAULT_RESTRICTION:READ_ONLY}
 data.storage.nfs.quota.triggers.evict.cron=${CP_API_NFS_QUOTA_TRIGGER_EVICT_CRON:0 0 9 ? * *}
 
+data.storage.nfs.events.disable.sync=${CP_API_DISABLE_STORAGE_EVENTS_SYNC:false}
+data.storage.nfs.events.sync.bucket=${CP_CAP_NFS_MNT_OBSERVER_TARGET_BUCKET:}
+data.storage.nfs.events.dump.timeout=${CP_API_STORAGE_EVENTS_DUMPING_TIMEOUT:30000}
+
 #Firecloud
 firecloud.auth.client.id=
 firecloud.auth.client.secret=

--- a/api/src/main/java/com/epam/pipeline/aspect/events/StorageEventCollectingAspect.java
+++ b/api/src/main/java/com/epam/pipeline/aspect/events/StorageEventCollectingAspect.java
@@ -16,40 +16,24 @@
 
 package com.epam.pipeline.aspect.events;
 
-import com.epam.pipeline.entity.datastorage.AbstractDataStorageItem;
-import com.epam.pipeline.entity.datastorage.DataStorageFile;
-import com.epam.pipeline.entity.datastorage.DataStorageFolder;
-import com.epam.pipeline.entity.datastorage.DataStorageItemType;
-import com.epam.pipeline.entity.datastorage.DataStorageListing;
 import com.epam.pipeline.entity.datastorage.nfs.NFSDataStorage;
 import com.epam.pipeline.entity.datastorage.nfs.NFSObserverEventType;
 import com.epam.pipeline.manager.datastorage.StorageEventsService;
-import com.epam.pipeline.manager.datastorage.providers.nfs.NFSStorageProvider;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.collections4.CollectionUtils;
 import org.aspectj.lang.JoinPoint;
-import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.After;
-import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Optional;
-import java.util.Queue;
-import java.util.stream.Collectors;
 
 @Aspect
 @Component
 @RequiredArgsConstructor
 public class StorageEventCollectingAspect {
 
-    private static final int LISTING_PAGE_SIZE = 100;
+    private static final String FOLDER_EVENT_WILDCARD = "/*";
 
     private final StorageEventsService storageEventsService;
-    private final NFSStorageProvider nfsStorageProvider;
 
 
     @After("execution(* com.epam.pipeline.manager.datastorage.providers.nfs.NFSStorageProvider.createFile(..)) && "
@@ -78,58 +62,17 @@ public class StorageEventCollectingAspect {
            + "args(dataStorage, oldFolderPath, newFolderPath, ..)")
     public void generateFolderMovingEvents(final JoinPoint joinPoint, final NFSDataStorage dataStorage,
                                            final String oldFolderPath, final String newFolderPath) {
-        listAllFilesInFolder(dataStorage, newFolderPath)
-            .forEach(file -> {
-                final String newFilePath = file.getPath();
-                final String oldFilePath = oldFolderPath + newFilePath.substring(newFolderPath.length());
-                storageEventsService.addEvent(dataStorage, oldFilePath, NFSObserverEventType.MOVED_FROM);
-                storageEventsService.addEvent(dataStorage, newFilePath, NFSObserverEventType.MOVED_TO);
-            });
+        storageEventsService.addEvent(dataStorage,
+                                      oldFolderPath + FOLDER_EVENT_WILDCARD,
+                                      newFolderPath + FOLDER_EVENT_WILDCARD,
+                                      NFSObserverEventType.FOLDER_MOVED);
 
     }
 
-    @Around("execution(* com.epam.pipeline.manager.datastorage.providers.nfs.NFSStorageProvider.deleteFolder(..)) && "
+    @After("execution(* com.epam.pipeline.manager.datastorage.providers.nfs.NFSStorageProvider.deleteFolder(..)) && "
             + "args(dataStorage, path, ..)")
-    public void generateFolderRemovalEvents(final ProceedingJoinPoint joinPoint,
-                                            final NFSDataStorage dataStorage, final String path) throws Throwable {
-        final List<String> pathsToBeRemoved = listAllFilesInFolder(dataStorage, path).stream()
-            .map(AbstractDataStorageItem::getPath)
-            .collect(Collectors.toList());
-        joinPoint.proceed();
-        storageEventsService.addEvents(dataStorage, pathsToBeRemoved, NFSObserverEventType.DELETED);
-    }
-
-    public List<DataStorageFile> listAllFilesInFolder(final NFSDataStorage storage, final String path) {
-        final List<DataStorageFile> allFiles = new ArrayList<>();
-        final Queue<DataStorageFolder> folders = new LinkedList<>();
-        final DataStorageFolder rootFolder = new DataStorageFolder();
-        rootFolder.setPath(path);
-        folders.add(rootFolder);
-        while (CollectionUtils.isEmpty(folders)) {
-            Optional.ofNullable(folders.peek())
-                .map(AbstractDataStorageItem::getPath)
-                .ifPresent(folderPath -> {
-                    String nextPageMarker = "0";
-                    do {
-                        nextPageMarker = extractFilesAndFolders(storage, folderPath, nextPageMarker, allFiles, folders);
-                    } while (nextPageMarker != null);
-                });
-        }
-        return allFiles;
-    }
-
-    private String extractFilesAndFolders(final NFSDataStorage storage, final String folderPath, final String marker,
-                                          final List<DataStorageFile> allFiles,
-                                          final Queue<DataStorageFolder> folders) {
-        final DataStorageListing items = nfsStorageProvider.getItems(storage, folderPath, false,
-                                                                     LISTING_PAGE_SIZE, marker);
-        items.getResults().forEach(element -> {
-            if (element.getType() == DataStorageItemType.Folder) {
-                folders.add((DataStorageFolder) element);
-            } else {
-                allFiles.add((DataStorageFile) element);
-            }
-        });
-        return items.getNextPageMarker();
+    public void generateFolderRemovalEvents(final JoinPoint joinPoint,
+                                            final NFSDataStorage dataStorage, final String path) {
+        storageEventsService.addEvent(dataStorage, path + FOLDER_EVENT_WILDCARD, NFSObserverEventType.DELETED);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/aspect/events/StorageEventCollectingAspect.java
+++ b/api/src/main/java/com/epam/pipeline/aspect/events/StorageEventCollectingAspect.java
@@ -23,18 +23,18 @@ import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.After;
 import org.aspectj.lang.annotation.Aspect;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
-
 
 @Aspect
 @Component
 @RequiredArgsConstructor
+@ConditionalOnProperty(value = "data.storage.nfs.events.disable.sync", matchIfMissing = true, havingValue = "false")
 public class StorageEventCollectingAspect {
 
     private static final String FOLDER_EVENT_WILDCARD = "/*";
 
     private final StorageEventsService storageEventsService;
-
 
     @After("execution(* com.epam.pipeline.manager.datastorage.providers.nfs.NFSStorageProvider.createFile(..)) && "
            + "args(dataStorage, path, ..)")
@@ -66,7 +66,6 @@ public class StorageEventCollectingAspect {
                                       oldFolderPath + FOLDER_EVENT_WILDCARD,
                                       newFolderPath + FOLDER_EVENT_WILDCARD,
                                       NFSObserverEventType.FOLDER_MOVED);
-
     }
 
     @After("execution(* com.epam.pipeline.manager.datastorage.providers.nfs.NFSStorageProvider.deleteFolder(..)) && "

--- a/api/src/main/java/com/epam/pipeline/aspect/events/StorageEventCollectingAspect.java
+++ b/api/src/main/java/com/epam/pipeline/aspect/events/StorageEventCollectingAspect.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.aspect.events;
+
+import com.epam.pipeline.entity.datastorage.AbstractDataStorageItem;
+import com.epam.pipeline.entity.datastorage.DataStorageFile;
+import com.epam.pipeline.entity.datastorage.DataStorageFolder;
+import com.epam.pipeline.entity.datastorage.DataStorageItemType;
+import com.epam.pipeline.entity.datastorage.DataStorageListing;
+import com.epam.pipeline.entity.datastorage.nfs.NFSDataStorage;
+import com.epam.pipeline.entity.datastorage.nfs.NFSObserverEventType;
+import com.epam.pipeline.manager.datastorage.StorageEventsService;
+import com.epam.pipeline.manager.datastorage.providers.nfs.NFSStorageProvider;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.CollectionUtils;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.After;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.stream.Collectors;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class StorageEventCollectingAspect {
+
+    private static final int LISTING_PAGE_SIZE = 100;
+
+    private final StorageEventsService storageEventsService;
+    private final NFSStorageProvider nfsStorageProvider;
+
+
+    @After("execution(* com.epam.pipeline.manager.datastorage.providers.nfs.NFSStorageProvider.createFile(..)) && "
+           + "args(dataStorage, path, ..)")
+    public void generateFileCreationEvent(final JoinPoint joinPoint,
+                                          final NFSDataStorage dataStorage, final String path) {
+        storageEventsService.addEvent(dataStorage, path, NFSObserverEventType.CREATED);
+    }
+
+    @After("execution(* com.epam.pipeline.manager.datastorage.providers.nfs.NFSStorageProvider.moveFile(..)) && "
+           + "args(dataStorage, oldPath, newPath, ..)")
+    public void generateFileMovingEvent(final JoinPoint joinPoint,
+                                        final NFSDataStorage dataStorage, final String oldPath, final String newPath) {
+        storageEventsService.addEvent(dataStorage, oldPath, NFSObserverEventType.MOVED_FROM);
+        storageEventsService.addEvent(dataStorage, newPath, NFSObserverEventType.MOVED_TO);
+    }
+
+    @After("execution(* com.epam.pipeline.manager.datastorage.providers.nfs.NFSStorageProvider.deleteFile(..)) && "
+           + "args(dataStorage, path, ..)")
+    public void generateFileRemovalEvent(final JoinPoint joinPoint,
+                                         final NFSDataStorage dataStorage, final String path) {
+        storageEventsService.addEvent(dataStorage, path, NFSObserverEventType.DELETED);
+    }
+
+    @After("execution(* com.epam.pipeline.manager.datastorage.providers.nfs.NFSStorageProvider.moveFolder(..)) && "
+           + "args(dataStorage, oldFolderPath, newFolderPath, ..)")
+    public void generateFolderMovingEvents(final JoinPoint joinPoint, final NFSDataStorage dataStorage,
+                                           final String oldFolderPath, final String newFolderPath) {
+        listAllFilesInFolder(dataStorage, newFolderPath)
+            .forEach(file -> {
+                final String newFilePath = file.getPath();
+                final String oldFilePath = oldFolderPath + newFilePath.substring(newFolderPath.length());
+                storageEventsService.addEvent(dataStorage, oldFilePath, NFSObserverEventType.MOVED_FROM);
+                storageEventsService.addEvent(dataStorage, newFilePath, NFSObserverEventType.MOVED_TO);
+            });
+
+    }
+
+    @Around("execution(* com.epam.pipeline.manager.datastorage.providers.nfs.NFSStorageProvider.deleteFolder(..)) && "
+            + "args(dataStorage, path, ..)")
+    public void generateFolderRemovalEvents(final ProceedingJoinPoint joinPoint,
+                                            final NFSDataStorage dataStorage, final String path) throws Throwable {
+        final List<String> pathsToBeRemoved = listAllFilesInFolder(dataStorage, path).stream()
+            .map(AbstractDataStorageItem::getPath)
+            .collect(Collectors.toList());
+        joinPoint.proceed();
+        storageEventsService.addEvents(dataStorage, pathsToBeRemoved, NFSObserverEventType.DELETED);
+    }
+
+    public List<DataStorageFile> listAllFilesInFolder(final NFSDataStorage storage, final String path) {
+        final List<DataStorageFile> allFiles = new ArrayList<>();
+        final Queue<DataStorageFolder> folders = new LinkedList<>();
+        final DataStorageFolder rootFolder = new DataStorageFolder();
+        rootFolder.setPath(path);
+        folders.add(rootFolder);
+        while (CollectionUtils.isEmpty(folders)) {
+            Optional.ofNullable(folders.peek())
+                .map(AbstractDataStorageItem::getPath)
+                .ifPresent(folderPath -> {
+                    String nextPageMarker = "0";
+                    do {
+                        nextPageMarker = extractFilesAndFolders(storage, folderPath, nextPageMarker, allFiles, folders);
+                    } while (nextPageMarker != null);
+                });
+        }
+        return allFiles;
+    }
+
+    private String extractFilesAndFolders(final NFSDataStorage storage, final String folderPath, final String marker,
+                                          final List<DataStorageFile> allFiles,
+                                          final Queue<DataStorageFolder> folders) {
+        final DataStorageListing items = nfsStorageProvider.getItems(storage, folderPath, false,
+                                                                     LISTING_PAGE_SIZE, marker);
+        items.getResults().forEach(element -> {
+            if (element.getType() == DataStorageItemType.Folder) {
+                folders.add((DataStorageFolder) element);
+            } else {
+                allFiles.add((DataStorageFile) element);
+            }
+        });
+        return items.getNextPageMarker();
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/config/Constants.java
+++ b/api/src/main/java/com/epam/pipeline/config/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,8 @@ public final class Constants {
     public static final String PATH_DELIMITER = "/";
     public static final String X509_BEGIN_CERTIFICATE = "-----BEGIN CERTIFICATE-----";
     public static final String X509_END_CERTIFICATE = "-----END CERTIFICATE-----";
+    public static final String COMMA = ",";
+    public static final String NEWLINE = "\n";
 
     public static final String FIRECLOUD_TOKEN_HEADER = "Firecloud-Token";
 

--- a/api/src/main/java/com/epam/pipeline/entity/datastorage/nfs/NFSObserverEvent.java
+++ b/api/src/main/java/com/epam/pipeline/entity/datastorage/nfs/NFSObserverEvent.java
@@ -23,6 +23,7 @@ public class NFSObserverEvent {
     private final Long timestamp;
     private final NFSObserverEventType eventType;
     private final String storage;
-    private final String filePath;
+    private final String filePathFrom;
+    private final String filePathTo;
 
 }

--- a/api/src/main/java/com/epam/pipeline/entity/datastorage/nfs/NFSObserverEvent.java
+++ b/api/src/main/java/com/epam/pipeline/entity/datastorage/nfs/NFSObserverEvent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.datastorage.nfs;
+
+import lombok.Value;
+
+@Value
+public class NFSObserverEvent {
+    private final Long timestamp;
+    private final NFSObserverEventType eventType;
+    private final String storage;
+    private final String filePath;
+
+}

--- a/api/src/main/java/com/epam/pipeline/entity/datastorage/nfs/NFSObserverEventType.java
+++ b/api/src/main/java/com/epam/pipeline/entity/datastorage/nfs/NFSObserverEventType.java
@@ -19,30 +19,15 @@ package com.epam.pipeline.entity.datastorage.nfs;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 @AllArgsConstructor
 @Getter
 public enum NFSObserverEventType {
     CREATED("c"),
     MODIFIED("m"),
+    FOLDER_MOVED("fm"),
     MOVED_FROM("mf"),
     MOVED_TO("mt"),
     DELETED("d");
 
     private final String eventCode;
-
-    private static final Map<String, NFSObserverEventType> CODES = Stream.of(NFSObserverEventType.values())
-        .collect(Collectors.toMap(NFSObserverEventType::getEventCode, Function.identity()));
-
-    public static NFSObserverEventType fromCode(final String code) {
-        final NFSObserverEventType event = CODES.get(code);
-        if (event == null) {
-            throw new IllegalArgumentException("Unsupported event code.");
-        }
-        return event;
-    }
 }

--- a/api/src/main/java/com/epam/pipeline/entity/datastorage/nfs/NFSObserverEventType.java
+++ b/api/src/main/java/com/epam/pipeline/entity/datastorage/nfs/NFSObserverEventType.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.datastorage.nfs;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@AllArgsConstructor
+@Getter
+public enum NFSObserverEventType {
+    CREATED("c"),
+    MODIFIED("m"),
+    MOVED_FROM("mf"),
+    MOVED_TO("mt"),
+    DELETED("d");
+
+    private final String eventCode;
+
+    private static final Map<String, NFSObserverEventType> CODES = Stream.of(NFSObserverEventType.values())
+        .collect(Collectors.toMap(NFSObserverEventType::getEventCode, Function.identity()));
+
+    public static NFSObserverEventType fromCode(final String code) {
+        final NFSObserverEventType event = CODES.get(code);
+        if (event == null) {
+            throw new IllegalArgumentException("Unsupported event code.");
+        }
+        return event;
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageEventsService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageEventsService.java
@@ -83,27 +83,30 @@ public class StorageEventsService {
         }
     }
 
+    public void addEvent(final AbstractDataStorage dataStorage, final String pathFrom, final String pathTo,
+                         final NFSObserverEventType eventType) {
+        events.add(fileToEvent(dataStorage, pathFrom, pathTo, eventType));
+    }
+
     public void addEvent(final AbstractDataStorage dataStorage, final String path,
                          final NFSObserverEventType eventType) {
-        events.add(fileToEvent(dataStorage, path, eventType));
+        addEvent(dataStorage, path, null, eventType);
     }
 
-    public void addEvents(final AbstractDataStorage dataStorage, final List<String> paths,
-                          final NFSObserverEventType eventType) {
-        final List<NFSObserverEvent> newEvents =
-            paths.stream().map(path -> fileToEvent(dataStorage, path, eventType)).collect(Collectors.toList());
-        events.addAll(newEvents);
-    }
-
-    private NFSObserverEvent fileToEvent(final AbstractDataStorage dataStorage, final String path,
+    private NFSObserverEvent fileToEvent(final AbstractDataStorage dataStorage,
+                                         final String pathFrom,
+                                         final String pathTo,
                                          final NFSObserverEventType eventType) {
-        return new NFSObserverEvent(Instant.now().toEpochMilli(), eventType, dataStorage.getPath(), path);
+        return new NFSObserverEvent(Instant.now().toEpochMilli(), eventType, dataStorage.getPath(), pathFrom, pathTo);
     }
 
     private String eventToString(final NFSObserverEvent event) {
-        return String.join(Constants.COMMA,
-                           event.getTimestamp().toString(), event.getEventType().getEventCode(),
-                           event.getStorage(), event.getFilePath());
+        final String eventString = String.join(Constants.COMMA,
+                                               event.getTimestamp().toString(), event.getEventType().getEventCode(),
+                                               event.getStorage(), event.getFilePathFrom());
+        return Optional.ofNullable(event.getFilePathTo())
+            .map(pathTo -> eventString + Constants.COMMA + pathTo)
+            .orElse(eventString);
     }
 
     private void checkBucketScheme(final URI eventsBucketURI) {

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageEventsService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageEventsService.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.datastorage;
+
+import com.epam.pipeline.config.Constants;
+import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
+import com.epam.pipeline.entity.datastorage.DataStorageType;
+import com.epam.pipeline.entity.datastorage.nfs.NFSObserverEvent;
+import com.epam.pipeline.entity.datastorage.nfs.NFSObserverEventType;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.StringJoiner;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+import javax.annotation.PreDestroy;
+
+@Service
+@Slf4j
+@ConditionalOnProperty(value = "data.storage.nfs.events.disable.sync", matchIfMissing = true, havingValue = "false")
+public class StorageEventsService {
+
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH:mm:ss.SSSSSS");
+    private static final String API_EVENTS_SUBFOLDER_NAME = "api";
+    private static final String EVENTS_FILE_PREFIX = "events-";
+
+    private final List<NFSObserverEvent> events;
+    private final DataStorageManager storageManager;
+    private final AbstractDataStorage syncStorage;
+    private final String eventsBucketEventsPath;
+
+    public StorageEventsService(final DataStorageManager storageManager,
+                                final @Value("${data.storage.nfs.events.sync.bucket:}") String eventsBucketUriStr) {
+        this.events = new CopyOnWriteArrayList<>();
+        final URI eventsBucketURI = URI.create(eventsBucketUriStr);
+        checkBucketScheme(eventsBucketURI);
+        this.syncStorage = storageManager.loadByPathOrId(eventsBucketURI.getHost());
+        this.eventsBucketEventsPath = buildEventsBucketInnerPath(eventsBucketURI);
+        this.storageManager = storageManager;
+    }
+
+    @Scheduled(fixedDelayString = "${data.storage.nfs.events.dump.timeout:30000}")
+    @PreDestroy
+    public void dumpEvents() {
+        if (CollectionUtils.isNotEmpty(events)) {
+            final StringJoiner joiner = new StringJoiner(Constants.NEWLINE);
+            final List<NFSObserverEvent> eventsToDump = events.stream()
+                .peek(event -> joiner.add(eventToString(event)))
+                .collect(Collectors.toList());
+            log.info("Dumping {} NFS events", eventsToDump.size());
+            storageManager.createDataStorageFile(syncStorage.getId(), eventsBucketEventsPath, getEventsFileName(),
+                                                 joiner.toString().getBytes(StandardCharsets.UTF_8));
+            events.removeAll(eventsToDump);
+        }
+    }
+
+    public void addEvent(final AbstractDataStorage dataStorage, final String path,
+                         final NFSObserverEventType eventType) {
+        events.add(fileToEvent(dataStorage, path, eventType));
+    }
+
+    public void addEvents(final AbstractDataStorage dataStorage, final List<String> paths,
+                          final NFSObserverEventType eventType) {
+        final List<NFSObserverEvent> newEvents =
+            paths.stream().map(path -> fileToEvent(dataStorage, path, eventType)).collect(Collectors.toList());
+        events.addAll(newEvents);
+    }
+
+    private NFSObserverEvent fileToEvent(final AbstractDataStorage dataStorage, final String path,
+                                         final NFSObserverEventType eventType) {
+        return new NFSObserverEvent(Instant.now().toEpochMilli(), eventType, dataStorage.getPath(), path);
+    }
+
+    private String eventToString(final NFSObserverEvent event) {
+        return String.join(Constants.COMMA,
+                           event.getTimestamp().toString(), event.getEventType().getEventCode(),
+                           event.getStorage(), event.getFilePath());
+    }
+
+    private void checkBucketScheme(final URI eventsBucketURI) {
+        Optional.ofNullable(eventsBucketURI.getScheme())
+            .filter(StringUtils::isNotEmpty)
+            .map(String::toUpperCase)
+            .map(DataStorageType::getById)
+            .filter(Objects::nonNull)
+            .orElseThrow(() -> new IllegalArgumentException("Scheme isn't specified for events bucket!"));
+    }
+
+    private String getEventsBucketFolder(final URI eventsBucketUri) {
+        return Optional.ofNullable(eventsBucketUri.getPath())
+            .map(path -> StringUtils.removeEnd(path, Constants.PATH_DELIMITER))
+            .map(path -> StringUtils.removeStart(path, Constants.PATH_DELIMITER))
+            .orElse(StringUtils.EMPTY);
+    }
+
+    private String buildEventsBucketInnerPath(URI eventsBucketURI) {
+        return Paths.get(getEventsBucketFolder(eventsBucketURI), API_EVENTS_SUBFOLDER_NAME).toString();
+    }
+
+    private String getEventsFileName() {
+        return EVENTS_FILE_PREFIX + TIME_FORMATTER.format(LocalDateTime.now(ZoneOffset.UTC));
+    }
+}

--- a/api/src/test/resources/test-application.properties
+++ b/api/src/test/resources/test-application.properties
@@ -143,6 +143,7 @@ data.storage.nfs.root.mount.point=pipeline-test
 # Mount options for NFS
 data.storage.nfs.options.rsize=1048576
 data.storage.nfs.options.wsize=1048576
+data.storage.nfs.events.disable.sync=true
 
 cluster.enable.autoscaling=false
 

--- a/deploy/docker/cp-api-srv/config/application.properties
+++ b/deploy/docker/cp-api-srv/config/application.properties
@@ -167,3 +167,7 @@ data.storage.nfs.quota.poll=${CP_API_NFS_QUOTA_POLL:60000}
 data.storage.nfs.quota.metadata.key=${CP_API_NFS_QUOTA_METADATA_KEY:fs_notifications}
 data.storage.nfs.quota.default.restrictive.status=${CP_API_NFS_QUOTA_DEFAULT_RESTRICTION:READ_ONLY}
 data.storage.nfs.quota.triggers.evict.cron=${CP_API_NFS_QUOTA_TRIGGER_EVICT_CRON:0 0 9 ? * *}
+
+data.storage.nfs.events.disable.sync=${CP_API_DISABLE_STORAGE_EVENTS_SYNC:false}
+data.storage.nfs.events.sync.bucket=${CP_CAP_NFS_MNT_OBSERVER_TARGET_BUCKET:}
+data.storage.nfs.events.dump.timeout=${CP_API_STORAGE_EVENTS_DUMPING_TIMEOUT:30000}

--- a/deploy/docker/cp-api-srv/init-api
+++ b/deploy/docker/cp-api-srv/init-api
@@ -126,15 +126,6 @@ function sign_and_publish_pipe_win_distribution() {
     rm -rf pipe
 }
 
-function extract_nfs_observing_script {
-    local jar_path="$1"
-    local output_dir="$2"
-    unzip -p "$jar_path" BOOT-INF/classes/static/pipe-common.tar.gz >pipe-common.tar.gz
-    tar -xf pipe-common.tar.gz scripts/watch_mount_shares.py --strip-components=1 &&\
-    mv watch_mount_shares.py $output_dir && \
-    rm -rf pipe-common.tar.gz
-}
-
 # Validate SSO and SSL certificates
 if [ -z "$CP_API_SRV_CERT_DIR" ]; then
     export CP_API_SRV_CERT_DIR="/opt/api/pki"
@@ -293,16 +284,6 @@ if [ "$CP_CLOUD_PLATFORM" == "az" ] && [ -f /root/.cloud/azureProfile.json ] && 
   cp /root/.cloud/* /root/.azure/
 fi
 
-if [ -z "$CP_CAP_NFS_MNT_OBSERVER_DISABLED" ]; then
-  WATCHER_HOME="$CP_API_HOME/nfs-watcher"
-  WATCHER_LOG_HOME="/var/log/nfs-watcher"
-  mkdir -p "$WATCHER_LOG_HOME" "$WATCHER_HOME"
-  extract_nfs_observing_script "$CP_API_HOME/pipeline.jar" "$WATCHER_HOME"
-  inotify_watchers=${CP_CAP_NFS_MNT_OBSERVER_API_WATCHERS:-131071}
-  sysctl -w fs.inotify.max_user_watches=$inotify_watchers && \
-  sysctl -w fs.inotify.max_queued_events=$((inotify_watchers*2)) && \
-  nohup python -u $WATCHER_HOME/watch_mount_shares.py 1>/dev/null 2>$WATCHER_LOG_HOME/.nohup.nfswatcher.log &
-fi
 
 # Workaround the container hanging when being terminated
 function sig_handler {

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/model/nfsobserver/NFSObserverEvent.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/model/nfsobserver/NFSObserverEvent.java
@@ -16,13 +16,22 @@
 
 package com.epam.pipeline.elasticsearchagent.model.nfsobserver;
 
+import lombok.AllArgsConstructor;
 import lombok.Value;
 
 @Value
+@AllArgsConstructor
 public class NFSObserverEvent {
+
+    public NFSObserverEvent(final Long timestamp, final NFSObserverEventType eventType, final String storage,
+                            final String filePath) {
+        this(timestamp, eventType, storage, filePath, null);
+    }
+
     private final Long timestamp;
     private final NFSObserverEventType eventType;
     private final String storage;
     private final String filePath;
+    private final String filePathTo;
 
 }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/model/nfsobserver/NFSObserverEventType.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/model/nfsobserver/NFSObserverEventType.java
@@ -29,6 +29,7 @@ import java.util.stream.Stream;
 public enum NFSObserverEventType {
     CREATED("c"),
     MODIFIED("m"),
+    FOLDER_MOVED("fm"),
     MOVED_FROM("mf"),
     MOVED_TO("mt"),
     DELETED("d");

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/ElasticsearchServiceClient.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/ElasticsearchServiceClient.java
@@ -21,6 +21,7 @@ import org.elasticsearch.action.search.MultiSearchRequest;
 import org.elasticsearch.action.search.MultiSearchResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.search.Scroll;
 
 import java.util.List;
 
@@ -33,5 +34,6 @@ public interface ElasticsearchServiceClient {
     void createIndexAlias(String indexName, String indexAlias);
     String getIndexNameByAlias(String alias);
     SearchResponse search(SearchRequest request);
+    SearchResponse nextScrollPage(String scrollId, Scroll scroll);
     MultiSearchResponse search(MultiSearchRequest request);
 }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/ElasticsearchServiceClientImpl.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/ElasticsearchServiceClientImpl.java
@@ -32,10 +32,13 @@ import org.elasticsearch.action.search.MultiSearchRequest;
 import org.elasticsearch.action.search.MultiSearchResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchScrollRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.search.Scroll;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
@@ -183,6 +186,19 @@ public class ElasticsearchServiceClientImpl implements ElasticsearchServiceClien
             return client.search(request, RequestOptions.DEFAULT);
         } catch (IOException e) {
             throw new ElasticsearchException("Failed to find results for search query:" + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public SearchResponse nextScrollPage(final String scrollId, final Scroll scroll) {
+        final SearchScrollRequest searchScrollRequest = new SearchScrollRequest();
+        searchScrollRequest.scrollId(scrollId);
+        searchScrollRequest.scroll(scroll);
+        try {
+            return client.scroll(searchScrollRequest, RequestOptions.DEFAULT);
+        } catch (IOException e) {
+            throw new ElasticsearchException("Failed to retrieve next scroll page for [{}]: {}",
+                                             scrollId,e.getMessage(), e);
         }
     }
 

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/NFSObserverEventSynchronizer.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/NFSObserverEventSynchronizer.java
@@ -114,6 +114,7 @@ public class NFSObserverEventSynchronizer extends NFSSynchronizer {
 
     @Override
     public void synchronize(final LocalDateTime lastSyncTime, final LocalDateTime syncStart) {
+        log.debug("Started NFS events synchronization");
         final Map<String, AbstractDataStorage> storagePathMapping = getCloudPipelineAPIClient().loadAllDataStorages()
             .stream()
             .collect(Collectors.toMap(AbstractDataStorage::getPath, Function.identity()));


### PR DESCRIPTION
This PR is related to issue #2182 

FS changes performed via API from now should be observed from the API itself without daemon, introduced in #2155 
- `StorageEventsService` for collecting and dumping events is introduced
- `StorageEventCollectingAspect` for NFS-changing operations detection is implemented
- NFS observer installation is removed from `init-api`
- `NFSObserverEventSynchronizer` is updated to handle folder-related events (for reducing the number of requests sent to underlying NFS, folder-events are extrapolated to file events based on the documents, presented for this folder in ES)