### PR TITLE
Configure ulimits properly on all supported platforms

### DIFF
--- a/scripts/pipeline-launch/launch.sh
+++ b/scripts/pipeline-launch/launch.sh
@@ -585,6 +585,12 @@ root hard nofile $_MAX_NOPEN_LIMIT
 root soft nproc $_MAX_PROCS_LIMIT
 root hard nproc $_MAX_PROCS_LIMIT
 EOT
+    if [[ -f "/etc/security/limits.d/20-nproc.conf" ]]; then
+        # On centos this configuration file contains some default nproc limits
+        # which overrides the ones we set in /etc/security/limits.conf.
+        # To prevent this from happening we remove the limits beforehand.
+        sed -i "\|nproc|d" "/etc/security/limits.d/20-nproc.conf"
+    fi
 }
 
 function add_self_to_no_proxy() {
@@ -1501,8 +1507,8 @@ echo "$_CP_ENV_SOURCE_COMMAND" >> /etc/profile
 sed -i "\|$_CP_ENV_SUDO_ALIAS|d" /etc/profile
 echo "$_CP_ENV_SUDO_ALIAS" >> /etc/profile
 
+# All ulimits are configured in update_user_limits procedure
 sed -i "\|ulimit|d" /etc/profile
-echo "$_CP_ENV_ULIMIT" >> /etc/profile
 
 # umask may be present in the existing file, so we are replacing it the updated value
 sed -i "s/umask [[:digit:]]\+/$_CP_ENV_UMASK/" /etc/profile
@@ -1528,10 +1534,10 @@ for _GLOBAL_BASHRC_PATH in "${_GLOBAL_BASHRC_PATHS[@]}"
 do
     sed -i "s/umask [[:digit:]]\+/$_CP_ENV_UMASK/" "$_GLOBAL_BASHRC_PATH"
     sed -i "1i$_CP_ENV_UMASK" "$_GLOBAL_BASHRC_PATH"
-    
+
+    # All ulimits are configured in update_user_limits procedure
     sed -i "\|ulimit|d" "$_GLOBAL_BASHRC_PATH"
-    sed -i "1i$_CP_ENV_ULIMIT" "$_GLOBAL_BASHRC_PATH"
-    
+
     sed -i "\|$_CP_ENV_SOURCE_COMMAND|d" "$_GLOBAL_BASHRC_PATH"
     sed -i "1i$_CP_ENV_SOURCE_COMMAND\n" "$_GLOBAL_BASHRC_PATH"
     


### PR DESCRIPTION
Relates to #842 and improves changes introduced in #993.

The pull request removes outdated ulimits configuration and fixes nproc soft limit configuration for cents platform. Checked to be working fine on _centos:7, ubuntu:16.04, ubuntu:18.04 and debian:9_.
