### PR TITLE
Share srv: preferences support

### DIFF
--- a/data-sharing-service/api/src/main/java/com/epam/pipeline/external/datastorage/controller/preference/PreferencesController.java
+++ b/data-sharing-service/api/src/main/java/com/epam/pipeline/external/datastorage/controller/preference/PreferencesController.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.external.datastorage.controller.preference;
+
+import com.epam.pipeline.external.datastorage.manager.preference.PreferenceService;
+import com.epam.pipeline.rest.Result;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@Api(value = "Preferences API")
+@RequestMapping("/preferences")
+@RequiredArgsConstructor
+public class PreferencesController {
+
+    private final PreferenceService preferenceService;
+
+    @GetMapping
+    @ApiOperation(
+            value = "Loads all preferences",
+            notes = "Loads all preferences",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public Result<Map<String, Map<String, Object>>> loadAll() {
+        return Result.success(preferenceService.loadAll());
+    }
+}

--- a/data-sharing-service/api/src/main/java/com/epam/pipeline/external/datastorage/manager/preference/PreferenceService.java
+++ b/data-sharing-service/api/src/main/java/com/epam/pipeline/external/datastorage/manager/preference/PreferenceService.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.external.datastorage.manager.preference;
+
+import com.epam.pipeline.external.datastorage.message.MessageHelper;
+import com.epam.pipeline.config.JsonMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import org.apache.commons.lang.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+@Service
+public class PreferenceService {
+    private static final String JSON_FILE_EXTENSION = ".json";
+
+    private final String preferencesPath;
+    private final MessageHelper messageHelper;
+
+    public PreferenceService(@Value("${preferences.path:}") final String preferencesPath,
+                             final MessageHelper messageHelper) {
+        this.preferencesPath = preferencesPath;
+        this.messageHelper = messageHelper;
+    }
+
+    public Map<String, Map<String, Object>> loadAll() {
+        final File preferencesFile = validatePreferencesFileAndGet();
+        final JsonMapper objectMapper = new JsonMapper();
+
+        try {
+            return objectMapper.readValue(preferencesFile, TypeFactory.defaultInstance()
+                    .constructParametricType(Map.class, String.class, Object.class));
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to parse preference file", e);
+        }
+    }
+
+    private File validatePreferencesFileAndGet() {
+        Assert.isTrue(StringUtils.isNotBlank(preferencesPath),
+                messageHelper.getMessage("preferences.path.not.found"));
+        Assert.isTrue(StringUtils.endsWithIgnoreCase(preferencesPath, JSON_FILE_EXTENSION),
+                messageHelper.getMessage("preferences.not.json.extension"));
+        final Path preferencesFile = Paths.get(preferencesPath);
+        Assert.isTrue(Files.exists(preferencesFile) && Files.isRegularFile(preferencesFile),
+                messageHelper.getMessage("preferences.file.not.found"));
+        return preferencesFile.toFile();
+    }
+}

--- a/data-sharing-service/api/src/main/resources/messages.properties
+++ b/data-sharing-service/api/src/main/resources/messages.properties
@@ -25,3 +25,8 @@ error.unsupported.operation=Error: Can not perform operation with ''{0}''.
 # logger
 logger.error=This operation has been aborted: {0}.
 logger.error.root.cause=This operation has been aborted: {0}. The root cause is:
+
+# preferences
+preferences.path.not.found=Preferences file was not specified
+preferences.not.json.extension=Preference file must have json format
+preferences.file.not.found=Preference file doesn't exist


### PR DESCRIPTION
The current PR provides ability to manage preferences for `data-sharing-service`. To enable this management the following steps shall be performed:
 - create `.json` file with structure:
 ```
{
  "preferences.group": {
    "preference.name": {}, # json node or string
    ...
  },
  ...
}
  ```
 - set application property `preferences.path=<path to this json file>`
 
Also, a new method added for retrieving all preferences: `GET /preferences`. This method returns preferences file content.