### PR TITLE
Introduce temporary resources cleanup in pipe

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -35,6 +35,7 @@ from src.model.pipeline_run_filter_model import DEFAULT_PAGE_SIZE, DEFAULT_PAGE_
 from src.model.pipeline_run_model import PriceType
 from src.utilities.cluster_monitoring_manager import ClusterMonitoringManager
 from src.utilities.du_format_type import DuFormatType
+from src.utilities.lock_operations_manager import LockOperationsManager
 from src.utilities.pipeline_run_share_manager import PipelineRunShareManager
 from src.utilities.tool_operations import ToolOperations
 from src.utilities import date_utilities, time_zone_param_type, state_utilities
@@ -200,7 +201,8 @@ def frozen_locking(func, ctx, *args, **kwargs):
     """
     if not is_frozen() or __bundle_info__['bundle_type'] != 'one-file':
         return ctx.invoke(func, *args, **kwargs)
-    CleanOperationsManager().lock(lambda: ctx.invoke(func, *args, **kwargs))
+    LockOperationsManager().execute(Config.get_base_source_dir(),
+                                    lambda: ctx.invoke(func, *args, **kwargs))
 
 
 @click_decorator

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+import os
 import traceback
-import functools
 
 import click
 import functools
@@ -28,6 +29,7 @@ from src.api.pipeline import Pipeline
 from src.api.pipeline_run import PipelineRun
 from src.api.user import User
 from src.config import Config, ConfigNotFoundError, silent_print_creds_info, is_frozen
+from src.utilities.clean_operations_manager import CleanOperationsManager
 from src.utilities.custom_abort_click_group import CustomAbortHandlingGroup
 from src.model.pipeline_run_filter_model import DEFAULT_PAGE_SIZE, DEFAULT_PAGE_INDEX
 from src.model.pipeline_run_model import PriceType
@@ -46,13 +48,19 @@ from src.utilities.update_cli_version import UpdateCLIVersionManager
 from src.utilities.user_operations_manager import UserOperationsManager
 from src.utilities.user_token_operations import UserTokenOperations
 from src.utilities.dts_operations_manager import DtsOperationsManager
-from src.version import __version__
+from src.version import __version__, __bundle_info__
 
 MAX_INSTANCE_COUNT = 1000
 MAX_CORES_COUNT = 10000
+DEFAULT_LOGGING_LEVEL = logging.ERROR
+DEFAULT_LOGGING_FORMAT = '%(asctime)s:%(levelname)s: %(message)s'
+LOGGING_LEVEL_OPTION_DESCRIPTION = 'Explicit logging level: CRITICAL, ERROR, WARNING, INFO or DEBUG. ' \
+                                   'Defaults to ERROR.'
 USER_OPTION_DESCRIPTION = 'The user name to perform operation from specified user. Available for admins only.'
 RETRIES_OPTION_DESCRIPTION = 'Number of retries to connect to specified pipeline run. Default is 10.'
-TRACE_OPTION_DESCRIPTION = 'Enables error stack traces displaying.'
+DEBUG_OPTION_DESCRIPTION = 'Enables verbose logging.'
+TRACE_OPTION_DESCRIPTION = 'Enables verbose errors.'
+NO_CLEAN_OPTION_DESCRIPTION = 'Disables temporary resources cleanup.'
 EDGE_REGION_OPTION_DESCRIPTION = 'The edge region name. If not specified the default edge region will be used.'
 SYNC_FLAG_DESCRIPTION = 'Perform operation in a sync mode. When set - terminal will be blocked' \
                         ' until the expected status of the operation won\'t be returned'
@@ -81,8 +89,9 @@ def print_version(ctx, param, value):
     silent_print_creds_info()
     ctx.exit()
 
+
 def enable_debug_logging(ctx, param, value):
-    if value is False:
+    if not value:
         return
     # Enable body/headers logging from httplib requests
     try:
@@ -90,56 +99,154 @@ def enable_debug_logging(ctx, param, value):
     except ImportError:
         from httplib import HTTPConnection      # py2
     HTTPConnection.debuglevel = 5
+    log_level = logging.DEBUG
+    log_format = os.getenv('CP_LOGGING_FORMAT') or ctx.params.get('log_format') or DEFAULT_LOGGING_FORMAT
     # Enable urlib3/boto/requests logging
-    import logging
-    logging.basicConfig(level='DEBUG')
+    logging.basicConfig(level=log_level, format=log_format)
     stream = logging.StreamHandler()
-    stream.setLevel(logging.DEBUG)
+    stream.setLevel(log_level)
     # Print current configuration
     click.echo('=====================Configuration=========================')
     _current_config = Config.instance(raise_config_not_found_exception=False)
     click.echo(_current_config.__dict__ if _current_config and _current_config.initialized else 'Not configured')
     # Print current environment
     click.echo('=====================Environment============================')
-    import os
     for k, v in sorted(os.environ.items()):
         click.echo('{}={}'.format(k, v))
     click.echo('============================================================')
 
+
 def set_user_token(ctx, param, value):
     if value:
+        logging.debug('Setting user %s access token...', value)
         UserTokenOperations().set_user_token(value)
 
 
-def stacktracing(func):
-    def _stacktracing_decorator(f):
+def click_decorator(decorator_func):
+    """
+    todo: Add proper doc
+    """
+    def _decorator(decorating_func):
         @click.pass_context
-        def _stacktracing_wrapper(ctx, *args, **kwargs):
-            trace = ctx.params.get('trace') or False
-            try:
-                return ctx.invoke(f, *args, **kwargs)
-            except Exception as runtime_error:
-                click.echo('Error: {}'.format(str(runtime_error)), err=True)
-                if trace:
-                    traceback.print_exc()
-                sys.exit(1)
-        return functools.update_wrapper(_stacktracing_wrapper, f)
-    return _stacktracing_decorator(func)
+        @functools.wraps(decorating_func)
+        def _wrapper(ctx, *args, **kwargs):
+            return decorator_func(decorating_func, ctx, *args, **kwargs)
+        return _wrapper
+    return _decorator
 
 
-def common_options(func):
-    @click.option(
-        '--debug',
-        is_eager=False,
-        is_flag=True,
-        expose_value=False,
-        callback=enable_debug_logging,
-        help='Enable verbose logging'
-    )
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        return func(*args, **kwargs)
-    return wrapper
+@click_decorator
+def stacktracing(func, ctx, *args, **kwargs):
+    """
+    todo: Add proper doc
+    """
+    trace = ctx.params.get('trace') or False
+    try:
+        return ctx.invoke(func, *args, **kwargs)
+    except Exception as runtime_error:
+        click.echo('Error: {}'.format(str(runtime_error)), err=True)
+        if trace:
+            traceback.print_exc()
+        sys.exit(1)
+
+
+@click_decorator
+def console_logging(func, ctx, *args, **kwargs):
+    """
+    todo: Add proper doc
+    """
+    if not ctx.params.get('debug'):
+        log_level = os.getenv('CP_LOGGING_LEVEL') or ctx.params.get('log_level') or DEFAULT_LOGGING_LEVEL
+        log_format = os.getenv('CP_LOGGING_FORMAT') or ctx.params.get('log_format') or DEFAULT_LOGGING_FORMAT
+        logging.basicConfig(level=log_level, format=log_format)
+    return ctx.invoke(func, *args, **kwargs)
+
+
+@click_decorator
+def signals_handling(func, ctx, *args, **kwargs):
+    """
+    todo: Add proper doc
+    """
+    def throw_keyboard_interrupt(signum, frame):
+        logging.debug('Received signal (%s). Gracefully exiting...', signum)
+        raise KeyboardInterrupt()
+
+    import signal
+    logging.debug('Configuring graceful signal (%s) handling...', signal.SIGTERM)
+    signal.signal(signal.SIGTERM, throw_keyboard_interrupt)
+    return ctx.invoke(func, *args, **kwargs)
+
+
+@click_decorator
+def frozen_cleaning(func, ctx, *args, **kwargs):
+    """
+    Relates to https://github.com/pyinstaller/pyinstaller/issues/2379
+
+    todo: Add proper doc
+    """
+    if ctx.params.get('noclean'):
+        return ctx.invoke(func, *args, **kwargs)
+    try:
+        CleanOperationsManager().clean()
+    except Exception:
+        logging.warn('Temporary directories cleaning has failed: %s', traceback.format_exc())
+    ctx.invoke(func, *args, **kwargs)
+
+
+@click_decorator
+def frozen_locking(func, ctx, *args, **kwargs):
+    """
+    todo: Add proper doc
+    """
+    if not is_frozen() or __bundle_info__['bundle_type'] != 'one-file' or ctx.params.get('noclean'):
+        return ctx.invoke(func, *args, **kwargs)
+    CleanOperationsManager().lock(lambda: ctx.invoke(func, *args, **kwargs))
+
+
+@click_decorator
+def skipped_cleaning(func, ctx, *args, **kwargs):
+    ctx.params['noclean'] = True
+    return ctx.invoke(func, *args, **kwargs)
+
+
+def common_options(_func=None, skip_user=False, skip_clean=False):
+    """
+    todo: Add proper doc
+    """
+    def _decorator(func):
+        @click.option('--debug', required=False, is_flag=True,
+                      callback=enable_debug_logging, expose_value=False,
+                      default=False, is_eager=False,
+                      help=DEBUG_OPTION_DESCRIPTION)
+        @click.option('--trace', required=False, is_flag=True,
+                      default=False,
+                      help=TRACE_OPTION_DESCRIPTION)
+        @stacktracing
+        @console_logging
+        @signals_handling
+        @frozen_locking
+        @frozen_cleaning
+        @Config.validate_access_token(quiet_flag_property_name='quiet')
+        @functools.wraps(func)
+        def _wrapper(*args, **kwargs):
+            kwargs.pop('trace', None)
+            kwargs.pop('noclean', None)
+            return func(*args, **kwargs)
+
+        if skip_clean:
+            _wrapper = skipped_cleaning(_wrapper)
+        else:
+            _wrapper = click.option('--noclean', required=False, is_flag=True,
+                                    default=False,
+                                    help=NO_CLEAN_OPTION_DESCRIPTION)(_wrapper)
+        if not skip_user:
+            _wrapper = click.option('-u', '--user', required=False,
+                                    callback=(lambda ctx, param, value: None) if skip_user else set_user_token,
+                                    expose_value=False,
+                                    help=USER_OPTION_DESCRIPTION)(_wrapper)
+        return _wrapper
+
+    return _decorator(_func) if _func else _decorator
 
 
 @click.group(cls=CustomAbortHandlingGroup, uninterruptible_cmd_list=['resume', 'pause'])
@@ -230,8 +337,7 @@ def echo_title(title, line=True):
 @click.option('-p', '--parameters', help='List parameters of a pipeline', is_flag=True)
 @click.option('-s', '--storage-rules', help='List storage rules of a pipeline', is_flag=True)
 @click.option('-r', '--permissions', help='List user permissions for a pipeline', is_flag=True)
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@Config.validate_access_token
+@common_options
 def view_pipes(pipeline, versions, parameters, storage_rules, permissions):
     """Lists pipelines definitions
     """
@@ -365,8 +471,7 @@ def view_pipe(pipeline, versions, parameters, storage_rules, permissions):
 @click.option('-nd', '--node-details', help='Display node details of a specific run', is_flag=True)
 @click.option('-pd', '--parameters-details', help='Display parameters of a specific run', is_flag=True)
 @click.option('-td', '--tasks-details', help='Display tasks of a specific run', is_flag=True)
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@Config.validate_access_token
+@common_options
 def view_runs(run_id,
               status,
               date_from,
@@ -557,8 +662,7 @@ def view_run(run_id, node_details, parameters_details, tasks_details):
 
 @cli.command(name='view-cluster')
 @click.argument('node-name', required=False)
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@Config.validate_access_token
+@common_options
 def view_cluster(node_name):
     """Lists cluster nodes
     """
@@ -765,9 +869,7 @@ def view_cluster_for_node(node_name):
                    'An admin can launch a run on behalf of a different user '
                    'exactly the same way the user would launch the same run by herself/himself. '
                    'Therefore no ORIGINAL_OWNER run parameter is set for admins.')
-@click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
-@Config.validate_access_token(quiet_flag_property_name='quiet')
-@stacktracing
+@common_options(skip_user=True)
 def run(pipeline,
         config,
         parameters,
@@ -792,8 +894,7 @@ def run(pipeline,
         status_notifications_recipient,
         status_notifications_subject,
         status_notifications_body,
-        user,
-        trace):
+        user):
     """
     Launches a new run.
 
@@ -843,11 +944,8 @@ def run(pipeline,
 @cli.command(name='stop')
 @click.argument('run-id', required=True, type=int)
 @click.option('-y', '--yes', is_flag=True, help='Do not ask confirmation')
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
-@Config.validate_access_token
-@stacktracing
-def stop(run_id, yes, trace):
+@common_options
+def stop(run_id, yes):
     """Stops a running pipeline
     """
     PipelineRunOperations.stop(run_id, yes)
@@ -857,7 +955,7 @@ def stop(run_id, yes, trace):
 @click.argument('run-id', required=True, type=int)
 @click.option('--check-size', is_flag=True, help='Checks if free disk space is enough for the commit operation')
 @click.option('-s', '--sync', is_flag=True, help=SYNC_FLAG_DESCRIPTION)
-@Config.validate_access_token
+@common_options
 def pause(run_id, check_size, sync):
     """Pauses a running pipeline
     """
@@ -867,7 +965,7 @@ def pause(run_id, check_size, sync):
 @cli.command(name='resume')
 @click.argument('run-id', required=True, type=int)
 @click.option('-s', '--sync', is_flag=True, help=SYNC_FLAG_DESCRIPTION)
-@Config.validate_access_token
+@common_options
 def resume(run_id, sync):
     """Resumes a paused pipeline
     """
@@ -877,8 +975,7 @@ def resume(run_id, sync):
 @cli.command(name='terminate-node')
 @click.argument('node-name', required=True, type=str)
 @click.option('-y', '--yes', is_flag=True, help='Do not ask confirmation')
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@Config.validate_access_token
+@common_options
 def terminate_node(node_name, yes):
     """Terminates a calculation node
     """
@@ -944,8 +1041,7 @@ def storage():
               prompt='Cloud Region ID where the datastorage shall be created')
 @click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False,
               help=USER_OPTION_DESCRIPTION, prompt=USER_OPTION_DESCRIPTION, default='')
-@Config.validate_access_token
-@common_options
+@common_options(skip_user=True)
 def create(name, description, short_term_storage, long_term_storage, versioning, backup_duration, type,
            parent_folder, on_cloud, path, region_id):
     """Creates a new object storage
@@ -958,8 +1054,6 @@ def create(name, description, short_term_storage, long_term_storage, versioning,
 @click.option('-n', '--name', required=True, help='Name of the storage to delete')
 @click.option('-c', '--on_cloud', help='Delete a datastorage from the Cloud', is_flag=True)
 @click.option('-y', '--yes', is_flag=True, help='Do not ask confirmation')
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@Config.validate_access_token
 @common_options
 def delete(name, on_cloud, yes):
     """Deletes an object storage
@@ -979,8 +1073,6 @@ def delete(name, on_cloud, yes):
               prompt='Do you want to enable versioning for this datastorage?',
               help='Enable versioning for this datastorage')
 @click.option('-b', '--backup_duration', default='', help='Number of days for storing backups of the datastorage')
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@Config.validate_access_token
 @common_options
 def update_policy(name, short_term_storage, long_term_storage, versioning, backup_duration):
     """Updates the policy of the datastorage
@@ -995,7 +1087,6 @@ def update_policy(name, short_term_storage, long_term_storage, versioning, backu
 @storage.command(name='mvtodir')
 @click.argument('name', required=True)
 @click.argument('directory', required=True)
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @common_options
 def mvtodir(name, directory):
     """Moves an object storage to a new parent folder
@@ -1010,8 +1101,6 @@ def mvtodir(name, directory):
 @click.option('-r', '--recursive', is_flag=True, help='Recursive listing')
 @click.option('-p', '--page', type=int, help='Maximum number of records to show')
 @click.option('-a', '--all', is_flag=True, help='Show all results at once ignoring page settings')
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@Config.validate_access_token
 @common_options
 def storage_list(path, show_details, show_versions, recursive, page, all):
     """Lists storage contents
@@ -1021,8 +1110,6 @@ def storage_list(path, show_details, show_versions, recursive, page, all):
 
 @storage.command(name='mkdir')
 @click.argument('folders', required=True, nargs=-1)
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@Config.validate_access_token
 @common_options
 def storage_mk_dir(folders):
     """ Creates a directory in a storage
@@ -1040,8 +1127,6 @@ def storage_mk_dir(folders):
               help='Exclude all files matching this pattern from processing')
 @click.option('-i', '--include', required=False, multiple=True,
               help='Include only files matching this pattern into processing')
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@Config.validate_access_token
 @common_options
 def storage_remove_item(path, yes, version, hard_delete, recursive, exclude, include):
     """ Removes file or folder from a datastorage
@@ -1081,11 +1166,7 @@ def storage_remove_item(path, yes, version, hard_delete, recursive, exclude, inc
               help='The number of threads to be used for a single file io operations')
 @click.option('-vd', '--verify-destination', is_flag=True, required=False,
               help=STORAGE_VERIFY_DESTINATION_OPTION_DESCRIPTION)
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
-@Config.validate_access_token(quiet_flag_property_name='quiet')
 @common_options
-@stacktracing
 def storage_move_item(source, destination, recursive, force, exclude, include, quiet, skip_existing, tags, file_list,
                       symlinks, threads, io_threads, verify_destination):
     """ Moves a file or a folder from one datastorage to another one
@@ -1128,13 +1209,9 @@ def storage_move_item(source, destination, recursive, force, exclude, include, q
               help='The number of threads to be used for a single file io operations')
 @click.option('-vd', '--verify-destination', is_flag=True, required=False,
               help=STORAGE_VERIFY_DESTINATION_OPTION_DESCRIPTION)
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
-@Config.validate_access_token(quiet_flag_property_name='quiet')
 @common_options
-@stacktracing
 def storage_copy_item(source, destination, recursive, force, exclude, include, quiet, skip_existing, tags, file_list,
-                      symlinks, threads, io_threads, verify_destination, trace):
+                      symlinks, threads, io_threads, verify_destination):
     """ Copies files from one datastorage to another one
     or between the local filesystem and a datastorage (in both directions)
     """
@@ -1149,9 +1226,6 @@ def storage_copy_item(source, destination, recursive, force, exclude, include, q
 @click.option('-f', '--format', help='Format for size [G/M/K]',
               type=click.Choice(DuFormatType.possible_types()), required=False, default='M')
 @click.option('-d', '--depth', help='Depth level', type=int, required=False)
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False,
-              help=USER_OPTION_DESCRIPTION)
-@Config.validate_access_token(quiet_flag_property_name='quiet')
 @common_options
 def du(name, relative_path, format, depth):
     DataStorageOperations.du(name, relative_path, format, depth)
@@ -1165,8 +1239,6 @@ def du(name, relative_path, format, depth):
               help='Exclude all files matching this pattern from processing')
 @click.option('-i', '--include', required=False, multiple=True,
               help='Include only files matching this pattern into processing')
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@Config.validate_access_token
 @common_options
 def storage_restore_item(path, version, recursive, exclude, include):
     """ Restores file version in a datastorage.\n
@@ -1180,8 +1252,6 @@ def storage_restore_item(path, version, recursive, exclude, include):
 @click.argument('path', required=True)
 @click.argument('tags', required=True, nargs=-1)
 @click.option('-v', '--version', required=False, help='Set tags for a specified version')
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@Config.validate_access_token
 @common_options
 def storage_set_object_tags(path, tags, version):
     """ Sets tags for a specified object.\n
@@ -1198,8 +1268,6 @@ def storage_set_object_tags(path, tags, version):
 @storage.command('get-object-tags')
 @click.argument('path', required=True)
 @click.option('-v', '--version', required=False, help='Get tags for a specified version')
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@Config.validate_access_token
 @common_options
 def storage_get_object_tags(path, version):
     """ Gets tags for a specified object.\n
@@ -1214,8 +1282,6 @@ def storage_get_object_tags(path, version):
 @click.argument('path', required=True)
 @click.argument('tags', required=True, nargs=-1)
 @click.option('-v', '--version', required=False, help='Delete tags for a specified version')
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@Config.validate_access_token
 @common_options
 def storage_delete_object_tags(path, tags, version):
     """ Deletes tags for a specified object.\n
@@ -1234,19 +1300,15 @@ def storage_delete_object_tags(path, tags, version):
 @click.option('-o', '--options', required=False, help='Any mount options supported by underlying FUSE implementation')
 @click.option('-c', '--custom-options', required=False, help='Mount options supported only by pipe fuse')
 @click.option('-l', '--log-file', required=False, help='Log file for mount')
-@click.option('-v', '--log-level', required=False, help='Log level for mount: '
-                                                        'CRITICAL, ERROR, WARNING, INFO or DEBUG')
+@click.option('-v', '--log-level', required=False, help=LOGGING_LEVEL_OPTION_DESCRIPTION)
 @click.option('-q', '--quiet', help='Enables quiet mode', is_flag=True)
 @click.option('-t', '--threads', help='Enables multithreading', is_flag=True)
 @click.option('-m', '--mode', required=False, help='Default file permissions',  default=700, type=int)
 @click.option('-w', '--timeout', required=False, help='Waiting time in ms to check whether mount was successful',
               default=1000, type=int)
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
-@Config.validate_access_token
-@stacktracing
-def mount_storage(mountpoint, file, bucket, options, custom_options, log_file, log_level, quiet, threads, mode, timeout,
-                  trace):
+@common_options
+def mount_storage(mountpoint, file, bucket, options, custom_options, log_file, log_level, quiet, threads, mode,
+                  timeout):
     """
     Mounts either all available network file systems or a single object storage to a local folder.
 
@@ -1277,7 +1339,7 @@ def mount_storage(mountpoint, file, bucket, options, custom_options, log_file, l
 @storage.command('umount')
 @click.argument('mountpoint', required=True)
 @click.option('-q', '--quiet', help='Quiet mode', is_flag=True)
-@Config.validate_access_token
+@common_options
 def umount_storage(mountpoint, quiet):
     """ Unmounts a mountpoint.
         Command is supported for Linux distributions and MacOS and requires
@@ -1295,8 +1357,7 @@ def umount_storage(mountpoint, quiet):
     required=True,
     type=click.Choice(ACLOperations.get_classes())
 )
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@Config.validate_access_token
+@common_options
 def view_acl(identifier, object_type):
     """ View object permissions.\n
     - IDENTIFIER: defines name or id of an object
@@ -1317,8 +1378,7 @@ def view_acl(identifier, object_type):
 @click.option('-a', '--allow', help='Allow permissions')
 @click.option('-d', '--deny', help='Deny permissions')
 @click.option('-i', '--inherit', help='Inherit permissions')
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@Config.validate_access_token
+@common_options
 def set_acl(identifier, object_type, sid, group, allow, deny, inherit):
     """ Set object permissions.\n
     - IDENTIFIER: defines name or id of an object
@@ -1334,8 +1394,7 @@ def set_acl(identifier, object_type, sid, group, allow, deny, inherit):
     required=False,
     type=click.Choice(ACLOperations.get_classes())
 )
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@Config.validate_access_token
+@common_options
 def view_user_objects(username, object_type):
     ACLOperations.print_sid_objects(username, True, object_type)
 
@@ -1348,8 +1407,7 @@ def view_user_objects(username, object_type):
     required=False,
     type=click.Choice(ACLOperations.get_classes())
 )
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@Config.validate_access_token
+@common_options
 def view_group_objects(group_name, object_type):
     ACLOperations.print_sid_objects(group_name, False, object_type)
 
@@ -1365,8 +1423,7 @@ def tag():
 @click.argument('entity_class', required=True)
 @click.argument('entity_id', required=True)
 @click.argument('data', required=True, nargs=-1)
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@Config.validate_access_token
+@common_options
 def set_tag(entity_class, entity_id, data):
     """ Sets tags for a specified object.\n
     If a specific tag key already exists for an object - it will be overwritten\n
@@ -1383,8 +1440,7 @@ def set_tag(entity_class, entity_id, data):
 @tag.command(name='get')
 @click.argument('entity_class', required=True)
 @click.argument('entity_id', required=True)
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@Config.validate_access_token
+@common_options
 def get_tag(entity_class, entity_id):
     """ Lists all tags for a specific object or list of objects.\n
     - ENTITY_CLASS: defines an object class. Possible values: data_storage,
@@ -1399,8 +1455,7 @@ def get_tag(entity_class, entity_id):
 @click.argument('entity_class', required=True)
 @click.argument('entity_id', required=True)
 @click.argument('keys', required=False, nargs=-1)
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@Config.validate_access_token
+@common_options
 def delete_tag(entity_class, entity_id, keys):
     """ Deletes specified tags for a specified object.\n
     - ENTITY_CLASS: defines an object class. Possible values: data_storage,
@@ -1416,8 +1471,7 @@ def delete_tag(entity_class, entity_id, keys):
 @click.argument('user_name', required=True)
 @click.argument('entity_class', required=True)
 @click.argument('entity_name', required=True)
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@Config.validate_access_token
+@common_options
 def chown(user_name, entity_class, entity_name):
     """ Changes current owner to specified.\n
     - USER_NAME: desired object owner\n
@@ -1433,14 +1487,11 @@ def chown(user_name, entity_class, entity_name):
     ignore_unknown_options=True,
     allow_extra_args=True))
 @click.argument('run-id', required=True, type=str)
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @click.option('-r', '--retries', required=False, type=int, default=10, help=RETRIES_OPTION_DESCRIPTION)
-@click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
 @click.option('-rg', '--region', required=False, help=EDGE_REGION_OPTION_DESCRIPTION)
 @click.pass_context
-@Config.validate_access_token
-@stacktracing
-def ssh(ctx, run_id, retries, trace, region):
+@common_options
+def ssh(ctx, run_id, retries, region):
     """Runs a single command or an interactive session over the SSH protocol for the specified job run\n
     Arguments:\n
     - run-id: ID of the job running in the platform to establish SSH connection with
@@ -1469,13 +1520,10 @@ def ssh(ctx, run_id, retries, trace, region):
 @click.option('-r', '--recursive', required=False, is_flag=True, default=False,
               help='Recursive transferring (required for directories transferring)')
 @click.option('-q', '--quiet', help='Quiet mode', is_flag=True, default=False)
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
 @click.option('--retries', required=False, type=int, default=10, help=RETRIES_OPTION_DESCRIPTION)
-@click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
 @click.option('-rg', '--region', required=False, help=EDGE_REGION_OPTION_DESCRIPTION)
-@Config.validate_access_token
-@stacktracing
-def scp(source, destination, recursive, quiet, retries, trace, region):
+@common_options
+def scp(source, destination, recursive, quiet, retries, region):
     """
     Transfers files or directories between local workstation and run instance.
 
@@ -1528,12 +1576,9 @@ def tunnel():
               help='Tunnels stopping timeout in ms.')
 @click.option('-f', '--force', required=False, is_flag=True, default=False,
               help='Killing tunnels rather than stopping them.')
-@click.option('-v', '--log-level', required=False, help='Explicit logging level: '
-                                                        'CRITICAL, ERROR, WARNING, INFO or DEBUG.')
-@click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
-@Config.validate_access_token
-@stacktracing
-def stop_tunnel(run_id, local_port, timeout, force, log_level, trace):
+@click.option('-v', '--log-level', required=False, help=LOGGING_LEVEL_OPTION_DESCRIPTION)
+@common_options
+def stop_tunnel(run_id, local_port, timeout, force, log_level):
     """
     Stops background tunnel processes.
 
@@ -1567,7 +1612,7 @@ def stop_tunnel(run_id, local_port, timeout, force, log_level, trace):
     kill_tunnels(run_id=run_id, local_ports_str=local_port, timeout=timeout, force=force, log_level=log_level)
 
 
-def start_tunnel_arguments(start_tunnel_command):
+def start_tunnel_options(decorating_func):
     @click.argument('host-id', required=True)
     @click.option('-lp', '--local-port', required=False, type=str,
                   help='A single local port (4567) or a range of ports (4567-4569) '
@@ -1596,8 +1641,7 @@ def start_tunnel_arguments(start_tunnel_command):
     @click.option('-d', '--direct', required=False, is_flag=True, default=False,
                   help='Configures direct tunnel connection without proxy.')
     @click.option('-l', '--log-file', required=False, help='Logs file for tunnel in background mode.')
-    @click.option('-v', '--log-level', required=False, help='Logs level for tunnel: '
-                                                            'CRITICAL, ERROR, WARNING, INFO or DEBUG.')
+    @click.option('-v', '--log-level', required=False, help=LOGGING_LEVEL_OPTION_DESCRIPTION)
     @click.option('-t', '--timeout', required=False, type=int, default=5 * 60,
                   help='Maximum timeout for background tunnel process health check in seconds.')
     @click.option('-ts', '--timeout-stop', required=False, type=int, default=60,
@@ -1613,31 +1657,28 @@ def start_tunnel_arguments(start_tunnel_command):
                   help='Replaces existing tunnel on the same local port.')
     @click.option('-rd', '--replace-different', required=False, is_flag=True, default=False,
                   help='Replaces existing tunnel on the same local port if it has different configuration.')
-    @click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False,
-                  help=USER_OPTION_DESCRIPTION)
     @click.option('-r', '--retries', required=False, type=int, default=10, help=RETRIES_OPTION_DESCRIPTION)
-    @click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
     @click.option('-rg', '--region', required=False, help=EDGE_REGION_OPTION_DESCRIPTION)
-    def _start_tunnel_command_decorator(*args, **kwargs):
-        return start_tunnel_command(*args, **kwargs)
-    return functools.update_wrapper(_start_tunnel_command_decorator, start_tunnel_command)
+    @functools.wraps(decorating_func)
+    def _decorator_func(*args, **kwargs):
+        return decorating_func(*args, **kwargs)
+    return _decorator_func
 
 
 @tunnel.command(name='start')
-@start_tunnel_arguments
+@start_tunnel_options
 def return_tunnel_args(*args, **kwargs):
     return kwargs
 
 
 @tunnel.command(name='start')
-@start_tunnel_arguments
-@Config.validate_access_token
-@stacktracing
+@start_tunnel_options
+@common_options
 def start_tunnel(host_id, local_port, remote_port, connection_timeout,
                  ssh, ssh_path, ssh_host, ssh_user, ssh_keep, direct, log_file, log_level,
                  timeout, timeout_stop, foreground,
                  keep_existing, keep_same, replace_existing, replace_different,
-                 retries, trace, region):
+                 retries, region):
     """
     Establishes tunnel connection to specified run instance port and serves it as a local port.
 
@@ -1728,8 +1769,7 @@ def start_tunnel(host_id, local_port, remote_port, connection_timeout,
 
 @cli.command(name='update')
 @click.argument('path', required=False)
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@Config.validate_access_token
+@common_options
 def update_cli_version(path):
     """
     Install latest Cloud Pipeline CLI version.
@@ -1750,8 +1790,7 @@ def update_cli_version(path):
 @click.option('-g', '--group', help='List group tools.')
 @click.option('-t', '--tool', help='List tool details.')
 @click.option('-v', '--version', help='List tool version details.')
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@Config.validate_access_token
+@common_options
 def view_tools(tool_path,
                registry,
                group,
@@ -1841,7 +1880,7 @@ def split_tool_path(tool_path, registry, group, tool, version, strict=False):
 @cli.command(name='token')
 @click.argument('user-id', required=True)
 @click.option('-d', '--duration', type=int, required=False, help='The number of days this token will be valid.')
-@Config.validate_access_token
+@common_options
 def token(user_id, duration):
     """
     Prints a JWT token for specified user
@@ -1858,8 +1897,7 @@ def share():
 
 @share.command(name='get')
 @click.argument('run-id', required=True)
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@Config.validate_access_token
+@common_options
 def get_share_run(run_id):
     """
     Returns users and groups this run shared
@@ -1874,8 +1912,7 @@ def get_share_run(run_id):
 @click.option('-sg', '--shared-group', required=False, multiple=True,
               help='The group to enable run sharing. Multiple options supported.')
 @click.option('-ssh', '--share-ssh', required=False, is_flag=True, default=False, help='Indicates ssh share')
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@Config.validate_access_token
+@common_options
 def add_share_run(run_id, shared_user, shared_group, share_ssh):
     """
     Shares specified pipeline run with users or groups
@@ -1890,8 +1927,7 @@ def add_share_run(run_id, shared_user, shared_group, share_ssh):
 @click.option('-sg', '--shared-group', required=False, multiple=True,
               help='The group to disable run sharing. Multiple options supported.')
 @click.option('-ssh', '--share-ssh', required=False, is_flag=True, default=False, help='Indicates ssh unshare')
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@Config.validate_access_token
+@common_options
 def remove_share_run(run_id, shared_user, shared_group, share_ssh):
     """
     Disables shared pipeline run for specified users or groups
@@ -1922,8 +1958,7 @@ def cluster():
                                                        'number of minutes/hours. Default: 1m.')
 @click.option('-rt', '--report-type', required=False, default='CSV',
               help='Exported report type (case insensitive). Currently `CSV` and `XLS` are supported. Default: CSV')
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@Config.validate_access_token
+@common_options
 def monitor(instance_id, run_id, output, date_from, date_to, interval, report_type):
     """
     Downloads node utilization report
@@ -1944,8 +1979,7 @@ def users():
 @click.option('-cg', '--create-group', required=False, is_flag=True, default=False, help='Allow new group creation')
 @click.option('-cm', '--create-metadata', required=False, multiple=True,
               help='Allow to create a new metadata with specified key. Multiple options supported.')
-@click.option('-u', '--user', required=False, callback=set_user_token, expose_value=False, help=USER_OPTION_DESCRIPTION)
-@Config.validate_access_token
+@common_options
 def import_users(file_path, create_user, create_group, create_metadata):
     """
     Registers a new users, roles and metadata specified in input file
@@ -1970,10 +2004,8 @@ def dts():
 @click.option('--preference', required=False, type=str, multiple=True,
               help='String, describing preference''s key and value: key=value. Multiple options supported')
 @click.option('--json-out', '-jo', required=False, is_flag=True, help='Defines if output should be JSON-formatted')
-@click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
-@Config.validate_access_token
-@stacktracing
-def create_dts(url, name, schedulable, prefix, preference, json_out, trace):
+@common_options
+def create_dts(url, name, schedulable, prefix, preference, json_out):
     """
     Registers new data transfer service.
 
@@ -1994,10 +2026,8 @@ def create_dts(url, name, schedulable, prefix, preference, json_out, trace):
 @dts.command(name='list')
 @click.argument('registry-name-or-id', required=False, type=str)
 @click.option('--json-out', '-jo', required=False, is_flag=True, help='Defines if output should be JSON-formatted')
-@click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
-@Config.validate_access_token
-@stacktracing
-def list_dts(registry_name_or_id, json_out, trace):
+@common_options
+def list_dts(registry_name_or_id, json_out):
     """
     Either shows details of a data transfer service or lists all data transfer services.
 
@@ -2022,10 +2052,8 @@ def list_dts(registry_name_or_id, json_out, trace):
 @dts.command(name='delete')
 @click.argument('registry-name-or-id', required=True, type=str)
 @click.option('--json-out', '-jo', required=False, is_flag=True, help='Defines if output should be JSON-formatted')
-@click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
-@Config.validate_access_token
-@stacktracing
-def delete_dts(registry_name_or_id, json_out, trace):
+@common_options
+def delete_dts(registry_name_or_id, json_out):
     """
     Deletes data transfer service.
 
@@ -2056,10 +2084,8 @@ def preferences():
 @click.option('--preference', '-p', multiple=True, type=str,
               help='String, describing preference''s key and value: key=value. Multiple options supported')
 @click.option('--json-out', '-jo', required=False, is_flag=True, help='Defines if output should be JSON-formatted')
-@click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
-@Config.validate_access_token
-@stacktracing
-def update_dts_preferences(registry_name_or_id, preference, json_out, trace):
+@common_options
+def update_dts_preferences(registry_name_or_id, preference, json_out):
     """
     Updates existing preferences or adds new preferences for the given data transfer service.
 
@@ -2086,10 +2112,8 @@ def update_dts_preferences(registry_name_or_id, preference, json_out, trace):
 @click.option('--preference', '-p', multiple=True, type=str,
               help="Key of the preference, that should be removed. Multiple options supported")
 @click.option('--json-out', '-jo', required=False, is_flag=True, help='Defines if output should be JSON-formatted')
-@click.option('--trace', required=False, is_flag=True, default=False, help=TRACE_OPTION_DESCRIPTION)
-@Config.validate_access_token
-@stacktracing
-def delete_dts_preferences(registry_name_or_id, preference, json_out, trace):
+@common_options
+def delete_dts_preferences(registry_name_or_id, preference, json_out):
     """
     Deletes preferences for the given data transfer service.
 
@@ -2109,6 +2133,31 @@ def delete_dts_preferences(registry_name_or_id, preference, json_out, trace):
 
     """
     DtsOperationsManager().delete_preferences(registry_name_or_id, preference, json_out)
+
+
+@cli.command(name='clean')
+@click.option('--force', required=False, is_flag=True,
+              help='Removes all temporary resources even the ones that may be still in use. '
+                   'This option is safe to use only if there are no running pipe processes.')
+@common_options(skip_user=True, skip_clean=True)
+def clean(force):
+    """
+    Cleans pipe cli local temporary resources.
+
+    Removes all temporary directories that pipe cli generated during previous launches in a user home directory.
+
+    Examples:
+
+    I.  Cleans pipe cli local temporary resources.
+
+        pipe clean
+
+    II. Cleans all pipe cli local temporary resources even if they are still in use if possible.
+
+        pipe clean --force
+
+    """
+    CleanOperationsManager().clean(force=force)
 
 
 # Used to run a PyInstaller "freezed" version

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -187,7 +187,7 @@ def frozen_cleaning(func, ctx, *args, **kwargs):
     if ctx.params.get('noclean'):
         return ctx.invoke(func, *args, **kwargs)
     try:
-        CleanOperationsManager().clean()
+        CleanOperationsManager().clean(quiet=ctx.params.get('quiet'))
     except Exception:
         logging.warn('Temporary directories cleaning has failed: %s', traceback.format_exc())
     ctx.invoke(func, *args, **kwargs)
@@ -198,7 +198,7 @@ def frozen_locking(func, ctx, *args, **kwargs):
     """
     todo: Add proper doc
     """
-    if not is_frozen() or __bundle_info__['bundle_type'] != 'one-file' or ctx.params.get('noclean'):
+    if not is_frozen() or __bundle_info__['bundle_type'] != 'one-file':
         return ctx.invoke(func, *args, **kwargs)
     CleanOperationsManager().lock(lambda: ctx.invoke(func, *args, **kwargs))
 

--- a/pipe-cli/src/config.py
+++ b/pipe-cli/src/config.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from functools import update_wrapper
 import base64
 import click
@@ -128,6 +129,7 @@ class Config(object):
                 if not skip_validation:
                     config = Config.instance(raise_config_not_found_exception=False)
                     if config is not None and config.initialized:
+                        logging.debug('Validating access token...')
                         config.validate()
                 return ctx.invoke(f, *args, **kwargs)
             return update_wrapper(validate_access_token_wrapper, f)

--- a/pipe-cli/src/utilities/clean_operations_manager.py
+++ b/pipe-cli/src/utilities/clean_operations_manager.py
@@ -32,10 +32,14 @@ class CleanOperationsManager:
         pass
 
     def clean(self, force=False, quiet=False):
-        logging.debug('Cleaning temporary directories...')
+        config_dir_path = os.path.dirname(Config.get_home_dir_config_path())
+        self._clean_pipe_tmp_dirs(config_dir_path, force, quiet)
+        self._clean_pipe_fuse_tmp_dirs(config_dir_path)
+
+    def _clean_pipe_tmp_dirs(self, config_dir_path, force, quiet):
+        logging.debug('Cleaning pipe temporary directories...')
         current_tmp_dir_path = sys._MEIPASS if is_frozen() else None
-        config_folder = os.path.dirname(Config.get_home_dir_config_path())
-        root_tmp_dir_path = os.path.join(config_folder, 'tmp')
+        root_tmp_dir_path = os.path.join(config_dir_path, 'tmp')
         if not os.path.isdir(root_tmp_dir_path):
             return
         any_tmp_dir_without_lock = False
@@ -44,13 +48,15 @@ class CleanOperationsManager:
             tmp_dir_lock_path = os.path.join(tmp_dir_path, self._LOCK_NAME)
             if not tmp_dir_name.startswith('_MEI') or tmp_dir_path == current_tmp_dir_path:
                 continue
+            if not os.path.isdir(tmp_dir_path):
+                continue
             if not os.path.exists(tmp_dir_lock_path) and not force:
-                logging.debug('Skipping temporary directory without lock deletion '
+                logging.debug('Skipping pipe temporary directory without lock deletion '
                               'because --force flag is not used %s...', tmp_dir_path)
                 any_tmp_dir_without_lock = True
                 continue
             if os.path.exists(tmp_dir_lock_path) and self._is_dir_locked(tmp_dir_path, tmp_dir_lock_path):
-                logging.debug('Skipping locked temporary directory deletion %s...', tmp_dir_path)
+                logging.debug('Skipping running pipe temporary directory deletion %s...', tmp_dir_path)
                 continue
             self._remove_dir(tmp_dir_path)
         if any_tmp_dir_without_lock and not quiet:
@@ -76,12 +82,51 @@ class CleanOperationsManager:
                 logging.debug('Unlocking temporary directory %s...', dir_path)
                 self._unlock(tmp_dir_lock_descriptor)
 
+    def _clean_pipe_fuse_tmp_dirs(self, config_dir_path):
+        logging.debug('Cleaning pipe fuse temporary directories...')
+        if not os.path.isdir(config_dir_path):
+            return
+        for tmp_item_name in os.listdir(config_dir_path):
+            tmp_item_path = os.path.join(config_dir_path, tmp_item_name)
+            if not tmp_item_name.startswith('pipe-fuse'):
+                continue
+            if os.path.isdir(tmp_item_path):
+                tmp_dir_executable_path = os.path.join(tmp_item_path, 'pipe-fuse')
+                if self._any_process_with_argument(tmp_dir_executable_path):
+                    logging.debug('Skipping running pipe fuse temporary directory deletion %s...', tmp_item_path)
+                    continue
+                self._remove_dir(tmp_item_path)
+            else:
+                if self._any_process_with_argument(tmp_item_path):
+                    logging.debug('Skipping running pipe fuse temporary file deletion %s...', tmp_item_path)
+                    continue
+                self._remove_file(tmp_item_path)
+
+    def _any_process_with_argument(self, argument):
+        logging.debug('Searching for any processes with argument %s...', argument)
+        import psutil
+        for proc in psutil.process_iter():
+            try:
+                if argument in proc.cmdline():
+                    logging.debug('Found process (%s) with argument %s', proc.pid, argument)
+                    return True
+            except psutil.AccessDenied:
+                pass
+        return False
+
     def _remove_dir(self, dir_path):
         try:
             logging.debug('Deleting temporary directory %s...', dir_path)
             shutil.rmtree(dir_path)
         except Exception:
             logging.warn('Temporary directory deletion has failed: %s', traceback.format_exc())
+
+    def _remove_file(self, file_path):
+        try:
+            logging.debug('Deleting temporary file %s...', file_path)
+            os.remove(file_path)
+        except Exception:
+            logging.warn('Temporary file deletion has failed: %s', traceback.format_exc())
 
     def lock(self, operation):
         tmp_dir_path = Config.get_base_source_dir()

--- a/pipe-cli/src/utilities/clean_operations_manager.py
+++ b/pipe-cli/src/utilities/clean_operations_manager.py
@@ -1,0 +1,98 @@
+# Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import platform
+import shutil
+import sys
+import traceback
+
+from src.config import Config, is_frozen
+
+
+class CleanOperationsManager:
+
+    _LOCK_NAME = 'pipe.frozen.lock'
+
+    def __init__(self):
+        pass
+
+    def clean(self, force=False):
+        logging.debug('Cleaning temporary directories...')
+        current_tmp_dir_path = sys._MEIPASS if is_frozen() else None
+        config_folder = os.path.dirname(Config.get_home_dir_config_path())
+        root_tmp_dir_path = os.path.join(config_folder, 'tmp')
+        if not os.path.isdir(root_tmp_dir_path):
+            return
+        for tmp_dir_name in os.listdir(root_tmp_dir_path):
+            tmp_dir_path = os.path.join(root_tmp_dir_path, tmp_dir_name)
+            tmp_dir_lock_path = os.path.join(tmp_dir_path, self._LOCK_NAME)
+            if not tmp_dir_name.startswith('_MEI') or tmp_dir_path == current_tmp_dir_path:
+                continue
+            if not os.path.exists(tmp_dir_lock_path) and not force:
+                logging.debug('Skipping temporary directory without lock deletion '
+                              'because --force flag is not used %s...', tmp_dir_path)
+                continue
+            if os.path.exists(tmp_dir_lock_path) and self._is_dir_locked(tmp_dir_path, tmp_dir_lock_path):
+                logging.debug('Skipping locked temporary directory deletion %s...', tmp_dir_path)
+                continue
+            self._remove_dir(tmp_dir_path)
+
+    def _is_dir_locked(self, dir_path, dir_lock_path):
+        logging.debug('Trying to lock temporary directory %s...', dir_path)
+        with open(dir_lock_path, 'w+') as tmp_dir_lock_descriptor:
+            try:
+                self._lock(tmp_dir_lock_descriptor)
+                return False
+            except (IOError, OSError):
+                return True
+            finally:
+                logging.debug('Unlocking temporary directory %s...', dir_path)
+                self._unlock(tmp_dir_lock_descriptor)
+
+    def _remove_dir(self, dir_path):
+        try:
+            logging.debug('Deleting temporary directory %s...', dir_path)
+            shutil.rmtree(dir_path)
+        except Exception:
+            logging.warn('Temporary directory deletion has failed: %s', traceback.format_exc())
+
+    def lock(self, operation):
+        tmp_dir_path = Config.get_base_source_dir()
+        tmp_dir_lock_path = os.path.join(tmp_dir_path, self._LOCK_NAME)
+        logging.debug('Locking temporary directory %s...', tmp_dir_path)
+        with open(tmp_dir_lock_path, 'w+') as tmp_dir_lock_descriptor:
+            try:
+                self._lock(tmp_dir_lock_descriptor)
+                return operation()
+            finally:
+                logging.debug('Unlocking temporary directory %s...', tmp_dir_path)
+                self._unlock(tmp_dir_lock_descriptor)
+
+    def _lock(self, descriptor):
+        if platform.system() == 'Windows':
+            import msvcrt
+            msvcrt.locking(descriptor.fileno(), msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl
+            fcntl.lockf(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    def _unlock(self, descriptor):
+        if platform.system() == 'Windows':
+            import msvcrt
+            msvcrt.locking(descriptor.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+            fcntl.lockf(descriptor, fcntl.LOCK_UN)

--- a/pipe-cli/src/utilities/lock_operations_manager.py
+++ b/pipe-cli/src/utilities/lock_operations_manager.py
@@ -1,0 +1,68 @@
+# Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import platform
+
+
+class LockOperationsManager:
+    _DEFAULT_LOCK_NAME = 'pipe.lock'
+
+    def __init__(self, lock_name=_DEFAULT_LOCK_NAME):
+        self._lock_name = lock_name
+        self._is_windows = platform.system() == 'Windows'
+
+    def execute(self, dir_path, func):
+        logging.debug('Locking directory %s...', dir_path)
+        dir_lock_path = self.get_lock_path(dir_path)
+        with open(dir_lock_path, 'w+') as dir_lock_descriptor:
+            try:
+                self._lock(dir_lock_descriptor)
+                return func()
+            finally:
+                logging.debug('Unlocking directory %s...', dir_path)
+                self._unlock(dir_lock_descriptor)
+
+    def is_locked(self, dir_path):
+        logging.debug('Trying to lock directory %s...', dir_path)
+        dir_lock_path = self.get_lock_path(dir_path)
+        with open(dir_lock_path, 'w+') as dir_lock_descriptor:
+            try:
+                self._lock(dir_lock_descriptor)
+                return False
+            except (IOError, OSError):
+                return True
+            finally:
+                logging.debug('Unlocking directory %s...', dir_path)
+                self._unlock(dir_lock_descriptor)
+
+    def get_lock_path(self, dir_path):
+        return os.path.join(dir_path, self._lock_name)
+
+    def _lock(self, descriptor):
+        if self._is_windows:
+            import msvcrt
+            msvcrt.locking(descriptor.fileno(), msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl
+            fcntl.lockf(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    def _unlock(self, descriptor):
+        if self._is_windows:
+            import msvcrt
+            msvcrt.locking(descriptor.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+            fcntl.lockf(descriptor, fcntl.LOCK_UN)


### PR DESCRIPTION
Resolves #2241 and resolves #1203 and resolves #1218.

The pull request brings support for automated temporary resources cleanup to pipe cli. Currently such temporary resources include:
- one-file pipe cli distribution extracted archives `~/.pipe/tmp/_MEI*`
- one-folder pipe fuse distribution directories `~/.pipe/pipe-fuse*`
- pipe fuse launch scripts `~/.pipe/pipe-fuse-script*`

In order to safely cleanup pipe cli distribution resources file locking mechanism is used. If any one-file pipe cli distribution command is used then it creates `pipe.lock` file in a corresponding `~/.pipe/tmp/_MEIxxxxxx` directory on startup, acquires the lock file, performs the cli command and frees the lock file.

By default all pipe cli commands remove all existing `~/.pipe/tmp/_MEI*` directories on startup except the ones where `pipe.lock` is acquired by another process.

In order to support backward compatibility pipe cli doesn't try to remove `~/.pipe/tmp/_MEI*` directories without `pipe.lock` in them. Rather it warns the user asking to stop all running pipe cli processes and execute `pipe clean --force` which removes all `~/.pipe/tmp/_MEI*` even the ones without `pipe.lock` in them.

Lastly resources which were generated by `pipe storage mount` are only cleaned up if there are no active processes which are using them. No locking mechanism is used in pipe fuse because it uses one-folder distribution.

## Related changes

### Clean command

New `pipe clean` command is introduced to perform explicit temporary resources cleanup. Additionally `--force` can be to used to clean up backwardly compatible resources. **Notice** that all running pipe cli processes should be stopped before running `pipe clean --force`.

### Common options

From now on most pipe cli commands\* have the following common options:
- `-u/--user` - The user name to perform operation from specified user. Available for admins only.
- `--noclean` - Disables temporary resources cleanup.
- `--debug` - Enables verbose logging.
- `--trace` - Enables verbose errors.

> \* The following commands have some of the common options either diverged or omitted: `pipe configure`, `pipe run`, `pipe dts create` and `pipe clean`.

### Common logging

From now on most pipe cli commands support the following environment variables:
- `CP_LOGGING_LEVEL` configures common logging level. Defaults to `ERROR`.
- `CP_LOGGING_FORMAT` configures common logging format. Defaults to `%(asctime)s:%(levelname)s: %(message)s`.

These logging variables can be used to inspect temporary resources cleanup, locking, signals handling and etc. Use `DEBUG` logging level to check how temporary resources cleanup goes.

```
CP_LOGGING_LEVEL=DEBUG pipe view-tools
```
