### PR TITLE
Issue #2280 Apply file search masks to file storage

### DIFF
--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/NFSSynchronizer.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/NFSSynchronizer.java
@@ -99,6 +99,7 @@ public class NFSSynchronizer implements ElasticsearchSynchronizer {
     @Override
     public void synchronize(final LocalDateTime lastSyncTime, final LocalDateTime syncStart) {
         log.debug("Started NFS synchronization");
+        fileMapper.updateSearchMasks(cloudPipelineAPIClient, log);
 
         List<AbstractDataStorage> allDataStorages = cloudPipelineAPIClient.loadAllDataStorages();
         allDataStorages.stream()

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/ObjectStorageIndexImpl.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/ObjectStorageIndexImpl.java
@@ -21,7 +21,6 @@ import com.epam.pipeline.elasticsearchagent.service.ElasticsearchServiceClient;
 import com.epam.pipeline.elasticsearchagent.service.ObjectStorageFileManager;
 import com.epam.pipeline.elasticsearchagent.service.ObjectStorageIndex;
 import com.epam.pipeline.elasticsearchagent.service.impl.converter.storage.StorageFileMapper;
-import com.epam.pipeline.entity.search.StorageFileSearchMask;
 import com.epam.pipeline.utils.StreamUtils;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.DataStorageAction;
@@ -35,20 +34,15 @@ import com.epam.pipeline.vo.data.storage.DataStorageTagLoadRequest;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
-import org.apache.commons.collections4.SetUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.elasticsearch.action.index.IndexRequest;
-import org.springframework.util.AntPathMatcher;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -73,12 +67,11 @@ public class ObjectStorageIndexImpl implements ObjectStorageIndex {
     @Getter
     private final SearchDocumentType documentType;
     private final StorageFileMapper fileMapper = new StorageFileMapper();
-    private final Map<String, Set<String>> searchMasks = new HashMap<>();
 
     @Override
     public void synchronize(final LocalDateTime lastSyncTime, final LocalDateTime syncStart) {
         log.debug("Started {} files synchronization", getStorageType());
-        updateSearchMasks();
+        fileMapper.updateSearchMasks(cloudPipelineAPIClient, log);
         final List<AbstractDataStorage> allStorages = cloudPipelineAPIClient.loadAllDataStorages();
         allStorages
                 .stream()
@@ -107,8 +100,7 @@ public class ObjectStorageIndexImpl implements ObjectStorageIndex {
                 final Stream<DataStorageFile> files = fileManager
                         .files(dataStorage.getRoot(),
                                 Optional.ofNullable(dataStorage.getPrefix()).orElse(StringUtils.EMPTY),
-                                credentialsSupplier)
-                        .map(file -> setHiddenFlag(dataStorage, file));
+                                credentialsSupplier);
                 StreamUtils.chunked(files, bulkLoadTagsSize)
                         .flatMap(filesChunk -> filesWithIncorporatedTags(dataStorage, filesChunk))
                         .peek(file -> file.setPath(dataStorage.resolveRelativePath(file.getPath())))
@@ -127,29 +119,6 @@ public class ObjectStorageIndexImpl implements ObjectStorageIndex {
                 elasticsearchServiceClient.deleteIndex(indexName);
             }
         }
-    }
-
-    private void updateSearchMasks() {
-        final Map<String, Set<String>> newMasks = cloudPipelineAPIClient.getStorageSearchMasks()
-            .stream()
-            .collect(Collectors.toMap(StorageFileSearchMask::getStorageName,
-                                      StorageFileSearchMask::getHiddenFilePathGlobs,
-                                      SetUtils::union));
-        searchMasks.clear();
-        log.info("Updating search masks: {}", newMasks);
-        searchMasks.putAll(newMasks);
-    }
-
-    private DataStorageFile setHiddenFlag(final AbstractDataStorage dataStorage,
-                                          final DataStorageFile file) {
-        final String storageName = dataStorage.getName();
-        if (searchMasks.containsKey(storageName)) {
-            final AntPathMatcher pathMatcher = new AntPathMatcher();
-            file.setIsHidden(CollectionUtils.emptyIfNull(searchMasks.get(storageName))
-                                 .stream()
-                                 .anyMatch(mask -> pathMatcher.match(mask, file.getPath())));
-        }
-        return file;
     }
 
     private IndexRequestContainer getRequestContainer(final String indexName, final int bulkInsertSize) {

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/storage/StorageFileMapper.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/storage/StorageFileMapper.java
@@ -41,7 +41,7 @@ import static com.epam.pipeline.elasticsearchagent.service.ElasticsearchSynchron
 
 public class StorageFileMapper {
 
-    final Map<String, Set<String>> searchMasks = new HashMap<>();
+    private final Map<String, Set<String>> searchMasks = new HashMap<>();
 
     public XContentBuilder fileToDocument(final DataStorageFile dataStorageFile,
                                           final AbstractDataStorage dataStorage,

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/storage/StorageFileMapper.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/storage/StorageFileMapper.java
@@ -18,19 +18,30 @@ package com.epam.pipeline.elasticsearchagent.service.impl.converter.storage;
 
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.epam.pipeline.elasticsearchagent.model.PermissionsContainer;
+import com.epam.pipeline.elasticsearchagent.service.impl.CloudPipelineAPIClient;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.DataStorageFile;
 import com.epam.pipeline.entity.search.SearchDocumentType;
+import com.epam.pipeline.entity.search.StorageFileSearchMask;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.collections4.SetUtils;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.slf4j.Logger;
+import org.springframework.util.AntPathMatcher;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.epam.pipeline.elasticsearchagent.service.ElasticsearchSynchronizer.DOC_TYPE_FIELD;
 
 public class StorageFileMapper {
+
+    final Map<String, Set<String>> searchMasks = new HashMap<>();
 
     public XContentBuilder fileToDocument(final DataStorageFile dataStorageFile,
                                           final AbstractDataStorage dataStorage,
@@ -51,7 +62,7 @@ public class StorageFileMapper {
                     .field("storage_id", dataStorage.getId())
                     .field("storage_name", dataStorage.getName())
                     .field("storage_region", region)
-                    .field("is_hidden", dataStorageFile.getIsHidden())
+                    .field("is_hidden", isHidden(dataStorage, dataStorageFile))
                     .field(DOC_TYPE_FIELD, type.name())
                     .array("metadata", tags.entrySet().stream()
                             .map(entry -> entry.getKey() + " " + entry.getValue())
@@ -67,5 +78,27 @@ public class StorageFileMapper {
         } catch (IOException e) {
             throw new AmazonS3Exception("An error occurred while creating document: ", e);
         }
+    }
+
+    public void updateSearchMasks(final CloudPipelineAPIClient cloudPipelineAPIClient, final Logger logger) {
+        final Map<String, Set<String>> newMasks = cloudPipelineAPIClient.getStorageSearchMasks()
+            .stream()
+            .collect(Collectors.toMap(StorageFileSearchMask::getStorageName,
+                                      StorageFileSearchMask::getHiddenFilePathGlobs,
+                                      SetUtils::union));
+        searchMasks.clear();
+        logger.info("Updating search masks: {}", newMasks);
+        searchMasks.putAll(newMasks);
+    }
+
+    private boolean isHidden(final AbstractDataStorage dataStorage, final DataStorageFile file) {
+        final String storageName = dataStorage.getName();
+        if (searchMasks.containsKey(storageName)) {
+            final AntPathMatcher pathMatcher = new AntPathMatcher();
+            return CollectionUtils.emptyIfNull(searchMasks.get(storageName))
+                                 .stream()
+                                 .anyMatch(mask -> pathMatcher.match(mask, file.getPath()));
+        }
+        return false;
     }
 }


### PR DESCRIPTION
This PR is related to issue #2280

Previously, search masks were introduced for object storage, but they can be applied to file ones as well since in both scenarios we are processing `DataStorageFile` objects.

- logic regarding masking is migrated to `StorageFileMapper `
- each synchronizer has its own instance of the mapper and triggers masks update at sync iteration start
- masks are applied during conversion to ES document