### PR TITLE
Issue #2232 NAT configuration improvements

### DIFF
--- a/api/profiles/dev/application.properties
+++ b/api/profiles/dev/application.properties
@@ -137,6 +137,7 @@ kube.node.token=
 kube.protected.node.labels=cloud-pipeline/role=EDGE
 kube.master.pod.check.url=http://localhost:4040
 kube.current.pod.name=${CP_API_CURRENT_POD_NAME:localhost}
+kube.default.service.target.port=${CP_API_KUBE_SVC_DEFAULT_TARGET_PORT:1000}
 kube.deployment.api.url.prefix=${CP_API_KUBE_DEPLOYMENT_API_URL_PREFIX:apis/extensions/v1beta1}
 ha.deploy.enabled=false
 

--- a/api/profiles/dev/application.properties
+++ b/api/profiles/dev/application.properties
@@ -137,6 +137,7 @@ kube.node.token=
 kube.protected.node.labels=cloud-pipeline/role=EDGE
 kube.master.pod.check.url=http://localhost:4040
 kube.current.pod.name=${CP_API_CURRENT_POD_NAME:localhost}
+kube.deployment.api.url.prefix=${CP_API_KUBE_DEPLOYMENT_API_URL_PREFIX:apis/extensions/v1beta1}
 ha.deploy.enabled=false
 
 nat.gateway.auto.config.poll=${CP_API_NAT_POLL:60000}

--- a/api/profiles/release/application.properties
+++ b/api/profiles/release/application.properties
@@ -91,6 +91,8 @@ kube.master.ip=
 kube.kubeadm.token=
 kube.kubeadm.cert.hash=
 kube.node.token=
+kube.default.service.target.port=${CP_API_KUBE_SVC_DEFAULT_TARGET_PORT:1000}
+kube.deployment.api.url.prefix=${CP_API_KUBE_DEPLOYMENT_API_URL_PREFIX:apis/extensions/v1beta1}
 
 nat.gateway.auto.config.poll=${CP_API_NAT_POLL:60000}
 nat.gateway.cp.core.service.name=${CP_API_NAT_PROXY_SERVICE_NAME:cp-tinyproxy}

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -663,7 +663,10 @@ public final class MessageConstants {
         "nat.gateway.route.creation.dns.resolving.failed";
     public static final String NAT_ROUTE_CONFIG_CANT_FIND_PORT =
         "nat.gateway.route.creation.port.forwarding.missing.port.error";
+    public static final String NAT_ROUTE_CONFIG_KUBE_DNS_RESTART_FAILED =
+        "nat.gateway.route.creation.kube.dns.restart.error";
 
+    public static final String NAT_ROUTE_REMOVAL_NO_PORT_SPECIFIED = "nat.gateway.route.removal.port.not.found";
     public static final String NAT_ROUTE_REMOVAL_DNS_MASK_REMOVAL_FAILED = "nat.gateway.route.removal.dns.failed";
     public static final String NAT_ROUTE_REMOVAL_PORT_REMOVAL_FAILED = "nat.gateway.route.removal.service.port.failed";
     public static final String NAT_ROUTE_REMOVAL_KEEP_DNS_MASK = "nat.gateway.route.removal.keep.dns.entry";

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -649,6 +649,18 @@ public final class MessageConstants {
         "storage.quota.unknown.share.type.for.percentage";
 
     // NAT configuration
+    public static final String NAT_ROUTE_CONFIG_TRANSFER_ROUTES_TO_KUBE = "nat.gateway.routes.transfer.to.kube";
+    public static final String NAT_ROUTE_CONFIG_ROUTE_ON_SERVICE_PORT = "nat.gateway.route.creation.route.service.port";
+    public static final String NAT_ROUTE_CONFIG_ROUTE_TRANSFER_SUMMARY = "nat.gateway.route.transfer.summary";
+    public static final String NAT_ROUTE_CONFIG_ADD_ROUTE_TO_EXISTING_SERVICE_FAILED =
+        "nat.gateway.route.creation.existing.service.add.port.failed";
+    public static final String NAT_ROUTE_CONFIG_NEW_SERVICE_CREATION = "nat.gateway.route.creation.new.service";
+    public static final String NAT_ROUTE_CONFIG_PORT_GENERATION_FAILED =
+        "nat.gateway.route.creation.port.generation.failed";
+    public static final String NAT_ROUTE_CONFIG_NEW_SERVICE_CREATION_FAILED =
+        "nat.gateway.route.creation.new.service.failed";
+    public static final String NAT_ROUTE_CONFIG_ADD_ROUTE_TO_EXISTING_SERVICE =
+        "nat.gateway.route.creation.existing.service.add.port";
     public static final String NAT_ROUTE_CONFIG_DNS_CREATION_FAILED = "nat.gateway.route.creation.dns.config.error";
     public static final String NAT_ROUTE_CONFIG_ERROR_EMPTY_RULE = "nat.gateway.route.creation.empty.rule";
     public static final String NAT_ROUTE_CONFIG_DEPLOYMENT_REFRESH_FAILED =
@@ -674,6 +686,8 @@ public final class MessageConstants {
         "nat.gateway.route.removal.deploy.refresh.failed";
     public static final String NAT_ROUTE_REMOVAL_PORT_FORWARDING_REMOVAL_FAILED =
         "nat.gateway.route.removal.port.forwarding.failed";
+    public static final String NAT_ROUTE_REMOVAL_NO_ACTIVE_SERVICE_PORTS = "nat.gateway.route.removal.no.service.ports";
+    public static final String NAT_ROUTE_REMOVAL_SERVICE_PORT = "nat.gateway.route.removal.service.port";
 
     // Search
     public static final String ERROR_SEARCH_SCROLLING_PARAMETER_DOC_ID_MISSING =

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -211,6 +211,8 @@ public final class MessageConstants {
     public static final String ERROR_KUBE_SERVICE_CREATE = "error.kube.service.create";
     public static final String ERROR_KUBE_ENDPOINTS_CREATE = "error.kube.endpoints.create";
     public static final String ERROR_KUBE_POD_NOT_FOUND = "error.kube.pod.not.found";
+    public static final String ERROR_KUBE_DEPLOYMENT_REFRESH_FAILED = "error.kube.deployment.refresh.failed";
+    public static final String ERROR_KUBE_NAMESPACE_NOT_SPECIFIED = "error.kube.namespace.not.specified";
 
     // Data storage messages
     public static final String ERROR_DATASTORAGE_NOT_FOUND = "error.datastorage.not.found";

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesConstants.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesConstants.java
@@ -106,6 +106,8 @@ public final class KubernetesConstants {
     }
 
     public static final DateTimeFormatter KUBE_DATE_FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
+    public static final DateTimeFormatter KUBE_LABEL_DATE_FORMATTER =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd_HH.mm.ss.SSSSSS");
 
     private KubernetesConstants() {
         //no op

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesConstants.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesConstants.java
@@ -58,6 +58,8 @@ public final class KubernetesConstants {
 
     public static final String CP_LABEL_PREFIX = "cloud-pipeline/";
     public static final String TRUE_LABEL_VALUE = "true";
+    public static final String KUBERNETES_APP_LABEL = "k8s-app";
+    public static final String KUBE_DNS_APP = "kube-dns";
 
     protected static final String SYSTEM_NAMESPACE = "kube-system";
     protected static final String POD_NODE_SELECTOR = "spec.nodeName";

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesDeploymentAPI.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesDeploymentAPI.java
@@ -19,7 +19,6 @@ package com.epam.pipeline.manager.cluster;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import retrofit2.Call;
 import retrofit2.http.Body;
-import retrofit2.http.GET;
 import retrofit2.http.Headers;
 import retrofit2.http.PATCH;
 import retrofit2.http.Path;
@@ -35,7 +34,4 @@ public interface KubernetesDeploymentAPI {
     @Headers("Content-Type: application/strategic-merge-patch+json")
     Call<Deployment> updateDeployment(@Path(NAMESPACE) String namespace, @Path(NAME) String deploymentName,
                                       @Body Map<String, Object> patch);
-
-    @GET("namespaces/{namespace}/deployments/{name}")
-    Call<Deployment> getDeployment(@Path(NAMESPACE) String namespace, @Path(NAME) String deploymentName);
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesDeploymentAPI.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesDeploymentAPI.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster;
+
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.GET;
+import retrofit2.http.Headers;
+import retrofit2.http.PATCH;
+import retrofit2.http.Path;
+
+import java.util.Map;
+
+public interface KubernetesDeploymentAPI {
+
+    String NAMESPACE = "namespace";
+    String NAME = "name";
+
+    @PATCH("namespaces/{namespace}/deployments/{name}")
+    @Headers("Content-Type: application/strategic-merge-patch+json")
+    Call<Deployment> updateDeployment(@Path(NAMESPACE) String namespace, @Path(NAME) String deploymentName,
+                                      @Body Map<String, Object> patch);
+
+    @GET("namespaces/{namespace}/deployments/{name}")
+    Call<Deployment> getDeployment(@Path(NAMESPACE) String namespace, @Path(NAME) String deploymentName);
+}

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesDeploymentAPIClient.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesDeploymentAPIClient.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster;
+
+import com.epam.pipeline.manager.datastorage.providers.ProviderUtils;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.utils.HttpClientUtils;
+import okhttp3.OkHttpClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import retrofit2.Call;
+import retrofit2.Response;
+import retrofit2.Retrofit;
+import retrofit2.converter.jackson.JacksonConverterFactory;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.Map;
+
+@Service
+public class KubernetesDeploymentAPIClient {
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH.mm.ss.SSSSSS");
+    private final KubernetesDeploymentAPI kubernetesDeploymentAPI;
+
+    public KubernetesDeploymentAPIClient(final @Value("${kube.deployment.api.url.prefix:apis/extensions/v1beta1}")
+                                             String deploymentOpsUrPrefix) {
+        this.kubernetesDeploymentAPI = buildRetrofitClient(deploymentOpsUrPrefix);
+    }
+
+    public Deployment updateDeployment(final String namespace, final String name) {
+        return executeRequest(kubernetesDeploymentAPI.updateDeployment(namespace, name, getUpdateTriggeringPatch()));
+    }
+
+    public Deployment getDeployment(final String namespace, final String name) {
+        return executeRequest(kubernetesDeploymentAPI.getDeployment(namespace, name));
+    }
+
+
+    private Map<String, Object> getUpdateTriggeringPatch() {
+        return Collections.singletonMap(
+            "spec",
+            Collections.singletonMap(
+                "template",
+                Collections.singletonMap(
+                    "metadata",
+                    Collections.singletonMap(
+                        "labels",
+                        Collections.singletonMap(
+                            "cp-updated", LocalDateTime.now().format(DATE_FORMATTER))))));
+    }
+
+    private <T> T executeRequest(final Call<T> request) {
+        try {
+            Response<T> response = request.execute();
+            if (response.isSuccessful()) {
+                return response.body();
+            } else {
+                throw new IllegalStateException("Error in response from kube deployment API received: "
+                                                + extractErrorMessage(response));
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Request to kube deployment API failed: " + e.getMessage());
+        }
+    }
+
+    private static String extractErrorMessage(final Response<?> response) throws IOException {
+        return response.errorBody() == null ? "" : response.errorBody().string();
+    }
+
+    private KubernetesDeploymentAPI buildRetrofitClient(final String deploymentGroupUrlPrefix) {
+        final Config kubeConfig = new Config();
+        final OkHttpClient client = HttpClientUtils.createHttpClient(kubeConfig);
+        final ObjectMapper mapper = new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        final Retrofit retrofit = new Retrofit.Builder()
+            .baseUrl(buildBaseUrlForDeploymentOperations(kubeConfig, deploymentGroupUrlPrefix))
+            .addConverterFactory(JacksonConverterFactory.create(mapper))
+            .client(client)
+            .build();
+        return retrofit.create(KubernetesDeploymentAPI.class);
+    }
+
+    private String buildBaseUrlForDeploymentOperations(final Config kubeConfig, final String deploymentGroupUrlPrefix) {
+        return ProviderUtils.withTrailingDelimiter(kubeConfig.getMasterUrl())
+               + ProviderUtils.withTrailingDelimiter(ProviderUtils.withoutLeadingDelimiter(deploymentGroupUrlPrefix));
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesDeploymentAPIClient.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesDeploymentAPIClient.java
@@ -41,8 +41,8 @@ public class KubernetesDeploymentAPIClient {
     private final KubernetesDeploymentAPI kubernetesDeploymentAPI;
 
     public KubernetesDeploymentAPIClient(final @Value("${kube.deployment.api.url.prefix:apis/extensions/v1beta1}")
-                                             String deploymentOpsUrPrefix) {
-        this.kubernetesDeploymentAPI = buildRetrofitClient(deploymentOpsUrPrefix);
+                                             String deploymentOperationsUrlPrefix) {
+        this.kubernetesDeploymentAPI = buildRetrofitClient(deploymentOperationsUrlPrefix);
     }
 
     public Deployment updateDeployment(final String namespace, final String name) {

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesDeploymentAPIClient.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesDeploymentAPIClient.java
@@ -32,14 +32,12 @@ import retrofit2.converter.jackson.JacksonConverterFactory;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.Map;
 
 @Service
 public class KubernetesDeploymentAPIClient {
 
-    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH.mm.ss.SSSSSS");
     private final KubernetesDeploymentAPI kubernetesDeploymentAPI;
 
     public KubernetesDeploymentAPIClient(final @Value("${kube.deployment.api.url.prefix:apis/extensions/v1beta1}")
@@ -51,11 +49,6 @@ public class KubernetesDeploymentAPIClient {
         return executeRequest(kubernetesDeploymentAPI.updateDeployment(namespace, name, getUpdateTriggeringPatch()));
     }
 
-    public Deployment getDeployment(final String namespace, final String name) {
-        return executeRequest(kubernetesDeploymentAPI.getDeployment(namespace, name));
-    }
-
-
     private Map<String, Object> getUpdateTriggeringPatch() {
         return Collections.singletonMap(
             "spec",
@@ -66,7 +59,8 @@ public class KubernetesDeploymentAPIClient {
                     Collections.singletonMap(
                         "labels",
                         Collections.singletonMap(
-                            "cp-updated", LocalDateTime.now().format(DATE_FORMATTER))))));
+                            "cp-updated",
+                            LocalDateTime.now().format(KubernetesConstants.KUBE_LABEL_DATE_FORMATTER))))));
     }
 
     private <T> T executeRequest(final Call<T> request) {

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesManager.java
@@ -91,8 +91,10 @@ public class KubernetesManager {
     private static final String EMPTY = "";
     private static final int NODE_READY_TIMEOUT = 5000;
     private static final int DEFAULT_TARGET_PORT = 1000;
-    private static final int CONNECTION_TIMEOUT_MS = 2 * DEFAULT_TARGET_PORT;
+    private static final int CONNECTION_TIMEOUT_MS = 2 * 1000;
     private static final int ATTEMPTS_STATUS_NODE = 60;
+    private static final long DEPLOYMENT_REFRESH_TIMEOUT_SEC = 3;
+    private static final int DEPLOYMENT_REFRESH_RETRIES = 10;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KubernetesManager.class);
     private static final int NODE_PULL_TIMEOUT = 200;
@@ -315,13 +317,13 @@ public class KubernetesManager {
     }
 
     public boolean refreshDeployment(final String namespace, final String deploymentName,
-                                     final Map<String, String> labelSelector, final int retries,
-                                     final long retryTimeoutSeconds) {
+                                     final Map<String, String> labelSelector) {
         try {
             final String resolvedNamespace = defaultNamespaceIfEmpty(namespace);
             deploymentAPIClient.updateDeployment(resolvedNamespace, deploymentName);
             try (KubernetesClient client = getKubernetesClient()) {
-                return waitForPodsStartup(client, resolvedNamespace, labelSelector, retries, retryTimeoutSeconds);
+                return waitForPodsStartup(client, resolvedNamespace, labelSelector,
+                                          DEPLOYMENT_REFRESH_RETRIES, DEPLOYMENT_REFRESH_TIMEOUT_SEC);
             }
         } catch (RuntimeException e) {
             return false;

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/NatGatewayManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/NatGatewayManager.java
@@ -234,7 +234,7 @@ public class NatGatewayManager {
                 messageHelper.getMessage(MessageConstants.NAT_ROUTE_REMOVAL_PORT_REMOVAL_FAILED));
         }
         if (activePorts.containsKey(port)
-            && !kubernetesManager.refreshDeployment(null, tinyproxyServiceName, tinyproxyLabelSelector)) {
+            && !kubernetesManager.refreshDeployment(tinyproxyServiceName, tinyproxyLabelSelector)) {
             return setStatusFailed(
                 serviceName, port,
                 messageHelper.getMessage(MessageConstants.NAT_ROUTE_REMOVAL_DEPLOYMENT_REFRESH_FAILED));
@@ -272,13 +272,13 @@ public class NatGatewayManager {
             removePortForwardingRule(service, activePorts, port);
             removeDnsMaks(service, activePorts, port);
             removePortFromService(service, activePorts, port);
-            return kubernetesManager.refreshDeployment(null, tinyproxyServiceName, tinyproxyLabelSelector);
+            return kubernetesManager.refreshDeployment(tinyproxyServiceName, tinyproxyLabelSelector);
         }
         return true;
     }
 
     private boolean tryRefreshDeployment(final String serviceName, final Integer port) {
-        if (kubernetesManager.refreshDeployment(null, tinyproxyServiceName, tinyproxyLabelSelector)) {
+        if (kubernetesManager.refreshDeployment(tinyproxyServiceName, tinyproxyLabelSelector)) {
             updateStatusForRoutingRule(serviceName, port, NatRouteStatus.ACTIVE);
             return true;
         } else {

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/NatGatewayManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/NatGatewayManager.java
@@ -229,9 +229,13 @@ public class NatGatewayManager {
                 messageHelper.getMessage(MessageConstants.NAT_ROUTE_REMOVAL_PORT_REMOVAL_FAILED));
         }
         if (activePorts.containsKey(port)
-            && !kubernetesManager.refreshCloudPipelineServiceDeployment(tinyproxyServiceName,
-                                                                        DEPLOYMENT_REFRESH_RETRIES,
-                                                                        DEPLOYMENT_REFRESH_TIMEOUT_SEC)) {
+            && !kubernetesManager.refreshDeployment(
+            null,
+            tinyproxyServiceName,
+            Collections.singletonMap(KubernetesConstants.CP_LABEL_PREFIX + tinyproxyServiceName,
+                                     KubernetesConstants.TRUE_LABEL_VALUE),
+            DEPLOYMENT_REFRESH_RETRIES,
+            DEPLOYMENT_REFRESH_TIMEOUT_SEC)) {
             return setStatusFailed(
                 serviceName, port,
                 messageHelper.getMessage(MessageConstants.NAT_ROUTE_REMOVAL_DEPLOYMENT_REFRESH_FAILED));
@@ -268,17 +272,25 @@ public class NatGatewayManager {
             removePortForwardingRule(service, activePorts, port);
             removeDnsMaks(service, activePorts, port);
             removePortFromService(service, activePorts, port);
-            return kubernetesManager.refreshCloudPipelineServiceDeployment(tinyproxyServiceName,
-                                                                           DEPLOYMENT_REFRESH_RETRIES,
-                                                                           DEPLOYMENT_REFRESH_TIMEOUT_SEC);
+            return kubernetesManager.refreshDeployment(
+                null,
+                tinyproxyServiceName,
+                Collections.singletonMap(KubernetesConstants.CP_LABEL_PREFIX + tinyproxyServiceName,
+                                         KubernetesConstants.TRUE_LABEL_VALUE),
+                DEPLOYMENT_REFRESH_RETRIES,
+                DEPLOYMENT_REFRESH_TIMEOUT_SEC);
         }
         return true;
     }
 
     private boolean tryRefreshDeployment(final String serviceName, final Integer port) {
-        if (kubernetesManager.refreshCloudPipelineServiceDeployment(tinyproxyServiceName,
-                                                                    DEPLOYMENT_REFRESH_RETRIES,
-                                                                    DEPLOYMENT_REFRESH_TIMEOUT_SEC)) {
+        if (kubernetesManager.refreshDeployment(
+            null,
+            tinyproxyServiceName,
+            Collections.singletonMap(KubernetesConstants.CP_LABEL_PREFIX + tinyproxyServiceName,
+                                     KubernetesConstants.TRUE_LABEL_VALUE),
+            DEPLOYMENT_REFRESH_RETRIES,
+            DEPLOYMENT_REFRESH_TIMEOUT_SEC)) {
             updateStatusForRoutingRule(serviceName, port, NatRouteStatus.ACTIVE);
             return true;
         } else {
@@ -615,7 +627,11 @@ public class NatGatewayManager {
     }
 
     private boolean checkNewDnsRecord(final String externalName, final String clusterIP) {
-        if (!kubernetesManager.refreshKubeDns(DEPLOYMENT_REFRESH_RETRIES, DEPLOYMENT_REFRESH_TIMEOUT_SEC)) {
+        if (!kubernetesManager.refreshDeployment(KubernetesConstants.SYSTEM_NAMESPACE, KubernetesConstants.KUBE_DNS_APP,
+                                                 Collections.singletonMap(KubernetesConstants.KUBERNETES_APP_LABEL,
+                                                                          KubernetesConstants.KUBE_DNS_APP),
+                                                 DEPLOYMENT_REFRESH_RETRIES,
+                                                 DEPLOYMENT_REFRESH_TIMEOUT_SEC)) {
             log.warn(messageHelper.getMessage(MessageConstants.NAT_ROUTE_CONFIG_KUBE_DNS_RESTART_FAILED));
             return false;
         }

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/NatGatewayManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/NatGatewayManager.java
@@ -541,7 +541,8 @@ public class NatGatewayManager {
     private boolean removePortForwardingRule(final Service service, final Map<Integer, ServicePort> activePorts,
                                              final Integer port) {
         if (!activePorts.containsKey(port)) {
-            log.warn("No active port {} is  defined for {}", port, getServiceName(service));
+            log.warn(messageHelper.getMessage(MessageConstants.NAT_ROUTE_REMOVAL_NO_PORT_SPECIFIED,
+                                              port, getServiceName(service)));
             return true;
         }
         final Optional<ConfigMap> globalConfigMap = kubernetesManager.findConfigMap(globalConfigMapName, null);
@@ -614,6 +615,10 @@ public class NatGatewayManager {
     }
 
     private boolean checkNewDnsRecord(final String externalName, final String clusterIP) {
+        if (!kubernetesManager.refreshKubeDns(DEPLOYMENT_REFRESH_RETRIES, DEPLOYMENT_REFRESH_TIMEOUT_SEC)) {
+            log.warn(messageHelper.getMessage(MessageConstants.NAT_ROUTE_CONFIG_KUBE_DNS_RESTART_FAILED));
+            return false;
+        }
         final Set<String> resolvedAddresses = tryResolveAddress(externalName);
         return resolvedAddresses.size() == 1 && resolvedAddresses.contains(clusterIP);
     }

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -607,6 +607,14 @@ nat.gateway.route.creation.dns.resolving.failed=Unable to resolve ''{0}'' as it 
 nat.gateway.route.creation.port.forwarding.missing.port.error=Unable to find port, defined for {0} in {1}.
 nat.gateway.route.creation.kube.dns.restart.error=''kube-dns'' pods were not able to start after the refresh.
 nat.gateway.route.creation.empty.rule=Empty rules are passed!
+nat.gateway.routes.transfer.to.kube=Transferring queued routes from DB to Kubernetes: {0} routes found
+nat.gateway.route.creation.route.service.port=Try to configure route on port {0} for ''{1}''
+nat.gateway.route.transfer.summary=Transferring route: [{0}]
+nat.gateway.route.creation.new.service=Creating new service for the route id={0}
+nat.gateway.route.creation.port.generation.failed=Unable to generate new target port, skip service creation for route id={0}
+nat.gateway.route.creation.new.service.failed=New service creation for the route id={0} failed: {1}
+nat.gateway.route.creation.existing.service.add.port=Adding route id={0} to the existing service ''{1}''
+nat.gateway.route.creation.existing.service.add.port.failed=Adding route id={0} to existing service ''{1}'' failed
 
 nat.gateway.route.removal.port.not.found=No active port {0} is defined for ''{1}''
 nat.gateway.route.removal.deploy.refresh.failed=Errors during deployment refresh.
@@ -614,6 +622,8 @@ nat.gateway.route.removal.service.port.failed=Unable to remove port from service
 nat.gateway.route.removal.dns.failed=Unable to remove DNS mask.
 nat.gateway.route.removal.keep.dns.entry=DNS mask should be removed only when the last existing port is being released.
 nat.gateway.route.removal.port.forwarding.failed=Unable to remove routing rule.
+nat.gateway.route.removal.no.service.ports=No active ports found assigned to the service ''{0}'', removing it
+nat.gateway.route.removal.service.port=Try to remove route on port {0} from ''{1}''
 
 # Search
 error.search.scrolling.parameter.doc.id.missing=Scrolling document id parameter is missing.

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -207,6 +207,8 @@ log.truncated=< ... Some of the preceding lines were skipped due to log size lim
 error.kube.service.create=Failed to create kubernetes service ''{0}''
 error.kube.endpoints.create=Failed to create kubernetes endpoints ''{0}''
 error.kube.pod.not.found=Pod with requested id ''{0}'' not found 
+error.kube.deployment.refresh.failed=Deployment refreshing failed: {0}
+error.kube.namespace.not.specified=Kube namespace should be specified!
 
 # Data sources messages
 error.datastorage.not.found=Error: data storage with id: ''{0}'' was not found.

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -605,8 +605,10 @@ nat.gateway.route.creation.port.assigning.error=Unable to assign port to the exi
 nat.gateway.route.creation.empty.config.map.port.forwarding=Unable to find configmap ''{0}'' - can''t remove port forwarding rule for {1}:{2}.
 nat.gateway.route.creation.dns.resolving.failed=Unable to resolve ''{0}'' as it was expected.
 nat.gateway.route.creation.port.forwarding.missing.port.error=Unable to find port, defined for {0} in {1}.
+nat.gateway.route.creation.kube.dns.restart.error=''kube-dns'' pods were not able to start after the refresh.
 nat.gateway.route.creation.empty.rule=Empty rules are passed!
 
+nat.gateway.route.removal.port.not.found=No active port {0} is defined for ''{1}''
 nat.gateway.route.removal.deploy.refresh.failed=Errors during deployment refresh.
 nat.gateway.route.removal.service.port.failed=Unable to remove port from service.
 nat.gateway.route.removal.dns.failed=Unable to remove DNS mask.

--- a/deploy/docker/cp-api-srv/config/application.properties
+++ b/deploy/docker/cp-api-srv/config/application.properties
@@ -105,6 +105,8 @@ kube.node.token=${CP_KUBE_NODE_TOKEN:}
 kube.master.pod.check.url=${CP_KUBE_MASTER_CHECK_URL:http://localhost:4040}
 ha.deploy.enabled=${CP_HA_DEPLOY_ENABLED:false}
 kube.current.pod.name=${CP_API_CURRENT_POD_NAME:localhost}
+kube.default.service.target.port=${CP_API_KUBE_SVC_DEFAULT_TARGET_PORT:1000}
+kube.deployment.api.url.prefix=${CP_API_KUBE_DEPLOYMENT_API_URL_PREFIX:apis/extensions/v1beta1}
 
 nat.gateway.auto.config.poll=${CP_API_NAT_POLL:60000}
 nat.gateway.cp.core.service.name=${CP_API_NAT_PROXY_SERVICE_NAME:cp-tinyproxy}


### PR DESCRIPTION
This PR is related to issue #2232

It brings the following improvements:
1. Add resolving in the non-exceptional way to complete route configuration flow correctly
2. Force `kube-dns` refresh before checking, that new entry added to DNS configuration map is resolved as expected