### PR TITLE
Issue #2249: Pre-commit hooks

### DIFF
--- a/.hooks/commit-msg
+++ b/.hooks/commit-msg
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# This hook script checks the message commit format.
+# If the message does not include an issue number in the 'Issue # / issue #' format, the script rejects the commit.
+# It is also possible to use the 'Issue #undefined#' format, but this should be avoided.
+#
+
+MESSAGE="$1"
+
+matched=$(grep -E "^.*(((I|i)ssue( |_)#)[1-9]+).*" "$MESSAGE")
+if [ -z "$matched" ] ; then
+    matched_undefined=$(grep -E "#(N|n)o( |_)(I|i)ssue#" "$MESSAGE")
+    if [ -n "$matched_undefined" ] ; then
+      echo "[warning] You are committing without a issue number" >&1
+    else
+      echo "[error] Your message is not formatted correctly. The commit message must contain 'Issue #' or 'issue #'" >&2
+      exit 1
+    fi
+fi

--- a/.hooks/prepare-commit-msg
+++ b/.hooks/prepare-commit-msg
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+# This hook script prepares a commit message in respecting format conventions.
+# An issue number will be placed as a prefix of the commit message using the branch name if the issue includes in it.
+# Otherwise, the 'Issue #undefined#' will be inserted.
+
+
+COMMIT_MSG_FILE=$1
+COMMIT_SOURCE=$2
+SHA1=$3
+
+if [[ -z "$COMMIT_SOURCE" ]]
+then
+  ref=$(git rev-parse --abbrev-ref HEAD)
+  if [[ $ref =~ ^.*((issue|issue_|issue#)[0-9]+).* ]]
+  then
+    default=$(cat "$COMMIT_MSG_FILE")
+    issue="${BASH_REMATCH[1]/_/ #}"
+  else
+    issue="Issue #undefined#"
+  fi
+  echo "${issue}: " > "$COMMIT_MSG_FILE"
+  echo "$default" >> "$COMMIT_MSG_FILE"
+fi


### PR DESCRIPTION
The PR provides git hooks for checking the commit message and preparing a commit message template in respecting format conventions.
The commit message should include an issue number in the `Issue # / issue #` format or `#no issue#` format, otherwise, the script rejects the commit. The `Issue #undefined#` format was introduced for exceptional cases and should be avoided.
To apply hooks in the project:
`git config core.hooksPath $PROJECT_DIR/.hooks`