### PR TITLE
Issue #2155 Separately process a single watcher unscheduling

### DIFF
--- a/workflows/pipe-common/scripts/watch_mount_shares.py
+++ b/workflows/pipe-common/scripts/watch_mount_shares.py
@@ -369,7 +369,8 @@ class NFSMountWatcher:
 
     def try_to_remove_path_from_observer(self, mnt_dest):
         try:
-            self._event_observer.unschedule(ObservedWatch(mnt_dest, True))
+            if len(self._target_path_mapping.items()) > 1:
+                self._event_observer.unschedule(ObservedWatch(mnt_dest, True))
             return True
         except OSError as e:
             logging.error(
@@ -681,7 +682,8 @@ class NFSMountWatcher:
 
     def release_resources(self):
         self._event_observer.stop()
-        self._event_observer.unschedule_all()
+        if len(self._target_path_mapping.items()) > 1:
+            self._event_observer.unschedule_all()
         self._event_handler.dump_to_storage()
 
     def start(self):


### PR DESCRIPTION
This PR is related to the NFS observer.
Currently, unscheduling procedure hangs in the case of the single watcher.
As a workaround it is proposed to skip such a case, it should not lead to any memory leakage, because under-the-hood watchdog stores all event handlers assigned to the certain path in a set, so reassigning the same handler to an existing path shouldn't change the collection's size.