### PR TITLE
Issue #2232 Deployment refresh configuration

### DIFF
--- a/api/profiles/dev/application.properties
+++ b/api/profiles/dev/application.properties
@@ -139,6 +139,8 @@ kube.master.pod.check.url=http://localhost:4040
 kube.current.pod.name=${CP_API_CURRENT_POD_NAME:localhost}
 kube.default.service.target.port=${CP_API_KUBE_SVC_DEFAULT_TARGET_PORT:1000}
 kube.deployment.api.url.prefix=${CP_API_KUBE_DEPLOYMENT_API_URL_PREFIX:apis/extensions/v1beta1}
+kube.deployment.refresh.timeout=${CP_API_KUBE_DEPLOYMENT_REFRESH_TIMEOUT_SEC:3}
+kube.deployment.refresh.retries=${CP_API_KUBE_DEPLOYMENT_REFRESH_RETRIES:15}
 ha.deploy.enabled=false
 
 nat.gateway.auto.config.poll=${CP_API_NAT_POLL:60000}

--- a/api/profiles/release/application.properties
+++ b/api/profiles/release/application.properties
@@ -93,6 +93,8 @@ kube.kubeadm.cert.hash=
 kube.node.token=
 kube.default.service.target.port=${CP_API_KUBE_SVC_DEFAULT_TARGET_PORT:1000}
 kube.deployment.api.url.prefix=${CP_API_KUBE_DEPLOYMENT_API_URL_PREFIX:apis/extensions/v1beta1}
+kube.deployment.refresh.timeout=${CP_API_KUBE_DEPLOYMENT_REFRESH_TIMEOUT_SEC:3}
+kube.deployment.refresh.retries=${CP_API_KUBE_DEPLOYMENT_REFRESH_RETRIES:15}
 
 nat.gateway.auto.config.poll=${CP_API_NAT_POLL:60000}
 nat.gateway.cp.core.service.name=${CP_API_NAT_PROXY_SERVICE_NAME:cp-tinyproxy}

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesConstants.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesConstants.java
@@ -60,6 +60,7 @@ public final class KubernetesConstants {
     public static final String TRUE_LABEL_VALUE = "true";
     public static final String KUBERNETES_APP_LABEL = "k8s-app";
     public static final String KUBE_DNS_APP = "kube-dns";
+    public static final String HYPHEN = "-";
 
     protected static final String SYSTEM_NAMESPACE = "kube-system";
     protected static final String POD_NODE_SELECTOR = "spec.nodeName";

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesManager.java
@@ -421,7 +421,7 @@ public class KubernetesManager {
     public Optional<ServicePort> addPortToExistingService(final String serviceName,
                                                           final Integer externalPort, final Integer internalPort) {
         try (KubernetesClient client = getKubernetesClient()) {
-            final ServicePort newPortSpec = getTcpPortSpec(serviceName + "-" + externalPort.toString(),
+            final ServicePort newPortSpec = getTcpPortSpec(getServicePortName(serviceName, externalPort),
                                                            externalPort, internalPort);
             client.services()
                 .inNamespace(kubeNamespace)
@@ -435,6 +435,10 @@ public class KubernetesManager {
         } catch (RuntimeException e) {
             return Optional.empty();
         }
+    }
+
+    public String getServicePortName(final String serviceName, final Integer externalPort) {
+        return serviceName + KubernetesConstants.HYPHEN + externalPort.toString();
     }
 
     public boolean removePortFromExistingService(final String serviceName, final String portName) {

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesManager.java
@@ -93,8 +93,6 @@ public class KubernetesManager {
     private static final int MILLIS_TO_SECONDS = 1000;
     private static final int CONNECTION_TIMEOUT_MS = 2 * MILLIS_TO_SECONDS;
     private static final int ATTEMPTS_STATUS_NODE = 60;
-    private static final long DEPLOYMENT_REFRESH_TIMEOUT_SEC = 3;
-    private static final int DEPLOYMENT_REFRESH_RETRIES = 10;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KubernetesManager.class);
     private static final int NODE_PULL_TIMEOUT = 200;
@@ -123,6 +121,12 @@ public class KubernetesManager {
 
     @Value("${kube.default.service.target.port:1000}")
     private Integer defaultKubeServiceTargetPort;
+
+    @Value("${kube.deployment.refresh.timeout.sec:3}")
+    private Integer deploymentRefreshTimeoutSec;
+
+    @Value("${kube.deployment.refresh.retries:15}")
+    private Integer deploymentRefreshRetries;
 
     public List<Service> getServicesByLabel(final String label) {
         return getServicesByLabel(SERVICE_ROLE_LABEL, label);
@@ -330,17 +334,18 @@ public class KubernetesManager {
             deploymentAPIClient.updateDeployment(namespace, deploymentName);
             try (KubernetesClient client = getKubernetesClient()) {
                 return waitForPodsStartup(client, namespace, labelSelector,
-                                          DEPLOYMENT_REFRESH_RETRIES, DEPLOYMENT_REFRESH_TIMEOUT_SEC);
+                                          deploymentRefreshRetries, deploymentRefreshTimeoutSec);
             }
         } catch (RuntimeException e) {
-            log.warn(messageHelper.getMessage(MessageConstants.ERROR_KUBE_DEPLOYMENT_REFRESH_FAILED, e.getMessage()));
+            log.warn(messageHelper.getMessage(MessageConstants.ERROR_KUBE_DEPLOYMENT_REFRESH_FAILED,
+                                              namespace, deploymentName, e.getMessage()));
             return false;
         }
     }
 
     private boolean waitForPodsStartup(final KubernetesClient client, final String namespace,
                                        final Map<String, String> labelSelector, final int retries,
-                                       final long retryTimeoutSeconds) {
+                                       final int retryTimeoutSeconds) {
         long attempts = retries;
         while (!podsAreReady(client, namespace, labelSelector)) {
             LOGGER.debug("Waiting for pods in [{},{}] to be ready.", namespace, labelSelector);

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/NatGatewayManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/NatGatewayManager.java
@@ -400,7 +400,7 @@ public class NatGatewayManager {
                                           route.getRouteId(), correspondingServiceName));
         final NatRouteStatus statusInQueue = route.getStatus();
         final Integer externalPort = route.getExternalPort();
-        if (NatRouteStatus.ACTIVE.equals(route.getStatus())) {
+        if (NatRouteStatus.CREATION_SCHEDULED.equals(route.getStatus())) {
             final Map<Integer, ServicePort> activePorts = getServiceActivePorts(service);
             if (!activePorts.containsKey(externalPort)) {
                 final boolean portCreationResult = kubernetesManager.generateFreeTargetPort()

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/NatGatewayManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/NatGatewayManager.java
@@ -16,6 +16,8 @@
 
 package com.epam.pipeline.manager.cluster;
 
+import static com.epam.pipeline.manager.cluster.KubernetesConstants.HYPHEN;
+
 import com.epam.pipeline.common.MessageConstants;
 import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.config.Constants;
@@ -72,7 +74,6 @@ public class NatGatewayManager {
     private static final String UNKNOWN = "UNKNOWN";
     private static final String NEW_LINE = "\n";
     private static final String PORT_FORWARDING_RULE_ATTRIBUTE_DESCRIPTOR = ":";
-    private static final String HYPHEN = "-";
 
     private final NatGatewayDao natGatewayDao;
     private final KubernetesManager kubernetesManager;
@@ -431,8 +432,7 @@ public class NatGatewayManager {
     private ServicePort buildNewServicePort(final String correspondingServiceName, final Integer externalPort,
                                             final IntOrString freeTargetPort) {
         final ServicePort newServicePort = new ServicePort();
-        newServicePort.setName(
-            String.join(HYPHEN, tinyproxyServiceName, correspondingServiceName, externalPort.toString()));
+        newServicePort.setName(kubernetesManager.getServicePortName(correspondingServiceName, externalPort));
         newServicePort.setTargetPort(freeTargetPort);
         newServicePort.setPort(externalPort);
         return newServicePort;

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -207,7 +207,7 @@ log.truncated=< ... Some of the preceding lines were skipped due to log size lim
 error.kube.service.create=Failed to create kubernetes service ''{0}''
 error.kube.endpoints.create=Failed to create kubernetes endpoints ''{0}''
 error.kube.pod.not.found=Pod with requested id ''{0}'' not found 
-error.kube.deployment.refresh.failed=Deployment refreshing failed: {0}
+error.kube.deployment.refresh.failed=Deployment [{0}/{1}] refreshing failed: {2}
 error.kube.namespace.not.specified=Kube namespace should be specified!
 
 # Data sources messages

--- a/deploy/docker/cp-api-srv/config/application.properties
+++ b/deploy/docker/cp-api-srv/config/application.properties
@@ -107,6 +107,8 @@ ha.deploy.enabled=${CP_HA_DEPLOY_ENABLED:false}
 kube.current.pod.name=${CP_API_CURRENT_POD_NAME:localhost}
 kube.default.service.target.port=${CP_API_KUBE_SVC_DEFAULT_TARGET_PORT:1000}
 kube.deployment.api.url.prefix=${CP_API_KUBE_DEPLOYMENT_API_URL_PREFIX:apis/extensions/v1beta1}
+kube.deployment.refresh.timeout=${CP_API_KUBE_DEPLOYMENT_REFRESH_TIMEOUT_SEC:3}
+kube.deployment.refresh.retries=${CP_API_KUBE_DEPLOYMENT_REFRESH_RETRIES:15}
 
 nat.gateway.auto.config.poll=${CP_API_NAT_POLL:60000}
 nat.gateway.cp.core.service.name=${CP_API_NAT_PROXY_SERVICE_NAME:cp-tinyproxy}


### PR DESCRIPTION
This PR is related to issue #2232

The main improvement in this PR - the ability to configure waiting time after deployment refresh. It is necessary since it might take a different amount of time for different k8s deployments to process the rolling update.
Other improvements are:
- immediate assigning of a port to service during route transfer
- DNS refresh triggering after route removal