### PR TITLE
Issue #2182 Resolve users from groups during recipients list building

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/notification/NotificationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/notification/NotificationManager.java
@@ -28,6 +28,7 @@ import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -39,6 +40,7 @@ import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.epam.pipeline.entity.cluster.monitoring.ELKUsageMetric;
 import com.epam.pipeline.entity.notification.NotificationTimestamp;
@@ -499,12 +501,20 @@ public class NotificationManager implements NotificationService { // TODO: rewri
         monitoringNotificationDao.createMonitoringNotification(notificationMessage);
     }
 
-    private List<Long> mapRecipientsToUserIds(List<NFSQuotaNotificationRecipient> recipients) {
-        return recipients.stream()
+    private List<Long> mapRecipientsToUserIds(final List<NFSQuotaNotificationRecipient> recipients) {
+        final Stream<PipelineUser> plainUsersStream = recipients.stream()
+            .filter(NFSQuotaNotificationRecipient::isPrincipal)
             .map(NFSQuotaNotificationRecipient::getName)
-            .map(userManager::loadUserByName)
+            .map(userManager::loadUserByName);
+        final Stream<PipelineUser> usersFromGroupsStream = recipients.stream()
+            .filter(recipient -> !recipient.isPrincipal())
+            .map(NFSQuotaNotificationRecipient::getName)
+            .map(userManager::loadUsersByGroup)
+            .flatMap(Collection::stream);
+        return Stream.concat(plainUsersStream, usersFromGroupsStream)
             .filter(Objects::nonNull)
             .map(PipelineUser::getId)
+            .distinct()
             .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
This PR is related to issue #2182 

It fixes recipients resolving: in case a user group is specified all of its users are added to the notification recipients list.