### PR TITLE
Issue #2342 System parameters restrictions

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/utils/DefaultSystemParameter.java
+++ b/api/src/main/java/com/epam/pipeline/entity/utils/DefaultSystemParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ import com.epam.pipeline.entity.configuration.PipeConfValueVO;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.Set;
+
 @Getter
 @Setter
 public class DefaultSystemParameter {
@@ -29,6 +31,7 @@ public class DefaultSystemParameter {
     private String description;
     private String defaultValue;
     private boolean passToWorkers;
+    private Set<String> roles;
 
     public DefaultSystemParameter() {
         this.type = PipeConfValueVO.DEFAULT_TYPE;

--- a/pipe-cli/src/api/pipeline.py
+++ b/pipe-cli/src/api/pipeline.py
@@ -19,6 +19,7 @@ from ..model.pipeline_model import PipelineModel
 from ..model.version_model import VersionModel
 from ..model.pipeline_run_parameters_model import PipelineRunParametersModel
 from ..model.pipeline_run_model import PipelineRunModel, PriceType
+from ..model.pipeline_run_parameter_model import PipelineRunParameterModel
 from ..model.datastorage_rule_model import DataStorageRuleModel
 from ..model.instance_price import InstancePrice
 from ..api.pipeline_run import PipelineRun
@@ -258,6 +259,16 @@ class Pipeline(API):
             api_url += '&config={}'.format(config_name)
         response_data = api.call(api_url, json.dumps(data))
         return InstancePrice.load(response_data['payload'])
+
+    @classmethod
+    def get_default_run_parameters(cls):
+        api = cls.instance()
+        response_data = api.call('/run/defaultParameters', None)
+        result = []
+        if 'payload' in response_data:
+            for parameter_json in response_data['payload']:
+                result.append(PipelineRunParameterModel.load_from_default_system_parameter(parameter_json))
+        return result
 
     @classmethod
     def __add_parent_node_params(cls, params, parent_node):

--- a/pipe-cli/src/api/pipeline.py
+++ b/pipe-cli/src/api/pipeline.py
@@ -265,9 +265,8 @@ class Pipeline(API):
         api = cls.instance()
         response_data = api.call('/run/defaultParameters', None)
         result = []
-        if 'payload' in response_data:
-            for parameter_json in response_data['payload']:
-                result.append(PipelineRunParameterModel.load_from_default_system_parameter(parameter_json))
+        for parameter_json in response_data.get('payload', []):
+            result.append(PipelineRunParameterModel.load_from_default_system_parameter(parameter_json))
         return result
 
     @classmethod

--- a/pipe-cli/src/model/pipeline_run_parameter_model.py
+++ b/pipe-cli/src/model/pipeline_run_parameter_model.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,10 +13,31 @@
 # limitations under the License.
 
 class PipelineRunParameterModel(object):
-    def __init__(self, name, value, parameter_type, required):
+    def __init__(self, name, value, parameter_type, required, roles=set()):
         self.name = name
         self.value = value
         self.parameter_type = parameter_type
         if parameter_type is None:
             self.parameter_type = 'string'
         self.required = required
+        if roles is None:
+            self.roles = set()
+        else:
+            self.roles = set(roles)
+
+    @staticmethod
+    def load_from_default_system_parameter(json):
+        name = None
+        value = None
+        parameter_type = None
+        required = 'false'
+        parameter_roles = []
+        if 'name' in json:
+            name = json['name']
+        if 'defaultValue' in json:
+            value = json['defaultValue']
+        if 'type' in json:
+            parameter_type = json['type']
+        if 'roles' in json:
+            parameter_roles = json['roles']
+        return PipelineRunParameterModel(name, value, parameter_type, required, roles=parameter_roles)

--- a/pipe-cli/src/model/pipeline_run_parameter_model.py
+++ b/pipe-cli/src/model/pipeline_run_parameter_model.py
@@ -24,16 +24,8 @@ class PipelineRunParameterModel(object):
 
     @staticmethod
     def load_from_default_system_parameter(parameter_json):
-        parameter_name = None
-        parameter_value = None
-        parameter_type = None
-        parameter_roles = []
-        if 'name' in parameter_json:
-            parameter_name = parameter_json['name']
-        if 'defaultValue' in parameter_json:
-            parameter_value = parameter_json['defaultValue']
-        if 'type' in parameter_json:
-            parameter_type = parameter_json['type']
-        if 'roles' in parameter_json:
-            parameter_roles = parameter_json['roles']
+        parameter_name = parameter_json.get('name')
+        parameter_value = parameter_json.get('defaultValue')
+        parameter_type = parameter_json.get('type')
+        parameter_roles = parameter_json.get('roles', [])
         return PipelineRunParameterModel(parameter_name, parameter_value, parameter_type, None, roles=parameter_roles)

--- a/pipe-cli/src/model/pipeline_run_parameter_model.py
+++ b/pipe-cli/src/model/pipeline_run_parameter_model.py
@@ -20,24 +20,20 @@ class PipelineRunParameterModel(object):
         if parameter_type is None:
             self.parameter_type = 'string'
         self.required = required
-        if roles is None:
-            self.roles = set()
-        else:
-            self.roles = set(roles)
+        self.roles = set() if roles is None else set(roles)
 
     @staticmethod
-    def load_from_default_system_parameter(json):
-        name = None
-        value = None
+    def load_from_default_system_parameter(parameter_json):
+        parameter_name = None
+        parameter_value = None
         parameter_type = None
-        required = 'false'
         parameter_roles = []
-        if 'name' in json:
-            name = json['name']
-        if 'defaultValue' in json:
-            value = json['defaultValue']
-        if 'type' in json:
-            parameter_type = json['type']
-        if 'roles' in json:
-            parameter_roles = json['roles']
-        return PipelineRunParameterModel(name, value, parameter_type, required, roles=parameter_roles)
+        if 'name' in parameter_json:
+            parameter_name = parameter_json['name']
+        if 'defaultValue' in parameter_json:
+            parameter_value = parameter_json['defaultValue']
+        if 'type' in parameter_json:
+            parameter_type = parameter_json['type']
+        if 'roles' in parameter_json:
+            parameter_roles = parameter_json['roles']
+        return PipelineRunParameterModel(parameter_name, parameter_value, parameter_type, None, roles=parameter_roles)

--- a/pipe-cli/src/utilities/pipeline_run_operations.py
+++ b/pipe-cli/src/utilities/pipeline_run_operations.py
@@ -30,6 +30,7 @@ from src.utilities.user_token_operations import UserTokenOperations
 
 from src.api.pipeline import Pipeline
 
+ROLE_ADMIN = 'ROLE_ADMIN'
 DELAY = 30
 
 
@@ -53,13 +54,14 @@ class PipelineRunOperations(object):
             status_notifications_subject=None, status_notifications_body=None,
             run_as_user=None):
 
-        if run_as_user:
-            user = User.whoami()
-            user_groups = user.get('groups', [])
-            user_roles = [role.get('name') for role in user.get('roles', [])]
-            # Preserving old style impersonation for admin users. Specified user token is generated and used
-            # for impersonation rather than run as capability which is used for non-admin users.
-            if 'ROLE_ADMIN' in (user_groups + user_roles):
+        user = User.whoami()
+        user_groups = user.get('groups', [])
+        user_roles = [role.get('name') for role in user.get('roles', [])]
+        all_user_roles = set((user_groups + user_roles))
+
+        # Preserving old style impersonation for admin users. Specified user token is generated and used
+        # for impersonation rather than run as capability which is used for non-admin users.
+        if run_as_user and ROLE_ADMIN in all_user_roles:
                 UserTokenOperations().set_user_token(run_as_user)
                 run_as_user = None
 
@@ -69,6 +71,7 @@ class PipelineRunOperations(object):
         # This approach is used because we do not know parameters list beforehand
 
         run_params_dict = dict([(k.strip('-'), v) for k, v in zip(run_params[::2], run_params[1::2])])
+        cls._validate_run_params(run_params_dict, all_user_roles)
 
         if instance_count == 0:
             instance_count = None
@@ -430,3 +433,19 @@ class PipelineRunOperations(object):
             except RuntimeError:
                 pass
         return pipeline_name
+
+    @classmethod
+    def _validate_run_params(cls, run_params_dict, all_user_roles):
+        if ROLE_ADMIN in all_user_roles:
+            return
+        default_system_parameters_dict = {param.name: param for param in Pipeline.get_default_run_parameters()}
+        for name, value in run_params_dict.iteritems():
+            if name in default_system_parameters_dict:
+                default_system_parameter = default_system_parameters_dict[name]
+                if default_system_parameter.value != value:
+                    allowed_roles = default_system_parameter.roles
+                    if allowed_roles:
+                        if len(allowed_roles.intersection(all_user_roles)) == 0:
+                            click.echo('An error has occurred while starting a job: "{}" parameter'
+                                       ' is not permitted for overriding'.format(name), err=True)
+                            sys.exit(1)

--- a/pipe-cli/src/utilities/pipeline_run_operations.py
+++ b/pipe-cli/src/utilities/pipeline_run_operations.py
@@ -21,11 +21,11 @@ from prettytable import prettytable
 
 from src.api.pipeline_run import PipelineRun
 from src.api.tool import Tool
-from src.api.user import User
 from src.model.pipeline_run_model import PriceType
 from src.model.pipeline_run_parameter_model import PipelineRunParameterModel
 from src.utilities.api_wait import wait_for_server_enabling_if_needed
 from src.utilities.cluster_manager import ClusterManager
+from src.utilities.user_operations_manager import UserOperationsManager
 from src.utilities.user_token_operations import UserTokenOperations
 
 from src.api.pipeline import Pipeline
@@ -54,11 +54,7 @@ class PipelineRunOperations(object):
             status_notifications_subject=None, status_notifications_body=None,
             run_as_user=None):
 
-        user = User.whoami()
-        user_groups = user.get('groups', [])
-        user_roles = [role.get('name') for role in user.get('roles', [])]
-        all_user_roles = set((user_groups + user_roles))
-
+        all_user_roles = UserOperationsManager().get_all_user_roles()
         # Preserving old style impersonation for admin users. Specified user token is generated and used
         # for impersonation rather than run as capability which is used for non-admin users.
         if run_as_user and ROLE_ADMIN in all_user_roles:

--- a/pipe-cli/src/utilities/pipeline_run_operations.py
+++ b/pipe-cli/src/utilities/pipeline_run_operations.py
@@ -435,13 +435,12 @@ class PipelineRunOperations(object):
         if ROLE_ADMIN in all_user_roles:
             return
         default_system_parameters_dict = {param.name: param for param in Pipeline.get_default_run_parameters()}
-        for name, value in run_params_dict.iteritems():
-            if name in default_system_parameters_dict:
-                default_system_parameter = default_system_parameters_dict[name]
-                if default_system_parameter.value != value:
+        for run_param_name, run_param_value in run_params_dict.iteritems():
+            if run_param_name in default_system_parameters_dict:
+                default_system_parameter = default_system_parameters_dict[run_param_name]
+                if default_system_parameter.value != run_param_value:
                     allowed_roles = default_system_parameter.roles
-                    if allowed_roles:
-                        if len(allowed_roles.intersection(all_user_roles)) == 0:
-                            click.echo('An error has occurred while starting a job: "{}" parameter'
-                                       ' is not permitted for overriding'.format(name), err=True)
-                            sys.exit(1)
+                    if allowed_roles and len(allowed_roles.intersection(all_user_roles)) == 0:
+                        click.echo('An error has occurred while starting a job: "{}" parameter'
+                                   ' is not permitted for overriding'.format(run_param_name), err=True)
+                        sys.exit(1)

--- a/pipe-cli/src/utilities/user_operations_manager.py
+++ b/pipe-cli/src/utilities/user_operations_manager.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -38,9 +38,12 @@ class UserOperationsManager:
             click.echo("[%s] %s" % (event.get('status', ''), event.get('message', '')))
 
     def is_admin(self):
+        return 'ROLE_ADMIN' in self.get_all_user_roles()
+
+    def get_all_user_roles(self):
         user_groups = self.user.get('groups', [])
         user_roles = [role.get('name') for role in self.user.get('roles', [])]
-        return 'ROLE_ADMIN' in (user_groups + user_roles)
+        return set((user_groups + user_roles))
 
     def whoami(self):
         return self.user

--- a/pipe-cli/src/utilities/user_operations_manager.py
+++ b/pipe-cli/src/utilities/user_operations_manager.py
@@ -43,7 +43,7 @@ class UserOperationsManager:
     def get_all_user_roles(self):
         user_groups = self.user.get('groups', [])
         user_roles = [role.get('name') for role in self.user.get('roles', [])]
-        return set((user_groups + user_roles))
+        return set(user_groups + user_roles)
 
     def whoami(self):
         return self.user


### PR DESCRIPTION
This PR is related to issue #2342

It adds a new `roles` field to `DefaultSystemParameter` object, which restricts users allowed to use the corresponding parameter. 

It also adds the related logic regarding validation at pipeline startup to the pipe CLI.