### PR TITLE
Issue #2182 NFS events watch fixes

### DIFF
--- a/scripts/pipeline-launch/launch.sh
+++ b/scripts/pipeline-launch/launch.sh
@@ -1829,6 +1829,8 @@ echo "-"
 
 if [ "$CP_CAP_NFS_MNT_OBSERVER_DISABLED" == "true" ]; then
     echo "NFS events observer is not requested"
+elif [ "$CP_SENSITIVE_RUN" == "true" ]; then
+    echo "NFS event watching are disabled for sensitive runs"
 else
     inotify_watchers=${CP_CAP_NFS_MNT_OBSERVER_RUN_WATCHERS:-65535}
     sysctl -w fs.inotify.max_user_watches=$inotify_watchers

--- a/scripts/pipeline-launch/launch.sh
+++ b/scripts/pipeline-launch/launch.sh
@@ -1830,7 +1830,7 @@ echo "-"
 if [ "$CP_CAP_NFS_MNT_OBSERVER_DISABLED" == "true" ]; then
     echo "NFS events observer is not requested"
 elif [ "$CP_SENSITIVE_RUN" == "true" ]; then
-    echo "NFS event watching are disabled for sensitive runs"
+    echo "NFS event watching is disabled for sensitive runs"
 else
     inotify_watchers=${CP_CAP_NFS_MNT_OBSERVER_RUN_WATCHERS:-65535}
     sysctl -w fs.inotify.max_user_watches=$inotify_watchers

--- a/workflows/pipe-common/scripts/watch_mount_shares.py
+++ b/workflows/pipe-common/scripts/watch_mount_shares.py
@@ -369,8 +369,7 @@ class NFSMountWatcher:
 
     def try_to_remove_path_from_observer(self, mnt_dest):
         try:
-            if len(self._target_path_mapping.items()) > 1:
-                self._event_observer.unschedule(ObservedWatch(mnt_dest, True))
+            self._event_observer.unschedule(ObservedWatch(mnt_dest, True))
             return True
         except OSError as e:
             logging.error(

--- a/workflows/pipe-common/scripts/watch_mount_shares.py
+++ b/workflows/pipe-common/scripts/watch_mount_shares.py
@@ -369,7 +369,8 @@ class NFSMountWatcher:
 
     def try_to_remove_path_from_observer(self, mnt_dest):
         try:
-            self._event_observer.unschedule(ObservedWatch(mnt_dest, True))
+            if len(self._target_path_mapping.items()) > 1:
+                self._event_observer.unschedule(ObservedWatch(mnt_dest, True))
             return True
         except OSError as e:
             logging.error(


### PR DESCRIPTION
Related to #2181 
Two fixes:
- NFS event watching is disabled for sensitive runs, since FS mounts are always read only in this case
- Minor bug fix for removing and reassigning event handler for single mount run