### PR TITLE
Issue #2338 Tool version commit status fix

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/docker/ToolVersion.java
+++ b/api/src/main/java/com/epam/pipeline/entity/docker/ToolVersion.java
@@ -20,13 +20,11 @@ import com.epam.pipeline.entity.configuration.ConfigurationEntry;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import java.util.Date;
 import java.util.List;
 
 @Data
-@NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class ToolVersion {
@@ -40,4 +38,8 @@ public class ToolVersion {
     private List<ConfigurationEntry> settings;
     @Builder.Default
     private boolean allowCommit = true;
+
+    public ToolVersion() {
+        this.allowCommit = true;
+    }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/docker/ToolVersionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/ToolVersionManager.java
@@ -60,7 +60,9 @@ public class ToolVersionManager {
         ToolVersion versionAttributes = dockerClient.getVersionAttributes(registry, imageName, version);
         versionAttributes.setToolId(toolId);
         if (toolVersion.isPresent()) {
-            versionAttributes.setId(toolVersion.get().getId());
+            final ToolVersion existingVersion = toolVersion.get();
+            versionAttributes.setId(existingVersion.getId());
+            versionAttributes.setAllowCommit(existingVersion.isAllowCommit());
             toolVersionDao.updateToolVersion(versionAttributes);
         } else {
             toolVersionDao.createToolVersion(versionAttributes);


### PR DESCRIPTION
This PR is related to issue #2338 

It brings:
1. Fix for the [bug](https://github.com/projectlombok/lombok/issues/1347) in`ToolVersion` object - `@Builder.Default` doesn't work correctly with a generated no-args constructor, so `allowedCommit` has value **false** or objects created this way. To make the behaviour more clear no-args constructor is created explicitly and **true** is being assigned to `allowCommit`
2. Fix for version update method: when a version is being synchronized with the docker registry state `allowCommit` status stored in the database should be used