### PR TITLE
Issue #2232 NAT gateway stability improvements

### DIFF
--- a/api/profiles/dev/application.properties
+++ b/api/profiles/dev/application.properties
@@ -141,10 +141,12 @@ kube.default.service.target.port=${CP_API_KUBE_SVC_DEFAULT_TARGET_PORT:1000}
 kube.deployment.api.url.prefix=${CP_API_KUBE_DEPLOYMENT_API_URL_PREFIX:apis/extensions/v1beta1}
 kube.deployment.refresh.timeout=${CP_API_KUBE_DEPLOYMENT_REFRESH_TIMEOUT_SEC:3}
 kube.deployment.refresh.retries=${CP_API_KUBE_DEPLOYMENT_REFRESH_RETRIES:15}
+kube.annotation.value.length.limit=${CP_API_KUBE_ANNOTATION_VALUE_LENGTH_LIMIT:254}
 ha.deploy.enabled=false
 
 nat.gateway.auto.config.poll=${CP_API_NAT_POLL:60000}
 nat.gateway.cp.core.service.name=${CP_API_NAT_PROXY_SERVICE_NAME:cp-tinyproxy}
+nat.gateway.cp.service.suffix=${CP_API_NAT_PROXY_SERVICE_SUFFIX:-nat}
 nat.gateway.cm.dns.proxy.name=${CP_API_NAT_CM_DNS_PROXY_NAME:cp-dnsmasq-hosts}
 nat.gateway.cm.global.name=${CP_API_NAT_CM_GLOBAL_NAME:cp-config-global}
 nat.gateway.port.forwarding.key=${CP_API_NAT_PORT_FORWARDING_RULE:CP_TP_TCP_DEST}

--- a/api/profiles/release/application.properties
+++ b/api/profiles/release/application.properties
@@ -95,9 +95,11 @@ kube.default.service.target.port=${CP_API_KUBE_SVC_DEFAULT_TARGET_PORT:1000}
 kube.deployment.api.url.prefix=${CP_API_KUBE_DEPLOYMENT_API_URL_PREFIX:apis/extensions/v1beta1}
 kube.deployment.refresh.timeout=${CP_API_KUBE_DEPLOYMENT_REFRESH_TIMEOUT_SEC:3}
 kube.deployment.refresh.retries=${CP_API_KUBE_DEPLOYMENT_REFRESH_RETRIES:15}
+kube.annotation.value.length.limit=${CP_API_KUBE_ANNOTATION_VALUE_LENGTH_LIMIT:254}
 
 nat.gateway.auto.config.poll=${CP_API_NAT_POLL:60000}
 nat.gateway.cp.core.service.name=${CP_API_NAT_PROXY_SERVICE_NAME:cp-tinyproxy}
+nat.gateway.cp.service.suffix=${CP_API_NAT_PROXY_SERVICE_SUFFIX:-nat}
 nat.gateway.cm.dns.proxy.name=${CP_API_NAT_CM_DNS_PROXY_NAME:cp-dnsmasq-hosts}
 nat.gateway.cm.global.name=${CP_API_NAT_CM_GLOBAL_NAME:cp-config-global}
 nat.gateway.port.forwarding.key=${CP_API_NAT_PORT_FORWARDING_RULE:CP_TP_TCP_DEST}

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -687,6 +687,8 @@ public final class MessageConstants {
         "nat.gateway.route.creation.port.forwarding.missing.port.error";
     public static final String NAT_ROUTE_CONFIG_KUBE_DNS_RESTART_FAILED =
         "nat.gateway.route.creation.kube.dns.restart.error";
+    public static final String NAT_ROUTE_CONFIG_EXTERNAL_IP_POINTS_TO_PROXY_SERVICE =
+        "nat.gateway.route.creation.invalid.external.ip";
 
     public static final String NAT_ROUTE_REMOVAL_NO_PORT_SPECIFIED = "nat.gateway.route.removal.port.not.found";
     public static final String NAT_ROUTE_REMOVAL_DNS_MASK_REMOVAL_FAILED = "nat.gateway.route.removal.dns.failed";

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -671,6 +671,7 @@ public final class MessageConstants {
         "nat.gateway.route.creation.existing.service.add.port";
     public static final String NAT_ROUTE_CONFIG_DNS_CREATION_FAILED = "nat.gateway.route.creation.dns.config.error";
     public static final String NAT_ROUTE_CONFIG_ERROR_EMPTY_RULE = "nat.gateway.route.creation.empty.rule";
+    public static final String NAT_ROUTE_CONFIG_INVALID_MANDATORY_FIELD = "nat.gateway.route.creation.invalid.field";
     public static final String NAT_ROUTE_CONFIG_INVALID_DESCRIPTION = "nat.gateway.route.creation.invalid.description";
     public static final String NAT_ROUTE_CONFIG_DEPLOYMENT_REFRESH_FAILED =
         "nat.gateway.route.creation.deploy.refresh.error";

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -671,6 +671,7 @@ public final class MessageConstants {
         "nat.gateway.route.creation.existing.service.add.port";
     public static final String NAT_ROUTE_CONFIG_DNS_CREATION_FAILED = "nat.gateway.route.creation.dns.config.error";
     public static final String NAT_ROUTE_CONFIG_ERROR_EMPTY_RULE = "nat.gateway.route.creation.empty.rule";
+    public static final String NAT_ROUTE_CONFIG_INVALID_DESCRIPTION = "nat.gateway.route.creation.invalid.description";
     public static final String NAT_ROUTE_CONFIG_DEPLOYMENT_REFRESH_FAILED =
         "nat.gateway.route.creation.deploy.refresh.error";
     public static final String NAT_ROUTE_CONFIG_PORT_FORWARDING_FAILED =

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesManager.java
@@ -394,25 +394,25 @@ public class KubernetesManager {
         }
     }
 
-    public boolean removeLabelsFromExistingService(final String serviceName, final Set<String> labels) {
+    public boolean removeAnnotationsFromExistingService(final String serviceName, final Set<String> annotations) {
         try (KubernetesClient client = getKubernetesClient()) {
-            final Map<String, String> correspondingLabels = client.services()
+            final Map<String, String> correspondingAnnotations = client.services()
                 .inNamespace(kubeNamespace)
                 .withName(serviceName)
                 .get()
                 .getMetadata()
-                .getLabels()
+                .getAnnotations()
                 .entrySet()
                 .stream()
-                .filter(e -> labels.contains(e.getKey()))
+                .filter(e -> annotations.contains(e.getKey()))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-            if (MapUtils.isNotEmpty(correspondingLabels)) {
+            if (MapUtils.isNotEmpty(correspondingAnnotations)) {
                 client.services()
                     .inNamespace(kubeNamespace)
                     .withName(serviceName)
                     .edit()
                     .editMetadata()
-                    .removeFromLabels(correspondingLabels)
+                    .removeFromAnnotations(correspondingAnnotations)
                     .endMetadata()
                     .done();
             }
@@ -445,14 +445,14 @@ public class KubernetesManager {
         return serviceName + KubernetesConstants.HYPHEN + externalPort.toString();
     }
 
-    public boolean removePortFromExistingService(final String serviceName, final String portName) {
+    public boolean setPortsToService(final String serviceName, final List<ServicePort> portsUpdate) {
         try (KubernetesClient client = getKubernetesClient()) {
             client.services()
                 .inNamespace(kubeNamespace)
                 .withName(serviceName)
                 .edit()
                     .editSpec()
-                        .removeFromPorts(getTcpPortSpec(portName, null, null))
+                        .withPorts(portsUpdate)
                     .endSpec()
                 .done();
             return true;

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesManager.java
@@ -1032,6 +1032,12 @@ public class KubernetesManager {
         }
     }
 
+    public Optional<Service> findServiceByName(final String serviceName) {
+        try (KubernetesClient client = getKubernetesClient()) {
+            return findServiceByName(client, serviceName);
+        }
+    }
+
     public boolean deleteService(final Service service) {
         try (KubernetesClient client = getKubernetesClient()) {
             return deleteService(client, service);

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesManager.java
@@ -128,7 +128,7 @@ public class KubernetesManager {
     @Value("${kube.deployment.refresh.retries:15}")
     private Integer deploymentRefreshRetries;
 
-    @Value("${kube.label.length.limit:254}")
+    @Value("${kube.annotation.value.length.limit:254}")
     private Integer kubeAnnotationLengthLimit;
 
     public List<Service> getServicesByLabel(final String label) {

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/NatGatewayManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/NatGatewayManager.java
@@ -661,13 +661,14 @@ public class NatGatewayManager {
                                                         String.join(Constants.COMMA, activeRules));
     }
 
-    private HashSet<String> getActivePortForwardingRules(final Optional<ConfigMap> globalConfigMap) {
+    private Set<String> getActivePortForwardingRules(final Optional<ConfigMap> globalConfigMap) {
         return globalConfigMap.map(ConfigMap::getData)
             .map(data -> data.get(portForwardingRuleKey))
             .map(portForwardingString -> portForwardingString.split(Constants.COMMA))
-            .map(Arrays::asList)
-            .map(HashSet::new)
-            .orElse(new HashSet<>());
+            .map(Stream::of)
+            .orElse(Stream.empty())
+            .filter(StringUtils::isNotBlank)
+            .collect(Collectors.toSet());
     }
 
     private boolean addDnsMask(final Service service, final Integer newPort) {

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/NatGatewayManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/NatGatewayManager.java
@@ -396,8 +396,8 @@ public class NatGatewayManager {
             if (NatRouteStatus.CREATION_SCHEDULED.equals(route.getStatus())
                 && correspondingService.getSpec().getClusterIP().equals(route.getExternalIp())) {
                 final NatRoute routeUpdate = route.toBuilder()
-                    .lastErrorMessage(messageHelper.getMessage
-                        (MessageConstants.NAT_ROUTE_CONFIG_EXTERNAL_IP_POINTS_TO_PROXY_SERVICE))
+                    .lastErrorMessage(messageHelper.getMessage(
+                        MessageConstants.NAT_ROUTE_CONFIG_EXTERNAL_IP_POINTS_TO_PROXY_SERVICE))
                     .status(NatRouteStatus.FAILED)
                     .build();
                 natGatewayDao.updateRoute(routeUpdate);

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/NatGatewayManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/NatGatewayManager.java
@@ -225,8 +225,18 @@ public class NatGatewayManager {
     }
 
     private List<Integer> getExternalPortsSpecifiedInAnnotations(final Map<String, String> annotations) {
-        return annotations.keySet().stream()
-            .filter(key -> key.startsWith(TARGET_STATUS_LABEL_PREFIX))
+        return annotations.entrySet().stream()
+            .filter(entry -> entry.getKey().startsWith(TARGET_STATUS_LABEL_PREFIX))
+            .sorted((statusEntry1, statusEntry2) -> {
+                if (NatRouteStatus.ACTIVE.name().equals(statusEntry1.getValue())) {
+                    return -1;
+                } else if (NatRouteStatus.ACTIVE.name().equals(statusEntry2.getValue())) {
+                    return 1;
+                } else {
+                    return 0;
+                }
+            })
+            .map(Map.Entry::getKey)
             .map(key -> key.substring(TARGET_STATUS_LABEL_PREFIX.length()))
             .map(Integer::valueOf)
             .collect(Collectors.toList());

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -612,6 +612,7 @@ nat.gateway.route.creation.empty.config.map.port.forwarding=Unable to find confi
 nat.gateway.route.creation.dns.resolving.failed=Unable to resolve ''{0}'' as it was expected.
 nat.gateway.route.creation.port.forwarding.missing.port.error=Unable to find port, defined for {0} in {1}.
 nat.gateway.route.creation.kube.dns.restart.error=''kube-dns'' pods were not able to start after the refresh.
+nat.gateway.route.creation.invalid.external.ip=Creation of the route with the proxying service address is forbidden, use proper external IP.
 nat.gateway.route.creation.empty.rule=Empty rules are passed!
 nat.gateway.route.creation.invalid.field=Invalid route field ''{0}'' value: empty or excess size limit.
 nat.gateway.route.creation.invalid.description=Invalid description ''{0}'', try to make it shorter.

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -613,6 +613,7 @@ nat.gateway.route.creation.dns.resolving.failed=Unable to resolve ''{0}'' as it 
 nat.gateway.route.creation.port.forwarding.missing.port.error=Unable to find port, defined for {0} in {1}.
 nat.gateway.route.creation.kube.dns.restart.error=''kube-dns'' pods were not able to start after the refresh.
 nat.gateway.route.creation.empty.rule=Empty rules are passed!
+nat.gateway.route.creation.invalid.field=Invalid route field ''{0}'' value: empty or excess size limit.
 nat.gateway.route.creation.invalid.description=Invalid description ''{0}'', try to make it shorter.
 nat.gateway.routes.transfer.to.kube=Transferring queued routes from DB to Kubernetes: {0} routes found
 nat.gateway.route.creation.route.service.port=Try to configure route on port {0} for ''{1}''

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -613,6 +613,7 @@ nat.gateway.route.creation.dns.resolving.failed=Unable to resolve ''{0}'' as it 
 nat.gateway.route.creation.port.forwarding.missing.port.error=Unable to find port, defined for {0} in {1}.
 nat.gateway.route.creation.kube.dns.restart.error=''kube-dns'' pods were not able to start after the refresh.
 nat.gateway.route.creation.empty.rule=Empty rules are passed!
+nat.gateway.route.creation.invalid.description=Invalid description ''{0}'', try to make it shorter.
 nat.gateway.routes.transfer.to.kube=Transferring queued routes from DB to Kubernetes: {0} routes found
 nat.gateway.route.creation.route.service.port=Try to configure route on port {0} for ''{1}''
 nat.gateway.route.transfer.summary=Transferring route: [{0}]

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/NatGatewayManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/NatGatewayManagerTest.java
@@ -26,7 +26,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -48,7 +47,7 @@ public class NatGatewayManagerTest extends AbstractManagerTest {
     @SpyBean
     private NatGatewayDao natGatewayDao;
 
-    @MockBean
+    @SpyBean
     private KubernetesManager kubernetesManager;
 
     @Before

--- a/deploy/docker/cp-api-srv/config/application.properties
+++ b/deploy/docker/cp-api-srv/config/application.properties
@@ -109,9 +109,11 @@ kube.default.service.target.port=${CP_API_KUBE_SVC_DEFAULT_TARGET_PORT:1000}
 kube.deployment.api.url.prefix=${CP_API_KUBE_DEPLOYMENT_API_URL_PREFIX:apis/extensions/v1beta1}
 kube.deployment.refresh.timeout=${CP_API_KUBE_DEPLOYMENT_REFRESH_TIMEOUT_SEC:3}
 kube.deployment.refresh.retries=${CP_API_KUBE_DEPLOYMENT_REFRESH_RETRIES:15}
+kube.annotation.value.length.limit=${CP_API_KUBE_ANNOTATION_VALUE_LENGTH_LIMIT:254}
 
 nat.gateway.auto.config.poll=${CP_API_NAT_POLL:60000}
 nat.gateway.cp.core.service.name=${CP_API_NAT_PROXY_SERVICE_NAME:cp-tinyproxy}
+nat.gateway.cp.service.suffix=${CP_API_NAT_PROXY_SERVICE_SUFFIX:-nat}
 nat.gateway.cm.dns.proxy.name=${CP_API_NAT_CM_DNS_PROXY_NAME:cp-dnsmasq-hosts}
 nat.gateway.cm.global.name=${CP_API_NAT_CM_GLOBAL_NAME:cp-config-global}
 nat.gateway.port.forwarding.key=${CP_API_NAT_PORT_FORWARDING_RULE:CP_TP_TCP_DEST}


### PR DESCRIPTION
This PR is related to issue #2232 and brings improvements and fixes into the current configuration procedure:

1. Routes details are migrated from labels to annotations because it: doesn't have strong restrictions on content format; has greater default length; no selection is performed using those details
2. Route description is being persisted in k8s service
3. Route fields are validated at queueing time
4. `description` is not considered when searching similar routes during termination schedule, because it is immutable and might be omitted in the request
5. Forbid using corresponding proxy IP as an external one when adding a route for existing hostname
6. Process route creation at first in case multiple operations are requested for the same service
7. Fixes to process removing multiple routes at once correctly