### PR TITLE
Issue #2338 commit restrictions use image only

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunDockerOperationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunDockerOperationManager.java
@@ -93,11 +93,15 @@ public class PipelineRunDockerOperationManager {
                 messageHelper.getMessage(MessageConstants.ERROR_REGISTRY_NOT_FOUND, registryId));
         String dockerImageFromRun = retrieveImageName(pipelineRun);
         String resolvedImageName = StringUtils.isEmpty(newImageName) ? dockerImageFromRun : newImageName;
-
-        toolManager.validateCommitOperationAllowed(dockerRegistry.getPath(), resolvedImageName);
+        final String registryPath = dockerRegistry.getPath();
+        if (resolvedImageName.startsWith(registryPath)) {
+            toolManager.validateCommitOperationAllowed(resolvedImageName);
+        } else {
+            toolManager.validateCommitOperationAllowed(registryPath, resolvedImageName);
+        }
 
         //check that there is no tool with this name in another registry
-        toolManager.assertThatToolUniqueAcrossRegistries(resolvedImageName, dockerRegistry.getPath());
+        toolManager.assertThatToolUniqueAcrossRegistries(resolvedImageName, registryPath);
 
         return dockerContainerOperationManager.commitContainer(
                 pipelineRun,

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunDockerOperationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunDockerOperationManager.java
@@ -93,15 +93,11 @@ public class PipelineRunDockerOperationManager {
                 messageHelper.getMessage(MessageConstants.ERROR_REGISTRY_NOT_FOUND, registryId));
         String dockerImageFromRun = retrieveImageName(pipelineRun);
         String resolvedImageName = StringUtils.isEmpty(newImageName) ? dockerImageFromRun : newImageName;
-        final String registryPath = dockerRegistry.getPath();
-        if (resolvedImageName.startsWith(registryPath)) {
-            toolManager.validateCommitOperationAllowed(resolvedImageName);
-        } else {
-            toolManager.validateCommitOperationAllowed(registryPath, resolvedImageName);
-        }
+
+        toolManager.validateCommitOperationAllowed(pipelineRun.getActualDockerImage());
 
         //check that there is no tool with this name in another registry
-        toolManager.assertThatToolUniqueAcrossRegistries(resolvedImageName, registryPath);
+        toolManager.assertThatToolUniqueAcrossRegistries(resolvedImageName, dockerRegistry.getPath());
 
         return dockerContainerOperationManager.commitContainer(
                 pipelineRun,


### PR DESCRIPTION
This PR is related to issue #2338

It changes the field being checked during run commit status validation:
1. It is right to check the actual image of the run being committed rather than the resolved image, because a new image could be in a different group or have another name
2. Run's actual image contains 'full' name, including registry path, so only the name is passed to the validation method