### PR TITLE
Issue #2367 VMMonitor notifications grouping

### DIFF
--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/model/vm/MissingLabelsSummary.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/model/vm/MissingLabelsSummary.java
@@ -16,7 +16,6 @@
 
 package com.epam.pipeline.vmmonitor.model.vm;
 
-import com.epam.pipeline.entity.cluster.NodeInstance;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -26,7 +25,6 @@ import java.util.List;
 @Getter
 public class MissingLabelsSummary {
 
-    private final VirtualMachine vm;
-    private final NodeInstance node;
+    private final String nodeName;
     private final List<String> labels;
 }

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/model/vm/MissingLabelsSummary.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/model/vm/MissingLabelsSummary.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.vmmonitor.model.vm;
+
+import com.epam.pipeline.entity.cluster.NodeInstance;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@AllArgsConstructor
+@Getter
+public class MissingLabelsSummary {
+
+    private final VirtualMachine vm;
+    private final NodeInstance node;
+    private final List<String> labels;
+}

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitor.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,6 +73,7 @@ public class VMMonitor {
     public void monitor() {
         ListUtils.emptyIfNull(apiClient.loadRegions())
                 .forEach(this::checkVMs);
+        notifier.notifyMissingNodes();
     }
 
     @SuppressWarnings("unchecked")
@@ -107,7 +108,7 @@ public class VMMonitor {
             } else {
                 log.debug("No matching nodes were found for VM {} {}.", vm.getInstanceId(), vm.getCloudProvider());
                 if (!matchingRunExists(vm)) {
-                    notifier.notifyMissingNode(vm);
+                    notifier.queueMissingNodeNotification(vm);
                 }
             }
         } catch (Exception e) {

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitor.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitor.java
@@ -73,7 +73,7 @@ public class VMMonitor {
     public void monitor() {
         ListUtils.emptyIfNull(apiClient.loadRegions())
                 .forEach(this::checkVMs);
-        notifier.notifyMissingNodes();
+        notifier.sendNotifications();
     }
 
     @SuppressWarnings("unchecked")
@@ -173,7 +173,7 @@ public class VMMonitor {
         log.debug("Checking whether node {} is labeled with required tags.", node.getName());
         final List<String> labels = getMissingLabels(node);
         if (CollectionUtils.isNotEmpty(labels)) {
-            notifier.notifyMissingLabels(vm, node, labels);
+            notifier.queueMissingLabelsNotification(vm, node, labels);
         } else {
             log.debug("All required labels are present on node {}.", node.getName());
         }

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitor.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitor.java
@@ -173,7 +173,7 @@ public class VMMonitor {
         log.debug("Checking whether node {} is labeled with required tags.", node.getName());
         final List<String> labels = getMissingLabels(node);
         if (CollectionUtils.isNotEmpty(labels)) {
-            notifier.queueMissingLabelsNotification(vm, node, labels);
+            notifier.queueMissingLabelsNotification(node, labels);
         } else {
             log.debug("All required labels are present on node {}.", node.getName());
         }

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMNotifier.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMNotifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 package com.epam.pipeline.vmmonitor.service.vm;
 
 import com.epam.pipeline.entity.cluster.NodeInstance;
+import com.epam.pipeline.vmmonitor.model.vm.MissingLabelsSummary;
 import com.epam.pipeline.vmmonitor.model.vm.VirtualMachine;
 import com.epam.pipeline.vmmonitor.service.notification.VMNotificationService;
 import lombok.extern.slf4j.Slf4j;
@@ -25,12 +26,11 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.Queue;
 
 @Component
 @Slf4j
@@ -41,7 +41,8 @@ public class VMNotifier {
     private final String missingNodeTemplatePath;
     private final String missingLabelsSubject;
     private final String missingLabelsTemplatePath;
-    private final List<VirtualMachine> missingNodes;
+    private final Queue<VirtualMachine> missingNodes;
+    private final Queue<MissingLabelsSummary> missingLabelsSummaries;
 
     public VMNotifier(
             final VMNotificationService notificationService,
@@ -54,43 +55,34 @@ public class VMNotifier {
         this.missingNodeTemplatePath = missingNodeTemplatePath;
         this.missingLabelsSubject = missingLabelsSubject;
         this.missingLabelsTemplatePath = missingLabelsTemplatePath;
-        this.missingNodes = new ArrayList<>();
+        this.missingNodes = new LinkedList<>();
+        this.missingLabelsSummaries = new LinkedList<>();
+    }
+
+    public void sendNotifications() {
+        notifyOnQueuedElements(missingNodeSubject, missingNodeTemplatePath, missingNodes, "nodes", "missingNodes");
+        notifyOnQueuedElements(missingLabelsSubject, missingLabelsTemplatePath, missingLabelsSummaries, "labels",
+                               "missingLabelsSummaries");
     }
 
     public void queueMissingNodeNotification(final VirtualMachine vm) {
         missingNodes.add(vm);
     }
 
-    public void notifyMissingNodes() {
-        if (CollectionUtils.isNotEmpty(missingNodes)) {
-            log.debug("Sending notification on {} missing nodes", missingNodes.size());
-            final Map<String, Object> parameters = Collections.singletonMap("missingNodes", missingNodes);
-            notificationService.sendMessage(parameters, missingNodeSubject, missingNodeTemplatePath);
-            missingNodes.clear();
+    public void queueMissingLabelsNotification(final VirtualMachine vm, final NodeInstance node,
+                                               final List<String> labels) {
+        missingLabelsSummaries.add(new MissingLabelsSummary(vm, node, labels));
+    }
+
+    private void notifyOnQueuedElements(final String emailSubject, final String emailTemplatePath,
+                                        final Queue<?> queue, final String queueName, final String parameterName) {
+        if (CollectionUtils.isNotEmpty(queue)) {
+            log.debug("Sending notification on {} missing {}}", queue.size(), queueName);
+            final Map<String, Object> parameters = Collections.singletonMap(parameterName, queue);
+            notificationService.sendMessage(parameters, emailSubject, emailTemplatePath);
+            queue.clear();
         } else {
-            log.debug("No missing nodes notifications queued.");
+            log.debug("No missing {} notifications queued.", queueName);
         }
-    }
-
-    public void notifyMissingLabels(final VirtualMachine vm,
-                                    final NodeInstance node,
-                                    final List<String> labels) {
-        final Map<String, Object> parameters = new HashMap<>();
-        addVmParameters(vm, parameters);
-        addNodeParameters(node, parameters);
-        parameters.put("missingLabels", labels.stream().collect(Collectors.joining(",")));
-        log.debug("Sending missing labels notification for VM {} {}", vm.getInstanceId(), vm.getCloudProvider());
-        notificationService.sendMessage(parameters, missingLabelsSubject, missingLabelsTemplatePath);
-    }
-
-    private void addNodeParameters(final NodeInstance node, final Map<String, Object> parameters) {
-        parameters.put("nodeName", node.getName());
-    }
-
-    private void addVmParameters(final VirtualMachine vm, final Map<String, Object> parameters) {
-        parameters.put("instanceId", vm.getInstanceId());
-        parameters.put("privateIp", vm.getPrivateIp());
-        parameters.put("provider", vm.getCloudProvider().name());
-        parameters.put("instanceName", vm.getInstanceName());
     }
 }

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMNotifier.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMNotifier.java
@@ -69,9 +69,8 @@ public class VMNotifier {
         missingNodes.add(vm);
     }
 
-    public void queueMissingLabelsNotification(final VirtualMachine vm, final NodeInstance node,
-                                               final List<String> labels) {
-        missingLabelsSummaries.add(new MissingLabelsSummary(vm, node, labels));
+    public void queueMissingLabelsNotification(final NodeInstance node, final List<String> labels) {
+        missingLabelsSummaries.add(new MissingLabelsSummary(node.getName(), labels));
     }
 
     private void notifyOnQueuedElements(final String emailSubject, final String emailTemplatePath,

--- a/vm-monitor/src/main/resources/application.properties
+++ b/vm-monitor/src/main/resources/application.properties
@@ -26,10 +26,10 @@ monitor.k8s.deployment.names=${CP_VM_MONITOR_DEPLOY_NAMES:cp-api-db,cp-api-srv,c
   cp-docker-comp,cp-clair,cp-search-elk,cp-search-srv,cp-heapster-elk,cp-heapster,cp-share-srv,cp-dav}
 
 #Notification settings
-notification.missing-node.subject=[$templateParameters["fullPlatformName"]] VM $templateParameters["instanceName"] is not registered in cluster
+notification.missing-node.subject=[$templateParameters["fullPlatformName"]] VMs are not registered in cluster
 notification.missing-node.template=${CP_VM_MONITOR_TEMPLATES:classpath:}/templates/MISSING-NODE.html
 
-notification.missing-labels.subject=[$templateParameters["fullPlatformName"]] VM $templateParameters["nodeName"] is missing required labels
+notification.missing-labels.subject=[$templateParameters["fullPlatformName"]] VMs have missing required labels
 notification.missing-labels.template=${CP_VM_MONITOR_TEMPLATES:classpath:}/templates/MISSING-LABELS.html
 
 notification.cert-expiration.subject=[$templateParameters["fullPlatformName"]] Certificate expires soon

--- a/vm-monitor/src/main/resources/templates/MISSING-LABELS.html
+++ b/vm-monitor/src/main/resources/templates/MISSING-LABELS.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+  ~ Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -32,8 +32,23 @@
 <body>
 <p>Dear user,</p>
 <p>*** This is a system generated email, do not reply to this email ***</p>
-<p>Looks like there is a node $templateParameters["nodeName"] in Cloud Pipeline cluster that is missing one of required labels $templateParameters["missingLabels"].</p>
-<p>This node won't be managed automatically by $templateParameters["fullPlatformName"] Platform, please verify node state and terminate it manually.</p>
+<p>Looks like there are some nodes which are missing one of the required labels:</p>
+<p>
+<table>
+    <tr><td><b>Node</b></td><td><b>Missing labels</b></td></tr>
+    #foreach( $summary in $templateParameters["missingLabelsSummaries"] )
+    <tr>
+        <td>$summary.node.name</td>
+        <td>
+            #foreach( $label in $summary.labels )
+            $label<br>
+            #end
+        </td>
+    </tr>
+    #end
+</table>
+</p>
+<p>Those nodes won't be managed automatically by $templateParameters["fullPlatformName"] Platform, please verify nodes' state and terminate them manually.</p>
 <p>Best regards,</p>
 <p>$templateParameters["fullPlatformName"] Platform</p>
 </body>

--- a/vm-monitor/src/main/resources/templates/MISSING-LABELS.html
+++ b/vm-monitor/src/main/resources/templates/MISSING-LABELS.html
@@ -38,7 +38,7 @@
     <tr><td><b>Node</b></td><td><b>Missing labels</b></td></tr>
     #foreach( $summary in $templateParameters["missingLabelsSummaries"] )
     <tr>
-        <td>$summary.node.name</td>
+        <td>$summary.nodeName</td>
         <td>
             #foreach( $label in $summary.labels )
             $label<br>

--- a/vm-monitor/src/main/resources/templates/MISSING-NODE.html
+++ b/vm-monitor/src/main/resources/templates/MISSING-NODE.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+  ~ Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -32,8 +32,16 @@
 <body>
 <p>Dear user,</p>
 <p>*** This is a system generated email, do not reply to this email ***</p>
-<p>Looks like there is a Virtual Machine [ instance ID $templateParameters["instanceId"], IP address $templateParameters["privateIp"] ] in the $templateParameters["provider"] cloud that is not registered in the $templateParameters["platformName"] cluster.</p>
-<p>Please verify the state of this Virtual Machine and terminate it from $templateParameters["provider"] console if Virtual Machine is not needed anymore.</p>
+<p>Looks like there are some Virtual Machines that are not registered in the $templateParameters["platformName"] cluster.</p>
+<p>
+<table>
+    <tr><td>Instance ID</td><td>Private IP</td><td>Provider</td></tr>
+    #foreach( $instance in $templateParameters["missingNodes"] )
+    <tr><td>$instance.instanceId</td><td>$instance.privateIp</td><td>$instance.cloudProvider</td></tr>
+    #end
+</table>
+</p>
+<p>Please verify the state of those Virtual Machines and terminate the ones not needed anymore from the corresponding provider console.</p>
 <p>Best regards,</p>
 <p>$templateParameters["fullPlatformName"] Platform</p>
 </body>

--- a/vm-monitor/src/main/resources/templates/MISSING-NODE.html
+++ b/vm-monitor/src/main/resources/templates/MISSING-NODE.html
@@ -35,9 +35,9 @@
 <p>Looks like there are some Virtual Machines that are not registered in the $templateParameters["platformName"] cluster.</p>
 <p>
 <table>
-    <tr><td>Instance ID</td><td>Private IP</td><td>Provider</td></tr>
+    <tr><td><b>Instance ID</b></td><td><b>Private IP</b></td><td><b>Provider</b></td></tr>
     #foreach( $instance in $templateParameters["missingNodes"] )
-    <tr><td>$instance.instanceId</td><td>$instance.privateIp</td><td>$instance.cloudProvider</td></tr>
+        <tr><td>$instance.instanceId</td><td>$instance.privateIp</td><td>$instance.cloudProvider</td></tr>
     #end
 </table>
 </p>

--- a/vm-monitor/src/test/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitorTest.java
+++ b/vm-monitor/src/test/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ public class VMMonitorTest {
     private final Map<String, String> vmTags = Collections.singletonMap(RUN_ID_LABEL, RUN_ID_VALUE);
     private final Map<String, String> nodeLabels = Collections.singletonMap(POOL_ID_LABEL, POOL_ID_VALUE);
     private final AwsRegion region = new AwsRegion(CloudProvider.AWS, TEST_STRING, TEST_STRING, TEST_STRING,
-            TEST_STRING, TEST_STRING, TEST_STRING, TEST_STRING, 0, true);
+            TEST_STRING, TEST_STRING, TEST_STRING, TEST_STRING, 0, true, TEST_STRING);
     private VirtualMachine vm;
     private VMMonitor monitor;
 
@@ -79,7 +79,7 @@ public class VMMonitorTest {
         doReturn(Collections.singletonList(nodePool)).when(mockApiClient).loadNodePools();
         monitor.monitor();
 
-        verify(notifier, never()).notifyMissingNode(vm);
+        verify(notifier, never()).queueMissingNodeNotification(vm);
     }
 
     @Test
@@ -88,6 +88,6 @@ public class VMMonitorTest {
         doReturn(Collections.singletonList(vm)).when(mockService).fetchRunningVms(region);
         monitor.monitor();
 
-        verify(notifier).notifyMissingNode(vm);
+        verify(notifier).queueMissingNodeNotification(vm);
     }
 }


### PR DESCRIPTION
This PR is related to issue #2367.

It changes the approach used for notifications regarding missing cluster nodes and missing labels.
Instead of sending notifications for each case, they are collected in a queue and sent at once.