### PR TITLE
Issue #2232 Use cluster DNS server IP as the default one

### DIFF
--- a/api/profiles/dev/application.properties
+++ b/api/profiles/dev/application.properties
@@ -145,7 +145,7 @@ kube.annotation.value.length.limit=${CP_API_KUBE_ANNOTATION_VALUE_LENGTH_LIMIT:2
 ha.deploy.enabled=false
 
 nat.gateway.auto.config.poll=${CP_API_NAT_POLL:60000}
-nat.gateway.custom.dns.server.ip=${CP_API_CUSTOM_DNS_SERVER_IP:8.8.8.8}
+nat.gateway.custom.dns.server.ip=${CP_API_CUSTOM_DNS_SERVER_IP:10.96.0.10}
 nat.gateway.cp.service.name=${CP_API_NAT_PROXY_SERVICE_NAME:cp-tinyproxy-nat}
 nat.gateway.cp.service.label.selector=${CP_API_NAT_PROXY_SERVICE_LABEL_SELECTOR:cp-tinyproxy}
 nat.gateway.cm.dns.proxy.name=${CP_API_NAT_CM_DNS_PROXY_NAME:cp-dnsmasq-hosts}

--- a/api/profiles/release/application.properties
+++ b/api/profiles/release/application.properties
@@ -98,7 +98,7 @@ kube.deployment.refresh.retries=${CP_API_KUBE_DEPLOYMENT_REFRESH_RETRIES:15}
 kube.annotation.value.length.limit=${CP_API_KUBE_ANNOTATION_VALUE_LENGTH_LIMIT:254}
 
 nat.gateway.auto.config.poll=${CP_API_NAT_POLL:60000}
-nat.gateway.custom.dns.server.ip=${CP_API_CUSTOM_DNS_SERVER_IP:8.8.8.8}
+nat.gateway.custom.dns.server.ip=${CP_API_CUSTOM_DNS_SERVER_IP:10.96.0.10}
 nat.gateway.cp.service.name=${CP_API_NAT_PROXY_SERVICE_NAME:cp-tinyproxy-nat}
 nat.gateway.cp.service.label.selector=${CP_API_NAT_PROXY_SERVICE_LABEL_SELECTOR:cp-tinyproxy}
 nat.gateway.cm.dns.proxy.name=${CP_API_NAT_CM_DNS_PROXY_NAME:cp-dnsmasq-hosts}

--- a/deploy/docker/cp-api-srv/config/application.properties
+++ b/deploy/docker/cp-api-srv/config/application.properties
@@ -112,7 +112,7 @@ kube.deployment.refresh.retries=${CP_API_KUBE_DEPLOYMENT_REFRESH_RETRIES:15}
 kube.annotation.value.length.limit=${CP_API_KUBE_ANNOTATION_VALUE_LENGTH_LIMIT:254}
 
 nat.gateway.auto.config.poll=${CP_API_NAT_POLL:60000}
-nat.gateway.custom.dns.server.ip=${CP_API_CUSTOM_DNS_SERVER_IP:8.8.8.8}
+nat.gateway.custom.dns.server.ip=${CP_API_CUSTOM_DNS_SERVER_IP:10.96.0.10}
 nat.gateway.cp.service.name=${CP_API_NAT_PROXY_SERVICE_NAME:cp-tinyproxy-nat}
 nat.gateway.cp.service.label.selector=${CP_API_NAT_PROXY_SERVICE_LABEL_SELECTOR:cp-tinyproxy}
 nat.gateway.cm.dns.proxy.name=${CP_API_NAT_CM_DNS_PROXY_NAME:cp-dnsmasq-hosts}


### PR DESCRIPTION
This PR is related to issue #2232 

It changes the default value of the default DNS server IP - k8s cluster DNS is used (`10.96.0.10`)