### PR TITLE
Issue #2232 Force usage of the system-default DNS 

### DIFF
--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -608,7 +608,7 @@ storage.quota.unknown.type=Unknown notification type [{0}], status ACTIVE will b
 storage.quota.unknown.share.type.for.percentage=PERCENTS quota is not implemented for [{0}] shares, status ACTIVE will be assigned.
 
 # NAT configuration
-nat.gateway.address.resolving.exception=An exception occurred during hostname resolving: {0}
+nat.gateway.address.resolving.exception=An exception occurred during ''{0}'' hostname resolving: {1}
 nat.gateway.route.creation.deploy.refresh.error=Deployment refreshing after NAT route creation failed.
 nat.gateway.route.creation.port.forwarding.error=Unable to add port-forwarding rule.
 nat.gateway.route.creation.dns.config.error=Errors during DNS mask creation.


### PR DESCRIPTION
This PR is related to issue #2232 

System default DNS should be used when checking a new cluster DNS record because `defaultCustomDnsIP` could be configured to some external resource, which is not aware of cluster-level records.