### PR TITLE
Add support for pipe tunnels listing

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1732,6 +1732,16 @@ def start_tunnel(host_id, local_port, remote_port, connection_timeout,
 @click.option('-v', '--log-level', required=False, help=LOGGING_LEVEL_OPTION_DESCRIPTION)
 @common_options
 def view_tunnels(log_level):
+    """
+    Lists all pipe tunnels.
+
+    Examples:
+
+    I.   List all pipe tunnels.
+
+        pipe tunnel list
+
+    """
     def _parse_tunnel_args(args):
         with return_tunnel_args.make_context('start', args) as ctx:
             return return_tunnel_args.invoke(ctx)

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -44,7 +44,7 @@ from src.utilities.datastorage_operations import DataStorageOperations
 from src.utilities.metadata_operations import MetadataOperations
 from src.utilities.permissions_operations import PermissionsOperations
 from src.utilities.pipeline_run_operations import PipelineRunOperations
-from src.utilities.ssh_operations import run_ssh, run_scp, create_tunnel, kill_tunnels
+from src.utilities.ssh_operations import run_ssh, run_scp, create_tunnel, kill_tunnels, list_tunnels
 from src.utilities.update_cli_version import UpdateCLIVersionManager
 from src.utilities.user_operations_manager import UserOperationsManager
 from src.utilities.user_token_operations import UserTokenOperations
@@ -1726,6 +1726,16 @@ def start_tunnel(host_id, local_port, remote_port, connection_timeout,
                   timeout, timeout_stop, foreground,
                   keep_existing, keep_same, replace_existing, replace_different,
                   retries, region, _parse_tunnel_args)
+
+
+@tunnel.command(name='list')
+@click.option('-v', '--log-level', required=False, help=LOGGING_LEVEL_OPTION_DESCRIPTION)
+@common_options
+def view_tunnels(log_level):
+    def _parse_tunnel_args(args):
+        with return_tunnel_args.make_context('start', args) as ctx:
+            return return_tunnel_args.invoke(ctx)
+    list_tunnels(log_level, _parse_tunnel_args)
 
 
 @cli.command(name='update')

--- a/pipe-cli/src/utilities/ssh_operations.py
+++ b/pipe-cli/src/utilities/ssh_operations.py
@@ -13,10 +13,14 @@
 # limitations under the License.
 
 import collections
+
+import click
 import itertools
 import logging
 import os
 import random
+
+import prettytable
 import select
 import socket
 import stat
@@ -50,6 +54,10 @@ PIPE_SCRIPT_NAME = 'pipe.py'
 
 run_conn_info = collections.namedtuple('conn_info', 'ssh_proxy ssh_endpoint ssh_pass owner '
                                                     'sensitive platform parameters')
+
+
+class TunnelError(Exception):
+    pass
 
 
 class PasswordlessSSHConfig:
@@ -151,7 +159,7 @@ def direct_connect(target, timeout=None, retries=None):
         return sock
     except KeyboardInterrupt:
         raise
-    except:
+    except Exception:
         if retries >= 1:
             if sock:
                 sock.close()
@@ -192,7 +200,7 @@ def http_proxy_tunnel_connect(proxy, target, timeout=None, retries=None):
         return sock
     except KeyboardInterrupt:
         raise
-    except:
+    except Exception:
         if retries >= 1:
             if sock:
                 sock.close()
@@ -251,7 +259,7 @@ def setup_paramiko_transport(conn_info, retries):
         transport = paramiko.Transport(sock)
         transport.start_client()
         return transport
-    except:
+    except Exception:
         if retries >= 1:
             if sock:
                 sock.close()
@@ -299,7 +307,7 @@ def is_ssh_default_root_user_enabled():
     try:
         ssh_default_root_user_enabled_preference = PreferenceAPI.get_preference('system.ssh.default.root.user.enabled')
         return get_boolean(ssh_default_root_user_enabled_preference.value)
-    except:
+    except Exception:
         return True
 
 
@@ -481,9 +489,17 @@ def check_existing_tunnels(host_id, local_ports, remote_ports,
                            region, retries, parse_tunnel_args):
     for tunnel_proc in find_tunnel_procs(run_id=None, local_ports=local_ports):
         logging.info('Process with pid %s was found (%s).', tunnel_proc.pid, ' '.join(tunnel_proc.cmdline()))
-        proc_parsed_args = parse_tunnel_proc_args(tunnel_proc, timeout_stop,
-                                                  replace_different, replace_existing,
-                                                  parse_tunnel_args)
+        proc_parsed_args = {}
+        try:
+            proc_parsed_args = parse_tunnel_proc_args(tunnel_proc, parse_tunnel_args)
+        except TunnelError:
+            if replace_existing or replace_different:
+                kill_process(tunnel_proc, timeout_stop)
+            else:
+                raise TunnelError('Existing tunnel process arguments parsing has failed. '
+                                  'Please use the following command to stop all existing tunnels and '
+                                  'then try again: \n\n'
+                                  'pipe tunnel stop')
         if not proc_parsed_args:
             return
         existing_tunnel = TunnelArgs.from_args(proc_parsed_args)
@@ -517,26 +533,19 @@ def check_existing_tunnels(host_id, local_ports, remote_ports,
                               existing_tunnel.ssh_path, ssh_user, existing_tunnel_remote_host,
                               log_file, retries)
             sys.exit(0)
-        raise RuntimeError('{} tunnel already exists on the same local port'
-                           .format('Same' if is_same_tunnel else 'Different'))
+        raise TunnelError('{} tunnel already exists on the same local port'
+                          .format('Same' if is_same_tunnel else 'Different'))
 
 
-def parse_tunnel_proc_args(proc, timeout_stop,
-                           replace_different, replace_existing,
-                           parse_start_tunnel_arguments):
+def parse_tunnel_proc_args(proc, parse_start_tunnel_arguments):
     try:
         proc_args = proc.cmdline()
         for i in range(len(proc_args)):
             if proc_args[i] == 'start':
                 return parse_start_tunnel_arguments(proc_args[i + 1:])
-    except:
+    except Exception:
         logging.debug('Existing tunnel process arguments parsing has failed.', exc_info=sys.exc_info())
-        if replace_existing or replace_different:
-            kill_process(proc, timeout_stop)
-        else:
-            raise RuntimeError('Existing tunnel process arguments parsing has failed. '
-                               'Please use the following command to stop all existing tunnels and then try again: \n\n'
-                               'pipe tunnel stop')
+        raise TunnelError('Existing tunnel process arguments parsing has failed.')
     return {}
 
 
@@ -749,7 +758,7 @@ def configure_ssh_and_execute_on_windows(run_id, local_port, remote_port, conn_i
         add_record_to_openssh_config(local_port, remote_host, passwordless_config)
         copy_remote_openssh_public_key_to_openssh_known_hosts(run_id, local_port, retries, passwordless_config)
         func()
-    except:
+    except Exception:
         logging.exception('Error occurred while trying to configure passwordless ssh')
         raise
     finally:
@@ -781,7 +790,7 @@ def configure_ssh_and_execute_on_linux(run_id, local_port, remote_port, conn_inf
         add_record_to_openssh_config(local_port, remote_host, passwordless_config)
         copy_remote_openssh_public_key_to_openssh_known_hosts(run_id, local_port, retries, passwordless_config)
         func()
-    except:
+    except Exception:
         logging.exception('Error occurred while trying to configure passwordless ssh')
         raise
     finally:
@@ -829,7 +838,7 @@ def create_foreground_tunnel(run_id, local_ports, remote_ports, connection_timeo
                         client_socket, address = input.accept()
                     except KeyboardInterrupt:
                         raise
-                    except:
+                    except Exception:
                         logging.exception('Cannot establish client connection %s:%s:%s.',
                                           local_port, remote_host, remote_port)
                         break
@@ -846,7 +855,7 @@ def create_foreground_tunnel(run_id, local_ports, remote_ports, connection_timeo
                                                                       retries=retries)
                     except KeyboardInterrupt:
                         raise
-                    except:
+                    except Exception:
                         logging.exception('Cannot establish tunnel connection %s:%s:%s.',
                                           local_port, remote_host, remote_port)
                         client_socket.close()
@@ -864,7 +873,7 @@ def create_foreground_tunnel(run_id, local_ports, remote_ports, connection_timeo
                     read_data = input.recv(chunk_size)
                 except KeyboardInterrupt:
                     raise
-                except:
+                except Exception:
                     logging.exception('Cannot read data from socket')
                 if read_data:
                     logging.debug('Writing data...')
@@ -873,7 +882,7 @@ def create_foreground_tunnel(run_id, local_ports, remote_ports, connection_timeo
                         sent_data = read_data
                     except KeyboardInterrupt:
                         raise
-                    except:
+                    except Exception:
                         logging.exception('Cannot write data to socket')
                 if not read_data or not sent_data:
                     logging.info('Closing client and tunnel connections...')
@@ -887,7 +896,7 @@ def create_foreground_tunnel(run_id, local_ports, remote_ports, connection_timeo
                     break
     except KeyboardInterrupt:
         logging.info('Interrupted...')
-    except:
+    except Exception:
         logging.exception('Errored...')
         raise
     finally:
@@ -1244,6 +1253,45 @@ def kill_tunnels(run_id=None, local_ports_str=None, timeout=None, force=False, l
         logging.info('Process with pid %s was found (%s)', tunnel_proc.pid, ' '.join(tunnel_proc.cmdline()))
         logging.info('Killing the process...')
         kill_process(tunnel_proc, timeout / 1000, force)
+
+
+def list_tunnels(log_level, parse_tunnel_args):
+    logging.basicConfig(level=log_level or logging.ERROR, format=DEFAULT_LOGGING_FORMAT)
+    tunnels_table = prettytable.PrettyTable()
+    tunnels_table.field_names = ['PID', 'PPID', 'Owner', 'Host', 'Local Ports', 'Remote Ports']
+    tunnels_table.sortby = 'PID'
+    tunnels_table.align = 'l'
+    tunnel_procs = list(find_tunnel_procs())
+    tunnel_procs_by_ppid = {tunnel_proc.ppid(): tunnel_proc for tunnel_proc in tunnel_procs}
+    for tunnel_proc in tunnel_procs:
+        logging.info('Process with pid %s was found (%s)', tunnel_proc.pid, ' '.join(tunnel_proc.cmdline()))
+        tunnel_proc_pid = tunnel_proc.pid
+        tunnel_proc_ppid = tunnel_proc.ppid()
+        tunnel_proc_username = tunnel_proc.username()
+        if tunnel_proc_pid in tunnel_procs_by_ppid:
+            continue
+        try:
+            proc_parsed_args = parse_tunnel_proc_args(tunnel_proc, parse_tunnel_args)
+        except TunnelError:
+            proc_parsed_args = {}
+        if not proc_parsed_args:
+            continue
+        tunnel_args = TunnelArgs.from_args(proc_parsed_args)
+        tunnels_table.add_row([tunnel_proc_pid,
+                               tunnel_proc_ppid,
+                               tunnel_proc_username,
+                               tunnel_args.host_id,
+                               stringify_ports(tunnel_args.local_ports),
+                               stringify_ports(tunnel_args.remote_ports)])
+    click.echo(tunnels_table)
+
+
+def stringify_ports(ports):
+    if not ports:
+        return ''
+    if len(ports) == 1:
+        return str(ports[0])
+    return '{}-{}'.format(ports[0], ports[-1])
 
 
 def find_tunnel_procs(run_id=None, local_ports=None):


### PR DESCRIPTION
Resolves #2363.

The pull request brings support for `pipe tunnel list` command which helps to list all locally existing pipe tunnel processes.

```
Usage: pipe.py tunnel list [OPTIONS]

  Lists all pipe tunnels.

  Examples:

  I.   List all pipe tunnels.

      pipe tunnel list

Options:
  -v, --log-level TEXT  Explicit logging level: CRITICAL, ERROR, WARNING, INFO
                        or DEBUG. Defaults to ERROR.
  -u, --user TEXT       The user name to perform operation from specified
                        user. Available for admins only.
  --noclean             Disables temporary resources cleanup.
  --debug               Enables verbose logging.
  --trace               Enables verbose errors.
  --help                Show this message and exit.
```