### PR TITLE
Respect process owner in pipe tunnel

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1529,7 +1529,7 @@ def tunnel():
 
 
 @tunnel.command(name='stop')
-@click.argument('host-id', required=True)
+@click.argument('host-id', required=False)
 @click.option('-lp', '--local-port', required=False, type=str,
               help='A single local port (4567) or a range of ports (4567-4569) '
                    'to stop corresponding tunnel processes for.')

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1529,17 +1529,19 @@ def tunnel():
 
 
 @tunnel.command(name='stop')
-@click.argument('run-id', required=False, type=int)
+@click.argument('host-id', required=True)
 @click.option('-lp', '--local-port', required=False, type=str,
               help='A single local port (4567) or a range of ports (4567-4569) '
                    'to stop corresponding tunnel processes for.')
-@click.option('-t', '--timeout', required=False, type=int, default=60 * 1000,
-              help='Tunnels stopping timeout in ms.')
+@click.option('-ts', '--timeout-stop', required=False, type=int, default=60,
+              help='Maximum timeout for background tunnel process stopping in seconds.')
 @click.option('-f', '--force', required=False, is_flag=True, default=False,
-              help='Killing tunnels rather than stopping them.')
+              help='Stops existing tunnel processes non gracefully.')
+@click.option('--ignore-owner', required=False, is_flag=True, default=False,
+              help='Stops existing tunnel processes owned by other users.')
 @click.option('-v', '--log-level', required=False, help=LOGGING_LEVEL_OPTION_DESCRIPTION)
 @common_options
-def stop_tunnel(run_id, local_port, timeout, force, log_level):
+def stop_tunnel(host_id, local_port, timeout_stop, force, ignore_owner, log_level):
     """
     Stops background tunnel processes.
 
@@ -1570,7 +1572,10 @@ def stop_tunnel(run_id, local_port, timeout, force, log_level):
         pipe tunnel stop -lp 4567 12345
 
     """
-    kill_tunnels(run_id=run_id, local_ports_str=local_port, timeout=timeout, force=force, log_level=log_level)
+    def _parse_tunnel_args(args):
+        with return_tunnel_args.make_context('start', args) as ctx:
+            return return_tunnel_args.invoke(ctx)
+    kill_tunnels(host_id, local_port, timeout_stop, force, ignore_owner, log_level, _parse_tunnel_args)
 
 
 def start_tunnel_options(decorating_func):
@@ -1618,6 +1623,8 @@ def start_tunnel_options(decorating_func):
                   help='Replaces existing tunnel on the same local port.')
     @click.option('-rd', '--replace-different', required=False, is_flag=True, default=False,
                   help='Replaces existing tunnel on the same local port if it has different configuration.')
+    @click.option('--ignore-owner', required=False, is_flag=True, default=False,
+                  help='Replaces existing tunnel processes owned by other users.')
     @click.option('-r', '--retries', required=False, type=int, default=10, help=RETRIES_OPTION_DESCRIPTION)
     @click.option('-rg', '--region', required=False, help=EDGE_REGION_OPTION_DESCRIPTION)
     @functools.wraps(decorating_func)
@@ -1638,7 +1645,7 @@ def return_tunnel_args(*args, **kwargs):
 def start_tunnel(host_id, local_port, remote_port, connection_timeout,
                  ssh, ssh_path, ssh_host, ssh_user, ssh_keep, direct, log_file, log_level,
                  timeout, timeout_stop, foreground,
-                 keep_existing, keep_same, replace_existing, replace_different,
+                 keep_existing, keep_same, replace_existing, replace_different, ignore_owner,
                  retries, region):
     """
     Establishes tunnel connection to specified run instance port and serves it as a local port.
@@ -1724,7 +1731,7 @@ def start_tunnel(host_id, local_port, remote_port, connection_timeout,
     create_tunnel(host_id, local_port, remote_port, connection_timeout,
                   ssh, ssh_path, ssh_host, ssh_user, ssh_keep, direct, log_file, log_level,
                   timeout, timeout_stop, foreground,
-                  keep_existing, keep_same, replace_existing, replace_different,
+                  keep_existing, keep_same, replace_existing, replace_different, ignore_owner,
                   retries, region, _parse_tunnel_args)
 
 

--- a/pipe-cli/src/utilities/clean_operations_manager.py
+++ b/pipe-cli/src/utilities/clean_operations_manager.py
@@ -58,15 +58,17 @@ class CleanOperationsManager:
                 continue
             self._remove_dir(tmp_dir_path)
         if any_tmp_dir_without_lock and not quiet:
-            pipe_command = sys.argv[0] if is_frozen() else (sys.executable + ' ' + sys.argv[0])
             click.echo(click.style('Outdated pipe temporary resources have been detected.\n'
                                    'To free up disk space in temporary directory and get rid of this warning please: \n'
                                    '- stop all running pipe cli processes if there are any \n'
                                    '- and execute the following command once. \n\n'
                                    '{pipe_command} clean --force\n'
-                                   .format(pipe_command=pipe_command),
+                                   .format(pipe_command=self._get_current_pipe_command()),
                                    fg='yellow'),
                        err=True)
+
+    def _get_current_pipe_command(self):
+        return sys.argv[0] if is_frozen() else (sys.executable + ' ' + sys.argv[0])
 
     def _clean_pipe_fuse_tmp_dirs(self, config_dir_path):
         logging.debug('Cleaning pipe fuse temporary directories...')

--- a/pipe-cli/src/utilities/ssh_operations.py
+++ b/pipe-cli/src/utilities/ssh_operations.py
@@ -519,9 +519,12 @@ def check_existing_tunnels(host_id, local_ports, remote_ports,
                     raise TunnelError('Same tunnel already exists '
                                       'and it cannot be replaced because it was launched by {tunnel_owner} user '
                                       'which is not the same as the current user {current_owner}. \n\n'
-                                      'Normally there is no need to replace the same tunnel but if it is required '
-                                      'and if you have sufficient permissions you can stop the existing tunnel '
-                                      'by executing the following command once. \n\n'
+                                      'Usually there is no need to replace the same tunnel '
+                                      'but if it is required then you can either '
+                                      'specify other local ports to use for the tunnel '
+                                      'or stop the existing tunnel if you have sufficient permissions. '
+                                      'In order to stop the existing tunnel '
+                                      'execute the following command once. \n\n'
                                       '{pipe_command} tunnel stop -lp {local_ports} --ignore-owner \n'
                                       .format(tunnel_owner=existing_tunnel.owner,
                                               current_owner=get_current_user(),
@@ -531,8 +534,10 @@ def check_existing_tunnels(host_id, local_ports, remote_ports,
                     raise TunnelError('Different tunnel already exists on {local_ports} local ports '
                                       'and it cannot be replaced because it was launched by {tunnel_owner} user '
                                       'which is not the same as the current user {current_owner}. \n\n'
-                                      'If you have sufficient permissions you can stop the existing tunnel '
-                                      'by executing the following command once. \n\n'
+                                      'You can either specify other local ports to use for the tunnel '
+                                      'or stop the existing tunnel if you have sufficient permissions. '
+                                      'In order to stop the existing tunnel '
+                                      'execute the following command once. \n\n'
                                       '{pipe_command} tunnel stop -lp {local_ports} --ignore-owner \n'
                                       .format(tunnel_owner=existing_tunnel.owner,
                                               current_owner=get_current_user(),
@@ -554,8 +559,10 @@ def check_existing_tunnels(host_id, local_ports, remote_ports,
                 raise TunnelError('Different tunnel already exists on {local_ports} local ports '
                                   'and it cannot be replaced because it was launched by {tunnel_owner} user '
                                   'which is not the same as the current user {current_owner}. \n\n'
-                                  'If you have sufficient permissions you can stop the existing tunnel '
-                                  'by executing the following command once. \n\n'
+                                  'You can either specify other local ports to use for the tunnel '
+                                  'or stop the existing tunnel if you have sufficient permissions. '
+                                  'In order to stop the existing tunnel '
+                                  'execute the following command once. \n\n'
                                   '{pipe_command} tunnel stop -lp {local_ports} --ignore-owner \n'
                                   .format(tunnel_owner=existing_tunnel.owner,
                                           current_owner=get_current_user(),
@@ -571,21 +578,56 @@ def check_existing_tunnels(host_id, local_ports, remote_ports,
                               existing_tunnel_args.ssh_path, ssh_user, existing_tunnel_remote_host,
                               log_file, retries)
             sys.exit(0)
-        if is_same_tunnel:
-            raise TunnelError('Same tunnel already exists. \n\n'
-                              'Normally there is no need to replace the same tunnel but if it is required '
-                              'you can stop the existing tunnel '
-                              'by executing the following command once. \n\n'
-                              '{pipe_command} tunnel stop -lp {local_ports} \n'
-                              .format(pipe_command=get_current_pipe_command(),
-                                      local_ports=stringify_ports(existing_tunnel_args.local_ports)))
+        if has_different_owner(existing_tunnel.owner):
+            if is_same_tunnel:
+                raise TunnelError('Same tunnel already exists on {local_ports} local ports. '
+                                  'It was launched by {tunnel_owner} user '
+                                  'which is not the same as the current user {current_owner}. \n\n'
+                                  'Usually there is no need to replace the same tunnel '
+                                  'but if it is required then you can either '
+                                  'specify other local ports to use for the tunnel '
+                                  'or stop the existing tunnel if you have sufficient permissions. '
+                                  'In order to stop the existing tunnel '
+                                  'execute the following command once. \n\n'
+                                  '{pipe_command} tunnel stop -lp {local_ports} --ignore-owner \n'
+                                  .format(tunnel_owner=existing_tunnel.owner,
+                                          current_owner=get_current_user(),
+                                          pipe_command=get_current_pipe_command(),
+                                          local_ports=stringify_ports(existing_tunnel_args.local_ports)))
+            else:
+                raise TunnelError('Different tunnel already exists on {local_ports} local ports. '
+                                  'It was launched by {tunnel_owner} user '
+                                  'which is not the same as the current user {current_owner}. \n\n'
+                                  'You can either specify other local ports to use for the tunnel '
+                                  'or stop the existing tunnel if you have sufficient permissions. '
+                                  'In order to stop the existing tunnel '
+                                  'execute the following command once. \n\n'
+                                  '{pipe_command} tunnel stop -lp {local_ports} --ignore-owner \n'
+                                  .format(tunnel_owner=existing_tunnel.owner,
+                                          current_owner=get_current_user(),
+                                          pipe_command=get_current_pipe_command(),
+                                          local_ports=stringify_ports(existing_tunnel_args.local_ports)))
         else:
-            raise TunnelError('Different tunnel already exists on {local_ports} local ports. \n\n'
-                              'You can stop the existing tunnel '
-                              'by executing the following command once. \n\n'
-                              '{pipe_command} tunnel stop -lp {local_ports} \n'
-                              .format(pipe_command=get_current_pipe_command(),
-                                      local_ports=stringify_ports(existing_tunnel_args.local_ports)))
+            if is_same_tunnel:
+                raise TunnelError('Same tunnel already exists. \n\n'
+                                  'Usually there is no need to replace the same tunnel '
+                                  'but if it is required then you can either '
+                                  'specify other local ports to use for the tunnel '
+                                  'or stop the existing tunnel. '
+                                  'In order to stop the existing tunnel '
+                                  'execute the following command once. \n\n'
+                                  '{pipe_command} tunnel stop -lp {local_ports} \n'
+                                  .format(pipe_command=get_current_pipe_command(),
+                                          local_ports=stringify_ports(existing_tunnel_args.local_ports)))
+            else:
+                raise TunnelError('Different tunnel already exists on {local_ports} local ports. \n\n'
+                                  'You can either specify other local ports to use for the tunnel '
+                                  'or stop the existing tunnel. '
+                                  'In order to stop the existing tunnel '
+                                  'execute the following command once. \n\n'
+                                  '{pipe_command} tunnel stop -lp {local_ports} \n'
+                                  .format(pipe_command=get_current_pipe_command(),
+                                          local_ports=stringify_ports(existing_tunnel_args.local_ports)))
 
 
 def get_current_pipe_command():


### PR DESCRIPTION
Resolves #2365.

The pull request brings exclusive access to pipe tunnel management to its owner. By default only pipe tunnel process owner can stop or replace it. Users are still able to list other user pipe tunnels using `pipe tunnel list` command.

_If a user has efficient permissions_ to other users processes then he/she can manage such processes by using newly added `--ignore-owner` flag.

### Examples

Stop current user tunnel processes.

```
pipe tunnel stop
```

Replace current user tunnel processes.

```
pipe tunnel start pipeline-12345 -lp 4567 -rp 4567 --replace-existing
```

Stop all users tunnel processes.  

```
pipe tunnel stop --ignore-owner
```

Replace all users tunnel processes.

```
pipe tunnel start pipeline-12345 -lp 4567 -rp 4567 --replace-existing --ignore-owner
```
