### PR TITLE
Use common date time format for user and billing reports

### DIFF
--- a/api/src/main/java/com/epam/pipeline/config/Constants.java
+++ b/api/src/main/java/com/epam/pipeline/config/Constants.java
@@ -19,6 +19,8 @@ package com.epam.pipeline.config;
 public final class Constants {
     public static final String FMT_ISO_LOCAL_DATE = "yyyy-MM-dd HH:mm:ss.SSS";
     public static final String TIME_FORMAT = "HH:mm:ss";
+    public static final String ELASTIC_DATE_TIME_FORMAT = FMT_ISO_LOCAL_DATE;
+    public static final String EXPORT_DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm:ss";
     public static final String SECURITY_DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS";
     public static final String SIMPLE_DATE_FORMAT = "yyyyMMdd";
     public static final String SIMPLE_TIME_FORMAT = "HHmmss";

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingUtils.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingUtils.java
@@ -19,8 +19,10 @@ public final class BillingUtils {
     public static final char SEPARATOR = ',';
 
     public static final String YEAR_MONTH_FORMAT = "MMMM yyyy";
-    public static final DateTimeFormatter DATE_TIME_FORMATTER =
-            DateTimeFormatter.ofPattern(Constants.FMT_ISO_LOCAL_DATE, Locale.US);
+    public static final DateTimeFormatter ELASTIC_DATE_TIME_FORMATTER =
+            DateTimeFormatter.ofPattern(Constants.ELASTIC_DATE_TIME_FORMAT, Locale.US);
+    public static final DateTimeFormatter EXPORT_DATE_TIME_FORMATTER =
+            DateTimeFormatter.ofPattern(Constants.EXPORT_DATE_TIME_FORMAT, Locale.US);
     public static final DateTimeFormatter YEAR_MONTH_FORMATTER =
             DateTimeFormatter.ofPattern(YEAR_MONTH_FORMAT, Locale.US);
     public static final int DECIMAL_SCALE = 2;
@@ -116,7 +118,7 @@ public final class BillingUtils {
     }
 
     public static String asString(final LocalDateTime value) {
-        return Optional.ofNullable(value).map(DATE_TIME_FORMATTER::format).orElse(null);
+        return Optional.ofNullable(value).map(EXPORT_DATE_TIME_FORMATTER::format).orElse(null);
     }
 
     public static String asString(final YearMonth value) {
@@ -129,7 +131,7 @@ public final class BillingUtils {
 
     public static LocalDateTime asDateTime(final String value) {
         return Optional.ofNullable(value)
-                .map(it -> DATE_TIME_FORMATTER.parse(it, LocalDateTime::from))
+                .map(it -> ELASTIC_DATE_TIME_FORMATTER.parse(it, LocalDateTime::from))
                 .orElse(null);
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/user/UserExporter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/UserExporter.java
@@ -17,6 +17,7 @@
 
 package com.epam.pipeline.manager.user;
 
+import com.epam.pipeline.config.Constants;
 import com.epam.pipeline.controller.vo.PipelineUserExportVO;
 import com.epam.pipeline.entity.metadata.PipeConfValue;
 import com.epam.pipeline.entity.user.PipelineUserWithStoragePath;
@@ -42,7 +43,7 @@ public class UserExporter {
 
     private static final String LIST_DELIMITER = "|";
     private static final DateTimeFormatter USER_DATE_FORMATTER =
-            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+            DateTimeFormatter.ofPattern(Constants.EXPORT_DATE_TIME_FORMAT);
     public static final String SPACE = " ";
 
     public String exportUsers(final PipelineUserExportVO exportSettings,


### PR DESCRIPTION
Relates to #1716.

The pull request brings common date time format to both user and billing reports. Notice that the chosen date time format is `.xls` compatible: `yyyy-MM-dd HH:mm:ss`.
