### PR TITLE
Issue #2399 Skip certain files during storage size calculation

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/search/StorageFileSearchMask.java
+++ b/api/src/main/java/com/epam/pipeline/entity/search/StorageFileSearchMask.java
@@ -17,10 +17,12 @@
 package com.epam.pipeline.entity.search;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 import java.util.Set;
 
 @AllArgsConstructor
+@Getter
 public class StorageFileSearchMask {
 
     private final String storageName;

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
@@ -59,6 +59,7 @@ import com.epam.pipeline.entity.pipeline.ToolFingerprint;
 import com.epam.pipeline.entity.pipeline.ToolVersionFingerprint;
 import com.epam.pipeline.entity.pipeline.run.parameter.DataStorageLink;
 import com.epam.pipeline.entity.region.AbstractCloudRegion;
+import com.epam.pipeline.entity.search.StorageFileSearchMask;
 import com.epam.pipeline.entity.security.acl.AclClass;
 import com.epam.pipeline.entity.templates.DataStorageTemplate;
 import com.epam.pipeline.entity.user.PipelineUser;
@@ -800,7 +801,17 @@ public class DataStorageManager implements SecuredEntityManager {
 
     public StorageUsage getStorageUsage(final String id, final String path) {
         final AbstractDataStorage dataStorage = loadByNameOrId(id);
-        return searchManager.getStorageUsage(dataStorage, path);
+        final Set<String> storageSizeMasks = loadSizeCalculationMasksMapping()
+            .getOrDefault(dataStorage.getName(), Collections.emptySet());
+        return searchManager.getStorageUsage(dataStorage, path, storageSizeMasks);
+    }
+
+    public Map<String, Set<String>> loadSizeCalculationMasksMapping() {
+        return Optional.ofNullable(preferenceManager.getPreference(SystemPreferences.STORAGE_SIZE_MASK_RULES))
+            .orElse(Collections.emptyList())
+            .stream()
+            .collect(Collectors.toMap(StorageFileSearchMask::getStorageName,
+                                      StorageFileSearchMask::getHiddenFilePathGlobs));
     }
 
     public void requestDataStorageDavMount(final Long id, final Long time) {

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
@@ -813,11 +813,11 @@ public class DataStorageManager implements SecuredEntityManager {
             .stream()
             .collect(Collectors.groupingBy(StorageFileSearchMask::getStorageName,
                                            Collector.of(HashSet::new,
-                                                        (set, mask) -> set.addAll(mask.getHiddenFilePathGlobs()),
-                                                        (left, right) -> {
-                                                            left.addAll(right);
-                                                            return left;
-                                                        })));
+                                               (set, mask) -> set.addAll(mask.getHiddenFilePathGlobs()),
+                                               (left, right) -> {
+                                                   left.addAll(right);
+                                                   return left;
+                                               })));
     }
 
     public void requestDataStorageDavMount(final Long id, final Long time) {

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
@@ -808,7 +808,7 @@ public class DataStorageManager implements SecuredEntityManager {
     }
 
     public Map<String, Set<String>> loadSizeCalculationMasksMapping() {
-        return Optional.ofNullable(preferenceManager.getPreference(SystemPreferences.STORAGE_SIZE_MASK_RULES))
+        return Optional.ofNullable(preferenceManager.getPreference(SystemPreferences.STORAGE_QUOTAS_SKIPPED_PATHS))
             .orElse(Collections.emptyList())
             .stream()
             .collect(Collectors.groupingBy(StorageFileSearchMask::getStorageName,

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSQuotasMonitor.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSQuotasMonitor.java
@@ -41,7 +41,6 @@ import com.epam.pipeline.manager.datastorage.FileShareMountManager;
 import com.epam.pipeline.manager.datastorage.lustre.LustreFSManager;
 import com.epam.pipeline.manager.metadata.MetadataManager;
 import com.epam.pipeline.manager.notification.NotificationManager;
-import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.search.SearchManager;
 import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.extern.slf4j.Slf4j;
@@ -75,7 +74,6 @@ public class NFSQuotasMonitor {
     private final LustreFSManager lustreManager;
     private final MessageHelper messageHelper;
     private final NotificationManager notificationManager;
-    private final PreferenceManager preferenceManager;
     private final String notificationsKey;
     private final NFSStorageMountStatus defaultRestrictiveStatus;
     private final Map<Long, NFSQuotaNotificationEntry> notificationTriggers;
@@ -87,7 +85,6 @@ public class NFSQuotasMonitor {
                             final LustreFSManager lustreManager,
                             final MessageHelper messageHelper,
                             final NotificationManager notificationManager,
-                            final PreferenceManager preferenceManager,
                             final @Value("${data.storage.nfs.quota.metadata.key:fs_notifications}")
                                         String notificationsKey,
                             final @Value("${data.storage.nfs.quota.default.restrictive.status:READ_ONLY}")
@@ -99,7 +96,6 @@ public class NFSQuotasMonitor {
         this.lustreManager = lustreManager;
         this.messageHelper = messageHelper;
         this.notificationManager = notificationManager;
-        this.preferenceManager = preferenceManager;
         this.notificationsKey = notificationsKey;
         this.defaultRestrictiveStatus = defaultRestrictiveStatus;
         this.notificationTriggers = new ConcurrentHashMap<>();

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSQuotasMonitor.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSQuotasMonitor.java
@@ -254,7 +254,7 @@ public class NFSQuotasMonitor {
 
     private boolean exceedsAbsoluteLimit(final Double originalLimit, final StorageUsage storageUsage) {
         final long limitBytes = (long) (originalLimit * GB_TO_BYTES);
-        return storageUsage.getSize() > limitBytes;
+        return storageUsage.getEffectiveSize() > limitBytes;
     }
 
     private boolean exceedsPercentageLimit(final NFSDataStorage storage, final Double originalLimit,
@@ -266,7 +266,7 @@ public class NFSQuotasMonitor {
                 return lustreManager.findLustreFS(shareMount)
                     .map(LustreFS::getCapacityGb)
                     .map(maxSize -> convertLustrePercentageLimitToAbsoluteValue(originalLimit, maxSize) * GB_TO_BYTES)
-                    .map(limit -> storageUsage.getSize() > limit)
+                    .map(limit -> storageUsage.getEffectiveSize() > limit)
                     .orElse(false);
             case NFS:
                 log.warn(messageHelper.getMessage(MessageConstants.STORAGE_QUOTA_NFS_PERCENTAGE_QUOTA_WARN,

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -823,6 +823,13 @@ public class SystemPreferences {
         SEARCH_GROUP,
         isNullOrValidJson(new TypeReference<List<StorageFileSearchMask>>() {}));
 
+    public static final ObjectPreference<List<StorageFileSearchMask>> STORAGE_SIZE_MASK_RULES = new ObjectPreference<>(
+        "storage.size.calculation.mask",
+        Collections.emptyList(),
+        new TypeReference<List<StorageFileSearchMask>>() {},
+        SEARCH_GROUP,
+        isNullOrValidJson(new TypeReference<List<StorageFileSearchMask>>() {}));
+
     // Grid engine autoscaling
     public static final IntPreference GE_AUTOSCALING_SCALE_UP_TIMEOUT =
             new IntPreference("ge.autoscaling.scale.up.timeout", 30,

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -232,6 +232,17 @@ public class SystemPreferences {
     public static final StringPreference STORAGE_FSBROWSER_BLACK_LIST = new StringPreference(
             "storage.fsbrowser.black.list", STORAGE_FSBROWSER_BLACK_LIST_DEFAULT, DATA_STORAGE_GROUP, pass);
 
+    /**
+     * Storage quotas configuration
+     */
+    public static final ObjectPreference<List<StorageFileSearchMask>> STORAGE_QUOTAS_SKIPPED_PATHS =
+        new ObjectPreference<>(
+            "storage.quotas.skipped.paths",
+            Collections.emptyList(),
+            new TypeReference<List<StorageFileSearchMask>>() {},
+            DATA_STORAGE_GROUP,
+            isNullOrValidJson(new TypeReference<List<StorageFileSearchMask>>() {}));
+
     // GIT_GROUP
     public static final StringPreference GIT_HOST = new StringPreference("git.host", null, GIT_GROUP, null);
     public static final StringPreference GIT_READER_HOST =
@@ -818,13 +829,6 @@ public class SystemPreferences {
 
     public static final ObjectPreference<List<StorageFileSearchMask>> FILE_SEARCH_MASK_RULES = new ObjectPreference<>(
         "search.storage.elements.hide.mask",
-        Collections.emptyList(),
-        new TypeReference<List<StorageFileSearchMask>>() {},
-        SEARCH_GROUP,
-        isNullOrValidJson(new TypeReference<List<StorageFileSearchMask>>() {}));
-
-    public static final ObjectPreference<List<StorageFileSearchMask>> STORAGE_SIZE_MASK_RULES = new ObjectPreference<>(
-        "storage.size.calculation.mask",
         Collections.emptyList(),
         new TypeReference<List<StorageFileSearchMask>>() {},
         SEARCH_GROUP,

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchManager.java
@@ -28,6 +28,7 @@ import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.manager.utils.GlobalSearchElasticHelper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.elasticsearch.action.search.MultiSearchRequest;
@@ -84,7 +85,8 @@ public class SearchManager {
             final MultiSearchRequest request = requestBuilder.buildStorageSumRequest(
                     dataStorage.getId(), dataStorage.getType(), path, allowNoIndex, storageSizeMasks);
             final MultiSearchResponse searchResponse = client.msearch(request, RequestOptions.DEFAULT);
-            return resultConverter.buildStorageUsageResponse(searchResponse, dataStorage, path);
+            final int responsesExpected = CollectionUtils.isEmpty(storageSizeMasks) ? 1 : 2;
+            return resultConverter.buildStorageUsageResponse(searchResponse, dataStorage, path, responsesExpected);
         } catch (IOException e) {
             log.error(e.getMessage(), e);
             throw new SearchException(e.getMessage(), e);

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchManager.java
@@ -30,6 +30,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.elasticsearch.action.search.MultiSearchRequest;
+import org.elasticsearch.action.search.MultiSearchResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.RequestOptions;
@@ -71,16 +73,17 @@ public class SearchManager {
         }
     }
 
-    public StorageUsage getStorageUsage(final AbstractDataStorage dataStorage, final String path) {
-        return getStorageUsage(dataStorage, path, false);
+    public StorageUsage getStorageUsage(final AbstractDataStorage dataStorage, final String path,
+                                        final Set<String> storageSizeMasks) {
+        return getStorageUsage(dataStorage, path, false, storageSizeMasks);
     }
 
     public StorageUsage getStorageUsage(final AbstractDataStorage dataStorage, final String path,
-                                        final boolean allowNoIndex) {
+                                        final boolean allowNoIndex, final Set<String> storageSizeMasks) {
         try (RestHighLevelClient client = globalSearchElasticHelper.buildClient()) {
-            final SearchRequest request = requestBuilder.buildSumAggregationForStorage(
-                    dataStorage.getId(), dataStorage.getType(), path, allowNoIndex);
-            final SearchResponse searchResponse = client.search(request, RequestOptions.DEFAULT);
+            final MultiSearchRequest request = requestBuilder.buildStorageSumRequest(
+                    dataStorage.getId(), dataStorage.getType(), path, allowNoIndex, storageSizeMasks);
+            final MultiSearchResponse searchResponse = client.msearch(request, RequestOptions.DEFAULT);
             return resultConverter.buildStorageUsageResponse(searchResponse, dataStorage, path);
         } catch (IOException e) {
             log.error(e.getMessage(), e);

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchRequestBuilder.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchRequestBuilder.java
@@ -43,6 +43,7 @@ import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
+import org.elasticsearch.action.search.MultiSearchRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.Strings;
@@ -144,16 +145,32 @@ public class SearchRequestBuilder {
                 .source(searchSource);
     }
 
-    public SearchRequest buildSumAggregationForStorage(final Long storageId, final DataStorageType storageType,
-                                                       final String path, final boolean allowNoIndex) {
+    public MultiSearchRequest buildStorageSumRequest(final Long storageId, final DataStorageType storageType,
+                                                     final String path, final boolean allowNoIndex,
+                                                     final Set<String> storageSizeMasks) {
+        final MultiSearchRequest multiSearchRequest = new MultiSearchRequest();
+        multiSearchRequest.add(buildSumAggRequest(storageId, storageType, path, allowNoIndex, null));
+        if (CollectionUtils.isNotEmpty(storageSizeMasks)) {
+            multiSearchRequest.add(buildSumAggRequest(storageId, storageType, path, allowNoIndex, storageSizeMasks));
+        }
+        return multiSearchRequest;
+    }
+
+    private SearchRequest buildSumAggRequest(final Long storageId, final DataStorageType storageType,
+                                             final String path, final boolean allowNoIndex,
+                                             final Set<String> storageSizeMasks) {
         final String searchIndex =
             String.format(ES_FILE_INDEX_PATTERN, storageType.toString().toLowerCase(), storageId);
         final SumAggregationBuilder sizeSumAggregator = AggregationBuilders.sum(STORAGE_SIZE_AGG_NAME)
                 .field(SIZE_FIELD);
         final SearchSourceBuilder sizeSumSearch = new SearchSourceBuilder().aggregation(sizeSumAggregator);
+        final BoolQueryBuilder boolQuery = QueryBuilders.boolQuery();
+        CollectionUtils.emptyIfNull(storageSizeMasks)
+            .forEach(mask -> boolQuery.mustNot(QueryBuilders.wildcardQuery(NAME_FIELD, mask)));
         if (StringUtils.isNotBlank(path)) {
-            sizeSumSearch.query(QueryBuilders.prefixQuery(NAME_FIELD, path));
+            boolQuery.must(QueryBuilders.prefixQuery(NAME_FIELD, path));
         }
+        sizeSumSearch.query(boolQuery);
         final SearchRequest request = new SearchRequest()
                 .indices(searchIndex)
                 .source(sizeSumSearch);

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchRequestBuilder.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchRequestBuilder.java
@@ -164,13 +164,13 @@ public class SearchRequestBuilder {
         final SumAggregationBuilder sizeSumAggregator = AggregationBuilders.sum(STORAGE_SIZE_AGG_NAME)
                 .field(SIZE_FIELD);
         final SearchSourceBuilder sizeSumSearch = new SearchSourceBuilder().aggregation(sizeSumAggregator);
-        final BoolQueryBuilder boolQuery = QueryBuilders.boolQuery();
+        final BoolQueryBuilder fileMatchersQuery = QueryBuilders.boolQuery();
         CollectionUtils.emptyIfNull(storageSizeMasks)
-            .forEach(mask -> boolQuery.mustNot(QueryBuilders.wildcardQuery(NAME_FIELD, mask)));
+            .forEach(mask -> fileMatchersQuery.mustNot(QueryBuilders.wildcardQuery(NAME_FIELD, mask)));
         if (StringUtils.isNotBlank(path)) {
-            boolQuery.must(QueryBuilders.prefixQuery(NAME_FIELD, path));
+            fileMatchersQuery.must(QueryBuilders.prefixQuery(NAME_FIELD, path));
         }
-        sizeSumSearch.query(boolQuery);
+        sizeSumSearch.query(fileMatchersQuery);
         final SearchRequest request = new SearchRequest()
                 .indices(searchIndex)
                 .source(sizeSumSearch);

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchResultConverter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchResultConverter.java
@@ -23,10 +23,12 @@ import com.epam.pipeline.entity.search.FacetedSearchResult;
 import com.epam.pipeline.entity.search.SearchDocument;
 import com.epam.pipeline.entity.search.SearchDocumentType;
 import com.epam.pipeline.entity.search.SearchResult;
+import com.epam.pipeline.exception.search.SearchException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.elasticsearch.action.search.MultiSearchResponse;
@@ -74,13 +76,14 @@ public class SearchResultConverter {
     }
 
     public StorageUsage buildStorageUsageResponse(final MultiSearchResponse searchResponse,
-                                                  final AbstractDataStorage dataStorage, final String path) {
-        final MultiSearchResponse.Item[] responses = searchResponse.getResponses();
-        final SearchResponse allDocsResponse = responses[0].getResponse();
+                                                  final AbstractDataStorage dataStorage, final String path,
+                                                  final int responsesExpected) {
+        final MultiSearchResponse.Item[] responses = tryExtractAllResponses(searchResponse, responsesExpected);
+        final SearchResponse allDocsResponse = tryExtractResponse(responses, 0);
         final Long totalSize = extractSizeAggregationFromResponse(allDocsResponse);
         final Long effectiveSize;
-        if (responses.length > 1) {
-            final SearchResponse effectiveDocsResponse = responses[1].getResponse();
+        if (responses.length != 1) {
+            final SearchResponse effectiveDocsResponse = tryExtractResponse(responses, 1);
             effectiveSize = extractSizeAggregationFromResponse(effectiveDocsResponse);
         } else {
             effectiveSize = totalSize;
@@ -229,6 +232,36 @@ public class SearchResultConverter {
         }
         return ListUtils.emptyIfNull(fieldAggregation.getBuckets()).stream()
                 .collect(Collectors.toMap(Terms.Bucket::getKeyAsString, Terms.Bucket::getDocCount));
+    }
+
+    private MultiSearchResponse.Item[] tryExtractAllResponses(final MultiSearchResponse searchResponse,
+                                                              final int responsesExpected) {
+        final MultiSearchResponse.Item[] items = Optional.ofNullable(searchResponse)
+            .map(MultiSearchResponse::getResponses)
+            .filter(searchResponses -> ArrayUtils.getLength(searchResponses) > 0)
+            .orElseThrow(() -> new SearchException(
+                "Empty multi-search response from ES, unable to calculate storage consumption."));
+        final int responsesCount = items.length;
+        if (responsesExpected != items.length) {
+            throw new SearchException(String.format(
+                "Unexpected number of responses during storage size calculation: %d expected, but %d found.",
+                responsesExpected, responsesCount));
+        }
+        return items;
+    }
+
+    private SearchResponse tryExtractResponse(final MultiSearchResponse.Item[] responses, final int index) {
+        final MultiSearchResponse.Item responseItem = responses[index];
+        if (responseItem == null) {
+            throw new SearchException(
+                String.format("Empty response item with id=[%d], unable to return storage usage.", index));
+        }
+        if (responseItem.isFailure()) {
+            throw new SearchException(
+                String.format("Error in response item with id=[%d], unable to return storage usage: %s",
+                              index, responseItem.getFailureMessage()));
+        }
+        return responseItem.getResponse();
     }
 
     private Long extractSizeAggregationFromResponse(final SearchResponse searchResponse) {

--- a/api/src/test/java/com/epam/pipeline/test/creator/datastorage/DatastorageCreatorUtils.java
+++ b/api/src/test/java/com/epam/pipeline/test/creator/datastorage/DatastorageCreatorUtils.java
@@ -260,7 +260,7 @@ public final class DatastorageCreatorUtils {
     }
 
     public static StorageUsage getStorageUsage() {
-        return new StorageUsage(ID, TEST_STRING, DataStorageType.S3, TEST_PATH, ID, ID);
+        return new StorageUsage(ID, TEST_STRING, DataStorageType.S3, TEST_PATH, ID, ID, ID);
     }
 
     public static StorageMountPath getDefaultStorageMountPath() {

--- a/core/src/main/java/com/epam/pipeline/entity/datastorage/StorageUsage.java
+++ b/core/src/main/java/com/epam/pipeline/entity/datastorage/StorageUsage.java
@@ -29,5 +29,6 @@ public class StorageUsage {
     private DataStorageType type;
     private String path;
     private Long size;
+    private Long effectiveSize;
     private Long count;
 }


### PR DESCRIPTION
This PR is related to issue #2399

It allows specifying masking rules for storage volume computation - files matching those masks are not affecting 'effective' storage size, which is used for quotas control from now on.
- volume calculation masks have the same format, as search hiding ones (`StorageFileSearchMask`), and are specified via system preferences as well
- `StorageUsage` received a new `effectiveSize` attribute
- masks are used in a separate request for 'effective' size retrieval (`MultiSearchRequest` is performed to receive both 'total' and 'effective' values at one request to ES)