### PR TITLE
Retrieve system logs from subsets of indices

### DIFF
--- a/api/profiles/dev/application.properties
+++ b/api/profiles/dev/application.properties
@@ -193,7 +193,7 @@ billing.center.key=${CP_BILLING_CENTER_KEY:billing-center}
 
 
 #logging
-log.security.elastic.index.prefix=${CP_SECURITY_LOGS_ELASTIC_PREFIX:security_log}*
+log.security.elastic.index.prefix=${CP_SECURITY_LOGS_ELASTIC_PREFIX:security_log}
 
 migration.alias.file=${CP_API_MIGRATION_ALIAS_FILE:}
 

--- a/deploy/docker/cp-api-srv/config/application.properties
+++ b/deploy/docker/cp-api-srv/config/application.properties
@@ -162,7 +162,7 @@ billing.index.common.prefix=cp-billing
 billing.center.key=${CP_BILLING_CENTER_KEY:billing-center}
 
 #logging
-log.security.elastic.index.prefix=${CP_SECURITY_LOGS_ELASTIC_PREFIX:security_log}*
+log.security.elastic.index.prefix=${CP_SECURITY_LOGS_ELASTIC_PREFIX:security_log}
 
 migration.alias.file=${CP_API_MIGRATION_ALIAS_FILE:}
 


### PR DESCRIPTION
Relates to #2407 and depends on #2416.

The pull request improves system logs searching by using only a subset of per day indices. Notice that it searches two adjacent per day indices in order to collect all documents of a requested period.
