### PR TITLE
Issue #2399 Add Ant-style patterns support for a storage name

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
@@ -802,8 +802,7 @@ public class DataStorageManager implements SecuredEntityManager {
 
     public StorageUsage getStorageUsage(final String id, final String path) {
         final AbstractDataStorage dataStorage = loadByNameOrId(id);
-        final Set<String> storageSizeMasks = loadSizeCalculationMasksMapping()
-            .getOrDefault(dataStorage.getName(), Collections.emptySet());
+        final Set<String> storageSizeMasks = resolveSizeMasks(loadSizeCalculationMasksMapping(), dataStorage);
         return searchManager.getStorageUsage(dataStorage, path, storageSizeMasks);
     }
 
@@ -818,6 +817,18 @@ public class DataStorageManager implements SecuredEntityManager {
                                                    left.addAll(right);
                                                    return left;
                                                })));
+    }
+
+    public Set<String> resolveSizeMasks(final Map<String, Set<String>> masksMapping,
+                                        final AbstractDataStorage storage) {
+        final String storageName = storage.getName();
+        final AntPathMatcher matcher = new AntPathMatcher();
+        return MapUtils.emptyIfNull(masksMapping).entrySet()
+            .stream()
+            .filter(e -> matcher.match(e.getKey(), storageName))
+            .map(Map.Entry::getValue)
+            .flatMap(Collection::stream)
+            .collect(Collectors.toSet());
     }
 
     public void requestDataStorageDavMount(final Long id, final Long time) {

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSQuotasMonitor.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSQuotasMonitor.java
@@ -50,7 +50,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -112,8 +111,8 @@ public class NFSQuotasMonitor {
         final Map<String, Set<String>> storageSizeMasksMapping = dataStorageManager.loadSizeCalculationMasksMapping();
         nfsDataStorages.forEach(storage -> {
             final NFSStorageMountStatus statusUpdate = Optional.ofNullable(activeQuotas.get(storage.getId()))
-                .map(quota -> processActiveQuota(quota, storage, storageSizeMasksMapping
-                    .getOrDefault(storage.getName(), Collections.emptySet())))
+                .map(quota -> processActiveQuota(
+                    quota, storage, dataStorageManager.resolveSizeMasks(storageSizeMasksMapping, storage)))
                 .orElse(NFSStorageMountStatus.ACTIVE);
             dataStorageManager.updateMountStatus(storage, statusUpdate);
         });

--- a/api/src/test/java/com/epam/pipeline/manager/datastorage/DataStorageManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/datastorage/DataStorageManagerTest.java
@@ -621,6 +621,7 @@ public class DataStorageManagerTest extends AbstractSpringTest {
     }
 
     @Test
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void testResolveSizeMasks() {
         final String firstStorageName = "storage1";
         final String secondStorageName = "storage2";

--- a/api/src/test/java/com/epam/pipeline/manager/datastorage/DataStorageManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/datastorage/DataStorageManagerTest.java
@@ -51,6 +51,7 @@ import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.manager.region.CloudRegionManager;
 import com.epam.pipeline.util.TestUtils;
+import com.google.common.collect.Sets;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.junit.Assert;
@@ -67,11 +68,15 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -613,6 +618,41 @@ public class DataStorageManagerTest extends AbstractSpringTest {
                                                                             TEST_MOUNT_OPTIONS);
         storageManager.create(storageVO, false, false, false);
         Assert.assertFalse(storageManager.createDefaultStorageForUser(NAME).isPresent());
+    }
+
+    @Test
+    public void testResolveSizeMasks() {
+        final String firstStorageName = "storage1";
+        final String secondStorageName = "storage2";
+        final String thirdStorageName = "anotherStorage";
+
+        final String mask1 = "mask1";
+        final String mask2 = "mask2";
+        final String mask3 = "mask3";
+        final String mask4 = "mask4";
+        final String mask5 = "mask5";
+
+        final Map<String, Set<String>> sizeMasks = new HashMap<>();
+        final String wildcardRegex = "*";
+        final String firstAndSecondPrefixRegex = "storage*";
+        sizeMasks.put(wildcardRegex, Sets.newHashSet(mask1, mask2));
+        sizeMasks.put(firstStorageName, Sets.newHashSet(mask3, mask4));
+        sizeMasks.put(firstAndSecondPrefixRegex, Sets.newHashSet(mask4, mask5));
+
+        assertResolvedSizeMasks(sizeMasks, firstStorageName, mask1, mask2, mask3, mask4, mask5);
+        assertResolvedSizeMasks(sizeMasks, secondStorageName, mask1, mask2, mask4, mask5);
+        assertResolvedSizeMasks(sizeMasks, thirdStorageName, mask1, mask2);
+    }
+
+    private void assertResolvedSizeMasks(final Map<String, Set<String>> masksMapping, final String storageName,
+                                         final String... expectedMasks) {
+        final AbstractDataStorage storage = new NFSDataStorage();
+        storage.setName(storageName);
+        final int initialMappingSize = masksMapping.size();
+        assertThat(storageManager.resolveSizeMasks(masksMapping, storage))
+            .hasSize(expectedMasks.length)
+            .containsOnly(expectedMasks);
+        assertThat(masksMapping).hasSize(initialMappingSize);
     }
 
     private void assertDataStorageAccordingToUpdateStorageVO(DataStorageVO updateStorageVO,


### PR DESCRIPTION
This PR is related to issue #2399 

It brings the support of "wildcards" (Ant-style patterns) for the storage name, allowing specifying in one entry a mask, that will be applied to multiple storages.