### PR TITLE
Issue #2232 NAT error handling impovements

### DIFF
--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -695,6 +695,12 @@ public final class MessageConstants {
         "nat.gateway.route.creation.kube.dns.restart.error";
     public static final String NAT_ROUTE_EXTENDING_INVALID_EXTERNAL_IP =
         "nat.gateway.route.extending.invalid.external.ip";
+    public static final String NAT_SERVICE_CONFIG_ERROR_NO_CLUSTER_IP = "nat.gateway.service.config.no.cluster.ip";
+    public static final String NAT_SERVICE_CONFIG_GENERAL_ERROR = "nat.gateway.service.config.general.error";
+    public static final String NAT_SERVICE_CONFIG_EMPTY_ANNOTATIONS_WITH_PORTS =
+        "nat.gateway.service.config.empty.annotations.with.ports.warn";
+    public static final String NAT_ROUTE_CONFIG_WARN_UNKNOWN_STATUS_PORT =
+        "nat.gateway.route.config.port.unknown.status";
 
     public static final String NAT_ROUTE_REMOVAL_NO_PORT_SPECIFIED = "nat.gateway.route.removal.port.not.found";
     public static final String NAT_ROUTE_REMOVAL_DNS_MASK_REMOVAL_FAILED = "nat.gateway.route.removal.dns.failed";

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/NatGatewayManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/NatGatewayManager.java
@@ -564,6 +564,7 @@ public class NatGatewayManager {
         final Map<String, String> requiredProxyServiceLabels = new HashMap<>();
         requiredProxyServiceLabels.put(getCurrentStatusLabelName(externalPort), statusInQueue.name());
         requiredProxyServiceLabels.put(getLastUpdateTimeLabelName(externalPort), getCurrentTimeString());
+        requiredProxyServiceLabels.put(getErrorDetailsLabelName(externalPort), null);
         final NatRouteStatus targetStatus = statusInQueue.isTerminationState()
                                             ? NatRouteStatus.TERMINATED
                                             : NatRouteStatus.ACTIVE;
@@ -921,6 +922,7 @@ public class NatGatewayManager {
         final Map<String, String> annotations = new HashMap<>();
         annotations.put(getCurrentStatusLabelName(externalPort), status.name());
         annotations.put(getLastUpdateTimeLabelName(externalPort), getCurrentTimeString());
+        annotations.put(getErrorDetailsLabelName(externalPort), null);
         if (errorMessage != null) {
             annotations.put(getErrorDetailsLabelName(externalPort), errorMessage);
             annotations.put(getTargetStatusLabelName(externalPort), NatRouteStatus.TERMINATED.name());
@@ -936,6 +938,7 @@ public class NatGatewayManager {
                                                 final String defaultValue) {
         return Optional.ofNullable(serviceAnnotations)
             .map(annotations -> annotations.get(labelName))
+            .map(StringUtils::trimToNull)
             .orElse(defaultValue);
     }
 

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -631,6 +631,10 @@ nat.gateway.route.creation.port.generation.failed=Unable to generate new target 
 nat.gateway.route.creation.new.service.failed=New service creation for the route id={0} failed: {1}
 nat.gateway.route.creation.existing.service.add.port=Adding route id={0} to the existing service ''{1}''
 nat.gateway.route.creation.existing.service.add.port.failed=Adding route id={0} to existing service ''{1}'' failed
+nat.gateway.service.config.no.cluster.ip=No cluster IP found for ''{0}''.
+nat.gateway.route.config.port.unknown.status=At least one of the {0}:{1} statuses [current={2}, target={3}] is not specified, skipping processing.
+nat.gateway.service.config.general.error=An error occurred during ''{0}'' configuration: {1}
+nat.gateway.service.config.empty.annotations.with.ports.warn=Ports found for the service ''{0}'', but no annotations, skipping processing.
 
 nat.gateway.route.removal.port.not.found=No active port {0} is defined for ''{1}''
 nat.gateway.route.removal.deploy.refresh.failed=Errors during deployment refresh.


### PR DESCRIPTION
This PR is related to issue #2232 

It improves route processing error handling. Some of the services (the ones created manually, but in transition under NAT manager control) might match listing selectors, which might lead to incorrect behavior:
1. Listing fails, as such services don't have all the expected required details in the annotations (or no annotations at all) and NPE occurs
2. They might be considered by NAT daemon as the ones to be terminated

To avoid situations mentioned above:
1. All of the operations regarding retrieving data from annotations are performed with `Optional` wrapping and default values (`UNKNOWN` or `null`)
2. Service processing is skipped if no annotations are found, but ports are presented in a service spec
3. Service processing is wrapped with `try-catch` to avoid complete failure of the monitoring cycle

Besides, some changes were made in a process of automatic failure recovering: previously, if route creation failed, all of the information (ports of the service, entries in config maps) were cleaned up immediately.
It seems confusing, as in the case of a failure route just disappearing from listing results.
It is proposed to keep a port on a service (data from config maps still purged immediately) - this way route exists till the next monitoring cycle with the termination scheduled, but at least, during the listing, we are able to see the route with some error message after an unsuccessful configuration.