### PR TITLE
Issue #2433: [Platform usage] Show user statuses

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/user/UserApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/user/UserApiService.java
@@ -132,6 +132,11 @@ public class UserApiService {
     }
 
     @PreAuthorize(ADMIN_OR_GENERAL_USER + OR_USER_READER)
+    public List<PipelineUser> loadUsersWithActivityStatus() {
+        return new ArrayList<>(userManager.loadUsersWithActivityStatus());
+    }
+
+    @PreAuthorize(ADMIN_OR_GENERAL_USER + OR_USER_READER)
     public List<UserInfo> loadUsersInfo(final List<String> userNames) {
         return userManager.loadUsersInfo(userNames);
     }

--- a/api/src/main/java/com/epam/pipeline/acl/user/UserApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/user/UserApiService.java
@@ -131,7 +131,7 @@ public class UserApiService {
         return new ArrayList<>(userManager.loadAllUsers());
     }
 
-    @PreAuthorize(ADMIN_OR_GENERAL_USER + OR_USER_READER)
+    @PreAuthorize(ADMIN_ONLY + OR_USER_READER)
     public List<PipelineUser> loadUsersWithActivityStatus() {
         return new ArrayList<>(userManager.loadUsersWithActivityStatus());
     }

--- a/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
@@ -223,8 +223,10 @@ public class UserController extends AbstractRestController {
     @ApiResponses(
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
             })
-    public Result<List<PipelineUser>> loadUsers() {
-        return Result.success(userApiService.loadUsers());
+    public Result<List<PipelineUser>> loadUsers(@RequestParam(defaultValue = "false") final boolean activities) {
+        return Result.success(activities
+                ? userApiService.loadUsersWithActivityStatus()
+                : userApiService.loadUsers());
     }
 
     @GetMapping(value = "/users/info")

--- a/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
@@ -223,8 +223,8 @@ public class UserController extends AbstractRestController {
     @ApiResponses(
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
             })
-    public Result<List<PipelineUser>> loadUsers(@RequestParam(defaultValue = "false") final boolean activities) {
-        return Result.success(activities
+    public Result<List<PipelineUser>> loadUsers(@RequestParam(defaultValue = "false") final boolean activity) {
+        return Result.success(activity
                 ? userApiService.loadUsersWithActivityStatus()
                 : userApiService.loadUsers());
     }

--- a/api/src/main/java/com/epam/pipeline/dao/user/UserDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/user/UserDao.java
@@ -53,6 +53,7 @@ public class UserDao extends NamedParameterJdbcDaoSupport {
     private String createUserQuery;
     private String updateUserQuery;
     private String loadAllUsersQuery;
+    private String loadAllUsersWithActivityStateQuery;
     private String loadAllUsersWithDefaultDataStoragePathQuery;
     private String loadUserByNameQuery;
     private String loadUsersByNamesQuery;
@@ -100,6 +101,12 @@ public class UserDao extends NamedParameterJdbcDaoSupport {
 
     public Collection<PipelineUser> loadAllUsers() {
         return getJdbcTemplate().query(loadAllUsersQuery, UserParameters.getUserExtractor());
+    }
+
+    public Collection<PipelineUser> loadUsersWithActivityStatus() {
+        return getJdbcTemplate().query(loadAllUsersWithActivityStateQuery,
+                UserParameters.getUserExtractor(true),
+                System.currentTimeMillis());
     }
 
     public Collection<PipelineUserWithStoragePath> loadAllUsersWithDataStoragePath() {
@@ -251,7 +258,8 @@ public class UserDao extends NamedParameterJdbcDaoSupport {
         REGISTRATION_DATE,
         FIRST_LOGIN_DATE,
         USER_BLOCK_DATE,
-        LAST_LOGIN_DATE;
+        LAST_LOGIN_DATE,
+        ONLINE;
 
         private static MapSqlParameterSource getParameterSource(Long userId, Long roleId) {
             MapSqlParameterSource params = new MapSqlParameterSource();
@@ -281,13 +289,17 @@ public class UserDao extends NamedParameterJdbcDaoSupport {
         }
 
         static ResultSetExtractor<Collection<PipelineUser>> getUserExtractor() {
-            return (ResultSet rs) -> {
+            return getUserExtractor(false);
+        }
+
+        static ResultSetExtractor<Collection<PipelineUser>> getUserExtractor(final boolean loadActivityState) {
+            return (rs) -> {
                 Map<Long, PipelineUser> users = new HashMap<>();
                 while (rs.next()) {
                     Long userId = rs.getLong(USER_ID.name());
                     PipelineUser user = users.get(userId);
                     if (user == null) {
-                        user = parseUser(rs, userId);
+                        user = parseUser(rs, userId, loadActivityState);
                         users.put(userId, user);
                     }
                     rs.getLong(RoleParameters.ROLE_ID.name());
@@ -325,7 +337,12 @@ public class UserDao extends NamedParameterJdbcDaoSupport {
             };
         }
 
-        static PipelineUser parseUser(ResultSet rs, Long userId) throws SQLException {
+        static PipelineUser parseUser(final ResultSet rs, final Long userId) throws SQLException {
+            return parseUser(rs, userId, false);
+        }
+
+        static PipelineUser parseUser(final ResultSet rs, final Long userId,
+                                      final boolean loadActivityState) throws SQLException {
             PipelineUser user = new PipelineUser();
             user.setId(userId);
             user.setUserName(rs.getString(USER_NAME.name()));
@@ -352,6 +369,9 @@ public class UserDao extends NamedParameterJdbcDaoSupport {
             long defaultProfileId = rs.getLong(USER_DEFAULT_PROFILE_ID.name());
             if (!rs.wasNull()) {
                 user.setDefaultProfileId(defaultProfileId);
+            }
+            if (loadActivityState) {
+                user.setOnline(rs.getBoolean(ONLINE.name()));
             }
             return user;
         }
@@ -424,6 +444,10 @@ public class UserDao extends NamedParameterJdbcDaoSupport {
         this.loadAllUsersQuery = loadAllUsersQuery;
     }
 
+    @Required
+    public void setLoadAllUsersWithActivityStateQuery(final String loadAllUsersWithActivityStateQuery) {
+        this.loadAllUsersWithActivityStateQuery = loadAllUsersWithActivityStateQuery;
+    }
 
     @Required
     public void setFindUsersByPrefixQuery(String findUsersByPrefixQuery) {

--- a/api/src/main/java/com/epam/pipeline/manager/user/UserManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/UserManager.java
@@ -191,6 +191,13 @@ public class UserManager {
         return userDao.loadAllUsers();
     }
 
+    public Collection<PipelineUser> loadUsersWithActivityStatus() {
+        final PipelineUser currentUser = getCurrentUser();
+        return currentUser.isAdmin()
+                ? userDao.loadUsersWithActivityStatus()
+                : loadAllUsers();
+    }
+
     public List<UserInfo> loadUsersInfo(final List<String> userNames) {
         final Collection<PipelineUser> users = CollectionUtils.isEmpty(userNames) ? loadAllUsers() :
                 loadUsersByNames(userNames);

--- a/api/src/main/resources/dao/user-dao.xml
+++ b/api/src/main/resources/dao/user-dao.xml
@@ -86,6 +86,40 @@
                 ]]>
             </value>
         </property>
+        <property name="loadAllUsersWithActivityStateQuery">
+            <value>
+                <![CDATA[
+                     SELECT
+                      u.id as user_id,
+                      u.name as user_name,
+                      u.groups as user_groups,
+                      u.attributes as attributes,
+                      u.default_storage_id as user_default_storage_id,
+                      u.default_profile_id as user_default_profile_id,
+                      u.blocked as user_blocked,
+                      u.block_date as user_block_date,
+                      u.registration_date,
+                      u.first_login_date,
+                      u.last_login_date,
+                      r.id as role_id,
+                      r.name as role_name,
+                      r.predefined as role_predefined,
+                      r.user_default as role_user_default,
+                      r.default_storage_id as role_default_storage_id,
+                      r.default_profile_id as role_default_profile_id,
+                      CASE
+                        WHEN EXISTS (
+                          SELECT 1 FROM pipeline.spring_session s
+                          WHERE s.principal_name = u.name
+                            AND (? - s.last_access_time) / 1000 < s.max_inactive_interval
+                        ) THEN true ELSE false
+                      END AS online
+                    FROM pipeline.user u
+                      LEFT JOIN pipeline.user_roles ur ON u.id = ur.user_id
+                      LEFT JOIN pipeline.role r ON ur.role_id = r.id
+                ]]>
+            </value>
+        </property>
         <property name="loadAllUsersWithDefaultDataStoragePathQuery">
             <value>
                 <![CDATA[

--- a/api/src/test/java/com/epam/pipeline/manager/contextual/ContextualPreferenceManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/contextual/ContextualPreferenceManagerTest.java
@@ -66,13 +66,13 @@ public class ContextualPreferenceManagerTest {
     private static final String USER_NAME = "userName";
     private static final PipelineUser USER = new PipelineUser(1L, null, Arrays.asList(ROLE_1, ROLE_2),
             Collections.emptyList(), false, false, null, null, null,
-            Collections.emptyMap(), Collections.emptyList(), null, Collections.emptyList(), null, null);
+            Collections.emptyMap(), Collections.emptyList(), null, Collections.emptyList(), null, null, null);
     private static final PipelineUser USER_WITHOUT_ROLES = new PipelineUser(USER.getId(), null, null,
             Collections.emptyList(), false, false, null, null, null,
-            Collections.emptyMap(), Collections.emptyList(), null, Collections.emptyList(), null, null);
+            Collections.emptyMap(), Collections.emptyList(), null, Collections.emptyList(), null, null, null);
     private static final PipelineUser USER_WITHOUT_ID = new PipelineUser(null, USER_NAME, Collections.emptyList(),
             Collections.emptyList(), false, false, null, null, null,
-            Collections.emptyMap(), Collections.emptyList(), null, Collections.emptyList(), null, null);
+            Collections.emptyMap(), Collections.emptyList(), null, Collections.emptyList(), null, null, null);
 
     private final ContextualPreferenceExternalResource toolResource =
             new ContextualPreferenceExternalResource(LEVEL, TOOL_ID);

--- a/core/src/main/java/com/epam/pipeline/entity/user/PipelineUser.java
+++ b/core/src/main/java/com/epam/pipeline/entity/user/PipelineUser.java
@@ -115,6 +115,9 @@ public class PipelineUser implements StorageContainer {
 
     private LocalDateTime blockDate;
 
+    @Transient
+    private Boolean online;
+
     public PipelineUser() {
         this.admin = false;
         this.blocked = false;


### PR DESCRIPTION
This PR provides implementation for issue #2433

The following changes were added:
- a new boolean request parameter `activity` added to `GET /users` API method (Default: false). If `activity=true` and current user is admin a new field `online` will be present at the pipeline user object.