### PR TITLE
Issue #2232 Change service name and port name creation process

### DIFF
--- a/api/profiles/dev/application.properties
+++ b/api/profiles/dev/application.properties
@@ -147,6 +147,9 @@ kube.deployment.api.url.prefix=${CP_API_KUBE_DEPLOYMENT_API_URL_PREFIX:apis/exte
 kube.deployment.refresh.timeout=${CP_API_KUBE_DEPLOYMENT_REFRESH_TIMEOUT_SEC:3}
 kube.deployment.refresh.retries=${CP_API_KUBE_DEPLOYMENT_REFRESH_RETRIES:15}
 kube.annotation.value.length.limit=${CP_API_KUBE_ANNOTATION_VALUE_LENGTH_LIMIT:254}
+kube.label.value.length.limit=${CP_API_KUBE_LABEL_VALUE_LENGTH_LIMIT:63}
+kube.label.long.value.suffix.length=${CP_API_KUBE_LABEL_LONG_VALUE_SUFFIX_LENGTH:5}
+kube.label.long.value.reducing.length=${CP_API_KUBE_LABEL_LONG_VALUE_REDUCING_LENGTH:12}
 ha.deploy.enabled=${CP_HA_DEPLOY_ENABLED:false}
 
 nat.gateway.auto.config.poll=${CP_API_NAT_POLL:60000}

--- a/api/profiles/release/application.properties
+++ b/api/profiles/release/application.properties
@@ -96,6 +96,9 @@ kube.deployment.api.url.prefix=${CP_API_KUBE_DEPLOYMENT_API_URL_PREFIX:apis/exte
 kube.deployment.refresh.timeout=${CP_API_KUBE_DEPLOYMENT_REFRESH_TIMEOUT_SEC:3}
 kube.deployment.refresh.retries=${CP_API_KUBE_DEPLOYMENT_REFRESH_RETRIES:15}
 kube.annotation.value.length.limit=${CP_API_KUBE_ANNOTATION_VALUE_LENGTH_LIMIT:254}
+kube.label.value.length.limit=${CP_API_KUBE_LABEL_VALUE_LENGTH_LIMIT:63}
+kube.label.long.value.suffix.length=${CP_API_KUBE_LABEL_LONG_VALUE_SUFFIX_LENGTH:5}
+kube.label.long.value.reducing.length=${CP_API_KUBE_LABEL_LONG_VALUE_REDUCING_LENGTH:12}
 
 nat.gateway.auto.config.poll=${CP_API_NAT_POLL:60000}
 nat.gateway.custom.dns.server.ip=${CP_API_CUSTOM_DNS_SERVER_IP:10.96.0.10}

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/NatGatewayManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/NatGatewayManager.java
@@ -16,8 +16,6 @@
 
 package com.epam.pipeline.manager.cluster;
 
-import static com.epam.pipeline.manager.cluster.KubernetesConstants.HYPHEN;
-
 import com.epam.pipeline.common.MessageConstants;
 import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.config.Constants;
@@ -477,7 +475,8 @@ public class NatGatewayManager {
             return false;
         }
         final String routeExternalName = route.getExternalName();
-        final String correspondingServiceName = buildProxyServiceName(routeExternalName);
+        final String correspondingServiceName = kubernetesManager.buildProxyServiceName(tinyproxyNatServiceName,
+                                                                                        routeExternalName);
         final NatRouteStatus statusInQueue = route.getStatus();
         final Integer externalPort = route.getExternalPort();
         final String targetStatusLabelName = getTargetStatusLabelName(externalPort);
@@ -898,10 +897,6 @@ public class NatGatewayManager {
 
     private String extractStringFromAnnotations(final Service service, final String labelName) {
         return Optional.ofNullable(getServiceAnnotations(service).get(labelName)).orElse(UNKNOWN);
-    }
-
-    public String buildProxyServiceName(final String externalName) {
-        return tinyproxyNatServiceName + HYPHEN + externalName.replaceAll("\\.", HYPHEN);
     }
 
     private String getCurrentStatusLabelName(final Integer port) {

--- a/deploy/docker/cp-api-srv/config/application.properties
+++ b/deploy/docker/cp-api-srv/config/application.properties
@@ -118,6 +118,9 @@ kube.deployment.api.url.prefix=${CP_API_KUBE_DEPLOYMENT_API_URL_PREFIX:apis/exte
 kube.deployment.refresh.timeout=${CP_API_KUBE_DEPLOYMENT_REFRESH_TIMEOUT_SEC:3}
 kube.deployment.refresh.retries=${CP_API_KUBE_DEPLOYMENT_REFRESH_RETRIES:15}
 kube.annotation.value.length.limit=${CP_API_KUBE_ANNOTATION_VALUE_LENGTH_LIMIT:254}
+kube.label.value.length.limit=${CP_API_KUBE_LABEL_VALUE_LENGTH_LIMIT:63}
+kube.label.long.value.suffix.length=${CP_API_KUBE_LABEL_LONG_VALUE_SUFFIX_LENGTH:5}
+kube.label.long.value.reducing.length=${CP_API_KUBE_LABEL_LONG_VALUE_REDUCING_LENGTH:12}
 
 nat.gateway.auto.config.poll=${CP_API_NAT_POLL:60000}
 nat.gateway.custom.dns.server.ip=${CP_API_CUSTOM_DNS_SERVER_IP:10.96.0.10}


### PR DESCRIPTION
This PR is related to issue #2232

In the case of a long external NAT route name, k8s limits on a service name (RFC 1035 Label Names, 63 chars) might be faced.
Some logic regarding service name and port names' reducing is added.


