### PR TITLE
Issue #2398 Set activation time to `null` in case of quota immediate activation

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSQuotasMonitor.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSQuotasMonitor.java
@@ -227,8 +227,11 @@ public class NFSQuotasMonitor {
             final NFSQuotaTrigger newTrigger = new NFSQuotaTrigger(storageId, notification, recipients,
                                                                    executionTime, newStatus, activationTime,
                                                                    isNotificationRequired);
-            updateTrigger(newTrigger);
-            if (isNotificationRequired && activationTime.isAfter(executionTime)) {
+            final boolean isDelayedActivation = activationTime.isAfter(executionTime);
+            updateTrigger(isDelayedActivation
+                          ? newTrigger
+                          : newTrigger.toBuilder().targetStatusActivationTime(null).build());
+            if (isNotificationRequired && isDelayedActivation) {
                 notificationManager.notifyOnStorageQuotaExceeding(storage, newStatus, notification, recipients,
                                                                   activationTime);
             }
@@ -239,7 +242,11 @@ public class NFSQuotasMonitor {
                                                 final NFSStorageMountStatus newMountStatus,
                                                 final LocalDateTime executionTime) {
         final NFSStorageMountStatus currentMountStatus = storage.getMountStatus();
-        if (currentMountStatus.getPriority() >= newMountStatus.getPriority()) {
+        final int graceDelay = searchCorrespondingAction(newMountStatus)
+            .map(graceConfiguration::get)
+            .orElse(0);
+        if (currentMountStatus.getPriority() >= newMountStatus.getPriority()
+            || graceDelay == 0) {
             return executionTime;
         } else {
             final LocalDateTime lastRestrictiveStatusActivation =
@@ -247,9 +254,6 @@ public class NFSQuotasMonitor {
                     .filter(trigger -> !trigger.getTargetStatus().equals(NFSStorageMountStatus.ACTIVE))
                     .map(NFSQuotaTrigger::getTargetStatusActivationTime)
                     .orElse(executionTime);
-            final int graceDelay = searchCorrespondingAction(newMountStatus)
-                .map(graceConfiguration::get)
-                .orElse(0);
             final LocalDateTime activationFromLastTrigger =
                 lastRestrictiveStatusActivation.plus(graceDelay, ChronoUnit.MINUTES);
             if (activationFromLastTrigger.isBefore(executionTime)) {
@@ -396,7 +400,9 @@ public class NFSQuotasMonitor {
 
     private void controlStatus(final Map<Long, NFSDataStorage> nfsMapping, final LocalDateTime checkTime) {
         latestTriggers.values().stream()
-            .filter(trigger -> trigger.getTargetStatusActivationTime().isBefore(checkTime))
+            .filter(trigger -> Optional.ofNullable(trigger.getTargetStatusActivationTime())
+                .map(activationTime -> activationTime.isBefore(checkTime))
+                .orElse(true))
             .map(trigger -> Pair.of(nfsMapping.get(trigger.getStorageId()), trigger))
             .filter(pair -> pair.getKey() != null)
             .filter(pair -> pair.getKey().getMountStatus() != pair.getValue().getTargetStatus())

--- a/api/src/main/resources/db/migration/v2022.01.13_20.00__issue_2398_quotas_grace_period_activation_constraint.sql
+++ b/api/src/main/resources/db/migration/v2022.01.13_20.00__issue_2398_quotas_grace_period_activation_constraint.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pipeline.last_triggered_storage_quota ALTER COLUMN status_activation_date DROP NOT NULL;


### PR DESCRIPTION
This PR is related to issue #2398 and fix activation date incorrectly calculation for some cases.

Activation time and a grace timeout merging should occur only in case more restrictive action with a grace period occur after less restrictive with its own timeout. In all other cases, a quota is either activated immediately or grace is calculated from checkup ('current') time.

From now `activationTime` is set to `null` is a sign of an instantly applied quota.