### PR TITLE
Use per month and per year billing indices

### DIFF
--- a/api/profiles/dev/application.properties
+++ b/api/profiles/dev/application.properties
@@ -195,7 +195,10 @@ cluster.disable.task.monitoring=${CP_API_DISABLE_POD_MONITOR:false}
 cluster.disable.autoscaling=${CP_API_DISABLE_AUTOSCALER:false}
 
 #Billing API
-billing.index.common.prefix=cp-billing
+billing.index.common.prefix=cp-billing-
+billing.index.period.disable=${CP_BILLING_INDEX_PERIOD_DISABLE:false}
+billing.run.index.name=pipeline-run
+billing.storage.index.name=storage
 billing.empty.report.value=unknown
 billing.center.key=${CP_BILLING_CENTER_KEY:billing-center}
 

--- a/api/src/main/java/com/epam/pipeline/app/BillingConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/BillingConfiguration.java
@@ -45,7 +45,8 @@ public class BillingConfiguration {
     @Bean
     @ConditionalOnProperty(value = "billing.index.period.disable", matchIfMissing = true, havingValue = FALSE)
     public BillingIndexHelper periodBillingIndexHelper(final GlobalSearchElasticHelper elasticHelper) {
-        final BillingIndexHelper helper = new PeriodBillingIndexHelper(commonIndexPrefix, runIndexName, storageIndexName);
+        final BillingIndexHelper helper = new PeriodBillingIndexHelper(commonIndexPrefix, runIndexName,
+                storageIndexName);
         return new BoundingBillingIndexHelper(helper, elasticHelper, commonIndexPrefix, runIndexName, storageIndexName);
     }
 

--- a/api/src/main/java/com/epam/pipeline/config/Constants.java
+++ b/api/src/main/java/com/epam/pipeline/config/Constants.java
@@ -19,6 +19,7 @@ package com.epam.pipeline.config;
 public final class Constants {
     public static final String FMT_ISO_LOCAL_DATE = "yyyy-MM-dd HH:mm:ss.SSS";
     public static final String TIME_FORMAT = "HH:mm:ss";
+    public static final String ELASTIC_DATE_FORMAT = "yyyy-MM-dd";
     public static final String ELASTIC_DATE_TIME_FORMAT = FMT_ISO_LOCAL_DATE;
     public static final String EXPORT_DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm:ss";
     public static final String SECURITY_DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS";

--- a/api/src/main/java/com/epam/pipeline/entity/billing/BillingGrouping.java
+++ b/api/src/main/java/com/epam/pipeline/entity/billing/BillingGrouping.java
@@ -16,37 +16,26 @@
 
 package com.epam.pipeline.entity.billing;
 
-public enum BillingGrouping {
-    RESOURCE_TYPE("resource_type", false, false),
-    RUN_INSTANCE_TYPE("instance_type", true, false),
-    RUN_COMPUTE_TYPE("compute_type", false, false),
-    PIPELINE("pipeline", true, false),
-    TOOL("tool", true, false),
-    STORAGE("storage_id", false, true),
-    STORAGE_TYPE("storage_type", false, false),
-    USER("owner", true, true),
-    BILLING_CENTER("billing_center", true, true);
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
+@Getter
+@RequiredArgsConstructor
+public enum BillingGrouping {
+
+    RESOURCE_TYPE(BillingGroupingType.COMMON, "resource_type", false, false),
+    RUN_INSTANCE_TYPE(BillingGroupingType.RUN, "instance_type", true, false),
+    RUN_COMPUTE_TYPE(BillingGroupingType.RUN, "compute_type", false, false),
+    PIPELINE(BillingGroupingType.RUN, "pipeline", true, false),
+    TOOL(BillingGroupingType.RUN, "tool", true, false),
+    STORAGE(BillingGroupingType.STORAGE, "storage_id", false, true),
+    STORAGE_TYPE(BillingGroupingType.STORAGE, "storage_type", false, false),
+    USER(BillingGroupingType.COMMON, "owner", true, true),
+    BILLING_CENTER(BillingGroupingType.COMMON, "billing_center", true, true);
+
+    private final BillingGroupingType type;
     private final String correspondingField;
     private final boolean runUsageDetailsRequired;
     private final boolean storageUsageDetailsRequired;
 
-    BillingGrouping(final String correspondingField, final boolean runUsageDetailsRequired,
-                    final boolean storageUsageDetailsRequired) {
-        this.correspondingField = correspondingField;
-        this.runUsageDetailsRequired = runUsageDetailsRequired;
-        this.storageUsageDetailsRequired = storageUsageDetailsRequired;
-    }
-
-    public String getCorrespondingField() {
-        return correspondingField;
-    }
-
-    public boolean runUsageDetailsRequired() {
-        return runUsageDetailsRequired;
-    }
-
-    public boolean storageUsageDetailsRequired() {
-        return storageUsageDetailsRequired;
-    }
 }

--- a/api/src/main/java/com/epam/pipeline/entity/billing/BillingGroupingType.java
+++ b/api/src/main/java/com/epam/pipeline/entity/billing/BillingGroupingType.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.billing;
+
+public enum BillingGroupingType {
+    COMMON,
+    RUN,
+    STORAGE;
+}

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingCenterBillingLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingCenterBillingLoader.java
@@ -38,6 +38,7 @@ import java.util.stream.Stream;
 public class BillingCenterBillingLoader implements BillingLoader<BillingCenterGeneralBilling> {
 
     private final BillingHelper billingHelper;
+    private final BillingSecurityHelper billingSecurityHelper;
     private final BillingIndexHelper billingIndexHelper;
     private final PreferenceManager preferenceManager;
 
@@ -46,7 +47,7 @@ public class BillingCenterBillingLoader implements BillingLoader<BillingCenterGe
                                                         final BillingExportRequest request) {
         final LocalDate from = request.getFrom();
         final LocalDate to = request.getTo();
-        final Map<String, List<String>> filters = billingHelper.getFilters(request.getFilters());
+        final Map<String, List<String>> filters = billingSecurityHelper.getFilters(request.getFilters());
         final BillingDiscount discount = Optional.ofNullable(request.getDiscount()).orElseGet(BillingDiscount::empty);
         return billings(client, from, to, filters, discount, getPageSize());
     }

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingCenterBillingLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingCenterBillingLoader.java
@@ -4,6 +4,7 @@ import com.epam.pipeline.controller.vo.billing.BillingExportRequest;
 import com.epam.pipeline.entity.billing.BillingCenterGeneralBilling;
 import com.epam.pipeline.entity.billing.BillingDiscount;
 import com.epam.pipeline.entity.billing.GeneralBillingMetrics;
+import com.epam.pipeline.manager.billing.index.BillingIndexHelper;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.utils.StreamUtils;
@@ -37,16 +38,17 @@ import java.util.stream.Stream;
 public class BillingCenterBillingLoader implements BillingLoader<BillingCenterGeneralBilling> {
 
     private final BillingHelper billingHelper;
+    private final BillingIndexHelper billingIndexHelper;
     private final PreferenceManager preferenceManager;
 
     @Override
-    public Stream<BillingCenterGeneralBilling> billings(final RestHighLevelClient elasticSearchClient,
+    public Stream<BillingCenterGeneralBilling> billings(final RestHighLevelClient client,
                                                         final BillingExportRequest request) {
         final LocalDate from = request.getFrom();
         final LocalDate to = request.getTo();
         final Map<String, List<String>> filters = billingHelper.getFilters(request.getFilters());
         final BillingDiscount discount = Optional.ofNullable(request.getDiscount()).orElseGet(BillingDiscount::empty);
-        return billings(elasticSearchClient, from, to, filters, discount, getPageSize());
+        return billings(client, from, to, filters, discount, getPageSize());
     }
 
     private int getPageSize() {
@@ -55,17 +57,17 @@ public class BillingCenterBillingLoader implements BillingLoader<BillingCenterGe
                 .orElse(BillingUtils.FALLBACK_EXPORT_PERIOD_AGGREGATION_PAGE_SIZE);
     }
 
-    private Stream<BillingCenterGeneralBilling> billings(final RestHighLevelClient elasticSearchClient,
+    private Stream<BillingCenterGeneralBilling> billings(final RestHighLevelClient client,
                                                          final LocalDate from,
                                                          final LocalDate to,
                                                          final Map<String, List<String>> filters,
                                                          final BillingDiscount discount,
                                                          final int pageSize) {
-        return StreamUtils.from(billingsIterator(elasticSearchClient, from, to, filters, discount, pageSize))
+        return StreamUtils.from(billingsIterator(client, from, to, filters, discount, pageSize))
                 .flatMap(this::billings);
     }
 
-    private Iterator<SearchResponse> billingsIterator(final RestHighLevelClient elasticSearchClient,
+    private Iterator<SearchResponse> billingsIterator(final RestHighLevelClient client,
                                                       final LocalDate from,
                                                       final LocalDate to,
                                                       final Map<String, List<String>> filters,
@@ -73,7 +75,7 @@ public class BillingCenterBillingLoader implements BillingLoader<BillingCenterGe
                                                       final int pageSize) {
         return new ElasticMultiBucketsIterator(BillingUtils.BILLING_CENTER_FIELD, pageSize,
             pageOffset -> getBillingsRequest(from, to, filters, discount, pageOffset, pageSize),
-            billingHelper.searchWith(elasticSearchClient),
+            billingHelper.searchWith(client),
             billingHelper::getTerms);
     }
 
@@ -84,8 +86,8 @@ public class BillingCenterBillingLoader implements BillingLoader<BillingCenterGe
                                              final int pageOffset,
                                              final int pageSize) {
         return new SearchRequest()
-                .indicesOptions(IndicesOptions.strictExpandOpen())
-                .indices(billingHelper.indicesByDate(from, to))
+                .indicesOptions(IndicesOptions.lenientExpandOpen())
+                .indices(billingIndexHelper.monthlyIndicesBetween(from, to))
                 .source(new SearchSourceBuilder()
                         .size(NumberUtils.INTEGER_ZERO)
                         .query(billingHelper.queryByDateAndFilters(from, to, filters))

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingHelper.java
@@ -75,7 +75,7 @@ public class BillingHelper {
                 .field(BillingUtils.STORAGE_ID_FIELD)
                 .size(Integer.MAX_VALUE)
                 .subAggregation(AggregationBuilders.avg(BillingUtils.SINGLE_STORAGE_USAGE_AGG)
-                        .field(BillingUtils.STORAGE_USAGE_FIELD));
+                        .script(new Script(BillingUtils.STORAGE_USAGE_AVG_SCRIPT)));
         this.storageUsageTotalAggregation = PipelineAggregatorBuilders
                 .sumBucket(BillingUtils.TOTAL_STORAGE_USAGE_AGG,
                         fieldsPath(BillingUtils.STORAGE_GROUPING_AGG, BillingUtils.SINGLE_STORAGE_USAGE_AGG));
@@ -183,7 +183,7 @@ public class BillingHelper {
 
     public AvgAggregationBuilder aggregateStorageUsageAvg() {
         return AggregationBuilders.avg(BillingUtils.STORAGE_USAGE_AGG)
-                .field(BillingUtils.STORAGE_USAGE_FIELD);
+                .script(new Script(BillingUtils.STORAGE_USAGE_AVG_SCRIPT));
     }
 
     public BucketSortPipelineAggregationBuilder aggregateCostSortBucket() {

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingHelper.java
@@ -65,9 +65,6 @@ import java.util.stream.Stream;
 public class BillingHelper {
 
     private final AuthManager authManager;
-    private final String billingIndicesMonthlyPattern;
-    private final String billingRunIndicesMonthlyPattern;
-    private final String billingStorageIndicesMonthlyPattern;
     private final SumAggregationBuilder costAggregation;
     private final SumAggregationBuilder runUsageAggregation;
     private final TermsAggregationBuilder storageUsageGroupingAggregation;
@@ -76,21 +73,8 @@ public class BillingHelper {
     private final TopHitsAggregationBuilder lastByDateStorageDocAggregation;
     private final TopHitsAggregationBuilder lastByDateDocAggregation;
 
-    public BillingHelper(final AuthManager authManager,
-                         final @Value("${billing.index.common.prefix}") String commonPrefix) {
+    public BillingHelper(final AuthManager authManager) {
         this.authManager = authManager;
-        this.billingIndicesMonthlyPattern = String.join("-",
-                commonPrefix,
-                BillingUtils.ES_WILDCARD,
-                BillingUtils.ES_MONTHLY_DATE_REGEXP);
-        this.billingRunIndicesMonthlyPattern = String.join("-",
-                commonPrefix,
-                BillingUtils.ES_WILDCARD + BillingUtils.RUN + BillingUtils.ES_WILDCARD,
-                BillingUtils.ES_MONTHLY_DATE_REGEXP);
-        this.billingStorageIndicesMonthlyPattern = String.join("-",
-                commonPrefix,
-                BillingUtils.ES_WILDCARD + BillingUtils.STORAGE + BillingUtils.ES_WILDCARD,
-                BillingUtils.ES_MONTHLY_DATE_REGEXP);
         this.costAggregation = AggregationBuilders.sum(BillingUtils.COST_FIELD)
                 .field(BillingUtils.COST_FIELD);
         this.runUsageAggregation = AggregationBuilders.sum(BillingUtils.RUN_USAGE_AGG)
@@ -130,25 +114,6 @@ public class BillingHelper {
                 .anyMatch(DefaultRoles.ROLE_BILLING_MANAGER.getName()::equals);
     }
 
-    public String[] indicesByDate(final LocalDate from, final LocalDate to) {
-        return indicesByDate(from, to, billingIndicesMonthlyPattern);
-    }
-
-    public String[] runIndicesByDate(final LocalDate from, final LocalDate to) {
-        return indicesByDate(from, to, billingRunIndicesMonthlyPattern);
-    }
-
-    public String[] storageIndicesByDate(final LocalDate from, final LocalDate to) {
-        return indicesByDate(from, to, billingStorageIndicesMonthlyPattern);
-    }
-
-    private String[] indicesByDate(final LocalDate from, final LocalDate to, final String indexPattern) {
-        return Stream.iterate(from, d -> d.plus(1, ChronoUnit.MONTHS))
-                .limit(ChronoUnit.MONTHS.between(YearMonth.from(from), YearMonth.from(to)) + 1)
-                .map(date -> String.format(indexPattern, date.getYear(), date.getMonthValue()))
-                .toArray(String[]::new);
-    }
-
     public BoolQueryBuilder queryByDateAndFilters(final LocalDate from,
                                                   final LocalDate to,
                                                   final Map<String, List<String>> filters) {
@@ -163,7 +128,7 @@ public class BillingHelper {
                     BoolQueryBuilder::filter);
     }
 
-    private RangeQueryBuilder queryByDate(final LocalDate from, final LocalDate to) {
+    public RangeQueryBuilder queryByDate(final LocalDate from, final LocalDate to) {
         return QueryBuilders.rangeQuery(BillingUtils.BILLING_DATE_FIELD)
                 .from(from, true)
                 .to(to, true);

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingLoader.java
@@ -7,6 +7,6 @@ import java.util.stream.Stream;
 
 public interface BillingLoader<B> {
 
-    Stream<B> billings(RestHighLevelClient elasticSearchClient,
+    Stream<B> billings(RestHighLevelClient client,
                        BillingExportRequest request);
 }

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
@@ -27,6 +27,7 @@ import com.epam.pipeline.entity.billing.BillingChartInfo;
 import com.epam.pipeline.entity.billing.BillingGrouping;
 import com.epam.pipeline.entity.security.acl.AclClass;
 import com.epam.pipeline.exception.search.SearchException;
+import com.epam.pipeline.manager.billing.index.BillingIndexHelper;
 import com.epam.pipeline.manager.metadata.MetadataManager;
 import com.epam.pipeline.manager.utils.GlobalSearchElasticHelper;
 import com.epam.pipeline.utils.CommonUtils;
@@ -109,6 +110,7 @@ public class BillingManager {
     private final Map<BillingGrouping, EntityBillingDetailsLoader> billingDetailsLoaders;
 
     private final BillingHelper billingHelper;
+    private final BillingIndexHelper billingIndexHelper;
     private final BillingExportManager billingExportManager;
     private final MessageHelper messageHelper;
     private final MetadataManager metadataManager;
@@ -119,6 +121,7 @@ public class BillingManager {
 
     @Autowired
     public BillingManager(final BillingHelper billingHelper,
+                          final BillingIndexHelper billingIndexHelper,
                           final BillingExportManager billingExportManager,
                           final MessageHelper messageHelper,
                           final MetadataManager metadataManager,
@@ -127,6 +130,7 @@ public class BillingManager {
                           final @Value("${billing.center.key}") String billingCenterKey,
                           final List<EntityBillingDetailsLoader> billingDetailsLoaders) {
         this.billingHelper = billingHelper;
+        this.billingIndexHelper = billingIndexHelper;
         this.billingExportManager = billingExportManager;
         this.messageHelper = messageHelper;
         this.metadataManager = metadataManager;
@@ -159,10 +163,12 @@ public class BillingManager {
             final Map<String, List<String>> filters = billingHelper.getFilters(request.getFilters());
             if (interval != null) {
                 return getBillingStats(elasticsearchClient, from, to, filters, interval);
-            } else {
+            }
+            if (grouping != null) {
                 return getBillingStats(elasticsearchClient.getLowLevelClient(), from, to, filters, grouping,
                         request.isLoadDetails());
             }
+            throw new IllegalArgumentException("Either interval or grouping parameter has to be specified.");
         } catch (IOException e) {
             throw new SearchException(e.getMessage(), e);
         }
@@ -189,7 +195,7 @@ public class BillingManager {
             final HashMap<String, List<String>> filters = buildQuotaFilters(quota);
             final SearchRequest searchRequest = new SearchRequest()
                     .indicesOptions(IndicesOptions.strictExpandOpen())
-                    .indices(billingHelper.indicesByDate(from, to))
+                    .indices(billingIndexHelper.yearlyIndicesBetween(from, to))
                     .source(new SearchSourceBuilder()
                             .size(0)
                             .aggregation(billingHelper.aggregateCostSum())
@@ -248,8 +254,8 @@ public class BillingManager {
                                                    final Map<String, List<String>> filters,
                                                    final DateHistogramInterval interval) {
         if (!validIntervals.contains(interval)) {
-            throw new IllegalArgumentException(messageHelper
-                                                   .getMessage(MessageConstants.ERROR_BILLING_INTERVAL_NOT_SUPPORTED));
+            throw new IllegalArgumentException(messageHelper.getMessage(
+                    MessageConstants.ERROR_BILLING_INTERVAL_NOT_SUPPORTED));
         }
 
         final AggregationBuilder intervalAgg = AggregationBuilders.dateHistogram(
@@ -261,8 +267,8 @@ public class BillingManager {
                     BillingUtils.COST_FIELD));
 
         final SearchRequest searchRequest = new SearchRequest()
-                .indicesOptions(IndicesOptions.strictExpandOpen())
-                .indices(billingHelper.indicesByDate(from, to))
+                .indicesOptions(IndicesOptions.lenientExpandOpen())
+                .indices(intervalIndicesBetween(from, to, interval))
                 .source(new SearchSourceBuilder()
                         .size(0)
                         .aggregation(intervalAgg)
@@ -281,36 +287,42 @@ public class BillingManager {
         }
     }
 
+    private String[] intervalIndicesBetween(final LocalDate from, final LocalDate to,
+                                            final DateHistogramInterval interval) {
+        if (interval.equals(DateHistogramInterval.DAY)) return billingIndexHelper.dailyIndicesBetween(from, to);
+        if (interval.equals(DateHistogramInterval.MONTH)) return billingIndexHelper.monthlyIndicesBetween(from, to);
+        throw new IllegalArgumentException(messageHelper.getMessage(
+                MessageConstants.ERROR_BILLING_INTERVAL_NOT_SUPPORTED));
+    }
+
     private List<BillingChartInfo> getBillingStats(final RestClient elasticsearchLowLevelClient,
                                                    final LocalDate from, final LocalDate to,
                                                    final Map<String, List<String>> filters,
                                                    final BillingGrouping grouping,
                                                    final boolean isLoadDetails) {
         final SearchSourceBuilder searchSource = new SearchSourceBuilder();
-        if (grouping != null) {
-            final AggregationBuilder fieldAgg = AggregationBuilders.terms(grouping.getCorrespondingField())
-                .field(grouping.getCorrespondingField())
-                .order(BucketOrder.aggregation(BillingUtils.COST_FIELD, false))
-                .size(Integer.MAX_VALUE);
-            fieldAgg.subAggregation(billingHelper.aggregateCostSum());
-            if (grouping.runUsageDetailsRequired()) {
-                fieldAgg.subAggregation(billingHelper.aggregateRunUsageSum());
-                fieldAgg.subAggregation(billingHelper.aggregateUniqueRunsCount());
-            }
-            if (grouping.storageUsageDetailsRequired()) {
-                fieldAgg.subAggregation(billingHelper.aggregateByStorageUsageGrouping());
-                fieldAgg.subAggregation(billingHelper.aggregateStorageUsageTotalSumBucket());
-                if (BillingGrouping.STORAGE.equals(grouping)) {
-                    fieldAgg.subAggregation(billingHelper.aggregateLastByDateStorageDoc());
-                }
-            }
-            searchSource.aggregation(fieldAgg);
+        final AggregationBuilder fieldAgg = AggregationBuilders.terms(grouping.getCorrespondingField())
+            .field(grouping.getCorrespondingField())
+            .order(BucketOrder.aggregation(BillingUtils.COST_FIELD, false))
+            .size(Integer.MAX_VALUE);
+        fieldAgg.subAggregation(billingHelper.aggregateCostSum());
+        if (grouping.isRunUsageDetailsRequired()) {
+            fieldAgg.subAggregation(billingHelper.aggregateRunUsageSum());
+            fieldAgg.subAggregation(billingHelper.aggregateUniqueRunsCount());
         }
+        if (grouping.isStorageUsageDetailsRequired()) {
+            fieldAgg.subAggregation(billingHelper.aggregateByStorageUsageGrouping());
+            fieldAgg.subAggregation(billingHelper.aggregateStorageUsageTotalSumBucket());
+            if (BillingGrouping.STORAGE.equals(grouping)) {
+                fieldAgg.subAggregation(billingHelper.aggregateLastByDateStorageDoc());
+            }
+        }
+        searchSource.aggregation(fieldAgg);
         searchSource.aggregation(billingHelper.aggregateCostSum());
 
         final SearchRequest searchRequest = new SearchRequest()
-                .indicesOptions(IndicesOptions.strictExpandOpen())
-                .indices(billingHelper.indicesByDate(from, to))
+                .indicesOptions(IndicesOptions.lenientExpandOpen())
+                .indices(groupingIndicesBetween(from, to, grouping))
                 .source(searchSource
                         .size(0)
                         .query(billingHelper.queryByDateAndFilters(from, to, filters)));
@@ -326,6 +338,15 @@ public class BillingManager {
         }
     }
 
+    private String[] groupingIndicesBetween(final LocalDate from, final LocalDate to,
+                                            final BillingGrouping grouping) {
+        switch (grouping.getType()) {
+            case RUN: return billingIndexHelper.yearlyRunIndicesBetween(from, to);
+            case STORAGE: return billingIndexHelper.yearlyStorageIndicesBetween(from, to);
+            default: return billingIndexHelper.yearlyIndicesBetween(from, to);
+        }
+    }
+
     private Optional<SearchResponse> searchForGrouping(final RestClient lowLevelClient, final SearchRequest request,
                                                        final String groupingName) throws IOException {
         final String searchEndpoint = String.format(BillingUtils.ES_INDICES_SEARCH_PATTERN,
@@ -334,6 +355,9 @@ public class BillingManager {
         final Map<String, String> parameters = new HashMap<>();
         parameters.put(BillingUtils.ES_FILTER_PATH, buildResponseFilterForGrouping(groupingName));
         parameters.put(RestSearchAction.TYPED_KEYS_PARAM, Boolean.TRUE.toString());
+        parameters.put("allow_no_indices", Boolean.TRUE.toString());
+        parameters.put("expand_wildcards", "open");
+        parameters.put("ignore_unavailable", Boolean.TRUE.toString());
         final Request lowLevelRequest = new Request(HttpPost.METHOD_NAME, searchEndpoint);
         MapUtils.emptyIfNull(parameters).forEach(lowLevelRequest::addParameter);
         lowLevelRequest.setEntity(httpEntity);
@@ -410,11 +434,11 @@ public class BillingManager {
     private List<BillingChartInfo> getEmptyGroupingResponse(final BillingGrouping grouping) {
         final Map<String, String> details = new HashMap<>();
         details.put(grouping.name(), emptyValue);
-        if (grouping.runUsageDetailsRequired()) {
+        if (grouping.isRunUsageDetailsRequired()) {
             details.put(BillingUtils.RUN_USAGE_FIELD, emptyValue);
             details.put(BillingUtils.RUN_COUNT_AGG, emptyValue);
         }
-        if (grouping.storageUsageDetailsRequired()) {
+        if (grouping.isStorageUsageDetailsRequired()) {
             details.put(BillingUtils.STORAGE_USAGE_FIELD, emptyValue);
         }
         final BillingChartInfo emptyResponse = BillingChartInfo.builder()
@@ -431,27 +455,21 @@ public class BillingManager {
         if (allAggregations == null) {
             return Collections.emptyList();
         }
-        if (grouping != null) {
-            final String groupingField = grouping.getCorrespondingField();
-            final ParsedStringTerms terms = allAggregations.get(groupingField);
-            return Optional.ofNullable(terms)
-                .map(ParsedTerms::getBuckets)
-                .map(Collection::stream)
-                .orElse(Stream.empty())
-                .map(bucket -> {
-                    final Aggregations aggregations = bucket.getAggregations();
-                    return getCostAggregation(from, to,
-                                              grouping,
-                                              (String) bucket.getKey(),
-                                              aggregations,
-                                              isLoadDetails);
-                })
-                .collect(Collectors.toList());
-        } else {
-            return CollectionUtils.isEmpty(allAggregations.asList())
-                   ? Collections.emptyList()
-                   : Collections.singletonList(getCostAggregation(from, to, null, null, allAggregations, false));
-        }
+        final String groupingField = grouping.getCorrespondingField();
+        final ParsedStringTerms terms = allAggregations.get(groupingField);
+        return Optional.ofNullable(terms)
+            .map(ParsedTerms::getBuckets)
+            .map(Collection::stream)
+            .orElse(Stream.empty())
+            .map(bucket -> {
+                final Aggregations aggregations = bucket.getAggregations();
+                return getCostAggregation(from, to,
+                                          grouping,
+                                          (String) bucket.getKey(),
+                                          aggregations,
+                                          isLoadDetails);
+            })
+            .collect(Collectors.toList());
     }
 
     private BillingChartInfo getCostAggregation(final LocalDate from, final LocalDate to,
@@ -468,24 +486,22 @@ public class BillingManager {
         final Map<String, String> groupingInfo = new HashMap<>();
         final EntityBillingDetailsLoader detailsLoader = billingDetailsLoaders.get(grouping);
         final Map<String, String> entityDetails = new HashMap<>();
-        if (grouping != null) {
-            if (detailsLoader == null) {
-                groupingInfo.put(grouping.toString(), groupValue);
-            } else {
-                entityDetails.putAll(detailsLoader.loadInformation(groupValue, loadDetails));
-                groupingInfo.put(grouping.name(), entityDetails.remove(EntityBillingDetailsLoader.NAME));
-            }
+        if (detailsLoader == null) {
+            groupingInfo.put(grouping.toString(), groupValue);
+        } else {
+            entityDetails.putAll(detailsLoader.loadInformation(groupValue, loadDetails));
+            groupingInfo.put(grouping.name(), entityDetails.remove(EntityBillingDetailsLoader.NAME));
         }
         if (loadDetails) {
             groupingInfo.putAll(entityDetails);
-            if (grouping.runUsageDetailsRequired()) {
+            if (grouping.isRunUsageDetailsRequired()) {
                 final ParsedSum usageAggResult = aggregations.get(BillingUtils.RUN_USAGE_AGG);
                 final long usageVal = new Double(usageAggResult.getValue()).longValue();
                 groupingInfo.put(BillingUtils.RUN_USAGE_AGG, Long.toString(usageVal));
                 final ParsedValueCount uniqueRunIds = aggregations.get(BillingUtils.RUN_COUNT_AGG);
                 groupingInfo.put(BillingUtils.RUNS, Long.toString(uniqueRunIds.getValue()));
             }
-            if (grouping.storageUsageDetailsRequired()) {
+            if (grouping.isStorageUsageDetailsRequired()) {
                 final ParsedSimpleValue totalStorageUsage = aggregations.get(BillingUtils.TOTAL_STORAGE_USAGE_AGG);
                 final long storageUsageVal = new Double(totalStorageUsage.value()).longValue();
                 groupingInfo.put(BillingUtils.TOTAL_STORAGE_USAGE_AGG, Long.toString(storageUsageVal));
@@ -534,4 +550,5 @@ public class BillingManager {
         }
         return builder.build();
     }
+
 }

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
@@ -110,6 +110,7 @@ public class BillingManager {
     private final Map<BillingGrouping, EntityBillingDetailsLoader> billingDetailsLoaders;
 
     private final BillingHelper billingHelper;
+    private final BillingSecurityHelper billingSecurityHelper;
     private final BillingIndexHelper billingIndexHelper;
     private final BillingExportManager billingExportManager;
     private final MessageHelper messageHelper;
@@ -121,6 +122,7 @@ public class BillingManager {
 
     @Autowired
     public BillingManager(final BillingHelper billingHelper,
+                          final BillingSecurityHelper billingSecurityHelper,
                           final BillingIndexHelper billingIndexHelper,
                           final BillingExportManager billingExportManager,
                           final MessageHelper messageHelper,
@@ -130,6 +132,7 @@ public class BillingManager {
                           final @Value("${billing.center.key}") String billingCenterKey,
                           final List<EntityBillingDetailsLoader> billingDetailsLoaders) {
         this.billingHelper = billingHelper;
+        this.billingSecurityHelper = billingSecurityHelper;
         this.billingIndexHelper = billingIndexHelper;
         this.billingExportManager = billingExportManager;
         this.messageHelper = messageHelper;
@@ -160,7 +163,7 @@ public class BillingManager {
             final LocalDate to = request.getTo();
             final BillingGrouping grouping = request.getGrouping();
             final DateHistogramInterval interval = request.getInterval();
-            final Map<String, List<String>> filters = billingHelper.getFilters(request.getFilters());
+            final Map<String, List<String>> filters = billingSecurityHelper.getFilters(request.getFilters());
             if (interval != null) {
                 return getBillingStats(elasticsearchClient, from, to, filters, interval);
             }

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
@@ -292,8 +292,12 @@ public class BillingManager {
 
     private String[] intervalIndicesBetween(final LocalDate from, final LocalDate to,
                                             final DateHistogramInterval interval) {
-        if (interval.equals(DateHistogramInterval.DAY)) return billingIndexHelper.dailyIndicesBetween(from, to);
-        if (interval.equals(DateHistogramInterval.MONTH)) return billingIndexHelper.monthlyIndicesBetween(from, to);
+        if (interval.equals(DateHistogramInterval.DAY)) {
+            return billingIndexHelper.dailyIndicesBetween(from, to);
+        }
+        if (interval.equals(DateHistogramInterval.MONTH)) {
+            return billingIndexHelper.monthlyIndicesBetween(from, to);
+        }
         throw new IllegalArgumentException(messageHelper.getMessage(
                 MessageConstants.ERROR_BILLING_INTERVAL_NOT_SUPPORTED));
     }

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingSecurityHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingSecurityHelper.java
@@ -1,0 +1,37 @@
+package com.epam.pipeline.manager.billing;
+
+import com.epam.pipeline.entity.user.DefaultRoles;
+import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.entity.user.Role;
+import com.epam.pipeline.manager.security.AuthManager;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.MapUtils;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class BillingSecurityHelper {
+
+    private final AuthManager authManager;
+
+    public Map<String, List<String>> getFilters(final Map<String, List<String>> requestedFilters) {
+        final Map<String, List<String>> filters = new HashMap<>(MapUtils.emptyIfNull(requestedFilters));
+        final PipelineUser authorizedUser = authManager.getCurrentUser();
+        if (!hasFullBillingAccess(authorizedUser)) {
+            filters.put(BillingUtils.OWNER_FIELD, Collections.singletonList(authorizedUser.getUserName()));
+        }
+        return filters;
+    }
+
+    private boolean hasFullBillingAccess(final PipelineUser authorizedUser) {
+        return authorizedUser.isAdmin()
+                || authorizedUser.getRoles().stream()
+                .map(Role::getName)
+                .anyMatch(DefaultRoles.ROLE_BILLING_MANAGER.getName()::equals);
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingUtils.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingUtils.java
@@ -69,6 +69,7 @@ public final class BillingUtils {
     public static final String TOTAL_STORAGE_USAGE_AGG = "usage_storages";
     public static final String LAST_STORAGE_USAGE_VALUE = "usage_storages_last";
     public static final String STORAGE_USAGE_FIELD = "usage_bytes";
+    public static final String STORAGE_USAGE_AVG_FIELD = "usage_bytes_avg";
     public static final String LAST_BY_DATE_DOC_AGG = "last_by_date";
     public static final String DOC_ID_FIELD = "_id";
     public static final String RUN_ID_FIELD = "run_id";

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingUtils.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingUtils.java
@@ -1,12 +1,6 @@
 package com.epam.pipeline.manager.billing;
 
 import com.epam.pipeline.config.Constants;
-import com.epam.pipeline.entity.metadata.MetadataEntry;
-import com.epam.pipeline.entity.security.acl.AclClass;
-import com.epam.pipeline.entity.user.PipelineUser;
-import com.epam.pipeline.manager.metadata.MetadataManager;
-import org.apache.commons.collections4.MapUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 
 import java.math.BigDecimal;
@@ -25,6 +19,8 @@ public final class BillingUtils {
     public static final char SEPARATOR = ',';
 
     public static final String YEAR_MONTH_FORMAT = "MMMM yyyy";
+    public static final DateTimeFormatter ELASTIC_DATE_FORMATTER =
+            DateTimeFormatter.ofPattern(Constants.ELASTIC_DATE_FORMAT, Locale.US);
     public static final DateTimeFormatter ELASTIC_DATE_TIME_FORMATTER =
             DateTimeFormatter.ofPattern(Constants.ELASTIC_DATE_TIME_FORMAT, Locale.US);
     public static final DateTimeFormatter EXPORT_DATE_TIME_FORMATTER =
@@ -74,6 +70,7 @@ public final class BillingUtils {
     public static final String LAST_STORAGE_USAGE_VALUE = "usage_storages_last";
     public static final String STORAGE_USAGE_FIELD = "usage_bytes";
     public static final String LAST_BY_DATE_DOC_AGG = "last_by_date";
+    public static final String DOC_ID_FIELD = "_id";
     public static final String RUN_ID_FIELD = "run_id";
     public static final String STORAGE_ID_FIELD = "storage_id";
     public static final String PAGE = "page";
@@ -165,15 +162,8 @@ public final class BillingUtils {
                 .toString();
     }
 
-    public static String getUserBillingCenter(final PipelineUser user,
-                                              final String billingCenterKey,
-                                              final MetadataManager metadataManager) {
-        return Optional.ofNullable(metadataManager.loadMetadataItem(user.getId(), AclClass.PIPELINE_USER))
-                .map(MetadataEntry::getData)
-                .filter(MapUtils::isNotEmpty)
-                .flatMap(attributes -> Optional.ofNullable(attributes.get(billingCenterKey)))
-                .flatMap(value -> Optional.ofNullable(value.getValue()))
-                .orElse(StringUtils.EMPTY);
+    public static long withDiscount(final int discount, final long cost) {
+        return cost - cost * discount;
     }
 
     private static long tenInPowerOf(final int scale) {

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingUtils.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingUtils.java
@@ -110,6 +110,8 @@ public final class BillingUtils {
     public static final String PROVIDER_FIELD = "provider";
     public static final String SORT_AGG = "sort";
     public static final String DISCOUNT_SCRIPT_TEMPLATE = "_value + _value * (%s)";
+    public static final String STORAGE_USAGE_AVG_SCRIPT =
+            "doc.containsKey('usage_bytes_avg') ? doc.usage_bytes_avg.value : doc.usage_bytes.value";
 
     private BillingUtils() {
     }

--- a/api/src/main/java/com/epam/pipeline/manager/billing/ElasticDocumentsIterator.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/ElasticDocumentsIterator.java
@@ -1,0 +1,47 @@
+package com.epam.pipeline.manager.billing;
+
+import lombok.RequiredArgsConstructor;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
+
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.function.Function;
+
+@RequiredArgsConstructor
+public class ElasticDocumentsIterator implements Iterator<SearchResponse> {
+
+    private final int pageSize;
+    private final Function<Object[], SearchRequest> getRequest;
+    private final Function<SearchRequest, SearchResponse> getResponse;
+
+    private Object[] searchAfter;
+    private SearchResponse response;
+
+    @Override
+    public boolean hasNext() {
+        return response == null || pageSizeOf(response) >= pageSize;
+    }
+
+    private Integer pageSizeOf(final SearchResponse response) {
+        return Optional.ofNullable(response)
+                .map(SearchResponse::getHits)
+                .map(SearchHits::getHits)
+                .map(documents -> documents.length)
+                .orElse(0);
+    }
+
+    @Override
+    public SearchResponse next() {
+        response = getResponse.apply(getRequest.apply(searchAfter));
+        searchAfter = Optional.ofNullable(response)
+                .map(SearchResponse::getHits)
+                .map(SearchHits::getHits)
+                .map(documents -> documents[documents.length - 1])
+                .map(SearchHit::getSortValues)
+                .orElse(null);
+        return response;
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/billing/ElasticsearchMergingFrame.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/ElasticsearchMergingFrame.java
@@ -18,22 +18,22 @@ import java.util.stream.Stream;
 public enum ElasticsearchMergingFrame {
 
     DAY(ChronoUnit.DAYS,
-            LocalDate::from,
-            LocalDate::from,
-            LocalDate::from,
-            date -> DateTimeFormatter.ofPattern("yyyy-MM-dd").format(date)),
+        LocalDate::from,
+        LocalDate::from,
+        LocalDate::from,
+        date -> DateTimeFormatter.ofPattern("yyyy-MM-dd").format(date)),
 
     MONTH(ChronoUnit.MONTHS,
-            YearMonth::from,
-            ym -> YearMonth.from(ym).atDay(1),
-            ym -> YearMonth.from(ym).atEndOfMonth(),
-            ym -> DateTimeFormatter.ofPattern("yyyy-MM'm'").format(ym)),
+        YearMonth::from,
+        ym -> YearMonth.from(ym).atDay(1),
+        ym -> YearMonth.from(ym).atEndOfMonth(),
+        ym -> DateTimeFormatter.ofPattern("yyyy-MM'm'").format(ym)),
 
     YEAR(ChronoUnit.YEARS,
-            Year::from,
-            y -> Year.from(y).atDay(1),
-            y -> Year.from(y).atDay(Year.from(y).length()),
-            y -> DateTimeFormatter.ofPattern("yyyy'y'").format(y));
+        Year::from,
+        y -> Year.from(y).atDay(1),
+        y -> Year.from(y).atDay(Year.from(y).length()),
+        y -> DateTimeFormatter.ofPattern("yyyy'y'").format(y));
 
     private static final Comparator<ElasticsearchMergingFrame> DURATION_COMPARATOR =
             Comparator.comparing(ElasticsearchMergingFrame::unit,

--- a/api/src/main/java/com/epam/pipeline/manager/billing/ElasticsearchMergingFrame.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/ElasticsearchMergingFrame.java
@@ -1,0 +1,100 @@
+package com.epam.pipeline.manager.billing;
+
+import com.epam.pipeline.exception.search.SearchException;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.Temporal;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+@RequiredArgsConstructor
+public enum ElasticsearchMergingFrame {
+
+    DAY(ChronoUnit.DAYS,
+            LocalDate::from,
+            LocalDate::from,
+            LocalDate::from,
+            date -> DateTimeFormatter.ofPattern("yyyy-MM-dd").format(date)),
+
+    MONTH(ChronoUnit.MONTHS,
+            YearMonth::from,
+            ym -> YearMonth.from(ym).atDay(1),
+            ym -> YearMonth.from(ym).atEndOfMonth(),
+            ym -> DateTimeFormatter.ofPattern("yyyy-MM'm'").format(ym)),
+
+    YEAR(ChronoUnit.YEARS,
+            Year::from,
+            y -> Year.from(y).atDay(1),
+            y -> Year.from(y).atDay(Year.from(y).length()),
+            y -> DateTimeFormatter.ofPattern("yyyy'y'").format(y));
+
+    private static final Comparator<ElasticsearchMergingFrame> DURATION_COMPARATOR =
+            Comparator.comparing(ElasticsearchMergingFrame::unit,
+                    Comparator.comparing(ChronoUnit::getDuration));
+
+    private final ChronoUnit unit;
+    private final Function<LocalDate, Temporal> getDatePeriod;
+    private final Function<Temporal, LocalDate> getPeriodStart;
+    private final Function<Temporal, LocalDate> getPeriodEnd;
+    private final Function<Temporal, String> getPeriodName;
+
+    public ChronoUnit unit() {
+        return unit;
+    }
+
+    public Temporal periodOf(final LocalDate date) {
+        return getDatePeriod.apply(date);
+    }
+
+    public LocalDate startOf(final Temporal period) {
+        return getPeriodStart.apply(period);
+    }
+
+    public LocalDate endOf(final Temporal period) {
+        return getPeriodEnd.apply(period);
+    }
+
+    public String nameOf(final Temporal period) {
+        return getPeriodName.apply(period);
+    }
+
+    public Stream<String> subPeriodNamesOf(final Temporal period) {
+        if (ordinal() < 1) {
+            throw new SearchException(String.format("Synchronization frame %s does not have child frame", name()));
+        }
+        final ElasticsearchMergingFrame childFrame = values()[ordinal() - 1];
+        return Stream.iterate(startOf(period), date -> date.plusDays(1))
+                .limit(ChronoUnit.DAYS.between(startOf(period), endOf(period)) + 1)
+                .map(childFrame::periodOf)
+                .distinct()
+                .map(childFrame::nameOf);
+    }
+
+    public Stream<Temporal> periods(final LocalDate from, final LocalDate to) {
+        return Stream.iterate(from, date -> date.plusDays(1))
+                .map(this::periodOf)
+                .distinct()
+                .limit(unit().between(from, to) + 1);
+    }
+
+    public Stream<ElasticsearchMergingFrame> children() {
+        return Arrays.stream(ElasticsearchMergingFrame.values())
+                .sorted(ElasticsearchMergingFrame.comparingByDuration().reversed())
+                .filter(frame -> frame.isLessOrEqual(this));
+    }
+
+    public boolean isLessOrEqual(final ElasticsearchMergingFrame frame) {
+        return comparingByDuration().compare(this, frame) <= 0;
+    }
+
+    public static Comparator<ElasticsearchMergingFrame> comparingByDuration() {
+        return DURATION_COMPARATOR;
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/billing/ElasticsearchMergingFrame.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/ElasticsearchMergingFrame.java
@@ -81,7 +81,7 @@ public enum ElasticsearchMergingFrame {
         return Stream.iterate(from, date -> date.plusDays(1))
                 .map(this::periodOf)
                 .distinct()
-                .limit(unit().between(from, to) + 1);
+                .limit(unit().between(periodOf(from), periodOf(to)) + 1);
     }
 
     public Stream<ElasticsearchMergingFrame> children() {

--- a/api/src/main/java/com/epam/pipeline/manager/billing/ElasticsearchMergingFramePeriod.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/ElasticsearchMergingFramePeriod.java
@@ -1,0 +1,39 @@
+package com.epam.pipeline.manager.billing;
+
+import lombok.Value;
+
+import java.time.LocalDate;
+import java.time.temporal.Temporal;
+
+@Value
+public class ElasticsearchMergingFramePeriod {
+
+    ElasticsearchMergingFrame frame;
+    Temporal period;
+
+    public String name() {
+        return frame.nameOf(period);
+    }
+
+    public LocalDate start() {
+        return frame.startOf(period);
+    }
+
+    public LocalDate end() {
+        return frame.endOf(period);
+    }
+
+    public boolean isAfter(final LocalDate date) {
+        final LocalDate start = start();
+        return start.isAfter(date) || start.isEqual(date);
+    }
+
+    public boolean isBefore(final LocalDate date) {
+        final LocalDate end = end();
+        return end.isBefore(date) || end.isEqual(date);
+    }
+
+    public boolean isBetween(final LocalDate start, final LocalDate end) {
+        return isAfter(start) && isBefore(end);
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/billing/InstanceBillingLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/InstanceBillingLoader.java
@@ -4,6 +4,7 @@ import com.epam.pipeline.controller.vo.billing.BillingExportRequest;
 import com.epam.pipeline.entity.billing.BillingDiscount;
 import com.epam.pipeline.entity.billing.InstanceBilling;
 import com.epam.pipeline.entity.billing.InstanceBillingMetrics;
+import com.epam.pipeline.manager.billing.index.BillingIndexHelper;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.utils.StreamUtils;
@@ -37,16 +38,17 @@ import java.util.stream.Stream;
 public class InstanceBillingLoader implements BillingLoader<InstanceBilling> {
 
     private final BillingHelper billingHelper;
+    private final BillingIndexHelper billingIndexHelper;
     private final PreferenceManager preferenceManager;
 
     @Override
-    public Stream<InstanceBilling> billings(final RestHighLevelClient elasticSearchClient,
+    public Stream<InstanceBilling> billings(final RestHighLevelClient client,
                                             final BillingExportRequest request) {
         final LocalDate from = request.getFrom();
         final LocalDate to = request.getTo();
         final Map<String, List<String>> filters = billingHelper.getFilters(request.getFilters());
         final BillingDiscount discount = Optional.ofNullable(request.getDiscount()).orElseGet(BillingDiscount::empty);
-        return billings(elasticSearchClient, from, to, filters, discount, getPageSize());
+        return billings(client, from, to, filters, discount, getPageSize());
     }
 
     private int getPageSize() {
@@ -55,17 +57,17 @@ public class InstanceBillingLoader implements BillingLoader<InstanceBilling> {
                 .orElse(BillingUtils.FALLBACK_EXPORT_PERIOD_AGGREGATION_PAGE_SIZE);
     }
 
-    private Stream<InstanceBilling> billings(final RestHighLevelClient elasticSearchClient,
+    private Stream<InstanceBilling> billings(final RestHighLevelClient client,
                                              final LocalDate from,
                                              final LocalDate to,
                                              final Map<String, List<String>> filters,
                                              final BillingDiscount discount,
                                              final int pageSize) {
-        return StreamUtils.from(billingsIterator(elasticSearchClient, from, to, filters, discount, pageSize))
+        return StreamUtils.from(billingsIterator(client, from, to, filters, discount, pageSize))
                 .flatMap(this::billings);
     }
 
-    private Iterator<SearchResponse> billingsIterator(final RestHighLevelClient elasticSearchClient,
+    private Iterator<SearchResponse> billingsIterator(final RestHighLevelClient client,
                                                       final LocalDate from,
                                                       final LocalDate to,
                                                       final Map<String, List<String>> filters,
@@ -73,7 +75,7 @@ public class InstanceBillingLoader implements BillingLoader<InstanceBilling> {
                                                       final int pageSize) {
         return new ElasticMultiBucketsIterator(BillingUtils.INSTANCE_TYPE_FIELD, pageSize,
             pageOffset -> getBillingsRequest(from, to, filters, discount, pageOffset, pageSize),
-            billingHelper.searchWith(elasticSearchClient),
+            billingHelper.searchWith(client),
             billingHelper::getTerms);
     }
 
@@ -84,8 +86,8 @@ public class InstanceBillingLoader implements BillingLoader<InstanceBilling> {
                                              final int pageOffset,
                                              final int pageSize) {
         return new SearchRequest()
-                .indicesOptions(IndicesOptions.strictExpandOpen())
-                .indices(billingHelper.runIndicesByDate(from, to))
+                .indicesOptions(IndicesOptions.lenientExpandOpen())
+                .indices(billingIndexHelper.monthlyRunIndicesBetween(from, to))
                 .source(new SearchSourceBuilder()
                         .size(NumberUtils.INTEGER_ZERO)
                         .query(billingHelper.queryByDateAndFilters(from, to, filters))

--- a/api/src/main/java/com/epam/pipeline/manager/billing/InstanceBillingLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/InstanceBillingLoader.java
@@ -38,6 +38,7 @@ import java.util.stream.Stream;
 public class InstanceBillingLoader implements BillingLoader<InstanceBilling> {
 
     private final BillingHelper billingHelper;
+    private final BillingSecurityHelper billingSecurityHelper;
     private final BillingIndexHelper billingIndexHelper;
     private final PreferenceManager preferenceManager;
 
@@ -46,7 +47,7 @@ public class InstanceBillingLoader implements BillingLoader<InstanceBilling> {
                                             final BillingExportRequest request) {
         final LocalDate from = request.getFrom();
         final LocalDate to = request.getTo();
-        final Map<String, List<String>> filters = billingHelper.getFilters(request.getFilters());
+        final Map<String, List<String>> filters = billingSecurityHelper.getFilters(request.getFilters());
         final BillingDiscount discount = Optional.ofNullable(request.getDiscount()).orElseGet(BillingDiscount::empty);
         return billings(client, from, to, filters, discount, getPageSize());
     }

--- a/api/src/main/java/com/epam/pipeline/manager/billing/LowLevelBillingLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/LowLevelBillingLoader.java
@@ -10,11 +10,11 @@ import java.util.stream.Stream;
 
 public interface LowLevelBillingLoader<B> {
 
-    Stream<B> billings(final RestHighLevelClient client,
-                       final String[] indices,
-                       final LocalDate from,
-                       final LocalDate to,
-                       final Map<String, List<String>> filters,
-                       final BillingDiscount discount,
-                       final int pageSize);
+    Stream<B> billings(RestHighLevelClient client,
+                       String[] indices,
+                       LocalDate from,
+                       LocalDate to,
+                       Map<String, List<String>> filters,
+                       BillingDiscount discount,
+                       int pageSize);
 }

--- a/api/src/main/java/com/epam/pipeline/manager/billing/LowLevelBillingLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/LowLevelBillingLoader.java
@@ -1,0 +1,20 @@
+package com.epam.pipeline.manager.billing;
+
+import com.epam.pipeline.entity.billing.BillingDiscount;
+import org.elasticsearch.client.RestHighLevelClient;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+public interface LowLevelBillingLoader<B> {
+
+    Stream<B> billings(final RestHighLevelClient client,
+                       final String[] indices,
+                       final LocalDate from,
+                       final LocalDate to,
+                       final Map<String, List<String>> filters,
+                       final BillingDiscount discount,
+                       final int pageSize);
+}

--- a/api/src/main/java/com/epam/pipeline/manager/billing/PipelineBillingLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/PipelineBillingLoader.java
@@ -38,6 +38,7 @@ import java.util.stream.Stream;
 public class PipelineBillingLoader implements BillingLoader<PipelineBilling> {
 
     private final BillingHelper billingHelper;
+    private final BillingSecurityHelper billingSecurityHelper;
     private final BillingIndexHelper billingIndexHelper;
     private final PreferenceManager preferenceManager;
     private final PipelineBillingDetailsLoader pipelineBillingDetailsLoader;
@@ -47,7 +48,7 @@ public class PipelineBillingLoader implements BillingLoader<PipelineBilling> {
                                             final BillingExportRequest request) {
         final LocalDate from = request.getFrom();
         final LocalDate to = request.getTo();
-        final Map<String, List<String>> filters = billingHelper.getFilters(request.getFilters());
+        final Map<String, List<String>> filters = billingSecurityHelper.getFilters(request.getFilters());
         final BillingDiscount discount = Optional.ofNullable(request.getDiscount()).orElseGet(BillingDiscount::empty);
         return billings(client, from, to, filters, discount, getPageSize());
     }

--- a/api/src/main/java/com/epam/pipeline/manager/billing/PipelineBillingLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/PipelineBillingLoader.java
@@ -4,6 +4,7 @@ import com.epam.pipeline.controller.vo.billing.BillingExportRequest;
 import com.epam.pipeline.entity.billing.BillingDiscount;
 import com.epam.pipeline.entity.billing.PipelineBilling;
 import com.epam.pipeline.entity.billing.PipelineBillingMetrics;
+import com.epam.pipeline.manager.billing.index.BillingIndexHelper;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.utils.StreamUtils;
@@ -37,17 +38,18 @@ import java.util.stream.Stream;
 public class PipelineBillingLoader implements BillingLoader<PipelineBilling> {
 
     private final BillingHelper billingHelper;
+    private final BillingIndexHelper billingIndexHelper;
     private final PreferenceManager preferenceManager;
     private final PipelineBillingDetailsLoader pipelineBillingDetailsLoader;
 
     @Override
-    public Stream<PipelineBilling> billings(final RestHighLevelClient elasticSearchClient,
+    public Stream<PipelineBilling> billings(final RestHighLevelClient client,
                                             final BillingExportRequest request) {
         final LocalDate from = request.getFrom();
         final LocalDate to = request.getTo();
         final Map<String, List<String>> filters = billingHelper.getFilters(request.getFilters());
         final BillingDiscount discount = Optional.ofNullable(request.getDiscount()).orElseGet(BillingDiscount::empty);
-        return billings(elasticSearchClient, from, to, filters, discount, getPageSize());
+        return billings(client, from, to, filters, discount, getPageSize());
     }
 
     private int getPageSize() {
@@ -56,17 +58,17 @@ public class PipelineBillingLoader implements BillingLoader<PipelineBilling> {
                 .orElse(BillingUtils.FALLBACK_EXPORT_PERIOD_AGGREGATION_PAGE_SIZE);
     }
 
-    private Stream<PipelineBilling> billings(final RestHighLevelClient elasticSearchClient,
+    private Stream<PipelineBilling> billings(final RestHighLevelClient client,
                                              final LocalDate from,
                                              final LocalDate to,
                                              final Map<String, List<String>> filters,
                                              final BillingDiscount discount,
                                              final int pageSize) {
-        return StreamUtils.from(billingsIterator(elasticSearchClient, from, to, filters, discount, pageSize))
+        return StreamUtils.from(billingsIterator(client, from, to, filters, discount, pageSize))
                 .flatMap(this::billings);
     }
 
-    private Iterator<SearchResponse> billingsIterator(final RestHighLevelClient elasticSearchClient,
+    private Iterator<SearchResponse> billingsIterator(final RestHighLevelClient client,
                                                       final LocalDate from,
                                                       final LocalDate to,
                                                       final Map<String, List<String>> filters,
@@ -74,7 +76,7 @@ public class PipelineBillingLoader implements BillingLoader<PipelineBilling> {
                                                       final int pageSize) {
         return new ElasticMultiBucketsIterator(BillingUtils.PIPELINE_ID_FIELD, pageSize,
             pageOffset -> getBillingsRequest(from, to, filters, discount, pageOffset, pageSize),
-            billingHelper.searchWith(elasticSearchClient),
+            billingHelper.searchWith(client),
             billingHelper::getTerms);
     }
 
@@ -85,8 +87,8 @@ public class PipelineBillingLoader implements BillingLoader<PipelineBilling> {
                                              final int pageOffset,
                                              final int pageSize) {
         return new SearchRequest()
-                .indicesOptions(IndicesOptions.strictExpandOpen())
-                .indices(billingHelper.runIndicesByDate(from, to))
+                .indicesOptions(IndicesOptions.lenientExpandOpen())
+                .indices(billingIndexHelper.monthlyRunIndicesBetween(from, to))
                 .source(new SearchSourceBuilder()
                         .size(NumberUtils.INTEGER_ZERO)
                         .query(billingHelper.queryByDateAndFilters(from, to, filters))

--- a/api/src/main/java/com/epam/pipeline/manager/billing/RunBillingLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/RunBillingLoader.java
@@ -37,6 +37,7 @@ import java.util.stream.Stream;
 public class RunBillingLoader implements BillingLoader<RunBilling> {
 
     private final BillingHelper billingHelper;
+    private final BillingSecurityHelper billingSecurityHelper;
     private final BillingIndexHelper billingIndexHelper;
     private final PreferenceManager preferenceManager;
 
@@ -45,7 +46,7 @@ public class RunBillingLoader implements BillingLoader<RunBilling> {
                                        final BillingExportRequest request) {
         final LocalDate from = request.getFrom();
         final LocalDate to = request.getTo();
-        final Map<String, List<String>> filters = billingHelper.getFilters(request.getFilters());
+        final Map<String, List<String>> filters = billingSecurityHelper.getFilters(request.getFilters());
         final BillingDiscount discount = Optional.ofNullable(request.getDiscount()).orElseGet(BillingDiscount::empty);
         return billings(client, from, to, filters, discount, getPageSize());
     }

--- a/api/src/main/java/com/epam/pipeline/manager/billing/RunBillingLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/RunBillingLoader.java
@@ -3,21 +3,28 @@ package com.epam.pipeline.manager.billing;
 import com.epam.pipeline.controller.vo.billing.BillingExportRequest;
 import com.epam.pipeline.entity.billing.BillingDiscount;
 import com.epam.pipeline.entity.billing.RunBilling;
+import com.epam.pipeline.manager.billing.index.BillingIndexHelper;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.utils.StreamUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.sort.SortBuilders;
+import org.elasticsearch.search.sort.SortOrder;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -30,16 +37,17 @@ import java.util.stream.Stream;
 public class RunBillingLoader implements BillingLoader<RunBilling> {
 
     private final BillingHelper billingHelper;
+    private final BillingIndexHelper billingIndexHelper;
     private final PreferenceManager preferenceManager;
 
     @Override
-    public Stream<RunBilling> billings(final RestHighLevelClient elasticSearchClient,
+    public Stream<RunBilling> billings(final RestHighLevelClient client,
                                        final BillingExportRequest request) {
         final LocalDate from = request.getFrom();
         final LocalDate to = request.getTo();
         final Map<String, List<String>> filters = billingHelper.getFilters(request.getFilters());
         final BillingDiscount discount = Optional.ofNullable(request.getDiscount()).orElseGet(BillingDiscount::empty);
-        return billings(elasticSearchClient, from, to, filters, discount, getPageSize());
+        return billings(client, from, to, filters, discount, getPageSize());
     }
 
     private int getPageSize() {
@@ -48,67 +56,167 @@ public class RunBillingLoader implements BillingLoader<RunBilling> {
                 .orElse(BillingUtils.FALLBACK_EXPORT_AGGREGATION_PAGE_SIZE);
     }
 
-    private Stream<RunBilling> billings(final RestHighLevelClient elasticSearchClient,
+    private Stream<RunBilling> billings(final RestHighLevelClient client,
                                         final LocalDate from,
                                         final LocalDate to,
                                         final Map<String, List<String>> filters,
                                         final BillingDiscount discount,
                                         final int pageSize) {
-        return StreamUtils.from(billingsIterator(elasticSearchClient, from, to, filters, discount, pageSize))
-                .flatMap(this::billings);
+        final String[] indices = billingIndexHelper.yearlyRunIndicesBetween(from, to);
+        final LowLevelBillingLoader<RunBilling> loader = indices.length > 1
+                ? new MultiIndexRunBillingLoader(billingHelper)
+                : new SingleIndexRunBillingLoader(billingHelper);
+        return loader.billings(client, indices, from, to, filters, discount, pageSize);
     }
 
-    private Iterator<SearchResponse> billingsIterator(final RestHighLevelClient elasticSearchClient,
-                                                      final LocalDate from,
-                                                      final LocalDate to,
-                                                      final Map<String, List<String>> filters,
-                                                      final BillingDiscount discount,
-                                                      final int pageSize) {
-        return new ElasticMultiBucketsIterator(BillingUtils.RUN_ID_FIELD, pageSize,
-            pageOffset -> getBillingsRequest(from, to, filters, discount, pageOffset, pageSize),
-            billingHelper.searchWith(elasticSearchClient),
-            billingHelper::getTerms);
+    @RequiredArgsConstructor
+    public static class SingleIndexRunBillingLoader implements LowLevelBillingLoader<RunBilling> {
+
+        private final BillingHelper billingHelper;
+
+        @Override
+        public Stream<RunBilling> billings(final RestHighLevelClient client,
+                                           final String[] indices,
+                                           final LocalDate from,
+                                           final LocalDate to,
+                                           final Map<String, List<String>> filters,
+                                           final BillingDiscount discount,
+                                           final int pageSize) {
+            return StreamUtils.from(iterator(client, indices, from, to, filters, discount, pageSize))
+                    .flatMap(response -> billings(response, discount));
+        }
+
+        private Iterator<SearchResponse> iterator(final RestHighLevelClient client,
+                                                  final String[] indices,
+                                                  final LocalDate from,
+                                                  final LocalDate to,
+                                                  final Map<String, List<String>> filters,
+                                                  final BillingDiscount discount,
+                                                  final int pageSize) {
+            return new ElasticDocumentsIterator(pageSize,
+                    searchAfter -> getRequest(indices, from, to, filters, discount, searchAfter, pageSize),
+                    billingHelper.searchWith(client));
+        }
+
+        private SearchRequest getRequest(final String[] indices,
+                                         final LocalDate from,
+                                         final LocalDate to,
+                                         final Map<String, List<String>> filters,
+                                         final BillingDiscount discount,
+                                         final Object[] searchAfter,
+                                         final int pageSize) {
+            final SearchSourceBuilder source = new SearchSourceBuilder()
+                    .size(pageSize)
+                    .query(billingHelper.queryByDateAndFilters(from, to, filters))
+                    .sort(SortBuilders.fieldSort(BillingUtils.COST_FIELD).order(SortOrder.DESC))
+                    .sort(SortBuilders.fieldSort(BillingUtils.DOC_ID_FIELD).order(SortOrder.DESC));
+            Optional.ofNullable(searchAfter).ifPresent(source::searchAfter);
+            return new SearchRequest()
+                    .indicesOptions(IndicesOptions.lenientExpandOpen())
+                    .indices(indices)
+                    .source(source);
+        }
+
+        private Stream<RunBilling> billings(final SearchResponse response, final BillingDiscount discount) {
+            return Optional.ofNullable(response)
+                    .map(SearchResponse::getHits)
+                    .map(SearchHits::getHits)
+                    .map(Arrays::stream)
+                    .orElseGet(Stream::empty)
+                    .map(hit -> getBilling(hit, discount));
+        }
+
+        private RunBilling getBilling(final SearchHit hit, final BillingDiscount discount) {
+            final Map<String, Object> topHitFields = MapUtils.emptyIfNull(hit.getSourceAsMap());
+            return RunBilling.builder()
+                    .runId(NumberUtils.toLong(BillingUtils.asString(topHitFields.get(BillingUtils.RUN_ID_FIELD))))
+                    .owner(BillingUtils.asString(topHitFields.get(BillingUtils.OWNER_FIELD)))
+                    .billingCenter(BillingUtils.asString(topHitFields.get(BillingUtils.BILLING_CENTER_FIELD)))
+                    .pipeline(BillingUtils.asString(topHitFields.get(BillingUtils.PIPELINE_NAME_FIELD)))
+                    .tool(BillingUtils.asString(topHitFields.get(BillingUtils.TOOL_FIELD)))
+                    .computeType(BillingUtils.asString(topHitFields.get(BillingUtils.COMPUTE_TYPE_FIELD)))
+                    .instanceType(BillingUtils.asString(topHitFields.get(BillingUtils.INSTANCE_TYPE_FIELD)))
+                    .started(BillingUtils.asDateTime(topHitFields.get(BillingUtils.STARTED_FIELD)))
+                    .finished(BillingUtils.asDateTime(topHitFields.get(BillingUtils.FINISHED_FIELD)))
+                    .duration(NumberUtils.toLong(BillingUtils.asString(topHitFields.get(BillingUtils.RUN_USAGE_FIELD))))
+                    .cost(BillingUtils.withDiscount(discount.getComputes(), NumberUtils.toLong(BillingUtils.asString(
+                            topHitFields.get(BillingUtils.COST_FIELD)))))
+                    .build();
+        }
     }
 
-    private SearchRequest getBillingsRequest(final LocalDate from,
-                                             final LocalDate to,
-                                             final Map<String, List<String>> filters,
-                                             final BillingDiscount discount,
-                                             final int pageOffset,
-                                             final int pageSize) {
-        return new SearchRequest()
-                .indicesOptions(IndicesOptions.strictExpandOpen())
-                .indices(billingHelper.runIndicesByDate(from, to))
-                .source(new SearchSourceBuilder()
-                        .size(NumberUtils.INTEGER_ZERO)
-                        .query(billingHelper.queryByDateAndFilters(from, to, filters))
-                        .aggregation(billingHelper.aggregateBy(BillingUtils.RUN_ID_FIELD)
-                                .size(Integer.MAX_VALUE)
-                                .subAggregation(billingHelper.aggregateCostSum(discount.getComputes()))
-                                .subAggregation(billingHelper.aggregateRunUsageSum())
-                                .subAggregation(billingHelper.aggregateLastByDateDoc())
-                                .subAggregation(billingHelper.aggregateCostSortBucket(pageOffset, pageSize))));
+    @RequiredArgsConstructor
+    public static class MultiIndexRunBillingLoader implements LowLevelBillingLoader<RunBilling> {
+
+        private final BillingHelper billingHelper;
+
+        @Override
+        public Stream<RunBilling> billings(final RestHighLevelClient client,
+                                           final String[] indices,
+                                           final LocalDate from,
+                                           final LocalDate to,
+                                           final Map<String, List<String>> filters,
+                                           final BillingDiscount discount,
+                                           final int pageSize) {
+            return StreamUtils.from(iterator(client, indices, from, to, filters, discount, pageSize))
+                    .flatMap(documents -> billings(documents, discount));
+        }
+
+        private Iterator<SearchResponse> iterator(final RestHighLevelClient client,
+                                                  final String[] indices,
+                                                  final LocalDate from,
+                                                  final LocalDate to,
+                                                  final Map<String, List<String>> filters,
+                                                  final BillingDiscount discount,
+                                                  final int pageSize) {
+            return new ElasticMultiBucketsIterator(BillingUtils.RUN_ID_FIELD, pageSize,
+                    pageOffset -> getRequest(indices, from, to, filters, discount, pageOffset, pageSize),
+                    billingHelper.searchWith(client),
+                    billingHelper::getTerms);
+        }
+
+        private SearchRequest getRequest(final String[] indices,
+                                         final LocalDate from,
+                                         final LocalDate to,
+                                         final Map<String, List<String>> filters,
+                                         final BillingDiscount discount,
+                                         final int pageOffset,
+                                         final int pageSize) {
+            return new SearchRequest()
+                    .indicesOptions(IndicesOptions.lenientExpandOpen())
+                    .indices(indices)
+                    .source(new SearchSourceBuilder()
+                            .size(NumberUtils.INTEGER_ZERO)
+                            .query(billingHelper.queryByDateAndFilters(from, to, filters))
+                            .aggregation(billingHelper.aggregateBy(BillingUtils.RUN_ID_FIELD)
+                                    .size(Integer.MAX_VALUE)
+                                    .subAggregation(billingHelper.aggregateCostSum(discount.getComputes()))
+                                    .subAggregation(billingHelper.aggregateRunUsageSum())
+                                    .subAggregation(billingHelper.aggregateLastByDateDoc())
+                                    .subAggregation(billingHelper.aggregateCostSortBucket(pageOffset, pageSize))));
+        }
+
+        private Stream<RunBilling> billings(final SearchResponse response, final BillingDiscount discount) {
+            return billingHelper.termBuckets(response.getAggregations(), BillingUtils.RUN_ID_FIELD)
+                    .map(bucket -> getBilling(bucket.getKeyAsString(), bucket.getAggregations()));
+        }
+
+        private RunBilling getBilling(final String id, final Aggregations aggregations) {
+            final Map<String, Object> topHitFields = billingHelper.getLastByDateDocFields(aggregations);
+            return RunBilling.builder()
+                    .runId(NumberUtils.toLong(id))
+                    .owner(BillingUtils.asString(topHitFields.get(BillingUtils.OWNER_FIELD)))
+                    .billingCenter(BillingUtils.asString(topHitFields.get(BillingUtils.BILLING_CENTER_FIELD)))
+                    .pipeline(BillingUtils.asString(topHitFields.get(BillingUtils.PIPELINE_NAME_FIELD)))
+                    .tool(BillingUtils.asString(topHitFields.get(BillingUtils.TOOL_FIELD)))
+                    .computeType(BillingUtils.asString(topHitFields.get(BillingUtils.COMPUTE_TYPE_FIELD)))
+                    .instanceType(BillingUtils.asString(topHitFields.get(BillingUtils.INSTANCE_TYPE_FIELD)))
+                    .started(BillingUtils.asDateTime(topHitFields.get(BillingUtils.STARTED_FIELD)))
+                    .finished(BillingUtils.asDateTime(topHitFields.get(BillingUtils.FINISHED_FIELD)))
+                    .duration(billingHelper.getRunUsageSum(aggregations))
+                    .cost(billingHelper.getCostSum(aggregations))
+                    .build();
+        }
     }
 
-    private Stream<RunBilling> billings(final SearchResponse response) {
-        return billingHelper.termBuckets(response.getAggregations(), BillingUtils.RUN_ID_FIELD)
-                .map(bucket -> getBilling(bucket.getKeyAsString(), bucket.getAggregations()));
-    }
-
-    private RunBilling getBilling(final String id, final Aggregations aggregations) {
-        final Map<String, Object> topHitFields = billingHelper.getLastByDateDocFields(aggregations);
-        return RunBilling.builder()
-                .runId(NumberUtils.toLong(id))
-                .owner(BillingUtils.asString(topHitFields.get(BillingUtils.OWNER_FIELD)))
-                .billingCenter(BillingUtils.asString(topHitFields.get(BillingUtils.BILLING_CENTER_FIELD)))
-                .pipeline(BillingUtils.asString(topHitFields.get(BillingUtils.PIPELINE_NAME_FIELD)))
-                .tool(BillingUtils.asString(topHitFields.get(BillingUtils.TOOL_FIELD)))
-                .computeType(BillingUtils.asString(topHitFields.get(BillingUtils.COMPUTE_TYPE_FIELD)))
-                .instanceType(BillingUtils.asString(topHitFields.get(BillingUtils.INSTANCE_TYPE_FIELD)))
-                .started(BillingUtils.asDateTime(topHitFields.get(BillingUtils.STARTED_FIELD)))
-                .finished(BillingUtils.asDateTime(topHitFields.get(BillingUtils.FINISHED_FIELD)))
-                .duration(billingHelper.getRunUsageSum(aggregations))
-                .cost(billingHelper.getCostSum(aggregations))
-                .build();
-    }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/billing/RunBillingLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/RunBillingLoader.java
@@ -9,22 +9,16 @@ import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.utils.StreamUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.search.SearchHit;
-import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
-import org.elasticsearch.search.sort.SortBuilders;
-import org.elasticsearch.search.sort.SortOrder;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -64,84 +58,8 @@ public class RunBillingLoader implements BillingLoader<RunBilling> {
                                         final BillingDiscount discount,
                                         final int pageSize) {
         final String[] indices = billingIndexHelper.yearlyRunIndicesBetween(from, to);
-        final LowLevelBillingLoader<RunBilling> loader = indices.length > 1
-                ? new MultiIndexRunBillingLoader(billingHelper)
-                : new SingleIndexRunBillingLoader(billingHelper);
+        final LowLevelBillingLoader<RunBilling> loader = new MultiIndexRunBillingLoader(billingHelper);
         return loader.billings(client, indices, from, to, filters, discount, pageSize);
-    }
-
-    @RequiredArgsConstructor
-    public static class SingleIndexRunBillingLoader implements LowLevelBillingLoader<RunBilling> {
-
-        private final BillingHelper billingHelper;
-
-        @Override
-        public Stream<RunBilling> billings(final RestHighLevelClient client,
-                                           final String[] indices,
-                                           final LocalDate from,
-                                           final LocalDate to,
-                                           final Map<String, List<String>> filters,
-                                           final BillingDiscount discount,
-                                           final int pageSize) {
-            return StreamUtils.from(iterator(client, indices, from, to, filters, pageSize))
-                    .flatMap(response -> billings(response, discount));
-        }
-
-        private Iterator<SearchResponse> iterator(final RestHighLevelClient client,
-                                                  final String[] indices,
-                                                  final LocalDate from,
-                                                  final LocalDate to,
-                                                  final Map<String, List<String>> filters,
-                                                  final int pageSize) {
-            return new ElasticDocumentsIterator(pageSize,
-                searchAfter -> getRequest(indices, from, to, filters, searchAfter, pageSize),
-                billingHelper.searchWith(client));
-        }
-
-        private SearchRequest getRequest(final String[] indices,
-                                         final LocalDate from,
-                                         final LocalDate to,
-                                         final Map<String, List<String>> filters,
-                                         final Object[] searchAfter,
-                                         final int pageSize) {
-            final SearchSourceBuilder source = new SearchSourceBuilder()
-                    .size(pageSize)
-                    .query(billingHelper.queryByDateAndFilters(from, to, filters))
-                    .sort(SortBuilders.fieldSort(BillingUtils.COST_FIELD).order(SortOrder.DESC))
-                    .sort(SortBuilders.fieldSort(BillingUtils.DOC_ID_FIELD).order(SortOrder.DESC));
-            Optional.ofNullable(searchAfter).ifPresent(source::searchAfter);
-            return new SearchRequest()
-                    .indicesOptions(IndicesOptions.lenientExpandOpen())
-                    .indices(indices)
-                    .source(source);
-        }
-
-        private Stream<RunBilling> billings(final SearchResponse response, final BillingDiscount discount) {
-            return Optional.ofNullable(response)
-                    .map(SearchResponse::getHits)
-                    .map(SearchHits::getHits)
-                    .map(Arrays::stream)
-                    .orElseGet(Stream::empty)
-                    .map(hit -> getBilling(hit, discount));
-        }
-
-        private RunBilling getBilling(final SearchHit hit, final BillingDiscount discount) {
-            final Map<String, Object> topHitFields = MapUtils.emptyIfNull(hit.getSourceAsMap());
-            return RunBilling.builder()
-                    .runId(NumberUtils.toLong(BillingUtils.asString(topHitFields.get(BillingUtils.RUN_ID_FIELD))))
-                    .owner(BillingUtils.asString(topHitFields.get(BillingUtils.OWNER_FIELD)))
-                    .billingCenter(BillingUtils.asString(topHitFields.get(BillingUtils.BILLING_CENTER_FIELD)))
-                    .pipeline(BillingUtils.asString(topHitFields.get(BillingUtils.PIPELINE_NAME_FIELD)))
-                    .tool(BillingUtils.asString(topHitFields.get(BillingUtils.TOOL_FIELD)))
-                    .computeType(BillingUtils.asString(topHitFields.get(BillingUtils.COMPUTE_TYPE_FIELD)))
-                    .instanceType(BillingUtils.asString(topHitFields.get(BillingUtils.INSTANCE_TYPE_FIELD)))
-                    .started(BillingUtils.asDateTime(topHitFields.get(BillingUtils.STARTED_FIELD)))
-                    .finished(BillingUtils.asDateTime(topHitFields.get(BillingUtils.FINISHED_FIELD)))
-                    .duration(NumberUtils.toLong(BillingUtils.asString(topHitFields.get(BillingUtils.RUN_USAGE_FIELD))))
-                    .cost(BillingUtils.withDiscount(discount.getComputes(), NumberUtils.toLong(BillingUtils.asString(
-                            topHitFields.get(BillingUtils.COST_FIELD)))))
-                    .build();
-        }
     }
 
     @RequiredArgsConstructor
@@ -158,7 +76,7 @@ public class RunBillingLoader implements BillingLoader<RunBilling> {
                                            final BillingDiscount discount,
                                            final int pageSize) {
             return StreamUtils.from(iterator(client, indices, from, to, filters, discount, pageSize))
-                    .flatMap(documents -> billings(documents));
+                    .flatMap(this::billings);
         }
 
         private Iterator<SearchResponse> iterator(final RestHighLevelClient client,

--- a/api/src/main/java/com/epam/pipeline/manager/billing/StorageBillingLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/StorageBillingLoader.java
@@ -5,6 +5,7 @@ import com.epam.pipeline.entity.billing.BillingDiscount;
 import com.epam.pipeline.entity.billing.StorageBilling;
 import com.epam.pipeline.entity.billing.StorageBillingMetrics;
 import com.epam.pipeline.entity.datastorage.DataStorageType;
+import com.epam.pipeline.manager.billing.index.BillingIndexHelper;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.utils.StreamUtils;
@@ -40,17 +41,18 @@ import java.util.stream.Stream;
 public class StorageBillingLoader implements BillingLoader<StorageBilling> {
 
     private final BillingHelper billingHelper;
+    private final BillingIndexHelper billingIndexHelper;
     private final PreferenceManager preferenceManager;
     private final StorageBillingDetailsLoader storageBillingDetailsLoader;
 
     @Override
-    public Stream<StorageBilling> billings(final RestHighLevelClient elasticSearchClient,
+    public Stream<StorageBilling> billings(final RestHighLevelClient client,
                                            final BillingExportRequest request) {
         final LocalDate from = request.getFrom();
         final LocalDate to = request.getTo();
         final Map<String, List<String>> filters = billingHelper.getFilters(request.getFilters());
         final BillingDiscount discount = Optional.ofNullable(request.getDiscount()).orElseGet(BillingDiscount::empty);
-        return billings(elasticSearchClient, from, to, filters, discount, getPageSize());
+        return billings(client, from, to, filters, discount, getPageSize());
     }
 
     private int getPageSize() {
@@ -59,17 +61,17 @@ public class StorageBillingLoader implements BillingLoader<StorageBilling> {
                 .orElse(BillingUtils.FALLBACK_EXPORT_PERIOD_AGGREGATION_PAGE_SIZE);
     }
 
-    private Stream<StorageBilling> billings(final RestHighLevelClient elasticSearchClient,
+    private Stream<StorageBilling> billings(final RestHighLevelClient client,
                                             final LocalDate from,
                                             final LocalDate to,
                                             final Map<String, List<String>> filters,
                                             final BillingDiscount discount,
                                             final int pageSize) {
-        return StreamUtils.from(billingsIterator(elasticSearchClient, from, to, filters, discount, pageSize))
+        return StreamUtils.from(billingsIterator(client, from, to, filters, discount, pageSize))
                 .flatMap(this::billings);
     }
 
-    private Iterator<SearchResponse> billingsIterator(final RestHighLevelClient elasticSearchClient,
+    private Iterator<SearchResponse> billingsIterator(final RestHighLevelClient client,
                                                       final LocalDate from,
                                                       final LocalDate to,
                                                       final Map<String, List<String>> filters,
@@ -77,7 +79,7 @@ public class StorageBillingLoader implements BillingLoader<StorageBilling> {
                                                       final int pageSize) {
         return new ElasticMultiBucketsIterator(BillingUtils.STORAGE_ID_FIELD, pageSize,
             pageOffset -> getBillingsRequest(from, to, filters, discount, pageOffset, pageSize),
-            billingHelper.searchWith(elasticSearchClient),
+            billingHelper.searchWith(client),
             billingHelper::getTerms);
     }
 
@@ -88,8 +90,8 @@ public class StorageBillingLoader implements BillingLoader<StorageBilling> {
                                              final int pageOffset,
                                              final int pageSize) {
         return new SearchRequest()
-                .indicesOptions(IndicesOptions.strictExpandOpen())
-                .indices(billingHelper.storageIndicesByDate(from, to))
+                .indicesOptions(IndicesOptions.lenientExpandOpen())
+                .indices(billingIndexHelper.monthlyStorageIndicesBetween(from, to))
                 .source(new SearchSourceBuilder()
                         .size(NumberUtils.INTEGER_ZERO)
                         .query(billingHelper.queryByDateAndFilters(from, to, filters))

--- a/api/src/main/java/com/epam/pipeline/manager/billing/StorageBillingLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/StorageBillingLoader.java
@@ -41,6 +41,7 @@ import java.util.stream.Stream;
 public class StorageBillingLoader implements BillingLoader<StorageBilling> {
 
     private final BillingHelper billingHelper;
+    private final BillingSecurityHelper billingSecurityHelper;
     private final BillingIndexHelper billingIndexHelper;
     private final PreferenceManager preferenceManager;
     private final StorageBillingDetailsLoader storageBillingDetailsLoader;
@@ -50,7 +51,7 @@ public class StorageBillingLoader implements BillingLoader<StorageBilling> {
                                            final BillingExportRequest request) {
         final LocalDate from = request.getFrom();
         final LocalDate to = request.getTo();
-        final Map<String, List<String>> filters = billingHelper.getFilters(request.getFilters());
+        final Map<String, List<String>> filters = billingSecurityHelper.getFilters(request.getFilters());
         final BillingDiscount discount = Optional.ofNullable(request.getDiscount()).orElseGet(BillingDiscount::empty);
         return billings(client, from, to, filters, discount, getPageSize());
     }

--- a/api/src/main/java/com/epam/pipeline/manager/billing/ToolBillingLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/ToolBillingLoader.java
@@ -38,6 +38,7 @@ import java.util.stream.Stream;
 public class ToolBillingLoader implements BillingLoader<ToolBilling> {
 
     private final BillingHelper billingHelper;
+    private final BillingSecurityHelper billingSecurityHelper;
     private final BillingIndexHelper billingIndexHelper;
     private final PreferenceManager preferenceManager;
     private final ToolBillingDetailsLoader toolBillingDetailsLoader;
@@ -47,7 +48,7 @@ public class ToolBillingLoader implements BillingLoader<ToolBilling> {
                                         final BillingExportRequest request) {
         final LocalDate from = request.getFrom();
         final LocalDate to = request.getTo();
-        final Map<String, List<String>> filters = billingHelper.getFilters(request.getFilters());
+        final Map<String, List<String>> filters = billingSecurityHelper.getFilters(request.getFilters());
         final BillingDiscount discount = Optional.ofNullable(request.getDiscount()).orElseGet(BillingDiscount::empty);
         return billings(client, from, to, filters, discount, getPageSize());
     }

--- a/api/src/main/java/com/epam/pipeline/manager/billing/UserBillingLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/UserBillingLoader.java
@@ -38,6 +38,7 @@ import java.util.stream.Stream;
 public class UserBillingLoader implements BillingLoader<UserGeneralBilling> {
 
     private final BillingHelper billingHelper;
+    private final BillingSecurityHelper billingSecurityHelper;
     private final BillingIndexHelper billingIndexHelper;
     private final PreferenceManager preferenceManager;
     private final UserBillingDetailsLoader userBillingDetailsLoader;
@@ -47,7 +48,7 @@ public class UserBillingLoader implements BillingLoader<UserGeneralBilling> {
                                                final BillingExportRequest request) {
         final LocalDate from = request.getFrom();
         final LocalDate to = request.getTo();
-        final Map<String, List<String>> filters = billingHelper.getFilters(request.getFilters());
+        final Map<String, List<String>> filters = billingSecurityHelper.getFilters(request.getFilters());
         final BillingDiscount discount = Optional.ofNullable(request.getDiscount()).orElseGet(BillingDiscount::empty);
         return billings(client, from, to, filters, discount, getPageSize());
     }

--- a/api/src/main/java/com/epam/pipeline/manager/billing/UserBillingLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/UserBillingLoader.java
@@ -4,6 +4,7 @@ import com.epam.pipeline.controller.vo.billing.BillingExportRequest;
 import com.epam.pipeline.entity.billing.BillingDiscount;
 import com.epam.pipeline.entity.billing.GeneralBillingMetrics;
 import com.epam.pipeline.entity.billing.UserGeneralBilling;
+import com.epam.pipeline.manager.billing.index.BillingIndexHelper;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.utils.StreamUtils;
@@ -37,17 +38,18 @@ import java.util.stream.Stream;
 public class UserBillingLoader implements BillingLoader<UserGeneralBilling> {
 
     private final BillingHelper billingHelper;
+    private final BillingIndexHelper billingIndexHelper;
     private final PreferenceManager preferenceManager;
     private final UserBillingDetailsLoader userBillingDetailsLoader;
 
     @Override
-    public Stream<UserGeneralBilling> billings(final RestHighLevelClient elasticSearchClient,
+    public Stream<UserGeneralBilling> billings(final RestHighLevelClient client,
                                                final BillingExportRequest request) {
         final LocalDate from = request.getFrom();
         final LocalDate to = request.getTo();
         final Map<String, List<String>> filters = billingHelper.getFilters(request.getFilters());
         final BillingDiscount discount = Optional.ofNullable(request.getDiscount()).orElseGet(BillingDiscount::empty);
-        return billings(elasticSearchClient, from, to, filters, discount, getPageSize());
+        return billings(client, from, to, filters, discount, getPageSize());
     }
 
     private int getPageSize() {
@@ -56,17 +58,17 @@ public class UserBillingLoader implements BillingLoader<UserGeneralBilling> {
                 .orElse(BillingUtils.FALLBACK_EXPORT_PERIOD_AGGREGATION_PAGE_SIZE);
     }
 
-    private Stream<UserGeneralBilling> billings(final RestHighLevelClient elasticSearchClient,
+    private Stream<UserGeneralBilling> billings(final RestHighLevelClient client,
                                                 final LocalDate from,
                                                 final LocalDate to,
                                                 final Map<String, List<String>> filters,
                                                 final BillingDiscount discount,
                                                 final int pageSize) {
-        return StreamUtils.from(billingsIterator(elasticSearchClient, from, to, filters, discount, pageSize))
+        return StreamUtils.from(billingsIterator(client, from, to, filters, discount, pageSize))
                 .flatMap(this::billings);
     }
 
-    private Iterator<SearchResponse> billingsIterator(final RestHighLevelClient elasticSearchClient,
+    private Iterator<SearchResponse> billingsIterator(final RestHighLevelClient client,
                                                       final LocalDate from,
                                                       final LocalDate to,
                                                       final Map<String, List<String>> filters,
@@ -74,7 +76,7 @@ public class UserBillingLoader implements BillingLoader<UserGeneralBilling> {
                                                       final int pageSize) {
         return new ElasticMultiBucketsIterator(BillingUtils.OWNER_FIELD, pageSize,
             pageOffset -> getBillingsRequest(from, to, filters, discount, pageOffset, pageSize),
-            billingHelper.searchWith(elasticSearchClient),
+            billingHelper.searchWith(client),
             billingHelper::getTerms);
     }
 
@@ -85,8 +87,8 @@ public class UserBillingLoader implements BillingLoader<UserGeneralBilling> {
                                              final int pageOffset,
                                              final int pageSize) {
         return new SearchRequest()
-                .indicesOptions(IndicesOptions.strictExpandOpen())
-                .indices(billingHelper.indicesByDate(from, to))
+                .indicesOptions(IndicesOptions.lenientExpandOpen())
+                .indices(billingIndexHelper.monthlyIndicesBetween(from, to))
                 .source(new SearchSourceBuilder()
                         .size(NumberUtils.INTEGER_ZERO)
                         .query(billingHelper.queryByDateAndFilters(from, to, filters))

--- a/api/src/main/java/com/epam/pipeline/manager/billing/index/BillingIndexHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/index/BillingIndexHelper.java
@@ -1,0 +1,18 @@
+package com.epam.pipeline.manager.billing.index;
+
+import java.time.LocalDate;
+
+public interface BillingIndexHelper {
+
+    String[] dailyIndicesBetween(LocalDate from, LocalDate to);
+    String[] dailyRunIndicesBetween(LocalDate from, LocalDate to);
+    String[] dailyStorageIndicesBetween(LocalDate from, LocalDate to);
+
+    String[] monthlyIndicesBetween(LocalDate from, LocalDate to);
+    String[] monthlyRunIndicesBetween(LocalDate from, LocalDate to);
+    String[] monthlyStorageIndicesBetween(LocalDate from, LocalDate to);
+
+    String[] yearlyIndicesBetween(LocalDate from, LocalDate to);
+    String[] yearlyRunIndicesBetween(LocalDate from, LocalDate to);
+    String[] yearlyStorageIndicesBetween(LocalDate from, LocalDate to);
+}

--- a/api/src/main/java/com/epam/pipeline/manager/billing/index/BoundingBillingIndexHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/index/BoundingBillingIndexHelper.java
@@ -119,7 +119,7 @@ public class BoundingBillingIndexHelper implements BillingIndexHelper {
     }
 
     private Stream<String> indices() {
-        try (final RestHighLevelClient client = elasticHelper.buildClient()) {
+        try (RestHighLevelClient client = elasticHelper.buildClient()) {
             final GetIndexRequest request = new GetIndexRequest(commonIndexPrefix + BillingUtils.ES_WILDCARD)
                     .indicesOptions(IndicesOptions.strictExpandOpen());
             final GetIndexResponse response = client.indices().get(request, RequestOptions.DEFAULT);

--- a/api/src/main/java/com/epam/pipeline/manager/billing/index/BoundingBillingIndexHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/index/BoundingBillingIndexHelper.java
@@ -1,0 +1,144 @@
+package com.epam.pipeline.manager.billing.index;
+
+import com.epam.pipeline.entity.utils.DateUtils;
+import com.epam.pipeline.manager.billing.BillingUtils;
+import com.epam.pipeline.manager.utils.GlobalSearchElasticHelper;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.indices.GetIndexRequest;
+import org.elasticsearch.client.indices.GetIndexResponse;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.Year;
+import java.time.format.DateTimeParseException;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+
+public class BoundingBillingIndexHelper implements BillingIndexHelper {
+
+    private final BillingIndexHelper inner;
+    private final GlobalSearchElasticHelper elasticHelper;
+    private final String commonIndexPrefix;
+    private final String runIndexPrefix;
+    private final String storageIndexPrefix;
+    private final AtomicReference<LocalDate> firstBillingDate;
+
+    public BoundingBillingIndexHelper(final BillingIndexHelper inner,
+                                      final GlobalSearchElasticHelper elasticHelper,
+                                      final String commonIndexPrefix,
+                                      final String runIndexName,
+                                      final String storageIndexName) {
+        this.inner = inner;
+        this.elasticHelper = elasticHelper;
+        this.commonIndexPrefix = commonIndexPrefix;
+        this.runIndexPrefix = commonIndexPrefix + runIndexName;
+        this.storageIndexPrefix = commonIndexPrefix + storageIndexName;
+        this.firstBillingDate = new AtomicReference<>();
+    }
+
+    @Override
+    public String[] dailyIndicesBetween(final LocalDate from, final LocalDate to) {
+        return inner.dailyIndicesBetween(normalizedFrom(from), normalizedTo(to));
+    }
+
+    @Override
+    public String[] dailyRunIndicesBetween(final LocalDate from, final LocalDate to) {
+        return inner.dailyRunIndicesBetween(normalizedFrom(from), normalizedTo(to));
+    }
+
+    @Override
+    public String[] dailyStorageIndicesBetween(final LocalDate from, final LocalDate to) {
+        return inner.dailyStorageIndicesBetween(normalizedFrom(from), normalizedTo(to));
+    }
+
+    @Override
+    public String[] monthlyIndicesBetween(final LocalDate from, final LocalDate to) {
+        return inner.monthlyIndicesBetween(normalizedFrom(from), normalizedTo(to));
+    }
+
+    @Override
+    public String[] monthlyRunIndicesBetween(final LocalDate from, final LocalDate to) {
+        return inner.monthlyRunIndicesBetween(normalizedFrom(from), normalizedTo(to));
+    }
+
+    @Override
+    public String[] monthlyStorageIndicesBetween(final LocalDate from, final LocalDate to) {
+        return inner.monthlyStorageIndicesBetween(normalizedFrom(from), normalizedTo(to));
+    }
+
+    @Override
+    public String[] yearlyIndicesBetween(final LocalDate from, final LocalDate to) {
+        return inner.yearlyIndicesBetween(normalizedFrom(from), normalizedTo(to));
+    }
+
+    @Override
+    public String[] yearlyRunIndicesBetween(final LocalDate from, final LocalDate to) {
+        return inner.yearlyRunIndicesBetween(normalizedFrom(from), normalizedTo(to));
+    }
+
+    @Override
+    public String[] yearlyStorageIndicesBetween(final LocalDate from, final LocalDate to) {
+        return inner.yearlyStorageIndicesBetween(normalizedFrom(from), normalizedTo(to));
+    }
+
+    private LocalDate normalizedFrom(final LocalDate from) {
+        final LocalDate firstBillingDate = getOrResolveFirstBillingDate().orElse(LocalDate.MIN);
+        return from.isBefore(firstBillingDate) ? Year.from(firstBillingDate).atDay(1) : from;
+    }
+
+    private LocalDate normalizedTo(final LocalDate to) {
+        final LocalDate lastBillingDate = DateUtils.nowUTC().toLocalDate().minusDays(1);
+        return to.isAfter(lastBillingDate) ? lastBillingDate : to;
+    }
+
+    private Optional<LocalDate> getOrResolveFirstBillingDate() {
+        return Optional.ofNullable(firstBillingDate.get())
+                .map(Optional::of)
+                .orElseGet(this::resolveAndSaveFirstBillingDate);
+    }
+
+    private Optional<LocalDate> resolveAndSaveFirstBillingDate() {
+        final Optional<LocalDate> resolvedFirstBillingDate = resolveFirstBillingDate();
+        resolvedFirstBillingDate.ifPresent(date -> firstBillingDate.compareAndSet(null, date));
+        return resolvedFirstBillingDate;
+    }
+
+    private Optional<LocalDate> resolveFirstBillingDate() {
+        return indices()
+                .map(this::fromIndexToDate)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .sorted()
+                .findFirst();
+    }
+
+    private Stream<String> indices() {
+        try (final RestHighLevelClient client = elasticHelper.buildClient()) {
+            final GetIndexRequest request = new GetIndexRequest(commonIndexPrefix + BillingUtils.ES_WILDCARD)
+                    .indicesOptions(IndicesOptions.strictExpandOpen());
+            final GetIndexResponse response = client.indices().get(request, RequestOptions.DEFAULT);
+            return Arrays.stream(response.getIndices());
+        } catch (IOException e) {
+            throw new ElasticsearchException("Failed to list indices.", e);
+        }
+    }
+
+    private Optional<LocalDate> fromIndexToDate(final String index) {
+        try {
+            final String indexPrefix = index.startsWith(runIndexPrefix) ? runIndexPrefix
+                    : index.startsWith(storageIndexPrefix) ? storageIndexPrefix
+                    : null;
+            return Optional.ofNullable(indexPrefix)
+                    .map(prefix -> index.substring(prefix.length() + 1))
+                    .map(dateString -> LocalDate.parse(dateString, BillingUtils.ELASTIC_DATE_FORMATTER));
+        } catch (DateTimeParseException e) {
+            return Optional.empty();
+        }
+    }
+
+}

--- a/api/src/main/java/com/epam/pipeline/manager/billing/index/BoundingBillingIndexHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/index/BoundingBillingIndexHelper.java
@@ -13,6 +13,7 @@ import org.elasticsearch.client.indices.GetIndexResponse;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.time.Year;
+import java.time.YearMonth;
 import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.Optional;
@@ -93,7 +94,7 @@ public class BoundingBillingIndexHelper implements BillingIndexHelper {
 
     private LocalDate normalizedTo(final LocalDate to) {
         final LocalDate lastBillingDate = DateUtils.nowUTC().toLocalDate().minusDays(1);
-        return to.isAfter(lastBillingDate) ? lastBillingDate : to;
+        return to.isBefore(lastBillingDate) ? to : YearMonth.from(lastBillingDate).atEndOfMonth();
     }
 
     private Optional<LocalDate> getOrResolveFirstBillingDate() {

--- a/api/src/main/java/com/epam/pipeline/manager/billing/index/DailyBillingIndexHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/index/DailyBillingIndexHelper.java
@@ -1,0 +1,83 @@
+package com.epam.pipeline.manager.billing.index;
+
+import com.epam.pipeline.manager.billing.BillingUtils;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.temporal.ChronoUnit;
+import java.util.stream.Stream;
+
+@Slf4j
+public class DailyBillingIndexHelper implements BillingIndexHelper {
+
+    private final String billingIndicesMonthlyPattern;
+    private final String billingRunIndicesMonthlyPattern;
+    private final String billingStorageIndicesMonthlyPattern;
+
+    public DailyBillingIndexHelper(final String commonIndexPrefix,
+                                   final String runIndexName,
+                                   final String storageIndexName) {
+        this.billingIndicesMonthlyPattern = String.join("-",
+                commonIndexPrefix + BillingUtils.ES_WILDCARD,
+                BillingUtils.ES_MONTHLY_DATE_REGEXP);
+        this.billingRunIndicesMonthlyPattern = String.join("-",
+                commonIndexPrefix + runIndexName,
+                BillingUtils.ES_MONTHLY_DATE_REGEXP);
+        this.billingStorageIndicesMonthlyPattern = String.join("-",
+                commonIndexPrefix + storageIndexName,
+                BillingUtils.ES_MONTHLY_DATE_REGEXP);
+    }
+
+    @Override
+    public String[] dailyIndicesBetween(final LocalDate from, final LocalDate to) {
+        return dailyIndicesBetween(from, to, billingIndicesMonthlyPattern);
+    }
+
+    @Override
+    public String[] dailyRunIndicesBetween(final LocalDate from, final LocalDate to) {
+        return dailyIndicesBetween(from, to, billingRunIndicesMonthlyPattern);
+    }
+
+    @Override
+    public String[] dailyStorageIndicesBetween(final LocalDate from, final LocalDate to) {
+        return dailyIndicesBetween(from, to, billingStorageIndicesMonthlyPattern);
+    }
+
+    @Override
+    public String[] monthlyIndicesBetween(final LocalDate from, final LocalDate to) {
+        return dailyIndicesBetween(from, to);
+    }
+
+    @Override
+    public String[] monthlyRunIndicesBetween(final LocalDate from, final LocalDate to) {
+        return dailyIndicesBetween(from, to);
+    }
+
+    @Override
+    public String[] monthlyStorageIndicesBetween(final LocalDate from, final LocalDate to) {
+        return dailyIndicesBetween(from, to);
+    }
+
+    @Override
+    public String[] yearlyIndicesBetween(final LocalDate from, final LocalDate to) {
+        return dailyIndicesBetween(from, to);
+    }
+
+    @Override
+    public String[] yearlyRunIndicesBetween(final LocalDate from, final LocalDate to) {
+        return dailyIndicesBetween(from, to);
+    }
+
+    @Override
+    public String[] yearlyStorageIndicesBetween(final LocalDate from, final LocalDate to) {
+        return dailyIndicesBetween(from, to);
+    }
+
+    public String[] dailyIndicesBetween(final LocalDate from, final LocalDate to, final String indexPattern) {
+        return Stream.iterate(from, d -> d.plus(1, ChronoUnit.MONTHS))
+                .limit(ChronoUnit.MONTHS.between(YearMonth.from(from), YearMonth.from(to)) + 1)
+                .map(date -> String.format(indexPattern, date.getYear(), date.getMonthValue()))
+                .toArray(String[]::new);
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/billing/index/PeriodBillingIndexHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/index/PeriodBillingIndexHelper.java
@@ -1,0 +1,128 @@
+package com.epam.pipeline.manager.billing.index;
+
+import com.epam.pipeline.manager.billing.ElasticsearchMergingFrame;
+import com.epam.pipeline.manager.billing.ElasticsearchMergingFramePeriod;
+import lombok.extern.slf4j.Slf4j;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
+import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestHighLevelClient;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+@Slf4j
+public class PeriodBillingIndexHelper implements BillingIndexHelper {
+
+    private final String runIndexPrefix;
+    private final String storageIndexPrefix;
+
+    public PeriodBillingIndexHelper(final String commonIndexPrefix,
+                                    final String runIndexName,
+                                    final String storageIndexName) {
+        this.runIndexPrefix = commonIndexPrefix + runIndexName;
+        this.storageIndexPrefix = commonIndexPrefix + storageIndexName;
+    }
+
+    @Override
+    public String[] dailyIndicesBetween(final LocalDate from, final LocalDate to) {
+        return dailyIndices(from, to, runIndexPrefix, storageIndexPrefix);
+    }
+
+    @Override
+    public String[] dailyRunIndicesBetween(final LocalDate from, final LocalDate to) {
+        return dailyIndices(from, to, runIndexPrefix);
+    }
+
+    @Override
+    public String[] dailyStorageIndicesBetween(final LocalDate from, final LocalDate to) {
+        return dailyIndices(from, to, storageIndexPrefix);
+    }
+
+    private String[] dailyIndices(final LocalDate from, final LocalDate to,
+                                  final String... indexPrefix) {
+        return indicesBetween(from, to, ElasticsearchMergingFrame.DAY, indexPrefix);
+    }
+
+    @Override
+    public String[] monthlyIndicesBetween(final LocalDate from, final LocalDate to) {
+        return monthlyIndices(from, to, runIndexPrefix, storageIndexPrefix);
+    }
+
+    @Override
+    public String[] monthlyRunIndicesBetween(final LocalDate from, final LocalDate to) {
+        return monthlyIndices(from, to, runIndexPrefix);
+    }
+
+    @Override
+    public String[] monthlyStorageIndicesBetween(final LocalDate from, final LocalDate to) {
+        return monthlyIndices(from, to, storageIndexPrefix);
+    }
+
+    private String[] monthlyIndices(final LocalDate from, final LocalDate to,
+                                    final String... indexPrefix) {
+        return indicesBetween(from, to, ElasticsearchMergingFrame.MONTH, indexPrefix);
+    }
+
+    @Override
+    public String[] yearlyIndicesBetween(final LocalDate from, final LocalDate to) {
+        return yearlyIndicesBetween(from, to, runIndexPrefix, storageIndexPrefix);
+    }
+
+    @Override
+    public String[] yearlyRunIndicesBetween(final LocalDate from, final LocalDate to) {
+        return yearlyIndicesBetween(from, to, runIndexPrefix);
+    }
+
+    @Override
+    public String[] yearlyStorageIndicesBetween(final LocalDate from, final LocalDate to) {
+        return yearlyIndicesBetween(from, to, storageIndexPrefix);
+    }
+
+    private String[] yearlyIndicesBetween(final LocalDate from, final LocalDate to,
+                                          final String... indexPrefix) {
+        return indicesBetween(from, to, ElasticsearchMergingFrame.YEAR, indexPrefix);
+    }
+
+    public String[] indicesBetween(final LocalDate from, final LocalDate to,
+                                   final ElasticsearchMergingFrame frame,
+                                   final String... indexPrefix) {
+        final List<String> indices = new ArrayList<>();
+        LocalDate current = from;
+        while (current.isBefore(to.plusDays(1))) {
+            final ElasticsearchMergingFramePeriod period = getNextPeriod(current, to, frame);
+            for (final String prefix : indexPrefix) {
+                indices.add(prefix + "-" + period.name());
+            }
+            current = period.end().plusDays(1);
+        }
+        return indices.toArray(new String[]{});
+    }
+
+    private ElasticsearchMergingFramePeriod getNextPeriod(final LocalDate from, final LocalDate to,
+                                                          final ElasticsearchMergingFrame frame) {
+        return frame.children()
+                .map(childFrame -> new ElasticsearchMergingFramePeriod(childFrame, childFrame.periodOf(from)))
+                .filter(period -> period.isBetween(from, to))
+                .findFirst()
+                .orElseGet(() -> new ElasticsearchMergingFramePeriod(ElasticsearchMergingFrame.DAY, from));
+    }
+
+    public Stream<String> indices(final RestHighLevelClient client) {
+        try {
+            final GetIndexRequest request = new GetIndexRequest()
+                    .indices("*")
+                    .indicesOptions(IndicesOptions.strictExpandOpen());
+            final GetIndexResponse response = client.indices().get(request, RequestOptions.DEFAULT);
+            return Arrays.stream(response.getIndices());
+        } catch (IOException e) {
+            throw new ElasticsearchException("Failed to list indices.", e);
+        }
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/billing/index/PeriodBillingIndexHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/index/PeriodBillingIndexHelper.java
@@ -3,19 +3,10 @@ package com.epam.pipeline.manager.billing.index;
 import com.epam.pipeline.manager.billing.ElasticsearchMergingFrame;
 import com.epam.pipeline.manager.billing.ElasticsearchMergingFramePeriod;
 import lombok.extern.slf4j.Slf4j;
-import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
-import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
-import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.client.RequestOptions;
-import org.elasticsearch.client.RestHighLevelClient;
 
-import java.io.IOException;
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Stream;
 
 @Slf4j
 public class PeriodBillingIndexHelper implements BillingIndexHelper {
@@ -112,17 +103,5 @@ public class PeriodBillingIndexHelper implements BillingIndexHelper {
                 .filter(period -> period.isBetween(from, to))
                 .findFirst()
                 .orElseGet(() -> new ElasticsearchMergingFramePeriod(ElasticsearchMergingFrame.DAY, from));
-    }
-
-    public Stream<String> indices(final RestHighLevelClient client) {
-        try {
-            final GetIndexRequest request = new GetIndexRequest()
-                    .indices("*")
-                    .indicesOptions(IndicesOptions.strictExpandOpen());
-            final GetIndexResponse response = client.indices().get(request, RequestOptions.DEFAULT);
-            return Arrays.stream(response.getIndices());
-        } catch (IOException e) {
-            throw new ElasticsearchException("Failed to list indices.", e);
-        }
     }
 }

--- a/api/src/test/java/com/epam/pipeline/app/TestApplication.java
+++ b/api/src/test/java/com/epam/pipeline/app/TestApplication.java
@@ -19,6 +19,8 @@ package com.epam.pipeline.app;
 import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.dao.monitoring.MonitoringESDao;
 import com.epam.pipeline.manager.billing.BillingManager;
+import com.epam.pipeline.manager.billing.BillingSecurityHelper;
+import com.epam.pipeline.manager.billing.index.BillingIndexHelper;
 import com.epam.pipeline.manager.cloud.CloudFacade;
 import com.epam.pipeline.manager.cloud.credentials.CloudProfileCredentialsManager;
 import com.epam.pipeline.manager.cloud.credentials.CloudProfileCredentialsManagerProvider;
@@ -117,6 +119,12 @@ public class TestApplication {
 
     @MockBean
     public BillingManager billingManager;
+
+    @MockBean
+    public BillingSecurityHelper billingSecurityHelper;
+
+    @MockBean
+    public BillingIndexHelper billingIndexHelper;
 
     @MockBean
     public OntologyManager ontologyManager;

--- a/api/src/test/java/com/epam/pipeline/manager/billing/index/PeriodBillingIndexHelperTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/billing/index/PeriodBillingIndexHelperTest.java
@@ -12,6 +12,7 @@ import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+@SuppressWarnings("checkstyle:MagicNumber")
 public class PeriodBillingIndexHelperTest {
 
     private static final String PREFIX = "index-";

--- a/api/src/test/java/com/epam/pipeline/manager/billing/index/PeriodBillingIndexHelperTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/billing/index/PeriodBillingIndexHelperTest.java
@@ -1,0 +1,217 @@
+package com.epam.pipeline.manager.billing.index;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.Year;
+import java.time.YearMonth;
+import java.util.Arrays;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+public class PeriodBillingIndexHelperTest {
+
+    private static final String PREFIX = "index-";
+    private static final String RUN = "run";
+    private static final String STORAGE = "storage";
+    private static final int YEAR = 2022;
+
+    private final PeriodBillingIndexHelper helper = new PeriodBillingIndexHelper(PREFIX, RUN, STORAGE);
+
+    @Test
+    public void dailyIndicesShouldGenerateProperIndicesForMonth() {
+        Assert.assertArrayEquals(
+                dailyIndices(Month.JANUARY, 1, 31),
+                helper.dailyIndicesBetween(
+                        LocalDate.of(YEAR, Month.JANUARY, 1),
+                        LocalDate.of(YEAR, Month.JANUARY, 31)));
+    }
+
+    @Test
+    public void dailyIndicesShouldGenerateProperIndicesForSeveralDaysInMonth() {
+        Assert.assertArrayEquals(
+                dailyIndices(Month.JANUARY, 5, 10),
+                helper.dailyIndicesBetween(
+                        LocalDate.of(YEAR, Month.JANUARY, 5),
+                        LocalDate.of(YEAR, Month.JANUARY, 10)));
+    }
+
+    @Test
+    public void dailyIndicesShouldGenerateProperIndicesForSeveralDaysInSeveralMonths() {
+        Assert.assertArrayEquals(concat(
+                        dailyIndices(Month.JANUARY, 20, 31),
+                        dailyIndices(Month.FEBRUARY, 1, 10)),
+                helper.dailyIndicesBetween(
+                        LocalDate.of(YEAR, Month.JANUARY, 20),
+                        LocalDate.of(YEAR, Month.FEBRUARY, 10)));
+    }
+
+    @Test
+    public void monthlyIndicesShouldGenerateProperIndicesForMonth() {
+        Assert.assertArrayEquals(
+                monthlyIndices(YearMonth.of(YEAR, Month.JANUARY)),
+                helper.monthlyIndicesBetween(
+                        LocalDate.of(YEAR, Month.JANUARY, 1),
+                        LocalDate.of(YEAR, Month.JANUARY, 31)));
+    }
+
+    @Test
+    public void monthlyIndicesShouldGenerateProperIndicesForSeveralDaysInMonth() {
+        Assert.assertArrayEquals(
+                dailyIndices(Month.JANUARY, 5, 10),
+                helper.monthlyIndicesBetween(
+                        LocalDate.of(YEAR, Month.JANUARY, 5),
+                        LocalDate.of(YEAR, Month.JANUARY, 10)));
+    }
+
+    @Test
+    public void monthlyIndicesShouldGenerateProperIndicesForSeveralDaysInSeveralMonths() {
+        Assert.assertArrayEquals(concat(
+                        dailyIndices(Month.JANUARY, 20, 31),
+                        dailyIndices(Month.FEBRUARY, 1, 10)),
+                helper.monthlyIndicesBetween(
+                        LocalDate.of(YEAR, Month.JANUARY, 20),
+                        LocalDate.of(YEAR, Month.FEBRUARY, 10)));
+    }
+
+    @Test
+    public void monthlyIndicesShouldGenerateProperIndicesForSeveralMonths() {
+        Assert.assertArrayEquals(concat(
+                        monthlyIndices(YearMonth.of(YEAR, Month.JANUARY)),
+                        monthlyIndices(YearMonth.of(YEAR, Month.FEBRUARY))),
+                helper.monthlyIndicesBetween(
+                        LocalDate.of(YEAR, Month.JANUARY, 1),
+                        LocalDate.of(YEAR, Month.FEBRUARY, 28)));
+    }
+
+    @Test
+    public void monthlyIndicesShouldGenerateProperIndicesForSeveralDaysAndSeveralMonths() {
+        Assert.assertArrayEquals(concat(
+                        dailyIndices(Month.JANUARY, 20, 31),
+                        monthlyIndices(YearMonth.of(YEAR, Month.FEBRUARY)),
+                        dailyIndices(Month.MARCH, 1, 15)),
+                helper.monthlyIndicesBetween(
+                        LocalDate.of(YEAR, Month.JANUARY, 20),
+                        LocalDate.of(YEAR, Month.MARCH, 15)));
+    }
+
+
+    @Test
+    public void yearIndicesShouldGenerateProperIndicesForMonth() {
+        Assert.assertArrayEquals(
+                monthlyIndices(YearMonth.of(YEAR, Month.JANUARY)),
+                helper.yearlyIndicesBetween(
+                        LocalDate.of(YEAR, Month.JANUARY, 1),
+                        LocalDate.of(YEAR, Month.JANUARY, 31)));
+    }
+
+    @Test
+    public void yearlyIndicesShouldGenerateProperIndicesForSeveralDaysInMonth() {
+        Assert.assertArrayEquals(
+                dailyIndices(Month.JANUARY, 5, 10),
+                helper.yearlyIndicesBetween(
+                        LocalDate.of(YEAR, Month.JANUARY, 5),
+                        LocalDate.of(YEAR, Month.JANUARY, 10)));
+    }
+
+    @Test
+    public void yearlyIndicesShouldGenerateProperIndicesForSeveralDaysInSeveralMonths() {
+        Assert.assertArrayEquals(concat(
+                        dailyIndices(Month.JANUARY, 20, 31),
+                        dailyIndices(Month.FEBRUARY, 1, 10)),
+                helper.yearlyIndicesBetween(
+                        LocalDate.of(YEAR, Month.JANUARY, 20),
+                        LocalDate.of(YEAR, Month.FEBRUARY, 10)));
+    }
+
+    @Test
+    public void yearlyIndicesShouldGenerateProperIndicesForSeveralMonths() {
+        Assert.assertArrayEquals(concat(
+                        monthlyIndices(YearMonth.of(YEAR, Month.JANUARY)),
+                        monthlyIndices(YearMonth.of(YEAR, Month.FEBRUARY))),
+                helper.yearlyIndicesBetween(
+                        LocalDate.of(YEAR, Month.JANUARY, 1),
+                        LocalDate.of(YEAR, Month.FEBRUARY, 28)));
+    }
+
+    @Test
+    public void yearlyIndicesShouldGenerateProperIndicesForSeveralDaysAndSeveralMonths() {
+        Assert.assertArrayEquals(concat(
+                        dailyIndices(Month.JANUARY, 20, 31),
+                        monthlyIndices(YearMonth.of(YEAR, Month.FEBRUARY)),
+                        dailyIndices(Month.MARCH, 1, 15)),
+                helper.yearlyIndicesBetween(
+                        LocalDate.of(YEAR, Month.JANUARY, 20),
+                        LocalDate.of(YEAR, Month.MARCH, 15)));
+    }
+
+    @Test
+    public void yearlyIndicesShouldGenerateProperIndicesForYear() {
+        Assert.assertArrayEquals(concat(
+                        yearlyIndices(Year.of(YEAR))),
+                helper.yearlyIndicesBetween(
+                        LocalDate.of(YEAR, Month.JANUARY, 1),
+                        LocalDate.of(YEAR, Month.DECEMBER, 31)));
+    }
+
+    @Test
+    public void yearlyIndicesShouldGenerateProperIndicesForSeveralDaysInSeveralYears() {
+        Assert.assertArrayEquals(concat(
+                        dailyIndices(Year.of(YEAR - 1), Month.DECEMBER, 20, 31),
+                        dailyIndices(Month.JANUARY, 1, 15)),
+                helper.yearlyIndicesBetween(
+                        LocalDate.of(YEAR - 1, Month.DECEMBER, 20),
+                        LocalDate.of(YEAR, Month.JANUARY, 15)));
+    }
+
+    @Test
+    public void yearlyIndicesShouldGenerateProperIndicesForSeveralDaysAndSeveralMonthsAndSeveralYears() {
+        Assert.assertArrayEquals(concat(
+                        dailyIndices(Year.of(YEAR - 2), Month.NOVEMBER, 20, 30),
+                        monthlyIndices(YearMonth.of(YEAR - 2, Month.DECEMBER)),
+                        yearlyIndices(Year.of(YEAR - 1)),
+                        dailyIndices(Month.JANUARY, 1, 15)),
+                helper.yearlyIndicesBetween(
+                        LocalDate.of(YEAR - 2, Month.NOVEMBER, 20),
+                        LocalDate.of(YEAR, Month.JANUARY, 15)));
+    }
+
+    private String[] concat(final String[]... items) {
+        return Arrays.stream(items)
+                .flatMap(Arrays::stream)
+                .toArray(String[]::new);
+    }
+
+    private String[] dailyIndices(final Month month,
+                                  final int startDayOfMonth, final int endDayOfMonth) {
+        return dailyIndices(Year.of(YEAR), month, startDayOfMonth, endDayOfMonth);
+    }
+
+    private String[] dailyIndices(final Year year, final Month month,
+                                  final int startDayOfMonth, final int endDayOfMonth) {
+        return IntStream.range(startDayOfMonth, endDayOfMonth + 1)
+                .mapToObj(day -> Stream.of(
+                        String.format("%s%s-%d-%02d-%02d", PREFIX, RUN, year.getValue(), month.getValue(), day),
+                        String.format("%s%s-%d-%02d-%02d", PREFIX, STORAGE, year.getValue(), month.getValue(), day)))
+                .flatMap(Function.identity())
+                .toArray(String[]::new);
+    }
+
+    private String[] monthlyIndices(final YearMonth ym) {
+        return new String[]{
+                String.format("%s%s-%d-%02dm", PREFIX, RUN, ym.getYear(), ym.getMonth().getValue()),
+                String.format("%s%s-%d-%02dm", PREFIX, STORAGE, ym.getYear(), ym.getMonth().getValue())
+        };
+    }
+
+    private String[] yearlyIndices(final Year year) {
+        return new String[]{
+                String.format("%s%s-%dy", PREFIX, RUN, year.getValue()),
+                String.format("%s%s-%dy", PREFIX, STORAGE, year.getValue())
+        };
+    }
+
+}

--- a/api/src/test/java/com/epam/pipeline/test/aspect/AspectTestBeans.java
+++ b/api/src/test/java/com/epam/pipeline/test/aspect/AspectTestBeans.java
@@ -67,6 +67,8 @@ import com.epam.pipeline.dao.tool.ToolVulnerabilityDao;
 import com.epam.pipeline.dao.user.GroupStatusDao;
 import com.epam.pipeline.dao.user.RoleDao;
 import com.epam.pipeline.dao.user.UserDao;
+import com.epam.pipeline.manager.billing.BillingSecurityHelper;
+import com.epam.pipeline.manager.billing.index.BillingIndexHelper;
 import com.epam.pipeline.manager.cluster.InstanceOfferScheduler;
 import com.epam.pipeline.manager.cluster.PodMonitor;
 import com.epam.pipeline.manager.contextual.handler.ContextualPreferenceHandler;
@@ -417,4 +419,10 @@ public class AspectTestBeans {
 
     @MockBean
     protected StorageQuotaTriggersManager storageQuotaTriggersManager;
+
+    @MockBean
+    protected BillingSecurityHelper billingSecurityHelper;
+
+    @MockBean
+    protected BillingIndexHelper billingIndexHelper;
 }

--- a/deploy/docker/cp-api-srv/config/application.properties
+++ b/deploy/docker/cp-api-srv/config/application.properties
@@ -169,7 +169,11 @@ luigi.graph.script=/usr/lib/python2.7/site-packages/scripts/deps_graph.py
 data.storage.nfs.root.mount.point=/opt/api/file-systems
 
 #Billing API
-billing.index.common.prefix=cp-billing
+billing.index.common.prefix=cp-billing-
+billing.index.period.disable=${CP_BILLING_INDEX_PERIOD_DISABLE:false}
+billing.run.index.name=pipeline-run
+billing.storage.index.name=storage
+billing.empty.report.value=unknown
 billing.center.key=${CP_BILLING_CENTER_KEY:billing-center}
 
 #logging


### PR DESCRIPTION
Relates to #2407 and depends on #2476.

## Indices usage

The pull request brings support for per month and per year billing indices usage in API. The new approach will use per month and per year indices rather than per day indices whenever possible.

The following application properties can be used to configure per month and per year indices usage:

- `billing.index.period.disable` disables per month and per year indices usage. Defaults to `false`.

The performance difference between the previous and the current indices usage approaches is shown in the diagram below. The heat map shows a percentage of a performance increase for each type of billing requests. The greener the better. One can see that most of the billing request types work significantly faster for most time periods.

<img width="534" alt="Снимок экрана 2022-01-19 в 10 08 45" src="https://user-images.githubusercontent.com/16464586/150489423-fa5d5c6e-8744-4500-9e9c-8a554bd7f5cb.png">

### Reports

The diagram below shows a performance difference in seconds between the previous and the current indices usage approaches for billing reports in Cloud Pipeline. The higher the better.

<img width="392" alt="Снимок экрана 2022-01-21 в 11 19 53" src="https://user-images.githubusercontent.com/16464586/150491753-e0d2763b-0f2e-4d23-8c27-6b23f2baa1a8.png">

### Plot charts

The diagram below shows a performance difference in seconds between the previous and the current indices usage approaches for billing request types required for billing plot charts in Cloud Pipeline. The higher the better.

<img width="392" alt="Снимок экрана 2022-01-21 в 11 19 45" src="https://user-images.githubusercontent.com/16464586/150491752-e05f82d8-6998-4342-b246-90c3b48c1369.png">


### Bar charts

The diagram below shows a performance difference in seconds between the previous and the current indices usage approaches for billing request types required for billing bar charts in Cloud Pipeline. The higher the better.

<img width="392" alt="Снимок экрана 2022-01-21 в 11 19 35" src="https://user-images.githubusercontent.com/16464586/150491746-e98f3d21-bb9b-4879-ba7d-f3c4d0c28924.png">

## Optimisations

### Run reports

Additional optimisation was implemented for run reports. If only a single day, month or year index is used to collect data for a report then no aggregations are performed in ElasticSearch and run billing documents are just streamed from ElasticSearch to Cloud Pipeline. This significantly speeds up reports generation time. Unfortunately in case several indices are used f.e. for a custom period then the optimisation is not applicable and aggregations are still performed in ElasticSearch.
