### PR TITLE
Issue 2400 Custom billing reports

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/billing/BillingApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/billing/BillingApiService.java
@@ -20,9 +20,14 @@ import com.epam.pipeline.controller.ResultWriter;
 import com.epam.pipeline.controller.vo.billing.BillingChartRequest;
 import com.epam.pipeline.controller.vo.billing.BillingExportRequest;
 import com.epam.pipeline.entity.billing.BillingChartInfo;
+import com.epam.pipeline.entity.billing.BillingReportTemplate;
 import com.epam.pipeline.entity.search.FacetedSearchResult;
 import com.epam.pipeline.manager.billing.BillingManager;
+import com.epam.pipeline.manager.billing.BillingTemplateManager;
+import com.epam.pipeline.security.acl.AclExpressions;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PostFilter;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -32,6 +37,7 @@ import java.util.List;
 public class BillingApiService {
 
     private final BillingManager billingManager;
+    private final BillingTemplateManager billingTemplateManager;
 
     public List<BillingChartInfo> getBillingChartInfo(final BillingChartRequest request) {
         return billingManager.getBillingChartInfo(request);
@@ -51,5 +57,30 @@ public class BillingApiService {
 
     public ResultWriter export(final BillingExportRequest request) {
         return billingManager.export(request);
+    }
+
+    @PostFilter(AclExpressions.BILLING_TEMPLATE_READ_FILTER)
+    public List<BillingReportTemplate> getAvailableCustomBillingTemplates() {
+        return billingTemplateManager.loadAll();
+    }
+
+    @PreAuthorize(AclExpressions.ADMIN_OR_GENERAL_USER)
+    public BillingReportTemplate createCustomBillingTemplates(final BillingReportTemplate template) {
+        return billingTemplateManager.create(template);
+    }
+
+    @PreAuthorize(AclExpressions.BILLING_TEMPLATE_ID_READ)
+    public BillingReportTemplate getCustomBillingTemplate(final Long id) {
+        return billingTemplateManager.load(id);
+    }
+
+    @PreAuthorize(AclExpressions.BILLING_TEMPLATE_ID_WRITE)
+    public void deleteCustomBillingTemplate(final Long id) {
+        billingTemplateManager.delete(id);
+    }
+
+    @PreAuthorize(AclExpressions.BILLING_TEMPLATE_WRITE)
+    public BillingReportTemplate updateCustomBillingTemplates(final BillingReportTemplate template) {
+        return billingTemplateManager.update(template);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/acl/billing/BillingApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/billing/BillingApiService.java
@@ -20,6 +20,7 @@ import com.epam.pipeline.controller.ResultWriter;
 import com.epam.pipeline.controller.vo.billing.BillingChartRequest;
 import com.epam.pipeline.controller.vo.billing.BillingExportRequest;
 import com.epam.pipeline.entity.billing.BillingChartInfo;
+import com.epam.pipeline.entity.search.FacetedSearchResult;
 import com.epam.pipeline.manager.billing.BillingManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -34,6 +35,14 @@ public class BillingApiService {
 
     public List<BillingChartInfo> getBillingChartInfo(final BillingChartRequest request) {
         return billingManager.getBillingChartInfo(request);
+    }
+
+    public List<String> getAvailableFacetValues(final String facet) {
+        return billingManager.getAvailableFacetValues(facet);
+    }
+
+    public FacetedSearchResult getAvailableFields(final BillingChartRequest request) {
+        return billingManager.getAvailableFacets(request);
     }
 
     public List<BillingChartInfo> getBillingChartInfoPaginated(final BillingChartRequest request) {

--- a/api/src/main/java/com/epam/pipeline/acl/billing/BillingApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/billing/BillingApiService.java
@@ -37,10 +37,6 @@ public class BillingApiService {
         return billingManager.getBillingChartInfo(request);
     }
 
-    public List<String> getAvailableFacetValues(final String facet) {
-        return billingManager.getAvailableFacetValues(facet);
-    }
-
     public FacetedSearchResult getAvailableFields(final BillingChartRequest request) {
         return billingManager.getAvailableFacets(request);
     }

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -594,6 +594,13 @@ public final class MessageConstants {
     public static final String ERROR_BILLING_GROUPING_SHOULD_BE_SPECIFIED =
             "error.billing.grouping.should.be.specified";
 
+    //Billing custom templates
+    public static final String ERROR_BILLING_CUSTOM_TEMPLATE_NOT_FOUND = "error.billing.custom.template.not.found";
+    public static final String ERROR_BILLING_CUSTOM_TEMPLATE_NOT_FOUND_BY_NAME =
+            "error.billing.custom.template.name.not.found";
+    public static final String ERROR_BILLING_CUSTOM_TEMPLATE_ID_EMPTY = "error.billing.custom.template.id.empty";
+
+
     //Disks
     public static final String ERROR_DISK_NODE_MISSING = "error.disk.node.missing";
     public static final String ERROR_DISK_DATE_MISSING = "error.disk.date.missing";

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -582,6 +582,8 @@ public final class MessageConstants {
     //Billing
     public static final String ERROR_BILLING_FIELD_DATE_GROUPING_NOT_SUPPORTED =
         "error.billing.date.field.grouping.not.supported";
+    public static final String ERROR_BILLING_NON_GROUPING_NOT_SUPPORTED =
+            "error.billing.non.grouping.not.supported";
     public static final String INFO_BILLING_ENTITY_FOR_DETAILS_NOT_FOUND =
         "error.billing.entity.for.grouping.not.found";
     public static final String ERROR_BILLING_DETAILS_NOT_SUPPORTED = "error.billing.details.not.supported";
@@ -589,6 +591,8 @@ public final class MessageConstants {
     public static final String ERROR_ILLEGAL_PAGING_PARAMETERS = "error.billing.invalid.paging";
     public static final String ERROR_BILLING_EXPORT_TYPE_NOT_SUPPORTED = "error.billing.export.type.not.supported";
     public static final String ERROR_BILLING_EXPORT_TYPES_MISSING = "error.billing.export.types.missing";
+    public static final String ERROR_BILLING_GROUPING_SHOULD_BE_SPECIFIED =
+            "error.billing.grouping.should.be.specified";
 
     //Disks
     public static final String ERROR_DISK_NODE_MISSING = "error.disk.node.missing";

--- a/api/src/main/java/com/epam/pipeline/controller/billing/BillingController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/billing/BillingController.java
@@ -22,12 +22,14 @@ import com.epam.pipeline.controller.Result;
 import com.epam.pipeline.controller.vo.billing.BillingChartRequest;
 import com.epam.pipeline.controller.vo.billing.BillingExportRequest;
 import com.epam.pipeline.entity.billing.BillingChartInfo;
+import com.epam.pipeline.entity.search.FacetedSearchResult;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -53,6 +55,28 @@ public class BillingController extends AbstractRestController {
     @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
     public Result<List<BillingChartInfo>> getBillingChartInfo(@RequestBody final BillingChartRequest request) {
         return Result.success(billingApi.getBillingChartInfo(request));
+    }
+
+    @RequestMapping(value = "/billing/facets", method = RequestMethod.POST)
+    @ResponseBody
+    @ApiOperation(
+            value = "Get info for available fields to filter on.",
+            notes = "Get info for available fields to filter on.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<FacetedSearchResult> getAvailableFacets(@RequestBody final BillingChartRequest request) {
+        return Result.success(billingApi.getAvailableFields(request));
+    }
+
+    @RequestMapping(value = "/billing/facets/values/{facet}", method = RequestMethod.GET)
+    @ResponseBody
+    @ApiOperation(
+            value = "Get info for available facet values to filter on.",
+            notes = "Get info for available facet values to filter on.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<List<String>> getAvailableFacetValues(@PathVariable final String facet) {
+        return Result.success(billingApi.getAvailableFacetValues(facet));
     }
 
     @RequestMapping(value = "/billing/charts/pagination", method = RequestMethod.POST)

--- a/api/src/main/java/com/epam/pipeline/controller/billing/BillingController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/billing/BillingController.java
@@ -22,6 +22,7 @@ import com.epam.pipeline.controller.Result;
 import com.epam.pipeline.controller.vo.billing.BillingChartRequest;
 import com.epam.pipeline.controller.vo.billing.BillingExportRequest;
 import com.epam.pipeline.entity.billing.BillingChartInfo;
+import com.epam.pipeline.entity.billing.BillingReportTemplate;
 import com.epam.pipeline.entity.search.FacetedSearchResult;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
@@ -29,6 +30,7 @@ import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -54,17 +56,6 @@ public class BillingController extends AbstractRestController {
     @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
     public Result<List<BillingChartInfo>> getBillingChartInfo(@RequestBody final BillingChartRequest request) {
         return Result.success(billingApi.getBillingChartInfo(request));
-    }
-
-    @RequestMapping(value = "/billing/facets", method = RequestMethod.POST)
-    @ResponseBody
-    @ApiOperation(
-            value = "Get info for available fields to filter on.",
-            notes = "Get info for available fields to filter on.",
-            produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
-    public Result<FacetedSearchResult> getAvailableFacets(@RequestBody final BillingChartRequest request) {
-        return Result.success(billingApi.getAvailableFields(request));
     }
 
     @RequestMapping(value = "/billing/charts/pagination", method = RequestMethod.POST)
@@ -99,5 +90,74 @@ public class BillingController extends AbstractRestController {
     @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
     public Result<List<String>> getAllBillingCenters() {
         return Result.success(billingApi.getAllBillingCenters());
+    }
+
+    @RequestMapping(value = "/billing/facets", method = RequestMethod.POST)
+    @ResponseBody
+    @ApiOperation(
+            value = "Get info for available fields to filter on.",
+            notes = "Get info for available fields to filter on.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<FacetedSearchResult> getAvailableFacets(@RequestBody final BillingChartRequest request) {
+        return Result.success(billingApi.getAvailableFields(request));
+    }
+
+    @RequestMapping(value = "/billing/templates", method = RequestMethod.GET)
+    @ResponseBody
+    @ApiOperation(
+            value = "List available custom billing report templates.",
+            notes = "List available custom billing report templates.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<List<BillingReportTemplate>> getAvailableCustomBillingTemplates() {
+        return Result.success(billingApi.getAvailableCustomBillingTemplates());
+    }
+
+    @RequestMapping(value = "/billing/templates/{id}", method = RequestMethod.GET)
+    @ResponseBody
+    @ApiOperation(
+            value = "Get custom billing report template by id.",
+            notes = "Get custom billing report template by id.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<BillingReportTemplate> getCustomBillingTemplates(@PathVariable final Long id) {
+        return Result.success(billingApi.getCustomBillingTemplate(id));
+    }
+
+    @RequestMapping(value = "/billing/templates/{id}", method = RequestMethod.DELETE)
+    @ResponseBody
+    @ApiOperation(
+            value = "Delete custom billing report template by id.",
+            notes = "Delete custom billing report template by id.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result deleteCustomBillingTemplates(@PathVariable final Long id) {
+        billingApi.deleteCustomBillingTemplate(id);
+        return Result.success();
+    }
+
+    @RequestMapping(value = "/billing/templates", method = RequestMethod.POST)
+    @ResponseBody
+    @ApiOperation(
+            value = "Create custom billing report template.",
+            notes = "Create custom billing report template.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<BillingReportTemplate> createCustomBillingTemplates(
+            @RequestBody final BillingReportTemplate template) {
+        return Result.success(billingApi.createCustomBillingTemplates(template));
+    }
+
+    @RequestMapping(value = "/billing/templates", method = RequestMethod.PUT)
+    @ResponseBody
+    @ApiOperation(
+            value = "Create custom billing report template.",
+            notes = "Create custom billing report template.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<BillingReportTemplate> updateCustomBillingTemplates(
+            @RequestBody final BillingReportTemplate template) {
+        return Result.success(billingApi.updateCustomBillingTemplates(template));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/billing/BillingController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/billing/BillingController.java
@@ -29,7 +29,6 @@ import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -66,17 +65,6 @@ public class BillingController extends AbstractRestController {
     @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
     public Result<FacetedSearchResult> getAvailableFacets(@RequestBody final BillingChartRequest request) {
         return Result.success(billingApi.getAvailableFields(request));
-    }
-
-    @RequestMapping(value = "/billing/facets/values/{facet}", method = RequestMethod.GET)
-    @ResponseBody
-    @ApiOperation(
-            value = "Get info for available facet values to filter on.",
-            notes = "Get info for available facet values to filter on.",
-            produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
-    public Result<List<String>> getAvailableFacetValues(@PathVariable final String facet) {
-        return Result.success(billingApi.getAvailableFacetValues(facet));
     }
 
     @RequestMapping(value = "/billing/charts/pagination", method = RequestMethod.POST)

--- a/api/src/main/java/com/epam/pipeline/controller/billing/BillingController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/billing/BillingController.java
@@ -152,8 +152,8 @@ public class BillingController extends AbstractRestController {
     @RequestMapping(value = "/billing/templates", method = RequestMethod.PUT)
     @ResponseBody
     @ApiOperation(
-            value = "Create custom billing report template.",
-            notes = "Create custom billing report template.",
+            value = "Update custom billing report template.",
+            notes = "Update custom billing report template.",
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
     public Result<BillingReportTemplate> updateCustomBillingTemplates(

--- a/api/src/main/java/com/epam/pipeline/controller/vo/billing/BillingChartRequest.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/billing/BillingChartRequest.java
@@ -16,7 +16,6 @@
 
 package com.epam.pipeline.controller.vo.billing;
 
-import com.epam.pipeline.entity.billing.BillingGrouping;
 import lombok.Value;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 
@@ -31,7 +30,7 @@ public class BillingChartRequest {
     private LocalDate to;
     private Map<String, List<String>> filters;
     private DateHistogramInterval interval;
-    private BillingGrouping grouping;
+    private String grouping;
     private boolean loadDetails;
     private Long pageSize;
     private Long pageNum;

--- a/api/src/main/java/com/epam/pipeline/dao/billing/BillingTemplateDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/billing/BillingTemplateDao.java
@@ -50,7 +50,7 @@ public class BillingTemplateDao  extends NamedParameterJdbcDaoSupport {
     public BillingReportTemplate create(final BillingReportTemplate template) {
         final KeyHolder keyHolder = new GeneratedKeyHolder();
         getNamedParameterJdbcTemplate().update(createBillingTemplateQuery,
-                BillingReportTemplateParameters.getParameters(template), keyHolder);
+                BillingReportTemplateParameters.getParameters(template), keyHolder, new String[] { "id" });
         template.setId(keyHolder.getKey().longValue());
         return template;
     }

--- a/api/src/main/java/com/epam/pipeline/dao/billing/BillingTemplateDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/billing/BillingTemplateDao.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.dao.billing;
+
+import com.epam.pipeline.entity.billing.BillingReportTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcDaoSupport;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+public class BillingTemplateDao  extends NamedParameterJdbcDaoSupport {
+
+    private String createBillingTemplateQuery;
+    private String updateBillingTemplateQuery;
+    private String deleteBillingTemplateQuery;
+    private String loadAllBillingTemplateQuery;
+    private String loadBillingTemplateByIdQuery;
+    private String loadBillingTemplateByNameQuery;
+
+    public List<BillingReportTemplate> loadAll() {
+        return getJdbcTemplate().query(loadAllBillingTemplateQuery, BillingReportTemplateParameters.getRowMapper());
+    }
+
+    public Optional<BillingReportTemplate> load(final Long id) {
+        return getJdbcTemplate().query(loadBillingTemplateByIdQuery, BillingReportTemplateParameters.getRowMapper(), id)
+                .stream().findFirst();
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public BillingReportTemplate create(final BillingReportTemplate template) {
+        final KeyHolder keyHolder = new GeneratedKeyHolder();
+        getNamedParameterJdbcTemplate().update(createBillingTemplateQuery,
+                BillingReportTemplateParameters.getParameters(template), keyHolder);
+        template.setId(keyHolder.getKey().longValue());
+        return template;
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public BillingReportTemplate update(final BillingReportTemplate template) {
+        getNamedParameterJdbcTemplate().update(updateBillingTemplateQuery,
+                BillingReportTemplateParameters.getParameters(template));
+        return template;
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void delete(final Long id) {
+        getJdbcTemplate().update(deleteBillingTemplateQuery, id);
+    }
+
+    public Optional<BillingReportTemplate> loadByName(final String name) {
+        return getJdbcTemplate().query(loadBillingTemplateByNameQuery, BillingReportTemplateParameters.getRowMapper(), name)
+                .stream().findFirst();
+    }
+
+    enum BillingReportTemplateParameters {
+        ID,
+        NAME,
+        DESCRIPTION,
+        TEMPLATE,
+        SETTINGS;
+
+        static MapSqlParameterSource getParameters(final BillingReportTemplate template) {
+            MapSqlParameterSource params = new MapSqlParameterSource();
+            params.addValue(ID.name(), template.getId());
+            params.addValue(NAME.name(), template.getName());
+            params.addValue(DESCRIPTION.name(), template.getDescription());
+            params.addValue(TEMPLATE.name(), template.getTemplate());
+            params.addValue(SETTINGS.name(), template.getSettings());
+            return params;
+        }
+
+        static RowMapper<BillingReportTemplate> getRowMapper() {
+            return (rs, rowNum) -> {
+                BillingReportTemplate template = new BillingReportTemplate();
+                template.setId(rs.getLong(ID.name()));
+                template.setName(rs.getString(NAME.name()));
+                template.setDescription(rs.getString(DESCRIPTION.name()));
+                template.setTemplate(TEMPLATE.name());
+                template.setSettings(SETTINGS.name());
+                return template;
+            };
+        }
+    }
+
+    public void setCreateBillingTemplateQuery(final String createBillingTemplateQuery) {
+        this.createBillingTemplateQuery = createBillingTemplateQuery;
+    }
+
+    public void setUpdateBillingTemplateQuery(final String updateBillingTemplateQuery) {
+        this.updateBillingTemplateQuery = updateBillingTemplateQuery;
+    }
+
+    public void setDeleteBillingTemplateQuery(final String deleteBillingTemplateQuery) {
+        this.deleteBillingTemplateQuery = deleteBillingTemplateQuery;
+    }
+
+    public void setLoadAllBillingTemplateQuery(final String loadAllBillingTemplateQuery) {
+        this.loadAllBillingTemplateQuery = loadAllBillingTemplateQuery;
+    }
+
+    public void setLoadBillingTemplateByIdQuery(final String loadBillingTemplateByIdQuery) {
+        this.loadBillingTemplateByIdQuery = loadBillingTemplateByIdQuery;
+    }
+
+    public void setLoadBillingTemplateByNameQuery(final String loadBillingTemplateByNameQuery) {
+        this.loadBillingTemplateByNameQuery = loadBillingTemplateByNameQuery;
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/entity/billing/BillingGrouping.java
+++ b/api/src/main/java/com/epam/pipeline/entity/billing/BillingGrouping.java
@@ -16,37 +16,64 @@
 
 package com.epam.pipeline.entity.billing;
 
-public enum BillingGrouping {
-    RESOURCE_TYPE("resource_type", false, false),
-    RUN_INSTANCE_TYPE("instance_type", true, false),
-    RUN_COMPUTE_TYPE("compute_type", false, false),
-    PIPELINE("pipeline", true, false),
-    TOOL("tool", true, false),
-    STORAGE("storage_id", false, true),
-    STORAGE_TYPE("storage_type", false, false),
-    USER("owner", true, true),
-    BILLING_CENTER("billing_center", true, true);
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+import java.util.HashMap;
+import java.util.Map;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@EqualsAndHashCode(of = "correspondingField")
+public class BillingGrouping {
+
+    public static final BillingGrouping RESOURCE_TYPE = new BillingGrouping("resource_type", "Resource",
+            false, false);
+    public static final BillingGrouping RUN_INSTANCE_TYPE = new BillingGrouping("instance_type", "Instance Type",
+            true, false);
+    public static final BillingGrouping RUN_COMPUTE_TYPE = new BillingGrouping("compute_type", "Compute Type",
+            false, false);
+    public static final BillingGrouping PIPELINE = new BillingGrouping("pipeline", "Pipeline",
+            true, false);
+    public static final BillingGrouping TOOL = new BillingGrouping("tool", "Tool",
+            true, false);
+    public static final BillingGrouping STORAGE = new BillingGrouping("storage_id", "Storage",
+            false, true);
+    public static final BillingGrouping STORAGE_TYPE = new BillingGrouping("storage_type", "Storage Type",
+            false, false);
+    public static final BillingGrouping USER = new BillingGrouping("owner", "Owner",
+            true, true);
+    public static final BillingGrouping BILLING_CENTER = new BillingGrouping("billing_center", "Billing Center",
+            true, true);
+
+    public static final Map<String, BillingGrouping> DEFAULT_GROUPING_BY_NAME = new HashMap<String, BillingGrouping>(){{
+        put(RESOURCE_TYPE.getCorrespondingField(), RESOURCE_TYPE);
+        put(RUN_INSTANCE_TYPE.getCorrespondingField(), RUN_INSTANCE_TYPE);
+        put(RUN_COMPUTE_TYPE.getCorrespondingField(), RUN_COMPUTE_TYPE);
+        put(PIPELINE.getCorrespondingField(), PIPELINE);
+        put(TOOL.getCorrespondingField(), TOOL);
+        put(STORAGE.getCorrespondingField(), STORAGE);
+        put(STORAGE_TYPE.getCorrespondingField(), STORAGE_TYPE);
+        put(USER.getCorrespondingField(), USER);
+        put(BILLING_CENTER.getCorrespondingField(), BILLING_CENTER);
+    }};
 
     private final String correspondingField;
+    private final String name;
     private final boolean runUsageDetailsRequired;
     private final boolean storageUsageDetailsRequired;
 
-    BillingGrouping(final String correspondingField, final boolean runUsageDetailsRequired,
-                    final boolean storageUsageDetailsRequired) {
-        this.correspondingField = correspondingField;
-        this.runUsageDetailsRequired = runUsageDetailsRequired;
-        this.storageUsageDetailsRequired = storageUsageDetailsRequired;
+    @NotNull
+    public static BillingGrouping getDefault(final String correspondingField) {
+        return DEFAULT_GROUPING_BY_NAME.getOrDefault(correspondingField, fromField(correspondingField));
     }
 
-    public String getCorrespondingField() {
-        return correspondingField;
+    private static BillingGrouping fromField(final String correspondingField) {
+        return BillingGrouping.builder().correspondingField(correspondingField).build();
     }
 
-    public boolean runUsageDetailsRequired() {
-        return runUsageDetailsRequired;
-    }
-
-    public boolean storageUsageDetailsRequired() {
-        return storageUsageDetailsRequired;
-    }
 }

--- a/api/src/main/java/com/epam/pipeline/entity/billing/BillingGrouping.java
+++ b/api/src/main/java/com/epam/pipeline/entity/billing/BillingGrouping.java
@@ -73,7 +73,7 @@ public class BillingGrouping {
     }
 
     private static BillingGrouping fromField(final String correspondingField) {
-        return BillingGrouping.builder().correspondingField(correspondingField).build();
+        return BillingGrouping.builder().name(correspondingField).correspondingField(correspondingField).build();
     }
 
 }

--- a/api/src/main/java/com/epam/pipeline/entity/billing/BillingReportTemplate.java
+++ b/api/src/main/java/com/epam/pipeline/entity/billing/BillingReportTemplate.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.billing;
+
+import com.epam.pipeline.entity.AbstractSecuredEntity;
+import com.epam.pipeline.entity.security.acl.AclClass;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BillingReportTemplate extends AbstractSecuredEntity {
+
+    private String description;
+    private String template;
+    private String settings;
+
+    @Override
+    public AbstractSecuredEntity getParent() {
+        return null;
+    }
+
+    @Override
+    public AclClass getAclClass() {
+        return AclClass.BILLING_REPORT_TEMPLATE;
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingHelper.java
@@ -132,10 +132,6 @@ public class BillingHelper {
                 .anyMatch(DefaultRoles.ROLE_BILLING_MANAGER.getName()::equals);
     }
 
-    public String indicesPattern() {
-        return billingIndicesMonthlyPattern;
-    }
-
     // TODO rewrite to get only year indices (it will be enough to get all available fields)
     public String allBillingIndicesPattern() {
         return billingIndicesPattern;

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingHelper.java
@@ -130,6 +130,10 @@ public class BillingHelper {
                 .anyMatch(DefaultRoles.ROLE_BILLING_MANAGER.getName()::equals);
     }
 
+    public String indicesPattern() {
+        return billingIndicesMonthlyPattern;
+    }
+
     public String[] indicesByDate(final LocalDate from, final LocalDate to) {
         return indicesByDate(from, to, billingIndicesMonthlyPattern);
     }

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingHelper.java
@@ -65,6 +65,7 @@ import java.util.stream.Stream;
 public class BillingHelper {
 
     private final AuthManager authManager;
+    private final String billingIndicesPattern;
     private final String billingIndicesMonthlyPattern;
     private final String billingRunIndicesMonthlyPattern;
     private final String billingStorageIndicesMonthlyPattern;
@@ -79,6 +80,7 @@ public class BillingHelper {
     public BillingHelper(final AuthManager authManager,
                          final @Value("${billing.index.common.prefix}") String commonPrefix) {
         this.authManager = authManager;
+        this.billingIndicesPattern = String.join("-", commonPrefix, BillingUtils.ES_WILDCARD);
         this.billingIndicesMonthlyPattern = String.join("-",
                 commonPrefix,
                 BillingUtils.ES_WILDCARD,
@@ -132,6 +134,10 @@ public class BillingHelper {
 
     public String indicesPattern() {
         return billingIndicesMonthlyPattern;
+    }
+
+    public String allBillingIndicesPattern() {
+        return billingIndicesPattern;
     }
 
     public String[] indicesByDate(final LocalDate from, final LocalDate to) {

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingHelper.java
@@ -136,6 +136,7 @@ public class BillingHelper {
         return billingIndicesMonthlyPattern;
     }
 
+    // TODO rewrite to get only year indices (it will be enough to get all available fields)
     public String allBillingIndicesPattern() {
         return billingIndicesPattern;
     }

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
@@ -374,7 +374,7 @@ public class BillingManager {
         final Map<String, BillingGrouping> billingFieldMapping = preferenceManager.getPreference(
                 SystemPreferences.BILLING_FIELD_MAPPING);
         return billingFieldMapping.getOrDefault(
-                request.getGrouping().toLowerCase(Locale.ROOT),
+                request.getGrouping(),
                 BillingGrouping.getDefault(request.getGrouping())
         );
     }
@@ -606,7 +606,7 @@ public class BillingManager {
         final Map<String, String> entityDetails = new HashMap<>();
         if (grouping != null) {
             if (detailsLoader == null) {
-                groupingInfo.put(grouping.toString(), groupValue);
+                groupingInfo.put(grouping.getCorrespondingField(), groupValue);
             } else {
                 entityDetails.putAll(detailsLoader.loadInformation(groupValue, loadDetails));
                 groupingInfo.put(grouping.getCorrespondingField(), entityDetails.remove(EntityBillingDetailsLoader.NAME));

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingTemplateManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingTemplateManager.java
@@ -16,11 +16,14 @@
 
 package com.epam.pipeline.manager.billing;
 
+import com.epam.pipeline.common.MessageConstants;
+import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.dao.billing.BillingTemplateDao;
 import com.epam.pipeline.entity.AbstractSecuredEntity;
 import com.epam.pipeline.entity.billing.BillingReportTemplate;
 import com.epam.pipeline.entity.security.acl.AclClass;
 import com.epam.pipeline.manager.security.SecuredEntityManager;
+import com.epam.pipeline.manager.security.acl.AclSync;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
@@ -33,6 +36,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+@AclSync
 @Service
 @Slf4j
 @RequiredArgsConstructor
@@ -40,26 +44,30 @@ import java.util.List;
 public class BillingTemplateManager implements SecuredEntityManager {
 
     private final BillingTemplateDao billingTemplateDao;
+    private final MessageHelper messageHelper;
 
     public List<BillingReportTemplate> loadAll() {
         return billingTemplateDao.loadAll();
     }
 
     @Override
-    public BillingReportTemplate load(Long id) {
+    public BillingReportTemplate load(final Long id) {
         return billingTemplateDao.load(id)
-                .orElseThrow(() -> new IllegalArgumentException("Can't find Billing report template with id: " + id));
+                .orElseThrow(() -> new IllegalArgumentException(
+                        messageHelper.getMessage(MessageConstants.ERROR_BILLING_CUSTOM_TEMPLATE_NOT_FOUND, id)));
     }
 
-    public BillingReportTemplate loadByName(String name) {
+    public BillingReportTemplate loadByName(final String name) {
         return billingTemplateDao.loadByName(name).orElseThrow(
-                () -> new IllegalArgumentException("Can't find Billing report template with name: " + name));
+                () -> new IllegalArgumentException(
+                        messageHelper.getMessage(MessageConstants.ERROR_BILLING_CUSTOM_TEMPLATE_NOT_FOUND, name)));
     }
 
     @Override
-    public BillingReportTemplate loadByNameOrId(String identifier) {
+    public BillingReportTemplate loadByNameOrId(final String identifier) {
         if (StringUtils.isEmpty(identifier)) {
-            throw new IllegalArgumentException("Provided identifier is empty!");
+            throw new IllegalArgumentException(
+                    messageHelper.getMessage(MessageConstants.ERROR_BILLING_CUSTOM_TEMPLATE_ID_EMPTY));
         }
         if (NumberUtils.isNumber(identifier)) {
             return load(Long.getLong(identifier));
@@ -69,16 +77,16 @@ public class BillingTemplateManager implements SecuredEntityManager {
     }
 
     @Transactional(propagation = Propagation.REQUIRED)
-    public BillingReportTemplate create(BillingReportTemplate template) {
+    public BillingReportTemplate create(final BillingReportTemplate template) {
         return billingTemplateDao.create(template);
     }
 
     @Transactional(propagation = Propagation.REQUIRED)
-    public BillingReportTemplate update(BillingReportTemplate template) {
+    public BillingReportTemplate update(final BillingReportTemplate template) {
         if (template.getId() == null) {
             throw new IllegalArgumentException();
         }
-        BillingReportTemplate loaded = load(template.getId());
+        final BillingReportTemplate loaded = load(template.getId());
         if (loaded != null) {
             return billingTemplateDao.update(template);
         } else {
@@ -109,12 +117,12 @@ public class BillingTemplateManager implements SecuredEntityManager {
     }
 
     @Override
-    public Collection<? extends AbstractSecuredEntity> loadAllWithParents(Integer page, Integer pageSize) {
+    public Collection<? extends AbstractSecuredEntity> loadAllWithParents(final Integer page, final Integer pageSize) {
         return Collections.emptyList();
     }
 
     @Override
-    public AbstractSecuredEntity loadWithParents(Long id) {
+    public AbstractSecuredEntity loadWithParents(final Long id) {
         return load(id);
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingTemplateManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingTemplateManager.java
@@ -118,7 +118,7 @@ public class BillingTemplateManager implements SecuredEntityManager {
 
     @Override
     public Collection<? extends AbstractSecuredEntity> loadAllWithParents(final Integer page, final Integer pageSize) {
-        return Collections.emptyList();
+        return loadAll();
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingTemplateManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingTemplateManager.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.billing;
+
+import com.epam.pipeline.dao.billing.BillingTemplateDao;
+import com.epam.pipeline.entity.AbstractSecuredEntity;
+import com.epam.pipeline.entity.billing.BillingReportTemplate;
+import com.epam.pipeline.entity.security.acl.AclClass;
+import com.epam.pipeline.manager.security.SecuredEntityManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.math.NumberUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@SuppressWarnings("PMD.AvoidCatchingGenericException")
+public class BillingTemplateManager implements SecuredEntityManager {
+
+    private final BillingTemplateDao billingTemplateDao;
+
+    public List<BillingReportTemplate> loadAll() {
+        return billingTemplateDao.loadAll();
+    }
+
+    @Override
+    public BillingReportTemplate load(Long id) {
+        return billingTemplateDao.load(id)
+                .orElseThrow(() -> new IllegalArgumentException("Can't find Billing report template with id: " + id));
+    }
+
+    public BillingReportTemplate loadByName(String name) {
+        return billingTemplateDao.loadByName(name).orElseThrow(
+                () -> new IllegalArgumentException("Can't find Billing report template with name: " + name));
+    }
+
+    @Override
+    public BillingReportTemplate loadByNameOrId(String identifier) {
+        if (StringUtils.isEmpty(identifier)) {
+            throw new IllegalArgumentException("Provided identifier is empty!");
+        }
+        if (NumberUtils.isNumber(identifier)) {
+            return load(Long.getLong(identifier));
+        } else {
+            return loadByName(identifier);
+        }
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public BillingReportTemplate create(BillingReportTemplate template) {
+        return billingTemplateDao.create(template);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public BillingReportTemplate update(BillingReportTemplate template) {
+        if (template.getId() == null) {
+            throw new IllegalArgumentException();
+        }
+        BillingReportTemplate loaded = load(template.getId());
+        if (loaded != null) {
+            return billingTemplateDao.update(template);
+        } else {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRED)
+    public BillingReportTemplate changeOwner(final Long id, final String owner) {
+        final BillingReportTemplate toBeUpdated = load(id);
+        if (toBeUpdated == null) {
+            throw new IllegalArgumentException();
+        }
+        toBeUpdated.setOwner(owner);
+        billingTemplateDao.update(toBeUpdated);
+        return toBeUpdated;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void delete(final Long id) {
+        billingTemplateDao.delete(id);
+    }
+
+    @Override
+    public Integer loadTotalCount() {
+        return loadAll().size();
+    }
+
+    @Override
+    public Collection<? extends AbstractSecuredEntity> loadAllWithParents(Integer page, Integer pageSize) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public AbstractSecuredEntity loadWithParents(Long id) {
+        return load(id);
+    }
+
+    @Override
+    public AclClass getSupportedClass() {
+        return AclClass.BILLING_REPORT_TEMPLATE;
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/billing/StorageBillingDetailsLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/StorageBillingDetailsLoader.java
@@ -112,8 +112,8 @@ public class StorageBillingDetailsLoader implements EntityBillingDetailsLoader {
     @Override
     public Map<String, String> getEmptyDetails() {
         return Stream.of(PROVIDER, REGION, OWNER, CREATED,
-                        BillingGrouping.BILLING_CENTER.getCorrespondingField(),
-                        BillingGrouping.STORAGE_TYPE.getCorrespondingField())
+                         BillingGrouping.BILLING_CENTER.getCorrespondingField(),
+                         BillingGrouping.STORAGE_TYPE.getCorrespondingField())
             .collect(Collectors.toMap(Function.identity(), k -> emptyValue));
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/billing/StorageBillingDetailsLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/StorageBillingDetailsLoader.java
@@ -112,8 +112,8 @@ public class StorageBillingDetailsLoader implements EntityBillingDetailsLoader {
     @Override
     public Map<String, String> getEmptyDetails() {
         return Stream.of(PROVIDER, REGION, OWNER, CREATED,
-                         BillingGrouping.BILLING_CENTER.getCorrespondingField(),
-                         BillingGrouping.STORAGE_TYPE.getCorrespondingField())
+                        BillingGrouping.BILLING_CENTER.getCorrespondingField(),
+                        BillingGrouping.STORAGE_TYPE.getCorrespondingField())
             .collect(Collectors.toMap(Function.identity(), k -> emptyValue));
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -19,6 +19,7 @@ package com.epam.pipeline.manager.preference;
 import com.amazonaws.services.fsx.model.LustreDeploymentType;
 import com.epam.pipeline.common.MessageConstants;
 import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.entity.billing.BillingGrouping;
 import com.epam.pipeline.entity.cluster.CloudRegionsConfiguration;
 import com.epam.pipeline.entity.cluster.ClusterKeepAlivePolicy;
 import com.epam.pipeline.entity.cluster.DockerMount;
@@ -914,6 +915,10 @@ public class SystemPreferences {
             "billing.export.aggregation.page.size", 5000, BILLING_GROUP, pass);
     public static final IntPreference BILLING_EXPORT_PERIOD_AGGREGATION_PAGE_SIZE = new IntPreference(
             "billing.export.period.aggregation.page.size", 1000, BILLING_GROUP, pass);
+    public static final ObjectPreference<Map<String, BillingGrouping>> BILLING_FIELD_MAPPING = new ObjectPreference<>(
+            "billing.fields.mapping", Collections.emptyMap(),
+            new TypeReference<Map<String, BillingGrouping>>() {},
+            BILLING_GROUP, isNullOrValidJson(new TypeReference<Map<String, BillingGrouping>>() {}));
 
     // Billing quotas
     public static final BooleanPreference BILLING_QUOTAS_ENABLED = new BooleanPreference(

--- a/api/src/main/java/com/epam/pipeline/manager/utils/GlobalSearchElasticHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/utils/GlobalSearchElasticHelper.java
@@ -1,17 +1,62 @@
+/*
+ * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.epam.pipeline.manager.utils;
 
+import com.epam.pipeline.entity.search.FacetedSearchResult;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.http.HttpHost;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.indices.GetMappingsRequest;
+import org.elasticsearch.client.indices.GetMappingsResponse;
+import org.elasticsearch.cluster.metadata.MappingMetaData;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @Slf4j
@@ -36,6 +81,94 @@ public class GlobalSearchElasticHelper {
                         + SystemPreferences.SEARCH_ELASTIC_SCHEME.getKey()
         );
         return RestClient.builder(new HttpHost(host, port, schema));
+    }
+
+    public Set<String> getAvailableFacetFields(final String... indices) {
+        try {
+            GetMappingsResponse fieldMapping = buildClient().indices()
+                    .getMapping(
+                            new GetMappingsRequest().indices(indices),
+                            RequestOptions.DEFAULT
+                    );
+            return fieldMapping.mappings().values()
+                    .stream()
+                    .map(MappingMetaData::sourceAsMap)
+                    .flatMap(source -> {
+                        final Object properties = source.get("properties");
+                        if (properties instanceof Map) {
+                            return ((Map<String, Object>) properties).keySet().stream().filter(Objects::nonNull);
+                        }
+                        return Stream.empty();
+                    })
+                    .collect(Collectors.toSet());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return Collections.emptySet();
+    }
+
+    public FacetedSearchResult buildFacets(final Collection<String> fields, final Map<String, List<String>> filters,
+                                      final String... indices) {
+        final SearchSourceBuilder searchSource = new SearchSourceBuilder()
+                .query(getFacetedQuery(filters))
+                .size(0);
+
+        CollectionUtils.emptyIfNull(fields)
+                .forEach(facet -> addTermAggregationToSource(searchSource, facet));
+
+        SearchRequest searchRequest = new SearchRequest()
+                .indicesOptions(IndicesOptions.strictExpandOpen())
+                .indices(indices)
+                .source(searchSource);
+
+        try {
+            final SearchResponse response = buildClient().search(searchRequest, RequestOptions.DEFAULT);
+            return FacetedSearchResult.builder()
+                    .totalHits(response.getHits().getTotalHits())
+                    .facets(buildFacets(response.getAggregations()))
+                    .build();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private Map<String, Map<String, Long>> buildFacets(final Aggregations aggregations) {
+        if (Objects.isNull(aggregations)) {
+            return Collections.emptyMap();
+        }
+        return MapUtils.emptyIfNull(aggregations.asMap()).entrySet().stream()
+                .map(e -> ImmutablePair.of(e.getKey(), buildFacetValues(e)))
+                .filter(p -> !p.getValue().isEmpty())
+                .collect(Collectors.toMap(ImmutablePair::getKey, ImmutablePair::getValue));
+    }
+
+    private Map<String, Long> buildFacetValues(final Map.Entry<String, Aggregation> entry) {
+        final Terms fieldAggregation = (Terms) entry.getValue();
+        if (Objects.isNull(fieldAggregation)) {
+            return Collections.emptyMap();
+        }
+        return ListUtils.emptyIfNull(fieldAggregation.getBuckets()).stream()
+                .collect(Collectors.toMap(Terms.Bucket::getKeyAsString, Terms.Bucket::getDocCount));
+    }
+
+    private QueryBuilder getFacetedQuery(final Map<String, List<String>> filters) {
+        final BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
+        MapUtils.emptyIfNull(filters)
+                .forEach((fieldName, values) -> boolQueryBuilder.must(filterToTermsQuery(fieldName, values)));
+        return boolQueryBuilder;
+    }
+
+    private QueryBuilder filterToTermsQuery(final String fieldName, final List<String> values) {
+        return QueryBuilders.termsQuery(fieldName, values);
+    }
+
+    private void addTermAggregationToSource(final SearchSourceBuilder searchSource, final String facet) {
+        searchSource.aggregation(aggregateBy(facet));
+    }
+
+    private TermsAggregationBuilder aggregateBy(final String field) {
+        return AggregationBuilders.terms(field)
+                .field(field);
     }
 
 }

--- a/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
+++ b/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
@@ -53,6 +53,18 @@ public final class AclExpressions {
     public static final String RUN_ID_OWNER =
             "hasRole('ADMIN') OR @runPermissionManager.runPermission(#runId, 'OWNER')";
 
+    public static final String BILLING_TEMPLATE_ID_WRITE =
+            "hasRole('ADMIN') OR hasPermission(#id, 'com.epam.pipeline.entity.billing.BillingReportTemplate', 'WRITE')";
+
+    public static final String BILLING_TEMPLATE_ID_READ =
+            "hasRole('ADMIN') OR hasPermission(#id, 'com.epam.pipeline.entity.billing.BillingReportTemplate', 'READ')";
+
+    public static final String BILLING_TEMPLATE_WRITE =
+            "hasRole('ADMIN') OR hasPermission(#template, 'WRITE')";
+
+    public static final String BILLING_TEMPLATE_READ_FILTER =
+            "hasRole('ADMIN') OR hasPermission(filterObject, 'READ')";
+
     public static final String RUN_ID_SSH =
             "hasRole('ADMIN') OR @runPermissionManager.isRunSshAllowed(#runId)";
 

--- a/api/src/main/resources/dao/billing-template-dao.xml
+++ b/api/src/main/resources/dao/billing-template-dao.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <bean class="com.epam.pipeline.dao.billing.BillingTemplateDao" id="billingTemplateDao" autowire="byName">
+        <property name="createBillingTemplateQuery">
+            <value>
+                <![CDATA[
+                    INSERT INTO pipeline.billing_report_template (
+                        name,
+                        description,
+                        template,
+                        settings
+                    ) VALUES (
+                        :NAME,
+                        :DESCRIPTION,
+                        :TEMPLATE,
+                        :SETTINGS
+                    )
+                ]]>
+            </value>
+        </property>
+        <property name="updateBillingTemplateQuery">
+            <value>
+                <![CDATA[
+                    UPDATE pipeline.billing_report_template SET
+                       name = :NAME,
+                       description = :DESCRIPTION,
+                       template = :TEMPLATE,
+                       settings = :SETTINGS
+                    WHERE
+                        id = :ID
+                ]]>
+            </value>
+        </property>
+        <property name="deleteBillingTemplateQuery">
+            <value>
+                <![CDATA[
+                    DELETE FROM pipeline.billing_report_template WHERE id = ?
+                ]]>
+            </value>
+        </property>
+        <property name="loadAllBillingTemplateQuery">
+            <value>
+                <![CDATA[
+                    SELECT
+                        id,
+                        name,
+                        description,
+                        template,
+                        settings
+                    FROM
+                        pipeline.billing_report_template
+                    ORDER BY id
+                ]]>
+            </value>
+        </property>
+        <property name="loadBillingTemplateByIdQuery">
+            <value>
+                <![CDATA[
+                    SELECT
+                        id,
+                        name,
+                        description,
+                        template,
+                        settings
+                    FROM
+                        pipeline.billing_report_template
+                    WHERE
+                        id = ?
+                ]]>
+            </value>
+        </property>
+        <property name="loadBillingTemplateByNameQuery">
+            <value>
+                <![CDATA[
+                    SELECT
+                        id,
+                        name,
+                        description,
+                        template,
+                        settings
+                    FROM
+                        pipeline.billing_report_template
+                    WHERE
+                        lower(name) = lower(:NAME)
+                ]]>
+            </value>
+        </property>
+    </bean>
+</beans>

--- a/api/src/main/resources/db/migration/v2022.01.17_14.00__issue_2400_custom_billing_report_templates.sql
+++ b/api/src/main/resources/db/migration/v2022.01.17_14.00__issue_2400_custom_billing_report_templates.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS PIPELINE.BILLING_REPORT_TEMPLATE
+(
+  ID            SERIAL PRIMARY KEY,
+  NAME          VARCHAR(200) NOT NULL,
+  DESCRIPTION   VARCHAR(200) DEFAULT NULL,
+  TEMPLATE      TEXT NOT NULL,
+  SETTINGS      TEXT NOT NULL,
+);
+
+INSERT INTO pipeline.acl_class (class) VALUES ('com.epam.pipeline.entity.billing.BillingReportTemplate');

--- a/api/src/main/resources/db/migration/v2022.01.17_14.00__issue_2400_custom_billing_report_templates.sql
+++ b/api/src/main/resources/db/migration/v2022.01.17_14.00__issue_2400_custom_billing_report_templates.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS PIPELINE.BILLING_REPORT_TEMPLATE
   NAME          VARCHAR(200) NOT NULL,
   DESCRIPTION   VARCHAR(200) DEFAULT NULL,
   TEMPLATE      TEXT NOT NULL,
-  SETTINGS      TEXT NOT NULL,
+  SETTINGS      TEXT NOT NULL
 );
 
 INSERT INTO pipeline.acl_class (class) VALUES ('com.epam.pipeline.entity.billing.BillingReportTemplate');

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -538,6 +538,11 @@ error.billing.export.type.not.supported=Billing export type {0} is not supported
 error.billing.export.types.missing=At least a single billing export type should be specified.
 error.billing.grouping.should.be.specified=Billing grouping should be specified for such type of request!
 
+#Billing custom templates
+error.billing.custom.template.not.found=Can not find billing report template with id ''{0}''
+error.billing.custom.template.name.not.found=Can not find billing report template with name ''{0}''
+error.billing.custom.template.id.empty="Billing custom template identifier is not provided!"
+
 #Disks
 error.disk.node.missing=Disk node id should be specified.
 error.disk.date.missing=Disk creation date should be specified.

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -528,13 +528,15 @@ error.aws.profile.uniqueness=Exactly one account profile is supported for AWS pr
 error.aws.s3.role.uniqueness=Exactly one role is supported to assume for AWS provider
 
 #Builling
-error.billing.date.field.grouping.not.supported="Currently field and date grouping at the same time isn't supporting!"
-error.billing.details.not.supported="Details are supported for grouping requests only!"
-error.billing.interval.not.supported="Given interval is not supported!"
-error.billing.entity.for.grouping.not.found="''{0}'' entity for ''{1}'' grouping is not found."
-error.billing.invalid.paging='Paging parameters can't be negative!'
+error.billing.date.field.grouping.not.supported=Currently field and date grouping at the same time isn't supporting!
+error.billing.non.grouping.not.supported=Please provide field for grouping or interval!
+error.billing.details.not.supported=Details are supported for grouping requests only!
+error.billing.interval.not.supported=Given interval is not supported!
+error.billing.entity.for.grouping.not.found=''{0}'' entity for ''{1}'' grouping is not found.
+error.billing.invalid.paging=Paging parameters can't be negative!
 error.billing.export.type.not.supported=Billing export type {0} is not supported yet.
 error.billing.export.types.missing=At least a single billing export type should be specified.
+error.billing.grouping.should.be.specified=Billing grouping should be specified for such type of request!
 
 #Disks
 error.disk.node.missing=Disk node id should be specified.

--- a/api/src/test/java/com/epam/pipeline/acl/billing/BillingApiServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/acl/billing/BillingApiServiceTest.java
@@ -60,7 +60,7 @@ public class BillingApiServiceTest extends AbstractAclTest {
                 LocalDate.MAX,
                 Collections.singletonMap("filter", Collections.singletonList("filter")),
                 DateHistogramInterval.DAY,
-                BillingGrouping.BILLING_CENTER,
+                BillingGrouping.BILLING_CENTER.getCorrespondingField(),
                 true,
                 1L,
                 1L

--- a/api/src/test/java/com/epam/pipeline/controller/billing/BillingControllerTest.java
+++ b/api/src/test/java/com/epam/pipeline/controller/billing/BillingControllerTest.java
@@ -50,7 +50,7 @@ public class BillingControllerTest extends AbstractControllerTest {
                                                 "\"to\":\"+999999999-12-31\"," +
                                                 "\"filters\":{\"test\":[\"test\"]}," +
                                                 "\"interval\":\"1d\"," +
-                                                "\"grouping\":\"BILLING_CENTER\"," +
+                                                "\"grouping\":\"billing_center\"," +
                                                 "\"loadDetails\":true," +
                                                 "\"pageSize\":5," +
                                                 "\"pageNum\":1}";

--- a/api/src/test/java/com/epam/pipeline/controller/billing/BillingControllerTest.java
+++ b/api/src/test/java/com/epam/pipeline/controller/billing/BillingControllerTest.java
@@ -57,7 +57,7 @@ public class BillingControllerTest extends AbstractControllerTest {
     private final BillingChartInfo billingChartInfo = BillingChartInfo.builder().cost(COST).build();
     private final BillingChartRequest billingChartRequest = new BillingChartRequest(
             LocalDate.MIN, LocalDate.MAX, Collections.singletonMap("test", Collections.singletonList("test")),
-            DateHistogramInterval.DAY, BillingGrouping.BILLING_CENTER, true, 5L, 1L
+            DateHistogramInterval.DAY, BillingGrouping.BILLING_CENTER.getCorrespondingField(), true, 5L, 1L
     );
     private final List<BillingChartInfo> billingChartInfos = Collections.singletonList(billingChartInfo);
 

--- a/api/src/test/java/com/epam/pipeline/test/acl/AclTestBeans.java
+++ b/api/src/test/java/com/epam/pipeline/test/acl/AclTestBeans.java
@@ -35,6 +35,7 @@ import com.epam.pipeline.dao.user.UserDao;
 import com.epam.pipeline.manager.EntityManager;
 import com.epam.pipeline.manager.HierarchicalEntityManager;
 import com.epam.pipeline.manager.billing.BillingManager;
+import com.epam.pipeline.manager.billing.BillingTemplateManager;
 import com.epam.pipeline.manager.cloud.TemporaryCredentialsManager;
 import com.epam.pipeline.manager.cloud.credentials.CloudProfileCredentialsManagerProvider;
 import com.epam.pipeline.manager.cluster.EdgeServiceManager;
@@ -541,6 +542,9 @@ public class AclTestBeans {
 
     @MockBean
     protected OnlineUsersService onlineUsersService;
+
+    @MockBean
+    protected BillingTemplateManager billingTemplateManager;
 
     @Bean
     public GrantPermissionManager grantPermissionManager() {

--- a/api/src/test/java/com/epam/pipeline/test/aspect/AspectTestBeans.java
+++ b/api/src/test/java/com/epam/pipeline/test/aspect/AspectTestBeans.java
@@ -20,6 +20,7 @@ import com.epam.pipeline.acl.datastorage.DataStorageApiService;
 import com.epam.pipeline.acl.docker.ToolApiService;
 import com.epam.pipeline.acl.folder.FolderApiService;
 import com.epam.pipeline.acl.pipeline.PipelineApiService;
+import com.epam.pipeline.dao.billing.BillingTemplateDao;
 import com.epam.pipeline.dao.cluster.ClusterDao;
 import com.epam.pipeline.dao.cluster.InstanceOfferDao;
 import com.epam.pipeline.dao.cluster.NatGatewayDao;
@@ -67,6 +68,7 @@ import com.epam.pipeline.dao.tool.ToolVulnerabilityDao;
 import com.epam.pipeline.dao.user.GroupStatusDao;
 import com.epam.pipeline.dao.user.RoleDao;
 import com.epam.pipeline.dao.user.UserDao;
+import com.epam.pipeline.manager.billing.BillingTemplateManager;
 import com.epam.pipeline.manager.cluster.InstanceOfferScheduler;
 import com.epam.pipeline.manager.cluster.PodMonitor;
 import com.epam.pipeline.manager.contextual.handler.ContextualPreferenceHandler;
@@ -425,4 +427,10 @@ public class AspectTestBeans {
 
     @MockBean
     protected OnlineUsersMapper onlineUsersMapper;
+
+    @MockBean
+    protected BillingTemplateManager billingTemplateManager;
+
+    @MockBean
+    protected BillingTemplateDao billingTemplateDao;
 }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/EntityContainer.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/EntityContainer.java
@@ -16,11 +16,14 @@
 
 package com.epam.pipeline.billingreportagent.model;
 
+import com.epam.pipeline.entity.metadata.PipeConfValue;
 import com.epam.pipeline.entity.user.PipelineUser;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.util.Map;
 
 @Data
 @NoArgsConstructor
@@ -29,5 +32,6 @@ import lombok.NoArgsConstructor;
 public class EntityContainer<T> {
 
     private T entity;
+    private Map<String, PipeConfValue> metadata;
     private EntityWithMetadata<PipelineUser> owner;
 }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapper.java
@@ -23,6 +23,7 @@ import com.epam.pipeline.billingreportagent.model.billing.PipelineRunBillingInfo
 import com.epam.pipeline.billingreportagent.service.AbstractEntityMapper;
 import com.epam.pipeline.config.Constants;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.pipeline.run.parameter.PipelineRunParameter;
 import com.epam.pipeline.entity.search.SearchDocumentType;
 import lombok.Getter;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -37,6 +38,7 @@ import java.math.RoundingMode;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Component
 @Getter
@@ -75,7 +77,10 @@ public class RunBillingMapper extends AbstractEntityMapper<PipelineRunBillingInf
                 .field("cloudRegionId", run.getInstance().getCloudRegionId())
                 .field("created_date", billingInfo.getDate())
                 .field("started_date", asString(run.getStartDate()))
-                .field("finished_date", asString(run.getEndDate()));
+                .field("finished_date", asString(run.getEndDate()))
+                .field("pipeline_run_parameters",
+                        run.getPipelineRunParameters().stream()
+                                .collect(Collectors.toMap(PipelineRunParameter::getName, p -> p)));
             buildUserContent(container.getOwner(), jsonBuilder);
             jsonBuilder.endObject();
             return jsonBuilder;

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapper.java
@@ -26,6 +26,7 @@ import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.run.parameter.PipelineRunParameter;
 import com.epam.pipeline.entity.search.SearchDocumentType;
 import lombok.Getter;
+import org.apache.commons.collections4.ListUtils;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -36,6 +37,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.text.SimpleDateFormat;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -77,10 +79,12 @@ public class RunBillingMapper extends AbstractEntityMapper<PipelineRunBillingInf
                 .field("cloudRegionId", run.getInstance().getCloudRegionId())
                 .field("created_date", billingInfo.getDate())
                 .field("started_date", asString(run.getStartDate()))
-                .field("finished_date", asString(run.getEndDate()))
-                .field("pipeline_run_parameters",
-                        run.getPipelineRunParameters().stream()
-                                .collect(Collectors.toMap(PipelineRunParameter::getName, p -> p)));
+                .field("finished_date", asString(run.getEndDate()));
+
+            for (PipelineRunParameter parameter : ListUtils.emptyIfNull(run.getPipelineRunParameters())) {
+                jsonBuilder.field(parameter.getName(), parameter.getValue());
+            }
+
             buildUserContent(container.getOwner(), jsonBuilder);
             jsonBuilder.endObject();
             return jsonBuilder;

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapper.java
@@ -48,6 +48,8 @@ public class StorageBillingMapper extends AbstractEntityMapper<StorageBillingInf
                 .startObject()
                 .field(DOC_TYPE_FIELD, documentType.name())
                 .field("storage_id", storage.getId())
+                .field("storage_name", storage.getName())
+                .field("storage_created", storage.getCreatedDate())
                 .field("resource_type", billingInfo.getResourceType())
                 .field("cloudRegionId", billingInfo.getRegionId())
                 .field("provider", storage.getType())

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapper.java
@@ -22,6 +22,7 @@ import com.epam.pipeline.billingreportagent.model.EntityContainer;
 import com.epam.pipeline.billingreportagent.model.billing.StorageBillingInfo;
 import com.epam.pipeline.billingreportagent.service.AbstractEntityMapper;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
+import com.epam.pipeline.entity.metadata.PipeConfValue;
 import com.epam.pipeline.entity.search.SearchDocumentType;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +30,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 
 import java.io.IOException;
+import java.util.Map;
 
 @RequiredArgsConstructor
 @Getter
@@ -53,6 +55,9 @@ public class StorageBillingMapper extends AbstractEntityMapper<StorageBillingInf
                 .field("usage_bytes", billingInfo.getUsageBytes())
                 .field("cost", billingInfo.getCost())
                 .field("created_date", billingInfo.getDate());
+            for (Map.Entry<String, PipeConfValue> entry : container.getMetadata().entrySet()) {
+                jsonBuilder.field(entry.getKey(), entry.getValue().getValue());
+            }
             buildUserContent(container.getOwner(), jsonBuilder);
             jsonBuilder.endObject();
             return jsonBuilder;

--- a/billing-report-agent/src/main/resources/templates/pipeline_run_billing.json
+++ b/billing-report-agent/src/main/resources/templates/pipeline_run_billing.json
@@ -1,7 +1,16 @@
 {
   "mappings": {
-    "dynamic":"runtime",
     "_doc": {
+      "dynamic_templates": [
+        {
+          "keywords": {
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "keyword"
+            }
+          }
+        }
+      ],
       "properties": {
         "doc_type": { "type": "keyword", "store": true },
         "run_id": { "type": "keyword", "store": true },

--- a/billing-report-agent/src/main/resources/templates/pipeline_run_billing.json
+++ b/billing-report-agent/src/main/resources/templates/pipeline_run_billing.json
@@ -1,5 +1,6 @@
 {
   "mappings": {
+    "dynamic":"runtime",
     "_doc": {
       "properties": {
         "doc_type": { "type": "keyword", "store": true },

--- a/billing-report-agent/src/main/resources/templates/storage_billing.json
+++ b/billing-report-agent/src/main/resources/templates/storage_billing.json
@@ -1,7 +1,16 @@
 {
   "mappings": {
-    "dynamic":"runtime",
     "_doc": {
+      "dynamic_templates": [
+        {
+          "keywords": {
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "keyword"
+            }
+          }
+        }
+      ],
       "properties": {
         "doc_type": { "type": "keyword", "store": true },
         "storage_id": { "type": "keyword", "store": true },

--- a/billing-report-agent/src/main/resources/templates/storage_billing.json
+++ b/billing-report-agent/src/main/resources/templates/storage_billing.json
@@ -1,5 +1,6 @@
 {
   "mappings": {
+    "dynamic":"runtime",
     "_doc": {
       "properties": {
         "doc_type": { "type": "keyword", "store": true },

--- a/core/src/main/java/com/epam/pipeline/entity/security/acl/AclClass.java
+++ b/core/src/main/java/com/epam/pipeline/entity/security/acl/AclClass.java
@@ -32,7 +32,8 @@ public enum AclClass {
     CLOUD_REGION,
     PIPELINE_USER(false),
     ROLE(false),
-    CATEGORICAL_ATTRIBUTE;
+    CATEGORICAL_ATTRIBUTE,
+    BILLING_REPORT_TEMPLATE;
 
     private final boolean supportsEntityManager;
 


### PR DESCRIPTION
This PR is related to #2400 
It provides mechanism to create custom billing dashboards templates to be saved and viewed.

List of changes:
 - CRUD Operation for new secured entity `BillingReportTemplate`
 - Changes for `billing service` to index additional information for `storage` and `run`
 - Changes is related to retrieving billing information:
   - `BillingGrouping` now is class and can represent custom field (run parameter for example)
   - New preference was added to be able to configure settings for custom `BillingGrouping`
   - Several new `GlobalSearchElasticHelper` methods where added to perform facet search with elastic index 