### PR TITLE
Implement grid engine batch autoscaling

### DIFF
--- a/workflows/pipe-common/test/test_cloud_pipeline_instance_helper.py
+++ b/workflows/pipe-common/test/test_cloud_pipeline_instance_helper.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 
-from scripts.autoscale_sge import CloudProvider, CloudPipelineInstanceHelper
+from scripts.autoscale_sge import CloudProvider, CloudPipelineInstanceProvider
+
+logging.basicConfig(level=logging.DEBUG, format='%(asctime)s [%(threadName)s] [%(levelname)s] %(message)s')
 
 AZURE_DSV = "Dsv3"
 AZURE_BMS = "Bms"
@@ -26,26 +29,26 @@ AWS_P2 = "p2"
 
 
 def test_aws_familes():
-    family = CloudPipelineInstanceHelper.get_family_from_type(CloudProvider.aws(), "c5.xlarge")
+    family = CloudPipelineInstanceProvider.get_family_from_type(CloudProvider.aws(), "c5.xlarge")
     assert family == AWS_C5
-    family = CloudPipelineInstanceHelper.get_family_from_type(CloudProvider.aws(), "p2.xlarge")
+    family = CloudPipelineInstanceProvider.get_family_from_type(CloudProvider.aws(), "p2.xlarge")
     assert family == AWS_P2
 
 
 def test_gcp_familes():
-    family = CloudPipelineInstanceHelper.get_family_from_type(CloudProvider.gcp(), "n2-standard-2")
+    family = CloudPipelineInstanceProvider.get_family_from_type(CloudProvider.gcp(), "n2-standard-2")
     assert family == GCP_STANDARD
-    family = CloudPipelineInstanceHelper.get_family_from_type(CloudProvider.gcp(), "n2-highcpu-2")
+    family = CloudPipelineInstanceProvider.get_family_from_type(CloudProvider.gcp(), "n2-highcpu-2")
     assert family == GCP_HIGHCPU
-    family = CloudPipelineInstanceHelper.get_family_from_type(CloudProvider.gcp(), "custom-12-16")
+    family = CloudPipelineInstanceProvider.get_family_from_type(CloudProvider.gcp(), "custom-12-16")
     assert family is None
 
 
 def test_azure_familes():
-    family = CloudPipelineInstanceHelper.get_family_from_type(CloudProvider.azure(), "Standard_B1ms")
+    family = CloudPipelineInstanceProvider.get_family_from_type(CloudProvider.azure(), "Standard_B1ms")
     assert family == AZURE_BMS
-    family = CloudPipelineInstanceHelper.get_family_from_type(CloudProvider.azure(), "Standard_D2s_v3")
+    family = CloudPipelineInstanceProvider.get_family_from_type(CloudProvider.azure(), "Standard_D2s_v3")
     assert family == AZURE_DSV
-    family = CloudPipelineInstanceHelper.get_family_from_type(CloudProvider.azure(), "Standard_D16s_v3")
+    family = CloudPipelineInstanceProvider.get_family_from_type(CloudProvider.azure(), "Standard_D16s_v3")
     assert family == AZURE_DSV
 

--- a/workflows/pipe-common/test/test_grid_engine.py
+++ b/workflows/pipe-common/test/test_grid_engine.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import datetime
+import logging
 
+from datetime import datetime
 from mock import MagicMock, Mock
 
 from scripts.autoscale_sge import GridEngine, GridEngineJobState, GridEngineJob
 from utils import assert_first_argument_contained, assert_first_argument_not_contained
+
+logging.basicConfig(level=logging.DEBUG, format='%(asctime)s [%(threadName)s] [%(levelname)s] %(message)s')
 
 MAX_CLUSTER_CORES = 6
 MAX_INSTANCE_CORES = 2
@@ -83,7 +86,6 @@ def test_qstat_array_job_parsing():
     executor.execute_to_lines = MagicMock(return_value=__to_lines(stdout))
     jobs = grid_engine.get_jobs()
 
-    assert [1] == [1]
     assert len([job for job in jobs if '2.' in job.id]) == 10
     assert len([job for job in jobs if '3.' in job.id]) == 5
     assert len([job for job in jobs if '4.' in job.id]) == 2
@@ -101,8 +103,8 @@ def test_qstat_empty_parsing():
 
 def test_kill_jobs():
     jobs = [
-        GridEngineJob(id=1, name='', user='', state='', datetime=''),
-        GridEngineJob(id=2, name='', user='', state='', datetime='')
+        GridEngineJob(id='1', root_id=1, name='', user='', state='', datetime=''),
+        GridEngineJob(id='2', root_id=2, name='', user='', state='', datetime='')
     ]
 
     grid_engine.kill_jobs(jobs)
@@ -113,8 +115,8 @@ def test_kill_jobs():
 
 def test_force_kill_jobs():
     jobs = [
-        GridEngineJob(id=1, name='', user='', state='', datetime=''),
-        GridEngineJob(id=2, name='', user='', state='', datetime='')
+        GridEngineJob(id='1', root_id=1, name='', user='', state='', datetime=''),
+        GridEngineJob(id='2', root_id=2, name='', user='', state='', datetime='')
     ]
 
     grid_engine.kill_jobs(jobs, force=True)

--- a/workflows/pipe-common/test/test_host_storage.py
+++ b/workflows/pipe-common/test/test_host_storage.py
@@ -12,26 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
 import tempfile
 
 import pytest
-
 from pytest import fail
 
-from scripts.autoscale_sge import FileSystemHostStorage, MemoryHostStorage, CmdExecutor, ScalingError
+from scripts.autoscale_sge import FileSystemHostStorage, MemoryHostStorage, ThreadSafeStorage, CmdExecutor, ScalingError
+
+logging.basicConfig(level=logging.DEBUG, format='%(asctime)s [%(threadName)s] [%(levelname)s] %(message)s')
 
 HOST1 = "host1"
 HOST2 = "host2"
 
 cmd_executor = CmdExecutor()
 _, storage_file = tempfile.mkstemp()
-host_storage = FileSystemHostStorage(cmd_executor=cmd_executor, storage_file=storage_file)
 
 
 @pytest.fixture(params=[
     MemoryHostStorage(),
-    FileSystemHostStorage(cmd_executor=cmd_executor, storage_file=storage_file)
+    FileSystemHostStorage(cmd_executor=cmd_executor, storage_file=storage_file),
+    ThreadSafeStorage(MemoryHostStorage())
 ])
 def host_storage(request):
     host_storage = request.param

--- a/workflows/pipe-common/test/test_host_storage.py
+++ b/workflows/pipe-common/test/test_host_storage.py
@@ -19,7 +19,7 @@ import tempfile
 import pytest
 from pytest import fail
 
-from scripts.autoscale_sge import FileSystemHostStorage, MemoryHostStorage, ThreadSafeStorage, CmdExecutor, ScalingError
+from scripts.autoscale_sge import FileSystemHostStorage, MemoryHostStorage, ThreadSafeHostStorage, CmdExecutor, ScalingError
 
 logging.basicConfig(level=logging.DEBUG, format='%(asctime)s [%(threadName)s] [%(levelname)s] %(message)s')
 
@@ -33,7 +33,7 @@ _, storage_file = tempfile.mkstemp()
 @pytest.fixture(params=[
     MemoryHostStorage(),
     FileSystemHostStorage(cmd_executor=cmd_executor, storage_file=storage_file),
-    ThreadSafeStorage(MemoryHostStorage())
+    ThreadSafeHostStorage(MemoryHostStorage())
 ])
 def host_storage(request):
     host_storage = request.param

--- a/workflows/pipe-common/test/test_sge_autoscaler_cpu_capacity_based_instance_selector.py
+++ b/workflows/pipe-common/test/test_sge_autoscaler_cpu_capacity_based_instance_selector.py
@@ -17,8 +17,8 @@ import logging
 import pytest
 from mock import MagicMock, Mock
 
-from scripts.autoscale_sge import CpuCapacityInstanceSelector, SolidDemand, InstanceDemand, Instance, \
-    FluidDemand
+from scripts.autoscale_sge import CpuCapacityInstanceSelector, IntegralDemand, InstanceDemand, Instance, \
+    FractionalDemand
 
 logging.basicConfig(level=logging.DEBUG, format='%(asctime)s [%(threadName)s] [%(levelname)s] %(message)s')
 
@@ -44,113 +44,113 @@ all_instances = [instance_2cpu, instance_4cpu,
 test_cases = [
     ['2cpu job using 2cpu instances',
      [instance_2cpu],
-     [SolidDemand(cpu=2, owner=owner)],
+     [IntegralDemand(cpu=2, owner=owner)],
      [InstanceDemand(instance=instance_2cpu, owner=owner)]],
 
     ['2x2cpu jobs using 2cpu instances',
      [instance_2cpu],
-     2 * [SolidDemand(cpu=2, owner=owner)],
+     2 * [IntegralDemand(cpu=2, owner=owner)],
      [InstanceDemand(instance=instance_2cpu, owner=owner),
       InstanceDemand(instance=instance_2cpu, owner=owner)]],
 
     ['3x1cpu and 2cpu jobs using 2cpu and 4cpu instances',
      [instance_2cpu,
       instance_4cpu],
-     3 * [SolidDemand(cpu=1, owner=owner)]
-     + [SolidDemand(cpu=3, owner=owner)],
+     3 * [IntegralDemand(cpu=1, owner=owner)]
+     + [IntegralDemand(cpu=3, owner=owner)],
      [InstanceDemand(instance=instance_4cpu, owner=owner),
       InstanceDemand(instance=instance_4cpu, owner=owner)]],
 
     ['3x3cpu jobs using 2cpu and 4cpu instances',
      [instance_2cpu,
       instance_4cpu],
-     3 * [SolidDemand(cpu=3, owner=owner)],
+     3 * [IntegralDemand(cpu=3, owner=owner)],
      3 * [InstanceDemand(instance=instance_4cpu, owner=owner)]],
 
     ['3x3cpu jobs using all instances',
      all_instances,
-     3 * [SolidDemand(cpu=3, owner=owner)],
+     3 * [IntegralDemand(cpu=3, owner=owner)],
      [InstanceDemand(instance=instance_16cpu, owner=owner)]],
 
     ['2cpu and 6cpu jobs using 2cpu and 4cpu and 8cpu instances',
      [instance_2cpu,
       instance_4cpu,
       instance_8cpu],
-     [SolidDemand(cpu=2, owner=owner),
-      SolidDemand(cpu=6, owner=owner)],
+     [IntegralDemand(cpu=2, owner=owner),
+      IntegralDemand(cpu=6, owner=owner)],
      [InstanceDemand(instance=instance_8cpu, owner=owner)]],
 
     ['10x16cpu jobs using all instances',
      all_instances,
-     10 * [SolidDemand(cpu=16, owner=owner)],
+     10 * [IntegralDemand(cpu=16, owner=owner)],
      [InstanceDemand(instance=instance_96cpu, owner=owner),
       InstanceDemand(instance=instance_64cpu, owner=owner)]],
 
     ['2cpu fluid job using 2cpu instances',
      [instance_2cpu],
-     [FluidDemand(cpu=2, owner=owner)],
+     [FractionalDemand(cpu=2, owner=owner)],
      [InstanceDemand(instance=instance_2cpu, owner=owner)]],
 
     ['2x2cpu fluid jobs using 2cpu instances',
      [instance_2cpu],
-     2 * [FluidDemand(cpu=2, owner=owner)],
+     2 * [FractionalDemand(cpu=2, owner=owner)],
      2 * [InstanceDemand(instance=instance_2cpu, owner=owner)]],
 
     ['3x1cpu and 2cpu fluid jobs using 2cpu and 4cpu instances',
      [instance_2cpu,
       instance_4cpu],
-     3 * [FluidDemand(cpu=1, owner=owner)]
-     + [FluidDemand(cpu=3, owner=owner)],
+     3 * [FractionalDemand(cpu=1, owner=owner)]
+     + [FractionalDemand(cpu=3, owner=owner)],
      [InstanceDemand(instance=instance_4cpu, owner=owner),
       InstanceDemand(instance=instance_2cpu, owner=owner)]],
 
     ['3x3cpu fluid jobs using 2cpu and 4cpu instances',
      [instance_2cpu,
       instance_4cpu],
-     3 * [FluidDemand(cpu=3, owner=owner)],
+     3 * [FractionalDemand(cpu=3, owner=owner)],
      2 * [InstanceDemand(instance=instance_4cpu, owner=owner)]
      + [InstanceDemand(instance=instance_2cpu, owner=owner)]],
 
     ['3x3cpu fluid jobs using all instances',
      all_instances,
-     3 * [FluidDemand(cpu=3, owner=owner)],
+     3 * [FractionalDemand(cpu=3, owner=owner)],
      [InstanceDemand(instance=instance_16cpu, owner=owner)]],
 
     ['2cpu and 6cpu fluid jobs using 2cpu and 4cpu and 8cpu instances',
      [instance_2cpu,
       instance_4cpu,
       instance_8cpu],
-     [FluidDemand(cpu=2, owner=owner),
-      FluidDemand(cpu=6, owner=owner)],
+     [FractionalDemand(cpu=2, owner=owner),
+      FractionalDemand(cpu=6, owner=owner)],
      [InstanceDemand(instance=instance_8cpu, owner=owner)]],
 
     ['10x16cpu fluid jobs using all instances',
      all_instances,
-     10 * [FluidDemand(cpu=16, owner=owner)],
+     10 * [FractionalDemand(cpu=16, owner=owner)],
      [InstanceDemand(instance=instance_96cpu, owner=owner),
       InstanceDemand(instance=instance_64cpu, owner=owner)]],
 
     ['16cpu owner jobs and 48cpu another owner jobs using all instances',
      all_instances,
-     [SolidDemand(cpu=16, owner=owner),
-      SolidDemand(cpu=48, owner=another_owner)],
+     [IntegralDemand(cpu=16, owner=owner),
+      IntegralDemand(cpu=48, owner=another_owner)],
      [InstanceDemand(instance=instance_64cpu, owner=another_owner)]],
 
     ['16cpu owner jobs and 48x1cpu another owner jobs using all instances',
      all_instances,
-     [SolidDemand(cpu=16, owner=owner)]
-     + 48 * [SolidDemand(cpu=1, owner=another_owner)],
+     [IntegralDemand(cpu=16, owner=owner)]
+     + 48 * [IntegralDemand(cpu=1, owner=another_owner)],
      [InstanceDemand(instance=instance_64cpu, owner=another_owner)]],
 
     ['4x16cpu another owner jobs and 4x16cpu owner jobs using all instances',
      all_instances,
-     4 * [SolidDemand(cpu=16, owner=owner)] + 4 * [SolidDemand(cpu=16, owner=another_owner)],
+     4 * [IntegralDemand(cpu=16, owner=owner)] + 4 * [IntegralDemand(cpu=16, owner=another_owner)],
      [InstanceDemand(instance=instance_96cpu, owner=owner),
       InstanceDemand(instance=instance_32cpu, owner=another_owner)]],
 
     ['4x16cpu another owner jobs and 4x16cpu owner jobs using 64cpu instances',
      [instance_64cpu],
-     4 * [SolidDemand(cpu=16, owner=owner)] + 4 * [SolidDemand(cpu=16, owner=another_owner)],
+     4 * [IntegralDemand(cpu=16, owner=owner)] + 4 * [IntegralDemand(cpu=16, owner=another_owner)],
      [InstanceDemand(instance=instance_64cpu, owner=owner),
       InstanceDemand(instance=instance_64cpu, owner=another_owner)]]
 ]

--- a/workflows/pipe-common/test/test_sge_autoscaler_cpu_capacity_based_instance_selector.py
+++ b/workflows/pipe-common/test/test_sge_autoscaler_cpu_capacity_based_instance_selector.py
@@ -1,0 +1,165 @@
+# Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import pytest
+from mock import MagicMock, Mock
+
+from scripts.autoscale_sge import CpuCapacityInstanceSelector, SolidDemand, InstanceDemand, Instance, \
+    FluidDemand
+
+logging.basicConfig(level=logging.DEBUG, format='%(asctime)s [%(threadName)s] [%(levelname)s] %(message)s')
+
+instance_provider = Mock()
+free_cores = 0
+price_type = 'price_type'
+owner = 'owner'
+another_owner = 'another_owner'
+
+instance_2cpu = Instance(name='m5.large', price_type=price_type, cpu=2, memory=8, gpu=0)
+instance_4cpu = Instance(name='m5.xlarge', price_type=price_type, cpu=4, memory=16, gpu=0)
+instance_8cpu = Instance(name='m5.2xlarge', price_type=price_type, cpu=8, memory=32, gpu=0)
+instance_16cpu = Instance(name='m5.4xlarge', price_type=price_type, cpu=16, memory=64, gpu=0)
+instance_32cpu = Instance(name='m5.8xlarge', price_type=price_type, cpu=32, memory=128, gpu=0)
+instance_48cpu = Instance(name='m5.12xlarge', price_type=price_type, cpu=48, memory=192, gpu=0)
+instance_64cpu = Instance(name='m5.16xlarge', price_type=price_type, cpu=64, memory=256, gpu=0)
+instance_96cpu = Instance(name='m5.24xlarge', price_type=price_type, cpu=96, memory=384, gpu=0)
+all_instances = [instance_2cpu, instance_4cpu,
+                 instance_8cpu, instance_16cpu,
+                 instance_32cpu, instance_48cpu,
+                 instance_64cpu, instance_96cpu]
+
+test_cases = [
+    ['2cpu job using 2cpu instances',
+     [instance_2cpu],
+     [SolidDemand(cpu=2, owner=owner)],
+     [InstanceDemand(instance=instance_2cpu, owner=owner)]],
+
+    ['2x2cpu jobs using 2cpu instances',
+     [instance_2cpu],
+     2 * [SolidDemand(cpu=2, owner=owner)],
+     [InstanceDemand(instance=instance_2cpu, owner=owner),
+      InstanceDemand(instance=instance_2cpu, owner=owner)]],
+
+    ['3x1cpu and 2cpu jobs using 2cpu and 4cpu instances',
+     [instance_2cpu,
+      instance_4cpu],
+     3 * [SolidDemand(cpu=1, owner=owner)]
+     + [SolidDemand(cpu=3, owner=owner)],
+     [InstanceDemand(instance=instance_4cpu, owner=owner),
+      InstanceDemand(instance=instance_4cpu, owner=owner)]],
+
+    ['3x3cpu jobs using 2cpu and 4cpu instances',
+     [instance_2cpu,
+      instance_4cpu],
+     3 * [SolidDemand(cpu=3, owner=owner)],
+     3 * [InstanceDemand(instance=instance_4cpu, owner=owner)]],
+
+    ['3x3cpu jobs using all instances',
+     all_instances,
+     3 * [SolidDemand(cpu=3, owner=owner)],
+     [InstanceDemand(instance=instance_16cpu, owner=owner)]],
+
+    ['2cpu and 6cpu jobs using 2cpu and 4cpu and 8cpu instances',
+     [instance_2cpu,
+      instance_4cpu,
+      instance_8cpu],
+     [SolidDemand(cpu=2, owner=owner),
+      SolidDemand(cpu=6, owner=owner)],
+     [InstanceDemand(instance=instance_8cpu, owner=owner)]],
+
+    ['10x16cpu jobs using all instances',
+     all_instances,
+     10 * [SolidDemand(cpu=16, owner=owner)],
+     [InstanceDemand(instance=instance_96cpu, owner=owner),
+      InstanceDemand(instance=instance_64cpu, owner=owner)]],
+
+    ['2cpu fluid job using 2cpu instances',
+     [instance_2cpu],
+     [FluidDemand(cpu=2, owner=owner)],
+     [InstanceDemand(instance=instance_2cpu, owner=owner)]],
+
+    ['2x2cpu fluid jobs using 2cpu instances',
+     [instance_2cpu],
+     2 * [FluidDemand(cpu=2, owner=owner)],
+     2 * [InstanceDemand(instance=instance_2cpu, owner=owner)]],
+
+    ['3x1cpu and 2cpu fluid jobs using 2cpu and 4cpu instances',
+     [instance_2cpu,
+      instance_4cpu],
+     3 * [FluidDemand(cpu=1, owner=owner)]
+     + [FluidDemand(cpu=3, owner=owner)],
+     [InstanceDemand(instance=instance_4cpu, owner=owner),
+      InstanceDemand(instance=instance_2cpu, owner=owner)]],
+
+    ['3x3cpu fluid jobs using 2cpu and 4cpu instances',
+     [instance_2cpu,
+      instance_4cpu],
+     3 * [FluidDemand(cpu=3, owner=owner)],
+     2 * [InstanceDemand(instance=instance_4cpu, owner=owner)]
+     + [InstanceDemand(instance=instance_2cpu, owner=owner)]],
+
+    ['3x3cpu fluid jobs using all instances',
+     all_instances,
+     3 * [FluidDemand(cpu=3, owner=owner)],
+     [InstanceDemand(instance=instance_16cpu, owner=owner)]],
+
+    ['2cpu and 6cpu fluid jobs using 2cpu and 4cpu and 8cpu instances',
+     [instance_2cpu,
+      instance_4cpu,
+      instance_8cpu],
+     [FluidDemand(cpu=2, owner=owner),
+      FluidDemand(cpu=6, owner=owner)],
+     [InstanceDemand(instance=instance_8cpu, owner=owner)]],
+
+    ['10x16cpu fluid jobs using all instances',
+     all_instances,
+     10 * [FluidDemand(cpu=16, owner=owner)],
+     [InstanceDemand(instance=instance_96cpu, owner=owner),
+      InstanceDemand(instance=instance_64cpu, owner=owner)]],
+
+    ['16cpu owner jobs and 48cpu another owner jobs using all instances',
+     all_instances,
+     [SolidDemand(cpu=16, owner=owner),
+      SolidDemand(cpu=48, owner=another_owner)],
+     [InstanceDemand(instance=instance_64cpu, owner=another_owner)]],
+
+    ['16cpu owner jobs and 48x1cpu another owner jobs using all instances',
+     all_instances,
+     [SolidDemand(cpu=16, owner=owner)]
+     + 48 * [SolidDemand(cpu=1, owner=another_owner)],
+     [InstanceDemand(instance=instance_64cpu, owner=another_owner)]],
+
+    ['4x16cpu another owner jobs and 4x16cpu owner jobs using all instances',
+     all_instances,
+     4 * [SolidDemand(cpu=16, owner=owner)] + 4 * [SolidDemand(cpu=16, owner=another_owner)],
+     [InstanceDemand(instance=instance_96cpu, owner=owner),
+      InstanceDemand(instance=instance_32cpu, owner=another_owner)]],
+
+    ['4x16cpu another owner jobs and 4x16cpu owner jobs using 64cpu instances',
+     [instance_64cpu],
+     4 * [SolidDemand(cpu=16, owner=owner)] + 4 * [SolidDemand(cpu=16, owner=another_owner)],
+     [InstanceDemand(instance=instance_64cpu, owner=owner),
+      InstanceDemand(instance=instance_64cpu, owner=another_owner)]]
+]
+
+
+@pytest.mark.parametrize('instances,input,output', [test_case[1:] for test_case in test_cases],
+                         ids=[test_case[0] for test_case in test_cases])
+def test_select(instances, input, output):
+    instance_provider.get_allowed_instances = MagicMock(return_value=instances)
+    selector = CpuCapacityInstanceSelector(instance_provider, free_cores)
+    actual_demands = list(selector.select(input, price_type))
+    assert output == actual_demands

--- a/workflows/pipe-common/test/test_sge_autoscaler_cpu_capacity_based_instance_selector.py
+++ b/workflows/pipe-common/test/test_sge_autoscaler_cpu_capacity_based_instance_selector.py
@@ -86,17 +86,17 @@ test_cases = [
      [InstanceDemand(instance=instance_96cpu, owner=owner),
       InstanceDemand(instance=instance_64cpu, owner=owner)]],
 
-    ['2cpu fluid job using 2cpu instances',
+    ['2cpu fractional job using 2cpu instances',
      [instance_2cpu],
      [FractionalDemand(cpu=2, owner=owner)],
      [InstanceDemand(instance=instance_2cpu, owner=owner)]],
 
-    ['2x2cpu fluid jobs using 2cpu instances',
+    ['2x2cpu fractional jobs using 2cpu instances',
      [instance_2cpu],
      2 * [FractionalDemand(cpu=2, owner=owner)],
      2 * [InstanceDemand(instance=instance_2cpu, owner=owner)]],
 
-    ['3x1cpu and 2cpu fluid jobs using 2cpu and 4cpu instances',
+    ['3x1cpu and 2cpu fractional jobs using 2cpu and 4cpu instances',
      [instance_2cpu,
       instance_4cpu],
      3 * [FractionalDemand(cpu=1, owner=owner)]
@@ -104,19 +104,19 @@ test_cases = [
      [InstanceDemand(instance=instance_4cpu, owner=owner),
       InstanceDemand(instance=instance_2cpu, owner=owner)]],
 
-    ['3x3cpu fluid jobs using 2cpu and 4cpu instances',
+    ['3x3cpu fractional jobs using 2cpu and 4cpu instances',
      [instance_2cpu,
       instance_4cpu],
      3 * [FractionalDemand(cpu=3, owner=owner)],
      2 * [InstanceDemand(instance=instance_4cpu, owner=owner)]
      + [InstanceDemand(instance=instance_2cpu, owner=owner)]],
 
-    ['3x3cpu fluid jobs using all instances',
+    ['3x3cpu fractional jobs using all instances',
      all_instances,
      3 * [FractionalDemand(cpu=3, owner=owner)],
      [InstanceDemand(instance=instance_16cpu, owner=owner)]],
 
-    ['2cpu and 6cpu fluid jobs using 2cpu and 4cpu and 8cpu instances',
+    ['2cpu and 6cpu fractional jobs using 2cpu and 4cpu and 8cpu instances',
      [instance_2cpu,
       instance_4cpu,
       instance_8cpu],
@@ -124,7 +124,7 @@ test_cases = [
       FractionalDemand(cpu=6, owner=owner)],
      [InstanceDemand(instance=instance_8cpu, owner=owner)]],
 
-    ['10x16cpu fluid jobs using all instances',
+    ['10x16cpu fractional jobs using all instances',
      all_instances,
      10 * [FractionalDemand(cpu=16, owner=owner)],
      [InstanceDemand(instance=instance_96cpu, owner=owner),
@@ -144,15 +144,34 @@ test_cases = [
 
     ['4x16cpu another owner jobs and 4x16cpu owner jobs using all instances',
      all_instances,
-     4 * [IntegralDemand(cpu=16, owner=owner)] + 4 * [IntegralDemand(cpu=16, owner=another_owner)],
+     4 * [IntegralDemand(cpu=16, owner=owner)]
+     + 4 * [IntegralDemand(cpu=16, owner=another_owner)],
      [InstanceDemand(instance=instance_96cpu, owner=owner),
       InstanceDemand(instance=instance_32cpu, owner=another_owner)]],
 
     ['4x16cpu another owner jobs and 4x16cpu owner jobs using 64cpu instances',
      [instance_64cpu],
-     4 * [IntegralDemand(cpu=16, owner=owner)] + 4 * [IntegralDemand(cpu=16, owner=another_owner)],
+     4 * [IntegralDemand(cpu=16, owner=owner)]
+     + 4 * [IntegralDemand(cpu=16, owner=another_owner)],
      [InstanceDemand(instance=instance_64cpu, owner=owner),
-      InstanceDemand(instance=instance_64cpu, owner=another_owner)]]
+      InstanceDemand(instance=instance_64cpu, owner=another_owner)]],
+
+    ['2x3cpu integral jobs and 2x1cpu fractional jobs using 2cpu and 4cpu instances',
+     [instance_2cpu,
+      instance_4cpu],
+     2 * [IntegralDemand(cpu=3, owner=owner)]
+     + 2 * [FractionalDemand(cpu=1, owner=owner)],
+     [InstanceDemand(instance=instance_4cpu, owner=owner),
+      InstanceDemand(instance=instance_4cpu, owner=owner)]],
+
+    ['2x3cpu integral jobs and 3x1cpu fractional jobs using 2cpu and 4cpu instances',
+     [instance_2cpu,
+      instance_4cpu],
+     2 * [IntegralDemand(cpu=3, owner=owner)]
+     + 3 * [FractionalDemand(cpu=1, owner=owner)],
+     [InstanceDemand(instance=instance_4cpu, owner=owner),
+      InstanceDemand(instance=instance_4cpu, owner=owner),
+      InstanceDemand(instance=instance_2cpu, owner=owner)]]
 ]
 
 

--- a/workflows/pipe-common/test/test_sge_autoscaler_scale_up.py
+++ b/workflows/pipe-common/test/test_sge_autoscaler_scale_up.py
@@ -18,7 +18,7 @@ from datetime import datetime, timedelta
 from mock import MagicMock, Mock
 
 from scripts.autoscale_sge import GridEngineAutoscaler, GridEngineJob, GridEngineJobState, Clock, MemoryHostStorage, \
-    SolidDemand
+    IntegralDemand
 
 logging.basicConfig(level=logging.DEBUG, format='%(asctime)s [%(threadName)s] [%(levelname)s] %(message)s')
 
@@ -76,7 +76,7 @@ def test_scale_up_if_some_of_the_jobs_are_in_queue_for_more_than_scale_up_timeou
             datetime=submit_datetime
         )
     ]
-    demands = 2 * [SolidDemand()]
+    demands = 2 * [IntegralDemand()]
     grid_engine.get_jobs = MagicMock(return_value=jobs)
     grid_engine.get_resource_demands = MagicMock(return_value=demands)
     clock.now = MagicMock(return_value=submit_datetime + timedelta(seconds=scale_up_timeout))
@@ -106,7 +106,7 @@ def test_not_scale_up_if_none_of_the_jobs_are_in_queue_for_more_than_scale_up_ti
             datetime=submit_datetime
         )
     ]
-    demands = 2 * [SolidDemand()]
+    demands = 2 * [IntegralDemand()]
     grid_engine.get_jobs = MagicMock(return_value=jobs)
     grid_engine.get_resource_demands = MagicMock(return_value=demands)
     clock.now = MagicMock(return_value=submit_datetime + timedelta(seconds=scale_up_timeout - 1))
@@ -136,7 +136,7 @@ def test_that_scale_up_will_not_launch_more_additional_workers_than_limit():
             datetime=submit_datetime
         )
     ]
-    demands = 2 * [SolidDemand()]
+    demands = 2 * [IntegralDemand()]
     grid_engine.get_jobs = MagicMock(return_value=jobs)
     grid_engine.get_resource_demands = MagicMock(return_value=demands)
     clock.now = MagicMock(return_value=submit_datetime + timedelta(seconds=scale_up_timeout))
@@ -168,7 +168,7 @@ def test_that_scale_up_will_try_to_scale_down_smallest_host_if_additional_worker
             datetime=submit_datetime
         )
     ]
-    demands = 2 * [SolidDemand()]
+    demands = 2 * [IntegralDemand()]
     grid_engine.get_jobs = MagicMock(return_value=jobs)
     grid_engine.get_resource_demands = MagicMock(return_value=demands)
     clock.now = MagicMock(return_value=submit_datetime + timedelta(seconds=scale_up_timeout))
@@ -240,7 +240,7 @@ def test_scale_up_if_some_of_the_array_jobs_are_in_queue_for_more_than_scale_up_
             datetime=submit_datetime,
         )
     ]
-    demands = 7 * [SolidDemand()]
+    demands = 7 * [IntegralDemand()]
     grid_engine.get_jobs = MagicMock(return_value=jobs)
     grid_engine.get_resource_demands = MagicMock(return_value=demands)
     clock.now = MagicMock(return_value=submit_datetime + timedelta(seconds=scale_up_timeout))
@@ -310,7 +310,7 @@ def test_not_scale_up_if_none_of_the_array_jobs_are_in_queue_for_more_than_scale
             datetime=submit_datetime,
         )
     ]
-    demands = 7 * [SolidDemand()]
+    demands = 7 * [IntegralDemand()]
     grid_engine.get_jobs = MagicMock(return_value=jobs)
     grid_engine.get_resource_demands = MagicMock(return_value=demands)
     clock.now = MagicMock(return_value=submit_datetime + timedelta(seconds=scale_up_timeout - 1))
@@ -342,7 +342,7 @@ def test_not_scale_up_if_number_of_additional_workers_is_already_equals_to_the_l
     ]
     for run_id in range(0, autoscaler.max_additional_hosts):
         autoscaler.host_storage.add_host(str(run_id))
-    demands = 2 * [SolidDemand()]
+    demands = 2 * [IntegralDemand()]
     grid_engine.get_jobs = MagicMock(return_value=jobs)
     grid_engine.get_resource_demands = MagicMock(return_value=demands)
     clock.now = MagicMock(return_value=submit_datetime + timedelta(seconds=scale_up_timeout))
@@ -414,7 +414,7 @@ def test_not_scale_up_if_number_of_additional_workers_is_already_equals_to_the_l
     ]
     for run_id in range(0, autoscaler.max_additional_hosts):
         autoscaler.host_storage.add_host(str(run_id))
-    demands = 7 * [SolidDemand()]
+    demands = 7 * [IntegralDemand()]
     grid_engine.get_jobs = MagicMock(return_value=jobs)
     grid_engine.get_resource_demands = MagicMock(return_value=demands)
     clock.now = MagicMock(return_value=submit_datetime + timedelta(seconds=scale_up_timeout))

--- a/workflows/pipe-common/test/test_worker_validator.py
+++ b/workflows/pipe-common/test/test_worker_validator.py
@@ -12,10 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 from mock import Mock, MagicMock
 
 from scripts.autoscale_sge import GridEngineWorkerValidator, MemoryHostStorage, GridEngineJob
 from utils import assert_first_argument_contained, assert_first_argument_not_contained
+
+logging.basicConfig(level=logging.DEBUG, format='%(asctime)s [%(threadName)s] [%(levelname)s] %(message)s')
 
 HOST1 = 'HOST-1'
 HOST2 = 'HOST-2'
@@ -47,7 +51,7 @@ def setup_function():
 def test_stopping_hosts_that_are_invalid_in_grid_engine():
     worker_validator.validate_hosts()
 
-    assert [HOST1, HOST3] == host_storage.load_hosts()
+    assert sorted([HOST1, HOST3]) == sorted(host_storage.load_hosts())
 
 
 def test_stopping_invalid_worker_pipeline():
@@ -59,7 +63,7 @@ def test_stopping_invalid_worker_pipeline():
 
 
 def test_force_killing_invalid_host_jobs():
-    jobs = [GridEngineJob(id=1, name='', user='', state='', datetime='', hosts=[HOST2])]
+    jobs = [GridEngineJob(id='1', root_id=1, name='', user='', state='', datetime='', hosts=[HOST2])]
     grid_engine.get_jobs = MagicMock(return_value=jobs)
 
     worker_validator.validate_hosts()


### PR DESCRIPTION
Resolves issue #2484 and depends on #1616.

The pull request brings support for grid engine batch autoscaling. From now it is possible to scale up multiple additional workers at once. _Notice that by default batch autoscaling is disabled._

The following new run parameters can be used to configure grid engine autoscaling:
- `CP_CAP_AUTOSCALE_SCALE_UP_BATCH_SIZE` specifies a maximum number of additional workers which can be scaled up at once. Defaults to `1`.
- `CP_CAP_AUTOSCALE_SCALE_UP_STRATEGY` specifies scaling up instance selection strategy.
  - `cpu-capacity` strategy selects a smallest instance which can process the biggest number of the currently waiting job cpu requirements. _The strategy respects local/mpi job differences._
  - `naive-cpu-capacity` strategy selects a smallest instance which has a number of cpus >= a sum of currently waiting job cpu requirements. If a sum of currently waiting job cpu requirements is too big to process using a single instance then the strategy selects the biggest instance. _The strategy ignores local/mpi job differences._
  - `default` strategy uses `naive-cpu-capacity` scaling if batch size is `1` and `cpu-capacity` otherwise. This strategy is _backwardly compatible_ and is _used by default_.
