### PR TITLE
Implementing logic for registering and de-registering of a samplesheet for special project type

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/preprocessing/NgsPreprocessingApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/preprocessing/NgsPreprocessingApiService.java
@@ -18,25 +18,25 @@ package com.epam.pipeline.acl.preprocessing;
 
 import com.epam.pipeline.controller.vo.preprocessing.SampleSheetRegistrationVO;
 import com.epam.pipeline.manager.preprocessing.NgsPreprocessingManager;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class NgsPreprocessingApiService {
 
-    @Autowired
-    private NgsPreprocessingManager preprocessingManager;
+    private final NgsPreprocessingManager preprocessingManager;
 
-    @PreAuthorize("hasRole('ADMIN') OR hasPermission(#registrationVO.folderId, "
-            + "'com.epam.pipeline.entity.pipeline.Folder', 'WRITE'))")
+    @PreAuthorize("hasRole('ADMIN') OR hasPermission(#registrationVO.folderId, " +
+            "'com.epam.pipeline.entity.pipeline.Folder', 'WRITE')")
     public void registerSampleSheet(final SampleSheetRegistrationVO registrationVO) {
         preprocessingManager.registerSampleSheet(registrationVO);
     }
 
     @PreAuthorize("hasRole('ADMIN') OR hasPermission(#folderId, 'com.epam.pipeline.entity.pipeline.Folder', 'WRITE')")
-    public void deleteSampleSheet(final Long folderId, final Long machineRunId) {
-        preprocessingManager.deleteSampleSheet(folderId, machineRunId);
+    public void unregisterSampleSheet(final Long folderId, final Long machineRunId, final boolean deleteFile) {
+        preprocessingManager.unregisterSampleSheet(folderId, machineRunId, deleteFile);
     }
 
 }

--- a/api/src/main/java/com/epam/pipeline/acl/preprocessing/NgsPreprocessingApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/preprocessing/NgsPreprocessingApiService.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.acl.preprocessing;
+
+import com.epam.pipeline.controller.vo.preprocessing.SampleSheetRegistrationVO;
+import com.epam.pipeline.manager.preprocessing.NgsPreprocessingManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NgsPreprocessingApiService {
+
+    @Autowired
+    private NgsPreprocessingManager preprocessingManager;
+
+    @PreAuthorize("hasRole('ADMIN') OR hasPermission(#registrationVO.folderId, "
+            + "'com.epam.pipeline.entity.pipeline.Folder', 'WRITE'))")
+    public void registerSampleSheet(final SampleSheetRegistrationVO registrationVO) {
+        preprocessingManager.registerSampleSheet(registrationVO);
+    }
+
+    @PreAuthorize("hasRole('ADMIN') OR hasPermission(#folderId, 'com.epam.pipeline.entity.pipeline.Folder', 'WRITE')")
+    public void deleteSampleSheet(final Long folderId, final Long machineRunId) {
+        preprocessingManager.deleteSampleSheet(folderId, machineRunId);
+    }
+
+}

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -735,6 +735,28 @@ public final class MessageConstants {
     public static final String ERROR_QUOTA_ACTION_NOT_ALLOWED = "error.quota.action.not.allowed";
     public static final String ERROR_BILLING_QUOTA_EXCEEDED_LAUNCH = "error.billing.quota.exceeded.launch";
 
+    // Ngs preprocessing
+    public static final String ERROR_NGS_PREPROCESSING_FOLDER_ID_NOT_PROVIDED =
+            "error.ngs.preprocessing.folder.id.is.not.provided";
+    public static final String ERROR_NGS_PREPROCESSING_MACHINE_RUN_NOT_PROVIDED =
+            "error.ngs.preprocessing.machine.run.id.is.not.provided";
+    public static final String ERROR_NGS_PREPROCESSING_SAMPLESHEET_CONTENT_NOT_PROVIDED =
+            "error.ngs.preprocessing.samplesheet.content.is.not.provided";
+    public static final String ERROR_NGS_PREPROCESSING_FOLDER_HAS_NO_METADATA =
+            "error.ngs.preprocessing.folder.has.no.metadata";
+    public static final String ERROR_NGS_PREPROCESSING_NO_MACHINE_RUN_METADATA =
+            "error.ngs.preprocessing.folder.has.no.machine.run.metadata";
+    public static final String ERROR_NGS_PREPROCESSING_MACHINE_RUN_WRONG_METADATA_CLASS =
+            "error.ngs.preprocessing.machine.run.metadata.wrong.class";
+    public static final String ERROR_NGS_PREPROCESSING_FOLDER_SHOULD_HAVE_METADATA =
+            "error.ngs.preprocessing.folder.should.have.metadata";
+    public static final String ERROR_NGS_PREPROCESSING_FOLDER_SHOULD_HAVE_DATA_PATH =
+            "error.ngs.preprocessing.folder.should.have.data.path";
+    public static final String ERROR_NGS_PREPROCESSING_NO_FOLDER_METADATA =
+            "error.ngs.preprocessing.no.folder.metadata";
+    public static final String ERROR_NGS_PREPROCESSING_SAMPLE_ID_NOT_FOUND =
+            "error.ngs.preprocessing.sampleid.is.not.found";
+
     private MessageConstants() {
         // no-op
     }

--- a/api/src/main/java/com/epam/pipeline/controller/preprocessing/NgsPreprocessingController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/preprocessing/NgsPreprocessingController.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.controller.preprocessing;
+
+import com.epam.pipeline.acl.preprocessing.NgsPreprocessingApiService;
+import com.epam.pipeline.controller.AbstractRestController;
+import com.epam.pipeline.controller.Result;
+import com.epam.pipeline.controller.vo.preprocessing.SampleSheetRegistrationVO;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+@Api(value = "NGS Project Preprocessing")
+public class NgsPreprocessingController extends AbstractRestController {
+
+    @Autowired
+    private NgsPreprocessingApiService preprocessingApiService;
+
+    @RequestMapping(value = "/preprocessing/samplesheet", method = RequestMethod.POST)
+    @ResponseBody
+    @ApiOperation(
+            value = "Registers a new or update an existing samplesheet.",
+            notes = "Registers a new or update an existing samplesheet.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public Result registerSampleSheet(@RequestBody final SampleSheetRegistrationVO sheetRegistrationVO) {
+        preprocessingApiService.registerSampleSheet(sheetRegistrationVO);
+        return Result.success();
+    }
+
+    @RequestMapping(value = "/preprocessing/samplesheet", method = RequestMethod.DELETE)
+    @ResponseBody
+    @ApiOperation(
+            value = "Deletes an existing samplesheet.",
+            notes = "Deletes an existing samplesheet.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public Result deleteSampleSheet(@RequestParam final Long folderId, @RequestParam final Long machineRunId) {
+        preprocessingApiService.deleteSampleSheet(folderId, machineRunId);
+        return Result.success();
+    }
+
+}

--- a/api/src/main/java/com/epam/pipeline/controller/preprocessing/NgsPreprocessingController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/preprocessing/NgsPreprocessingController.java
@@ -26,21 +26,21 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
-import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 @Api(value = "NGS Project Preprocessing")
 public class NgsPreprocessingController extends AbstractRestController {
 
     @Autowired
     private NgsPreprocessingApiService preprocessingApiService;
 
-    @RequestMapping(value = "/preprocessing/samplesheet", method = RequestMethod.POST)
+    @PostMapping(value = "/preprocessing/samplesheet")
     @ResponseBody
     @ApiOperation(
             value = "Registers a new or update an existing samplesheet.",
@@ -54,7 +54,7 @@ public class NgsPreprocessingController extends AbstractRestController {
         return Result.success();
     }
 
-    @RequestMapping(value = "/preprocessing/samplesheet", method = RequestMethod.DELETE)
+    @DeleteMapping(value = "/preprocessing/samplesheet")
     @ResponseBody
     @ApiOperation(
             value = "Deletes an existing samplesheet.",
@@ -63,8 +63,9 @@ public class NgsPreprocessingController extends AbstractRestController {
     @ApiResponses(
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
             })
-    public Result deleteSampleSheet(@RequestParam final Long folderId, @RequestParam final Long machineRunId) {
-        preprocessingApiService.deleteSampleSheet(folderId, machineRunId);
+    public Result deleteSampleSheet(@RequestParam final Long folderId, @RequestParam final Long machineRunId,
+                                    @RequestParam(defaultValue = "false") final Boolean deleteFile) {
+        preprocessingApiService.unregisterSampleSheet(folderId, machineRunId, deleteFile);
         return Result.success();
     }
 

--- a/api/src/main/java/com/epam/pipeline/controller/preprocessing/NgsPreprocessingController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/preprocessing/NgsPreprocessingController.java
@@ -24,45 +24,38 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
+@RequestMapping(value = "/preprocessing")
 @Api(value = "NGS Project Preprocessing")
 public class NgsPreprocessingController extends AbstractRestController {
 
-    @Autowired
-    private NgsPreprocessingApiService preprocessingApiService;
+    private final NgsPreprocessingApiService preprocessingApiService;
 
-    @PostMapping(value = "/preprocessing/samplesheet")
-    @ResponseBody
+    @PostMapping(value = "/samplesheet")
     @ApiOperation(
             value = "Registers a new or update an existing samplesheet.",
             notes = "Registers a new or update an existing samplesheet.",
             produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiResponses(
-            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
-            })
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
     public Result registerSampleSheet(@RequestBody final SampleSheetRegistrationVO sheetRegistrationVO) {
         preprocessingApiService.registerSampleSheet(sheetRegistrationVO);
         return Result.success();
     }
 
-    @DeleteMapping(value = "/preprocessing/samplesheet")
-    @ResponseBody
-    @ApiOperation(
-            value = "Deletes an existing samplesheet.",
-            notes = "Deletes an existing samplesheet.",
+    @DeleteMapping(value = "/samplesheet")
+    @ApiOperation(value = "Deletes an existing samplesheet.", notes = "Deletes an existing samplesheet.",
             produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiResponses(
-            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
-            })
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
     public Result deleteSampleSheet(@RequestParam final Long folderId, @RequestParam final Long machineRunId,
                                     @RequestParam(defaultValue = "false") final Boolean deleteFile) {
         preprocessingApiService.unregisterSampleSheet(folderId, machineRunId, deleteFile);

--- a/api/src/main/java/com/epam/pipeline/controller/vo/preprocessing/SampleSheetRegistrationVO.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/preprocessing/SampleSheetRegistrationVO.java
@@ -24,6 +24,5 @@ import lombok.NoArgsConstructor;
 public class SampleSheetRegistrationVO {
     private Long folderId;
     private Long machineRunId;
-    private boolean overwriteContent;
     private byte[] content;
 }

--- a/api/src/main/java/com/epam/pipeline/controller/vo/preprocessing/SampleSheetRegistrationVO.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/preprocessing/SampleSheetRegistrationVO.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.controller.vo.preprocessing;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class SampleSheetRegistrationVO {
+    Long folderId;
+    Long machineRunId;
+    byte[] content;
+}

--- a/api/src/main/java/com/epam/pipeline/controller/vo/preprocessing/SampleSheetRegistrationVO.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/preprocessing/SampleSheetRegistrationVO.java
@@ -16,13 +16,14 @@
 
 package com.epam.pipeline.controller.vo.preprocessing;
 
-import lombok.Builder;
-import lombok.Value;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-@Value
-@Builder
+@Data
+@NoArgsConstructor
 public class SampleSheetRegistrationVO {
-    Long folderId;
-    Long machineRunId;
-    byte[] content;
+    private Long folderId;
+    private Long machineRunId;
+    private boolean overwriteContent;
+    private byte[] content;
 }

--- a/api/src/main/java/com/epam/pipeline/entity/samplesheet/SampleSheet.java
+++ b/api/src/main/java/com/epam/pipeline/entity/samplesheet/SampleSheet.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.samplesheet;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.util.List;
+import java.util.Map;
+
+@Value
+@Builder
+public class SampleSheet {
+
+    boolean withHeader;
+    Map<String, String> header;
+
+    boolean withManifests;
+    Map<String, String> manifests;
+
+    boolean withReads;
+    List<Integer> reads;
+
+    boolean withSettings;
+    Map<String, String> settings;
+
+    boolean withData;
+    List<String> dataHeader;
+    List<String> dataLines;
+}

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
@@ -137,6 +137,7 @@ public class DataStorageManager implements SecuredEntityManager {
     private static final String DEFAULT_USER_STORAGE_DESCRIPTION_TEMPLATE = "Home folder for user @@";
     public static final String DAV_MOUNT_TAG = "dav-mount";
     private static final String SHARED_STORAGE_SUFFIX = "share";
+    public static final String DATA_STORAGE_PROVIDER_MASK = "[A-Za-z0-9]+://";
 
     @Autowired
     private MessageHelper messageHelper;
@@ -598,6 +599,11 @@ public class DataStorageManager implements SecuredEntityManager {
         });
     }
 
+    /**
+     * Tries to match value from values as path to an item in some datastorage.
+     * For this purpose it loads all storage -> could be slow and consuming
+     * See method analyzePathV2, to choose what sites you best
+     * */
     public void analyzePaths(List<PipeConfValue> values) {
         if (CollectionUtils.isEmpty(values)) {
             return;
@@ -613,6 +619,26 @@ public class DataStorageManager implements SecuredEntityManager {
             }
             if (!links.isEmpty()) {
                 value.setDataStorageLinks(links);
+            }
+        });
+    }
+
+    /**
+     * Tries to match value from values as path to an item in some datastorage.
+     * This method instead of loading all storages, tries to load storage by prefix from provided values
+     * Performance could degrade when there is a lot of values and paths in those values because of many
+     * independent calls to database to load storage by prefix.
+     * But works pretty well for semi-individual path values.
+     * See method analyzePath, to choose what sites you best
+     * */
+    public void analyzePathsV2(List<PipeConfValue> values) {
+        if (CollectionUtils.isEmpty(values)) {
+            return;
+        }
+        values.forEach(value -> {
+            List<DataStorageLink> dataStorageLinks = getLinks(value.getValue());
+            if (!dataStorageLinks.isEmpty()) {
+                value.setDataStorageLinks(dataStorageLinks);
             }
         });
     }
@@ -1204,31 +1230,54 @@ public class DataStorageManager implements SecuredEntityManager {
         String paramDelimiter = paramValue.contains(",") ? "," : ";";
         for (String path : paramValue.split(paramDelimiter)) {
             if (path.toLowerCase().trim().startsWith(mask.toLowerCase())) {
-                DataStorageLink dataStorageLink = new DataStorageLink();
-                dataStorageLink.setAbsolutePath(path.trim());
-                dataStorageLink.setDataStorageId(dataStorage.getId());
-                String relativePath = path.trim().substring(mask.length());
-                if (relativePath.startsWith(ProviderUtils.DELIMITER)) {
-                    relativePath = relativePath.substring(1);
-                }
-                String[] parts = relativePath.split(ProviderUtils.DELIMITER);
-                final String lastPart = parts[parts.length - 1];
-                if (lastPart.contains(".")) {
-                    String newPath = "";
-                    for (int i = 0; i < parts.length - 1; i++) {
-                        newPath = newPath.concat(parts[i] + ProviderUtils.DELIMITER);
-                    }
-                    if (newPath.endsWith(ProviderUtils.DELIMITER)) {
-                        newPath = newPath.substring(0, newPath.length() - 1);
-                    }
-                    dataStorageLink.setPath(newPath);
-                } else {
-                    dataStorageLink.setPath(relativePath);
-                }
-                links.add(dataStorageLink);
+                links.add(constructDataStorageLink(path, dataStorage, mask));
             }
         }
         return links;
+    }
+
+    private List<DataStorageLink> getLinks(final String paramValue) {
+        if (StringUtils.isBlank(paramValue)) {
+            return Collections.emptyList();
+        }
+        final String providerMask = DATA_STORAGE_PROVIDER_MASK + ".+";
+        List<DataStorageLink> links = new ArrayList<>();
+        String paramDelimiter = paramValue.contains(",") ? "," : ";";
+        for (String path : paramValue.split(paramDelimiter)) {
+            if (path.toLowerCase().trim().matches(providerMask)) {
+                path = path.replaceAll(DATA_STORAGE_PROVIDER_MASK, StringUtils.EMPTY);
+            }
+            final AbstractDataStorage dataStorage = loadByNameOrId(path);
+            final String mask = dataStorage.getPathMask() + ProviderUtils.DELIMITER;
+            links.add(constructDataStorageLink(path, dataStorage, mask));
+        }
+        return links;
+    }
+
+    private DataStorageLink constructDataStorageLink(final String path, final AbstractDataStorage dataStorage,
+                                                     final String mask) {
+        final DataStorageLink dataStorageLink = new DataStorageLink();
+        dataStorageLink.setAbsolutePath(path.trim());
+        dataStorageLink.setDataStorageId(dataStorage.getId());
+        String relativePath = path.trim().substring(mask.length());
+        if (relativePath.startsWith(ProviderUtils.DELIMITER)) {
+            relativePath = relativePath.substring(1);
+        }
+        final String[] parts = relativePath.split(ProviderUtils.DELIMITER);
+        final String lastPart = parts[parts.length - 1];
+        if (lastPart.contains(".")) {
+            String newPath = "";
+            for (int i = 0; i < parts.length - 1; i++) {
+                newPath = newPath.concat(parts[i] + ProviderUtils.DELIMITER);
+            }
+            if (newPath.endsWith(ProviderUtils.DELIMITER)) {
+                newPath = newPath.substring(0, newPath.length() - 1);
+            }
+            dataStorageLink.setPath(newPath);
+        } else {
+            dataStorageLink.setPath(relativePath);
+        }
+        return dataStorageLink;
     }
 
     private void validateStorageIsNotUsedAsDefault(final Long storageId,

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
@@ -602,7 +602,7 @@ public class DataStorageManager implements SecuredEntityManager {
     /**
      * Tries to match value from values as path to an item in some datastorage.
      * For this purpose it loads all storage -> could be slow and consuming
-     * See method analyzePathV2, to choose what sites you best
+     * See method analyzePathsV2, to choose what fits you best
      * */
     public void analyzePaths(List<PipeConfValue> values) {
         if (CollectionUtils.isEmpty(values)) {
@@ -629,7 +629,7 @@ public class DataStorageManager implements SecuredEntityManager {
      * Performance could degrade when there is a lot of values and paths in those values because of many
      * independent calls to database to load storage by prefix.
      * But works pretty well for semi-individual path values.
-     * See method analyzePath, to choose what sites you best
+     * See method analyzePaths, to choose what fits you best
      * */
     public void analyzePathsV2(List<PipeConfValue> values) {
         if (CollectionUtils.isEmpty(values)) {
@@ -1244,10 +1244,12 @@ public class DataStorageManager implements SecuredEntityManager {
         List<DataStorageLink> links = new ArrayList<>();
         String paramDelimiter = paramValue.contains(",") ? "," : ";";
         for (String path : paramValue.split(paramDelimiter)) {
-            if (path.toLowerCase().trim().matches(providerMask)) {
-                path = path.replaceAll(DATA_STORAGE_PROVIDER_MASK, StringUtils.EMPTY);
+            if (!path.toLowerCase().trim().matches(providerMask)) {
+                log.warn("Data Storage path should start with storage mask: " + path + ", skipping.");
+                continue;
             }
-            final AbstractDataStorage dataStorage = loadByNameOrId(path);
+            final String pathWithOutStorageMask = path.replaceAll(DATA_STORAGE_PROVIDER_MASK, StringUtils.EMPTY);
+            final AbstractDataStorage dataStorage = loadByPathOrId(pathWithOutStorageMask);
             final String mask = dataStorage.getPathMask() + ProviderUtils.DELIMITER;
             links.add(constructDataStorageLink(path, dataStorage, mask));
         }

--- a/api/src/main/java/com/epam/pipeline/manager/metadata/MetadataEntityManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/metadata/MetadataEntityManager.java
@@ -111,6 +111,7 @@ public class MetadataEntityManager implements SecuredEntityManager {
         return metadataClass;
     }
 
+    @Transactional(propagation = Propagation.REQUIRED)
     public MetadataClass getOrCreate(final String name) {
         final MetadataClass metadataClass = metadataClassDao.loadMetadataClass(name);
         if (metadataClass == null) {

--- a/api/src/main/java/com/epam/pipeline/manager/metadata/MetadataEntityManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/metadata/MetadataEntityManager.java
@@ -111,6 +111,14 @@ public class MetadataEntityManager implements SecuredEntityManager {
         return metadataClass;
     }
 
+    public MetadataClass getOrCreate(final String name) {
+        final MetadataClass metadataClass = metadataClassDao.loadMetadataClass(name);
+        if (metadataClass == null) {
+            return createMetadataClass(name);
+        }
+        return metadataClass;
+    }
+
     public MetadataClass loadClass(Long id) {
         MetadataClass metadataClass = metadataClassDao.loadMetadataClass(id);
         Assert.notNull(metadataClass,

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -118,6 +118,7 @@ public class SystemPreferences {
     private static final String LUSTRE_GROUP = "Lustre FS";
     private static final String LDAP_GROUP = "LDAP";
     private static final String BILLING_QUOTAS_GROUP= "Billing Quotas";
+    private static final String NGS_PREPROCESSING_GROUP = "NGS Preprocessing";
 
     private static final String STORAGE_FSBROWSER_BLACK_LIST_DEFAULT =
             "/bin,/var,/home,/root,/sbin,/sys,/usr,/boot,/dev,/lib,/proc,/etc";
@@ -596,6 +597,8 @@ public class SystemPreferences {
     // UI_GROUP
     public static final StringPreference UI_PROJECT_INDICATOR = new StringPreference("ui.project.indicator",
                                                                                      "type=project", UI_GROUP, pass);
+    public static final StringPreference UI_NGS_PROJECT_INDICATOR = new StringPreference("ui.ngs.project.indicator",
+                                                                        "project-type=ngs-project", UI_GROUP, pass);
     public static final ObjectPreference<Map<String, String>> UI_CLI_CONFIGURE_TEMPLATE = new ObjectPreference<>(
         "ui.pipe.cli.configure.template", null, new TypeReference<Map<String, String>>() {}, UI_GROUP,
             isNullOrValidJson(new TypeReference<Map<String, String>>() {}));
@@ -966,6 +969,23 @@ public class SystemPreferences {
             "ldap.blocked.user.name.attribute", "sAMAccountName", LDAP_GROUP, pass);
     public static final IntPreference LDAP_BLOCKED_USERS_FILTER_PAGE_SIZE = new IntPreference(
             "ldap.blocked.user.filter.page.size", 50, LDAP_GROUP, pass);
+
+    //NGS Preprocessing
+    public static final StringPreference PREPROCESSING_MACHINE_RUN_CLASS = new StringPreference(
+            "ngs.preprocessing.machine.run.metadata.class", "MachineRun",
+            NGS_PREPROCESSING_GROUP, PreferenceValidators.isNotBlank);
+    public static final StringPreference PREPROCESSING_SAMPLE_CLASS = new StringPreference(
+            "ngs.preprocessing.sample.metadata.class", "Sample",
+            NGS_PREPROCESSING_GROUP, PreferenceValidators.isNotBlank);
+    public static final StringPreference PREPROCESSING_MACHINE_RUN_TO_SAMPLE_COLUMN = new StringPreference(
+            "ngs.preprocessing.machinerun.to.sample.column", "Samples",
+            NGS_PREPROCESSING_GROUP, PreferenceValidators.isNotBlank);
+    public static final StringPreference PREPROCESSING_SAMPLESHEET_FILE_NAME = new StringPreference(
+            "ngs.preprocessing.samplesheet.file.name", "samplesheet.csv",
+            NGS_PREPROCESSING_GROUP, PreferenceValidators.isNotBlank);
+    public static final StringPreference PREPROCESSING_DATA_FOLDER = new StringPreference(
+            "ngs.preprocessing.data.folder", "ngs-data",
+            NGS_PREPROCESSING_GROUP, PreferenceValidators.isNotBlank);
 
     private static final Pattern GIT_VERSION_PATTERN = Pattern.compile("(\\d)\\.(\\d)");
 

--- a/api/src/main/java/com/epam/pipeline/manager/preprocessing/NgsPreprocessingManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preprocessing/NgsPreprocessingManager.java
@@ -150,11 +150,10 @@ public class NgsPreprocessingManager {
                     if (EntityTypeField.isArrayType(value.getType())) {
                         final List<String> samples = JsonMapper
                                 .parseData(value.getValue(), new TypeReference<List<String>>() {});
-                        for (String sample : samples) {
-                            final MetadataEntity sampleMetadataEntity = metadataEntityManager
-                                    .loadByExternalId(sample, sampleMetadataClass.getName(), folderId);
-                            metadataEntityManager.deleteMetadataEntity(sampleMetadataEntity.getId());
-                        }
+                        samples.stream().map(sample -> metadataEntityManager
+                                .loadByExternalId(sample, sampleMetadataClass.getName(), folderId))
+                                .forEach(sampleMetadataEntity ->
+                                        metadataEntityManager.deleteMetadataEntity(sampleMetadataEntity.getId()));
                     }
                 });
 

--- a/api/src/main/java/com/epam/pipeline/manager/preprocessing/NgsPreprocessingManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preprocessing/NgsPreprocessingManager.java
@@ -110,7 +110,7 @@ public class NgsPreprocessingManager {
         final List<MetadataEntityVO> samples = mapSampleSheetToMetadataEntities(
                 folderId, sampleSheet, sampleMetadataClass, dataHeader);
 
-        unregisterSampleSheet(folderId, machineRunId, registrationVO.isOverwriteContent());
+        unregisterSampleSheet(folderId, machineRunId, true);
         samples.forEach(metadataEntityManager::updateMetadataEntity);
 
         final String machineRunToSampleColumn = preferenceManager.getPreference(
@@ -119,12 +119,12 @@ public class NgsPreprocessingManager {
         linkSamplesToMachineRun(folderId, machineRunMetadataEntity, sampleMetadataClassName,
                 samples, machineRunToSampleColumn);
 
-        storageManager.createDataStorageFile(
-                dataFolderPath.getDataStorageId(),
-                Paths.get(dataFolderPath.getPath(), machineRunMetadataEntity.getExternalId()).toString(),
-                preferenceManager.getPreference(SystemPreferences.PREPROCESSING_SAMPLESHEET_FILE_NAME),
-                content
-        );
+        final String sampleSheetFilePath = Paths.get(
+                dataFolderPath.getPath(),
+                machineRunMetadataEntity.getExternalId(),
+                preferenceManager.getPreference(SystemPreferences.PREPROCESSING_SAMPLESHEET_FILE_NAME)
+        ).toString();
+        storageManager.createDataStorageFile(dataFolderPath.getDataStorageId(), sampleSheetFilePath, content);
     }
 
     @Transactional(propagation = Propagation.REQUIRED)

--- a/api/src/main/java/com/epam/pipeline/manager/preprocessing/NgsPreprocessingManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preprocessing/NgsPreprocessingManager.java
@@ -1,0 +1,347 @@
+/*
+ * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.preprocessing;
+
+import com.epam.pipeline.common.MessageConstants;
+import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.config.JsonMapper;
+import com.epam.pipeline.controller.vo.EntityVO;
+import com.epam.pipeline.controller.vo.data.storage.UpdateDataStorageItemVO;
+import com.epam.pipeline.controller.vo.metadata.MetadataEntityVO;
+import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
+import com.epam.pipeline.entity.datastorage.DataStorageItemType;
+import com.epam.pipeline.entity.metadata.MetadataClass;
+import com.epam.pipeline.entity.metadata.MetadataEntity;
+import com.epam.pipeline.entity.metadata.MetadataEntry;
+import com.epam.pipeline.entity.metadata.PipeConfValue;
+import com.epam.pipeline.entity.metadata.PipeConfValueType;
+import com.epam.pipeline.entity.pipeline.Folder;
+import com.epam.pipeline.entity.pipeline.run.parameter.DataStorageLink;
+import com.epam.pipeline.entity.samplesheet.SampleSheet;
+import com.epam.pipeline.controller.vo.preprocessing.SampleSheetRegistrationVO;
+import com.epam.pipeline.entity.security.acl.AclClass;
+import com.epam.pipeline.manager.datastorage.DataStorageManager;
+import com.epam.pipeline.manager.metadata.MetadataEntityManager;
+import com.epam.pipeline.manager.metadata.MetadataManager;
+import com.epam.pipeline.manager.metadata.parser.EntityTypeField;
+import com.epam.pipeline.manager.metadata.parser.MetadataParsingResult;
+import com.epam.pipeline.manager.pipeline.FolderManager;
+import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.epam.pipeline.manager.preference.SystemPreferences;
+import com.fasterxml.jackson.core.type.TypeReference;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.util.Pair;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.Assert;
+
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@SuppressWarnings("PMD.AvoidCatchingGenericException")
+public class NgsPreprocessingManager {
+
+    public static final String TAG_KEY_VALUE_DELIMITER = "=";
+    public static final String SAMPLE_PREFIX = "_S";
+    public static final String LANE_PREFIX = "_L";
+
+    @Autowired
+    private FolderManager folderManager;
+
+    @Autowired
+    private MetadataManager metadataManager;
+
+    @Autowired
+    private MetadataEntityManager metadataEntityManager;
+
+    @Autowired
+    private DataStorageManager storageManager;
+
+    @Autowired
+    private PreferenceManager preferenceManager;
+
+    @Autowired
+    private MessageHelper messageHelper;
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void registerSampleSheet(final SampleSheetRegistrationVO registrationVO) {
+        final Long folderId = registrationVO.getFolderId();
+        Assert.notNull(folderId,
+                messageHelper.getMessage(MessageConstants.ERROR_NGS_PREPROCESSING_FOLDER_ID_NOT_PROVIDED));
+        final Folder folder = folderManager.load(folderId);
+
+        final MetadataEntry folderMetadata = fetchFolderMetadata(folder);
+        final DataStorageLink dataFolderPath = fetchDataFolder(folderMetadata);
+
+        final Long machineRunId = registrationVO.getMachineRunId();
+        Assert.notNull(machineRunId,
+                messageHelper.getMessage(MessageConstants.ERROR_NGS_PREPROCESSING_MACHINE_RUN_NOT_PROVIDED));
+        final MetadataEntity machineRunMetadataEntity = fetchMachineRunMetadataEntity(dataFolderPath, machineRunId);
+
+        final byte[] content = registrationVO.getContent();
+        Assert.state(ArrayUtils.isNotEmpty(content),
+                messageHelper.getMessage(MessageConstants.ERROR_NGS_PREPROCESSING_SAMPLESHEET_CONTENT_NOT_PROVIDED));
+        final SampleSheet sampleSheet = SampleSheetParser.parseSampleSheet(content);
+
+        final String sampleMetadataClass = preferenceManager.getStringPreference(
+                SystemPreferences.PREPROCESSING_SAMPLE_CLASS.getKey());
+        final MetadataClass metadataClass = metadataEntityManager.loadClass(sampleMetadataClass);
+        final List<String> dataHeader = sampleSheet.getDataHeader();
+
+        final List<MetadataEntityVO> samples = mapSampleSheetToMetadataEntities(
+                folderId, sampleSheet, metadataClass, dataHeader);
+
+        deleteSampleSheet(folderId, machineRunId);
+
+        for (MetadataEntityVO sample : samples) {
+            metadataEntityManager.updateMetadataEntity(sample);
+        }
+
+        final String machineRunToSampleColumn = preferenceManager.getStringPreference(
+                SystemPreferences.PREPROCESSING_MACHINE_RUN_TO_SAMPLE_COLUMN.getKey());
+
+        linkSamplesToMachineRun(folderId, machineRunMetadataEntity, sampleMetadataClass, samples, machineRunToSampleColumn);
+
+        storageManager.createDataStorageFile(
+                dataFolderPath.getDataStorageId(),
+                Paths.get(dataFolderPath.getPath(), machineRunMetadataEntity.getExternalId()).toString(),
+                preferenceManager.getStringPreference(SystemPreferences.PREPROCESSING_SAMPLESHEET_FILE_NAME.getKey()),
+                content
+        );
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void deleteSampleSheet(final Long folderId, final Long machineRunId) {
+        final MetadataEntry folderMetadata = metadataManager.listMetadataItems(
+                        Collections.singletonList(new EntityVO(folderId, AclClass.FOLDER))).stream().findFirst()
+                .orElseThrow(() -> new IllegalStateException(
+                        messageHelper.getMessage(MessageConstants.ERROR_NGS_PREPROCESSING_FOLDER_HAS_NO_METADATA,
+                                folderId)));
+        final DataStorageLink dataFolderPath = fetchDataFolder(folderMetadata);
+
+        final MetadataEntity machineRunMetadata = fetchMachineRunMetadataEntity(dataFolderPath, machineRunId);
+
+        final String sampleMetadataClassName = preferenceManager.getStringPreference(
+                SystemPreferences.PREPROCESSING_SAMPLE_CLASS.getKey());
+        final MetadataClass sampleMetadataClass = metadataEntityManager.loadClass(sampleMetadataClassName);
+
+        final String machineRunToSampleColumn = preferenceManager.getStringPreference(
+                SystemPreferences.PREPROCESSING_MACHINE_RUN_TO_SAMPLE_COLUMN.getKey());
+
+        Optional.ofNullable(machineRunMetadata.getData().get(machineRunToSampleColumn))
+                .ifPresent(value -> {
+                    if (EntityTypeField.isArrayType(value.getType())) {
+                        final List<String> samples = JsonMapper
+                                .parseData(value.getValue(), new TypeReference<List<String>>() {});
+                        for (String sample : samples) {
+                            final MetadataEntity sampleMetadataEntity = metadataEntityManager
+                                    .loadByExternalId(sample, sampleMetadataClass.getName(), folderId);
+                            metadataEntityManager.deleteMetadataEntity(sampleMetadataEntity.getId());
+                        }
+                    }
+                });
+
+        metadataEntityManager.deleteMetadataItemKey(machineRunMetadata.getId(), machineRunToSampleColumn);
+
+        final String sampleSheetFilePath = Paths.get(
+                dataFolderPath.getPath(),
+                machineRunMetadata.getExternalId(),
+                preferenceManager.getStringPreference(SystemPreferences.PREPROCESSING_SAMPLESHEET_FILE_NAME.getKey())
+        ).toString();
+        final AbstractDataStorage dataStorage = storageManager.load(dataFolderPath.getDataStorageId());
+        if (checkPathExistence(dataStorage.getId(), sampleSheetFilePath)) {
+            final UpdateDataStorageItemVO sampleSheetItem = new UpdateDataStorageItemVO();
+            sampleSheetItem.setPath(sampleSheetFilePath);
+            sampleSheetItem.setType(DataStorageItemType.File);
+            storageManager.deleteDataStorageItems(
+                    dataFolderPath.getDataStorageId(),
+                    Collections.singletonList(sampleSheetItem),
+                    dataStorage.isVersioningEnabled()
+            );
+        }
+    }
+
+    private void linkSamplesToMachineRun(final Long folderId, final MetadataEntity machineRunMetadataEntity,
+                                         final String sampleMetadataClass, final List<MetadataEntityVO> samples,
+                                         final String machineRunToSampleColumn) {
+        machineRunMetadataEntity.getData().put(
+                machineRunToSampleColumn,
+                new PipeConfValue(String.format(EntityTypeField.ARRAY_TYPE, sampleMetadataClass),
+                        JsonMapper.convertDataToJsonStringForQuery(
+                                samples.stream().map(MetadataEntityVO::getExternalId).collect(Collectors.toList())
+                        )
+                ));
+        final MetadataParsingResult toUpd = new MetadataParsingResult(
+                machineRunMetadataEntity.getClassEntity(),
+                Collections.singletonMap(sampleMetadataClass,
+                        samples.stream().map(MetadataEntityVO::getExternalId).collect(Collectors.toSet())
+                ),
+                Collections.singletonMap(machineRunMetadataEntity.getExternalId(), machineRunMetadataEntity)
+        );
+        metadataEntityManager.createAndUpdateEntities(folderId, toUpd);
+    }
+
+    private MetadataEntity fetchMachineRunMetadataEntity(final DataStorageLink dataFolderPath,
+                                                         final Long machineRunId) {
+        final String machineRunMetadataClass = preferenceManager.getStringPreference(
+                SystemPreferences.PREPROCESSING_MACHINE_RUN_CLASS.getKey());
+
+        final MetadataEntity machineRunMetadataEntity = metadataEntityManager.load(machineRunId);
+        Assert.notNull(machineRunMetadataEntity,
+                messageHelper.getMessage(
+                        MessageConstants.ERROR_NGS_PREPROCESSING_NO_MACHINE_RUN_METADATA, machineRunId));
+        Assert.state(machineRunMetadataEntity.getClassEntity().getName().equals(machineRunMetadataClass),
+                messageHelper.getMessage(MessageConstants.ERROR_NGS_PREPROCESSING_MACHINE_RUN_WRONG_METADATA_CLASS,
+                machineRunId, machineRunMetadataEntity.getClassEntity().getName(), machineRunMetadataClass));
+
+        // check that folder for machineRun exists
+        if (!checkPathExistence(dataFolderPath.getDataStorageId(),
+                Paths.get(dataFolderPath.getPath(), machineRunMetadataEntity.getExternalId()).toString())) {
+            throw new IllegalStateException(
+                    messageHelper.getMessage(MessageConstants.ERROR_DATASTORAGE_PATH_NOT_FOUND,
+                            dataFolderPath.getPath(), dataFolderPath.getDataStorageId()));
+        }
+        return machineRunMetadataEntity;
+    }
+
+    private DataStorageLink fetchDataFolder(final MetadataEntry metadata) {
+        final String dataFolderMetadataKey = preferenceManager.getStringPreference(
+                SystemPreferences.PREPROCESSING_DATA_FOLDER.getKey());
+        final PipeConfValue dataPath = metadata.getData().get(dataFolderMetadataKey);
+        Assert.notNull(dataPath,
+                messageHelper.getMessage(MessageConstants.ERROR_NGS_PREPROCESSING_FOLDER_SHOULD_HAVE_METADATA,
+                        dataFolderMetadataKey)
+        );
+        storageManager.analyzePaths(Collections.singletonList(dataPath));
+
+        return Optional.ofNullable(dataPath.getDataStorageLinks())
+                .flatMap(sl -> sl.stream().findFirst())
+                .orElseThrow(() -> new IllegalStateException(
+                        messageHelper.getMessage(MessageConstants.ERROR_NGS_PREPROCESSING_FOLDER_SHOULD_HAVE_DATA_PATH,
+                                dataFolderMetadataKey + TAG_KEY_VALUE_DELIMITER + dataPath.getValue())));
+    }
+
+    private MetadataEntry fetchFolderMetadata(final Folder folder) {
+        final MetadataEntry folderMetadata = metadataManager.listMetadataItems(
+                        Collections.singletonList(new EntityVO(folder.getId(), AclClass.FOLDER))).stream().findFirst()
+                .orElseThrow(() -> new IllegalStateException(
+                        messageHelper.getMessage(
+                                MessageConstants.ERROR_NGS_PREPROCESSING_FOLDER_HAS_NO_METADATA,
+                                folder.getId())));
+
+        final Pair<String, String> projectIndicator =
+                fetchProjectIndicatorPair(SystemPreferences.UI_PROJECT_INDICATOR.getKey());
+
+        PipeConfValue projectAttribute = folderMetadata.getData().get(projectIndicator.getFirst());
+        Assert.state(projectAttribute != null
+                        && projectAttribute.getValue().equals(projectIndicator.getSecond()),
+                messageHelper.getMessage(
+                        MessageConstants.ERROR_NGS_PREPROCESSING_FOLDER_SHOULD_HAVE_METADATA,
+                        projectIndicator
+                ));
+
+        final Pair<String, String> projectTypeIndicator =
+                fetchProjectIndicatorPair(SystemPreferences.UI_NGS_PROJECT_INDICATOR.getKey());
+        PipeConfValue projectTypeAttribute = folderMetadata.getData().get(projectTypeIndicator.getFirst());
+        Assert.state(projectTypeAttribute != null
+                        && projectTypeAttribute.getValue().equals(projectTypeIndicator.getSecond()),
+                messageHelper.getMessage(
+                        MessageConstants.ERROR_NGS_PREPROCESSING_FOLDER_SHOULD_HAVE_METADATA,
+                        projectTypeIndicator
+                ));
+
+        return folderMetadata;
+    }
+
+    private List<MetadataEntityVO> mapSampleSheetToMetadataEntities(final Long folderId, final SampleSheet sampleSheet,
+                                                                    final MetadataClass metadataClass,
+                                                                    final List<String> dataHeader) {
+        final int sampleIdIndex = dataHeader.indexOf(SampleSheetParser.SAMPLE_ID_COLUMN);
+        Assert.state(sampleIdIndex != -1,
+                messageHelper.getMessage(MessageConstants.ERROR_NGS_PREPROCESSING_SAMPLE_ID_NOT_FOUND));
+        final int laneIndex = dataHeader.indexOf(SampleSheetParser.LANE_COLUMN);
+
+        List<MetadataEntityVO> result = new ArrayList<>();
+        for (int i = 0; i < sampleSheet.getDataLines().size(); i++) {
+            String l = sampleSheet.getDataLines().get(i);
+            final List<String> fields = Arrays.asList(l.split(SampleSheetParser.SAMPLESHEET_DELIMETR));
+
+            final MetadataEntityVO entityVO = new MetadataEntityVO();
+
+            entityVO.setClassName(metadataClass.getName());
+            entityVO.setClassId(metadataClass.getId());
+            entityVO.setParentId(folderId);
+            if (laneIndex < 0) {
+                entityVO.setExternalId(fields.get(sampleIdIndex) + SAMPLE_PREFIX + i);
+            } else {
+                entityVO.setExternalId(fields.get(sampleIdIndex) + SAMPLE_PREFIX + i
+                        + LANE_PREFIX + fields.get(laneIndex));
+            }
+            final Map<String, PipeConfValue> data = new HashMap<>();
+            for (int j = 0; j < dataHeader.size(); j++) {
+                data.put(dataHeader.get(j),
+                        new PipeConfValue(
+                                PipeConfValueType.STRING.toString(),
+                                fields.size() > j ? fields.get(j) : StringUtils.EMPTY
+                        )
+                );
+            }
+            entityVO.setData(data);
+            result.add(entityVO);
+        }
+
+        return result;
+    }
+
+    private Pair<String, String> fetchProjectIndicatorPair(final String preferenceKey) {
+        final String projectIndicator = preferenceManager.getStringPreference(preferenceKey);
+
+        Assert.state(StringUtils.isNotBlank(projectIndicator) && projectIndicator.matches(".+=.+"),
+                messageHelper.getMessage(MessageConstants.ERROR_PREFERENCE_VALUE_INVALID,
+                        preferenceKey, projectIndicator));
+
+        final String[] projectIndicatorKeyValue = projectIndicator.split(TAG_KEY_VALUE_DELIMITER);
+        Assert.state(projectIndicatorKeyValue.length == 2,
+                messageHelper.getMessage(MessageConstants.ERROR_PREFERENCE_VALUE_INVALID,
+                        preferenceKey, projectIndicator));
+        return Pair.of(projectIndicatorKeyValue[0], projectIndicatorKeyValue[1]);
+    }
+
+    private boolean checkPathExistence(final Long dataStorageId, final String path) {
+        try {
+            // if we can list it, it should exist
+            storageManager.getDataStorageItems(dataStorageId, path, false, 1, null);
+            return true;
+        } catch (RuntimeException e) {
+            log.debug("Fail to list storage", e);
+            return false;
+        }
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/preprocessing/SampleSheetParser.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preprocessing/SampleSheetParser.java
@@ -17,6 +17,8 @@
 package com.epam.pipeline.manager.preprocessing;
 
 import com.epam.pipeline.entity.samplesheet.SampleSheet;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.springframework.data.util.Pair;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -35,7 +37,9 @@ import java.util.stream.Collectors;
  * This class parses provided content regarding to sample sheet description:
  * https://www.illumina.com/content/dam/illumina-marketing/documents/products/technotes/sequencing-sheet-format-specifications-technical-note-970-2017-004.pdf
  * */
-public class SampleSheetParser {
+@SuppressWarnings({"LineLength", "HideUtilityClassConstructor"})
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class SampleSheetParser {
 
     public static final String SAMPLE_ID_COLUMN = "Sample_ID";
     public static final String LANE_COLUMN = "Lane";
@@ -50,11 +54,11 @@ public class SampleSheetParser {
     public static final int SETTINGS_SECTION_NUMBER = 4;
     public static final String DATA_SECTION = "[Data]";
     public static final int DATA_SECTION_NUMBER = 5;
-    public static final String SAMPLESHEET_DELIMETR = ",";
+    public static final String SAMPLESHEET_DELIMITER = ",";
     public static final int SECTION_DEFAULT_VALUE = 0;
 
     public static SampleSheet parseSampleSheet(final byte[] content) {
-        try(final BufferedReader reader = new BufferedReader(new InputStreamReader(
+        try(BufferedReader reader = new BufferedReader(new InputStreamReader(
                 new ByteArrayInputStream(content)))) {
             final SampleSheet.SampleSheetBuilder sampleSheetBuilder = SampleSheet.builder();
             int section = SECTION_DEFAULT_VALUE;
@@ -82,6 +86,7 @@ public class SampleSheetParser {
                             break;
                         case DATA_SECTION_NUMBER:
                             throw new IllegalStateException("Data section should be last one!");
+                        default:
                     }
                     section = newSection;
                     lineStorage.clear();
@@ -108,7 +113,7 @@ public class SampleSheetParser {
     private static List<String> parseDataHeader(final List<String> lines) {
         Assert.state(lines.size() > 1, "No data lines in sample sheet!");
         String dataHeaderLine = lines.stream().findFirst().orElseThrow(
-                () -> new IllegalStateException("No data lines in sample sheet!"));
+            () -> new IllegalStateException("No data lines in sample sheet!"));
         return Arrays.asList(dataHeaderLine.split(","));
     }
 
@@ -118,7 +123,7 @@ public class SampleSheetParser {
 
     private static Map<String, String> parseMapLines(final List<String> lines) {
         return lines.stream().map(l -> {
-            String[] firstSecond = l.split(SAMPLESHEET_DELIMETR);
+            String[] firstSecond = l.split(SAMPLESHEET_DELIMITER);
             return Pair.of(firstSecond[0], firstSecond[1]);
         }).collect(Collectors.toMap(Pair::getFirst, Pair::getSecond));
     }

--- a/api/src/main/java/com/epam/pipeline/manager/preprocessing/SampleSheetParser.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preprocessing/SampleSheetParser.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.preprocessing;
+
+import com.epam.pipeline.entity.samplesheet.SampleSheet;
+import org.springframework.data.util.Pair;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * This class parses provided content regarding to sample sheet description:
+ * https://www.illumina.com/content/dam/illumina-marketing/documents/products/technotes/sequencing-sheet-format-specifications-technical-note-970-2017-004.pdf
+ * */
+public class SampleSheetParser {
+
+    public static final String SAMPLE_ID_COLUMN = "Sample_ID";
+    public static final String LANE_COLUMN = "Lane";
+
+    public static final String HEADER_SECTION = "[Header]";
+    public static final int HEADER_SECTION_NUMBER = 1;
+    public static final String MANIFESTS_SECTION = "[Manifests]";
+    public static final int MANIFESTS_SECTION_NUMBER = 2;
+    public static final String READS_SECTION = "[Reads]";
+    public static final int READS_SECTION_NUMBER = 3;
+    public static final String SETTINGS_SECTION = "[Settings]";
+    public static final int SETTINGS_SECTION_NUMBER = 4;
+    public static final String DATA_SECTION = "[Data]";
+    public static final int DATA_SECTION_NUMBER = 5;
+    public static final String SAMPLESHEET_DELIMETR = ",";
+    public static final int SECTION_DEFAULT_VALUE = 0;
+
+    public static SampleSheet parseSampleSheet(final byte[] content) {
+        try(final BufferedReader reader = new BufferedReader(new InputStreamReader(
+                new ByteArrayInputStream(content)))) {
+            final SampleSheet.SampleSheetBuilder sampleSheetBuilder = SampleSheet.builder();
+            int section = SECTION_DEFAULT_VALUE;
+            final List<String> lineStorage = new ArrayList<>();
+            for (String line : reader.lines().filter(StringUtils::hasText)
+                    .filter(l -> !l.matches("^,+$")).collect(Collectors.toList())) {
+                if (line.isEmpty()) {
+                    continue;
+                }
+
+                int newSection = checkForNewSection(line, sampleSheetBuilder);
+                if (newSection != SECTION_DEFAULT_VALUE) {
+                    switch (section) {
+                        case HEADER_SECTION_NUMBER:
+                            sampleSheetBuilder.header(parseMapLines(lineStorage));
+                            break;
+                        case MANIFESTS_SECTION_NUMBER:
+                            sampleSheetBuilder.manifests(parseMapLines(lineStorage));
+                            break;
+                        case READS_SECTION_NUMBER:
+                            sampleSheetBuilder.reads(parseReadLines(lineStorage));
+                            break;
+                        case SETTINGS_SECTION_NUMBER:
+                            sampleSheetBuilder.settings(parseMapLines(lineStorage));
+                            break;
+                        case DATA_SECTION_NUMBER:
+                            throw new IllegalStateException("Data section should be last one!");
+                    }
+                    section = newSection;
+                    lineStorage.clear();
+                    continue;
+                }
+                lineStorage.add(line);
+            }
+
+            sampleSheetBuilder.dataHeader(parseDataHeader(lineStorage));
+            sampleSheetBuilder.dataLines(
+                    // filter header line
+                    lineStorage.stream().skip(1).collect(Collectors.toList())
+            );
+
+            SampleSheet result = sampleSheetBuilder.build();
+            Assert.state(result.isWithHeader(), "Sample sheet has no header!");
+            Assert.state(result.isWithData(), "Sample sheet has no data!");
+            return result;
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot parse sample sheet", e);
+        }
+    }
+
+    private static List<String> parseDataHeader(final List<String> lines) {
+        Assert.state(lines.size() > 1, "No data lines in sample sheet!");
+        String dataHeaderLine = lines.stream().findFirst().orElseThrow(
+                () -> new IllegalStateException("No data lines in sample sheet!"));
+        return Arrays.asList(dataHeaderLine.split(","));
+    }
+
+    private static List<Integer> parseReadLines(final List<String> lineContainer) {
+        return lineContainer.stream().map(Integer::getInteger).collect(Collectors.toList());
+    }
+
+    private static Map<String, String> parseMapLines(final List<String> lines) {
+        return lines.stream().map(l -> {
+            String[] firstSecond = l.split(SAMPLESHEET_DELIMETR);
+            return Pair.of(firstSecond[0], firstSecond[1]);
+        }).collect(Collectors.toMap(Pair::getFirst, Pair::getSecond));
+    }
+
+    private static int checkForNewSection(final String line, final SampleSheet.SampleSheetBuilder builder) {
+        if (line.contains(HEADER_SECTION)) {
+            builder.withHeader(true);
+            return HEADER_SECTION_NUMBER;
+        } else if (line.contains(MANIFESTS_SECTION)) {
+            builder.withManifests(true);
+            return MANIFESTS_SECTION_NUMBER;
+        } else if (line.contains(READS_SECTION)) {
+            builder.withReads(true);
+            return READS_SECTION_NUMBER;
+        } else if (line.contains(SETTINGS_SECTION)) {
+            builder.withSettings(true);
+            return SETTINGS_SECTION_NUMBER;
+        } else if (line.contains(DATA_SECTION)) {
+            builder.withData(true);
+            return DATA_SECTION_NUMBER;
+        }
+        return SECTION_DEFAULT_VALUE;
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/preprocessing/SampleSheetParser.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preprocessing/SampleSheetParser.java
@@ -33,10 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-/**
- * This class parses provided content regarding to sample sheet description:
- * https://www.illumina.com/content/dam/illumina-marketing/documents/products/technotes/sequencing-sheet-format-specifications-technical-note-970-2017-004.pdf
- * */
 @SuppressWarnings({"LineLength", "HideUtilityClassConstructor"})
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class SampleSheetParser {
@@ -57,6 +53,10 @@ public final class SampleSheetParser {
     public static final String SAMPLESHEET_DELIMITER = ",";
     public static final int SECTION_DEFAULT_VALUE = 0;
 
+    /**
+     * Parses provided content regarding sample sheet description:
+     * https://www.illumina.com/content/dam/illumina-marketing/documents/products/technotes/sequencing-sheet-format-specifications-technical-note-970-2017-004.pdf
+     * */
     public static SampleSheet parseSampleSheet(final byte[] content) {
         try(BufferedReader reader = new BufferedReader(new InputStreamReader(
                 new ByteArrayInputStream(content)))) {

--- a/api/src/main/java/com/epam/pipeline/manager/utils/SystemPreferenceUtils.java
+++ b/api/src/main/java/com/epam/pipeline/manager/utils/SystemPreferenceUtils.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.utils;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * This class contains util method somehow related to SystemPreference usage
+ * */
+@SuppressWarnings("HideUtilityClassConstructor")
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class SystemPreferenceUtils {
+
+    private static final String PROJECT_INDICATOR_DELIMITER = "=";
+
+    public static Set<Pair<String, String>> parseProjectIndicator(final String preference) {
+        List<String> projectIndicator = Arrays.asList(preference.split(","));
+        if (CollectionUtils.isEmpty(projectIndicator)) {
+            return Collections.emptySet();
+        }
+        return projectIndicator
+                .stream()
+                .filter(indicator -> indicator.contains(PROJECT_INDICATOR_DELIMITER))
+                .map(indicator -> {
+                    String[] splittedProjectIndicator = indicator.split(PROJECT_INDICATOR_DELIMITER);
+                    Assert.state(splittedProjectIndicator.length == 2,
+                            "Invalid project indicator pair: " + indicator);
+                    String key = splittedProjectIndicator[0];
+                    String value = splittedProjectIndicator[1];
+                    if (StringUtils.isEmpty(key) || StringUtils.isEmpty(value)) {
+                        throw new IllegalArgumentException("Invalid project indicator pair.");
+                    }
+                    return new ImmutablePair<>(key, value);
+                }).collect(Collectors.toSet());
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/utils/DataStorageUtils.java
+++ b/api/src/main/java/com/epam/pipeline/utils/DataStorageUtils.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.utils;
+
+import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
+import com.epam.pipeline.entity.pipeline.run.parameter.DataStorageLink;
+import com.epam.pipeline.manager.datastorage.providers.ProviderUtils;
+
+public class DataStorageUtils {
+
+    public static DataStorageLink constructDataStorageLink(final AbstractDataStorage dataStorage,
+                                                           final String path,
+                                                           final String mask) {
+        final DataStorageLink dataStorageLink = new DataStorageLink();
+        dataStorageLink.setAbsolutePath(path.trim());
+        dataStorageLink.setDataStorageId(dataStorage.getId());
+        String relativePath = path.trim().substring(mask.length());
+        if (relativePath.startsWith(ProviderUtils.DELIMITER)) {
+            relativePath = relativePath.substring(1);
+        }
+        final String[] parts = relativePath.split(ProviderUtils.DELIMITER);
+        final String lastPart = parts[parts.length - 1];
+        if (lastPart.contains(".")) {
+            String newPath = "";
+            for (int i = 0; i < parts.length - 1; i++) {
+                newPath = newPath.concat(parts[i] + ProviderUtils.DELIMITER);
+            }
+            if (newPath.endsWith(ProviderUtils.DELIMITER)) {
+                newPath = newPath.substring(0, newPath.length() - 1);
+            }
+            dataStorageLink.setPath(newPath);
+        } else {
+            dataStorageLink.setPath(relativePath);
+        }
+        return dataStorageLink;
+    }
+
+}

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -664,3 +664,15 @@ error.quota.subject.empty=Quota subject cannot be empty
 error.quota.type.empty=Quota type cannot be empty
 error.quota.action.not.allowed=Quota action ''{0}'' is not allowed for ''{1}''. Allowed actions: ''{2}''
 error.billing.quota.exceeded.launch=Launch of new compute instances is forbidden due to exceeded billing quota.
+
+# Ngs preprocessing
+error.ngs.preprocessing.folder.id.is.not.provided=Folder id is not provided in the request.
+error.ngs.preprocessing.machine.run.id.is.not.provided=MachineRunId is not provided in the request.
+error.ngs.preprocessing.samplesheet.content.is.not.provided=Content of sample sheet should be provided!
+error.ngs.preprocessing.folder.has.no.metadata=No MetadataEntry found for folder with id ''{0}''
+error.ngs.preprocessing.folder.has.no.machine.run.metadata=Folder does not contain MetadataEntity record with id ''{0}'' 
+error.ngs.preprocessing.machine.run.metadata.wrong.class=Folder MetadataEntity with id ''{0}'' has wrong class ''{1}'' expected ''{3}''
+error.ngs.preprocessing.folder.should.have.metadata=Folder expected to have metadata ''{0}''
+error.ngs.preprocessing.folder.should.have.data.path=Folder tagged with metadata ''{0}'' but there is no storage with such path
+error.ngs.preprocessing.no.folder.metadata=No metadata for folder ''{0}''
+error.ngs.preprocessing.sampleid.is.not.found=Sample_ID column is not found in sample sheet!

--- a/api/src/test/java/com/epam/pipeline/test/acl/AclTestBeans.java
+++ b/api/src/test/java/com/epam/pipeline/test/acl/AclTestBeans.java
@@ -117,6 +117,7 @@ import com.epam.pipeline.manager.pipeline.ToolScanInfoManager;
 import com.epam.pipeline.manager.pipeline.runner.ConfigurationProviderManager;
 import com.epam.pipeline.manager.pipeline.runner.ConfigurationRunner;
 import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.epam.pipeline.manager.preprocessing.NgsPreprocessingManager;
 import com.epam.pipeline.manager.quota.QuotaService;
 import com.epam.pipeline.manager.region.CloudRegionManager;
 import com.epam.pipeline.manager.report.UsersUsageReportService;
@@ -541,6 +542,9 @@ public class AclTestBeans {
 
     @MockBean
     protected OnlineUsersService onlineUsersService;
+
+    @MockBean
+    protected NgsPreprocessingManager preprocessingManager;
 
     @Bean
     public GrantPermissionManager grantPermissionManager() {

--- a/api/src/test/java/com/epam/pipeline/test/web/ControllerTestBeans.java
+++ b/api/src/test/java/com/epam/pipeline/test/web/ControllerTestBeans.java
@@ -23,6 +23,7 @@ import com.epam.pipeline.acl.datastorage.lustre.LustreFSApiService;
 import com.epam.pipeline.acl.log.LogApiService;
 import com.epam.pipeline.acl.ontology.OntologyApiService;
 import com.epam.pipeline.acl.pipeline.PipelineApiService;
+import com.epam.pipeline.acl.preprocessing.NgsPreprocessingApiService;
 import com.epam.pipeline.acl.quota.QuotaApiService;
 import com.epam.pipeline.acl.report.ReportApiService;
 import com.epam.pipeline.acl.run.RunApiService;
@@ -250,4 +251,7 @@ public class ControllerTestBeans {
 
     @MockBean
     protected ReportApiService reportApiService;
+
+    @MockBean
+    protected NgsPreprocessingApiService preprocessingApiService;
 }


### PR DESCRIPTION
Related to #2494

This PR provides functionality for registration and deletion of samplesheet for project that are marked with special metadata.

There are several new `system preference`s that are related:

`ui.ngs.project.indicator` - Need for UI and backend to check that this project is a `ngs` project
`ngs.preprocessing.machine.run.metadata.class` - Name of the metadata class for Machine Run 
`ngs.preprocessing.sample.metadata.class` -  Name of the metadata class for sample in samplesheet 
`ngs.preprocessing.machinerun.to.sample.column` - Name of the column for matching samples with machine run metadataEntity
`ngs.preprocessing.file.name` - How to name file of the samplesheet that would be loaded to the data folder with in a machine run
`ngs.preprocessing.data.folder` - folder with ngs data (root folder where all machine run folders are located)

`registerSampleSheet` method will do the following for provided folderId, machineRunId, samplesheet content

After all checks are done: 
- Project has right type
- Data folder exists
- Machine run metadata entity exists 
- Folder for this machine run also exists

For each record in sample sheet it will:
- Creates metadataEntity and link it to Machine Run metadataEntity. 
- Save content of the samplesheet to machine run data directory

`deleteSampleSheet` will do the opposite:

For each MetadataEntity linked to provided MachineRun it will:
- Remove such metadataEntity. 
- Remove samplesheet file from machine run data directory
 
