### PR TITLE
Redis clusterizaton

### DIFF
--- a/api/profiles/dev/application.properties
+++ b/api/profiles/dev/application.properties
@@ -206,7 +206,13 @@ log.security.elastic.index.prefix=${CP_SECURITY_LOGS_ELASTIC_PREFIX:security_log
 migration.alias.file=${CP_API_MIGRATION_ALIAS_FILE:}
 
 #Cache
-cache.type=MEMORY
+cache.type=${CP_API_CACHE_TYPE:MEMORY}
+redis.cluster.hosts=${CP_API_REDIS_CLUSTER_CACHE_HOSTS:}
+redis.cluster.max-redirects=${CP_API_REDIS_CLUSTER_MAX_REDIRECTS:3}
+redis.host=${CP_REDIS_INTERNAL_HOST:}
+redis.port=${CP_REDIS_INTERNAL_PORT:}
+redis.pool.timeout=${CP_REDIS_POOL_TIMEOUT:20000}
+redis.max.connections=${CP_REDIS_MAX_CONNECTIONS:20}
 
 #edge
 edge.internal.host=${CP_EDGE_INTERNAL_HOST:cp-edge.default.svc.cluster.local}

--- a/api/src/main/java/com/epam/pipeline/app/CacheConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/CacheConfiguration.java
@@ -93,6 +93,7 @@ public class CacheConfiguration {
     public RedisConnectionFactory redisConnectionFactory() {
         final Set<String> nodes = CollectionUtils.emptyIfNull(redisClusterNodes)
             .stream()
+            .map(StringUtils::trim)
             .filter(StringUtils::isNotBlank)
             .collect(Collectors.toSet());
         final JedisConnectionFactory jedisConnectionFactory;

--- a/api/src/main/java/com/epam/pipeline/app/CacheConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/CacheConfiguration.java
@@ -15,6 +15,8 @@
 
 package com.epam.pipeline.app;
 
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cache.CacheManager;
@@ -24,6 +26,7 @@ import org.springframework.cache.support.NoOpCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisClusterConfiguration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -31,6 +34,8 @@ import redis.clients.jedis.JedisPoolConfig;
 
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @EnableCaching
 public class CacheConfiguration {
@@ -57,6 +62,12 @@ public class CacheConfiguration {
     @Value("${redis.pool.timeout:20000}")
     private Integer poolTimeout;
 
+    @Value("${redis.cluster.max-redirects:3}")
+    private Integer redisClusterMaxRedirects;
+
+    @Value("#{'${redis.cluster.hosts:}'.split(',')}")
+    private Set<String> redisClusterNodes;
+
     @Bean
     @Primary
     public CacheManager cacheManager(final Optional<RedisCacheManager> redisCacheManager) {
@@ -80,9 +91,20 @@ public class CacheConfiguration {
     @Bean
     @ConditionalOnProperty(value = CACHE_TYPE, havingValue = REDIS)
     public RedisConnectionFactory redisConnectionFactory() {
-        final JedisConnectionFactory jedisConnectionFactory = new JedisConnectionFactory();
-        jedisConnectionFactory.setHostName(redisHost);
-        jedisConnectionFactory.setPort(redisPort);
+        final Set<String> nodes = CollectionUtils.emptyIfNull(redisClusterNodes)
+            .stream()
+            .filter(StringUtils::isNotBlank)
+            .collect(Collectors.toSet());
+        final JedisConnectionFactory jedisConnectionFactory;
+        if (CollectionUtils.isNotEmpty(nodes)) {
+            final RedisClusterConfiguration redisClusterConfiguration = new RedisClusterConfiguration(nodes);
+            redisClusterConfiguration.setMaxRedirects(redisClusterMaxRedirects);
+            jedisConnectionFactory = new JedisConnectionFactory(redisClusterConfiguration);
+        } else {
+            jedisConnectionFactory = new JedisConnectionFactory();
+            jedisConnectionFactory.setHostName(redisHost);
+            jedisConnectionFactory.setPort(redisPort);
+        }
         jedisConnectionFactory.setTimeout(poolTimeout);
         final JedisPoolConfig poolConfig = new JedisPoolConfig();
         poolConfig.setMaxTotal(redisPoolConnections);

--- a/deploy/contents/k8s/cp-redis/cp-redis-cluster-cm.yaml
+++ b/deploy/contents/k8s/cp-redis/cp-redis-cluster-cm.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cp-redis-cluster-config
+  namespace: default
+data:
+  redis.conf: |+
+    port 6379
+    cluster-enabled yes
+    cluster-require-full-coverage no
+    cluster-node-timeout 20000
+    cluster-config-file /data/nodes.conf
+    cluster-migration-barrier 1

--- a/deploy/contents/k8s/cp-redis/cp-redis-cluster-cm.yaml
+++ b/deploy/contents/k8s/cp-redis/cp-redis-cluster-cm.yaml
@@ -10,4 +10,7 @@ data:
     cluster-require-full-coverage no
     cluster-node-timeout 20000
     cluster-config-file /data/nodes.conf
-    cluster-migration-barrier 1
+    cluster-migration-barrier 0
+    cluster-require-full-coverage no
+    cluster-allow-reads-when-down yes
+    protected-mode no

--- a/deploy/contents/k8s/cp-redis/cp-redis-cluster-statefulset.yaml
+++ b/deploy/contents/k8s/cp-redis/cp-redis-cluster-statefulset.yaml
@@ -15,6 +15,11 @@ spec:
       labels:
         cloud-pipeline/cp-redis-cluster: "true"
     spec:
+      nodeSelector:
+        cloud-pipeline/cp-redis: "true"
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       containers:
         - name: redis
           image: redis:6.0.5

--- a/deploy/contents/k8s/cp-redis/cp-redis-cluster-statefulset.yaml
+++ b/deploy/contents/k8s/cp-redis/cp-redis-cluster-statefulset.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: cp-redis-ha
+  namespace: default
+spec:
+  serviceName: redis-ha
+  replicas: 3
+  selector:
+    matchLabels:
+      cloud-pipeline/cp-redis-cluster: "true"
+  template:
+    metadata:
+      namespace: default
+      labels:
+        cloud-pipeline/cp-redis-cluster: "true"
+    spec:
+      containers:
+        - name: redis
+          image: redis:6.0.5
+          ports:
+            - containerPort: 6379
+              name: client
+            - containerPort: 16379
+              name: cluster-port
+          command: ["redis-server", "/conf/redis.conf"]
+          volumeMounts:
+            - name: config
+              mountPath: /conf
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: cp-redis-cluster-config
+            defaultMode: 0755

--- a/deploy/contents/k8s/cp-redis/cp-redis-cluster-svc.yaml
+++ b/deploy/contents/k8s/cp-redis/cp-redis-cluster-svc.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    cloud-pipeline/cp-redis-cluster: "true"
+  name: redis-ha
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 6379
+      targetPort: 6379
+      name: cp-redis-port-http
+    - protocol: TCP
+      port: 16379
+      targetPort: 16379
+      name: cp-redis-cluster-port
+  selector:
+    cloud-pipeline/cp-redis-cluster: "true"

--- a/deploy/docker/cp-api-srv/config/application.properties
+++ b/deploy/docker/cp-api-srv/config/application.properties
@@ -179,6 +179,8 @@ migration.alias.file=${CP_API_MIGRATION_ALIAS_FILE:}
 
 #Cache
 cache.type=${CP_API_CACHE_TYPE:MEMORY}
+redis.cluster.hosts=${CP_API_REDIS_CLUSTER_CACHE_HOSTS:}
+redis.cluster.max-redirects=${CP_API_REDIS_CLUSTER_MAX_REDIRECTS:3}
 redis.host=${CP_REDIS_INTERNAL_HOST:}
 redis.port=${CP_REDIS_INTERNAL_PORT:}
 redis.pool.timeout=${CP_REDIS_POOL_TIMEOUT:20000}


### PR DESCRIPTION
This PR is related to Redis clusterization.
Some deployments with a huge amount of active runs and significant user activity might be affected by Redis's high load.
It is proposed to try Redis in a cluster mode to improve its performance.

This PR contains Kubernetes manifests for the objects backing up the Redis cluster and modification in API's CacheConfiguration:

To enable Redis in HA:
1. Create Kubernetes objects:
1.1. Create ConfigMap
1.2. Create StatefulSet
1.3. Create Service

2. Configure pods in the cluster with the folowing commands:
```bash
export REDIS_NODES=$(kubectl get pods  -l cloud-pipeline/cp-redis-cluster=true -o json | jq -r '.items | map(.status.podIP) | join(":6379 ")'):6379
kubectl exec -it cp-redis-ha-0 -- redis-cli --cluster create ${REDIS_NODES} --cluster-yes 
```
3. Update `CP_API_REDIS_CLUSTER_CACHE_HOSTS` value in `cp-config-global`: fill in comma-separated list of values 

> cp-redis-ha-<replica#>.redis-ha.default.svc.cluster.local:6379

So, in the case of 3 replicas, it should look like:
> CP_API_CACHE_TYPE: REDIS
> CP_API_REDIS_CLUSTER_CACHE_HOSTS: cp-redis-ha-0.redis-ha.default.svc.cluster.local:6379,cp-redis-ha-1.redis-ha.default.svc.cluster.local:6379

4. Restart API


