### PR TITLE
issue #2511 parsing of new field section for PipeConfValueVO

### DIFF
--- a/api/src/test/java/com/epam/pipeline/entity/PipelineConfigurationTest.java
+++ b/api/src/test/java/com/epam/pipeline/entity/PipelineConfigurationTest.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.*;
 
 public class PipelineConfigurationTest {
 
+    private static final String GENERAL_SECTION = "General";
     private static final String WITH_TYPE_OF_PARAMS_JSON =
             "{" +
                 "\"parameters\": {" +
@@ -38,6 +39,7 @@ public class PipelineConfigurationTest {
                         "\"value\" : \"\"," +
                         "\"required\" : \"true\"," +
                         "\"type\" : \"string\"," +
+                        "\"section\" : \"" + GENERAL_SECTION + "\"," +
                         "\"enum\" : [{\"name\": \"v1\"}, {\"name\": \"v2\"}]" +
                     "}," +
                     "\"main_class\" : {" +
@@ -85,6 +87,7 @@ public class PipelineConfigurationTest {
         final PipeConfValueVO mainFile = pipelineConfiguration.getParameters().get("main_file");
         assertEquals(STRING_TYPE, mainFile.getType());
         assertTrue(mainFile.isRequired());
+        assertEquals(mainFile.getSection(), GENERAL_SECTION);
 
         final PipeConfValueVO mainClass = pipelineConfiguration.getParameters().get("main_class");
         assertEquals(CLASS_TYPE, mainClass.getType());

--- a/core/src/main/java/com/epam/pipeline/entity/configuration/PipeConfValueVO.java
+++ b/core/src/main/java/com/epam/pipeline/entity/configuration/PipeConfValueVO.java
@@ -40,6 +40,9 @@ public class PipeConfValueVO {
     @JsonProperty(value = "type")
     private String type;
 
+    @JsonProperty(value = "section")
+    private String section;
+
     @JsonProperty(value = "required")
     private boolean required;
 

--- a/core/src/main/java/com/epam/pipeline/entity/configuration/PipelineConfValuesMapDeserializer.java
+++ b/core/src/main/java/com/epam/pipeline/entity/configuration/PipelineConfValuesMapDeserializer.java
@@ -39,6 +39,7 @@ public class PipelineConfValuesMapDeserializer extends JsonDeserializer<Map<Stri
 
     private static final String VALUE_FIELD = "value";
     private static final String TYPE_FIELD = "type";
+    private static final String SECTION_FIELD = "section";
     private static final String REQUIRED_FIELD = "required";
     private static final String NO_OVERRIDE_FIELD = "no_override";
     private static final String ENUM_FIELD = "enum";
@@ -74,6 +75,10 @@ public class PipelineConfValuesMapDeserializer extends JsonDeserializer<Map<Stri
                 JsonNode type = child.get(TYPE_FIELD);
                 if (hasValue(type)) {
                     parameter.setType(type.asText());
+                }
+                JsonNode section = child.get(SECTION_FIELD);
+                if (hasValue(section)) {
+                    parameter.setSection(section.asText());
                 }
                 JsonNode required = child.get(REQUIRED_FIELD);
                 if (hasValue(required)) {


### PR DESCRIPTION
As asked in #2511, PipelineConfiguration now respect `section` fields as well