### PR TITLE
Fix bug when it was impossible to cleanup docker container form env vars

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerCommitCommand.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerCommitCommand.java
@@ -33,6 +33,7 @@ public class DockerCommitCommand extends AbstractDockerCommand {
     private final String runId;
     private final String containerId;
     private final String cleanUp;
+    private final String additionalEnvsToClean;
     private final String stopPipeline;
     private final String timeout;
     private final String registryToPush;
@@ -62,6 +63,7 @@ public class DockerCommitCommand extends AbstractDockerCommand {
         command.add(runId);
         command.add(containerId);
         command.add(cleanUp);
+        command.add(additionalEnvsToClean);
         command.add(stopPipeline);
         command.add(timeout);
         command.add(registryToPush);

--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerContainerOperationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerContainerOperationManager.java
@@ -92,6 +92,7 @@ public class DockerContainerOperationManager {
     public static final String PAUSE_RUN_TASK = "PausePipelineRun";
     public static final String DELIMITER = "/";
     public static final int COMMAND_CANNOT_EXECUTE_CODE = 126;
+    public static final String NONE = "NONE";
 
     @Autowired
     private PipelineRunManager runManager;
@@ -184,6 +185,7 @@ public class DockerContainerOperationManager {
                     .runId(String.valueOf(run.getId()))
                     .containerId(containerId)
                     .cleanUp(String.valueOf(clearContainer))
+                    .additionalEnvsToClean(getEnvsToCleanUp())
                     .stopPipeline(String.valueOf(stopPipeline))
                     .timeout(String.valueOf(preferenceManager.getPreference(SystemPreferences.COMMIT_TIMEOUT)))
                     .registryToPush(registry.getPath())
@@ -267,6 +269,12 @@ public class DockerContainerOperationManager {
             failRunAndTerminateNode(run, e);
             throw new IllegalArgumentException(REJOIN_COMMAND_DESCRIPTION, e);
         }
+    }
+
+    private String getEnvsToCleanUp() {
+        return preferenceManager.getPreference(SystemPreferences.ADDITIONAL_ENVS_TO_CLEAN).equals(EMPTY)
+                ? NONE
+                : "\"" + preferenceManager.getPreference(SystemPreferences.ADDITIONAL_ENVS_TO_CLEAN) + "\"";
     }
 
     //method is synchronized to prevent double pod creation

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -143,6 +143,9 @@ public class SystemPreferences {
             "/root/post_commit.sh", COMMIT_GROUP, PreferenceValidators.isNotBlank);
     public static final IntPreference PAUSE_TIMEOUT = new IntPreference("pause.timeout", 24 * 60 * 60,
             COMMIT_GROUP, isGreaterThan(0));
+    // List of ',' separated env vars to be cleaned up from docker image before commit
+    public static final StringPreference ADDITIONAL_ENVS_TO_CLEAN = new StringPreference(
+            "commit.additional.envs.to.clean", "CP_EXEC_TIMEOUT", COMMIT_GROUP, pass);
 
     // DATA_STORAGE_GROUP
     public static final IntPreference DATA_STORAGE_MAX_DOWNLOAD_SIZE = new IntPreference(

--- a/scripts/commit-run-scripts/cleanup_container.sh
+++ b/scripts/commit-run-scripts/cleanup_container.sh
@@ -21,6 +21,7 @@ function check_installed {
 }
 
 CLEANUP_USER=$1
+ADDITIONAL_ENVS_TO_CLEAN_UP=$2
 
 IFS="@" read -r -a owner_info <<< "$OWNER"
 
@@ -53,6 +54,13 @@ if [[ $ENV_TO_CLEAN_COUNT -ne 0 ]]; then
         PARAM_NAME=${PARAM_TYPE_NAME%$PARAM_TYPE_SUFFIX}
         ENVS_TO_UNSET="$ENVS_TO_UNSET $PARAM_TYPE_NAME= $PARAM_NAME= "
     done <<< "$(env | grep ${PARAM_TYPE_SUFFIX})"
+fi
+
+if [[ ! -z $ADDITIONAL_ENVS_TO_CLEAN_UP && $ADDITIONAL_ENVS_TO_CLEAN_UP != "NONE" ]] ; then
+  IFS=","
+  for env_value in $ADDITIONAL_ENVS_TO_CLEAN_UP; do
+    ENVS_TO_UNSET="$ENVS_TO_UNSET $env_value= "
+  done
 fi
 
 echo $ENVS_TO_UNSET

--- a/scripts/commit-run-scripts/commit_run.sh
+++ b/scripts/commit-run-scripts/commit_run.sh
@@ -31,7 +31,7 @@ commit_hook ${tmp_container} "post" ${CLEAN_UP} ${STOP_PIPELINE} ${POST_COMMIT_C
 pipe_log_info "[INFO] Clean up container with env vars and files ..." "$TASK_NAME"
 docker cp $SCRIPTS_DIR/cleanup_container.sh "${tmp_container}":/
 
-ENVS_TO_UNSET=`docker exec "${tmp_container}" sh -c "chmod +x /cleanup_container.sh && /cleanup_container.sh $CLEAN_UP && rm /cleanup_container.sh"`
+ENVS_TO_UNSET=`docker exec "${tmp_container}" sh -c "chmod +x /cleanup_container.sh && /cleanup_container.sh $CLEAN_UP $ADDITIONAL_ENVS_TO_CLEAN_UP && rm /cleanup_container.sh"`
 
 check_last_exit_code $? "[ERROR] There are some troubles while clean up pipeline's container." \
                         "[INFO] Clean up for pipeline's container was successfully performed." \

--- a/scripts/commit-run-scripts/commit_run_starter.sh
+++ b/scripts/commit-run-scripts/commit_run_starter.sh
@@ -28,12 +28,13 @@ DISTRIBUTION_URL=$4
 export RUN_ID=$5
 export CONTAINER_ID=$6
 export CLEAN_UP=$7
-export STOP_PIPELINE=$8
-TIMEOUT=$9
-export REGISTRY_TO_PUSH=${10}
-export REGISTRY_TO_PUSH_ID=${11}
-export TOOL_GROUP_ID=${12}
-export NEW_IMAGE_NAME=${13}
+export ADDITIONAL_ENVS_TO_CLEAN_UP=$8
+export STOP_PIPELINE=$9
+TIMEOUT=${10}
+export REGISTRY_TO_PUSH=${11}
+export REGISTRY_TO_PUSH_ID=${12}
+export TOOL_GROUP_ID=${13}
+export NEW_IMAGE_NAME=${14}
 
 export SCRIPTS_DIR="$(pwd)/commit-run-scripts"
 export COMMON_REPO_DIR="$(pwd)/pipe-common"
@@ -41,17 +42,17 @@ export COMMON_REPO_DIR="$(pwd)/pipe-common"
 export FULL_NEW_IMAGE_NAME="${REGISTRY_TO_PUSH}/${NEW_IMAGE_NAME}"
 export CP_PYTHON2_PATH=python
 
-if [[ "$#" -ge 15 ]]; then
-    export DOCKER_LOGIN=${14}
-    export DOCKER_PASSWORD=${15}
-fi
-
 if [[ "$#" -ge 16 ]]; then
-    export IS_PIPELINE_AUTH=${16}
+    export DOCKER_LOGIN=${15}
+    export DOCKER_PASSWORD=${16}
 fi
 
-export PRE_COMMIT_COMMAND=${17}
-export POST_COMMIT_COMMAND=${18}
+if [[ "$#" -ge 17 ]]; then
+    export IS_PIPELINE_AUTH=${17}
+fi
+
+export PRE_COMMIT_COMMAND=${18}
+export POST_COMMIT_COMMAND=${19}
 
 export TASK_NAME="CommitPipelineRun"
 


### PR DESCRIPTION
Related to a problem when commited image contains previous exported envs that could lead to unexpected behavior 