### PR TITLE
GUI DataStorage - hide version control buttons  preference

### DIFF
--- a/client/src/components/pipelines/browser/DataStorage.js
+++ b/client/src/components/pipelines/browser/DataStorage.js
@@ -294,11 +294,13 @@ export default class DataStorage extends React.Component {
       info.value.storagePolicy &&
       info.value.storagePolicy.versioningEnabled
     ) {
-      // TODO: change .enableVersionControlsMock to valid preference name when API will be ready
-      const enableControls = preferences.enableVersionControlsMock === undefined
-        ? true
-        : preferences.enableVersionControlsMock;
-      return enableControls || authenticatedUserInfo.value.admin;
+      const isAdmin = authenticatedUserInfo.value.admin;
+      const preferenceValue = preferences
+        .getPreferenceValue('storage.policy.backup.visible.non.admins');
+      if (isAdmin || preferenceValue === undefined) {
+        return true;
+      }
+      return `${preferenceValue}` === 'true';
     }
     return false;
   }
@@ -2214,6 +2216,7 @@ export default class DataStorage extends React.Component {
           dataStorage={this.props.info.value}
           pending={this.props.info.pending}
           policySupported={this.props.info.value.policySupported}
+          versionControlsEnabled={this.versionControlsEnabled}
           onDelete={this.deleteStorage}
           onCancel={this.closeEditDialog}
           onSubmit={this.onDataStorageEdit} />

--- a/client/src/components/pipelines/browser/DataStorage.js
+++ b/client/src/components/pipelines/browser/DataStorage.js
@@ -295,12 +295,7 @@ export default class DataStorage extends React.Component {
       info.value.storagePolicy.versioningEnabled
     ) {
       const isAdmin = authenticatedUserInfo.value.admin;
-      const preferenceValue = preferences
-        .getPreferenceValue('storage.policy.backup.visible.non.admins');
-      if (isAdmin || preferenceValue === undefined) {
-        return true;
-      }
-      return `${preferenceValue}` === 'true';
+      return isAdmin || preferences.storagePolicyBackupVisibleNonAdmins;
     }
     return false;
   }

--- a/client/src/components/pipelines/browser/forms/DataStorageEditDialog.js
+++ b/client/src/components/pipelines/browser/forms/DataStorageEditDialog.js
@@ -61,7 +61,12 @@ export class DataStorageEditDialog extends React.Component {
     dataStorage: PropTypes.object,
     addExistingStorageFlag: PropTypes.bool,
     isNfsMount: PropTypes.bool,
-    policySupported: PropTypes.bool
+    policySupported: PropTypes.bool,
+    versionControlsEnabled: PropTypes.bool
+  };
+
+  static defaultProps = {
+    versionControlsEnabled: true
   };
 
   state = {
@@ -483,8 +488,10 @@ export class DataStorageEditDialog extends React.Component {
                     </Col>
                   </Row>
                 }
-                {
-                  !this.isNfsMount && this.props.policySupported && this.currentRegionSupportsPolicy &&
+                {!this.isNfsMount &&
+                this.props.policySupported &&
+                this.currentRegionSupportsPolicy &&
+                this.props.versionControlsEnabled && (
                   <Row>
                     <Col xs={24} sm={6} />
                     <Col xs={24} sm={18}>
@@ -498,24 +505,26 @@ export class DataStorageEditDialog extends React.Component {
                       </Form.Item>
                     </Col>
                   </Row>
-                }
-                {
-                  !this.isNfsMount && this.props.policySupported &&
-                  this.state.versioningEnabled && this.currentRegionSupportsPolicy &&
-                    <Form.Item
-                      className={styles.dataStorageFormItem}
-                      {...this.formItemLayout}
-                      label="Backup duration">
-                      {getFieldDecorator('backupDuration', {
-                        initialValue: this.props.dataStorage && this.props.dataStorage.storagePolicy
-                          ? this.props.dataStorage.storagePolicy.backupDuration : undefined
-                      })(
-                        <InputNumber
-                          style={{width: '100%'}}
-                          disabled={this.props.pending || isReadOnly} />
-                      )}
-                    </Form.Item>
-                }
+                )}
+                {!this.isNfsMount &&
+                this.props.policySupported &&
+                this.state.versioningEnabled &&
+                this.currentRegionSupportsPolicy &&
+                this.props.versionControlsEnabled && (
+                  <Form.Item
+                    className={styles.dataStorageFormItem}
+                    {...this.formItemLayout}
+                    label="Backup duration">
+                    {getFieldDecorator('backupDuration', {
+                      initialValue: this.props.dataStorage && this.props.dataStorage.storagePolicy
+                        ? this.props.dataStorage.storagePolicy.backupDuration : undefined
+                    })(
+                      <InputNumber
+                        style={{width: '100%'}}
+                        disabled={this.props.pending || isReadOnly} />
+                    )}
+                  </Form.Item>
+                )}
                 {
                   !this.state.mountDisabled && (
                     <Form.Item

--- a/client/src/models/preferences/PreferencesLoad.js
+++ b/client/src/models/preferences/PreferencesLoad.js
@@ -335,6 +335,12 @@ class PreferencesLoad extends Remote {
     return this.getPreferenceValue('system.maintenance.mode.banner');
   }
 
+  @computed
+  get storagePolicyBackupVisibleNonAdmins () {
+    const value = this.getPreferenceValue('storage.policy.backup.visible.non.admins');
+    return value === undefined || `${value}` !== 'false';
+  }
+
   get dataSharingBaseApi () {
     return this.getPreferenceValue('data.sharing.base.api');
   }


### PR DESCRIPTION
DataStorage - Hide version control buttons, such as 'delete', 'restore', 'edit' and 
'Show files versions' checkbox, according to preference and role.