### PR TITLE
Improve build speed by reusing computations from previous builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
         - psql -c "CREATE SCHEMA pipeline; ALTER ROLE postgres IN DATABASE pipeline_test SET search_path TO pipeline;" -U postgres -d pipeline_test
       install: true
       language: java
-      script: ./gradlew :api:test --no-daemon
+      script: ./gradlew :api:test --daemon
       if: tag IS present
   
     - stage: "Build"
@@ -30,7 +30,7 @@ jobs:
       install: true
       language: java
       script: 
-        - ./gradlew -PbuildNumber=${TRAVIS_BUILD_NUMBER}.${TRAVIS_COMMIT} -Pprofile=release client:buildUI --no-daemon
+        - ./gradlew -PbuildNumber=${TRAVIS_BUILD_NUMBER}.${TRAVIS_COMMIT} -Pprofile=release client:buildUI --daemon
         - tar -zcf client.tgz client/build
       after_success:
         - aws s3 mv client.tgz s3://cloud-pipeline-oss-builds/temp/${TRAVIS_BUILD_NUMBER}/
@@ -44,8 +44,8 @@ jobs:
         # But this caused an invalid version set to the second one. See https://github.com/epam/cloud-pipeline/issues/561
         # As a workaround - commands were divided into two calls for now
         # FIXME: this shall be reviewed further to uncover the real causes of such a behavior
-        - ./gradlew -PbuildNumber=${TRAVIS_BUILD_NUMBER}.${TRAVIS_COMMIT} -Pprofile=release pipe-cli:build --no-daemon
-        - ./gradlew -PbuildNumber=${TRAVIS_BUILD_NUMBER}.${TRAVIS_COMMIT} -Pprofile=release pipe-cli:buildLinux --no-daemon
+        - ./gradlew -PbuildNumber=${TRAVIS_BUILD_NUMBER}.${TRAVIS_COMMIT} -Pprofile=release pipe-cli:build --daemon
+        - ./gradlew -PbuildNumber=${TRAVIS_BUILD_NUMBER}.${TRAVIS_COMMIT} -Pprofile=release pipe-cli:buildLinux --daemon
         - tar -zcf cli-linux.tgz pipe-cli/dist
       after_success:
         - aws s3 mv cli-linux.tgz s3://cloud-pipeline-oss-builds/temp/${TRAVIS_BUILD_NUMBER}/
@@ -56,7 +56,7 @@ jobs:
       install: true
       language: java
       script:
-        - _BUILD_DOCKER_IMAGE="${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:python2.7-centos6" ./gradlew -PbuildNumber=${TRAVIS_BUILD_NUMBER}.${TRAVIS_COMMIT} -Pprofile=release pipe-cli:buildLinux --no-daemon
+        - _BUILD_DOCKER_IMAGE="${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:python2.7-centos6" ./gradlew -PbuildNumber=${TRAVIS_BUILD_NUMBER}.${TRAVIS_COMMIT} -Pprofile=release pipe-cli:buildLinux --daemon
         - tar -zcf cli-linux-el6.tgz pipe-cli/dist
       after_success:
         - aws s3 mv cli-linux-el6.tgz s3://cloud-pipeline-oss-builds/temp/${TRAVIS_BUILD_NUMBER}/
@@ -66,7 +66,7 @@ jobs:
       install: true
       language: java
       script:
-        - ./gradlew -PbuildNumber=${TRAVIS_BUILD_NUMBER}.${TRAVIS_COMMIT} -Pprofile=release pipe-cli:buildWin --no-daemon
+        - ./gradlew -PbuildNumber=${TRAVIS_BUILD_NUMBER}.${TRAVIS_COMMIT} -Pprofile=release pipe-cli:buildWin --daemon
         - tar -zcf cli-win.tgz pipe-cli/dist
       after_success:
         - aws s3 mv cli-win.tgz s3://cloud-pipeline-oss-builds/temp/${TRAVIS_BUILD_NUMBER}/
@@ -76,7 +76,7 @@ jobs:
       install: true
       language: java
       script:
-        - ./gradlew -PbuildNumber=${TRAVIS_BUILD_NUMBER}.${TRAVIS_COMMIT} -Pprofile=release fs-browser:build --no-daemon
+        - ./gradlew -PbuildNumber=${TRAVIS_BUILD_NUMBER}.${TRAVIS_COMMIT} -Pprofile=release fs-browser:build --daemon
       after_success:
         - aws s3 mv fs-browser/dist/fsbrowser-*.tar.gz s3://cloud-pipeline-oss-builds/temp/${TRAVIS_BUILD_NUMBER}/
 
@@ -85,7 +85,7 @@ jobs:
       install: true
       language: java
       script:
-        - ./gradlew -PbuildNumber=${TRAVIS_BUILD_NUMBER}.${TRAVIS_COMMIT} -Pprofile=release cloud-pipeline-webdav-client:buildLinux --no-daemon
+        - ./gradlew -PbuildNumber=${TRAVIS_BUILD_NUMBER}.${TRAVIS_COMMIT} -Pprofile=release cloud-pipeline-webdav-client:buildLinux --daemon
       after_success:
         - aws s3 mv cloud-pipeline-webdav-client/out/cloud-data-linux.tar.gz s3://cloud-pipeline-oss-builds/temp/${TRAVIS_BUILD_NUMBER}/
 
@@ -94,7 +94,7 @@ jobs:
       install: true
       language: java
       script:
-        - ./gradlew -PbuildNumber=${TRAVIS_BUILD_NUMBER}.${TRAVIS_COMMIT} -Pprofile=release cloud-pipeline-webdav-client:buildWin --no-daemon
+        - ./gradlew -PbuildNumber=${TRAVIS_BUILD_NUMBER}.${TRAVIS_COMMIT} -Pprofile=release cloud-pipeline-webdav-client:buildWin --daemon
       after_success:
         - aws s3 mv cloud-pipeline-webdav-client/out/cloud-data-win64.zip s3://cloud-pipeline-oss-builds/temp/${TRAVIS_BUILD_NUMBER}/
 

--- a/deploy/appveyor/appveyor_build_macos.sh
+++ b/deploy/appveyor/appveyor_build_macos.sh
@@ -20,7 +20,7 @@ source ~/venv2.7.18/bin/activate
 ./gradlew -PbuildNumber=${APPVEYOR_BUILD_NUMBER}.${APPVEYOR_REPO_COMMIT} \
           -Pprofile=release \
           pipe-cli:buildMac \
-          --no-daemon \
+          --daemon \
           -x :pipe-cli:test
 
 deactivate

--- a/deploy/appveyor/appveyor_pack_dist.sh
+++ b/deploy/appveyor/appveyor_pack_dist.sh
@@ -29,7 +29,7 @@ tar -zxf $_OSX_CLI_PATH/$_OSX_CLI_TAR_NAME -C $_OSX_CLI_PATH
 mv $_OSX_CLI_PATH/dist/dist-file/pipe-osx ${API_STATIC_PATH}/pipe-osx
 mv $_OSX_CLI_PATH/dist/dist-folder/pipe-osx.tar.gz ${API_STATIC_PATH}/pipe-osx.tar.gz
 
-_BUILD_DOCKER_IMAGE="${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:python2.7-centos6" ./gradlew -PbuildNumber=${APPVEYOR_BUILD_NUMBER}.${APPVEYOR_REPO_COMMIT} -Pprofile=release pipe-cli:buildLinux --no-daemon -x :pipe-cli:test
+_BUILD_DOCKER_IMAGE="${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:python2.7-centos6" ./gradlew -PbuildNumber=${APPVEYOR_BUILD_NUMBER}.${APPVEYOR_REPO_COMMIT} -Pprofile=release pipe-cli:buildLinux --daemon -x :pipe-cli:test
 mv pipe-cli/dist/dist-file/pipe ${API_STATIC_PATH}/pipe-el6
 mv pipe-cli/dist/dist-folder/pipe.tar.gz ${API_STATIC_PATH}/pipe-el6.tar.gz
 
@@ -37,7 +37,7 @@ mv pipe-cli/dist/dist-folder/pipe.tar.gz ${API_STATIC_PATH}/pipe-el6.tar.gz
                     -Pprofile=release \
                     -x test \
                     -Pfast \
-                    --no-daemon
+                    --daemon
 
 if [ "$APPVEYOR_REPO_NAME" == "epam/cloud-pipeline" ]; then
     DIST_TGZ_NAME=$(echo build/install/dist/cloud-pipeline*)

--- a/deploy/travis/travis_pack_dist.sh
+++ b/deploy/travis/travis_pack_dist.sh
@@ -64,7 +64,7 @@ cd ..
 ./gradlew api:checkstyleMain \
           api:pmdMain \
           api:checkstyleTest \
-          api:pmdTest --no-daemon
+          api:pmdTest --daemon
 
 # Create distribution tgz
 ./gradlew distTar   -PbuildNumber=${TRAVIS_BUILD_NUMBER}.${TRAVIS_COMMIT} \
@@ -78,7 +78,7 @@ cd ..
                     -x cloud-pipeline-webdav-client:buildLinux \
                     -x cloud-pipeline-webdav-client:buildWin \
                     -Pfast \
-                    --no-daemon
+                    --daemon
 
 if [ "$TRAVIS_REPO_SLUG" == "epam/cloud-pipeline" ]; then
     DIST_TGZ_NAME=$(echo build/install/dist/cloud-pipeline*)

--- a/deploy/travis/travis_publish_docs.sh
+++ b/deploy/travis/travis_publish_docs.sh
@@ -26,7 +26,7 @@ fi
 
 # Build docs - it will produce a tar.gz file in ./dist/
 echo "Building docs"
-./gradlew -PbuildNumber=${TRAVIS_BUILD_NUMBER}.${TRAVIS_COMMIT} -Pprofile=release buildDoc --no-daemon
+./gradlew -PbuildNumber=${TRAVIS_BUILD_NUMBER}.${TRAVIS_COMMIT} -Pprofile=release buildDoc --daemon
 mkdir -p $HOME/cloud-pipeline-docs
 tar -zxf dist/cloud-pipeline-docs.tar.gz -C $HOME/cloud-pipeline-docs
 


### PR DESCRIPTION

[Gradle daemon](https://docs.gradle.org/current/userguide/gradle_daemon.html#header). The Daemon is a long-lived process that help to avoid the cost of JVM startup for every build. Since Gradle 3.0, Gradle daemon is enabled by default. For an older version, you should enable it by setting `org.gradle.daemon=true`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
