### PR TITLE
Improve multiple SGE queues autoscaling

### DIFF
--- a/scripts/pipeline-launch/launch.sh
+++ b/scripts/pipeline-launch/launch.sh
@@ -145,6 +145,24 @@ function setup_nfs_if_required {
 
 }
 
+function check_cp_cap {
+      _CAP="$1"
+      if [ -z "$_CAP" ]; then
+            return 1
+      fi
+
+      _CAP_VALUE=${!_CAP}
+      if [ -z "$_CAP_VALUE" ]; then
+            return 1
+      fi
+
+      if [ ${_CAP_VALUE,,} == 'true' ] || [ ${_CAP_VALUE,,} == 'yes' ]; then
+            return 0
+      else
+            return 1
+      fi
+}
+
 function cp_cap_publish {
       if [ -z "$cluster_role" ]; then
             return 0

--- a/workflows/pipe-common/scripts/generate_sge_profiles.py
+++ b/workflows/pipe-common/scripts/generate_sge_profiles.py
@@ -33,7 +33,8 @@ def generate_sge_profiles():
         profile['CP_CAP_SGE_QUEUE_NAME'] = unique_profile_queues[profile_indexes.index(profile_index)]
         profile['CP_CAP_SGE_HOSTLIST_NAME'] = '@{}'.format(profile['CP_CAP_SGE_QUEUE_NAME'])
 
-    common_profile['CP_CAP_SGE_STATIC'] = 'true'
+    common_profile['CP_CAP_SGE_QUEUE_STATIC'] = 'true'
+    common_profile['CP_CAP_SGE_QUEUE_DEFAULT'] = 'true'
     common_profile['CP_CAP_AUTOSCALE_TASK'] = 'GridEngineAutoscaling'
 
     logging.info('Generating sge profile scripts...')

--- a/workflows/pipe-common/shell/sge_setup_queue
+++ b/workflows/pipe-common/shell/sge_setup_queue
@@ -141,7 +141,7 @@ check_last_exit_code $? "Master host was added to $CP_CAP_SGE_HOSTLIST_NAME host
                         "Fail to add master host to $CP_CAP_SGE_HOSTLIST_NAME hostlist"
 
 # If CP_CAP_SGE_MASTER_CORES is set to "0" - we'll not use master as a worker
-if [ "$CP_CAP_SGE_MASTER_CORES" == "0" ] || ! check_cp_cap "CP_CAP_SGE_STATIC"; then
+if [ "$CP_CAP_SGE_MASTER_CORES" == "0" ] || ! check_cp_cap "CP_CAP_SGE_QUEUE_STATIC"; then
   disable_worker_in_queue "$CP_CAP_SGE_QUEUE_NAME"
   pipe_log_info "CP_CAP_SGE_MASTER_CORES is set to 0. Master host was disabled in $CP_CAP_SGE_QUEUE_NAME queue" "$SGE_MASTER_SETUP_TASK"
 else

--- a/workflows/pipe-common/shell/sge_setup_worker
+++ b/workflows/pipe-common/shell/sge_setup_worker
@@ -73,6 +73,14 @@ add_worker() {
     fi
 }
 
+remove_worker() {
+    local _QUEUE=$1
+    local _HOSTLIST=$2
+
+    qconf -purge queue slots "$_QUEUE@$HOSTNAME"
+    qconf -dattr hostgroup hostlist "$HOSTNAME" "$_HOSTLIST"
+}
+
 run_redhat_installation() {
     _SGE_ROLE=$1
 
@@ -252,8 +260,8 @@ _WORKER_CORES=$(($_WORKER_CORES - $CP_CAP_SGE_WORKER_FREE_CORES))
 if ! check_cp_cap CP_CAP_SGE_DISABLE_DEFAULT_QUEUE \
   || [[ "$cluster_role_type" == "additional" ]]; then
     add_worker "$CP_CAP_SGE_QUEUE_NAME" "$CP_CAP_SGE_HOSTLIST_NAME" "$_WORKER_CORES" $MASTER_NAME
-    check_last_exit_code $? "Host was added as a worker to $CP_CAP_SGE_QUEUE_NAME queue and $CP_CAP_SGE_HOSTLIST_NAME hostlist" \
-                            "Fail to add host as worker to $CP_CAP_SGE_QUEUE_NAME queue and $CP_CAP_SGE_HOSTLIST_NAME hostlist"
+    check_last_exit_code $? "Host was added to $CP_CAP_SGE_QUEUE_NAME queue and $CP_CAP_SGE_HOSTLIST_NAME hostlist" \
+                            "Fail to add host to $CP_CAP_SGE_QUEUE_NAME queue and $CP_CAP_SGE_HOSTLIST_NAME hostlist"
 fi
 
 export _CP_CAP_SGE_DEFAULT_QUEUE_NAME="$CP_CAP_SGE_QUEUE_NAME"
@@ -263,13 +271,20 @@ for sge_profile_script in $CP_CAP_SCRIPTS_DIR/sge_profile_*.sh; do
     (
         # shellcheck source=/dev/null
         [[ -e "$sge_profile_script" ]] && source "$sge_profile_script"
-        if check_cp_cap "CP_CAP_SGE_STATIC" \
+        if check_cp_cap "CP_CAP_SGE_QUEUE_STATIC" \
           && [[ "$cluster_role_type" != "additional" ]] \
           && [[ "$CP_CAP_SGE_QUEUE_NAME" != "$_CP_CAP_SGE_DEFAULT_QUEUE_NAME" ]] \
           && [[ "$CP_CAP_SGE_HOSTLIST_NAME" != "$_CP_CAP_SGE_DEFAULT_HOSTLIST_NAME" ]]; then
             add_worker "$CP_CAP_SGE_QUEUE_NAME" "$CP_CAP_SGE_HOSTLIST_NAME" "$_WORKER_CORES" $MASTER_NAME
-            check_last_exit_code $? "Host was added as a worker to $CP_CAP_SGE_QUEUE_NAME queue and $CP_CAP_SGE_HOSTLIST_NAME hostlist" \
-                                    "Fail to add host as worker to $CP_CAP_SGE_QUEUE_NAME queue and $CP_CAP_SGE_HOSTLIST_NAME hostlist"
+            check_last_exit_code $? "Host was added to $CP_CAP_SGE_QUEUE_NAME queue and $CP_CAP_SGE_HOSTLIST_NAME hostlist" \
+                                    "Fail to add host to $CP_CAP_SGE_QUEUE_NAME queue and $CP_CAP_SGE_HOSTLIST_NAME hostlist"
+        fi
+        if [[ "$cluster_role_type" == "additional" ]] \
+          && [[ "$CP_CAP_SGE_QUEUE_NAME" != "$_CP_CAP_SGE_DEFAULT_QUEUE_NAME" ]] \
+          && [[ "$CP_CAP_SGE_HOSTLIST_NAME" != "$_CP_CAP_SGE_DEFAULT_HOSTLIST_NAME" ]]; then
+            remove_worker "$CP_CAP_SGE_QUEUE_NAME" "$CP_CAP_SGE_HOSTLIST_NAME"
+            check_last_exit_code $? "Host was removed from $CP_CAP_SGE_QUEUE_NAME queue and $CP_CAP_SGE_HOSTLIST_NAME hostlist" \
+                                    "Fail to remove host from $CP_CAP_SGE_QUEUE_NAME queue and $CP_CAP_SGE_HOSTLIST_NAME hostlist"
         fi
     )
 done


### PR DESCRIPTION
Improves changes introduced in #1622, depends on #1623 and relates to #1521.

The pull request resolves the following issues introduced in #1622:
- Missing `check_cp_cap` function in `launch.sh` script.
- Excessive additional hosts registration in `@allhosts` grid engine host group.
- Extra additional hosts scaling in case a grid engine job is submitted without an explicitly specified queue.

See #1622 to find out more about multiple SGE queues autoscaling.
