### PR TITLE
Issue #2552 Implement core FS monitoring

### DIFF
--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/config/Constants.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/config/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ public final class Constants {
     public static final String X509_END_CERTIFICATE = "-----END CERTIFICATE-----";
     public static final String MODEL_PARAMETERS_FILE_NAME = "src/model_parameters.json";
     public static final String HTTP_AUTH_COOKIE = "HttpAuthorization";
+    public static final double HUNDRED_PERCENTS = 100.0;
 
     public static final String FIRECLOUD_TOKEN_HEADER = "Firecloud-Token";
 

--- a/deploy/contents/k8s/cp-vm-monitor/cp-vm-monitor-dpl.yaml
+++ b/deploy/contents/k8s/cp-vm-monitor/cp-vm-monitor-dpl.yaml
@@ -56,6 +56,9 @@ spec:
             - mountPath: /opt/common/pki
               name: common-pki
               readOnly: true
+            - mountPath: /opt/cp-core-fs
+              name: cp-core-fs
+              readOnly: true
             - name: cp-cloud-credentials
               mountPath: "/root/.cloud"
               readOnly: true
@@ -105,5 +108,8 @@ spec:
         - name: kube-pki
           hostPath:
             path: /etc/kubernetes/pki
+        - name: cp-core-fs
+          hostPath:
+            path: /opt
       imagePullSecrets:
         - name: cp-distr-docker-registry-secret

--- a/deploy/contents/k8s/cp-vm-monitor/cp-vm-monitor-dpl.yaml
+++ b/deploy/contents/k8s/cp-vm-monitor/cp-vm-monitor-dpl.yaml
@@ -56,7 +56,7 @@ spec:
             - mountPath: /opt/common/pki
               name: common-pki
               readOnly: true
-            - mountPath: /opt/cp-core-fs
+            - mountPath: /fs/core-fs
               name: cp-core-fs
               readOnly: true
             - name: cp-cloud-credentials

--- a/deploy/docker/cp-vm-monitor/config/application.properties
+++ b/deploy/docker/cp-vm-monitor/config/application.properties
@@ -24,6 +24,10 @@ monitor.k8s.deployment.default.namespace=${CP_VM_MONITOR_DEPLOY_NAMESPACE:defaul
 monitor.k8s.deployment.names=${CP_VM_MONITOR_DEPLOY_NAMES:cp-api-db,cp-api-srv,cp-notifier,cp-git,cp-git-sync,cp-edge,cp-docker-registry,\
   cp-docker-comp,cp-clair,cp-search-elk,cp-search-srv,cp-heapster-elk,cp-heapster,cp-share-srv,cp-dav}
 
+# File system monitor
+monitor.filesystem.cron=${CP_VM_MONITOR_FILESYSTEM_MONITORING_CRON:0 * * ? * *}
+monitor.filesystem.scan.configuration=${CP_VM_MONITOR_FILESYSTEM_CONFIGURATION: {'/opt/cp-core-fs':80}}
+
 #Notification settings
 notification.subject.prefix=${CP_VM_MONITOR_SUBJECT_PREFIX:}
 notification.missing-node.subject=[$templateParameters["fullPlatformName"]] VMs are not registered in cluster
@@ -40,6 +44,9 @@ notification.missing-deploy.template=${CP_VM_MONITOR_TEMPLATES:classpath:}/templ
 
 notification.not-ready-deploy.subject=[$templateParameters["fullPlatformName"]] k8s deployment is not ready
 notification.not-ready-deploy.template=${CP_VM_MONITOR_TEMPLATES:classpath:}/templates/NOT-READY-DEPLOY.html
+
+notification.filesystem.subject=[$templateParameters["fullPlatformName"]] monitored core file system exceeds threshold
+notification.filesystem.template=${CP_VM_MONITOR_TEMPLATES:classpath:}/templates/FILESYSTEM_THRESHOLD.html
 
 notification.to-user=${CP_VM_MONITOR_TO_USER}
 notification.copy-users=${CP_VM_MONITOR_CC_USERS}

--- a/deploy/docker/cp-vm-monitor/config/application.properties
+++ b/deploy/docker/cp-vm-monitor/config/application.properties
@@ -26,7 +26,7 @@ monitor.k8s.deployment.names=${CP_VM_MONITOR_DEPLOY_NAMES:cp-api-db,cp-api-srv,c
 
 # File system monitor
 monitor.filesystem.cron=${CP_VM_MONITOR_FILESYSTEM_MONITORING_CRON:0 * * ? * *}
-monitor.filesystem.scan.configuration=${CP_VM_MONITOR_FILESYSTEM_CONFIGURATION: {'/opt/cp-core-fs':80}}
+monitor.filesystem.scan.configuration=${CP_VM_MONITOR_FILESYSTEM_CONFIGURATION: {'/fs/core-fs':80}}
 
 #Notification settings
 notification.subject.prefix=${CP_VM_MONITOR_SUBJECT_PREFIX:}

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/model/filesystem/FileSystemUsageSummary.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/model/filesystem/FileSystemUsageSummary.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.vmmonitor.model.filesystem;
+
+import com.epam.pipeline.config.Constants;
+import lombok.Getter;
+import org.apache.commons.io.FileUtils;
+
+@Getter
+public class FileSystemUsageSummary {
+
+    private final String path;
+    private final String usedSpace;
+    private final String totalSpace;
+    private final Double consumptionPercentage;
+    private final Double thresholdPercentage;
+
+    public FileSystemUsageSummary(final String path, final Long usedSpaceBytes, final Long totalSpaceBytes,
+                                  final Double threshold) {
+        this.path = path;
+        this.usedSpace = FileUtils.byteCountToDisplaySize(usedSpaceBytes);
+        this.totalSpace = FileUtils.byteCountToDisplaySize(totalSpaceBytes);
+        this.consumptionPercentage = Constants.HUNDRED_PERCENTS * usedSpaceBytes / totalSpaceBytes;
+        this.thresholdPercentage = threshold;
+    }
+
+    public boolean exceedsThreshold() {
+        return consumptionPercentage > thresholdPercentage;
+    }
+}

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/MonitorScheduleService.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/MonitorScheduleService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 package com.epam.pipeline.vmmonitor.service;
 
 import com.epam.pipeline.vmmonitor.service.certificate.CertificateMonitor;
+import com.epam.pipeline.vmmonitor.service.filesystem.FileSystemMonitor;
 import com.epam.pipeline.vmmonitor.service.k8s.KubernetesDeploymentMonitor;
 import com.epam.pipeline.vmmonitor.service.vm.VMMonitor;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +35,7 @@ public class MonitorScheduleService {
     private final VMMonitor vmMonitor;
     private final CertificateMonitor certificateMonitor;
     private final KubernetesDeploymentMonitor deploymentMonitor;
+    private final FileSystemMonitor fileSystemMonitor;
 
     @Scheduled(cron = "${monitor.schedule.cron}")
     public void monitor() {
@@ -68,4 +70,14 @@ public class MonitorScheduleService {
         }
     }
 
+    @Scheduled(cron = "${monitor.filesystem.cron}")
+    public void monitorFileSystem() {
+        try {
+            log.debug("Starting filesystem check.");
+            fileSystemMonitor.checkFileSystemConsumption();
+            log.debug("Finished filesystem check.");
+        } catch (Exception e) {
+            log.error("An error occurred during filesystem check.", e);
+        }
+    }
 }

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/filesystem/FileSystemMonitor.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/filesystem/FileSystemMonitor.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.vmmonitor.service.filesystem;
+
+import com.epam.pipeline.vmmonitor.model.filesystem.FileSystemUsageSummary;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+public class FileSystemMonitor {
+
+    private final FileSystemNotifier notifier;
+    private final Map<String, Double> thresholdMapping;
+
+    @Autowired
+    public FileSystemMonitor(final FileSystemNotifier notifier,
+                             @Value("#{${monitor.filesystem.scan.configuration:{}}}")
+                             final Map<String, Double> thresholdMapping) {
+        this.notifier = notifier;
+        this.thresholdMapping = thresholdMapping;
+    }
+
+    public void checkFileSystemConsumption() {
+        final List<FileSystemUsageSummary> fsPathsExceedingLimits = thresholdMapping.entrySet()
+            .stream()
+            .map(this::mapToFileSystemUsageSummary)
+            .filter(FileSystemUsageSummary::exceedsThreshold)
+            .collect(Collectors.toList());
+        if (CollectionUtils.isNotEmpty(fsPathsExceedingLimits)) {
+            notifier.notifyFilesystemThresholds(fsPathsExceedingLimits);
+        } else {
+            log.debug("None of the target paths exceeds threshold configured.");
+        }
+    }
+
+    private FileSystemUsageSummary mapToFileSystemUsageSummary(final Map.Entry<String, Double> fsMonitoringRule) {
+        final String path = fsMonitoringRule.getKey();
+        final Double percentageThreshold = fsMonitoringRule.getValue();
+        final File fsPath = new File(path);
+        final long totalSpaceBytes = fsPath.getTotalSpace();
+        final long usedSpaceBytes = totalSpaceBytes - fsPath.getFreeSpace();
+        return new FileSystemUsageSummary(path, usedSpaceBytes, totalSpaceBytes, percentageThreshold);
+    }
+}

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/filesystem/FileSystemNotifier.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/filesystem/FileSystemNotifier.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.vmmonitor.service.filesystem;
+
+import com.epam.pipeline.vmmonitor.model.filesystem.FileSystemUsageSummary;
+import com.epam.pipeline.vmmonitor.service.notification.VMNotificationService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@Slf4j
+public class FileSystemNotifier {
+
+    private final VMNotificationService notificationService;
+    private final String fileSystemUsageSubject;
+    private final String fileSystemThresholdSubject;
+
+    @Autowired
+    public FileSystemNotifier(final VMNotificationService notificationService,
+                              final @Value("${notification.filesystem.subject}") String fileSystemUsageSubject,
+                              final @Value("${notification.filesystem.template}") String fileSystemThresholdSubject) {
+        this.notificationService = notificationService;
+        this.fileSystemUsageSubject = fileSystemUsageSubject;
+        this.fileSystemThresholdSubject = fileSystemThresholdSubject;
+    }
+
+    public void notifyFilesystemThresholds(final List<FileSystemUsageSummary> thresholdSummaries) {
+        final Map<String, Object> parameters = Collections.singletonMap("fileSystemUsageSummaries", thresholdSummaries);
+        log.debug("Sending filesystem threshold notification on {} monitored paths", thresholdSummaries.size());
+        notificationService.sendMessage(parameters, fileSystemUsageSubject, fileSystemThresholdSubject);
+    }
+}

--- a/vm-monitor/src/main/resources/application.properties
+++ b/vm-monitor/src/main/resources/application.properties
@@ -27,7 +27,7 @@ monitor.k8s.deployment.names=${CP_VM_MONITOR_DEPLOY_NAMES:cp-api-db,cp-api-srv,c
 
 # File system monitor
 monitor.filesystem.cron=${CP_VM_MONITOR_FILESYSTEM_MONITORING_CRON:0 * * ? * *}
-monitor.filesystem.scan.configuration=${CP_VM_MONITOR_FILESYSTEM_CONFIGURATION: {'/opt/cp-core-fs':80}}
+monitor.filesystem.scan.configuration=${CP_VM_MONITOR_FILESYSTEM_CONFIGURATION: {'/fs/core-fs':80}}
 
 #Notification settings
 notification.missing-node.subject=[$templateParameters["fullPlatformName"]] VMs are not registered in cluster

--- a/vm-monitor/src/main/resources/application.properties
+++ b/vm-monitor/src/main/resources/application.properties
@@ -25,6 +25,10 @@ monitor.k8s.deployment.default.namespace=default
 monitor.k8s.deployment.names=${CP_VM_MONITOR_DEPLOY_NAMES:cp-api-db,cp-api-srv,cp-notifier,cp-git,cp-git-sync,cp-edge,cp-docker-registry,\
   cp-docker-comp,cp-clair,cp-search-elk,cp-search-srv,cp-heapster-elk,cp-heapster,cp-share-srv,cp-dav}
 
+# File system monitor
+monitor.filesystem.cron=${CP_VM_MONITOR_FILESYSTEM_MONITORING_CRON:0 * * ? * *}
+monitor.filesystem.scan.configuration=${CP_VM_MONITOR_FILESYSTEM_CONFIGURATION: {'/opt/cp-core-fs':80}}
+
 #Notification settings
 notification.missing-node.subject=[$templateParameters["fullPlatformName"]] VMs are not registered in cluster
 notification.missing-node.template=${CP_VM_MONITOR_TEMPLATES:classpath:}/templates/MISSING-NODE.html
@@ -40,6 +44,9 @@ notification.missing-deploy.template=${CP_VM_MONITOR_TEMPLATES:classpath:}/templ
 
 notification.not-ready-deploy.subject=[$templateParameters["fullPlatformName"]] k8s deployment is not ready
 notification.not-ready-deploy.template=${CP_VM_MONITOR_TEMPLATES:classpath:}/templates/NOT-READY-DEPLOY.html
+
+notification.filesystem.subject=[$templateParameters["fullPlatformName"]] monitored core file system exceeds threshold
+notification.filesystem.template=${CP_VM_MONITOR_TEMPLATES:classpath:}/templates/FILESYSTEM_THRESHOLD.html
 
 notification.to-user=TEST
 notification.copy-users=TEST,TEST

--- a/vm-monitor/src/main/resources/templates/FILESYSTEM_THRESHOLD.html
+++ b/vm-monitor/src/main/resources/templates/FILESYSTEM_THRESHOLD.html
@@ -1,0 +1,62 @@
+<!--
+  ~ Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <style>
+        table,
+        td {
+            border: 1px solid black;
+            border-collapse: collapse;
+            padding: 5px;
+        }
+    </style>
+</head>
+
+<body>
+<p>Dear user,</p>
+<p>*** This is a system generated email, do not reply to this email ***</p>
+<p>Looks like $templateParameters["deployment"] deployment in $templateParameters["fullPlatformName"] cluster reached some filesystem thresholds.</p>
+<p>
+<table>
+    <tr>
+        <td><b>FS path</b></td>
+        <td><b>Total space</b></td>
+        <td><b>Used space</b></td>
+        <td><b>Space consumption(%)</b></td>
+        <td><b>Threshold (%)</b></td>
+    </tr>
+    #foreach( $summary in $templateParameters["fileSystemUsageSummaries"] )
+    <tr>
+        <td>$summary.path</td>
+        <td>$summary.totalSpace</td>
+        <td>$summary.usedSpace</td>
+        <td>$summary.consumptionPercentage</td>
+        <td>$summary.thresholdPercentage</td>
+    </tr>
+    #end
+</table>
+</p>
+<p>Please verify filesystem state to avoid global platform outage.</p>
+<p>Best regards,</p>
+<p>$templateParameters["fullPlatformName"] Platform</p>
+</body>
+
+</html>


### PR DESCRIPTION
This PR is related to issue #2552

It extends `vm-monitor` service, allowing scanning of the core file system.