### PR TITLE
Add pipe cli run as e2e test cases

### DIFF
--- a/docs/testcases/UI/Pipe_CLI/1948_launch_run_as_different_user/1948_1_check_pipe_cli_admin_run_as_user.md
+++ b/docs/testcases/UI/Pipe_CLI/1948_launch_run_as_different_user/1948_1_check_pipe_cli_admin_run_as_user.md
@@ -1,0 +1,20 @@
+# Check Pipe CLI Admin Run As User
+
+Test verifies that an admin can launch a run as a different user using pipe CLI.
+
+**Prerequisites**:
+- Admin user
+- Regular user
+
+| Steps | Actions                                                                                              | Expected results |
+|:-----:|------------------------------------------------------------------------------------------------------| -- |
+|   1   | Login as the admin user from the prerequisites                                                       | |
+|   2   | Open the Tools page                                                                                  | |
+|   3   | Select any tool                                                                                      | |
+|   4   | Run tool with *Custom settings*                                                                      | |
+|   5   | At the Runs page, click the just-launched run                                                        | |
+|   6   | Wait until the SSH hyperlink appears                                                                 | |
+|   7   | Click the SSH hyperlink                                                                              | |
+|   8   | In the opened tab, enter and perform the `pipe run -di library/centos:latest -u <REGULAR USER> -y`   | |
+|   9   | Open the Runs page                                                                                   | |
+|  10   | Click the just-launched run                                                                          | The owner of the run is USER3. The run does not have ORIGINAL_OWNER parameter specified. |

--- a/docs/testcases/UI/Pipe_CLI/1948_launch_run_as_different_user/1948_1_check_pipe_cli_admin_run_as_user.md
+++ b/docs/testcases/UI/Pipe_CLI/1948_launch_run_as_different_user/1948_1_check_pipe_cli_admin_run_as_user.md
@@ -11,14 +11,14 @@ Test verifies that an admin can launch a run as a different user using pipe CLI.
 | 1 | Login as the admin user from the prerequisites | |
 | 2 | Open the **Tools** page | |
 | 3 | Select test tool | |
-| 4 | Run tool with *Custom settings* | |
+| 4 | Run tool with *Default settings* | |
 | 5 | At the Runs page, click the just-launched run | |
 | 6 | Wait until the **SSH** hyperlink appears | |
 | 7 | Click the **SSH** hyperlink | |
-| 8 | In the opened tab, enter and perform the `pipe run -di <tool>:latest -u <REGULAR USER> -y` command, where `<tool>` is any tool name with group, `<REGULAR USER>` is the Regular user from the Prerequisites | The output contains `Pipeline run scheduled with RunId: <runID>` |
+| 8 | In the opened tab, enter and perform the `pipe run -di <tool>:latest -u <REGULAR USER> -y` command, where `<tool>` is name of any tool that shall be accessible for the `<REGULAR USER>` for the running, `<REGULAR USER>` is the Regular user from the Prerequisites | The output contains `Pipeline run scheduled with RunId: <runID>` |
 | 9 | Store `runID` from output | | 
 | 10 | Open the **Runs** page | |
-| 11 | Click the run with *ID* stored at step 9 | <li> The owner of the run is USER3. <li> The run does not have *ORIGINAL_OWNER* parameter specified. |
+| 11 | Click the run with *ID* stored at step 9 | <li> The owner of the run is `<REGULAR USER>`, where `<REGULAR USER>` is the regular user from the Prerequisites. <li> The run does not have *ORIGINAL_OWNER* parameter specified. |
 
 **After:**
 - Stop the runs launched at steps 4 and 8

--- a/docs/testcases/UI/Pipe_CLI/1948_launch_run_as_different_user/1948_1_check_pipe_cli_admin_run_as_user.md
+++ b/docs/testcases/UI/Pipe_CLI/1948_launch_run_as_different_user/1948_1_check_pipe_cli_admin_run_as_user.md
@@ -6,15 +6,19 @@ Test verifies that an admin can launch a run as a different user using pipe CLI.
 - Admin user
 - Regular user
 
-| Steps | Actions                                                                                              | Expected results |
-|:-----:|------------------------------------------------------------------------------------------------------| -- |
-|   1   | Login as the admin user from the prerequisites                                                       | |
-|   2   | Open the Tools page                                                                                  | |
-|   3   | Select any tool                                                                                      | |
-|   4   | Run tool with *Custom settings*                                                                      | |
-|   5   | At the Runs page, click the just-launched run                                                        | |
-|   6   | Wait until the SSH hyperlink appears                                                                 | |
-|   7   | Click the SSH hyperlink                                                                              | |
-|   8   | In the opened tab, enter and perform the `pipe run -di library/centos:latest -u <REGULAR USER> -y`   | |
-|   9   | Open the Runs page                                                                                   | |
-|  10   | Click the just-launched run                                                                          | The owner of the run is USER3. The run does not have ORIGINAL_OWNER parameter specified. |
+| Steps | Actions | Expected results |
+| :---: | --- | --- |
+| 1 | Login as the admin user from the prerequisites | |
+| 2 | Open the **Tools** page | |
+| 3 | Select test tool | |
+| 4 | Run tool with *Custom settings* | |
+| 5 | At the Runs page, click the just-launched run | |
+| 6 | Wait until the **SSH** hyperlink appears | |
+| 7 | Click the **SSH** hyperlink | |
+| 8 | In the opened tab, enter and perform the `pipe run -di <tool>:latest -u <REGULAR USER> -y` command, where `<tool>` is any tool name with group, `<REGULAR USER>` is the Regular user from the Prerequisites | The output contains `Pipeline run scheduled with RunId: <runID>` |
+| 9 | Store `runID` from output | | 
+| 10 | Open the **Runs** page | |
+| 11 | Click the run with *ID* stored at step 9 | <li> The owner of the run is USER3. <li> The run does not have *ORIGINAL_OWNER* parameter specified. |
+
+**After:**
+- Stop the runs launched at steps 4 and 8

--- a/docs/testcases/UI/Pipe_CLI/1948_launch_run_as_different_user/1948_2_check_pipe_cli_user_run_as_user.md
+++ b/docs/testcases/UI/Pipe_CLI/1948_launch_run_as_different_user/1948_2_check_pipe_cli_user_run_as_user.md
@@ -20,11 +20,11 @@ Test verifies that a user with sufficient permissions can launch a run as a diff
 | 10 | Login as the regular user from the prerequisites | |
 | 11 | Open the **Tools** page | |
 | 12 | Select test tool | |
-| 13 | Run tool with *Custom settings* | |
+| 13 | Run tool with *Default settings* | |
 | 14 | At the **Runs** page, click the just-launched run | |
 | 15 | Wait until the **SSH** hyperlink appears | |
 | 16 | Click the **SSH** hyperlink | |
-| 17 | In the opened tab, enter and perform the `pipe run -di <tool>:latest -u <ADMIN_USER> -y` command, where `<tool>` is any tool name with group, `<ADMIN_USER>` is the admin user from the Prerequisites | The output contains `Pipeline run scheduled with RunId: <runID>` |
+| 17 | In the opened tab, enter and perform the `pipe run -di <tool>:latest -u <ADMIN_USER> -y` command, where `<tool>` is name of any tool that shall be accessible for the `<REGULAR USER>` for the running, `<ADMIN_USER>` is the admin user from the Prerequisites | The output contains `Pipeline run scheduled with RunId: <runID>` |
 | 18 | Store `runID` from output | | 
 | 19 | Logout | |
 | 20 | Login as the admin user from the prerequisites | |

--- a/docs/testcases/UI/Pipe_CLI/1948_launch_run_as_different_user/1948_2_check_pipe_cli_user_run_as_user.md
+++ b/docs/testcases/UI/Pipe_CLI/1948_launch_run_as_different_user/1948_2_check_pipe_cli_user_run_as_user.md
@@ -1,0 +1,26 @@
+# Check Pipe CLI User Run As User
+
+Test verifies that a user with sufficient permissions can launch a run as a different user using pipe CLI.
+
+**Prerequisites**:
+- Admin user
+- Regular user
+
+| Steps | Actions                                                                                            | Expected results |
+|:-----:|----------------------------------------------------------------------------------------------------| -- |
+|   1   | Login as the admin user from the prerequisites                                                     | |
+|   2   | Open the Settings page                                                                             | |
+|   3   | Open the User Management tab                                                                       | |
+|   4   | Find the regular user from the prerequisites and open their settings                               | |
+|   5   | Add the regular user to the list of users who can run as the admin user                            | |
+|   6   | Save changes                                                                                       | |
+|   7   | Login as the regular user from the prerequisites                                                   | |
+|   8   | Open the Tools page                                                                                | |
+|   9   | Select any tool                                                                                    | |
+|  10   | Run tool with *Custom settings*                                                                    | |
+|  11   | At the Runs page, click the just-launched run                                                      | |
+|  12   | Wait until the SSH hyperlink appears                                                               | |
+|  13   | Click the SSH hyperlink                                                                            | |
+|  14   | In the opened tab, enter and perform the `pipe run -di library/centos:latest -u <ADMIN USER> -y`   | |
+|  15   | Open the Runs page                                                                                 | |
+|  16   | Click the just-launched run                                                                        | The owner of the run is the admin user. The run has ORIGINAL_OWNER parameter set to the regular user. |

--- a/docs/testcases/UI/Pipe_CLI/1948_launch_run_as_different_user/1948_2_check_pipe_cli_user_run_as_user.md
+++ b/docs/testcases/UI/Pipe_CLI/1948_launch_run_as_different_user/1948_2_check_pipe_cli_user_run_as_user.md
@@ -6,21 +6,31 @@ Test verifies that a user with sufficient permissions can launch a run as a diff
 - Admin user
 - Regular user
 
-| Steps | Actions                                                                                            | Expected results |
-|:-----:|----------------------------------------------------------------------------------------------------| -- |
-|   1   | Login as the admin user from the prerequisites                                                     | |
-|   2   | Open the Settings page                                                                             | |
-|   3   | Open the User Management tab                                                                       | |
-|   4   | Find the regular user from the prerequisites and open their settings                               | |
-|   5   | Add the regular user to the list of users who can run as the admin user                            | |
-|   6   | Save changes                                                                                       | |
-|   7   | Login as the regular user from the prerequisites                                                   | |
-|   8   | Open the Tools page                                                                                | |
-|   9   | Select any tool                                                                                    | |
-|  10   | Run tool with *Custom settings*                                                                    | |
-|  11   | At the Runs page, click the just-launched run                                                      | |
-|  12   | Wait until the SSH hyperlink appears                                                               | |
-|  13   | Click the SSH hyperlink                                                                            | |
-|  14   | In the opened tab, enter and perform the `pipe run -di library/centos:latest -u <ADMIN USER> -y`   | |
-|  15   | Open the Runs page                                                                                 | |
-|  16   | Click the just-launched run                                                                        | The owner of the run is the admin user. The run has ORIGINAL_OWNER parameter set to the regular user. |
+| Steps | Actions | Expected results |
+| :---: | --- | --- |
+| 1 | Login as the admin user from the prerequisites | |
+| 2 | Open the **Settings** page | |
+| 3 | Open the **User Management** tab | |
+| 4 | Find the admin user from the prerequisites and open their settings | |
+| 5 | Click the configure button next to the ***Can run as this user:***  | |
+| 6 | Click *Add user* button | |
+| 7 | Specify the regular user from the prerequisites. Click **OK** button | |
+| 8 | Click **OK** button | |
+| 9 | Logout | |
+| 10 | Login as the regular user from the prerequisites | |
+| 11 | Open the **Tools** page | |
+| 12 | Select test tool | |
+| 13 | Run tool with *Custom settings* | |
+| 14 | At the **Runs** page, click the just-launched run | |
+| 15 | Wait until the **SSH** hyperlink appears | |
+| 16 | Click the **SSH** hyperlink | |
+| 17 | In the opened tab, enter and perform the `pipe run -di <tool>:latest -u <ADMIN_USER> -y` command, where `<tool>` is any tool name with group, `<ADMIN_USER>` is the admin user from the Prerequisites | The output contains `Pipeline run scheduled with RunId: <runID>` |
+| 18 | Store `runID` from output | | 
+| 19 | Logout | |
+| 20 | Login as the admin user from the prerequisites | |
+| 21 | Open the **Runs** page | |
+| 22 | Click the run with *ID* stored at step 18 | <li> The *Owner* of the run is the admin user from the Prerequisites. <li> The run has ORIGINAL_OWNER parameter set to the regular user from the Prerequisites. |
+
+**After:**
+- Stop the runs launched at steps 13 and 17
+- Remove regular user from the prerequisites from the the ***Can run as this user:*** for admin user from the prerequisites

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/PipeCLITest.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/PipeCLITest.java
@@ -15,9 +15,13 @@
  */
 package com.epam.pipeline.autotests;
 
+import com.epam.pipeline.autotests.ao.ToolTab;
+import com.epam.pipeline.autotests.mixins.Authorization;
+import com.epam.pipeline.autotests.mixins.Navigation;
 import com.epam.pipeline.autotests.utils.C;
 import com.epam.pipeline.autotests.utils.TestCase;
 import com.epam.pipeline.autotests.utils.Utils;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -25,14 +29,34 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
 
+import static com.codeborne.selenide.Condition.exist;
+import static com.epam.pipeline.autotests.ao.LogAO.configurationParameter;
+import static com.epam.pipeline.autotests.ao.Primitive.PARAMETERS;
+import static com.epam.pipeline.autotests.utils.Utils.nameWithoutGroup;
 import static java.lang.String.format;
 import static org.testng.Assert.assertTrue;
 
-public class PipeCLITest extends AbstractAutoRemovingPipelineRunningTest {
+public class PipeCLITest extends AbstractSeveralPipelineRunningTest
+        implements Navigation, Authorization {
 
+    private static final String command = "pipe run -di %s:latest -u %s -y";
+    private static final String result = "Pipeline run scheduled with RunId: ";
+    private static final String ORIGINAL_OWNER = "ORIGINAL_OWNER";
     private final String registry = C.DEFAULT_REGISTRY;
     private final String group = C.DEFAULT_GROUP;
     private final String tool = C.TESTING_TOOL_NAME;
+
+    @AfterClass(alwaysRun = true)
+    public void resetPreference() {
+        navigationMenu()
+                .settings()
+                .switchToUserManagement()
+                .switchToUsers()
+                .searchUserEntry(admin.login.toUpperCase())
+                .edit()
+                .resetConfigureRunAs(user.login)
+                .ok();
+    }
 
     @Test
     @TestCase(value = {"2115_1"})
@@ -64,14 +88,75 @@ public class PipeCLITest extends AbstractAutoRemovingPipelineRunningTest {
         final String cliConfigureCommandConfigStore = format("%s --config-store install-dir", cliConfigureCommand);
         tools()
                 .perform(registry, group, tool, tool -> tool.run(this))
-                .showLog(getRunId())
+                .showLog(getLastRunId())
                 .waitForSshLink()
                 .ssh(shell -> shell
-                        .waitUntilTextAppears(getRunId())
+                        .waitUntilTextAppears(getLastRunId())
                         .execute(cliConfigureCommand)
                         .assertOutputContains(pipeConfigOutput.get(0))
                         .execute(cliConfigureCommandConfigStore)
                         .assertOutputContains(pipeConfigOutput.get(1))
                         .close());
+    }
+
+    @Test
+    @TestCase(value = {"1948_1"})
+    public void checkPipeCLIAdminRunAsUser() {
+        String runID = launchRunAsUser(user.login);
+        runsMenu()
+                .viewAvailableActiveRuns()
+                .shouldContainRun("pipeline", runID)
+                .validatePipelineOwner(runID, user.login)
+                .showLog(runID)
+                .ensureParameterIsNotPresent(ORIGINAL_OWNER);
+        runsMenu()
+                .stopRun(runID);
+    }
+
+    @Test
+    @TestCase(value = {"1948_2"})
+    public void checkPipeCLIUserRunAsUser() {
+        navigationMenu()
+                .settings()
+                .switchToUserManagement()
+                .switchToUsers()
+                .searchUserEntry(admin.login.toUpperCase())
+                .edit()
+                .configureRunAs(user.login.toUpperCase(), false)
+                .ok();
+        logout();
+        loginAs(user);
+        String runID = launchRunAsUser(admin.login);
+        logout();
+        loginAs(admin);
+        runsMenu()
+                .viewAvailableActiveRuns()
+                .shouldContainRun("pipeline", runID)
+                .validatePipelineOwner(runID, admin.login)
+                .showLog(runID)
+                .expandTab(PARAMETERS)
+                .ensure(configurationParameter("ORIGINAL_OWNER", user.login), exist);
+        runsMenu()
+                .stopRun(runID);
+    }
+
+    private String launchRunAsUser(String userName) {
+        final String[] output = new String[1];
+        tools()
+                .perform(registry, group, tool, ToolTab::runWithCustomSettings)
+                .doNotMountStoragesSelect(true)
+                .launchTool(this, nameWithoutGroup(tool))
+                .showLog(getLastRunId())
+                .waitForSshLink()
+                .ssh(shell -> {
+                    output[0] = shell
+                            .waitUntilTextAppears(getLastRunId())
+                            .execute(format(command, tool, userName))
+                            .assertOutputContains(result)
+                            .lastCommandResult(format(command, tool, userName));
+                    shell.close();
+                });
+        return output[0].substring(output[0].indexOf(": ")+2,
+                output[0].indexOf("root"));
     }
 }

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/LogAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/LogAO.java
@@ -374,7 +374,7 @@ public class LogAO implements AccessObject<LogAO> {
 
     public LogAO ensureParameterIsNotPresent(String name) {
         if (!get(PARAMETERS).exists()) {
-                return this;
+            return this;
         }
         $(byXpath(format(
                 "//tr[.//td[contains(@class, 'log__task-parameter-name') " +

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/LogAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/LogAO.java
@@ -372,6 +372,16 @@ public class LogAO implements AccessObject<LogAO> {
         throw new AssertionError("Valid parameter value is absent.");
     }
 
+    public LogAO ensureParameterIsNotPresent(String name) {
+        if (!get(PARAMETERS).exists()) {
+                return this;
+            }
+        $(byXpath(format(
+                "//tr[.//td[contains(@class, 'log__task-parameter-name') " +
+                        "and contains(.//text(), '%s')]", name))).shouldNotBe(visible);
+        return this;
+    }
+
     /**
      * Selects entry of a parameters panel on a run page.
      *

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/LogAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/LogAO.java
@@ -375,7 +375,7 @@ public class LogAO implements AccessObject<LogAO> {
     public LogAO ensureParameterIsNotPresent(String name) {
         if (!get(PARAMETERS).exists()) {
                 return this;
-            }
+        }
         $(byXpath(format(
                 "//tr[.//td[contains(@class, 'log__task-parameter-name') " +
                         "and contains(.//text(), '%s')]", name))).shouldNotBe(visible);

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/SettingsPageAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/SettingsPageAO.java
@@ -864,7 +864,7 @@ public class SettingsPageAO extends PopupAO<SettingsPageAO, PipelinesLibraryAO> 
 
                     public boolean checkConfigureRunAs(final String name) {
                         return context().$(byXpath(".//span[.='Can run as this user:']/following-sibling::a"))
-                                .$$(byXpath(".//span")).texts().contains(name);
+                                .shouldBe(visible).$$(byXpath(".//span")).texts().contains(name);
                     }
 
                     public NavigationHomeAO impersonate() {

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/SettingsPageAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/SettingsPageAO.java
@@ -862,6 +862,11 @@ public class SettingsPageAO extends PopupAO<SettingsPageAO, PipelinesLibraryAO> 
                         return this;
                     }
 
+                    public boolean checkConfigureRunAs(final String name) {
+                        return context().$(byXpath(".//span[.='Can run as this user:']/following-sibling::a"))
+                                .$$(byXpath(".//span")).texts().contains(name);
+                    }
+
                     public NavigationHomeAO impersonate() {
                         click(IMPERSONATE);
                         return new NavigationHomeAO();

--- a/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/ShellAO.java
+++ b/e2e/gui/src/test/java/com/epam/pipeline/autotests/ao/ShellAO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -123,7 +123,7 @@ public class ShellAO implements AccessObject<ShellAO> {
         return this;
     }
 
-    private String lastCommandResult(String command) {
+    public String lastCommandResult(String command) {
         return context().text().substring(context().text().indexOf(command))
                 .replace("\n", "").replace(command, "");
     }


### PR DESCRIPTION
Relates to #1948 and #2185.

The pull request brings several e2e test cases for pipe cli *run as* functionality support.
