### PR TITLE
Add support for additional mount options in pipe mount

### DIFF
--- a/deploy/contents/install/preferences/launch.system.parameters.json
+++ b/deploy/contents/install/preferences/launch.system.parameters.json
@@ -129,6 +129,12 @@
         "defaultValue": "ERROR"
     },
     {
+        "name": "CP_PIPE_FUSE_MOUNT_OPTIONS",
+        "type": "string",
+        "description": "Declares pipefuse additional mount options",
+        "defaultValue": ""
+    },
+    {
         "name": "CP_CAP_SGE_MASTER_CORES",
         "type": "string",
         "description": "Allow to limit Grid Engine master cores usage (0 - do not use)",

--- a/workflows/pipe-common/scripts/mount_storage.py
+++ b/workflows/pipe-common/scripts/mount_storage.py
@@ -516,6 +516,7 @@ class S3Mounter(StorageMounter):
 
     def build_mount_command(self, params):
         if params['aws_token'] is not None or params['fuse_type'] == FUSE_PIPE_ID:
+            mount_options = os.getenv('CP_PIPE_FUSE_MOUNT_OPTIONS')
             persist_logs = os.getenv('CP_PIPE_FUSE_PERSIST_LOGS', 'false').lower() == 'true'
             debug_libfuse = os.getenv('CP_PIPE_FUSE_DEBUG_LIBFUSE', 'false').lower() == 'true'
             logging_level = os.getenv('CP_PIPE_FUSE_LOGGING_LEVEL')
@@ -525,6 +526,7 @@ class S3Mounter(StorageMounter):
                     + ('-l {logging_file} ' if persist_logs else '')
                     + ('-v {logging_level} ' if logging_level else '')
                     + ('-o allow_other,debug ' if debug_libfuse else '-o allow_other ')
+                    + (mount_options if mount_options else '')
                     ).format(**params)
         elif params['fuse_type'] == FUSE_GOOFYS_ID:
             params['path'] = '{bucket}:{relative_path}'.format(**params) if params['relative_path'] else params['path']


### PR DESCRIPTION
Resolves #2558.

The pull request brings an additional run parameter that allows to specify pipe fuse additional mount options.

| Parameter | Description |
| --- | ---|
| CP_PIPE_FUSE_MOUNT_OPTIONS | Specifies additional mount options for pipe fuse. Defaults to no additional options. |
