### PR TITLE
Issue 2182 Use negative value in 'no action quota'

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/datastorage/nfs/NFSQuotaNotificationEntry.java
+++ b/api/src/main/java/com/epam/pipeline/entity/datastorage/nfs/NFSQuotaNotificationEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,8 @@ import java.util.Set;
 public class NFSQuotaNotificationEntry {
 
     public static final NFSQuotaNotificationEntry NO_ACTIVE_QUOTAS_NOTIFICATION =
-        new NFSQuotaNotificationEntry(0.0, StorageQuotaType.GIGABYTES, Collections.singleton(StorageQuotaAction.EMAIL));
+        new NFSQuotaNotificationEntry(-1.0,
+                                      StorageQuotaType.GIGABYTES, Collections.singleton(StorageQuotaAction.EMAIL));
 
     private final Double value;
     private final StorageQuotaType type;


### PR DESCRIPTION
This PR is related to [comment](https://github.com/epam/cloud-pipeline/issues/2182#issuecomment-1074929937) in #2182

Right now, if a storage has any quotas applied, and its effective size changed to 0 - its status will not change. 
It happens due to comparison with `NFSQuotaNotificationEntry.NO_ACTIVE_QUOTAS_NOTIFICATION`:  equation `0 > 0` is false.

Value used in the `NO_ACTIVE_QUOTAS_NOTIFICATION` is changed to negative, so any valid (non-negative) effective storage size will exceed this synthetic quota.