### PR TITLE
Issue #2568 Extend notification on missing node/label

### DIFF
--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
@@ -48,10 +48,12 @@ import com.epam.pipeline.entity.region.AbstractCloudRegion;
 import com.epam.pipeline.entity.region.AwsRegion;
 import com.epam.pipeline.entity.security.acl.AclClass;
 import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.rest.PagedResult;
 import com.epam.pipeline.rest.Result;
 import com.epam.pipeline.vo.EntityPermissionVO;
 import com.epam.pipeline.vo.EntityVO;
 import com.epam.pipeline.vo.FilterNodesVO;
+import com.epam.pipeline.vo.PagingRunFilterExpressionVO;
 import com.epam.pipeline.vo.RunStatusVO;
 import com.epam.pipeline.vo.cluster.pool.NodePoolUsage;
 import com.epam.pipeline.vo.data.storage.DataStorageTagInsertBatchRequest;
@@ -113,6 +115,9 @@ public interface CloudPipelineAPI {
 
     @GET("run/{runId}/logs")
     Call<Result<List<RunLog>>> loadLogs(@Path(RUN_ID) Long runId);
+
+    @POST("run/search")
+    Call<Result<PagedResult<List<PipelineRun>>>> searchPipelineRuns(@Body PagingRunFilterExpressionVO filterVO);
 
     @POST("metadata/load")
     Call<Result<List<MetadataEntry>>> loadFolderMetadata(@Body List<EntityVO> entities);

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/filter/FilterExpression.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/filter/FilterExpression.java
@@ -14,25 +14,19 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.rest;
+package com.epam.pipeline.entity.filter;
 
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
 @NoArgsConstructor
-public class PagedResult<T> { // TODO: refactor to extend Result class
-    private T elements; // TODO; refactor to contain a list of T
-    private int totalCount;
+public class FilterExpression {
 
-    public PagedResult(T elements, int totalCount) {
-        this.elements = elements;
-        this.totalCount = totalCount;
-    }
-
-    public T getElements() {
-        return elements;
-    }
-
-    public int getTotalCount() {
-        return totalCount;
-    }
+    private String field;
+    private String value;
+    private String operand;
+    private String filterExpressionType;
 }

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/vo/PagingRunFilterExpressionVO.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/vo/PagingRunFilterExpressionVO.java
@@ -14,25 +14,29 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.rest;
+package com.epam.pipeline.vo;
 
+import com.epam.pipeline.entity.filter.AclSecuredFilter;
+import com.epam.pipeline.entity.filter.FilterExpression;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+import java.util.List;
+
+@Getter
+@Setter
 @NoArgsConstructor
-public class PagedResult<T> { // TODO: refactor to extend Result class
-    private T elements; // TODO; refactor to contain a list of T
-    private int totalCount;
+public class PagingRunFilterExpressionVO implements AclSecuredFilter {
 
-    public PagedResult(T elements, int totalCount) {
-        this.elements = elements;
-        this.totalCount = totalCount;
-    }
+    private int page;
+    private int pageSize;
+    private int timezoneOffsetInMinutes;
+    private FilterExpression filterExpression;
 
-    public T getElements() {
-        return elements;
-    }
-
-    public int getTotalCount() {
-        return totalCount;
-    }
+    @JsonIgnore
+    private List<Long> allowedPipelines;
+    @JsonIgnore
+    private String ownershipFilter;
 }

--- a/deploy/docker/cp-vm-monitor/config/application.properties
+++ b/deploy/docker/cp-vm-monitor/config/application.properties
@@ -5,6 +5,9 @@ cloud.pipeline.api.version=0.15
 cloud.pipeline.platform.name=${CP_PREF_UI_PIPELINE_DEPLOYMENT_NAME:Cloud Pipeline}
 cloud.pipeline.deployment.name=${CP_DEPLOYMENT_ID:}
 
+cloud.pipeline.external.host=${CP_API_SRV_EXTERNAL_HOST:}
+cloud.pipeline.external.port=${CP_API_SRV_EXTERNAL_PORT:}
+
 #Moniroting settings in ms
 monitor.schedule.cron=0 0 */${CP_VM_MONITOR_HOUR_INTERVAL} * * *
 monitor.instance.tag=${CP_VM_MONITOR_INSTANCE_TAG_NAME}=${CP_VM_MONITOR_INSTANCE_TAG_VALUE}

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/model/vm/MissingLabelsSummary.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/model/vm/MissingLabelsSummary.java
@@ -16,6 +16,7 @@
 
 package com.epam.pipeline.vmmonitor.model.vm;
 
+import com.epam.pipeline.entity.pipeline.run.RunStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -27,4 +28,8 @@ public class MissingLabelsSummary {
 
     private final String nodeName;
     private final List<String> labels;
+    private final String instanceType;
+    private final String creationTimestamp;
+    private final RunStatus correspondingRunStatus;
+    private final Long correspondingPoolId;
 }

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/model/vm/MissingNodeSummary.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/model/vm/MissingNodeSummary.java
@@ -14,25 +14,18 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.rest;
+package com.epam.pipeline.vmmonitor.model.vm;
 
-import lombok.NoArgsConstructor;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
-@NoArgsConstructor
-public class PagedResult<T> { // TODO: refactor to extend Result class
-    private T elements; // TODO; refactor to contain a list of T
-    private int totalCount;
+import java.util.List;
 
-    public PagedResult(T elements, int totalCount) {
-        this.elements = elements;
-        this.totalCount = totalCount;
-    }
+@AllArgsConstructor
+@Getter
+public class MissingNodeSummary {
 
-    public T getElements() {
-        return elements;
-    }
-
-    public int getTotalCount() {
-        return totalCount;
-    }
+    private final VirtualMachine vm;
+    private final List<PipelineRun> matchingRuns;
 }

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/model/vm/VirtualMachine.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/model/vm/VirtualMachine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ public class VirtualMachine {
     private String instanceId;
     private String instanceName;
     private String privateIp;
+    private String instanceType;
     private CloudProvider cloudProvider;
     private Map<String, String> tags;
     private LocalDateTime created;

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/notification/VMNotificationServiceImpl.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/notification/VMNotificationServiceImpl.java
@@ -48,6 +48,8 @@ public class VMNotificationServiceImpl implements VMNotificationService {
     private final String platformName;
     private final String deploymentName;
     private final String subjectPrefix;
+    private final String externalHost;
+    private final String externalPort;
 
     public VMNotificationServiceImpl(
             final NotificationSender notificationSender,
@@ -55,13 +57,17 @@ public class VMNotificationServiceImpl implements VMNotificationService {
             @Value("${cloud.pipeline.deployment.name}") final String deploymentName,
             @Value("${notification.to-user}") final String toUser,
             @Value("${notification.copy-users}") final String copyUsers,
-            @Value("${notification.subject.prefix:}") final String subjectPrefix) {
+            @Value("${notification.subject.prefix:}") final String subjectPrefix,
+            @Value("${cloud.pipeline.external.host:}") final String externalHost,
+            @Value("${cloud.pipeline.external.port:}") final String externalPort) {
         this.notificationSender = notificationSender;
         this.platformName = platformName;
         this.deploymentName = deploymentName;
         this.subjectPrefix = subjectPrefix;
         this.toUser = toUser;
         this.copyUsers = Arrays.asList(copyUsers.split(","));
+        this.externalHost = externalHost;
+        this.externalPort = externalPort;
     }
 
     @Override
@@ -87,6 +93,8 @@ public class VMNotificationServiceImpl implements VMNotificationService {
         commonParams.put("platformName", platformName);
         commonParams.put("deploymentName", deploymentName);
         commonParams.put("fullPlatformName", StringUtils.defaultIfBlank(deploymentName, platformName));
+        commonParams.put("externalPort", externalPort);
+        commonParams.put("externalHost", externalHost);
 
         if (MapUtils.isEmpty(parameters)) {
             return commonParams;

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/AWSMonitorService.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/AWSMonitorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -115,6 +115,7 @@ public class AWSMonitorService implements VMMonitorService<AwsRegion> {
                 .instanceName(instance.getPrivateDnsName())
                 .tags(mapTags(instance.getTags()))
                 .privateIp(mapPrivateIp(instance.getNetworkInterfaces()))
+                .instanceType(instance.getInstanceType())
                 .created(convertDateToLocalDateTime(instance.getLaunchTime()))
                 .build();
     }

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/AzureMonitorService.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/AzureMonitorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,6 +77,7 @@ public class AzureMonitorService implements VMMonitorService<AzureRegion> {
                 .instanceId(azureVM.name())
                 .instanceName(azureVM.name())
                 .privateIp(azureVM.getPrimaryNetworkInterface().primaryPrivateIP())
+                .instanceType(azureVM.type())
                 .tags(azureVM.tags())
                 .cloudProvider(CloudProvider.AZURE)
                 .build();

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/GCPMonitorService.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/GCPMonitorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -135,6 +135,7 @@ public class GCPMonitorService implements VMMonitorService<GCPRegion> {
                              .cloudProvider(provider())
                              .instanceId(instance.getId().toString())
                              .privateIp(getInternalIP(instance))
+                             .instanceType(instance.getMachineType())
                              .tags(instance.getLabels())
                              .created(Instant.parse(instance.getCreationTimestamp())
                                      .atZone(ZoneOffset.UTC)

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitor.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -125,7 +125,7 @@ public class VMMonitor {
             } else {
                 log.debug("No matching nodes were found for VM {} {}.", vm.getInstanceId(), vm.getCloudProvider());
                 if (!matchingRunExists(vm) && !checkVMPoolNode(vm)) {
-                    notifier.queueMissingNodeNotification(vm);
+                    notifier.queueMissingNodeNotification(vm, apiClient.searchRunsByInstanceId(vm.getInstanceId()));
                 }
             }
         } catch (Exception e) {

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitor.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitor.java
@@ -20,6 +20,7 @@ package com.epam.pipeline.vmmonitor.service.vm;
 import com.epam.pipeline.entity.cluster.NodeInstance;
 import com.epam.pipeline.entity.cluster.pool.NodePool;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.pipeline.run.RunStatus;
 import com.epam.pipeline.entity.region.AbstractCloudRegion;
 import com.epam.pipeline.entity.region.CloudProvider;
 import com.epam.pipeline.exception.PipelineResponseException;
@@ -183,16 +184,24 @@ public class VMMonitor {
     }
 
     private boolean isRunActive(final VirtualMachine vm, final long runId) {
+        return loadPipelineRun(runId)
+            .map(PipelineRun::getStatus)
+            .map(status -> {
+                if (status.isFinal()) {
+                    log.debug("Run {} is in final status, but VM {} is still up.", runId, vm.getInstanceId());
+                    return false;
+                }
+                return true;
+            })
+            .orElse(false);
+    }
+
+    private Optional<PipelineRun> loadPipelineRun(final long runId) {
         try {
-            final PipelineRun run = apiClient.loadRun(runId);
-            if (run.getStatus().isFinal()) {
-                log.debug("Run {} is in final status, but VM {} is still up.", runId, vm.getInstanceId());
-                return false;
-            }
-            return true;
+            return Optional.of(apiClient.loadRun(runId));
         } catch (PipelineResponseException e) {
             log.error("Failed to load run {}: {}", runId, e.getMessage());
-            return false;
+            return Optional.empty();
         }
     }
 
@@ -209,10 +218,32 @@ public class VMMonitor {
         log.debug("Checking whether node {} is labeled with required tags.", node.getName());
         final List<String> labels = getMissingLabels(node);
         if (CollectionUtils.isNotEmpty(labels)) {
-            notifier.queueMissingLabelsNotification(node, labels);
+            final Map<String, String> vmTags = MapUtils.emptyIfNull(vm.getTags());
+            final Map<String, String> nodeTags = MapUtils.emptyIfNull(node.getLabels());
+            final Optional<Long> runIdFromNode = findLongValueInTags(nodeTags, runIdLabel);
+            final Optional<Long> runId = runIdFromNode.isPresent()
+                                         ? runIdFromNode
+                                         : findLongValueInTags(vmTags, runIdLabel);
+            final RunStatus matchingRunStatus = runId
+                .map(this::loadPipelineRun)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .map(run -> new RunStatus(run.getId(), run.getStatus(), null))
+                .orElse(null);
+            final Long matchingPoolId = findLongValueInTags(nodeTags, poolIdLabel)
+                .filter(this::isNodePoolExists)
+                .orElse(null);
+            notifier.queueMissingLabelsNotification(node, vm, labels, matchingRunStatus, matchingPoolId);
         } else {
             log.debug("All required labels are present on node {}.", node.getName());
         }
+    }
+
+    private Optional<Long> findLongValueInTags(final Map<String, String> tags, final String labelName) {
+        return Optional.ofNullable(tags.get(labelName))
+            .filter(StringUtils::isNotBlank)
+            .filter(NumberUtils::isDigits)
+            .map(Long::parseLong);
     }
 
     private List<String> getMissingLabels(final NodeInstance node) {

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMNotifier.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMNotifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,9 @@
 package com.epam.pipeline.vmmonitor.service.vm;
 
 import com.epam.pipeline.entity.cluster.NodeInstance;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.vmmonitor.model.vm.MissingLabelsSummary;
+import com.epam.pipeline.vmmonitor.model.vm.MissingNodeSummary;
 import com.epam.pipeline.vmmonitor.model.vm.VirtualMachine;
 import com.epam.pipeline.vmmonitor.service.notification.VMNotificationService;
 import lombok.extern.slf4j.Slf4j;
@@ -41,7 +43,7 @@ public class VMNotifier {
     private final String missingNodeTemplatePath;
     private final String missingLabelsSubject;
     private final String missingLabelsTemplatePath;
-    private final Queue<VirtualMachine> missingNodes;
+    private final Queue<MissingNodeSummary> missingNodes;
     private final Queue<MissingLabelsSummary> missingLabelsSummaries;
 
     public VMNotifier(
@@ -65,8 +67,8 @@ public class VMNotifier {
                                "missingLabelsSummaries");
     }
 
-    public void queueMissingNodeNotification(final VirtualMachine vm) {
-        missingNodes.add(vm);
+    public void queueMissingNodeNotification(final VirtualMachine vm, final List<PipelineRun> matchingRuns) {
+        missingNodes.add(new MissingNodeSummary(vm, matchingRuns));
     }
 
     public void queueMissingLabelsNotification(final NodeInstance node, final List<String> labels) {

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMNotifier.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMNotifier.java
@@ -19,6 +19,7 @@ package com.epam.pipeline.vmmonitor.service.vm;
 
 import com.epam.pipeline.entity.cluster.NodeInstance;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.pipeline.run.RunStatus;
 import com.epam.pipeline.vmmonitor.model.vm.MissingLabelsSummary;
 import com.epam.pipeline.vmmonitor.model.vm.MissingNodeSummary;
 import com.epam.pipeline.vmmonitor.model.vm.VirtualMachine;
@@ -71,8 +72,11 @@ public class VMNotifier {
         missingNodes.add(new MissingNodeSummary(vm, matchingRuns));
     }
 
-    public void queueMissingLabelsNotification(final NodeInstance node, final List<String> labels) {
-        missingLabelsSummaries.add(new MissingLabelsSummary(node.getName(), labels));
+    public void queueMissingLabelsNotification(final NodeInstance node, final VirtualMachine vm,
+                                               final List<String> labels, final RunStatus runStatus,
+                                               final Long poolId) {
+        missingLabelsSummaries.add(new MissingLabelsSummary(node.getName(), labels, vm.getInstanceType(),
+                                                            node.getCreationTimestamp(), runStatus, poolId));
     }
 
     private void notifyOnQueuedElements(final String emailSubject, final String emailTemplatePath,

--- a/vm-monitor/src/main/resources/application.properties
+++ b/vm-monitor/src/main/resources/application.properties
@@ -6,6 +6,9 @@ cloud.pipeline.api.version=0.15
 cloud.pipeline.platform.name=${CP_PREF_UI_PIPELINE_DEPLOYMENT_NAME:Cloud Pipeline}
 cloud.pipeline.deployment.name=${CP_DEPLOYMENT_ID:}
 
+cloud.pipeline.external.host=${CP_API_SRV_EXTERNAL_HOST:}
+cloud.pipeline.external.port=${CP_API_SRV_EXTERNAL_PORT:}
+
 #VM-monitoring settings
 monitor.schedule.cron=0 */2 * ? * *
 monitor.instance.tag=monitored=true

--- a/vm-monitor/src/main/resources/templates/MISSING-LABELS.html
+++ b/vm-monitor/src/main/resources/templates/MISSING-LABELS.html
@@ -51,11 +51,11 @@
         <td>
             #set( $correspondingRunStatus = $summary.correspondingRunStatus )
             #if ($correspondingRunStatus)
-                Run <a href="https://$CP_API_SRV_EXTERNAL_HOST:$CP_API_SRV_EXTERNAL_PORT/pipeline/#/run/$correspondingRunStatus.runId">$correspondingRunStatus.runId</a> [ $correspondingRunStatus.status ] <br>
+                Run <a href="https://$templateParameters["externalHost"]:$templateParameters["externalPort"]/pipeline/#/run/$correspondingRunStatus.runId">$correspondingRunStatus.runId</a> [ $correspondingRunStatus.status ] <br>
             #end
             #set( $correspondingPoolId = $summary.correspondingPoolId )
             #if ($correspondingPoolId)
-                Pool <a href="https://$CP_API_SRV_EXTERNAL_HOST:$CP_API_SRV_EXTERNAL_PORT/pipeline/#/cluster?pool_id=$correspondingPoolId">$correspondingPoolId</a><br>
+                Pool <a href="https://$templateParameters["externalHost"]:$templateParameters["externalPort"]/pipeline/#/cluster?pool_id=$correspondingPoolId">$correspondingPoolId</a><br>
             #end
         </td>
         <td>
@@ -64,7 +64,7 @@
             #end
         </td>
         <td>
-            Delete <a href="https://$CP_API_SRV_EXTERNAL_HOST:$CP_API_SRV_EXTERNAL_PORT/pipeline/#/cluster/$summary.nodeName">instance</a> in the <b>$templateParameters["deploymentName"]</b> console
+            Delete <a href="https://$templateParameters["externalHost"]:$templateParameters["externalPort"]/pipeline/#/cluster/$summary.nodeName">instance</a> in the <b>$templateParameters["deploymentName"]</b> console
         </td>
     </tr>
     #end

--- a/vm-monitor/src/main/resources/templates/MISSING-LABELS.html
+++ b/vm-monitor/src/main/resources/templates/MISSING-LABELS.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+  ~ Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -35,14 +35,36 @@
 <p>Looks like there are some nodes which are missing one of the required labels:</p>
 <p>
 <table>
-    <tr><td><b>Node</b></td><td><b>Missing labels</b></td></tr>
+    <tr>
+        <td><b>Node</b></td>
+        <td><b>Instance type</b></td>
+        <td><b>Creation date</b></td>
+        <td><b>Corresponding run/pool</b></td>
+        <td><b>Missing labels</b></td>
+        <td><b>Action proposed</b></td>
+    </tr>
     #foreach( $summary in $templateParameters["missingLabelsSummaries"] )
     <tr>
         <td>$summary.nodeName</td>
+        <td>$summary.instanceType</td>
+        <td>$summary.creationTimestamp</td>
+        <td>
+            #set( $correspondingRunStatus = $summary.correspondingRunStatus )
+            #if ($correspondingRunStatus)
+                Run <a href="https://$CP_API_SRV_EXTERNAL_HOST:$CP_API_SRV_EXTERNAL_PORT/pipeline/#/run/$correspondingRunStatus.runId">$correspondingRunStatus.runId</a> [ $correspondingRunStatus.status ] <br>
+            #end
+            #set( $correspondingPoolId = $summary.correspondingPoolId )
+            #if ($correspondingPoolId)
+                Pool <a href="https://$CP_API_SRV_EXTERNAL_HOST:$CP_API_SRV_EXTERNAL_PORT/pipeline/#/cluster?pool_id=$correspondingPoolId">$correspondingPoolId</a><br>
+            #end
+        </td>
         <td>
             #foreach( $label in $summary.labels )
             $label<br>
             #end
+        </td>
+        <td>
+            Delete <a href="https://$CP_API_SRV_EXTERNAL_HOST:$CP_API_SRV_EXTERNAL_PORT/pipeline/#/cluster/$summary.nodeName">instance</a> in the <b>$templateParameters["deploymentName"]</b> console
         </td>
     </tr>
     #end

--- a/vm-monitor/src/main/resources/templates/MISSING-NODE.html
+++ b/vm-monitor/src/main/resources/templates/MISSING-NODE.html
@@ -52,7 +52,7 @@
             <td>$summary.vm.privateIp</td>
             <td>
                 #foreach( $run in $summary.matchingRuns )
-                    <a href="https://$CP_API_SRV_EXTERNAL_HOST:$CP_API_SRV_EXTERNAL_PORT/pipeline/#/run/$run.id">$run.id</a> [ $run.status.name ] <br>
+                    <a href="https://$templateParameters["externalHost"]:$templateParameters["externalPort"]/pipeline/#/run/$run.id">$run.id</a> [ $run.status.name ] <br>
                 #end
             </td>
             <td>$summary.vm.cloudProvider</td>

--- a/vm-monitor/src/main/resources/templates/MISSING-NODE.html
+++ b/vm-monitor/src/main/resources/templates/MISSING-NODE.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+  ~ Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -35,9 +35,29 @@
 <p>Looks like there are some Virtual Machines that are not registered in the $templateParameters["platformName"] cluster.</p>
 <p>
 <table>
-    <tr><td><b>Instance ID</b></td><td><b>Private IP</b></td><td><b>Provider</b></td></tr>
-    #foreach( $instance in $templateParameters["missingNodes"] )
-        <tr><td>$instance.instanceId</td><td>$instance.privateIp</td><td>$instance.cloudProvider</td></tr>
+    <tr>
+        <td><b>Instance ID</b></td>
+        <td><b>Creation date</b></td>
+        <td><b>Instance type</b></td>
+        <td><b>Private IP</b></td>
+        <td><b>Matching runs</b></td>
+        <td><b>Provider</b></td>
+        <td><b>Action proposed</b></td>
+    </tr>
+    #foreach( $summary in $templateParameters["missingNodes"] )
+        <tr>
+            <td>$summary.vm.instanceId</td>
+            <td>$summary.vm.created</td>
+            <td>$summary.vm.instanceType</td>
+            <td>$summary.vm.privateIp</td>
+            <td>
+                #foreach( $run in $summary.matchingRuns )
+                    <a href="https://$CP_API_SRV_EXTERNAL_HOST:$CP_API_SRV_EXTERNAL_PORT/pipeline/#/run/$run.id">$run.id</a> [ $run.status.name ] <br>
+                #end
+            </td>
+            <td>$summary.vm.cloudProvider</td>
+            <td>Delete instance in the <b>$summary.vm.cloudProvider</b> console</td>
+        </tr>
     #end
 </table>
 </p>

--- a/vm-monitor/src/test/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitorTest.java
+++ b/vm-monitor/src/test/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitorTest.java
@@ -80,7 +80,7 @@ public class VMMonitorTest {
         doReturn(Collections.singletonList(nodePool)).when(mockApiClient).loadNodePools();
         monitor.monitor();
 
-        verify(notifier, never()).queueMissingNodeNotification(vm);
+        verify(notifier, never()).queueMissingNodeNotification(vm, Collections.emptyList());
     }
 
     @Test
@@ -89,6 +89,6 @@ public class VMMonitorTest {
         doReturn(Collections.singletonList(vm)).when(mockService).fetchRunningVms(region);
         monitor.monitor();
 
-        verify(notifier).queueMissingNodeNotification(vm);
+        verify(notifier).queueMissingNodeNotification(vm, Collections.emptyList());
     }
 }


### PR DESCRIPTION
This PR is related to issue #2568 
It extends the description on missing labels and cluster nodes received in VM monitor notification. Monitor tries to resolve and specify:
- instance type
- creation date
- matching run/pool ID
- run status
- recommendations regarding necessary actions
