### PR TITLE
FUSE: fix for read operation inside write

### DIFF
--- a/pipe-cli/mount/pipe-fuse.py
+++ b/pipe-cli/mount/pipe-fuse.py
@@ -128,10 +128,6 @@ def start(mountpoint, webdav, bucket,
         client = CachingFileSystemClient(client, cache)
     else:
         logging.info('Caching is disabled.')
-    if write_buffer_size > 0:
-        client = BufferingWriteFileSystemClient(client, capacity=write_buffer_size)
-    else:
-        logging.info('Write buffering is disabled.')
     if read_buffer_size > 0:
         client = BufferingReadAheadFileSystemClient(client,
                                                     read_ahead_min_size=read_ahead_min_size,
@@ -140,6 +136,10 @@ def start(mountpoint, webdav, bucket,
                                                     capacity=read_buffer_size)
     else:
         logging.info('Read buffering is disabled.')
+    if write_buffer_size > 0:
+        client = BufferingWriteFileSystemClient(client, capacity=write_buffer_size)
+    else:
+        logging.info('Write buffering is disabled.')
     if trunc_buffer_size > 0:
         if webdav:
             client = CopyOnDownTruncateFileSystemClient(client, capacity=trunc_buffer_size)

--- a/pipe-cli/mount/pipefuse/buffwrite.py
+++ b/pipe-cli/mount/pipefuse/buffwrite.py
@@ -87,6 +87,13 @@ class BufferingWriteFileSystemClient(FileSystemClientDecorator):
             attrs = attrs._replace(size=max(attrs.size, write_buf.file_size))
         return attrs
 
+    def download_range(self, fh, buf, path, offset=0, length=0):
+        write_buf = self._buffs.get(path, None)
+        if write_buf:
+            logging.info('Flushing inside read %d:%s.' % (fh, path))
+            self.flush(fh, path)
+        self._inner.download_range(fh, buf, path, offset, length)
+
     def upload_range(self, fh, buf, path, offset=0):
         try:
             file_buf = self._buffs.get(path)

--- a/pipe-cli/mount/pipefuse/storage.py
+++ b/pipe-cli/mount/pipefuse/storage.py
@@ -1,3 +1,17 @@
+# Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import io
 import logging
 from abc import abstractmethod, ABCMeta
@@ -88,6 +102,10 @@ class StorageHighLevelFileSystemClient(FileSystemClientDecorator):
 
     def download_range(self, fh, buf, path, offset=0, length=0):
         source_path = path.lstrip(self._delimiter)
+        mpu = self._mpus.get(path, None)
+        if mpu:
+            logging.info('Flushing MPU inside READ: %d:%s' % (fh, path))
+            self.flush(fh, path)
         self._inner.download_range(fh, buf, source_path, offset, length)
 
     def upload_range(self, fh, buf, path, offset=0):


### PR DESCRIPTION
### Background
`pipe-fuse` was not able to support read operation during write 

### Approach
Flush write buffer if read operation initialed

### Known performance issues 
In general this changes shall not affect performance in common cases. But in some cases (read inside write; many small intervals into buffer) performance is dramatically slow. 
1. `python-intervals` library is not effective in large data. This way it would be great to consider another approach for buffer bounds storing.  
2. flush operation inside read (in case if write buffer exists only) is quite heavy. It would be nice to improve it.