### PR TITLE
pipe storage cp/mv: fix for bucket root

### DIFF
--- a/pipe-cli/src/utilities/datastorage_operations.py
+++ b/pipe-cli/src/utilities/datastorage_operations.py
@@ -143,6 +143,10 @@ class DataStorageOperations(object):
             if not include and not exclude:
                 if not source_wrapper.is_file():
                     possible_folder_name = source_wrapper.path_with_trailing_separator()
+                    # if operation from source root
+                    if possible_folder_name == source_wrapper.path_separator:
+                        filtered_items.append(item)
+                        continue
                     if not full_path.startswith(possible_folder_name):
                         continue
             if not PatternMatcher.match_any(relative_path, include):


### PR DESCRIPTION
The current PR provides fix for `cp/mv` operations for case if source is a bucket's root.

### Bug description
There was a bug with `pipe storage cp/mv` operation. If user initiated the following operation:
`pipe storage cp/mv -fr cp://bucket_name/ /path/to/source/` folders hierarchy copied only.

#### Expected:
All files copied/moved successfully.

#### Actual:
Folder markers `.DS_Store` copied only.
