### PR TITLE
Issue #2580 Skip certain storage billing

### DIFF
--- a/billing-report-agent/src/main/resources/application.properties
+++ b/billing-report-agent/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -57,3 +57,5 @@ sync.storage.index.mapping=classpath:/templates/storage_billing.json
 sync.storage.index.name=storage-
 sync.storage.file.index.pattern=*cp-%s-%s-%d
 sync.aws.json.price.endpoint.template=https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/%s/current/index.json
+sync.storage.billing.exclude.metadata.key=Billing status
+sync.storage.billing.exclude.metadata.value=Exclude

--- a/deploy/docker/cp-billing-srv/config/application.properties
+++ b/deploy/docker/cp-billing-srv/config/application.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -57,3 +57,5 @@ sync.storage.index.name=storage-
 sync.storage.price.load.mode=${CP_BILLING_AWS_PRICE_TYPE:json}
 sync.storage.file.index.pattern=${CP_BILLING_STORAGE_INDEX_PATTERN:*cp-%s-%s-%d}
 sync.aws.json.price.endpoint.template=${CP_BILLING_AWS_PRICES_ENDPOINT:https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/%s/current/index.json}
+sync.storage.billing.exclude.metadata.key=${CP_BILLING_STORAGE_EXCLUDE_METADATA_KEY:Billing status}
+sync.storage.billing.exclude.metadata.value=${CP_BILLING_STORAGE_EXCLUDE_METADATA_VALUE:Exclude}


### PR DESCRIPTION
This PR is related to issue #2580 

It improves `billing-report-agent`, allowing to skip billing synchronization for:
- shared storage, as it is a mirror for another bucket, and we consider share's space consumption during processing of the source one
- storage with specific (configurable via agent's `application.properties`) tag key and value

Besides, it replaces usage of deprecated `QueryUtils` API with `RetryingCloudPipelineApiExecutor` in billing agent.
