### PR TITLE
Issue #2581 CLI extended storage listing

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1064,11 +1064,25 @@ def mvtodir(name, directory):
 @click.option('-r', '--recursive', is_flag=True, help='Recursive listing')
 @click.option('-p', '--page', type=int, help='Maximum number of records to show')
 @click.option('-a', '--all', is_flag=True, help='Show all results at once ignoring page settings')
+@click.option('-o', '--output', default='compact', show_default=False,
+              help="Option for configuring storage summary details listing mode. Possible values:"
+                   "compact - brief summary only"                   
+                   "full - show extended details")
 @common_options
-def storage_list(path, show_details, show_versions, recursive, page, all):
+def storage_list(path, show_details, show_versions, recursive, page, all, output):
     """Lists storage contents
     """
-    DataStorageOperations.storage_list(path, show_details, show_versions, recursive, page, all)
+    show_extended = False
+    if output != 'compact':
+        if output != 'full':
+            click.echo('Invalid listing mode: `{}`, possible values are [full, compact]!'.format(output), err=True)
+            sys.exit(1)
+        elif path is not None and output == 'full' or not show_details:
+            click.echo('Extended output could be configured for the storage summary listing only!', err=True)
+            sys.exit(1)
+        else:
+            show_extended = True if output == 'full' else False
+    DataStorageOperations.storage_list(path, show_details, show_versions, recursive, page, all, show_extended)
 
 
 @storage.command(name='mkdir')

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1064,24 +1064,20 @@ def mvtodir(name, directory):
 @click.option('-r', '--recursive', is_flag=True, help='Recursive listing')
 @click.option('-p', '--page', type=int, help='Maximum number of records to show')
 @click.option('-a', '--all', is_flag=True, help='Show all results at once ignoring page settings')
-@click.option('-o', '--output', default='compact', show_default=False,
-              help="Option for configuring storage summary details listing mode. Possible values:"
-                   "compact - brief summary only"                   
-                   "full - show extended details")
+@click.option('-o', '--output', default='compact', type=click.Choice(['full', 'compact']),
+              help="Option for configuring storage summary details listing mode. Possible values: "
+                   "compact - brief summary only (default); "
+                   "full - show extended details, works for the storage summary listing only")
 @common_options
 def storage_list(path, show_details, show_versions, recursive, page, all, output):
     """Lists storage contents
     """
     show_extended = False
-    if output != 'compact':
-        if output != 'full':
-            click.echo('Invalid listing mode: `{}`, possible values are [full, compact]!'.format(output), err=True)
-            sys.exit(1)
-        elif path is not None and output == 'full' or not show_details:
+    if output == 'full':
+        if path is not None or not show_details:
             click.echo('Extended output could be configured for the storage summary listing only!', err=True)
             sys.exit(1)
-        else:
-            show_extended = True if output == 'full' else False
+        show_extended = True
     DataStorageOperations.storage_list(path, show_details, show_versions, recursive, page, all, show_extended)
 
 

--- a/pipe-cli/src/api/data_storage.py
+++ b/pipe-cli/src/api/data_storage.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,6 +51,17 @@ class DataStorage(API):
         return storage, \
                full_path.replace(url.netloc, '').lstrip(storage.delimiter), \
                full_path.replace(storage.path, '').lstrip(storage.delimiter)
+
+    @classmethod
+    def list_with_mount_limits(cls):
+        api = cls.instance()
+        response_data = api.call('datastorage/availableWithMounts', None)
+        if 'payload' not in response_data:
+            return
+        for data_storages_json in response_data['payload']:
+            if 'storage' in data_storages_json:
+                data_storage = DataStorageModel.load(data_storages_json['storage'])
+                yield data_storage
 
     @classmethod
     def list(cls):

--- a/pipe-cli/src/api/metadata.py
+++ b/pipe-cli/src/api/metadata.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,21 +39,43 @@ class Metadata(API):
 
     @classmethod
     def load(cls, entity_id, entity_class):
+        return cls.load_all_for_ids([entity_id], entity_class)[0]
+
+    @classmethod
+    def load_all_for_ids(cls, entity_ids, entity_class):
         api = cls.instance()
-        data = json.dumps([{
-            'entityId': entity_id,
-            'entityClass': str(entity_class).upper()
-        }])
+        data = json.dumps([cls.convert_to_entity_vo(entity_id, entity_class) for entity_id in entity_ids])
         response_data = api.call('metadata/load', data=data, http_method='POST')
         if 'payload' in response_data:
-            for response_data_item in response_data['payload']:
-                return MetadataModel.load(response_data_item)
+            return [MetadataModel.load(response_data_item) for response_data_item in response_data['payload']]
         if 'status' in response_data and response_data['status'] == "OK":
-            return MetadataModel()
+            return [MetadataModel()]
         if 'message' in response_data:
             raise RuntimeError(response_data['message'])
         else:
             raise RuntimeError("Failed to load metadata.")
+
+    @classmethod
+    def load_metadata_mapping(cls, entity_ids, entity_class):
+        metadata_list = Metadata.load_all_for_ids(entity_ids, entity_class)
+        metadata_mapping = dict()
+        for metadata_entry in metadata_list:
+            metadata_data_dict = {}
+            for key, data in metadata_entry.data.iteritems():
+                if 'value' in data:
+                    value = data['value']
+                    if not value.startswith('{'):
+                        metadata_data_dict[key] = value
+            if len(metadata_data_dict):
+                metadata_mapping[metadata_entry.entity_id] = metadata_data_dict
+        return metadata_mapping
+
+    @classmethod
+    def convert_to_entity_vo(cls, entity_id, entity_class):
+        return {
+            'entityId': entity_id,
+            'entityClass': str(entity_class).upper()
+        }
 
     @classmethod
     def update(cls, entity_id, entity_class, metadata):

--- a/pipe-cli/src/api/metadata.py
+++ b/pipe-cli/src/api/metadata.py
@@ -14,6 +14,7 @@
 
 import json
 
+from future.utils import iteritems
 from src.api.base import API
 from src.model.metadata_model import MetadataModel
 
@@ -61,7 +62,7 @@ class Metadata(API):
         metadata_mapping = dict()
         for metadata_entry in metadata_list:
             metadata_data_dict = {}
-            for key, data in metadata_entry.data.iteritems():
+            for key, data in iteritems(metadata_entry.data):
                 if 'value' in data:
                     value = data['value']
                     if not value.startswith('{'):

--- a/pipe-cli/src/model/data_storage_item_model.py
+++ b/pipe-cli/src/model/data_storage_item_model.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ class DataStorageItemModel(object):
         self.latest = False
         self.delete_marker = False
         self.deleted = None
+        self.metadata = {}
 
     @classmethod
     def load(cls, json):

--- a/pipe-cli/src/utilities/datastorage_operations.py
+++ b/pipe-cli/src/utilities/datastorage_operations.py
@@ -509,7 +509,7 @@ class DataStorageOperations(object):
         metadata_mapping = dict()
         for metadata_entry in metadata_list:
             metadata_data_dict = {}
-            for key, data in metadata_entry.data.iteritems():
+            for key, data in iteritems(metadata_entry.data):
                 if 'value' in data:
                     data_value = data['value']
                     if len(data_value) > 0:


### PR DESCRIPTION
This PR is related to the issue #2581 

It allows configuring 'extended' storage listing mode via` -o|--output full/compact` parameter. 
When `full` mode selected, storage metadata, status and mount limits are shown. Note, that `full` format works for storage summary listing only and takes effect with `-l|--show_details` flag only.

Ex:
- `extended` mode
```
pipe storage ls -l -o full

Type    Labels    Modified               Size    Name          Mount status      Mount limits                                   Metadata
S3                2022-01-13 20:00:11            bucket1       ACTIVE            cp-deployment.com:443/library/ubuntu                                                                                                                                                 
S3                2021-12-29 03:11:34            bucket2       DISABLED                                                         key_1=value_1, key_2=value_2                                                                                          
NFS               2022-03-09 16:44:16            nfs-storage   READ_ONLY         cp-deployment.com:443/library/centos:latest                                                                                                                                                          

```
- `compact` mode keeps the current behavior

```
pipe storage ls -l

Type    Labels    Modified               Size    Name          
S3                2022-01-13 20:00:11            bucket1       
S3                2021-12-29 03:11:34            bucket2                                                                                            
NFS               2022-03-09 16:44:16            nfs-storage    
```