### PR TITLE
pipe storage cp: fix for bucket root cp/mv with advanced args

### DIFF
--- a/pipe-cli/src/utilities/datastorage_operations.py
+++ b/pipe-cli/src/utilities/datastorage_operations.py
@@ -140,7 +140,7 @@ class DataStorageOperations(object):
                 continue
             if source_wrapper.is_file() and not source_wrapper.path == full_path:
                 continue
-            if not include and not exclude:
+            if not include and not exclude and not skip_existing and not verify_destination:
                 if not source_wrapper.is_file():
                     possible_folder_name = source_wrapper.path_with_trailing_separator()
                     # if operation from source root


### PR DESCRIPTION
This PR provides fix for cp/mv operation. The bug was found during the iteration over root bucket source: additional arguments `--skip-existing (-s)` and `--verify-destination (-vd)` were ignored.