### PR TITLE
Issue #2568 Propagate pool ID to cloud instance tags, extend missing labels/node notification

### DIFF
--- a/scripts/autoscaling/aws/nodeup.py
+++ b/scripts/autoscaling/aws/nodeup.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ MIN_SWAP_DEVICE_SIZE = 5
 LOCAL_NVME_INSTANCE_TYPES = [ 'c5d.' , 'm5d.', 'r5d.' ]
 DEFAULT_FS_TYPE = 'btrfs'
 SUPPORTED_FS_TYPES = [DEFAULT_FS_TYPE, 'ext4']
+POOL_ID_KEY = 'pool_id'
 
 current_run_id = 0
 api_url = None
@@ -340,15 +341,21 @@ def merge_tags(region_tags, global_tags):
     return merged
 
 
-def run_id_tag(run_id):
-    return [{
+def run_id_tag(run_id, pool_id):
+    tags = [{
         'Value': run_id,
         'Key': 'Name'
     }]
+    if pool_id:
+        tags.append({
+            'Value': pool_id,
+            'Key': POOL_ID_KEY
+        })
+    return tags
 
 
-def get_tags(run_id, cloud_region):
-    tags = run_id_tag(run_id)
+def get_tags(run_id, cloud_region, pool_id):
+    tags = run_id_tag(run_id, pool_id)
     res_tags = resource_tags(cloud_region)
     if res_tags:
         tags.extend(res_tags)
@@ -363,22 +370,22 @@ def run_id_filter(run_id):
 
 
 def run_instance(api_url, api_token, api_user, bid_price, ec2, aws_region, ins_hdd, kms_encyr_key_id, ins_img, ins_platform, ins_key, ins_type,
-                 is_spot, num_rep, run_id, time_rep, kube_ip, kubeadm_token, kubeadm_cert_hash, kube_node_token, kube_client, pre_pull_images,
+                 is_spot, num_rep, run_id, pool_id, time_rep, kube_ip, kubeadm_token, kubeadm_cert_hash, kube_node_token, kube_client, pre_pull_images,
                  instance_additional_spec):
     swap_size = get_swap_size(aws_region, ins_type, is_spot)
     user_data_script = get_user_data_script(api_url, api_token, api_user, aws_region, ins_type, ins_img, ins_platform, kube_ip,
                                             kubeadm_token, kubeadm_cert_hash, kube_node_token, swap_size, pre_pull_images)
     if is_spot:
-        ins_id, ins_ip = find_spot_instance(ec2, aws_region, bid_price, run_id, ins_img, ins_type, ins_key, ins_hdd, kms_encyr_key_id,
+        ins_id, ins_ip = find_spot_instance(ec2, aws_region, bid_price, run_id, pool_id, ins_img, ins_type, ins_key, ins_hdd, kms_encyr_key_id,
                                             user_data_script, num_rep, time_rep, swap_size, kube_client, instance_additional_spec)
     else:
-        ins_id, ins_ip = run_on_demand_instance(ec2, aws_region, ins_img, ins_key, ins_type, ins_hdd, kms_encyr_key_id, run_id, user_data_script,
+        ins_id, ins_ip = run_on_demand_instance(ec2, aws_region, ins_img, ins_key, ins_type, ins_hdd, kms_encyr_key_id, run_id, pool_id, user_data_script,
                                                 num_rep, time_rep, swap_size, kube_client, instance_additional_spec)
     return ins_id, ins_ip
 
 
 def run_on_demand_instance(ec2, aws_region, ins_img, ins_key, ins_type, ins_hdd,
-                           kms_encyr_key_id, run_id, user_data_script, num_rep, time_rep,
+                           kms_encyr_key_id, run_id, pool_id, user_data_script, num_rep, time_rep,
                            swap_size, kube_client, instance_additional_spec):
     pipe_log('Creating on demand instance')
     allowed_networks = get_networks_config(ec2, aws_region, ins_type)
@@ -406,7 +413,7 @@ def run_on_demand_instance(ec2, aws_region, ins_img, ins_key, ins_type, ins_hdd,
             TagSpecifications=[
                 {
                     'ResourceType': 'instance',
-                    "Tags": get_tags(run_id, aws_region)
+                    "Tags": get_tags(run_id, aws_region, pool_id)
                 }
             ],
              MetadataOptions={
@@ -931,7 +938,7 @@ def exit_if_spot_unavailable(run_id, last_status):
                  status=TaskStatus.FAILURE)
         sys.exit(SPOT_UNAVAILABLE_EXIT_CODE)
 
-def find_spot_instance(ec2, aws_region, bid_price, run_id, ins_img, ins_type, ins_key,
+def find_spot_instance(ec2, aws_region, bid_price, run_id, pool_id, ins_img, ins_type, ins_key,
                        ins_hdd, kms_encyr_key_id, user_data_script, num_rep, time_rep,
                        swap_size, kube_client, instance_additional_spec):
     pipe_log('Creating spot request')
@@ -1021,7 +1028,7 @@ def find_spot_instance(ec2, aws_region, bid_price, run_id, ins_img, ins_type, in
     pipe_log('- Spot request {} is registered'.format(request_id))
     ec2.create_tags(
         Resources=[request_id],
-        Tags=run_id_tag(run_id),
+        Tags=run_id_tag(run_id, pool_id),
     )
 
     pipe_log('- Spot request {} was tagged with RunID {}. Waiting for request fulfillment...'.format(request_id, run_id))
@@ -1060,7 +1067,7 @@ def find_spot_instance(ec2, aws_region, bid_price, run_id, ins_img, ins_type, in
             ins_ip = instance_reservation['PrivateIpAddress']
             ec2.create_tags(
                 Resources=[ins_id],
-                Tags=get_tags(run_id, aws_region),
+                Tags=get_tags(run_id, aws_region, pool_id),
             )
 
             ebs_tags = resource_tags(aws_region)
@@ -1119,7 +1126,7 @@ def wait_for_fulfilment(status):
            or status == 'pending-fulfillment' or status == 'fulfilled'
 
 
-def check_spot_request_exists(ec2, num_rep, run_id, time_rep, aws_region):
+def check_spot_request_exists(ec2, num_rep, run_id, time_rep, aws_region, pool_id):
     pipe_log('Checking if spot request for RunID {} already exists...'.format(run_id))
     for interation in range(0, 5):
         spot_req = get_spot_req_by_run_id(ec2, run_id)
@@ -1129,7 +1136,7 @@ def check_spot_request_exists(ec2, num_rep, run_id, time_rep, aws_region):
             pipe_log('- Spot request for RunID {} already exists: SpotInstanceRequestId: {}, Status: {}'.format(run_id, request_id, status))
             rep = 0
             if status == 'request-canceled-and-instance-running' and instance_is_active(ec2, spot_req['InstanceId']):
-                return tag_and_get_instance(ec2, spot_req, run_id)
+                return tag_and_get_instance(ec2, spot_req, run_id, aws_region, pool_id)
             if wait_for_fulfilment(status):
                 while status != 'fulfilled':
                     pipe_log('- Spot request ({}) is not yet fulfilled. Waiting...'.format(request_id))
@@ -1144,7 +1151,7 @@ def check_spot_request_exists(ec2, num_rep, run_id, time_rep, aws_region):
                         exit_if_spot_unavailable(run_id, status)
                         return '', ''
                 if  instance_is_active(ec2, spot_req['InstanceId']):
-                    return tag_and_get_instance(ec2, spot_req, run_id, aws_region)
+                    return tag_and_get_instance(ec2, spot_req, run_id, aws_region, pool_id)
         sleep(5)
     pipe_log('No spot request for RunID {} found\n-'.format(run_id))
     return '', ''
@@ -1159,7 +1166,7 @@ def get_spot_req_by_run_id(ec2, run_id):
     return None
 
 
-def tag_and_get_instance(ec2, spot_req, run_id, aws_region):
+def tag_and_get_instance(ec2, spot_req, run_id, aws_region, pool_id):
     ins_id = spot_req['InstanceId']
     pipe_log('Setting \"Name={}\" tag for instance {}'.format(run_id, ins_id))
     instance = ec2.describe_instances(InstanceIds=[ins_id])
@@ -1167,7 +1174,7 @@ def tag_and_get_instance(ec2, spot_req, run_id, aws_region):
     if not tag_name_is_present(instance):  # create tag name if not presents
         ec2.create_tags(
             Resources=[ins_id],
-            Tags=get_tags(run_id, aws_region),
+            Tags=get_tags(run_id, aws_region, pool_id),
         )
         pipe_log('Tag ({}) created for instance ({})\n-'.format(run_id, ins_id))
     else:
@@ -1233,6 +1240,7 @@ def main():
     region_id = args.region_id
     pre_pull_images = args.image
     additional_labels = args.label
+    pool_id = additional_labels.get(POOL_ID_KEY)
 
     if not kube_ip or not kubeadm_token:
         raise RuntimeError('Kubernetes configuration is required to create a new node')
@@ -1307,7 +1315,7 @@ def main():
 
         ins_id, ins_ip = verify_run_id(ec2, run_id)
         if not ins_id:
-            ins_id, ins_ip = check_spot_request_exists(ec2, num_rep, run_id, time_rep, aws_region)
+            ins_id, ins_ip = check_spot_request_exists(ec2, num_rep, run_id, time_rep, aws_region, pool_id)
 
         if not ins_id:
             api_url = os.environ["API"]

--- a/scripts/autoscaling/nodeup.py
+++ b/scripts/autoscaling/nodeup.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -66,6 +66,7 @@ def main():
     cloud = args.cloud
     pre_pull_images = args.image
     additional_labels = args.label
+    pool_id = additional_labels.get('pool_id')
 
     if not kube_ip or not kubeadm_token:
         raise RuntimeError('Kubernetes configuration is required to create a new node')
@@ -78,7 +79,7 @@ def main():
 
 
     cloud_provider = autoscaling.create_cloud_provider(cloud, region_id)
-    utils.pipe_log('Started initialization of new calculation node in AWS region {}:\n'
+    utils.pipe_log('Started initialization of new calculation node in {} region {}:\n'
                    '- RunID: {}\n'
                    '- Type: {}\n'
                    '- Disk: {}\n'
@@ -87,7 +88,8 @@ def main():
                    '- IsSpot: {}\n'
                    '- BidPrice: {}\n'
                    '- Repeat attempts: {}\n'
-                   '- Repeat timeout: {}\n-'.format(region_id,
+                   '- Repeat timeout: {}\n-'.format(cloud,
+                                              region_id,
                                               run_id,
                                               ins_type,
                                               ins_hdd,
@@ -117,7 +119,7 @@ def main():
 
         if not ins_id:
             ins_id, ins_ip = cloud_provider.run_instance(is_spot, bid_price, ins_type, ins_hdd, ins_img, ins_platform, ins_key, run_id,
-                                                         kms_encyr_key_id, num_rep, time_rep, kube_ip,
+                                                         pool_id, kms_encyr_key_id, num_rep, time_rep, kube_ip,
                                                          kubeadm_token, kubeadm_cert_hash, kube_node_token,
                                                          pre_pull_images)
 

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/model/vm/MissingNodeSummary.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/model/vm/MissingNodeSummary.java
@@ -28,4 +28,5 @@ public class MissingNodeSummary {
 
     private final VirtualMachine vm;
     private final List<PipelineRun> matchingRuns;
+    private final Long matchingPoolId;
 }

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMNotifier.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMNotifier.java
@@ -68,8 +68,9 @@ public class VMNotifier {
                                "missingLabelsSummaries");
     }
 
-    public void queueMissingNodeNotification(final VirtualMachine vm, final List<PipelineRun> matchingRuns) {
-        missingNodes.add(new MissingNodeSummary(vm, matchingRuns));
+    public void queueMissingNodeNotification(final VirtualMachine vm, final List<PipelineRun> matchingRuns,
+                                             final Long matchingPoolId) {
+        missingNodes.add(new MissingNodeSummary(vm, matchingRuns, matchingPoolId));
     }
 
     public void queueMissingLabelsNotification(final NodeInstance node, final VirtualMachine vm,

--- a/vm-monitor/src/main/resources/templates/MISSING-LABELS.html
+++ b/vm-monitor/src/main/resources/templates/MISSING-LABELS.html
@@ -51,7 +51,8 @@
         <td>
             #set( $correspondingRunStatus = $summary.correspondingRunStatus )
             #if ($correspondingRunStatus)
-                Run <a href="https://$templateParameters["externalHost"]:$templateParameters["externalPort"]/pipeline/#/run/$correspondingRunStatus.runId">$correspondingRunStatus.runId</a> [ $correspondingRunStatus.status ] <br>
+                #set( $statusCode = $correspondingRunStatus.status )
+                Run <a href="https://$templateParameters["externalHost"]:$templateParameters["externalPort"]/pipeline/#/run/$correspondingRunStatus.runId">$correspondingRunStatus.runId</a> [ #if( $statusCode )$statusCode#{else}UNKNOWN#end] <br>
             #end
             #set( $correspondingPoolId = $summary.correspondingPoolId )
             #if ($correspondingPoolId)

--- a/vm-monitor/src/main/resources/templates/MISSING-LABELS.html
+++ b/vm-monitor/src/main/resources/templates/MISSING-LABELS.html
@@ -50,13 +50,12 @@
         <td>$summary.creationTimestamp</td>
         <td>
             #set( $correspondingRunStatus = $summary.correspondingRunStatus )
-            #if ($correspondingRunStatus)
+            #if ( $correspondingRunStatus )
                 #set( $statusCode = $correspondingRunStatus.status )
                 Run <a href="https://$templateParameters["externalHost"]:$templateParameters["externalPort"]/pipeline/#/run/$correspondingRunStatus.runId">$correspondingRunStatus.runId</a> [ #if( $statusCode )$statusCode#{else}UNKNOWN#end] <br>
             #end
-            #set( $correspondingPoolId = $summary.correspondingPoolId )
-            #if ($correspondingPoolId)
-                Pool <a href="https://$templateParameters["externalHost"]:$templateParameters["externalPort"]/pipeline/#/cluster?pool_id=$correspondingPoolId">$correspondingPoolId</a><br>
+            #if ( $summary.correspondingPoolId )
+                Pool <a href="https://$templateParameters["externalHost"]:$templateParameters["externalPort"]/pipeline/#/cluster?pool_id=$summary.correspondingPoolId">$summary.correspondingPoolId</a><br>
             #end
         </td>
         <td>

--- a/vm-monitor/src/main/resources/templates/MISSING-NODE.html
+++ b/vm-monitor/src/main/resources/templates/MISSING-NODE.html
@@ -40,7 +40,7 @@
         <td><b>Creation date</b></td>
         <td><b>Instance type</b></td>
         <td><b>Private IP</b></td>
-        <td><b>Matching runs</b></td>
+        <td><b>Matching runs/pool</b></td>
         <td><b>Provider</b></td>
         <td><b>Action proposed</b></td>
     </tr>
@@ -54,7 +54,10 @@
                 #foreach( $run in $summary.matchingRuns )
                     #set( $runId = $run.id )
                     #set( $runStatus =  $run.status )
-                    <a href="https://$templateParameters["externalHost"]:$templateParameters["externalPort"]/pipeline/#/run/$runId">$runId</a> [ #if( $runStatus )$runStatus.name#{else}UNKNOWN#end ] <br>
+                    Run <a href="https://$templateParameters["externalHost"]:$templateParameters["externalPort"]/pipeline/#/run/$runId">$runId</a> [ #if( $runStatus )$runStatus.name#{else}UNKNOWN#end ] <br>
+                #end
+                #if ( $summary.matchingPoolId )
+                    Pool <a href="https://$templateParameters["externalHost"]:$templateParameters["externalPort"]/pipeline/#/cluster?pool_id=$summary.matchingPoolId">$summary.matchingPoolId</a><br>
                 #end
             </td>
             <td>$summary.vm.cloudProvider</td>

--- a/vm-monitor/src/main/resources/templates/MISSING-NODE.html
+++ b/vm-monitor/src/main/resources/templates/MISSING-NODE.html
@@ -52,7 +52,9 @@
             <td>$summary.vm.privateIp</td>
             <td>
                 #foreach( $run in $summary.matchingRuns )
-                    <a href="https://$templateParameters["externalHost"]:$templateParameters["externalPort"]/pipeline/#/run/$run.id">$run.id</a> [ $run.status.name ] <br>
+                    #set( $runId = $run.id )
+                    #set( $runStatus =  $run.status )
+                    <a href="https://$templateParameters["externalHost"]:$templateParameters["externalPort"]/pipeline/#/run/$runId">$runId</a> [ #if( $runStatus )$runStatus.name#{else}UNKNOWN#end ] <br>
                 #end
             </td>
             <td>$summary.vm.cloudProvider</td>

--- a/vm-monitor/src/test/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitorTest.java
+++ b/vm-monitor/src/test/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitorTest.java
@@ -80,7 +80,7 @@ public class VMMonitorTest {
         doReturn(Collections.singletonList(nodePool)).when(mockApiClient).loadNodePools();
         monitor.monitor();
 
-        verify(notifier, never()).queueMissingNodeNotification(vm, Collections.emptyList());
+        verify(notifier, never()).queueMissingNodeNotification(vm, Collections.emptyList(), POOL_ID);
     }
 
     @Test
@@ -89,6 +89,6 @@ public class VMMonitorTest {
         doReturn(Collections.singletonList(vm)).when(mockService).fetchRunningVms(region);
         monitor.monitor();
 
-        verify(notifier).queueMissingNodeNotification(vm, Collections.emptyList());
+        verify(notifier).queueMissingNodeNotification(vm, Collections.emptyList(), null);
     }
 }

--- a/workflows/pipe-common/pipeline/autoscaling/azureprovider.py
+++ b/workflows/pipe-common/pipeline/autoscaling/azureprovider.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ class AzureInstanceProvider(AbstractInstanceProvider):
         self.compute_client = get_client_from_auth_file(ComputeManagementClient)
         self.resource_group_name = os.environ["AZURE_RESOURCE_GROUP"]
 
-    def run_instance(self, is_spot, bid_price, ins_type, ins_hdd, ins_img, ins_platform, ins_key, run_id, kms_encyr_key_id,
+    def run_instance(self, is_spot, bid_price, ins_type, ins_hdd, ins_img, ins_platform, ins_key, run_id, pool_id, kms_encyr_key_id,
                      num_rep, time_rep, kube_ip, kubeadm_token, kubeadm_cert_hash, kube_node_token, pre_pull_images=[]):
         try:
             ins_key = utils.read_ssh_key(ins_key)
@@ -68,10 +68,10 @@ class AzureInstanceProvider(AbstractInstanceProvider):
                 disable_external_access = DISABLE_ACCESS in access_config and access_config[DISABLE_ACCESS]
             if not is_spot:
                 self.__create_nic(instance_name, run_id, disable_external_access)
-                return self.__create_vm(instance_name, run_id, ins_type, ins_img, ins_hdd, user_data_script,
+                return self.__create_vm(instance_name, run_id, pool_id, ins_type, ins_img, ins_hdd, user_data_script,
                                         ins_key, "pipeline", swap_size)
             else:
-                return self.__create_low_priority_vm(instance_name, run_id, ins_type, ins_img, ins_hdd,
+                return self.__create_low_priority_vm(instance_name, run_id, pool_id, ins_type, ins_img, ins_hdd,
                                                      user_data_script, ins_key, "pipeline", swap_size, disable_external_access)
         except Exception as e:
             self.__delete_all_by_run_id(run_id)
@@ -285,7 +285,7 @@ class AzureInstanceProvider(AbstractInstanceProvider):
                         break
         return disk_type
 
-    def __create_vm(self, instance_name, run_id, instance_type, instance_image, disk, user_data_script,
+    def __create_vm(self, instance_name, run_id, pool_id, instance_type, instance_image, disk, user_data_script,
                   ssh_pub_key, user, swap_size):
         nic = self.network_client.network_interfaces.get(
             self.resource_group_name,
@@ -312,7 +312,7 @@ class AzureInstanceProvider(AbstractInstanceProvider):
                     'id': nic.id
                 }]
             },
-            'tags': AzureInstanceProvider.get_tags(run_id)
+            'tags': AzureInstanceProvider.get_tags(run_id, pool_id)
         }
 
         self.__create_node_resource(self.compute_client.virtual_machines, instance_name, vm_parameters)
@@ -322,7 +322,7 @@ class AzureInstanceProvider(AbstractInstanceProvider):
 
         return instance_name, private_ip
 
-    def __create_low_priority_vm(self, scale_set_name, run_id, instance_type, instance_image,
+    def __create_low_priority_vm(self, scale_set_name, run_id, pool_id, instance_type, instance_image,
                                  disk, user_data_script, ssh_pub_key, user, swap_size, disable_external_access):
 
         resource_group, image_name = AzureInstanceProvider.get_res_grp_and_res_name_from_string(instance_image, 'images')
@@ -378,7 +378,7 @@ class AzureInstanceProvider(AbstractInstanceProvider):
                     }
                 }
             },
-            'tags': AzureInstanceProvider.get_tags(run_id)
+            'tags': AzureInstanceProvider.get_tags(run_id, pool_id)
         }
 
         if not disable_external_access:
@@ -579,9 +579,11 @@ class AzureInstanceProvider(AbstractInstanceProvider):
         }
 
     @staticmethod
-    def get_tags(run_id):
-        tags = AzureInstanceProvider.run_id_tag(run_id)
+    def get_tags(run_id, pool_id=None):
+        tags = AzureInstanceProvider.run_id_tag(run_id, pool_id)
         res_tags = AzureInstanceProvider.resource_tags()
         if res_tags:
             tags.update(res_tags)
+        if pool_id:
+            tags['pool_id'] = pool_id
         return tags

--- a/workflows/pipe-common/pipeline/autoscaling/cloudprovider.py
+++ b/workflows/pipe-common/pipeline/autoscaling/cloudprovider.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ LIMIT_EXCEEDED_EXIT_CODE = 6
 
 class AbstractInstanceProvider(object):
 
-    def run_instance(self, is_spot, bid_price, ins_type, ins_hdd, ins_img, ins_platform, ins_key, run_id, kms_encyr_key_id,
+    def run_instance(self, is_spot, bid_price, ins_type, ins_hdd, ins_img, ins_platform, ins_key, run_id, pool_id, kms_encyr_key_id,
                      num_rep, time_rep, kube_ip, kubeadm_token, kubeadm_cert_hash, kube_node_token):
         pass
 

--- a/workflows/pipe-common/pipeline/autoscaling/gcpprovider.py
+++ b/workflows/pipe-common/pipeline/autoscaling/gcpprovider.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ class GCPInstanceProvider(AbstractInstanceProvider):
         self.project_id = os.environ["GOOGLE_PROJECT_ID"]
         self.client = discovery.build('compute', 'v1')
 
-    def run_instance(self, is_spot, bid_price, ins_type, ins_hdd, ins_img, ins_platform, ins_key, run_id, kms_encyr_key_id,
+    def run_instance(self, is_spot, bid_price, ins_type, ins_hdd, ins_img, ins_platform, ins_key, run_id, pool_id, kms_encyr_key_id,
                      num_rep, time_rep, kube_ip, kubeadm_token, kubeadm_cert_hash, kube_node_token, pre_pull_images=[]):
         ssh_pub_key = utils.read_ssh_key(ins_key)
         swap_size = utils.get_swap_size(self.cloud_region, ins_type, is_spot, "GCP")
@@ -74,7 +74,7 @@ class GCPInstanceProvider(AbstractInstanceProvider):
             'canIpForward': False,
             'disks': self.__get_disk_devices(ins_img, OS_DISK_SIZE, ins_hdd, swap_size),
             'networkInterfaces': network_interfaces,
-            'labels': GCPInstanceProvider.get_tags(run_id, self.cloud_region),
+            'labels': GCPInstanceProvider.get_tags(run_id, pool_id, self.cloud_region),
             'tags': {
                 'items': utils.get_network_tags(self.cloud_region)
             },
@@ -351,8 +351,10 @@ class GCPInstanceProvider(AbstractInstanceProvider):
         }
 
     @staticmethod
-    def get_tags(run_id, cloud_region):
+    def get_tags(run_id, pool_id, cloud_region):
         tags = GCPInstanceProvider.run_id_tag(run_id)
+        if pool_id:
+            GCPInstanceProvider.append_tags(tags, {'pool_id': pool_id})
         GCPInstanceProvider.append_tags(tags, GCPInstanceProvider.resource_tags())
         GCPInstanceProvider.append_tags(tags, utils.get_region_tags(cloud_region))
         return tags


### PR DESCRIPTION
This PR is related to issue #2568 

It removes checks whether run or pool, retrieved from labels of cluster node or cloud provider virtual machine, exists.
Since those notifications are used for administration, it seems useful to inform if any matches are found, even if they are out of date at sending time.