### PR TITLE
Issue #2590 `cp-tinyproxy` monitoring

### DIFF
--- a/deploy/docker/cp-vm-monitor/config/application.properties
+++ b/deploy/docker/cp-vm-monitor/config/application.properties
@@ -37,6 +37,7 @@ monitor.tinyproxy.cron=${CP_VM_MONITOR_TINYPROXY_MONITORING_CRON:0 * * ? * *}
 monitor.tinyproxy.http.proxy.url=${CP_VM_MONITOR_TINYPROXY_MONITORING_PROXY_URL:cp-tinyproxy.default.svc.cluster.local:3128}
 monitor.tinyproxy.stats.endpoint.url=${CP_VM_MONITOR_TINYPROXY_MONITORING_STATS_URL:http://tinyproxy.stats}
 monitor.tinyproxy.stats.thresholds=${CP_VM_MONITOR_TINYPROXY_MONITORING_THRESHOLDS:{:}}
+monitor.tinyproxy.stats.request.timeout.seconds=${CP_VM_MONITOR_TINYPROXY_REQUEST_TIMEOUT_SECONDS:10}
 monitor.tinyproxy.notification.resend.delay.mins=${CP_VM_MONITOR_TINYPROXY_MONITORING_RESEND_DELAY_MINUTES:120}
 
 #Notification settings

--- a/deploy/docker/cp-vm-monitor/config/application.properties
+++ b/deploy/docker/cp-vm-monitor/config/application.properties
@@ -31,6 +31,14 @@ monitor.k8s.deployment.names=${CP_VM_MONITOR_DEPLOY_NAMES:cp-api-db,cp-api-srv,c
 monitor.filesystem.cron=${CP_VM_MONITOR_FILESYSTEM_MONITORING_CRON:0 * * ? * *}
 monitor.filesystem.scan.configuration=${CP_VM_MONITOR_FILESYSTEM_CONFIGURATION: {'/fs/core-fs':80}}
 
+# Tinyproxy monitor
+monitor.tinyproxy.enable=${CP_VM_MONITOR_TINYPROXY_MONITORING_ENABLE:false}
+monitor.tinyproxy.cron=${CP_VM_MONITOR_TINYPROXY_MONITORING_CRON:0 * * ? * *}
+monitor.tinyproxy.http.proxy.url=${CP_VM_MONITOR_TINYPROXY_MONITORING_PROXY_URL:cp-tinyproxy.default.svc.cluster.local:3128}
+monitor.tinyproxy.stats.endpoint.url=${CP_VM_MONITOR_TINYPROXY_MONITORING_STATS_URL:http://tinyproxy.stats}
+monitor.tinyproxy.stats.thresholds=${CP_VM_MONITOR_TINYPROXY_MONITORING_THRESHOLDS:{:}}
+monitor.tinyproxy.notification.resend.delay.mins=${CP_VM_MONITOR_TINYPROXY_MONITORING_RESEND_DELAY_MINUTES:120}
+
 #Notification settings
 notification.subject.prefix=${CP_VM_MONITOR_SUBJECT_PREFIX:}
 notification.missing-node.subject=[$templateParameters["fullPlatformName"]] VMs are not registered in cluster
@@ -50,6 +58,9 @@ notification.not-ready-deploy.template=${CP_VM_MONITOR_TEMPLATES:classpath:}/tem
 
 notification.filesystem.subject=[$templateParameters["fullPlatformName"]] monitored core file system exceeds threshold
 notification.filesystem.template=${CP_VM_MONITOR_TEMPLATES:classpath:}/templates/FILESYSTEM_THRESHOLD.html
+
+notification.tinyproxy.subject=[$templateParameters["fullPlatformName"]] tinyproxy stats exceeds threshold
+notification.tinyproxy.template=${CP_VM_MONITOR_TEMPLATES:classpath:}/templates/TINYPROXY-THRESHOLD.html
 
 notification.to-user=${CP_VM_MONITOR_TO_USER}
 notification.copy-users=${CP_VM_MONITOR_CC_USERS}

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/exception/TinyproxyMonitoringException.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/exception/TinyproxyMonitoringException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.vmmonitor.exception;
+
+public class TinyproxyMonitoringException extends RuntimeException {
+
+    public TinyproxyMonitoringException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/model/k8s/TinyproxyThresholdEvent.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/model/k8s/TinyproxyThresholdEvent.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.vmmonitor.model.k8s;
+
+import lombok.Value;
+
+import java.time.LocalDateTime;
+
+@Value
+public class TinyproxyThresholdEvent {
+
+    private final String thresholdKey;
+    private final Long thresholdValue;
+    private final Long actualValue;
+    private final LocalDateTime timestamp;
+}

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/MonitorScheduleService.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/MonitorScheduleService.java
@@ -89,6 +89,7 @@ public class MonitorScheduleService {
     @Scheduled(cron = "${monitor.tinyproxy.cron}")
     public void monitorTinyproxy() {
         if (tinyproxyMonitor == null) {
+            log.debug("Tinyproxy monitoring is disabled.");
             return;
         }
         try {

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/MonitorScheduleService.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/MonitorScheduleService.java
@@ -20,11 +20,14 @@ package com.epam.pipeline.vmmonitor.service;
 import com.epam.pipeline.vmmonitor.service.certificate.CertificateMonitor;
 import com.epam.pipeline.vmmonitor.service.filesystem.FileSystemMonitor;
 import com.epam.pipeline.vmmonitor.service.k8s.KubernetesDeploymentMonitor;
+import com.epam.pipeline.vmmonitor.service.k8s.TinyproxyMonitor;
 import com.epam.pipeline.vmmonitor.service.vm.VMMonitor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+
+import javax.annotation.Nullable;
 
 @Service
 @RequiredArgsConstructor
@@ -36,6 +39,8 @@ public class MonitorScheduleService {
     private final CertificateMonitor certificateMonitor;
     private final KubernetesDeploymentMonitor deploymentMonitor;
     private final FileSystemMonitor fileSystemMonitor;
+    @Nullable
+    private final TinyproxyMonitor tinyproxyMonitor;
 
     @Scheduled(cron = "${monitor.schedule.cron}")
     public void monitor() {
@@ -78,6 +83,20 @@ public class MonitorScheduleService {
             log.debug("Finished filesystem check.");
         } catch (Exception e) {
             log.error("An error occurred during filesystem check.", e);
+        }
+    }
+
+    @Scheduled(cron = "${monitor.tinyproxy.cron}")
+    public void monitorTinyproxy() {
+        if (tinyproxyMonitor == null) {
+            return;
+        }
+        try {
+            log.debug("Starting tinyproxy check.");
+            tinyproxyMonitor.monitor();
+            log.debug("Finished tinyproxy check.");
+        } catch (Exception e) {
+            log.error("An error occurred during tinyproxy check.", e);
         }
     }
 }

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/k8s/KubernetesNotifier.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/k8s/KubernetesNotifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,14 @@
 
 package com.epam.pipeline.vmmonitor.service.k8s;
 
+import com.epam.pipeline.vmmonitor.model.k8s.TinyproxyThresholdEvent;
 import com.epam.pipeline.vmmonitor.service.notification.VMNotificationService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Component
@@ -33,18 +35,24 @@ public class KubernetesNotifier {
     private final String missingDeploymentTemplate;
     private final String notReadyDeploymentSubject;
     private final String notReadyDeploymentTemplate;
+    private final String tinyproxyThresholdSubject;
+    private final String tinyproxyThresholdTemplate;
 
     public KubernetesNotifier(
             final VMNotificationService notificationService,
             final @Value("${notification.missing-deploy.subject}") String missingDeploymentSubject,
             final @Value("${notification.missing-deploy.template}") String missingDeploymentTemplate,
             final @Value("${notification.not-ready-deploy.subject}") String notReadyDeploymentSubject,
-            final @Value("${notification.not-ready-deploy.template}") String notReadyDeploymentTemplate) {
+            final @Value("${notification.not-ready-deploy.template}") String notReadyDeploymentTemplate,
+            final @Value("${notification.tinyproxy.subject}") String tinyproxyThresholdSubject,
+            final @Value("${notification.tinyproxy.template}") String tinyproxyThresholdTemplate) {
         this.notificationService = notificationService;
         this.missingDeploymentSubject = missingDeploymentSubject;
         this.missingDeploymentTemplate = missingDeploymentTemplate;
         this.notReadyDeploymentSubject = notReadyDeploymentSubject;
         this.notReadyDeploymentTemplate = notReadyDeploymentTemplate;
+        this.tinyproxyThresholdSubject = tinyproxyThresholdSubject;
+        this.tinyproxyThresholdTemplate = tinyproxyThresholdTemplate;
     }
 
     public void notifyMissingDeployment(final String deploymentName) {
@@ -60,5 +68,10 @@ public class KubernetesNotifier {
         parameters.put("requiredReplicas", required);
         parameters.put("readyReplicas", ready);
         notificationService.sendMessage(parameters, notReadyDeploymentSubject, notReadyDeploymentTemplate);
+    }
+
+    public void notifyTinyproxyThreshold(final List<TinyproxyThresholdEvent> events) {
+        notificationService.sendMessage(Collections.singletonMap("thresholdEvents", events),
+                                        tinyproxyThresholdSubject, tinyproxyThresholdTemplate);
     }
 }

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/k8s/TinyproxyMonitor.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/k8s/TinyproxyMonitor.java
@@ -65,10 +65,10 @@ public class TinyproxyMonitor {
         log.info("Checking {} configured tinyproxy stats thresholds", statsThresholds.size());
         final LocalDateTime checkTime = LocalDateTime.now();
         final List<TinyproxyThresholdEvent> thresholdEvents = getExceedingThresholdsEvents(checkTime);
-        log.info("{} tinyproxy threshold events detected", thresholdEvents.size());
+        log.info("Tinyproxy threshold events detected: {}", getEventsNames(thresholdEvents));
         thresholdEvents.removeIf(this::beforeNextNotificationTime);
         if (CollectionUtils.isNotEmpty(thresholdEvents)) {
-            log.info("Sending notifications on {} tinyproxy threshold events", thresholdEvents.size());
+            log.info("Sending notifications on tinyproxy threshold events: {}", getEventsNames(thresholdEvents));
             kubernetesNotifier.notifyTinyproxyThreshold(thresholdEvents);
             thresholdEvents.forEach(event -> lastNotification.put(event.getThresholdKey(), checkTime));
         } else {
@@ -101,5 +101,11 @@ public class TinyproxyMonitor {
         return statsClient.load().entrySet().stream()
             .filter(e -> NumberUtils.isDigits(e.getValue()))
             .collect(Collectors.toMap(Map.Entry::getKey, e -> Long.parseLong(e.getValue())));
+    }
+
+    private List<String> getEventsNames(final List<TinyproxyThresholdEvent> thresholdEvents) {
+        return thresholdEvents.stream()
+            .map(TinyproxyThresholdEvent::getThresholdKey)
+            .collect(Collectors.toList());
     }
 }

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/k8s/TinyproxyMonitor.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/k8s/TinyproxyMonitor.java
@@ -82,7 +82,7 @@ public class TinyproxyMonitor {
             .map(e -> {
                 final String thresholdKey = e.getKey();
                 final Long thresholdValue = e.getValue();
-                final Long latestValue = latestStats.getOrDefault(thresholdKey, 0L);
+                final Long latestValue = latestStats.getOrDefault(thresholdKey, -1L);
                 return new TinyproxyThresholdEvent(thresholdKey, thresholdValue, latestValue, checkTime);
             })
             .filter(event -> event.getActualValue() > event.getThresholdValue())

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/k8s/TinyproxyMonitor.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/k8s/TinyproxyMonitor.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.vmmonitor.service.k8s;
+
+import com.epam.pipeline.vmmonitor.model.k8s.TinyproxyThresholdEvent;
+import com.epam.pipeline.vmmonitor.service.pipeline.TinyproxyStatsClient;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@ConditionalOnProperty(value = "monitor.tinyproxy.enable", havingValue = "true")
+public class TinyproxyMonitor {
+
+    private final KubernetesNotifier kubernetesNotifier;
+    private final TinyproxyStatsClient statsClient;
+    private final Integer notificationResendDelayMinutes;
+    private final Map<String, Long> statsThresholds;
+    private final Map<String, LocalDateTime> lastNotification;
+
+    public TinyproxyMonitor(final KubernetesNotifier kubernetesNotifier,
+                            final TinyproxyStatsClient statsClient,
+                            @Value("#{${monitor.tinyproxy.stats.thresholds:{:}}}")
+                            final Map<String, Long> statsThresholds,
+                            @Value("${monitor.tinyproxy.notification.resend.delay.mins:120}")
+                            final Integer notificationResendDelayMinutes) {
+        this.kubernetesNotifier = kubernetesNotifier;
+        this.statsClient = statsClient;
+        this.notificationResendDelayMinutes = notificationResendDelayMinutes;
+        this.statsThresholds = MapUtils.emptyIfNull(statsThresholds);
+        this.lastNotification = new HashMap<>();
+    }
+
+    public void monitor() {
+        if (MapUtils.isEmpty(statsThresholds)) {
+            log.info("No thresholds configured for tinyproxy monitoring.");
+            return;
+        }
+        log.info("Checking {} configured tinyproxy stats thresholds", statsThresholds.size());
+        final LocalDateTime checkTime = LocalDateTime.now();
+        final List<TinyproxyThresholdEvent> thresholdEvents = getExceedingThresholdsEvents(checkTime);
+        log.info("{} tinyproxy threshold events detected", thresholdEvents.size());
+        thresholdEvents.removeIf(this::beforeNextNotificationTime);
+        if (CollectionUtils.isNotEmpty(thresholdEvents)) {
+            log.info("Sending notifications on {} tinyproxy threshold events", thresholdEvents.size());
+            kubernetesNotifier.notifyTinyproxyThreshold(thresholdEvents);
+            thresholdEvents.forEach(event -> lastNotification.put(event.getThresholdKey(), checkTime));
+        } else {
+            log.info("No threshold events requires notification");
+        }
+    }
+
+    private List<TinyproxyThresholdEvent> getExceedingThresholdsEvents(final LocalDateTime checkTime) {
+        final Map<String, Long> latestStats = loadTinyproxyNumericStats();
+        return statsThresholds.entrySet().stream()
+            .map(e -> {
+                final String thresholdKey = e.getKey();
+                final Long thresholdValue = e.getValue();
+                final Long latestValue = latestStats.getOrDefault(thresholdKey, 0L);
+                return new TinyproxyThresholdEvent(thresholdKey, thresholdValue, latestValue, checkTime);
+            })
+            .filter(event -> event.getActualValue() > event.getThresholdValue())
+            .collect(Collectors.toList());
+    }
+
+    private boolean beforeNextNotificationTime(final TinyproxyThresholdEvent event) {
+        final LocalDateTime nextNotificationTimestamp =
+            lastNotification.getOrDefault(event.getThresholdKey(), LocalDateTime.MIN)
+                .plus(notificationResendDelayMinutes, ChronoUnit.MINUTES);
+        return event.getTimestamp().isBefore(nextNotificationTimestamp);
+    }
+
+    private Map<String, Long> loadTinyproxyNumericStats() {
+        log.info("Loading tinyproxy stats");
+        return statsClient.load().entrySet().stream()
+            .filter(e -> NumberUtils.isDigits(e.getValue()))
+            .collect(Collectors.toMap(Map.Entry::getKey, e -> Long.parseLong(e.getValue())));
+    }
+}

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/pipeline/TinyproxyStatsClient.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/pipeline/TinyproxyStatsClient.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.vmmonitor.service.pipeline;
+
+import com.epam.pipeline.utils.URLUtils;
+import com.epam.pipeline.vmmonitor.exception.TinyproxyMonitoringException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.OkHttpClient;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import retrofit2.Call;
+import retrofit2.Response;
+import retrofit2.Retrofit;
+import retrofit2.converter.scalars.ScalarsConverterFactory;
+import retrofit2.http.GET;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.security.GeneralSecurityException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+@Service
+public class TinyproxyStatsClient {
+
+    private final ObjectMapper mapper;
+    private final String proxyUrl;
+    private final String tinyproxyStatsUrl;
+
+    public TinyproxyStatsClient(
+        @Value("${monitor.tinyproxy.http.proxy.url:cp-tinyproxy.default.svc.cluster.local:3128}") final String proxyUrl,
+        @Value("${monitor.tinyproxy.stats.endpoint.url:tinyproxy.stats}") final String tinyproxyStatsUrl) {
+        this.proxyUrl = proxyUrl;
+        this.tinyproxyStatsUrl = tinyproxyStatsUrl;
+        this.mapper = new ObjectMapper();
+    }
+
+    public Map<String, String> load() {
+        try {
+            final Response<String> response = buildClient().loadStats().execute();
+            return mapper.readValue(response.body(), new TypeReference<Map<String, String>>() {});
+        } catch (IOException e) {
+            throw new TinyproxyMonitoringException("Error during tinyproxy stats requesting", e);
+        }
+    }
+
+    private TinyproxyStatsAPI buildClient() {
+        return new Retrofit.Builder()
+            .baseUrl(URLUtils.normalizeUrl(tinyproxyStatsUrl))
+            .addConverterFactory(ScalarsConverterFactory.create())
+            .client(buildHttpClient())
+            .build()
+            .create(TinyproxyStatsAPI.class);
+    }
+
+    private OkHttpClient buildHttpClient() {
+        final TrustManager[] trustAllCerts = new TrustManager[]{
+            new X509TrustManager() {
+                @Override
+                public void checkClientTrusted(java.security.cert.X509Certificate[] chain, String authType) {
+                }
+
+                @Override
+                public void checkServerTrusted(java.security.cert.X509Certificate[] chain, String authType) {
+                }
+
+                @Override
+                public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+                    return new java.security.cert.X509Certificate[]{};
+                }
+            }
+        };
+        final SSLContext sslContext = buildSSLContext(trustAllCerts);
+        final SSLSocketFactory sslSocketFactory = sslContext.getSocketFactory();
+
+        OkHttpClient.Builder builder = new OkHttpClient.Builder();
+        builder.sslSocketFactory(sslSocketFactory, (X509TrustManager)trustAllCerts[0]);
+        builder.hostnameVerifier((hostname, session) -> true);
+        final String[] proxyUrlChunks = proxyUrl.split(":");
+        final String proxyHostname = proxyUrlChunks[0];
+        final Integer proxyPort = Optional.of(proxyUrlChunks)
+            .filter(chunks -> chunks.length == 2)
+            .map(chunks -> chunks[1])
+            .filter(NumberUtils::isDigits)
+            .map(Integer::parseInt)
+            .orElse(3128);
+        return builder.readTimeout(10L, TimeUnit.SECONDS)
+            .connectTimeout(10L, TimeUnit.SECONDS)
+            .hostnameVerifier((s, sslSession) -> true)
+            .proxy(new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHostname, proxyPort)))
+            .build();
+    }
+
+    private SSLContext buildSSLContext(TrustManager[] trustAllCerts) {
+        try {
+            final SSLContext sslContext = SSLContext.getInstance("SSL");
+            sslContext.init(null, trustAllCerts, new java.security.SecureRandom());
+            return sslContext;
+        } catch (GeneralSecurityException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
+
+    }
+
+    private interface TinyproxyStatsAPI {
+
+        @GET("/")
+        Call<String> loadStats();
+    }
+}

--- a/vm-monitor/src/main/resources/application.properties
+++ b/vm-monitor/src/main/resources/application.properties
@@ -32,6 +32,14 @@ monitor.k8s.deployment.names=${CP_VM_MONITOR_DEPLOY_NAMES:cp-api-db,cp-api-srv,c
 monitor.filesystem.cron=${CP_VM_MONITOR_FILESYSTEM_MONITORING_CRON:0 * * ? * *}
 monitor.filesystem.scan.configuration=${CP_VM_MONITOR_FILESYSTEM_CONFIGURATION: {'/fs/core-fs':80}}
 
+# Tinyproxy monitor
+monitor.tinyproxy.enable=${CP_VM_MONITOR_TINYPROXY_MONITORING_ENABLE:false}
+monitor.tinyproxy.cron=${CP_VM_MONITOR_TINYPROXY_MONITORING_CRON:0 * * ? * *}
+monitor.tinyproxy.http.proxy.url=${CP_VM_MONITOR_TINYPROXY_MONITORING_PROXY_URL:cp-tinyproxy.default.svc.cluster.local:3128}
+monitor.tinyproxy.stats.endpoint.url=${CP_VM_MONITOR_TINYPROXY_MONITORING_STATS_URL:http://tinyproxy.stats}
+monitor.tinyproxy.stats.thresholds=${CP_VM_MONITOR_TINYPROXY_MONITORING_THRESHOLDS:{:}}
+monitor.tinyproxy.notification.resend.delay.mins=${CP_VM_MONITOR_TINYPROXY_MONITORING_RESEND_DELAY_MINUTES:120}
+
 #Notification settings
 notification.missing-node.subject=[$templateParameters["fullPlatformName"]] VMs are not registered in cluster
 notification.missing-node.template=${CP_VM_MONITOR_TEMPLATES:classpath:}/templates/MISSING-NODE.html
@@ -50,6 +58,9 @@ notification.not-ready-deploy.template=${CP_VM_MONITOR_TEMPLATES:classpath:}/tem
 
 notification.filesystem.subject=[$templateParameters["fullPlatformName"]] monitored core file system exceeds threshold
 notification.filesystem.template=${CP_VM_MONITOR_TEMPLATES:classpath:}/templates/FILESYSTEM_THRESHOLD.html
+
+notification.tinyproxy.subject=[$templateParameters["fullPlatformName"]] tinyproxy stats exceeds threshold
+notification.tinyproxy.template=${CP_VM_MONITOR_TEMPLATES:classpath:}/templates/TINYPROXY-THRESHOLD.html
 
 notification.to-user=TEST
 notification.copy-users=TEST,TEST

--- a/vm-monitor/src/main/resources/application.properties
+++ b/vm-monitor/src/main/resources/application.properties
@@ -38,6 +38,7 @@ monitor.tinyproxy.cron=${CP_VM_MONITOR_TINYPROXY_MONITORING_CRON:0 * * ? * *}
 monitor.tinyproxy.http.proxy.url=${CP_VM_MONITOR_TINYPROXY_MONITORING_PROXY_URL:cp-tinyproxy.default.svc.cluster.local:3128}
 monitor.tinyproxy.stats.endpoint.url=${CP_VM_MONITOR_TINYPROXY_MONITORING_STATS_URL:http://tinyproxy.stats}
 monitor.tinyproxy.stats.thresholds=${CP_VM_MONITOR_TINYPROXY_MONITORING_THRESHOLDS:{:}}
+monitor.tinyproxy.stats.request.timeout.seconds=${CP_VM_MONITOR_TINYPROXY_REQUEST_TIMEOUT_SECONDS:10}
 monitor.tinyproxy.notification.resend.delay.mins=${CP_VM_MONITOR_TINYPROXY_MONITORING_RESEND_DELAY_MINUTES:120}
 
 #Notification settings

--- a/vm-monitor/src/main/resources/templates/TINYPROXY-THRESHOLD.html
+++ b/vm-monitor/src/main/resources/templates/TINYPROXY-THRESHOLD.html
@@ -1,0 +1,59 @@
+<!--
+  ~ Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <style>
+        table,
+        td {
+            border: 1px solid black;
+            border-collapse: collapse;
+            padding: 5px;
+        }
+    </style>
+</head>
+
+<body>
+<p>Dear user,</p>
+<p>*** This is a system generated email, do not reply to this email ***</p>
+<p>Looks like <b>tiniproxy</b> in the <b>$templateParameters["platformName"]</b> cluster exceeds some configured thresholds:</p>
+<p>
+<table>
+    <tr>
+        <td><b>Parameter</b></td>
+        <td><b>Threshold value</b></td>
+        <td><b>Actual value</b></td>
+        <td><b>Timestamp</b></td>
+    </tr>
+    #foreach( $event in $templateParameters["thresholdEvents"] )
+    <tr>
+        <td>$event.thresholdKey</td>
+        <td>$event.thresholdValue</td>
+        <td>$event.actualValue</td>
+        <td>$event.timestamp</td>
+    </tr>
+    #end
+</table>
+</p>
+<p>Please verify <b>tinyproxy</b> state.</p>
+<p>Best regards,</p>
+<p>$templateParameters["fullPlatformName"] Platform</p>
+</body>
+
+</html>


### PR DESCRIPTION
This PR is related to issue #2590 

It extends `vm-monitor` capabilities: there is a new service, which is requesting usage stats from `cp-tinyproxy` constantly and compare them to thresholds configured.

In case any value exceeds the corresponding threshold - notification should be sent. All the 'exceeding events' are collected and only a single notification is created for the whole monitoring cycle.

There is also the notification delay, which prevents firing too many messages regarding thresholds.