### PR TITLE
Issue #2568 Double-check active VMs for missing node notification

### DIFF
--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitor.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMMonitor.java
@@ -39,12 +39,15 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Main monitoring service class, checks VM status on a scheduled basis
@@ -86,6 +89,7 @@ public class VMMonitor {
         try {
             ListUtils.emptyIfNull(apiClient.loadRegions())
                     .forEach(this::checkVMs);
+            sendRunningVmsToNotifier();
         } finally {
             notifier.sendNotifications();
         }
@@ -260,5 +264,16 @@ public class VMMonitor {
                     return !nodeLabels.containsKey(label) || StringUtils.isBlank(nodeLabels.get(label));
                 })
                 .collect(Collectors.toList());
+    }
+
+    private void sendRunningVmsToNotifier() {
+        final Set<String> runningVmsIds = ListUtils.emptyIfNull(apiClient.loadRegions()).stream()
+            .flatMap(region -> getVmService(region)
+                .map(service -> service.fetchRunningVms(region))
+                .map(Collection<VirtualMachine>::stream)
+                .orElse(Stream.empty()))
+            .map(VirtualMachine::getInstanceId)
+            .collect(Collectors.toSet());
+        notifier.checkMissingNodesQueue(runningVmsIds);
     }
 }

--- a/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMNotifier.java
+++ b/vm-monitor/src/main/java/com/epam/pipeline/vmmonitor/service/vm/VMNotifier.java
@@ -34,6 +34,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.Set;
 
 @Component
 @Slf4j
@@ -71,6 +72,13 @@ public class VMNotifier {
     public void queueMissingNodeNotification(final VirtualMachine vm, final List<PipelineRun> matchingRuns,
                                              final Long matchingPoolId) {
         missingNodes.add(new MissingNodeSummary(vm, matchingRuns, matchingPoolId));
+    }
+
+    public void checkMissingNodesQueue(final Set<String> runningVmsIds) {
+        if (CollectionUtils.isNotEmpty(missingNodes)) {
+            missingNodes.removeIf(missingNodeSummary ->
+                                      !runningVmsIds.contains(missingNodeSummary.getVm().getInstanceId()));
+        }
     }
 
     public void queueMissingLabelsNotification(final NodeInstance node, final VirtualMachine vm,


### PR DESCRIPTION
This PR is related to the bug described in the comment https://github.com/epam/cloud-pipeline/issues/2568#issuecomment-1091858826

Cloud-Pipeline node down operation consists of 2 steps: 
- removing k8s node;
- terminating VM in the cloud.

It might lead to false-positive missing node notifications in case monitoring cycle started during that transition. 

PR brings additional fetching of active VMs from the cloud provider at the end of checking iteration - all the notifications on the missing nodes for VMs, that are already terminated, are dropped.