### PR TITLE
Support source deletion in data transfer service

### DIFF
--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/cmd/PipelineCLI.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/cmd/PipelineCLI.java
@@ -35,6 +35,10 @@ public interface PipelineCLI {
         return uploadData(source, destination, include, null);
     }
 
+    default String uploadData(String source, String destination, List<String> include, String username) {
+        return uploadData(source, destination, include, username, false);
+    }
+
     /**
      * Upload local file {@code source} to s3 bucket by path {@code destination}.
      *
@@ -42,7 +46,7 @@ public interface PipelineCLI {
      * @param destination Destination S3 file path.
      * @return Url of the file in bucket.
      */
-    String uploadData(String source, String destination, List<String> include, String username);
+    String uploadData(String source, String destination, List<String> include, String username, boolean deleteSource);
 
     default void downloadData(String source, Path destination) {
         downloadData(source, destination.toString());
@@ -56,13 +60,17 @@ public interface PipelineCLI {
         downloadData(source, destination, include, null);
     }
 
+    default void downloadData(String source, String destination, List<String> include, String username) {
+        downloadData(source, destination, include, username, false);
+    }
+
     /**
      * Download file from {@code destination} to local file {@code source}.
      *
      * @param source S3 file path.
      * @param destination Path to a file to be downloaded.
      */
-    void downloadData(String source, String destination, List<String> include, String username);
+    void downloadData(String source, String destination, List<String> include, String username, boolean deleteSource);
 
     /**
      * Retrieves a remote file description if one exists.

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/cmd/PipelineCLIImpl.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/cmd/PipelineCLIImpl.java
@@ -73,9 +73,7 @@ public class PipelineCLIImpl implements PipelineCLI {
 
             while (attempts < retryCount) {
                 try {
-                    final String command = deleteSource
-                            ? pipeMV(source, destination, include)
-                            : pipeCP(source, destination, include);
+                    final String command = buildPipeTransferCommand(source, destination, include, deleteSource);
                     cmdExecutor.executeCommand(command, username);
                     log.info(String.format("Successfully uploaded from %s to %s", source, destination));
                     return destination;
@@ -106,9 +104,7 @@ public class PipelineCLIImpl implements PipelineCLI {
 
         while (attempts < retryCount) {
             try {
-                final String command = deleteSource
-                        ? pipeMV(source, destination, include)
-                        : pipeCP(source, destination, include);
+                final String command = buildPipeTransferCommand(source, destination, include, deleteSource);
                 cmdExecutor.executeCommand(command, username);
                 log.info(String.format("Successfully downloaded from %s to %s", source, destination));
                 return;
@@ -184,17 +180,20 @@ public class PipelineCLIImpl implements PipelineCLI {
         };
     }
 
-    private String pipeCP(final String source,
-                          final String destination,
-                          final List<String> include) {
-        String command = String.format(PIPE_CP_TEMPLATE, pipelineCliExecutable, source, destination, pipeCpSuffix);
-        return CollectionUtils.isEmpty(include) ? command : command + SPACE + getIncludesArguments(include);
+    private String buildPipeTransferCommand(final String source,
+                                            final String destination,
+                                            final List<String> include,
+                                            final boolean deleteSource) {
+        return deleteSource
+                ? buildPipeTransferCommand(PIPE_MV_TEMPLATE, source, destination, include)
+                : buildPipeTransferCommand(PIPE_CP_TEMPLATE, source, destination, include);
     }
 
-    private String pipeMV(final String source,
-                          final String destination,
-                          final List<String> include) {
-        String command = String.format(PIPE_MV_TEMPLATE, pipelineCliExecutable, source, destination, pipeCpSuffix);
+    private String buildPipeTransferCommand(final String template,
+                                            final String source,
+                                            final String destination,
+                                            final List<String> include) {
+        final String command = String.format(template, pipelineCliExecutable, source, destination, pipeCpSuffix);
         return CollectionUtils.isEmpty(include) ? command : command + SPACE + getIncludesArguments(include);
     }
 

--- a/data-transfer-service/src/main/java/com/epam/pipeline/dts/sync/model/AutonomousSyncRule.java
+++ b/data-transfer-service/src/main/java/com/epam/pipeline/dts/sync/model/AutonomousSyncRule.java
@@ -23,9 +23,10 @@ import org.thymeleaf.util.StringUtils;
 @Value
 public class AutonomousSyncRule {
 
-    private String source;
-    private String destination;
-    private String cron;
+    String source;
+    String destination;
+    String cron;
+    Boolean deleteSource;
 
     public boolean isSameSyncPaths(final AutonomousSyncRule anotherRule) {
         return StringUtils.equals(source, anotherRule.getSource())

--- a/data-transfer-service/src/main/java/com/epam/pipeline/dts/sync/service/PreferenceService.java
+++ b/data-transfer-service/src/main/java/com/epam/pipeline/dts/sync/service/PreferenceService.java
@@ -26,5 +26,6 @@ public interface PreferenceService {
     Optional<List<AutonomousSyncRule>> getSyncRules();
     boolean isShutdownRequired();
     boolean isHeartbeatEnabled();
+    boolean isSourceDeletionEnabled();
     void clearShutdownFlag();
 }

--- a/data-transfer-service/src/main/java/com/epam/pipeline/dts/sync/service/impl/CloudPipelineApiPreferenceService.java
+++ b/data-transfer-service/src/main/java/com/epam/pipeline/dts/sync/service/impl/CloudPipelineApiPreferenceService.java
@@ -50,6 +50,7 @@ public class CloudPipelineApiPreferenceService implements PreferenceService {
     private final String dtsShutdownKey;
     private final String dtsSyncRulesKey;
     private final String dtsHeartbeatEnabledKey;
+    private final String dtsSourceDeletionEnabledKey;
 
     @Autowired
     public CloudPipelineApiPreferenceService(
@@ -59,6 +60,8 @@ public class CloudPipelineApiPreferenceService implements PreferenceService {
             final String dtsSyncRulesKey,
             @Value("${dts.preference.heartbeat.enabled.key:dts.heartbeat.enabled}")
             final String dtsHeartbeatEnabledKey,
+            @Value("${dts.preference.source.deletion.enabled.key:dts.source.deletion.enabled}")
+            final String dtsSourceDeletionEnabledKey,
             final CloudPipelineAPIClient apiClient,
             final IdentificationService identificationService) {
         this.apiClient = apiClient;
@@ -67,6 +70,7 @@ public class CloudPipelineApiPreferenceService implements PreferenceService {
         this.dtsShutdownKey = dtsShutdownKey;
         this.dtsSyncRulesKey = dtsSyncRulesKey;
         this.dtsHeartbeatEnabledKey = dtsHeartbeatEnabledKey;
+        this.dtsSourceDeletionEnabledKey = dtsSourceDeletionEnabledKey;
         log.info("Synchronizing preferences for current host: `{}`", identificationService.getId());
     }
 
@@ -100,6 +104,11 @@ public class CloudPipelineApiPreferenceService implements PreferenceService {
     @Override
     public boolean isHeartbeatEnabled() {
         return getBooleanPreference(dtsHeartbeatEnabledKey);
+    }
+
+    @Override
+    public boolean isSourceDeletionEnabled() {
+        return getBooleanPreference(dtsSourceDeletionEnabledKey);
     }
 
     private boolean getBooleanPreference(final String preference) {

--- a/data-transfer-service/src/main/java/com/epam/pipeline/dts/sync/service/impl/DtsSynchronizationService.java
+++ b/data-transfer-service/src/main/java/com/epam/pipeline/dts/sync/service/impl/DtsSynchronizationService.java
@@ -217,7 +217,9 @@ public class DtsSynchronizationService {
                                                final StorageItem transferDestination) {
         try {
             transferDestination.setCredentials(getPipeCredentialsAsString());
-            return transferService.runTransferTask(transferSource, transferDestination, Collections.emptyList());
+            return transferService.runTransferTask(transferSource, transferDestination,
+                    Collections.emptyList(),
+                    preferenceService.isSourceDeletionEnabled());
         } catch (JsonProcessingException e) {
             log.warn("Error parsing PIPE credentials!");
         } catch (Exception e) {

--- a/data-transfer-service/src/main/java/com/epam/pipeline/dts/transfer/model/TransferTask.java
+++ b/data-transfer-service/src/main/java/com/epam/pipeline/dts/transfer/model/TransferTask.java
@@ -72,4 +72,6 @@ public class TransferTask {
     @ElementCollection
     private List<String> included;
     private String user;
+
+    private boolean deleteSource;
 }

--- a/data-transfer-service/src/main/java/com/epam/pipeline/dts/transfer/rest/controller/TransferController.java
+++ b/data-transfer-service/src/main/java/com/epam/pipeline/dts/transfer/rest/controller/TransferController.java
@@ -70,7 +70,8 @@ public class TransferController extends AbstractRestController {
         TransferTask task = transferService.runTransferTask(
                 storageItemMapper.dtoToModel(taskCreationDTO.getSource()),
                 storageItemMapper.dtoToModel(taskCreationDTO.getDestination()),
-                taskCreationDTO.getIncluded());
+                taskCreationDTO.getIncluded(),
+                taskCreationDTO.isDeleteSource());
         return Result.success(taskMapper.modelToDto(task));
     }
 

--- a/data-transfer-service/src/main/java/com/epam/pipeline/dts/transfer/rest/dto/TaskCreationDTO.java
+++ b/data-transfer-service/src/main/java/com/epam/pipeline/dts/transfer/rest/dto/TaskCreationDTO.java
@@ -29,4 +29,5 @@ public class TaskCreationDTO {
     private StorageItemWithCredentialsDTO source;
     private StorageItemWithCredentialsDTO destination;
     private List<String> included = new ArrayList<>();
+    private boolean deleteSource;
 }

--- a/data-transfer-service/src/main/java/com/epam/pipeline/dts/transfer/service/TaskService.java
+++ b/data-transfer-service/src/main/java/com/epam/pipeline/dts/transfer/service/TaskService.java
@@ -33,7 +33,13 @@ public interface TaskService {
         return createTask(source, destination, included, null);
     }
 
-    TransferTask createTask(StorageItem source, StorageItem destination, List<String> included, String user);
+    default TransferTask createTask(StorageItem source, StorageItem destination, List<String> included, String user) {
+        return createTask(source, destination, included, user, false);
+    }
+
+    TransferTask createTask(StorageItem source, StorageItem destination, List<String> included, String user,
+                            boolean deleteSource);
+
     TransferTask updateStatus(Long id, TaskStatus status);
     TransferTask updateStatus(Long id, TaskStatus status, String reason);
     TransferTask updateTask(TransferTask transferTask);

--- a/data-transfer-service/src/main/java/com/epam/pipeline/dts/transfer/service/TransferService.java
+++ b/data-transfer-service/src/main/java/com/epam/pipeline/dts/transfer/service/TransferService.java
@@ -26,7 +26,8 @@ public interface TransferService {
 
     TransferTask runTransferTask(@NonNull StorageItem source,
                                  @NonNull StorageItem destination,
-                                 List<String> included);
+                                 List<String> included,
+                                 boolean deleteSource);
     
     void failRunningTasks();
 }

--- a/data-transfer-service/src/main/java/com/epam/pipeline/dts/transfer/service/impl/AbstractDataUploader.java
+++ b/data-transfer-service/src/main/java/com/epam/pipeline/dts/transfer/service/impl/AbstractDataUploader.java
@@ -31,10 +31,12 @@ public abstract class AbstractDataUploader implements DataUploader {
         final StorageItem destination = transferTask.getDestination();
         if (source.getType() == StorageType.LOCAL) {
             checkStoragePath(destination.getPath());
-            upload(source, destination, transferTask.getIncluded(), transferTask.getUser());
+            upload(source, destination, transferTask.getIncluded(), transferTask.getUser(),
+                    transferTask.isDeleteSource());
         } else {
             checkStoragePath(source.getPath());
-            download(source, destination, transferTask.getIncluded(), transferTask.getUser());
+            download(source, destination, transferTask.getIncluded(), transferTask.getUser(),
+                    transferTask.isDeleteSource());
         }
     }
 
@@ -44,9 +46,11 @@ public abstract class AbstractDataUploader implements DataUploader {
             String.format("%s path must have %s scheme.", getStorageType(), expectedPathPrefix));
     }
 
-    public abstract void upload(StorageItem source, StorageItem destination, List<String> include, String username);
+    public abstract void upload(StorageItem source, StorageItem destination, List<String> include, String username,
+                                boolean deleteSource);
 
-    public abstract void download(StorageItem source, StorageItem destination, List<String> include, String username);
+    public abstract void download(StorageItem source, StorageItem destination, List<String> include, String username,
+                                  boolean deleteSource);
 
     public abstract String getFilesPathPrefix();
 }

--- a/data-transfer-service/src/main/java/com/epam/pipeline/dts/transfer/service/impl/AbstractPipeCliDataUploader.java
+++ b/data-transfer-service/src/main/java/com/epam/pipeline/dts/transfer/service/impl/AbstractPipeCliDataUploader.java
@@ -34,21 +34,25 @@ public abstract class AbstractPipeCliDataUploader extends AbstractDataUploader {
     public void upload(final StorageItem source,
                        final StorageItem destination,
                        final List<String> included,
-                       final String username) {
+                       final String username,
+                       final boolean deleteSource) {
         final PipelineCredentials credentials = PipelineCredentials.from(destination.getCredentials());
         final PipelineCLI pipelineCLI =
                 pipelineCliProvider.getPipelineCLI(credentials.getApi(), credentials.getApiToken());
-        pipelineCLI.uploadData(source.getPath(), destination.getPath(), included, username);
+        pipelineCLI.uploadData(source.getPath(), destination.getPath(), included, username,
+                deleteSource);
     }
 
     @Override
     public void download(final StorageItem source,
                          final StorageItem destination,
                          final List<String> included,
-                         final String username) {
+                         final String username,
+                         final boolean deleteSource) {
         final PipelineCredentials credentials = PipelineCredentials.from(source.getCredentials());
         final PipelineCLI pipelineCLI =
                 pipelineCliProvider.getPipelineCLI(credentials.getApi(), credentials.getApiToken());
-        pipelineCLI.downloadData(source.getPath(), destination.getPath(), included, username);
+        pipelineCLI.downloadData(source.getPath(), destination.getPath(), included, username,
+                deleteSource);
     }
 }

--- a/data-transfer-service/src/main/java/com/epam/pipeline/dts/transfer/service/impl/GSJavaClientDataUploader.java
+++ b/data-transfer-service/src/main/java/com/epam/pipeline/dts/transfer/service/impl/GSJavaClientDataUploader.java
@@ -50,10 +50,11 @@ public class GSJavaClientDataUploader extends AbstractDataUploader {
     /**
      * @param include Is not supported yet.
      * @param username not supported.
+     * @param deleteSource Is not supported yet.
      */
     @Override
     public void upload(final StorageItem source, final StorageItem destination, final List<String> include,
-                       final String username) {
+                       final String username, final boolean deleteSource) {
         upload(source.getPath(), destination.getPath(), destination.getCredentials());
     }
 
@@ -81,10 +82,11 @@ public class GSJavaClientDataUploader extends AbstractDataUploader {
     /**
      * @param include Is not supported yet.
      * @param username not supported.
+     * @param deleteSource Is not supported yet.
      */
     @Override
     public void download(final StorageItem source, final StorageItem destination, final List<String> include,
-                         final String username) {
+                         final String username, final boolean deleteSource) {
         download(source.getPath(), destination.getPath(), source.getCredentials());
     }
 

--- a/data-transfer-service/src/main/java/com/epam/pipeline/dts/transfer/service/impl/ImpersonatingTransferServiceImpl.java
+++ b/data-transfer-service/src/main/java/com/epam/pipeline/dts/transfer/service/impl/ImpersonatingTransferServiceImpl.java
@@ -46,9 +46,11 @@ public class ImpersonatingTransferServiceImpl implements TransferService {
     @Override
     public TransferTask runTransferTask(@NonNull final StorageItem source,
                                         @NonNull final StorageItem destination,
-                                        final List<String> included) {
+                                        final List<String> included,
+                                        final boolean deleteSource) {
         final String impersonatingUser = getImpersonatingUser(source, destination);
-        final TransferTask transferTask = taskService.createTask(source, destination, included, impersonatingUser);
+        final TransferTask transferTask = taskService.createTask(source, destination, included, impersonatingUser,
+                deleteSource);
         taskService.updateStatus(transferTask.getId(), TaskStatus.RUNNING);
         dataUploaderProviderManager.transferData(transferTask);
         return transferTask;

--- a/data-transfer-service/src/main/java/com/epam/pipeline/dts/transfer/service/impl/TaskServiceImpl.java
+++ b/data-transfer-service/src/main/java/com/epam/pipeline/dts/transfer/service/impl/TaskServiceImpl.java
@@ -40,7 +40,8 @@ public class TaskServiceImpl implements TaskService {
     public TransferTask createTask(@NonNull StorageItem source,
                                    @NonNull StorageItem destination,
                                    List<String> included,
-                                   String user) {
+                                   String user,
+                                   boolean deleteSource) {
         TransferTask transferTask = TransferTask.builder()
                 .source(source)
                 .destination(destination)
@@ -49,6 +50,7 @@ public class TaskServiceImpl implements TaskService {
                 .reason("New transfer task created")
                 .included(included)
                 .user(user)
+                .deleteSource(deleteSource)
                 .build();
         return taskRepository.save(transferTask);
     }

--- a/data-transfer-service/src/main/java/com/epam/pipeline/dts/transfer/service/impl/TransferServiceImpl.java
+++ b/data-transfer-service/src/main/java/com/epam/pipeline/dts/transfer/service/impl/TransferServiceImpl.java
@@ -38,8 +38,9 @@ public class TransferServiceImpl implements TransferService {
     @Override
     public TransferTask runTransferTask(@NonNull StorageItem source,
                                         @NonNull StorageItem destination,
-                                        List<String> included) {
-        TransferTask transferTask = taskService.createTask(source, destination, included);
+                                        List<String> included,
+                                        boolean deleteSource) {
+        TransferTask transferTask = taskService.createTask(source, destination, included, null, deleteSource);
         taskService.updateStatus(transferTask.getId(), TaskStatus.RUNNING);
         dataUploaderProviderManager.transferData(transferTask);
         return transferTask;


### PR DESCRIPTION
Relates to #2044.

The pull request brings support for optional source deletion to data transfer service autonomous synchronization. It allows to delete already transferred local files and directories.

The following command can be used to enable autonomous transfer source deletion for all syncing paths.

```bash
pipe dts preferences update dtsname -p 'dts.source.deletion.enabled=true'
```

The following command can be used to enable autonomous transfer source deletion for specific syncing paths.

```bash
pipe dts preferences update "$DTS_NAME" -p 'dts.local.sync.rules=[{
                                                "source": "c:\\local\\path\\to\\source\\directory",
                                                "destination": "s3://data/storage/path/to/destination/directory",
                                                "cron": "0 0/1 * ? * *",
                                                "deleteSource": true
                                            }, {
                                                "source": "c:\\Program Files\\CloudPipeline\\DTS\\logs",
                                                "destination": "s3://data/storage/path/to/logs/directory",
                                                "cron": "0 0/1 * ? * *"
                                            }]'
```
