### PR TITLE
Issue #762 Add methods to get billing quota state

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/quota/QuotaApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/quota/QuotaApiService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ public class QuotaApiService {
     }
 
     @PreAuthorize(ADMIN_OR_BILLING_MANAGER)
-    public List<Quota> getAll() {
-        return quotaService.getAll();
+    public List<Quota> getAll(final boolean loadActive) {
+        return quotaService.getAll(loadActive);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/acl/user/UserApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/user/UserApiService.java
@@ -113,8 +113,8 @@ public class UserApiService {
     }
 
     @PreAuthorize(ADMIN_ONLY + OR_USER_READER)
-    public PipelineUser loadUser(Long id) {
-        return userManager.loadUserById(id);
+    public PipelineUser loadUser(Long id, final boolean quotas) {
+        return userManager.loadUserById(id, quotas);
     }
 
     @PreAuthorize(ADMIN_ONLY + OR_USER_READER)
@@ -133,13 +133,13 @@ public class UserApiService {
     }
 
     @PreAuthorize(ADMIN_ONLY + OR_USER_READER)
-    public List<PipelineUser> loadUsers() {
-        return new ArrayList<>(userManager.loadAllUsers());
+    public List<PipelineUser> loadUsers(final boolean loadQuotas) {
+        return new ArrayList<>(userManager.loadAllUsers(loadQuotas));
     }
 
     @PreAuthorize(ADMIN_ONLY + OR_USER_READER)
-    public List<PipelineUser> loadUsersWithActivityStatus() {
-        return new ArrayList<>(userManager.loadUsersWithActivityStatus());
+    public List<PipelineUser> loadUsersWithActivityStatus(final boolean loadQuotas) {
+        return new ArrayList<>(userManager.loadUsersWithActivityStatus(loadQuotas));
     }
 
     @PreAuthorize(ADMIN_OR_GENERAL_USER + OR_USER_READER)

--- a/api/src/main/java/com/epam/pipeline/controller/AbstractRestController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/AbstractRestController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,6 +67,7 @@ public abstract class AbstractRestController {
 
     private static final String NO_FILES_MESSAGE = "No files specified";
     private static final String NOT_A_MULTIPART_REQUEST = "Not a multipart request";
+    public static final String FALSE = "false";
 
     /**
      * Writes passed content to {@code HttpServletResponse} to allow it's downloading from

--- a/api/src/main/java/com/epam/pipeline/controller/quota/QuotaController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/quota/QuotaController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2021-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -75,7 +76,8 @@ public class QuotaController extends AbstractRestController {
     @GetMapping
     @ApiOperation(value = "Gets all quotas", produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
-    public Result<List<Quota>> getAll() {
-        return Result.success(quotaApiService.getAll());
+    public Result<List<Quota>> getAll(
+            @RequestParam(required = false, defaultValue = "false") final boolean loadActive) {
+        return Result.success(quotaApiService.getAll(loadActive));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -173,8 +173,9 @@ public class UserController extends AbstractRestController {
     @ApiResponses(
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
             })
-    public Result<PipelineUser> loadUser(@PathVariable Long id) {
-        return Result.success(userApiService.loadUser(id));
+    public Result<PipelineUser> loadUser(@PathVariable Long id,
+                                         @RequestParam(defaultValue = FALSE) final boolean quotas) {
+        return Result.success(userApiService.loadUser(id, quotas));
     }
 
     @GetMapping(value = "/user")
@@ -226,10 +227,11 @@ public class UserController extends AbstractRestController {
     @ApiResponses(
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
             })
-    public Result<List<PipelineUser>> loadUsers(@RequestParam(defaultValue = "false") final boolean activity) {
+    public Result<List<PipelineUser>> loadUsers(@RequestParam(defaultValue = FALSE) final boolean activity,
+                                                @RequestParam(defaultValue = FALSE) final boolean quotas) {
         return Result.success(activity
-                ? userApiService.loadUsersWithActivityStatus()
-                : userApiService.loadUsers());
+                ? userApiService.loadUsersWithActivityStatus(quotas)
+                : userApiService.loadUsers(quotas));
     }
 
     @GetMapping(value = "/users/info")
@@ -404,8 +406,8 @@ public class UserController extends AbstractRestController {
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
     public Result<List<PipelineUserEvent>> importUsersFromCsv(
-            @RequestParam(defaultValue = "false") final boolean createUser,
-            @RequestParam(defaultValue = "false") final boolean createGroup,
+            @RequestParam(defaultValue = FALSE) final boolean createUser,
+            @RequestParam(defaultValue = FALSE) final boolean createGroup,
             @RequestParam(required = false) final List<String> createMetadata,
             final HttpServletRequest request) throws FileUploadException {
         final MultipartFile file = consumeMultipartFile(request);

--- a/api/src/main/java/com/epam/pipeline/dao/user/UserDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/user/UserDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -314,6 +314,9 @@ public class UserDao extends NamedParameterJdbcDaoSupport {
                         Role role = new Role();
                         RoleParameters.parseRole(rs, role, false);
                         user.getRoles().add(role);
+                        if (role.getName().equals(DefaultRoles.ROLE_ADMIN.getName())) {
+                            user.setAdmin(true);
+                        }
                     }
                 }
                 return users.values();

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -933,6 +933,9 @@ public class SystemPreferences {
             "billing.quotas.enabled", false, BILLING_QUOTAS_GROUP, pass);
     public static final IntPreference BILLING_QUOTAS_MONITORING_PERIOD_SECONDS = new IntPreference(
             "billing.quotas.period.seconds", Constants.SECONDS_IN_DAY, BILLING_QUOTAS_GROUP, isGreaterThan(10));
+    public static final IntPreference BILLING_QUOTAS_CLEARING_PERIOD_SECONDS = new IntPreference(
+            "billing.quotas.clear.period.seconds", Constants.SECONDS_IN_DAY * 30,
+            BILLING_QUOTAS_GROUP, isGreaterThan(10));
 
     // Lustre FS
     public static final IntPreference LUSTRE_FS_DEFAULT_SIZE_GB = new IntPreference(

--- a/api/src/main/java/com/epam/pipeline/manager/quota/BillingQuotasScheduler.java
+++ b/api/src/main/java/com/epam/pipeline/manager/quota/BillingQuotasScheduler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.epam.pipeline.manager.quota;
 
 import com.epam.pipeline.manager.preference.SystemPreferences;
@@ -20,5 +36,10 @@ public class BillingQuotasScheduler extends AbstractSchedulingManager {
                 SystemPreferences.BILLING_QUOTAS_MONITORING_PERIOD_SECONDS,
                 TimeUnit.SECONDS,
                 "Billing quota check");
+
+        scheduleFixedDelaySecured(monitor::clearQuotas,
+                SystemPreferences.BILLING_QUOTAS_CLEARING_PERIOD_SECONDS,
+                TimeUnit.SECONDS,
+                "Billing quota clear");
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/quota/QuotaService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/quota/QuotaService.java
@@ -18,8 +18,10 @@ package com.epam.pipeline.manager.quota;
 
 import com.epam.pipeline.common.MessageConstants;
 import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.dto.quota.ActiveAction;
 import com.epam.pipeline.dto.quota.AppliedQuota;
 import com.epam.pipeline.dto.quota.Quota;
+import com.epam.pipeline.dto.quota.QuotaAction;
 import com.epam.pipeline.dto.quota.QuotaActionType;
 import com.epam.pipeline.dto.quota.QuotaGroup;
 import com.epam.pipeline.dto.quota.QuotaPeriod;
@@ -36,8 +38,10 @@ import com.epam.pipeline.repository.quota.AppliedQuotaRepository;
 import com.epam.pipeline.repository.quota.AppliedQuotaSpecification;
 import com.epam.pipeline.repository.quota.QuotaActionRepository;
 import com.epam.pipeline.repository.quota.QuotaRepository;
+import com.epam.pipeline.utils.CommonUtils;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.collections4.SetUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.springframework.beans.factory.annotation.Value;
@@ -45,12 +49,15 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
+import java.time.LocalDate;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 @Service
 public class QuotaService {
@@ -127,9 +134,19 @@ public class QuotaService {
 
     @Transactional
     public List<Quota> getAll() {
-        return StreamSupport.stream(quotaRepository.findAll().spliterator(), false)
+        return getAll(false);
+    }
+
+    @Transactional
+    public List<Quota> getAll(final boolean loadActive) {
+        final List<Quota> quotas = CommonUtils.toList(quotaRepository.findAll())
+                .stream()
                 .map(quotaMapper::quotaToDto)
                 .collect(Collectors.toList());
+        if (loadActive) {
+            appendActiveQuotas(quotas);
+        }
+        return quotas;
     }
 
     @Transactional
@@ -147,19 +164,46 @@ public class QuotaService {
     }
 
     @Transactional
+    public void deleteAppliedQuotas(final List<AppliedQuota> quotas) {
+        appliedQuotaRepository.delete(ListUtils.emptyIfNull(quotas).stream()
+                .map(quotaMapper::appliedQuotaToEntity)
+                .collect(Collectors.toList()));
+    }
+
+    @Transactional
     public List<AppliedQuota> findActiveQuotaForAction(final Long actionId) {
         return ListUtils.emptyIfNull(appliedQuotaRepository.findAll(
-                AppliedQuotaSpecification.activeQuotas(actionId)))
+                        AppliedQuotaSpecification.activeQuotas(actionId)))
                 .stream()
                 .map(quotaMapper::appliedQuotaToDto)
                 .collect(Collectors.toList());
     }
 
     @Transactional
+    public List<Quota> loadActiveQuotasForUser(final PipelineUser user) {
+        final List<AppliedQuota> activeQuotasForUser = findActiveQuotasForUser(user);
+        final Map<Long, List<AppliedQuota>> groupedQuotas = ListUtils.emptyIfNull(activeQuotasForUser)
+                .stream()
+                .collect(Collectors.groupingBy(active -> active.getQuota().getId()));
+        return groupedQuotas.values()
+                .stream()
+                .map(active -> {
+                    final Quota quota = active.get(0).getQuota();
+                    quota.setActions(active.stream().map(a -> {
+                        final QuotaAction action = a.getAction();
+                        action.setActiveAction(buildActiveAction(a));
+                        return action;
+                    })
+                        .collect(Collectors.toList()));
+                    return quota;
+                }).collect(Collectors.toList());
+    }
+
+    @Transactional
     public List<AppliedQuota> findActiveQuotasForUser(final PipelineUser user) {
         return ListUtils.emptyIfNull(appliedQuotaRepository.findAll(
-                AppliedQuotaSpecification.userActiveQuotas(user,
-                        BillingUtils.getUserBillingCenter(user, billingCenterKey, metadataManager))))
+                        AppliedQuotaSpecification.userActiveQuotas(user,
+                                BillingUtils.getUserBillingCenter(user, billingCenterKey, metadataManager))))
                 .stream()
                 .map(quotaMapper::appliedQuotaToDto)
                 .collect(Collectors.toList());
@@ -183,6 +227,17 @@ public class QuotaService {
                 .filter(quota -> group.equals(quota.getQuota().getQuotaGroup()) &&
                         quota.getAction().getActions().contains(actionType))
                 .findAny();
+    }
+
+    @Transactional
+    public void deleteObsoleteQuotas(final LocalDate stamp) {
+        appliedQuotaRepository.deleteByToBefore(stamp);
+    }
+
+    @Transactional
+    public void attachQuotaInfo(Collection<PipelineUser> pipelineUsers) {
+        final List<Quota> quotas = getAll(true);
+        pipelineUsers.forEach(user -> findActiveQuotas(user, quotas));
     }
 
     private void deleteObsoleteActions(final QuotaEntity loaded, final QuotaEntity entity) {
@@ -240,15 +295,15 @@ public class QuotaService {
         }
         if (QuotaType.OVERALL.equals(quota.getType())) {
             Assert.isNull(quotaRepository.findByQuotaGroupAndTypeAndPeriod(
-                    quota.getQuotaGroup(), QuotaType.OVERALL, quota.getPeriod()),
+                            quota.getQuotaGroup(), QuotaType.OVERALL, quota.getPeriod()),
                     messageHelper.getMessage(MessageConstants.ERROR_QUOTA_OVERALL_ALREADY_EXISTS,
                             quota.getQuotaGroup(), quota.getPeriod()));
             return;
         }
         Assert.isNull(quotaRepository.findByTypeAndSubjectAndQuotaGroupAndPeriod(quota.getType(), quota.getSubject(),
-                quota.getQuotaGroup(), quota.getPeriod()),
+                        quota.getQuotaGroup(), quota.getPeriod()),
                 messageHelper.getMessage(MessageConstants.ERROR_QUOTA_ALREADY_EXISTS,
-                quota.getQuotaGroup().name(), quota.getType().name(), quota.getSubject(), quota.getPeriod()));
+                        quota.getQuotaGroup().name(), quota.getType().name(), quota.getSubject(), quota.getPeriod()));
     }
 
     private void validateQuotaName(final Quota quota, final QuotaType type) {
@@ -266,5 +321,73 @@ public class QuotaService {
             return;
         }
         Assert.notNull(quota.getType(), messageHelper.getMessage(MessageConstants.ERROR_QUOTA_TYPE_EMPTY));
+    }
+
+    private void appendActiveQuotas(List<Quota> quotas) {
+        final Map<Long, AppliedQuotaEntity> active = CommonUtils.toList(appliedQuotaRepository.findAll())
+                .stream()
+                .collect(Collectors.toMap(q -> q.getAction().getId(), Function.identity(),
+                    (q1, q2) -> q1.getTo().isAfter(q2.getTo()) ? q1 : q2));
+        quotas.forEach(quota -> ListUtils.emptyIfNull(quota.getActions())
+                .forEach(action -> {
+                    final AppliedQuotaEntity appliedQuota = active.get(action.getId());
+                    if (Objects.nonNull(appliedQuota)) {
+                        action.setActiveAction(
+                                buildActiveAction(appliedQuota));
+                    }
+                }));
+    }
+
+    private ActiveAction buildActiveAction(final AppliedQuotaEntity appliedQuota) {
+        return ActiveAction.builder()
+                .expense(appliedQuota.getExpense())
+                .from(appliedQuota.getFrom())
+                .to(appliedQuota.getTo())
+                .build();
+    }
+
+    private ActiveAction buildActiveAction(final AppliedQuota appliedQuota) {
+        return ActiveAction.builder()
+                .expense(appliedQuota.getExpense())
+                .from(appliedQuota.getFrom())
+                .to(appliedQuota.getTo())
+                .build();
+    }
+
+    private void findActiveQuotas(final PipelineUser user, final List<Quota> quotas) {
+        if (user.isAdmin()) {
+            return;
+        }
+        user.setActiveQuotas(ListUtils.emptyIfNull(quotas)
+                .stream()
+                .peek(quota -> {
+                    final List<QuotaAction> active = ListUtils.emptyIfNull(quota.getActions())
+                            .stream()
+                            .filter(action -> Objects.nonNull(action.getActiveAction()))
+                            .collect(Collectors.toList());
+                    quota.setActions(active);
+                })
+                .filter(quota -> CollectionUtils.isNotEmpty(quota.getActions()) && affectsUser(user, quota))
+                .collect(Collectors.toList()));
+    }
+
+    private boolean affectsUser(final PipelineUser user, final Quota quota) {
+        final QuotaType type = quota.getType();
+        if (quota.getQuotaGroup().equals(QuotaGroup.GLOBAL) || type.equals(QuotaType.OVERALL)) {
+            return true;
+        }
+        final String subject = quota.getSubject();
+        if (type.equals(QuotaType.USER)) {
+            return subject.equalsIgnoreCase(user.getUserName());
+        }
+        if (type.equals(QuotaType.BILLING_CENTER)) {
+            return subject.equalsIgnoreCase(
+                    BillingUtils.getUserBillingCenter(user, billingCenterKey, metadataManager));
+        }
+        if (type.equals(QuotaType.GROUP)) {
+            return SetUtils.emptyIfNull(user.getAuthorities()).stream()
+                    .anyMatch(subject::equalsIgnoreCase);
+        }
+        return false;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/mapper/quota/QuotaMapper.java
+++ b/api/src/main/java/com/epam/pipeline/mapper/quota/QuotaMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2021-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ public interface QuotaMapper {
 
     QuotaSidEntity recipientToEntity(SidImpl dto);
 
+    @Mapping(target = "activeAction", ignore = true)
     QuotaAction actionToEntity(QuotaActionEntity entity);
 
     @Mapping(target = "quota", ignore = true)

--- a/api/src/main/java/com/epam/pipeline/repository/quota/AppliedQuotaRepository.java
+++ b/api/src/main/java/com/epam/pipeline/repository/quota/AppliedQuotaRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -19,10 +19,13 @@ import com.epam.pipeline.entity.quota.AppliedQuotaEntity;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.repository.CrudRepository;
 
+import java.time.LocalDate;
+
 
 @SuppressWarnings({"PMD.MethodNamingConventions"})
 public interface AppliedQuotaRepository extends CrudRepository<AppliedQuotaEntity, Long>,
         JpaSpecificationExecutor<AppliedQuotaEntity> {
     void deleteAllByAction_Quota_Id(Long quotaId);
     void deleteAllByAction_Id(Long actionId);
+    void deleteByToBefore(LocalDate to);
 }

--- a/api/src/main/java/com/epam/pipeline/utils/CommonUtils.java
+++ b/api/src/main/java/com/epam/pipeline/utils/CommonUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,15 +23,18 @@ import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.EnumUtils;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 public final class CommonUtils {
 
@@ -90,5 +93,13 @@ public final class CommonUtils {
                 .map(Supplier::get)
                 .flatMap(o -> o.map(Stream::of).orElseGet(Stream::empty))
                 .findFirst();
+    }
+
+    public static <T> List<T> toList(final Iterable<T> items) {
+        if (Objects.isNull(items)) {
+            return Collections.emptyList();
+        }
+        return StreamSupport.stream(items.spliterator(), false)
+                .collect(Collectors.toList());
     }
 }

--- a/api/src/test/java/com/epam/pipeline/acl/user/UserApiServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/acl/user/UserApiServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -179,17 +179,17 @@ public class UserApiServiceTest extends AbstractAclTest {
     @Test
     @WithMockUser(roles = ADMIN_ROLE)
     public void shouldLoadUserForAdmin() {
-        doReturn(pipelineUser).when(mockUserManager).loadUserById(ID);
+        doReturn(pipelineUser).when(mockUserManager).loadUserById(ID, false);
 
-        assertThat(userApiService.loadUser(ID)).isEqualTo(pipelineUser);
+        assertThat(userApiService.loadUser(ID, false)).isEqualTo(pipelineUser);
     }
 
     @Test
     @WithMockUser(roles = USER_READER_ROLE)
     public void shouldLoadUserForUserReader() {
-        doReturn(pipelineUser).when(mockUserManager).loadUserById(ID);
+        doReturn(pipelineUser).when(mockUserManager).loadUserById(ID, false);
 
-        assertThat(userApiService.loadUser(ID)).isEqualTo(pipelineUser);
+        assertThat(userApiService.loadUser(ID, false)).isEqualTo(pipelineUser);
     }
 
     @Test
@@ -197,7 +197,7 @@ public class UserApiServiceTest extends AbstractAclTest {
     public void shouldDenyLoadUserForNotUserReader() {
         doReturn(pipelineUser).when(mockUserManager).loadUserById(ID);
 
-        assertThrows(AccessDeniedException.class, () -> userApiService.loadUser(ID));
+        assertThrows(AccessDeniedException.class, () -> userApiService.loadUser(ID, false));
     }
 
     @Test
@@ -261,17 +261,17 @@ public class UserApiServiceTest extends AbstractAclTest {
     @Test
     @WithMockUser(roles = ADMIN_ROLE)
     public void shouldLoadUsersForAdmin() {
-        doReturn(pipelineUserList).when(mockUserManager).loadAllUsers();
+        doReturn(pipelineUserList).when(mockUserManager).loadAllUsers(false);
 
-        assertThat(userApiService.loadUsers()).isEqualTo(pipelineUserList);
+        assertThat(userApiService.loadUsers(false)).isEqualTo(pipelineUserList);
     }
 
     @Test
     @WithMockUser(roles = USER_READER_ROLE)
     public void shouldLoadUsersForUserReader() {
-        doReturn(pipelineUserList).when(mockUserManager).loadAllUsers();
+        doReturn(pipelineUserList).when(mockUserManager).loadAllUsers(false);
 
-        assertThat(userApiService.loadUsers()).isEqualTo(pipelineUserList);
+        assertThat(userApiService.loadUsers(false)).isEqualTo(pipelineUserList);
     }
 
     @Test
@@ -279,7 +279,7 @@ public class UserApiServiceTest extends AbstractAclTest {
     public void shouldDenyLoadUsersForNotUserReader() {
         doReturn(pipelineUserList).when(mockUserManager).loadAllUsers();
 
-        assertThrows(AccessDeniedException.class, () -> userApiService.loadUsers());
+        assertThrows(AccessDeniedException.class, () -> userApiService.loadUsers(false));
     }
 
     @Test

--- a/api/src/test/java/com/epam/pipeline/controller/user/UserControllerTest.java
+++ b/api/src/test/java/com/epam/pipeline/controller/user/UserControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -251,11 +251,11 @@ public class UserControllerTest extends AbstractControllerTest {
     @Test
     @WithMockUser
     public void shouldLoadUser() {
-        doReturn(pipelineUser).when(mockUserApiService).loadUser(ID);
+        doReturn(pipelineUser).when(mockUserApiService).loadUser(ID, false);
 
         final MvcResult mvcResult = performRequest(get(String.format(USER_ID_URL, ID)));
 
-        verify(mockUserApiService).loadUser(ID);
+        verify(mockUserApiService).loadUser(ID, false);
         assertResponse(mvcResult, pipelineUser, UserCreatorUtils.PIPELINE_USER_INSTANCE_TYPE);
     }
 
@@ -314,11 +314,11 @@ public class UserControllerTest extends AbstractControllerTest {
     @Test
     @WithMockUser
     public void shouldLoadUsers() {
-        doReturn(pipelineUserList).when(mockUserApiService).loadUsers();
+        doReturn(pipelineUserList).when(mockUserApiService).loadUsers(false);
 
         final MvcResult mvcResult = performRequest(get(USERS_URL));
 
-        verify(mockUserApiService).loadUsers();
+        verify(mockUserApiService).loadUsers(false);
         assertResponse(mvcResult, pipelineUserList, UserCreatorUtils.PIPELINE_USER_LIST_INSTANCE_TYPE);
     }
 

--- a/api/src/test/java/com/epam/pipeline/manager/contextual/ContextualPreferenceManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/contextual/ContextualPreferenceManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,13 +66,13 @@ public class ContextualPreferenceManagerTest {
     private static final String USER_NAME = "userName";
     private static final PipelineUser USER = new PipelineUser(1L, null, Arrays.asList(ROLE_1, ROLE_2),
             Collections.emptyList(), false, false, null, null, null,
-            Collections.emptyMap(), Collections.emptyList(), null, Collections.emptyList(), null, null, null);
+            Collections.emptyMap(), Collections.emptyList(), null, Collections.emptyList(), null, null, null, null);
     private static final PipelineUser USER_WITHOUT_ROLES = new PipelineUser(USER.getId(), null, null,
             Collections.emptyList(), false, false, null, null, null,
-            Collections.emptyMap(), Collections.emptyList(), null, Collections.emptyList(), null, null, null);
+            Collections.emptyMap(), Collections.emptyList(), null, Collections.emptyList(), null, null, null, null);
     private static final PipelineUser USER_WITHOUT_ID = new PipelineUser(null, USER_NAME, Collections.emptyList(),
             Collections.emptyList(), false, false, null, null, null,
-            Collections.emptyMap(), Collections.emptyList(), null, Collections.emptyList(), null, null, null);
+            Collections.emptyMap(), Collections.emptyList(), null, Collections.emptyList(), null, null, null, null);
 
     private final ContextualPreferenceExternalResource toolResource =
             new ContextualPreferenceExternalResource(LEVEL, TOOL_ID);

--- a/core/src/main/java/com/epam/pipeline/dto/quota/ActiveAction.java
+++ b/core/src/main/java/com/epam/pipeline/dto/quota/ActiveAction.java
@@ -21,15 +21,14 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
+import java.time.LocalDate;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class QuotaAction {
-    private Long id;
-    private Double threshold;
-    private List<QuotaActionType> actions;
-    private ActiveAction activeAction;
+public class ActiveAction {
+    private LocalDate from;
+    private LocalDate to;
+    private Double expense;
 }

--- a/core/src/main/java/com/epam/pipeline/entity/user/PipelineUser.java
+++ b/core/src/main/java/com/epam/pipeline/entity/user/PipelineUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.epam.pipeline.entity.user;
 
+import com.epam.pipeline.dto.quota.Quota;
 import com.epam.pipeline.entity.cloud.credentials.CloudProfileCredentialsEntity;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -117,6 +118,9 @@ public class PipelineUser implements StorageContainer {
 
     @Transient
     private Boolean online;
+
+    @Transient
+    private List<Quota> activeQuotas;
 
     public PipelineUser() {
         this.admin = false;


### PR DESCRIPTION
Add new parameter to API methods to get billing quota state:
- method `GET /quotas` supports parameter `loadActive`
- methods `GET /users` and `GET /user/id` support parameter `quotas`