### PR TITLE
Add NFS events synchronisation deployment

### DIFF
--- a/deploy/contents/k8s/cp-search/cp-search-srv-dpl.yaml
+++ b/deploy/contents/k8s/cp-search/cp-search-srv-dpl.yaml
@@ -26,6 +26,9 @@ spec:
           command: ["/init"]
           ports:
             - containerPort: 8080
+          env:
+            - name: CP_SEARCH_DISABLE_NFS_OBSERVER_SYNC
+              value: "true"
           envFrom:
           - configMapRef:
               name: cp-config-global

--- a/deploy/contents/k8s/cp-search/cp-search-srv-dpl.yaml
+++ b/deploy/contents/k8s/cp-search/cp-search-srv-dpl.yaml
@@ -27,8 +27,12 @@ spec:
           ports:
             - containerPort: 8080
           env:
+            - name: CP_SEARCH_DISABLE_NFS_FILE
+              value: "false"
             - name: CP_SEARCH_DISABLE_NFS_OBSERVER_SYNC
               value: "true"
+            - name: LANG
+              value: en_US.UTF-8
           envFrom:
           - configMapRef:
               name: cp-config-global

--- a/deploy/contents/k8s/cp-search/cp-search-srv-nfs-events-dpl.yaml
+++ b/deploy/contents/k8s/cp-search/cp-search-srv-nfs-events-dpl.yaml
@@ -65,6 +65,8 @@ spec:
               value: "true"
             - name: CP_SEARCH_DISABLE_NFS_OBSERVER_SYNC
               value: "false"
+            - name: LANG
+              value: en_US.UTF-8
           envFrom:
             - configMapRef:
                 name: cp-config-global

--- a/deploy/contents/k8s/cp-search/cp-search-srv-nfs-events-dpl.yaml
+++ b/deploy/contents/k8s/cp-search/cp-search-srv-nfs-events-dpl.yaml
@@ -1,13 +1,13 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: cp-search-srv-nfs-only
+  name: cp-search-srv-nfs-events
   namespace: default
 spec:
   replicas: 1
   template:
     metadata:
-      name: cp-search-srv-nfs-only
+      name: cp-search-srv-nfs-events
       namespace: default
       labels:
         cloud-pipeline/cp-search-srv: "true"
@@ -28,7 +28,7 @@ spec:
             - containerPort: 8080
           env:
             - name: CP_SEARCH_SYNC_TIMEOUT
-              value: "86400000"
+              value: "60000"
             - name: CP_SEARCH_DISABLE_AZ_BLOB_FILE
               value: "true"
             - name: CP_SEARCH_DISABLE_AZ_BLOB_STORAGE
@@ -62,9 +62,9 @@ spec:
             - name: CP_SEARCH_DISABLE_PIPELINE
               value: "true"
             - name: CP_SEARCH_DISABLE_NFS_FILE
-              value: "false"
-            - name: CP_SEARCH_DISABLE_NFS_OBSERVER_SYNC
               value: "true"
+            - name: CP_SEARCH_DISABLE_NFS_OBSERVER_SYNC
+              value: "false"
           envFrom:
             - configMapRef:
                 name: cp-config-global
@@ -88,6 +88,6 @@ spec:
       volumes:
         - name: search-logs
           hostPath:
-            path: /opt/search-nfs-only/logs
+            path: /opt/search-nfs-events/logs
       imagePullSecrets:
         - name: cp-distr-docker-registry-secret

--- a/deploy/contents/k8s/cp-search/cp-search-srv-nfs-only-dpl.yaml
+++ b/deploy/contents/k8s/cp-search/cp-search-srv-nfs-only-dpl.yaml
@@ -65,6 +65,8 @@ spec:
               value: "false"
             - name: CP_SEARCH_DISABLE_NFS_OBSERVER_SYNC
               value: "true"
+            - name: LANG
+              value: en_US.UTF-8
           envFrom:
             - configMapRef:
                 name: cp-config-global


### PR DESCRIPTION
Relates to #2155.

The pull request brings a separate search service kubernetes deployment solely for nfs events synchronisation. Additionally the request brings support for utf-8 paths processing to nfs events synchronisation.

It is also recommended to merge #2236 along with the current one as long as it removes configuration parameters differences between multiple Cloud Pipeline services.
