### PR TITLE
Remove repository configurations in launch.sh

### DIFF
--- a/deploy/contents/install/preferences/launch.env.properties.json
+++ b/deploy/contents/install/preferences/launch.env.properties.json
@@ -10,7 +10,8 @@
         "CP_CAP_DCV_PROXY_HOST": "${CP_EDGE_EXTERNAL_HOST}",
         "CP_CAP_DCV_PROXY_PORT": "${CP_EDGE_EXTERNAL_PORT}",
         "CP_NOLOCK": "true",
-        "CP_NOCLEAN": "true"
+        "CP_NOCLEAN": "true",
+        "CP_REMOVE_REP_CONFIGURATION": "true"
     },
     "sensitive": {
         "http_proxy": "http://cp-sensitive-proxy.default.svc.cluster.local:3128",

--- a/deploy/contents/install/preferences/launch.env.properties.json
+++ b/deploy/contents/install/preferences/launch.env.properties.json
@@ -11,7 +11,7 @@
         "CP_CAP_DCV_PROXY_PORT": "${CP_EDGE_EXTERNAL_PORT}",
         "CP_NOLOCK": "true",
         "CP_NOCLEAN": "true",
-        "CP_REMOVE_REP_CONFIGURATION": "true"
+        "CP_CAP_REMOVE_FILES": "/etc/apt/sources.list.d/cuda.list,/etc/apt/sources.list.d/nvidia-ml.list"
     },
     "sensitive": {
         "http_proxy": "http://cp-sensitive-proxy.default.svc.cluster.local:3128",

--- a/scripts/pipeline-launch/launch.sh
+++ b/scripts/pipeline-launch/launch.sh
@@ -334,7 +334,11 @@ function upgrade_installed_packages {
 }
 
 function remove_repository_configurations() {
-      rm -f /etc/apt/sources.list.d/cuda.list /etc/apt/sources.list.d/nvidia-ml.list
+      IFS=',' read -r -a REMOVE_FILES_LIST <<< "$CP_CAP_REMOVE_FILES"
+      for FILE_TO_REMOVE in "${REMOVE_FILES_LIST[@]}"
+      do
+          rm -f $FILE_TO_REMOVE
+      done
 }
 
 # This function handle any distro/version - specific package manager state, e.g. clean up or reconfigure
@@ -369,9 +373,8 @@ function configure_package_manager {
       export CP_OS
       export CP_VER
 
-      CP_REMOVE_REP_CONFIGURATION=${CP_REMOVE_REP_CONFIGURATION:-"true"}
       # Remove apt repository configurations if needed
-      if [ "$CP_OS" == "ubuntu" ] && [ "$CP_REMOVE_REP_CONFIGURATION" == "true" ]; then
+      if [ "$CP_OS" == "ubuntu" ] && [ ! -z "$CP_CAP_REMOVE_FILES" ]; then
             remove_repository_configurations
       fi
 

--- a/scripts/pipeline-launch/launch.sh
+++ b/scripts/pipeline-launch/launch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -333,6 +333,10 @@ function upgrade_installed_packages {
       return $?
 }
 
+function remove_repository_configurations() {
+      rm -f /etc/apt/sources.list.d/cuda.list /etc/apt/sources.list.d/nvidia-ml.list
+}
+
 # This function handle any distro/version - specific package manager state, e.g. clean up or reconfigure
 function configure_package_manager {
       # Get the distro name and version
@@ -364,6 +368,12 @@ function configure_package_manager {
 
       export CP_OS
       export CP_VER
+
+      CP_REMOVE_REP_CONFIGURATION=${CP_REMOVE_REP_CONFIGURATION:-"true"}
+      # Remove apt repository configurations if needed
+      if [ "$CP_OS" == "ubuntu" ] && [ "$CP_REMOVE_REP_CONFIGURATION" == "true" ]; then
+            remove_repository_configurations
+      fi
 
       # Perform any specific cleanup/configuration
       if [ "$CP_OS" == "debian" ] && [ "$CP_VER" == "8" ]; then


### PR DESCRIPTION
The PR contains removing `cuda.list` and `nvidia-ml.list` repositories configurations for Ubuntu distribution in `launch.sh`.
`CP_REMOVE_REP_CONFIGURATION` environment variable was added to enable/disable removal.