### PR TITLE
Issue #2641 Implement user/group-level run launch limits 

### DIFF
--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -736,6 +736,10 @@ public final class MessageConstants {
     public static final String ERROR_QUOTA_TYPE_EMPTY = "error.quota.type.empty";
     public static final String ERROR_QUOTA_ACTION_NOT_ALLOWED = "error.quota.action.not.allowed";
     public static final String ERROR_BILLING_QUOTA_EXCEEDED_LAUNCH = "error.billing.quota.exceeded.launch";
+
+    // Launch limits
+    public static final String ERROR_RUN_LAUNCH_USER_LIMIT_EXCEEDED = "error.run.launch.user.limit.exceeded";
+    public static final String ERROR_RUN_LAUNCH_GROUP_LIMIT_EXCEEDED = "error.run.launch.group.limit.exceeded";
 
     // Ngs preprocessing
     public static final String ERROR_NGS_PREPROCESSING_FOLDER_ID_NOT_PROVIDED =

--- a/api/src/main/java/com/epam/pipeline/exception/quota/LaunchQuotaExceededException.java
+++ b/api/src/main/java/com/epam/pipeline/exception/quota/LaunchQuotaExceededException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.exception.quota;
+
+public class LaunchQuotaExceededException extends RuntimeException {
+
+    public LaunchQuotaExceededException(final String message) {
+        super(message);
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/contextual/ContextualPreferenceManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/contextual/ContextualPreferenceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,8 +73,12 @@ public class ContextualPreferenceManager {
                         MessageConstants.ERROR_CONTEXTUAL_PREFERENCE_NOT_FOUND, name, resource)));
     }
 
+    public List<ContextualPreference> load(final String name) {
+        return contextualPreferenceDao.load(name);
+    }
+
     public Optional<ContextualPreference> find(final String name,
-                                                final ContextualPreferenceExternalResource resource) {
+                                               final ContextualPreferenceExternalResource resource) {
         return contextualPreferenceDao.load(name, resource);
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/contextual/ContextualPreferenceManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/contextual/ContextualPreferenceManager.java
@@ -68,9 +68,14 @@ public class ContextualPreferenceManager {
     public ContextualPreference load(final String name, final ContextualPreferenceExternalResource resource) {
         validateName(name);
         validateResource(resource);
-        return contextualPreferenceDao.load(name, resource)
+        return find(name, resource)
                 .orElseThrow(() -> new IllegalArgumentException(messageHelper.getMessage(
                         MessageConstants.ERROR_CONTEXTUAL_PREFERENCE_NOT_FOUND, name, resource)));
+    }
+
+    public Optional<ContextualPreference> find(final String name,
+                                                final ContextualPreferenceExternalResource resource) {
+        return contextualPreferenceDao.load(name, resource);
     }
 
     private void validateName(final String name) {

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,6 +74,7 @@ import com.epam.pipeline.manager.pipeline.runner.ConfigurationProviderManager;
 import com.epam.pipeline.manager.pipeline.runner.PipeRunCmdBuilder;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
+import com.epam.pipeline.manager.quota.RunLimitsService;
 import com.epam.pipeline.manager.region.CloudRegionManager;
 import com.epam.pipeline.manager.security.AuthManager;
 import com.epam.pipeline.manager.security.CheckPermissionHelper;
@@ -214,6 +215,9 @@ public class PipelineRunManager {
     @Autowired
     private NodePoolManager nodePoolManager;
 
+    @Autowired
+    private RunLimitsService runLimitsService;
+
     /**
      * Launches cmd command execution, uses Tool as ACL identity
      * @param runVO
@@ -233,7 +237,7 @@ public class PipelineRunManager {
         LOGGER.debug("Allowed runs count - {}, actual - {}", maxRunsNumber, getNodeCount(runVO.getNodeCount(), 1));
         Assert.isTrue(getNodeCount(runVO.getNodeCount(), 1) <= maxRunsNumber, messageHelper.getMessage(
                 MessageConstants.ERROR_EXCEED_MAX_RUNS_COUNT, maxRunsNumber, getNodeCount(runVO.getNodeCount(), 1)));
-
+        checkRunLaunchLimits(runVO);
         final Tool tool = toolManager.loadByNameOrId(runVO.getDockerImage());
         final PipelineConfiguration configuration = configurationManager.getPipelineConfiguration(runVO, tool);
         runVO.setRunSids(mergeRunSids(runVO.getRunSids(), configuration.getSharedWithUsers(),
@@ -266,6 +270,7 @@ public class PipelineRunManager {
         PipelineRun parentRun = loadPipelineRun(runVO.getUseRunId());
         Assert.state(parentRun.getStatus() == TaskStatus.RUNNING,
                 messageHelper.getMessage(MessageConstants.ERROR_PIPELINE_RUN_NOT_RUNNING, runVO.getUseRunId()));
+        checkRunLaunchLimits(runVO);
         PipelineConfiguration configuration = configurationManager.getPipelineConfiguration(runVO);
         Tool tool = getToolForRun(configuration);
         configuration.setSecretName(tool.getSecretName());
@@ -307,7 +312,7 @@ public class PipelineRunManager {
         LOGGER.debug("Allowed runs count - {}, actual - {}", maxRunsNumber, getNodeCount(runVO.getNodeCount(), 1));
         Assert.isTrue(getNodeCount(runVO.getNodeCount(), 1) <= maxRunsNumber, messageHelper.getMessage(
                 MessageConstants.ERROR_EXCEED_MAX_RUNS_COUNT, maxRunsNumber, getNodeCount(runVO.getNodeCount(), 1)));
-
+        checkRunLaunchLimits(runVO);
         final Pipeline pipeline = pipelineManager.load(pipelineId);
         final PipelineConfiguration configuration = configurationManager
                 .getPipelineConfigurationForPipeline(pipeline, runVO);
@@ -1519,5 +1524,12 @@ public class PipelineRunManager {
         return runsSids.stream()
                 .peek(runSid -> runSid.setIsPrincipal(principal))
                 .collect(Collectors.toList());
+    }
+
+    private void checkRunLaunchLimits(final PipelineStart runVO) {
+        final int totalStaticNodesCount = Optional.of(runVO)
+                                              .map(PipelineStart::getNodeCount)
+                                              .orElse(0) + 1;
+        runLimitsService.checkRunLaunchLimits(totalStaticNodesCount);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/runner/ConfigurationRunner.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/runner/ConfigurationRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.manager.configuration.RunConfigurationManager;
 import com.epam.pipeline.manager.metadata.MetadataEntityManager;
 import com.epam.pipeline.manager.pipeline.FolderManager;
+import com.epam.pipeline.manager.quota.RunLimitsService;
 import com.epam.pipeline.mapper.AbstractRunConfigurationMapper;
 import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,6 +65,9 @@ public class ConfigurationRunner {
     @Autowired
     private ConfigurationProviderManager configurationProvider;
 
+    @Autowired
+    private RunLimitsService runLimitsService;
+
     /**
      * Schedules execution of a {@link RunConfiguration} and creates a number
      * of associated {@link PipelineRun} instances. Default values of {@link RunConfiguration}
@@ -99,23 +103,30 @@ public class ConfigurationRunner {
         configuration.getEntries().forEach(entry -> configurationProvider.assertExecutionEnvironment(entry));
 
         List<Long> entitiesIds = getIdsToProcess(runConfiguration);
-        return configuration.getEntries().stream()
-                .collect(Collectors.groupingBy(AbstractRunConfigurationEntry::getExecutionEnvironment))
-                .entrySet()
-                .stream()
-                .map(env -> {
-                    AnalysisConfiguration<AbstractRunConfigurationEntry> conf = AnalysisConfiguration
-                            .builder()
-                            .configurationId(configuration.getId())
-                            .entries(env.getValue())
-                            .entitiesIds(entitiesIds)
-                            .expansionExpression(expansionExpression)
-                            .refreshToken(refreshToken)
-                            .build();
-                    return configurationProvider.runAnalysis(conf);
-                })
-                .flatMap(Collection::stream)
-                .collect(Collectors.toList());
+        final List<AnalysisConfiguration<AbstractRunConfigurationEntry>> configurations = configuration.getEntries()
+            .stream()
+            .collect(Collectors.groupingBy(AbstractRunConfigurationEntry::getExecutionEnvironment))
+            .entrySet()
+            .stream()
+            .map(env -> AnalysisConfiguration
+                .builder()
+                .configurationId(configuration.getId())
+                .entries(env.getValue())
+                .entitiesIds(entitiesIds)
+                .expansionExpression(expansionExpression)
+                .refreshToken(refreshToken)
+                .build())
+            .collect(Collectors.toList());
+        final int configurationsNodes = configurations.stream()
+            .map(AnalysisConfiguration::getEntries)
+            .flatMap(Collection::stream)
+            .mapToInt(AbstractRunConfigurationEntry::getWorkerCount)
+            .reduce(0, (sum, count) -> sum + count + 1);
+        runLimitsService.checkRunLaunchLimits(configurationsNodes);
+        return configurations.stream()
+            .map(configurationProvider::runAnalysis)
+            .flatMap(Collection::stream)
+            .collect(Collectors.toList());
     }
 
     private List<Long> getIdsToProcess(RunConfigurationWithEntitiesVO runConfiguration) {

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -588,6 +588,16 @@ public class SystemPreferences {
         new ObjectPreference<>("launch.system.parameters", null,
                                new TypeReference<List<DefaultSystemParameter>>() {},
                                LAUNCH_GROUP, isNullOrValidJson(new TypeReference<List<DefaultSystemParameter>>() {}));
+
+    /**
+     * Controls maximum number of active runs for specific user/group
+     */
+    public static final IntPreference LAUNCH_MAX_RUNS_USER_LIMIT = new IntPreference(
+        "launch.max.runs.user", null, LAUNCH_GROUP, isGreaterThan(0));
+
+    public static final IntPreference LAUNCH_MAX_RUNS_GROUP_LIMIT = new IntPreference(
+        "launch.max.runs.group", null, LAUNCH_GROUP, isGreaterThan(0));
+
     /**
      * Sets task status update rate, on which application will query Kubernetes cluster for running task status,
      * milliseconds

--- a/api/src/main/java/com/epam/pipeline/manager/quota/RunLimitsService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/quota/RunLimitsService.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.quota;
+
+import com.epam.pipeline.common.MessageConstants;
+import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.controller.vo.PipelineRunFilterVO;
+import com.epam.pipeline.entity.contextual.ContextualPreference;
+import com.epam.pipeline.entity.contextual.ContextualPreferenceExternalResource;
+import com.epam.pipeline.entity.contextual.ContextualPreferenceLevel;
+import com.epam.pipeline.entity.pipeline.TaskStatus;
+import com.epam.pipeline.entity.user.ExtendedRole;
+import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.entity.user.Role;
+import com.epam.pipeline.exception.quota.LaunchQuotaExceededException;
+import com.epam.pipeline.manager.contextual.ContextualPreferenceManager;
+import com.epam.pipeline.manager.pipeline.PipelineRunManager;
+import com.epam.pipeline.manager.preference.SystemPreferences;
+import com.epam.pipeline.manager.security.AuthManager;
+import com.epam.pipeline.manager.user.RoleManager;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RunLimitsService {
+
+    private static final List<TaskStatus> ACTIVE_RUN_STATUSES = new ArrayList<>(Arrays.asList(TaskStatus.RESUMING,
+                                                                                              TaskStatus.RUNNING));
+    private final PipelineRunManager runManager;
+    private final RoleManager roleManager;
+    private final ContextualPreferenceManager contextualPreferenceManager;
+    private final MessageHelper messageHelper;
+    private final AuthManager authManager;
+
+    public void checkRunLaunchLimits(final Integer newInstancesCount) {
+        if (authManager.isAdmin()) {
+            return;
+        }
+        final PipelineUser user = authManager.getCurrentUser();
+        final String userName = user.getUserName();
+        final List<ContextualPreference> allPreferences = contextualPreferenceManager.loadAll();
+        checkUserLimits(user.getId(), userName, newInstancesCount, allPreferences);
+        checkUserGroupsLimits(userName, user.getGroups(), newInstancesCount, allPreferences);
+    }
+
+    private void checkUserLimits(final Long userId, final String userName, final Integer newInstancesCount,
+                                 final List<ContextualPreference> allPreferences) {
+        allPreferences.stream()
+            .filter(pref -> pref.getName().equals(SystemPreferences.LAUNCH_MAX_RUNS_USER_LIMIT.getKey()))
+            .filter(pref -> isUserPreference(pref, userId))
+            .map(ContextualPreference::getValue)
+            .filter(NumberUtils::isNumber)
+            .map(Integer::parseInt)
+            .filter(limit -> getActiveRunsForUser(userName) + newInstancesCount > limit)
+            .findFirst()
+            .ifPresent(limit -> {
+                log.info("Launch of new jobs is restricted as [{}] user will exceed runs limit [{}]", userName, limit);
+                throw new LaunchQuotaExceededException(messageHelper.getMessage(
+                    MessageConstants.ERROR_RUN_LAUNCH_USER_LIMIT_EXCEEDED, userName, limit));
+            });
+    }
+
+    private void checkUserGroupsLimits(final String userName, final List<String> groups,
+                                       final Integer newInstancesCount,
+                                       final List<ContextualPreference> allPreferences) {
+        final Map<String, ExtendedRole> groupIdsMapping = getAllMatchingGroupsMapping(groups);
+        allPreferences.stream()
+            .filter(pref -> pref.getName().equals(SystemPreferences.LAUNCH_MAX_RUNS_GROUP_LIMIT.getKey()))
+            .filter(pref -> isTargetGroupPreference(pref, groupIdsMapping.keySet()))
+            .map(pref -> mapToLimitDetails(pref, groupIdsMapping))
+            .filter(limitDetails -> exceedsGroupLimit(limitDetails, newInstancesCount))
+            .findFirst()
+            .ifPresent(limitDetails -> {
+                log.info("Launch of new jobs is restricted as [{}] user will exceed [{}] group runs limit [{}]",
+                         userName, limitDetails.getGroupName(), limitDetails.getRunsLimit());
+                throw new LaunchQuotaExceededException(messageHelper.getMessage(
+                    MessageConstants.ERROR_RUN_LAUNCH_GROUP_LIMIT_EXCEEDED, userName,
+                    limitDetails.getGroupName(), limitDetails.getRunsLimit()));
+            });
+    }
+
+    private Map<String, ExtendedRole> getAllMatchingGroupsMapping(final List<String> groups) {
+        return roleManager.loadAllRoles(true).stream()
+            .filter(role -> !role.isPredefined())
+            .filter(ExtendedRole.class::isInstance)
+            .map(ExtendedRole.class::cast)
+            .filter(role -> groups.contains(getNameWithoutRolePrefix(role.getName())))
+            .collect(Collectors.toMap(role -> role.getId().toString(), Function.identity()));
+    }
+
+    private GroupLimit mapToLimitDetails(final ContextualPreference pref,
+                                         final Map<String, ExtendedRole> groupIdsMapping) {
+        final ExtendedRole groupDetails = groupIdsMapping.get(pref.getResource().getResourceId());
+        final String groupName = getNameWithoutRolePrefix(groupDetails.getName());
+        final List<String> groupUsers = groupDetails.getUsers().stream()
+            .map(PipelineUser::getUserName)
+            .collect(Collectors.toList());
+        return new GroupLimit(groupName, Integer.parseInt(pref.getValue()), groupUsers);
+    }
+
+    private boolean exceedsGroupLimit(final GroupLimit limitDetails, final Integer newInstancesCount) {
+        return getActiveRunsForUsers(limitDetails.getGroupUsers()) + newInstancesCount > limitDetails.getRunsLimit();
+    }
+
+    private Integer getActiveRunsForUser(final String userName) {
+        return getActiveRunsForUsers(Collections.singletonList(userName));
+    }
+
+    private Integer getActiveRunsForUsers(final List<String> userNames) {
+        final PipelineRunFilterVO runFilterVO = new PipelineRunFilterVO();
+        runFilterVO.setOwners(userNames);
+        runFilterVO.setStatuses(ACTIVE_RUN_STATUSES);
+        return runManager.countPipelineRuns(runFilterVO);
+    }
+
+    private boolean isUserPreference(final ContextualPreference preference, final Long userId) {
+        return preference.getResource().equals(
+            new ContextualPreferenceExternalResource(ContextualPreferenceLevel.USER, userId.toString()));
+    }
+
+    private boolean isTargetGroupPreference(final ContextualPreference preference, final Set<String> targetGroupIds) {
+        final ContextualPreferenceExternalResource resource = preference.getResource();
+        return resource.getLevel().equals(ContextualPreferenceLevel.ROLE)
+               && targetGroupIds.contains(resource.getResourceId());
+    }
+
+    private String getNameWithoutRolePrefix(final String fullName) {
+        return fullName.substring(Role.ROLE_PREFIX.length());
+    }
+
+    @Value
+    private static class GroupLimit {
+
+        private final String groupName;
+        private final Integer runsLimit;
+        private final List<String> groupUsers;
+    }
+}

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -668,7 +668,7 @@ error.quota.action.not.allowed=Quota action ''{0}'' is not allowed for ''{1}''. 
 error.billing.quota.exceeded.launch=Launch of new compute instances is forbidden due to exceeded billing quota.
 
 error.run.launch.user.limit.exceeded=Launch of new jobs is restricted as [{0}] user will exceed runs limit [{1}]
-error.run.launch.group.limit.exceeded=Launch of new jobs is restricted as [{0}] user will exceed [{1}] group runs limit [{2}]
+error.run.launch.group.limit.exceeded=Launch of new jobs is restricted as [{0}] user will exceed group runs limit [{1}, {2}]
 
 # Ngs preprocessing
 error.ngs.preprocessing.folder.id.is.not.provided=Folder id is not provided in the request.

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -666,6 +666,9 @@ error.quota.subject.empty=Quota subject cannot be empty
 error.quota.type.empty=Quota type cannot be empty
 error.quota.action.not.allowed=Quota action ''{0}'' is not allowed for ''{1}''. Allowed actions: ''{2}''
 error.billing.quota.exceeded.launch=Launch of new compute instances is forbidden due to exceeded billing quota.
+
+error.run.launch.user.limit.exceeded=Launch of new jobs is restricted as [{0}] user will exceed runs limit [{1}]
+error.run.launch.group.limit.exceeded=Launch of new jobs is restricted as [{0}] user will exceed [{1}] group runs limit [{2}]
 
 # Ngs preprocessing
 error.ngs.preprocessing.folder.id.is.not.provided=Folder id is not provided in the request.

--- a/api/src/test/java/com/epam/pipeline/manager/quota/RunLimitsServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/quota/RunLimitsServiceTest.java
@@ -92,7 +92,8 @@ public class RunLimitsServiceTest {
     @Test
     public void shouldFailIfGroupLimitExceeds() {
         mockRoleLoading();
-        mockLimitPreference(SystemPreferences.LAUNCH_MAX_RUNS_GROUP_LIMIT, 1, ContextualPreferenceLevel.ROLE, GROUP_ID);
+        mockLimitPreferencesByKey(SystemPreferences.LAUNCH_MAX_RUNS_GROUP_LIMIT,
+                                  1, ContextualPreferenceLevel.ROLE, GROUP_ID);
         assertThrows(LaunchQuotaExceededException.class, () -> runLimitsService.checkRunLaunchLimits(1));
         verify(roleManager).loadAllRoles(Mockito.anyBoolean());
     }
@@ -112,6 +113,15 @@ public class RunLimitsServiceTest {
         final ContextualPreference limitPreference =
             new ContextualPreference(pref.getKey(), value.toString(), preferenceResource);
         doReturn(Optional.of(limitPreference)).when(preferenceManager).find(pref.getKey(), preferenceResource);
+    }
+
+    private void mockLimitPreferencesByKey(final AbstractSystemPreference.IntPreference pref, final Integer value,
+                                           final ContextualPreferenceLevel resourceLevel, final Long resourceId) {
+        final ContextualPreferenceExternalResource preferenceResource =
+            new ContextualPreferenceExternalResource(resourceLevel, resourceId.toString());
+        final ContextualPreference limitPreference =
+            new ContextualPreference(pref.getKey(), value.toString(), preferenceResource);
+        doReturn(Collections.singletonList(limitPreference)).when(preferenceManager).load(pref.getKey());
     }
 
     private void mockRoleLoading() {

--- a/api/src/test/java/com/epam/pipeline/manager/quota/RunLimitsServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/quota/RunLimitsServiceTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.quota;
+
+import static com.epam.pipeline.util.CustomAssertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.entity.contextual.ContextualPreference;
+import com.epam.pipeline.entity.contextual.ContextualPreferenceExternalResource;
+import com.epam.pipeline.entity.contextual.ContextualPreferenceLevel;
+import com.epam.pipeline.entity.user.ExtendedRole;
+import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.entity.user.Role;
+import com.epam.pipeline.exception.quota.LaunchQuotaExceededException;
+import com.epam.pipeline.manager.contextual.ContextualPreferenceManager;
+import com.epam.pipeline.manager.pipeline.PipelineRunManager;
+import com.epam.pipeline.manager.preference.AbstractSystemPreference;
+import com.epam.pipeline.manager.preference.SystemPreferences;
+import com.epam.pipeline.manager.security.AuthManager;
+import com.epam.pipeline.manager.user.RoleManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+
+public class RunLimitsServiceTest {
+
+    private static final Long USER_ID = 1L;
+    private static final Long GROUP_ID = 2L;
+    private static final String USER_NAME = "TEST_USER";
+    private static final String GROUP_NAME = "TEST_GROUP";
+
+    private final PipelineRunManager runManager = Mockito.mock(PipelineRunManager.class);
+    private final RoleManager roleManager = Mockito.mock(RoleManager.class);
+    private final ContextualPreferenceManager preferenceManager = Mockito.mock(ContextualPreferenceManager.class);
+    private final MessageHelper messageHelper = Mockito.mock(MessageHelper.class);
+    private final AuthManager authManager = Mockito.mock(AuthManager.class);
+
+    private final RunLimitsService runLimitsService =
+        new RunLimitsService(runManager, roleManager, preferenceManager, messageHelper, authManager);
+
+    @Before
+    public void init() {
+        doReturn(false).when(authManager).isAdmin();
+        doReturn(getUser()).when(authManager).getCurrentUser();
+        doReturn(1).when(runManager).countPipelineRuns(Mockito.any());
+    }
+
+    @Test
+    public void shouldSkipPreferenceChecksIfAdmin() {
+        doReturn(true).when(authManager).isAdmin();
+        runLimitsService.checkRunLaunchLimits(1);
+        verify(authManager, Mockito.never()).getCurrentUser();
+        verify(preferenceManager, Mockito.never()).loadAll();
+        verify(roleManager, Mockito.never()).loadAllRoles(Mockito.anyBoolean());
+    }
+
+    @Test
+    public void shouldProcessSuccessfullyIfNoLimitsSpecified() {
+        doReturn(Collections.emptyList()).when(preferenceManager).loadAll();
+        runLimitsService.checkRunLaunchLimits(1);
+    }
+
+    @Test
+    public void shouldFailIfUserLimitExceeds() {
+        mockLimitPreference(SystemPreferences.LAUNCH_MAX_RUNS_USER_LIMIT, 1, ContextualPreferenceLevel.USER, USER_ID);
+        assertThrows(LaunchQuotaExceededException.class, () -> runLimitsService.checkRunLaunchLimits(1));
+        verify(roleManager, Mockito.never()).loadAllRoles(Mockito.anyBoolean());
+    }
+
+    @Test
+    public void shouldFailIfGroupLimitExceeds() {
+        mockRoleLoading();
+        mockLimitPreference(SystemPreferences.LAUNCH_MAX_RUNS_GROUP_LIMIT, 1, ContextualPreferenceLevel.ROLE, GROUP_ID);
+        assertThrows(LaunchQuotaExceededException.class, () -> runLimitsService.checkRunLaunchLimits(1));
+        verify(roleManager).loadAllRoles(Mockito.anyBoolean());
+    }
+
+    private PipelineUser getUser() {
+        final PipelineUser user = new PipelineUser();
+        user.setId(USER_ID);
+        user.setUserName(USER_NAME);
+        user.setGroups(Collections.singletonList(GROUP_NAME));
+        return user;
+    }
+
+    private void mockLimitPreference(final AbstractSystemPreference.IntPreference pref, final Integer value,
+                                     final ContextualPreferenceLevel resourceLevel, final Long resourceId) {
+        final ContextualPreferenceExternalResource preferenceResource =
+            new ContextualPreferenceExternalResource(resourceLevel, resourceId.toString());
+        final ContextualPreference limitPreference =
+            new ContextualPreference(pref.getKey(), value.toString(), preferenceResource);
+        doReturn(Collections.singletonList(limitPreference)).when(preferenceManager).loadAll();
+    }
+
+    private void mockRoleLoading() {
+        final ExtendedRole extendedRole = new ExtendedRole();
+        extendedRole.setId(GROUP_ID);
+        extendedRole.setName(Role.ROLE_PREFIX + GROUP_NAME);
+        extendedRole.setUsers(Collections.singletonList(getUser()));
+        doReturn(Collections.singletonList(extendedRole)).when(roleManager).loadAllRoles(true);
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/manager/quota/RunLimitsServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/quota/RunLimitsServiceTest.java
@@ -39,6 +39,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.util.Collections;
+import java.util.Optional;
 
 public class RunLimitsServiceTest {
 
@@ -61,6 +62,9 @@ public class RunLimitsServiceTest {
         doReturn(false).when(authManager).isAdmin();
         doReturn(getUser()).when(authManager).getCurrentUser();
         doReturn(1).when(runManager).countPipelineRuns(Mockito.any());
+        doReturn(Optional.empty())
+            .when(preferenceManager)
+            .find(Mockito.anyString(), Mockito.any(ContextualPreferenceExternalResource.class));
     }
 
     @Test
@@ -107,7 +111,7 @@ public class RunLimitsServiceTest {
             new ContextualPreferenceExternalResource(resourceLevel, resourceId.toString());
         final ContextualPreference limitPreference =
             new ContextualPreference(pref.getKey(), value.toString(), preferenceResource);
-        doReturn(Collections.singletonList(limitPreference)).when(preferenceManager).loadAll();
+        doReturn(Optional.of(limitPreference)).when(preferenceManager).find(pref.getKey(), preferenceResource);
     }
 
     private void mockRoleLoading() {


### PR DESCRIPTION
This PR is related to issue #2641

It allows configuring launch limits for a specific user or group.
In case "static" part of submitted run (master + workers count) potentially exceeds any limits - an exception with limit details is thrown and launch is being aborted.