### PR TITLE
Issue #2642 Instance limits listing via pipe CLI

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/user/UserApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/user/UserApiService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import com.epam.pipeline.entity.user.ImpersonationStatus;
 import com.epam.pipeline.entity.user.PipelineUser;
 import com.epam.pipeline.entity.user.PipelineUserEvent;
 import com.epam.pipeline.entity.user.RunnerSid;
+import com.epam.pipeline.manager.quota.RunLimitsService;
 import com.epam.pipeline.manager.user.OnlineUsersService;
 import com.epam.pipeline.manager.user.UserManager;
 import com.epam.pipeline.manager.user.UserRunnersManager;
@@ -39,6 +40,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static com.epam.pipeline.security.acl.AclExpressions.ADMIN_ONLY;
 import static com.epam.pipeline.security.acl.AclExpressions.ADMIN_OR_GENERAL_USER;
@@ -58,6 +60,9 @@ public class UserApiService {
 
     @Autowired
     private OnlineUsersService onlineUsersService;
+
+    @Autowired
+    private RunLimitsService runLimitsService;
 
     /**
      * Registers a new user
@@ -254,5 +259,9 @@ public class UserApiService {
     @PreAuthorize(ADMIN_ONLY)
     public boolean deleteExpiredOnlineUsers(final LocalDate date) {
         return onlineUsersService.deleteExpired(date);
+    }
+
+    public Map<String, Integer> getCurrentUserLaunchLimits() {
+        return runLimitsService.getCurrentUserLaunchLimits();
     }
 }

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -740,6 +740,7 @@ public final class MessageConstants {
     // Launch limits
     public static final String ERROR_RUN_LAUNCH_USER_LIMIT_EXCEEDED = "error.run.launch.user.limit.exceeded";
     public static final String ERROR_RUN_LAUNCH_GROUP_LIMIT_EXCEEDED = "error.run.launch.group.limit.exceeded";
+    public static final String ERROR_RUN_LAUNCH_PLATFORM_LIMIT_EXCEEDED = "error.run.launch.platform.limit.exceeded";
 
     // Ngs preprocessing
     public static final String ERROR_NGS_PREPROCESSING_FOLDER_ID_NOT_PROVIDED =

--- a/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
@@ -61,6 +61,7 @@ import java.io.IOException;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 @Controller
 @Api(value = "Users")
@@ -469,5 +470,16 @@ public class UserController extends AbstractRestController {
     public Result<Boolean> deleteOnlineUsers(@DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @RequestParam
                                                  final LocalDate date) {
         return Result.success(userApiService.deleteExpiredOnlineUsers(date));
+    }
+
+    @GetMapping("/user/launchLimits")
+    @ResponseBody
+    @ApiOperation(
+            value = "Loads launch limits for a user.",
+            notes = "Loads a map of launch limits, configured via contextual preferences.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<Map<String, Integer>> getCurrentUserLaunchLimits() {
+        return Result.success(userApiService.getCurrentUserLaunchLimits());
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/quota/RunLimitsService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/quota/RunLimitsService.java
@@ -30,6 +30,7 @@ import com.epam.pipeline.exception.quota.LaunchQuotaExceededException;
 import com.epam.pipeline.manager.contextual.ContextualPreferenceManager;
 import com.epam.pipeline.manager.pipeline.PipelineRunManager;
 import com.epam.pipeline.manager.preference.AbstractSystemPreference;
+import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.manager.security.AuthManager;
 import com.epam.pipeline.manager.user.RoleManager;
@@ -57,6 +58,7 @@ import java.util.stream.Stream;
 public class RunLimitsService {
 
     private static final String USER_LIMIT_KEY = "<user-limit>";
+    private static final String PLATFORM_LIMIT_KEY = "<platform-limit>";
     private static final List<TaskStatus> ACTIVE_RUN_STATUSES = new ArrayList<>(Arrays.asList(TaskStatus.RESUMING,
                                                                                               TaskStatus.RUNNING));
     private final PipelineRunManager runManager;
@@ -64,6 +66,7 @@ public class RunLimitsService {
     private final ContextualPreferenceManager contextualPreferenceManager;
     private final MessageHelper messageHelper;
     private final AuthManager authManager;
+    private final PreferenceManager preferenceManager;
 
     public void checkRunLaunchLimits(final Integer newInstancesCount) {
         if (authManager.isAdmin()) {
@@ -73,6 +76,7 @@ public class RunLimitsService {
         final String userName = user.getUserName();
         checkUserLimits(user.getId(), userName, newInstancesCount);
         checkUserGroupsLimits(userName, getGroups(user), newInstancesCount);
+        checkPlatformLimit(userName);
     }
 
     public Map<String, Integer> getCurrentUserLaunchLimits() {
@@ -83,6 +87,8 @@ public class RunLimitsService {
         final Map<String, Integer> result = findUserGroupsLimits(getGroups(user))
             .collect(Collectors.toMap(GroupLimit::getGroupName, GroupLimit::getRunsLimit));
         findUserLimit(user.getId()).ifPresent(limitValue -> result.put(USER_LIMIT_KEY, limitValue));
+        getClusterGlobalLimit()
+            .ifPresent(limitValue -> result.put(PLATFORM_LIMIT_KEY, limitValue));
         return result;
     }
 
@@ -125,6 +131,21 @@ public class RunLimitsService {
                     MessageConstants.ERROR_RUN_LAUNCH_GROUP_LIMIT_EXCEEDED, userName,
                     limitDetails.getGroupName(), limitDetails.getRunsLimit()));
             });
+    }
+
+    private void checkPlatformLimit(final String userName) {
+        getClusterGlobalLimit()
+            .filter(limit -> getActiveRunsForUsers(Collections.emptyList()) > limit)
+            .ifPresent(clusterLimit -> {
+                log.info("Launch of new jobs is restricted as [{}] user will exceed cluster max runs limit [{}]",
+                         userName, clusterLimit);
+                throw new LaunchQuotaExceededException(messageHelper.getMessage(
+                    MessageConstants.ERROR_RUN_LAUNCH_PLATFORM_LIMIT_EXCEEDED, userName, clusterLimit));
+            });
+    }
+
+    private Optional<Integer> getClusterGlobalLimit() {
+        return preferenceManager.findPreference(SystemPreferences.CLUSTER_MAX_SIZE);
     }
 
     private Stream<GroupLimit> findUserGroupsLimits(final Set<String> groups) {
@@ -171,8 +192,10 @@ public class RunLimitsService {
 
     private Integer getActiveRunsForUsers(final List<String> userNames) {
         final PipelineRunFilterVO runFilterVO = new PipelineRunFilterVO();
-        runFilterVO.setOwners(userNames);
         runFilterVO.setStatuses(ACTIVE_RUN_STATUSES);
+        if (CollectionUtils.isNotEmpty(userNames)) {
+            runFilterVO.setOwners(userNames);
+        }
         return runManager.countPipelineRuns(runFilterVO);
     }
 

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -669,6 +669,7 @@ error.billing.quota.exceeded.launch=Launch of new compute instances is forbidden
 
 error.run.launch.user.limit.exceeded=Launch of new jobs is restricted as [{0}] user will exceed runs limit [{1}]
 error.run.launch.group.limit.exceeded=Launch of new jobs is restricted as [{0}] user will exceed group runs limit [{1}, {2}]
+error.run.launch.platform.limit.exceeded=Launch of new jobs is restricted as [{0}] user will exceed cluster max runs limit [{1}]
 
 # Ngs preprocessing
 error.ngs.preprocessing.folder.id.is.not.provided=Folder id is not provided in the request.

--- a/api/src/test/java/com/epam/pipeline/acl/user/UserApiServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/acl/user/UserApiServiceTest.java
@@ -24,6 +24,7 @@ import com.epam.pipeline.entity.user.CustomControl;
 import com.epam.pipeline.entity.user.GroupStatus;
 import com.epam.pipeline.entity.user.PipelineUser;
 import com.epam.pipeline.entity.user.PipelineUserEvent;
+import com.epam.pipeline.manager.quota.RunLimitsService;
 import com.epam.pipeline.manager.user.UserManager;
 import com.epam.pipeline.manager.user.UsersFileImportManager;
 import com.epam.pipeline.test.acl.AbstractAclTest;
@@ -36,7 +37,9 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static com.epam.pipeline.test.creator.CommonCreatorConstants.ID;
 import static com.epam.pipeline.test.creator.CommonCreatorConstants.TEST_ARRAY;
@@ -71,6 +74,9 @@ public class UserApiServiceTest extends AbstractAclTest {
 
     @Autowired
     private UsersFileImportManager mockUsersFileImportManager;
+
+    @Autowired
+    private RunLimitsService mockRunLimitsService;
 
     @Test
     @WithMockUser(roles = ADMIN_ROLE)
@@ -418,5 +424,15 @@ public class UserApiServiceTest extends AbstractAclTest {
 
         assertThrows(AccessDeniedException.class, () -> userApiService
                 .importUsersFromCsv(true, true, TEST_STRING_LIST, null));
+    }
+
+    @Test
+    @WithMockUser
+    public void shouldReturnRunLaunchLimits() {
+        final Map<String, Integer> usersLimits = new HashMap<>();
+        usersLimits.put("group1", 1);
+        usersLimits.put("group2", 2);
+        doReturn(usersLimits).when(mockRunLimitsService).getCurrentUserLaunchLimits();
+        assertThat(userApiService.getCurrentUserLaunchLimits()).isEqualTo(usersLimits);
     }
 }

--- a/api/src/test/java/com/epam/pipeline/controller/user/UserControllerTest.java
+++ b/api/src/test/java/com/epam/pipeline/controller/user/UserControllerTest.java
@@ -38,6 +38,7 @@ import org.springframework.test.web.servlet.MvcResult;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static com.epam.pipeline.test.creator.CommonCreatorConstants.ID;
 import static com.epam.pipeline.test.creator.CommonCreatorConstants.OBJECT_TYPE;
@@ -75,6 +76,7 @@ public class UserControllerTest extends AbstractControllerTest {
     private static final String GROUP_NAME_BLOCK_URL = GROUP_NAME_URL + "/block";
     private static final String GROUPS_BLOCK_URL = SERVLET_PATH + "/groups/block";
     private static final String ROUTE_URL = SERVLET_PATH + "/route";
+    private static final String LAUNCH_LIMITS_URL = SERVLET_PATH + "/user/launchLimits";
 
     private static final String EXPIRATION = "expiration";
     private static final String NAME = "name";
@@ -114,6 +116,7 @@ public class UserControllerTest extends AbstractControllerTest {
     private final List<UserInfo> userInfoList = Collections.singletonList(userInfo);
     private final List<CustomControl> customControlList = Collections.singletonList(customControl);
     private final List<GroupStatus> groupStatusList = Collections.singletonList(groupStatus);
+    private final Map<String, Integer> launchLimits = Collections.singletonMap(GROUP_NAME, 1);
 
     @Autowired
     private UserApiService mockUserApiService;
@@ -506,6 +509,15 @@ public class UserControllerTest extends AbstractControllerTest {
 
         verify(mockUserApiService).loadAllGroupsBlockingStatuses();
         assertResponse(mvcResult, groupStatusList, UserCreatorUtils.GROUP_STATUS_LIST_INSTANCE_TYPE);
+    }
+
+    @Test
+    @WithMockUser
+    public void shouldLoadUserLaunchLimits() {
+        doReturn(launchLimits).when(mockUserApiService).getCurrentUserLaunchLimits();
+        final MvcResult mvcResult = performRequest(get(LAUNCH_LIMITS_URL));
+        verify(mockUserApiService).getCurrentUserLaunchLimits();
+        assertResponse(mvcResult, launchLimits, UserCreatorUtils.LAUNCH_LIMITS_RESPONSE_TYPE);
     }
 
     @Test

--- a/api/src/test/java/com/epam/pipeline/manager/quota/RunLimitsServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/quota/RunLimitsServiceTest.java
@@ -31,6 +31,7 @@ import com.epam.pipeline.exception.quota.LaunchQuotaExceededException;
 import com.epam.pipeline.manager.contextual.ContextualPreferenceManager;
 import com.epam.pipeline.manager.pipeline.PipelineRunManager;
 import com.epam.pipeline.manager.preference.AbstractSystemPreference;
+import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.manager.security.AuthManager;
 import com.epam.pipeline.manager.user.RoleManager;
@@ -51,12 +52,15 @@ public class RunLimitsServiceTest {
 
     private final PipelineRunManager runManager = Mockito.mock(PipelineRunManager.class);
     private final RoleManager roleManager = Mockito.mock(RoleManager.class);
-    private final ContextualPreferenceManager preferenceManager = Mockito.mock(ContextualPreferenceManager.class);
+    private final ContextualPreferenceManager contextualPreferenceManager =
+        Mockito.mock(ContextualPreferenceManager.class);
     private final MessageHelper messageHelper = Mockito.mock(MessageHelper.class);
     private final AuthManager authManager = Mockito.mock(AuthManager.class);
+    private final PreferenceManager preferenceManager = Mockito.mock(PreferenceManager.class);
 
     private final RunLimitsService runLimitsService =
-        new RunLimitsService(runManager, roleManager, preferenceManager, messageHelper, authManager);
+        new RunLimitsService(runManager, roleManager, contextualPreferenceManager, messageHelper, authManager,
+                             preferenceManager);
 
     @Before
     public void init() {
@@ -64,7 +68,7 @@ public class RunLimitsServiceTest {
         doReturn(getUser()).when(authManager).getCurrentUser();
         doReturn(1).when(runManager).countPipelineRuns(Mockito.any());
         doReturn(Optional.empty())
-            .when(preferenceManager)
+            .when(contextualPreferenceManager)
             .find(Mockito.anyString(), Mockito.any(ContextualPreferenceExternalResource.class));
     }
 
@@ -73,13 +77,13 @@ public class RunLimitsServiceTest {
         doReturn(true).when(authManager).isAdmin();
         runLimitsService.checkRunLaunchLimits(1);
         verify(authManager, Mockito.never()).getCurrentUser();
-        verify(preferenceManager, Mockito.never()).loadAll();
+        verify(contextualPreferenceManager, Mockito.never()).loadAll();
         verify(roleManager, Mockito.never()).loadAllRoles(Mockito.anyBoolean());
     }
 
     @Test
     public void shouldProcessSuccessfullyIfNoLimitsSpecified() {
-        doReturn(Collections.emptyList()).when(preferenceManager).loadAll();
+        doReturn(Collections.emptyList()).when(contextualPreferenceManager).loadAll();
         runLimitsService.checkRunLaunchLimits(1);
     }
 
@@ -107,6 +111,7 @@ public class RunLimitsServiceTest {
 
     @Test
     public void shouldReturnConfiguredLimitsForUser() {
+        doReturn(Optional.empty()).when(preferenceManager).findPreference(SystemPreferences.CLUSTER_MAX_SIZE);
         Assertions.assertThat(runLimitsService.getCurrentUserLaunchLimits()).hasSize(0);
         mockLimitPreference(SystemPreferences.LAUNCH_MAX_RUNS_USER_LIMIT, 1, ContextualPreferenceLevel.USER, USER_ID);
         Assertions.assertThat(runLimitsService.getCurrentUserLaunchLimits())
@@ -135,7 +140,8 @@ public class RunLimitsServiceTest {
             new ContextualPreferenceExternalResource(resourceLevel, resourceId.toString());
         final ContextualPreference limitPreference =
             new ContextualPreference(pref.getKey(), value.toString(), preferenceResource);
-        doReturn(Optional.of(limitPreference)).when(preferenceManager).find(pref.getKey(), preferenceResource);
+        doReturn(Optional.of(limitPreference)).when(contextualPreferenceManager)
+            .find(pref.getKey(), preferenceResource);
     }
 
     private void mockLimitPreferencesByKey(final AbstractSystemPreference.IntPreference pref, final Integer value,
@@ -144,7 +150,7 @@ public class RunLimitsServiceTest {
             new ContextualPreferenceExternalResource(resourceLevel, resourceId.toString());
         final ContextualPreference limitPreference =
             new ContextualPreference(pref.getKey(), value.toString(), preferenceResource);
-        doReturn(Collections.singletonList(limitPreference)).when(preferenceManager).load(pref.getKey());
+        doReturn(Collections.singletonList(limitPreference)).when(contextualPreferenceManager).load(pref.getKey());
     }
 
     private void mockRoleLoading() {

--- a/api/src/test/java/com/epam/pipeline/test/acl/AclTestBeans.java
+++ b/api/src/test/java/com/epam/pipeline/test/acl/AclTestBeans.java
@@ -121,6 +121,7 @@ import com.epam.pipeline.manager.pipeline.runner.ConfigurationRunner;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preprocessing.NgsPreprocessingManager;
 import com.epam.pipeline.manager.quota.QuotaService;
+import com.epam.pipeline.manager.quota.RunLimitsService;
 import com.epam.pipeline.manager.region.CloudRegionManager;
 import com.epam.pipeline.manager.report.NodePoolReportService;
 import com.epam.pipeline.manager.report.UsersUsageReportService;
@@ -557,6 +558,9 @@ public class AclTestBeans {
 
     @MockBean
     protected PipelineRepositoryService pipelineRepositoryService;
+
+    @MockBean
+    protected RunLimitsService runLimitsService;
 
     @Bean
     public GrantPermissionManager grantPermissionManager() {

--- a/api/src/test/java/com/epam/pipeline/test/creator/user/UserCreatorUtils.java
+++ b/api/src/test/java/com/epam/pipeline/test/creator/user/UserCreatorUtils.java
@@ -53,6 +53,8 @@ public final class UserCreatorUtils {
             new TypeReference<Result<PipelineUser>>() {};
     public static final TypeReference<Result<GroupStatus>> GROUP_STATUS_INSTANCE_TYPE =
             new TypeReference<Result<GroupStatus>>() {};
+    public static final TypeReference<Result<Map<String, Integer>>> LAUNCH_LIMITS_RESPONSE_TYPE =
+            new TypeReference<Result<Map<String, Integer>>>() {};
 
     public static final TypeReference<Result<List<PipelineUser>>> PIPELINE_USER_LIST_INSTANCE_TYPE =
             new TypeReference<Result<List<PipelineUser>>>() {};

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -2048,6 +2048,16 @@ def import_users(file_path, create_user, create_group, create_metadata):
     UserOperationsManager().import_users(file_path, create_user, create_group, create_metadata)
 
 
+@users.command(name='instances')
+@click.option('-v', '--verbose', required=False, is_flag=True, default=False, help='Show all active limits in a table')
+@common_options
+def list_instance_limits(verbose):
+    """
+    Shows information on user's instance limits
+    """
+    UserOperationsManager().get_instance_limits(verbose)
+
+
 @cli.group()
 def dts():
     """

--- a/pipe-cli/src/api/user.py
+++ b/pipe-cli/src/api/user.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -101,3 +101,8 @@ class User(API):
     def whoami(cls):
         api = cls.instance()
         return api.retryable_call('GET', '/whoami') or {}
+
+    @classmethod
+    def load_launch_limits(cls):
+        api = cls.instance()
+        return api.retryable_call('GET', '/user/launchLimits') or {}

--- a/pipe-cli/src/utilities/user_operations_manager.py
+++ b/pipe-cli/src/utilities/user_operations_manager.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ import sys
 
 import click
 
+from prettytable import prettytable
 from src.api.user import User
 
 
@@ -36,6 +37,27 @@ class UserOperationsManager:
         events = User().import_users(full_path, create_user, create_group, metadata_list)
         for event in events:
             click.echo("[%s] %s" % (event.get('status', ''), event.get('message', '')))
+
+    def get_instance_limits(self, verbose=False):
+        active_limits = User.load_launch_limits()
+        if len(active_limits) == 0:
+            click.echo('No restrictions on runs launching configured')
+            return
+        if not verbose:
+            source, limit = min(active_limits.items(), key=lambda x: x[1])
+            click.echo('The following restriction applied on runs launching: [{}: {}]'.format(source, limit))
+        else:
+            self.print_limits_table(active_limits)
+
+    def print_limits_table(self, limits_dict):
+        click.echo('The following restrictions applied on runs launching:\n')
+        limit_details_table = prettytable.PrettyTable()
+        limit_details_table.field_names = ['Source', 'Value']
+        limit_details_table.sortby = 'Value'
+        limit_details_table.align = 'l'
+        for source, value in limits_dict.items():
+            limit_details_table.add_row([source, value])
+        click.echo(limit_details_table)
 
     def is_admin(self):
         return 'ROLE_ADMIN' in self.get_all_user_roles()


### PR DESCRIPTION
This PR is related to issue #2642

It exposes an API endpoint, that allows users retrieving configured launch limits details.

pipe CLI functionality is extended with `users instances` command. By default, the most strict limitation is showed:
```bash
> pipe users instances
The following restriction applied on runs launching: [<user-limit>: 5]
```
The command supports `-v/--verbose` flag as well - in that case, all the limits are shown (ascending order by value):
```
> pipe users instances --verbose
The following restrictions applied on runs launching:
+--------------+-------+
| Source       | Value |
+--------------+-------+
| <user-limit> | 5     |
| GROUP_1      | 20    |
+--------------+-------+
```