### PR TITLE
Issue 2642 Fix configured user limits resolving

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/user/UserApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/user/UserApiService.java
@@ -261,7 +261,7 @@ public class UserApiService {
         return onlineUsersService.deleteExpired(date);
     }
 
-    public Map<String, Integer> getCurrentUserLaunchLimits() {
-        return runLimitsService.getCurrentUserLaunchLimits();
+    public Map<String, Integer> getCurrentUserLaunchLimits(final boolean loadAll) {
+        return runLimitsService.getCurrentUserLaunchLimits(loadAll);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -740,8 +740,6 @@ public final class MessageConstants {
 
     // Launch limits
     public static final String ERROR_RUN_LAUNCH_USER_LIMIT_EXCEEDED = "error.run.launch.user.limit.exceeded";
-    public static final String ERROR_RUN_LAUNCH_GROUP_LIMIT_EXCEEDED = "error.run.launch.group.limit.exceeded";
-    public static final String ERROR_RUN_LAUNCH_PLATFORM_LIMIT_EXCEEDED = "error.run.launch.platform.limit.exceeded";
 
     // Ngs preprocessing
     public static final String ERROR_NGS_PREPROCESSING_FOLDER_ID_NOT_PROVIDED =

--- a/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
@@ -479,7 +479,8 @@ public class UserController extends AbstractRestController {
             notes = "Loads a map of launch limits, configured via contextual preferences.",
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
-    public Result<Map<String, Integer>> getCurrentUserLaunchLimits() {
-        return Result.success(userApiService.getCurrentUserLaunchLimits());
+    public Result<Map<String, Integer>> getCurrentUserLaunchLimits(
+        @RequestParam(required = false, defaultValue = "false") final boolean loadAll) {
+        return Result.success(userApiService.getCurrentUserLaunchLimits(loadAll));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -598,6 +598,9 @@ public class SystemPreferences {
     public static final IntPreference LAUNCH_MAX_RUNS_GROUP_LIMIT = new IntPreference(
         "launch.max.runs.group", null, LAUNCH_GROUP, isGreaterThan(0));
 
+    public static final IntPreference LAUNCH_MAX_RUNS_USER_GLOBAL_LIMIT = new IntPreference(
+        "launch.max.runs.user.global", null, LAUNCH_GROUP, isGreaterThan(0));
+
     /**
      * Sets task status update rate, on which application will query Kubernetes cluster for running task status,
      * milliseconds

--- a/api/src/main/java/com/epam/pipeline/manager/quota/RunLimitsService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/quota/RunLimitsService.java
@@ -117,7 +117,7 @@ public class RunLimitsService {
 
         final Optional<Integer> platformGlobalLimit = getPlatformGlobalLimit();
         if (requiresSingleLimitOnly(platformGlobalLimit, loadAll)) {
-            return returnLimitAsMap(platformGlobalLimit, USER_GLOBAL_LIMIT_KEY);
+            return returnLimitAsMap(platformGlobalLimit, PLATFORM_LIMIT_KEY);
         }
 
         addLimitIfPresent(groupsLimits, userContextualLimit, USER_LIMIT_KEY);

--- a/api/src/main/java/com/epam/pipeline/manager/quota/RunLimitsService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/quota/RunLimitsService.java
@@ -38,6 +38,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.springframework.stereotype.Service;
 
@@ -57,7 +58,8 @@ import java.util.stream.Stream;
 @Slf4j
 public class RunLimitsService {
 
-    private static final String USER_LIMIT_KEY = "<user-limit>";
+    private static final String USER_LIMIT_KEY = "<user-contextual-limit>";
+    private static final String USER_GLOBAL_LIMIT_KEY = "<user-global-limit>";
     private static final String PLATFORM_LIMIT_KEY = "<platform-limit>";
     private static final List<TaskStatus> ACTIVE_RUN_STATUSES = new ArrayList<>(Arrays.asList(TaskStatus.RESUMING,
                                                                                               TaskStatus.RUNNING));
@@ -73,23 +75,75 @@ public class RunLimitsService {
             return;
         }
         final PipelineUser user = authManager.getCurrentUser();
-        final String userName = user.getUserName();
-        checkUserLimits(user.getId(), userName, newInstancesCount);
-        checkUserGroupsLimits(userName, getGroups(user), newInstancesCount);
-        checkPlatformLimit(userName);
+        final Map<String, Integer> currentLimits = getCurrentUserLaunchLimits(user, false);
+        currentLimits.entrySet().stream()
+            .findFirst()
+            .filter(e -> exceedsUserLimit("", newInstancesCount, e.getValue()))
+            .ifPresent(e -> {
+                final String userName = user.getUserName();
+                final String limitName = e.getKey();
+                final Integer limitValue = e.getValue();
+                log.info("Launch of new jobs is restricted as [{}] user will exceed [{}] runs limit [{}]",
+                         userName, limitName, limitValue);
+                throw new LaunchQuotaExceededException(messageHelper.getMessage(
+                    MessageConstants.ERROR_RUN_LAUNCH_USER_LIMIT_EXCEEDED, userName, limitName, limitValue));
+            });
     }
 
-    public Map<String, Integer> getCurrentUserLaunchLimits() {
+    public Map<String, Integer> getCurrentUserLaunchLimits(final boolean loadAll) {
         if (authManager.isAdmin()) {
             return Collections.emptyMap();
         }
-        final PipelineUser user = authManager.getCurrentUser();
-        final Map<String, Integer> result = findUserGroupsLimits(getGroups(user))
+        return getCurrentUserLaunchLimits(authManager.getCurrentUser(), loadAll);
+    }
+
+    private Map<String, Integer> getCurrentUserLaunchLimits(final PipelineUser user, final boolean loadAll ) {
+
+        final Optional<Integer> userContextualLimit = findUserLimit(user.getId());
+        if (requiresSingleLimitOnly(userContextualLimit, loadAll)) {
+            return returnLimitAsMap(userContextualLimit, USER_LIMIT_KEY);
+        }
+
+        final Map<String, Integer> groupsLimits = findUserGroupsLimits(getGroups(user))
             .collect(Collectors.toMap(GroupLimit::getGroupName, GroupLimit::getRunsLimit));
-        findUserLimit(user.getId()).ifPresent(limitValue -> result.put(USER_LIMIT_KEY, limitValue));
-        getClusterGlobalLimit()
-            .ifPresent(limitValue -> result.put(PLATFORM_LIMIT_KEY, limitValue));
-        return result;
+        if (MapUtils.isNotEmpty(groupsLimits) && !loadAll) {
+            return findMostStrictGroupLimit(groupsLimits);
+        }
+
+        final Optional<Integer> userGlobalLimit = getUserGlobalLimit();
+        if (requiresSingleLimitOnly(userGlobalLimit, loadAll)) {
+            return returnLimitAsMap(userGlobalLimit, USER_GLOBAL_LIMIT_KEY);
+        }
+
+        final Optional<Integer> platformGlobalLimit = getPlatformGlobalLimit();
+        if (requiresSingleLimitOnly(platformGlobalLimit, loadAll)) {
+            return returnLimitAsMap(platformGlobalLimit, USER_GLOBAL_LIMIT_KEY);
+        }
+
+        addLimitIfPresent(groupsLimits, userContextualLimit, USER_LIMIT_KEY);
+        addLimitIfPresent(groupsLimits, userGlobalLimit, USER_GLOBAL_LIMIT_KEY);
+        addLimitIfPresent(groupsLimits, platformGlobalLimit, PLATFORM_LIMIT_KEY);
+        return groupsLimits;
+    }
+    
+    private boolean requiresSingleLimitOnly(final Optional<Integer> limit, final boolean loadAll) {
+        return limit.isPresent() && !loadAll;
+    }
+
+    private Map<String, Integer> findMostStrictGroupLimit(final Map<String, Integer> groupsLimits) {
+        return groupsLimits.entrySet().stream()
+            .min(Map.Entry.comparingByValue())
+            .map(e -> Collections.singletonMap(e.getKey(), e.getValue()))
+            .get();
+    }
+
+    private Map<String, Integer> returnLimitAsMap(final Optional<Integer> limit, final String limitKey) {
+        return limit.map(limitValue -> Collections.singletonMap(limitKey, limitValue)).get();
+    }
+
+    private void addLimitIfPresent(final Map<String, Integer> allLimits, final Optional<Integer> limit,
+                                   final String limitKey) {
+        limit.ifPresent(limitValue -> allLimits.put(limitKey, limitValue));
     }
 
     private Set<String> getGroups(final PipelineUser user) {
@@ -102,16 +156,6 @@ public class RunLimitsService {
         return groups;
     }
 
-    private void checkUserLimits(final Long userId, final String userName, final Integer newInstancesCount) {
-        findUserLimit(userId)
-            .filter(limit -> exceedsUserLimit(userName, newInstancesCount, limit))
-            .ifPresent(limit -> {
-                log.info("Launch of new jobs is restricted as [{}] user will exceed runs limit [{}]", userName, limit);
-                throw new LaunchQuotaExceededException(messageHelper.getMessage(
-                    MessageConstants.ERROR_RUN_LAUNCH_USER_LIMIT_EXCEEDED, userName, limit));
-            });
-    }
-
     private Optional<Integer> findUserLimit(final Long userId) {
         return findLimitPreference(SystemPreferences.LAUNCH_MAX_RUNS_USER_LIMIT, ContextualPreferenceLevel.USER, userId)
             .map(ContextualPreference::getValue)
@@ -119,32 +163,11 @@ public class RunLimitsService {
             .map(Integer::parseInt);
     }
 
-    private void checkUserGroupsLimits(final String userName, final Set<String> groups,
-                                       final Integer newInstancesCount) {
-        findUserGroupsLimits(groups)
-            .filter(limitDetails -> exceedsGroupLimit(limitDetails, newInstancesCount))
-            .findFirst()
-            .ifPresent(limitDetails -> {
-                log.info("Launch of new jobs is restricted as [{}] user will exceed group runs limit [{}, {}]",
-                         userName, limitDetails.getGroupName(), limitDetails.getRunsLimit());
-                throw new LaunchQuotaExceededException(messageHelper.getMessage(
-                    MessageConstants.ERROR_RUN_LAUNCH_GROUP_LIMIT_EXCEEDED, userName,
-                    limitDetails.getGroupName(), limitDetails.getRunsLimit()));
-            });
+    private Optional<Integer> getUserGlobalLimit() {
+        return preferenceManager.findPreference(SystemPreferences.LAUNCH_MAX_RUNS_USER_GLOBAL_LIMIT);
     }
 
-    private void checkPlatformLimit(final String userName) {
-        getClusterGlobalLimit()
-            .filter(limit -> getActiveRunsForUsers(Collections.emptyList()) > limit)
-            .ifPresent(clusterLimit -> {
-                log.info("Launch of new jobs is restricted as [{}] user will exceed cluster max runs limit [{}]",
-                         userName, clusterLimit);
-                throw new LaunchQuotaExceededException(messageHelper.getMessage(
-                    MessageConstants.ERROR_RUN_LAUNCH_PLATFORM_LIMIT_EXCEEDED, userName, clusterLimit));
-            });
-    }
-
-    private Optional<Integer> getClusterGlobalLimit() {
+    private Optional<Integer> getPlatformGlobalLimit() {
         return preferenceManager.findPreference(SystemPreferences.CLUSTER_MAX_SIZE);
     }
 
@@ -180,10 +203,6 @@ public class RunLimitsService {
         final ContextualPreferenceExternalResource preferenceResource =
             new ContextualPreferenceExternalResource(resourceLevel, resourceId.toString());
         return contextualPreferenceManager.find(pref.getKey(), preferenceResource);
-    }
-
-    private boolean exceedsGroupLimit(final GroupLimit limitDetails, final Integer newInstancesCount) {
-        return getActiveRunsForUsers(limitDetails.getGroupUsers()) + newInstancesCount > limitDetails.getRunsLimit();
     }
 
     private boolean exceedsUserLimit(final String userName, final Integer newInstancesCount, final Integer limit) {

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -668,9 +668,7 @@ error.quota.type.empty=Quota type cannot be empty
 error.quota.action.not.allowed=Quota action ''{0}'' is not allowed for ''{1}''. Allowed actions: ''{2}''
 error.billing.quota.exceeded.launch=Launch of new compute instances is forbidden due to exceeded billing quota.
 
-error.run.launch.user.limit.exceeded=Launch of new jobs is restricted as [{0}] user will exceed runs limit [{1}]
-error.run.launch.group.limit.exceeded=Launch of new jobs is restricted as [{0}] user will exceed group runs limit [{1}, {2}]
-error.run.launch.platform.limit.exceeded=Launch of new jobs is restricted as [{0}] user will exceed cluster max runs limit [{1}]
+error.run.launch.user.limit.exceeded=Launch of new jobs is restricted as [{0}] user will exceed [{1}] runs limit [{2}]
 
 # Ngs preprocessing
 error.ngs.preprocessing.folder.id.is.not.provided=Folder id is not provided in the request.

--- a/api/src/test/java/com/epam/pipeline/acl/user/UserApiServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/acl/user/UserApiServiceTest.java
@@ -432,7 +432,7 @@ public class UserApiServiceTest extends AbstractAclTest {
         final Map<String, Integer> usersLimits = new HashMap<>();
         usersLimits.put("group1", 1);
         usersLimits.put("group2", 2);
-        doReturn(usersLimits).when(mockRunLimitsService).getCurrentUserLaunchLimits();
-        assertThat(userApiService.getCurrentUserLaunchLimits()).isEqualTo(usersLimits);
+        doReturn(usersLimits).when(mockRunLimitsService).getCurrentUserLaunchLimits(true);
+        assertThat(userApiService.getCurrentUserLaunchLimits(true)).isEqualTo(usersLimits);
     }
 }

--- a/api/src/test/java/com/epam/pipeline/controller/user/UserControllerTest.java
+++ b/api/src/test/java/com/epam/pipeline/controller/user/UserControllerTest.java
@@ -514,9 +514,9 @@ public class UserControllerTest extends AbstractControllerTest {
     @Test
     @WithMockUser
     public void shouldLoadUserLaunchLimits() {
-        doReturn(launchLimits).when(mockUserApiService).getCurrentUserLaunchLimits();
+        doReturn(launchLimits).when(mockUserApiService).getCurrentUserLaunchLimits(false);
         final MvcResult mvcResult = performRequest(get(LAUNCH_LIMITS_URL));
-        verify(mockUserApiService).getCurrentUserLaunchLimits();
+        verify(mockUserApiService).getCurrentUserLaunchLimits(false);
         assertResponse(mvcResult, launchLimits, UserCreatorUtils.LAUNCH_LIMITS_RESPONSE_TYPE);
     }
 

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManagerTest.java
@@ -208,7 +208,7 @@ public class ResourceMonitoringManagerTest {
         when(instanceOfferManager.getAllInstanceTypesObservable()).thenReturn(mockSubject);
 
         RunInstance spotInstance = new RunInstance(testType.getName(), 0, 0, null,
-                null, null, "spotNode", PLATFORM, true, null, null, null, null);
+                null, null, "spotNode", PLATFORM, true, null, null, null, null, null);
         final Map <String, String> stubTagMap = new HashMap<>();
         okayRun = new PipelineRun();
         okayRun.setInstance(spotInstance);
@@ -222,7 +222,7 @@ public class ResourceMonitoringManagerTest {
 
         idleSpotRun = new PipelineRun();
         idleSpotRun.setInstance(new RunInstance(testType.getName(), 0, 0, null,
-                null, null, "idleSpotNode", PLATFORM, true, null, null, null, null));
+                null, null, "idleSpotNode", PLATFORM, true, null, null, null, null, null));
         idleSpotRun.setPodId("idle-spot");
         idleSpotRun.setId(TEST_IDLE_SPOT_RUN_ID);
         idleSpotRun.setStartDate(new Date(Instant.now().minus(TEST_MAX_IDLE_MONITORING_TIMEOUT + 1, ChronoUnit.MINUTES)
@@ -233,7 +233,7 @@ public class ResourceMonitoringManagerTest {
 
         autoscaleMasterRun = new PipelineRun();
         autoscaleMasterRun.setInstance(new RunInstance(testType.getName(), 0, 0, null,
-                null, null, "autoscaleMasterRun", PLATFORM, false, null, null, null, null));
+                null, null, "autoscaleMasterRun", PLATFORM, false, null, null, null, null, null));
         autoscaleMasterRun.setPodId("autoscaleMasterRun");
         autoscaleMasterRun.setId(TEST_AUTOSCALE_RUN_ID);
         autoscaleMasterRun
@@ -248,7 +248,7 @@ public class ResourceMonitoringManagerTest {
         idleOnDemandRun = new PipelineRun();
         idleOnDemandRun.setInstance(
                 new RunInstance(testType.getName(), 0, 0, null, null, null, 
-                        "idleNode", PLATFORM, false, null, null, null, null));
+                        "idleNode", PLATFORM, false, null, null, null, null, null));
         idleOnDemandRun.setPodId("idle-on-demand");
         idleOnDemandRun.setId(TEST_IDLE_ON_DEMAND_RUN_ID);
         idleOnDemandRun.setStartDate(new Date(Instant.now().minus(TEST_MAX_IDLE_MONITORING_TIMEOUT + 1,
@@ -260,7 +260,7 @@ public class ResourceMonitoringManagerTest {
         idleRunToProlong = new PipelineRun();
         idleRunToProlong.setInstance(
                 new RunInstance(testType.getName(), 0, 0, null, null, null, 
-                        "prolongedNode", PLATFORM, false, null, null, null, null));
+                        "prolongedNode", PLATFORM, false, null, null, null, null, null));
         idleRunToProlong.setPodId("idle-to-prolong");
         idleRunToProlong.setId(TEST_IDLE_RUN_TO_PROLONG_ID);
         idleRunToProlong.setStartDate(new Date(Instant.now().minus(TEST_MAX_IDLE_MONITORING_TIMEOUT + 1,
@@ -271,7 +271,7 @@ public class ResourceMonitoringManagerTest {
 
         highConsumingRun = new PipelineRun();
         highConsumingRun.setInstance(new RunInstance(testType.getName(), 0, 0, null,
-                null, null, "highConsumingNode", PLATFORM, true, null, null, null, null));
+                null, null, "highConsumingNode", PLATFORM, true, null, null, null, null, null));
         highConsumingRun.setPodId(HIGH_CONSUMING_POD_ID);
         highConsumingRun.setId(TEST_HIGH_CONSUMING_RUN_ID);
         highConsumingRun.setStartDate(new Date(Instant.now().toEpochMilli()));

--- a/pipe-cli/src/api/user.py
+++ b/pipe-cli/src/api/user.py
@@ -103,6 +103,6 @@ class User(API):
         return api.retryable_call('GET', '/whoami') or {}
 
     @classmethod
-    def load_launch_limits(cls):
+    def load_launch_limits(cls, load_all=False):
         api = cls.instance()
-        return api.retryable_call('GET', '/user/launchLimits') or {}
+        return api.retryable_call('GET', '/user/launchLimits?loadAll={}'.format(load_all)) or {}

--- a/pipe-cli/src/utilities/user_operations_manager.py
+++ b/pipe-cli/src/utilities/user_operations_manager.py
@@ -39,12 +39,14 @@ class UserOperationsManager:
             click.echo("[%s] %s" % (event.get('status', ''), event.get('message', '')))
 
     def get_instance_limits(self, verbose=False):
-        active_limits = User.load_launch_limits()
+        active_limits = User.load_launch_limits(verbose)
         if len(active_limits) == 0:
             click.echo('No restrictions on runs launching configured')
             return
         if not verbose:
-            source, limit = min(active_limits.items(), key=lambda x: x[1])
+            limit_entry = active_limits.items()[0]
+            source = limit_entry[0]
+            limit = limit_entry[1]
             click.echo('The following restriction applied on runs launching: [{}: {}]'.format(source, limit))
         else:
             self.print_limits_table(active_limits)


### PR DESCRIPTION
This PR extends the logic of limits processing in API:
- add global user limit as system preference (`launch.max.runs.user.global`)
- fix precedence processing