### PR TITLE
Feature to specify network interface in nodeup

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/cloud/commands/ClusterCommandService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/commands/ClusterCommandService.java
@@ -58,6 +58,7 @@ public class ClusterCommandService {
                 .kubeNodeToken(kubeNodeToken)
                 .cloud(cloud)
                 .availabilityZone(instance.getAvailabilityZone())
+                .networkInterface(instance.getNetworkInterfaceId())
                 .region(region.getRegionCode());
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/commands/NodeUpCommand.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/commands/NodeUpCommand.java
@@ -51,6 +51,7 @@ public class NodeUpCommand extends AbstractClusterCommand {
     private final Map<String, String> additionalLabels;
     private final Set<String> prePulledImages;
     private final String availabilityZone;
+    private final String networkInterface;
 
     @Override
     protected List<String> buildCommandArguments() {
@@ -104,6 +105,10 @@ public class NodeUpCommand extends AbstractClusterCommand {
         if (StringUtils.isNotBlank(availabilityZone)) {
             commands.add("--availability_zone");
             commands.add(availabilityZone);
+        }
+        if (StringUtils.isNotBlank(networkInterface)) {
+            commands.add("--network_interface");
+            commands.add(networkInterface);
         }
         return commands;
     }

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/AutoscaleManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/AutoscaleManager.java
@@ -97,6 +97,7 @@ public class AutoscaleManager extends AbstractSchedulingManager {
     static class AutoscaleManagerCore {
 
         private static final String TARGET_AZ_PARAMETER_NAME = "CP_CAP_TARGET_AVAILABILITY_ZONE";
+        private static final String TARGET_NETWORK_INTERFACE_PARAMETER_NAME = "CP_CAP_TARGET_NETWORK_INTERFACE";
 
         private final PipelineRunManager pipelineRunManager;
         private final ParallelExecutorService executorService;
@@ -556,6 +557,7 @@ public class AutoscaleManager extends AbstractSchedulingManager {
             instanceRequest.setInstance(instance);
             instanceRequest.setRequestedImage(run.getActualDockerImage());
             setAvailabilityZoneIfSpecified(instanceRequest, run);
+            setNetworkInterfaceIfSpecified(instanceRequest, run);
             return instanceRequest;
         }
 
@@ -563,6 +565,12 @@ public class AutoscaleManager extends AbstractSchedulingManager {
             run.getParameterValue(TARGET_AZ_PARAMETER_NAME)
                 .filter(StringUtils::isNotBlank)
                 .ifPresent(availabilityZone -> requiredInstance.getInstance().setAvailabilityZone(availabilityZone));
+        }
+
+        private void setNetworkInterfaceIfSpecified(final InstanceRequest requiredInstance, final PipelineRun run) {
+            run.getParameterValue(TARGET_NETWORK_INTERFACE_PARAMETER_NAME)
+                    .filter(StringUtils::isNotBlank)
+                    .ifPresent(ni -> requiredInstance.getInstance().setNetworkInterfaceId(ni));
         }
 
         private int getPoolNodeUpTasksCount() {

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/RunInstance.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/RunInstance.java
@@ -61,6 +61,7 @@ public class RunInstance {
     private Set<String> prePulledDockerImages;
     private Long poolId;
     private String availabilityZone;
+    private String networkInterfaceId;
 
     @JsonIgnore
     public boolean isEmpty() {

--- a/deploy/contents/install/preferences/launch.system.parameters.json
+++ b/deploy/contents/install/preferences/launch.system.parameters.json
@@ -495,7 +495,7 @@
         "passToWorkers": true
     },
     {
-        "name": "CP_CAP_TARGET_ENI",
+        "name": "CP_CAP_TARGET_NETWORK_INTERFACE",
         "type": "string",
         "description": "Specifies the target ENI to be attached to the node for run",
         "defaultValue": "",

--- a/deploy/contents/install/preferences/launch.system.parameters.json
+++ b/deploy/contents/install/preferences/launch.system.parameters.json
@@ -493,5 +493,12 @@
         "description": "Specifies the target availability zone for a run",
         "defaultValue": "",
         "passToWorkers": true
+    },
+    {
+        "name": "CP_CAP_TARGET_ENI",
+        "type": "string",
+        "description": "Specifies the target ENI to be attached to the node for run",
+        "defaultValue": "",
+        "passToWorkers": false
     }
 ]


### PR DESCRIPTION
This PR adds ability to specify id of existing `aws eni` to be attached to node.
Such feature could be helpful when we need to have ability to spin up nodes with the same eni over and over again,
f.e. some software licenses could relay on eni `MAC` address.
So there is only one possible solution to use such software with re-creatable nodes.

Technical notes:
 - New system launch parameter is introduced `CP_CAP_TARGET_NETWORK_INTERFACE`
 - when this parameter is set - value will be passed to `nodeup` script 
 - `nodeup` script will try to describe `eni` and check several criteria to be met:
    - `eni` can be described
    - `eni` has status `available`
    - if `availability_zone` is provided it matches to `az` of `eni`
    - if `allowed_networks` provided `eni` should be placed in one of them
  - if all criteria are met new node will be launched with specified `eni` attached 