### PR TITLE
Issue #2642 Check run limits while resuming a run

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunDockerOperationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunDockerOperationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import com.epam.pipeline.manager.docker.DockerContainerOperationManager;
 import com.epam.pipeline.manager.docker.DockerRegistryManager;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
+import com.epam.pipeline.manager.quota.RunLimitsService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.ListUtils;
@@ -65,6 +66,7 @@ public class PipelineRunDockerOperationManager {
     private final RunStatusManager runStatusManager;
     private final MessageHelper messageHelper;
     private final PreferenceManager preferenceManager;
+    private final RunLimitsService runLimitsService;
 
     /**
      * Commits docker image and push it to a docker registry from specified run
@@ -147,6 +149,8 @@ public class PipelineRunDockerOperationManager {
             throw new IllegalArgumentException(messageHelper.getMessage(
                     MessageConstants.ERROR_ACTUAL_CMD_NOT_FOUND, runId));
         }
+        final Integer totalRunInstances = 1 + Optional.ofNullable(pipelineRun.getNodeCount()).orElse(0);
+        runLimitsService.checkRunLaunchLimits(totalRunInstances);
         Tool tool = toolManager.loadByNameOrId(pipelineRun.getDockerImage());
         pipelineRun.setStatus(TaskStatus.RESUMING);
         // prolong the run here in order to get rid off idle notification right after resume

--- a/api/src/main/java/com/epam/pipeline/manager/quota/RunLimitsService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/quota/RunLimitsService.java
@@ -59,7 +59,6 @@ public class RunLimitsService {
 
     private static final String USER_LIMIT_KEY = "<user-contextual-limit>";
     private static final String USER_GLOBAL_LIMIT_KEY = "<user-global-limit>";
-    private static final String PLATFORM_LIMIT_KEY = "<platform-limit>";
     private static final List<TaskStatus> ACTIVE_RUN_STATUSES = Arrays.asList(TaskStatus.RESUMING, TaskStatus.RUNNING);
     private final PipelineRunManager runManager;
     private final RoleManager roleManager;
@@ -113,14 +112,8 @@ public class RunLimitsService {
             return returnLimitAsMap(userGlobalLimit, USER_GLOBAL_LIMIT_KEY);
         }
 
-        final Optional<Integer> platformGlobalLimit = getPlatformGlobalLimit();
-        if (requiresSingleLimitOnly(platformGlobalLimit, loadAll)) {
-            return returnLimitAsMap(platformGlobalLimit, PLATFORM_LIMIT_KEY);
-        }
-
         addLimitIfPresent(groupsLimits, userContextualLimit, USER_LIMIT_KEY);
         addLimitIfPresent(groupsLimits, userGlobalLimit, USER_GLOBAL_LIMIT_KEY);
-        addLimitIfPresent(groupsLimits, platformGlobalLimit, PLATFORM_LIMIT_KEY);
         return groupsLimits;
     }
     
@@ -163,10 +156,6 @@ public class RunLimitsService {
 
     private Optional<Integer> getUserGlobalLimit() {
         return preferenceManager.findPreference(SystemPreferences.LAUNCH_MAX_RUNS_USER_GLOBAL_LIMIT);
-    }
-
-    private Optional<Integer> getPlatformGlobalLimit() {
-        return preferenceManager.findPreference(SystemPreferences.CLUSTER_MAX_SIZE);
     }
 
     private Stream<GroupLimit> findUserGroupsLimits(final Set<String> groups) {

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -208,7 +208,7 @@ public class ResourceMonitoringManagerTest {
         when(instanceOfferManager.getAllInstanceTypesObservable()).thenReturn(mockSubject);
 
         RunInstance spotInstance = new RunInstance(testType.getName(), 0, 0, null,
-                null, null, "spotNode", PLATFORM, true, null, null, null, null, null);
+                null, null, "spotNode", PLATFORM, true, null, null, null, null, null, null);
         final Map <String, String> stubTagMap = new HashMap<>();
         okayRun = new PipelineRun();
         okayRun.setInstance(spotInstance);
@@ -222,7 +222,7 @@ public class ResourceMonitoringManagerTest {
 
         idleSpotRun = new PipelineRun();
         idleSpotRun.setInstance(new RunInstance(testType.getName(), 0, 0, null,
-                null, null, "idleSpotNode", PLATFORM, true, null, null, null, null, null));
+                null, null, "idleSpotNode", PLATFORM, true, null, null, null, null, null, null));
         idleSpotRun.setPodId("idle-spot");
         idleSpotRun.setId(TEST_IDLE_SPOT_RUN_ID);
         idleSpotRun.setStartDate(new Date(Instant.now().minus(TEST_MAX_IDLE_MONITORING_TIMEOUT + 1, ChronoUnit.MINUTES)
@@ -233,7 +233,7 @@ public class ResourceMonitoringManagerTest {
 
         autoscaleMasterRun = new PipelineRun();
         autoscaleMasterRun.setInstance(new RunInstance(testType.getName(), 0, 0, null,
-                null, null, "autoscaleMasterRun", PLATFORM, false, null, null, null, null, null));
+                null, null, "autoscaleMasterRun", PLATFORM, false, null, null, null, null, null, null));
         autoscaleMasterRun.setPodId("autoscaleMasterRun");
         autoscaleMasterRun.setId(TEST_AUTOSCALE_RUN_ID);
         autoscaleMasterRun
@@ -248,7 +248,7 @@ public class ResourceMonitoringManagerTest {
         idleOnDemandRun = new PipelineRun();
         idleOnDemandRun.setInstance(
                 new RunInstance(testType.getName(), 0, 0, null, null, null, 
-                        "idleNode", PLATFORM, false, null, null, null, null, null));
+                        "idleNode", PLATFORM, false, null, null, null, null, null, null));
         idleOnDemandRun.setPodId("idle-on-demand");
         idleOnDemandRun.setId(TEST_IDLE_ON_DEMAND_RUN_ID);
         idleOnDemandRun.setStartDate(new Date(Instant.now().minus(TEST_MAX_IDLE_MONITORING_TIMEOUT + 1,
@@ -260,7 +260,7 @@ public class ResourceMonitoringManagerTest {
         idleRunToProlong = new PipelineRun();
         idleRunToProlong.setInstance(
                 new RunInstance(testType.getName(), 0, 0, null, null, null, 
-                        "prolongedNode", PLATFORM, false, null, null, null, null, null));
+                        "prolongedNode", PLATFORM, false, null, null, null, null, null, null));
         idleRunToProlong.setPodId("idle-to-prolong");
         idleRunToProlong.setId(TEST_IDLE_RUN_TO_PROLONG_ID);
         idleRunToProlong.setStartDate(new Date(Instant.now().minus(TEST_MAX_IDLE_MONITORING_TIMEOUT + 1,
@@ -271,7 +271,7 @@ public class ResourceMonitoringManagerTest {
 
         highConsumingRun = new PipelineRun();
         highConsumingRun.setInstance(new RunInstance(testType.getName(), 0, 0, null,
-                null, null, "highConsumingNode", PLATFORM, true, null, null, null, null, null));
+                null, null, "highConsumingNode", PLATFORM, true, null, null, null, null, null, null));
         highConsumingRun.setPodId(HIGH_CONSUMING_POD_ID);
         highConsumingRun.setId(TEST_HIGH_CONSUMING_RUN_ID);
         highConsumingRun.setStartDate(new Date(Instant.now().toEpochMilli()));

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunDockerOperationManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunDockerOperationManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import com.epam.pipeline.manager.cluster.performancemonitoring.UsageMonitoringMa
 import com.epam.pipeline.manager.docker.DockerContainerOperationManager;
 import com.epam.pipeline.manager.docker.DockerRegistryManager;
 import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.epam.pipeline.manager.quota.RunLimitsService;
 import org.apache.commons.lang.time.DateUtils;
 import org.junit.Test;
 
@@ -68,6 +69,7 @@ public class PipelineRunDockerOperationManagerTest {
     private final PreferenceManager preferenceManager = mock(PreferenceManager.class);
     private final RunLogManager runLogManager = mock(RunLogManager.class);
     private final RunStatusManager runStatusManager = mock(RunStatusManager.class);
+    private final RunLimitsService runLimitsService = mock(RunLimitsService.class);
     private final PipelineRunDockerOperationManager pipelineRunDockerOperationManager =
             new PipelineRunDockerOperationManager(
                     dockerContainerOperationManager,
@@ -80,7 +82,8 @@ public class PipelineRunDockerOperationManagerTest {
                     runLogManager,
                     runStatusManager,
                     messageHelper,
-                    preferenceManager);
+                    preferenceManager,
+                    runLimitsService);
 
     @Test
     public void pauseRunShouldBeRelaunched() {


### PR DESCRIPTION
This PR extends resuming logic as requested in the [comment](https://github.com/epam/cloud-pipeline/issues/2642#issuecomment-1157643963) : checking against configured limits should be performed as well.

Besides, `cluster.max.size` is not considered as a launch limit anymore since it has a different purpose: it is restricted from scaling, not pipeline launching perspective.