### PR TITLE
Issue 2675: Billing - empty summary chart when custom range selected fix

### DIFF
--- a/client/src/components/billing/reports/charts/summary.js
+++ b/client/src/components/billing/reports/charts/summary.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,6 +62,7 @@ function generateEmptySet (filters) {
   let unit = 'day';
   if (tick === '1M') {
     unit = 'M';
+    start = moment(start).startOf('M');
   }
   while (start <= end) {
     emptySet.push({

--- a/client/src/components/special/periods.js
+++ b/client/src/components/special/periods.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ function getTickFormat (start, end) {
   if (!start || !end) {
     return '1M';
   }
-  return moment.duration(end.diff(start)).asMonths() >= 1 ? '1M' : '1d';
+  return end.diff(start, 'month') >= 1 ? '1M' : '1d';
 }
 
 function buildRangeString ({start, end}, period) {


### PR DESCRIPTION
This PR fixes billing charts error described in the issue #2675