### PR TITLE
Implement API graceful shutdown

### DIFF
--- a/api/profiles/dev/application.properties
+++ b/api/profiles/dev/application.properties
@@ -1,5 +1,6 @@
 #tomcat configuration
 server.port=9999
+server.shutdown=${CP_API_SRV_SHUTDOWN_TYPE:graceful}
 server.context-path=/pipeline
 server.compression.enabled=true
 server.compression.min-response-size=2048
@@ -10,6 +11,7 @@ spring.http.encoding.charset=UTF-8
 spring.http.encoding.force=true
 spring.http.encoding.force-response=true
 spring.session.store-type=jdbc
+spring.lifecycle.timeout-per-shutdown-phase=${CP_API_SRV_SHUTDOWN_TIMEOUT:30}s
 
 #Security
 api.security.anonymous.urls=${CP_API_SRV_ANONYMOUS_URLS:/restapi/route,/restapi/whoami}

--- a/api/src/main/java/com/epam/pipeline/app/GracefulShutdownConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/GracefulShutdownConfiguration.java
@@ -1,0 +1,100 @@
+package com.epam.pipeline.app;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.catalina.connector.Connector;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.apache.coyote.ProtocolHandler;
+import org.apache.tomcat.util.threads.ThreadPoolExecutor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizer;
+import org.springframework.boot.context.embedded.tomcat.TomcatConnectorCustomizer;
+import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.ContextClosedEvent;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+@ConditionalOnProperty(value = "server.shutdown", havingValue = "graceful")
+public class GracefulShutdownConfiguration {
+
+    @Bean
+    public GracefulShutdownListener gracefulShutdownListener(
+            @Value("${spring.lifecycle.timeout-per-shutdown-phase:30s}")
+            final String gracefulShutdownTimeoutString) {
+        final long gracefulShutdownTimeoutInSeconds = toSeconds(gracefulShutdownTimeoutString);
+        return new GracefulShutdownListener(gracefulShutdownTimeoutInSeconds);
+    }
+
+    private int toSeconds(final String timeoutString) {
+        return NumberUtils.toInt(StringUtils.removeEnd(timeoutString, "s"));
+    }
+
+    @Bean
+    public EmbeddedServletContainerCustomizer embeddedServletContainerCustomizer(
+            final GracefulShutdownListener gracefulShutdownListener) {
+        return container -> Optional.of(container)
+                .filter(TomcatEmbeddedServletContainerFactory.class::isInstance)
+                .map(TomcatEmbeddedServletContainerFactory.class::cast)
+                .ifPresent(factory -> factory.addConnectorCustomizers(gracefulShutdownListener));
+    }
+
+    @Slf4j
+    @RequiredArgsConstructor
+    private static class GracefulShutdownListener implements TomcatConnectorCustomizer,
+            ApplicationListener<ContextClosedEvent> {
+
+        private final long timeoutSeconds;
+
+        private volatile Connector connector;
+
+        @Override
+        public void customize(final Connector connector) {
+            this.connector = connector;
+        }
+
+        @Override
+        public void onApplicationEvent(final ContextClosedEvent event) {
+            log.info("Gracefully shutting down application...");
+
+            log.debug("Resetting new connections...");
+            connector.pause();
+
+            log.debug("Terminating connections pool...");
+            getThreadPoolExecutor(connector).ifPresent(this::terminate);
+
+            log.debug("Proceeding with application shutting down...");
+        }
+
+        private Optional<ThreadPoolExecutor> getThreadPoolExecutor(final Connector connector) {
+            return Optional.of(connector)
+                    .map(Connector::getProtocolHandler)
+                    .map(ProtocolHandler::getExecutor)
+                    .filter(ThreadPoolExecutor.class::isInstance)
+                    .map(ThreadPoolExecutor.class::cast);
+        }
+
+        private void terminate(final ThreadPoolExecutor executor) {
+            try {
+                executor.shutdown();
+                log.debug("Waiting for connections pool to terminate...");
+                if (executor.awaitTermination(timeoutSeconds, TimeUnit.SECONDS)) {
+                    log.debug("Connections pool has been terminated successfully.");
+                } else {
+                    log.warn("Connections pool has not been terminated after %s seconds. " +
+                            "Proceeding with forceful connections shutting down...");
+                }
+            } catch (InterruptedException e) {
+                log.warn("Connections pool termination has been interrupted. " +
+                        "Proceeding with forceful connections shutting down...");
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+}

--- a/deploy/contents/k8s/cp-api-srv/cp-api-srv-dpl.yaml
+++ b/deploy/contents/k8s/cp-api-srv/cp-api-srv-dpl.yaml
@@ -11,6 +11,7 @@ spec:
       labels:
         cloud-pipeline/cp-api-srv: "true"
     spec:
+      terminationGracePeriodSeconds: 40
       nodeSelector:
         cloud-pipeline/cp-api-srv: "true"
       tolerations:

--- a/deploy/docker/cp-api-srv/config/application.properties
+++ b/deploy/docker/cp-api-srv/config/application.properties
@@ -1,5 +1,6 @@
 # Connectivity config
 server.port=8080
+server.shutdown=${CP_API_SRV_SHUTDOWN_TYPE:graceful}
 server.context-path=/pipeline
 server.compression.enabled=true
 server.compression.min-response-size=2048
@@ -15,6 +16,7 @@ api.security.impersonation.operations.root.url=${CP_API_SECURITY_IMPERSONATION_R
 api.security.public.urls=${CP_API_SECURITY_PUBLIC_URLS:/launch.sh,/launch.py,/PipelineCLI.tar.gz,/pipe-common.tar.gz,/commit-run-scripts/**,/pipe,/fsbrowser.tar.gz,/pipe.zip,/pipe.tar.gz,/pipe-el6,/pipe-el6.tar.gz,/pipe-osx,/pipe-osx.tar.gz,/cloud-data-linux.tar.gz,/cloud-data-win64.zip,/fsautoscale.sh,/data-transfer-service.jar,/data-transfer-service-windows.zip,/data-transfer-service-linux.zip,/DeployDts.ps1,/deploy_dts.sh}
 # supported values - jdbc, HASH_MAP
 spring.session.store-type=${CP_API_SRV_SESSION_STORE_TYPE:jdbc}
+spring.lifecycle.timeout-per-shutdown-phase=${CP_API_SRV_SHUTDOWN_TIMEOUT:30}s
 
 # DB config
 database.url=jdbc:postgresql://${PSG_HOST:cp-api-db.default.svc.cluster.local}:${PSG_PORT:5432}/${PSG_DB:pipeline}


### PR DESCRIPTION
Relates to #2639.

In order to implement Cloud Pipeline API autoscaling all the incoming connections shall be completed normally even if some Cloud Pipeline API replicas are shutting down.

The pull request introduces Cloud Pipeline API graceful shutdown implementation.

As long as the currently used Spring Boot version doesn't support graceful shutdown out of the box it is implemented manually with the usage of the same application properties as the newest Spring Boot versions use. As a result once Spring Boot version is updated then graceful shutdown configuration will remain the same.

The following new application properties can be used to configure graceful shutdown:
- `server.shutdown` specifies server shutdown type. Allowed values are `graceful` and `default` (ungraceful). Defaults to `graceful`. Also can be configured using `CP_API_SRV_SHUTDOWN_TYPE` environment variable.
- `spring.lifecycle.timeout-per-shutdown-phase` specifies graceful shutdown timeout in seconds. Defaults to `30s`.  Also can be configured using `CP_API_SRV_SHUTDOWN_TIMEOUT`. In this case `s` suffix shall be omitted.

### Related changes

Additionally in order to implement smooth Cloud Pipeline API autoscaling graceful shutdown timeout shall be less than Kubernetes pod termination grace period. In order to comply with the limitation the pull request increases Cloud Pipeline API replicas termination grace period from 30 seconds to 40 seconds.
