### PR TITLE
Issue #2642 Extend launch limits output in CLI

### DIFF
--- a/pipe-cli/src/api/pipeline_run.py
+++ b/pipe-cli/src/api/pipeline_run.py
@@ -92,3 +92,13 @@ class PipelineRun(API):
         if response_data and 'payload' in response_data:
             return response_data['payload']
         return None
+
+    @classmethod
+    def count_user_runs(cls, target_statuses=None, owner=None):
+        if target_statuses is None:
+            target_statuses = ['RUNNING', 'PAUSED', 'PAUSING', 'RESUMING']
+        api = cls.instance()
+        filter_data = {'statuses': target_statuses, 'owners': [owner], 'userModified': False}
+        response_data = api.call('run/count', json.dumps(filter_data))
+        if 'payload' in response_data:
+            return response_data['payload']

--- a/pipe-cli/src/utilities/user_operations_manager.py
+++ b/pipe-cli/src/utilities/user_operations_manager.py
@@ -17,6 +17,8 @@ import sys
 import click
 
 from prettytable import prettytable
+
+from src.api.pipeline_run import PipelineRun
 from src.api.user import User
 
 
@@ -39,6 +41,9 @@ class UserOperationsManager:
             click.echo("[%s] %s" % (event.get('status', ''), event.get('message', '')))
 
     def get_instance_limits(self, verbose=False):
+        username = self.user['userName']
+        active_runs_count = PipelineRun.count_user_runs(target_statuses=['RUNNING', 'RESUMING'], owner=username)
+        click.echo('Active runs detected for a user: [{}: {}]'.format(username, active_runs_count))
         active_limits = User.load_launch_limits(verbose)
         if len(active_limits) == 0:
             click.echo('No restrictions on runs launching configured')


### PR DESCRIPTION
This PR is related to a [comment](https://github.com/epam/cloud-pipeline/issues/2642#issuecomment-1157647316) in the original issue.

Output regarding instance limits configured is extended: number of currently active (`RUNNING` or `RESUMING` state) runs is shown for a user.