### PR TITLE
Issue #2642 Allow null values in `launch.max.runs.user.global` preference

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -601,8 +601,9 @@ public class SystemPreferences {
     public static final IntPreference LAUNCH_MAX_RUNS_GROUP_LIMIT = new IntPreference(
         "launch.max.runs.group", null, LAUNCH_GROUP, isGreaterThan(0));
 
-    public static final IntPreference LAUNCH_MAX_RUNS_USER_GLOBAL_LIMIT = new IntPreference(
-        "launch.max.runs.user.global", null, LAUNCH_GROUP, isGreaterThan(0));
+    public static final ObjectPreference<Integer> LAUNCH_MAX_RUNS_USER_GLOBAL_LIMIT = new ObjectPreference<>(
+        "launch.max.runs.user.global", null, new TypeReference<Integer>() {},
+        LAUNCH_GROUP, isNullOrGreaterThan(0));
 
     /**
      * Sets task status update rate, on which application will query Kubernetes cluster for running task status,


### PR DESCRIPTION
This PR contains a fix according to a [comment](https://github.com/epam/cloud-pipeline/issues/2642#issuecomment-1157643012) regarding a preference nullability in the original issue.