### PR TITLE
Support service account kubernetes configuration in aws node scripts

### DIFF
--- a/scripts/autoscaling/aws/node_reassign.py
+++ b/scripts/autoscaling/aws/node_reassign.py
@@ -19,6 +19,7 @@ import pykube
 RUN_ID_LABEL = 'runid'
 AWS_REGION_LABEL = 'aws_region'
 CLOUD_REGION_LABEL = 'cloud_region'
+KUBE_CONFIG_PATH = '~/.kube/config'
 
 
 def find_and_tag_instance(ec2, old_id, new_id):
@@ -98,7 +99,10 @@ def get_aws_region(api, run_id):
 
 
 def get_kube_api():
-    api = pykube.HTTPClient(pykube.KubeConfig.from_file("~/.kube/config"))
+    try:
+        api = pykube.HTTPClient(pykube.KubeConfig.from_service_account())
+    except Exception:
+        api = pykube.HTTPClient(pykube.KubeConfig.from_file(KUBE_CONFIG_PATH))
     api.session.verify = False
     return api
 

--- a/scripts/autoscaling/aws/nodedown.py
+++ b/scripts/autoscaling/aws/nodedown.py
@@ -20,6 +20,7 @@ import time
 RUN_ID_LABEL = 'runid'
 AWS_REGION_LABEL = 'aws_region'
 CLOUD_REGION_LABEL = 'cloud_region'
+KUBE_CONFIG_PATH = '~/.kube/config'
 AWS_TERMINATION_ATTEMPTS = 3
 
 
@@ -110,7 +111,10 @@ def get_aws_region(api, run_id):
 
 
 def get_kube_api():
-    api = pykube.HTTPClient(pykube.KubeConfig.from_file("~/.kube/config"))
+    try:
+        api = pykube.HTTPClient(pykube.KubeConfig.from_service_account())
+    except Exception:
+        api = pykube.HTTPClient(pykube.KubeConfig.from_file(KUBE_CONFIG_PATH))
     api.session.verify = False
     return api
 

--- a/scripts/autoscaling/aws/nodeup.py
+++ b/scripts/autoscaling/aws/nodeup.py
@@ -53,6 +53,7 @@ LOCAL_NVME_INSTANCE_TYPES = [ 'c5d.' , 'm5d.', 'r5d.' ]
 DEFAULT_FS_TYPE = 'btrfs'
 SUPPORTED_FS_TYPES = [DEFAULT_FS_TYPE, 'ext4']
 POOL_ID_KEY = 'pool_id'
+KUBE_CONFIG_PATH = '~/.kube/config'
 
 current_run_id = 0
 api_url = None
@@ -1307,7 +1308,10 @@ def main():
             ec2 = boto3.client('ec2', config=Config(retries={'max_attempts': BOTO3_RETRY_COUNT}))
 
         # Setup kubernetes client
-        api = pykube.HTTPClient(pykube.KubeConfig.from_file("~/.kube/config"))
+        try:
+            api = pykube.HTTPClient(pykube.KubeConfig.from_service_account())
+        except Exception:
+            api = pykube.HTTPClient(pykube.KubeConfig.from_file(KUBE_CONFIG_PATH))
         api.session.verify = False
 
         instance_additional_spec = None

--- a/scripts/autoscaling/aws/terminate_node.py
+++ b/scripts/autoscaling/aws/terminate_node.py
@@ -78,7 +78,10 @@ def get_aws_region(api, nodename):
 
 
 def get_kube_api():
-    api = pykube.HTTPClient(pykube.KubeConfig.from_file(KUBE_CONFIG_PATH))
+    try:
+        api = pykube.HTTPClient(pykube.KubeConfig.from_service_account())
+    except Exception:
+        api = pykube.HTTPClient(pykube.KubeConfig.from_file(KUBE_CONFIG_PATH))
     api.session.verify = False
     return api
 


### PR DESCRIPTION
Relates to #2639.

The pull request brings support for service account kubernetes configuration to aws node scripts. Previously only kubernetes local file configuration was supported.
