### PR TITLE
Issue #2678: Automatically renew API_TOKEN for the compute instances

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -621,6 +621,8 @@ public class SystemPreferences {
      */
     public static final IntPreference RELEASE_UNUSED_NODES_RATE = new IntPreference(
         "launch.pods.release.rate", 3000, LAUNCH_GROUP, isLessThan(LAUNCH_TASK_STATUS_UPDATE_RATE.getDefaultValue()));
+    public static final LongPreference LAUNCH_JWT_TOKEN_EXPIRATION_REFRESH_THRESHOLD = new LongPreference(
+            "launch.jwt.token.expiration.refresh.threshold", 172800L, LAUNCH_GROUP, isGreaterThan(0L));
 
     // UI_GROUP
     public static final StringPreference UI_PROJECT_INDICATOR = new StringPreference("ui.project.indicator",

--- a/scripts/pipeline-launch/launch.sh
+++ b/scripts/pipeline-launch/launch.sh
@@ -1903,7 +1903,7 @@ echo "-"
 if [ "$CP_API_TOKEN_REFRESHER_DISABLED" == "true" ]; then
     echo "API_TOKEN refresh is not requested"
 else
-    nohup $CP_PYTHON2_PATH -u $COMMON_REPO_DIR/scripts/token_experation_refresher.py 1>/dev/null 2> $LOG_DIR/.nohup.token.refresher.log &
+    nohup $CP_PYTHON2_PATH -u $COMMON_REPO_DIR/scripts/token_expiration_refresher.py &> $LOG_DIR/.nohup.token.refresher.log &
 fi
 
 ######################################################

--- a/scripts/pipeline-launch/launch.sh
+++ b/scripts/pipeline-launch/launch.sh
@@ -1893,6 +1893,21 @@ fi
 
 ######################################################
 
+######################################################
+# Enable API_TOKEN refresher
+######################################################
+
+echo "Setup API_TOKEN refresher"
+echo "-"
+
+if [ "$CP_API_TOKEN_REFRESHER_DISABLED" == "true" ]; then
+    echo "API_TOKEN refresh is not requested"
+else
+    nohup $CP_PYTHON2_PATH -u $COMMON_REPO_DIR/scripts/token_experation_refresher.py 1>/dev/null 2> $LOG_DIR/.nohup.token.refresher.log &
+fi
+
+######################################################
+
 
 ######################################################
 echo Executing task

--- a/workflows/pipe-common/pipeline/api/api.py
+++ b/workflows/pipe-common/pipeline/api/api.py
@@ -706,6 +706,18 @@ class PipelineAPI:
             raise RuntimeError("Failed to get system preference %s. "
                                "Error message: %s" % (preference_name, e.message))
 
+    def get_contextual_preference(self, preference_name, preference_level, resource_id):
+        try:
+            url = self.api_url \
+                  + '/contextual/preference/load?name=' +  preference_name \
+                  + '&level=' + preference_level \
+                  + '&resourceId=' + str(resource_id)
+            result = self.execute_request(url, method='get')
+            return {} if result is None else result
+        except BaseException as e:
+            raise RuntimeError("Failed to get contextual preference %s for %s level and resource id %s. "
+                               "Error message: %s" % (preference_name, preference_level, str(resource_id), e.message))
+
     def load_tool_version_settings(self, tool_id, version):
         get_tool_version_settings_url = self.TOOL_VERSION_SETTINGS % tool_id
         if version:
@@ -957,6 +969,18 @@ class PipelineAPI:
             return self.execute_request(url, method='get')
         except Exception as e:
             raise RuntimeError("Failed to load current user. Error message: {}".format(str(e.message)))
+
+    def generate_user_token(self, user_name, duration=None):
+        try:
+            if duration:
+                expiration_query = '&expiration=' + str(duration)
+            url = str(self.api_url) \
+                  + '/user/token?name=' + user_name \
+                  + (expiration_query if duration else '')
+            return self.execute_request(url, method='get')
+        except Exception as e:
+            raise RuntimeError("Failed to load user token. Error message: {}".format(str(e.message)))
+
 
     def load_roles(self, load_users=False):
         try:

--- a/workflows/pipe-common/scripts/token_experation_refresher.py
+++ b/workflows/pipe-common/scripts/token_experation_refresher.py
@@ -1,0 +1,136 @@
+# Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from time import sleep, time
+from pipeline.api import PipelineAPI
+import jwt
+
+ENV_SRC = "/etc/cp_env.sh"
+API_TOKEN_PREFIX = "export API_TOKEN="
+MONITORING_DELAY = 1
+GLOBAL_REFRESH_THRESHOLD = "launch.jwt.token.expiration.refresh.threshold"
+API_URL = os.environ['API']
+LOG_DIR = os.environ.get('LOG_DIR', 'logs')
+
+
+def read_env_src():
+    with open(ENV_SRC, 'r') as f:
+        return f.readlines()
+
+
+def get_token_from_env_src():
+    lines = read_env_src()
+    token = None
+    for line in lines:
+        if line.startswith(API_TOKEN_PREFIX):
+            token = line[len(API_TOKEN_PREFIX):].strip()
+    return token
+
+
+def get_global_token_refresh_threshold(api):
+    preference = api.get_preference(GLOBAL_REFRESH_THRESHOLD)
+    if not preference or not preference.get('value'):
+        return None
+    return preference.get('value')
+
+
+def load_contextual_preference(api, user_id):
+    try:
+        query = '/contextual/preference/load?name=%s&level=USER&resourceId=%d' % (GLOBAL_REFRESH_THRESHOLD, user_id)
+        result = api.execute_request(str(API_URL) + query)
+        return {} if result is None else result
+    except BaseException as error:
+        print("Failed to load user refresh threshold from contextual preferences. Error message: %s" % error.message)
+        return None
+
+
+def get_user_token_refresh_threshold(api, user_id):
+    preference = load_contextual_preference(api, user_id)
+    if not preference or not preference.get('value'):
+        return None
+    return preference.get('value')
+
+
+def load_user_token(api, user_name, duration=None):
+    try:
+        query = '/user/token?name=%s' % user_name
+        if duration:
+            query = '&expiration='.join([query, str(duration)])
+        result = api.execute_request(str(API_URL) + query)
+        return {} if result is None else result
+    except BaseException as e:
+        raise RuntimeError("Failed to load user token. Error message: %s" % e.message)
+
+
+def get_user_token(api, user_name, duration=None):
+    token_response = load_user_token(api, user_name, duration)
+    token = token_response.get('token', None)
+    if not token:
+        raise RuntimeError('User token is empty')
+    return token
+
+
+def get_refresh_threshold(api, user_id):
+    refresh_threshold = get_user_token_refresh_threshold(api, user_id)
+    if not refresh_threshold:
+        refresh_threshold = get_global_token_refresh_threshold(api)
+    if not refresh_threshold:
+        raise RuntimeError("Token refresh threshold was not specified")
+    return refresh_threshold
+
+
+def token_refresh_required(api, user_id, token_expiration_date):
+    refresh_threshold = get_refresh_threshold(api, user_id)
+    current_time = time()
+    return (int(token_expiration_date) - current_time) <= int(refresh_threshold)
+
+
+def refresh_token():
+    api_token = get_token_from_env_src()
+    token_from_file = True
+    if not api_token:
+        token_from_file = False
+        api_token = os.getenv("API_TOKEN")
+    if not api_token:
+        raise RuntimeError("API_TOKEN was not provided")
+    token_payload = jwt.decode(api_token, verify=False)
+    token_expiration_date = token_payload.get('exp', None)
+    if not token_expiration_date:
+        raise RuntimeError("Cannot determine expiration date for current token")
+
+    api = PipelineAPI(API_URL, LOG_DIR)
+    user = api.load_current_user()
+    username = user.get("userName", None)
+    user_id = user.get("id", None)
+
+    if not token_refresh_required(api, user_id, token_expiration_date):
+        print("No token refresh required")
+        return
+
+    new_token = get_user_token(api, username)
+    if token_from_file:
+        os.system("sed -i 's|API_TOKEN=.*|API_TOKEN=%s|g' %s" % (new_token, ENV_SRC))
+    else:
+        os.system('echo "export API_TOKEN=%s" >> %s' % (new_token, ENV_SRC))
+
+
+if __name__ == '__main__':
+    while True:
+        try:
+            refresh_token()
+        except BaseException as e:
+            print(e)
+        delay = os.getenv("CP_JWT_TOKEN_EXPIRATION_CHECK_TIMEOUT_HOUR", MONITORING_DELAY)
+        sleep(int(delay) * 60 * 60)

--- a/workflows/pipe-common/scripts/token_expiration_refresher.py
+++ b/workflows/pipe-common/scripts/token_expiration_refresher.py
@@ -12,20 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import datetime
 import os
 from time import sleep, time
 from pipeline.api import PipelineAPI
 import jwt
 
-ENV_SRC = "/etc/cp_env.sh"
+ENV_SRC = os.environ.get('CP_ENV_FILE_TO_SOURCE', '/etc/cp_env.sh')
 API_TOKEN_PREFIX = "export API_TOKEN="
-MONITORING_DELAY = 1
+MONITORING_DELAY_HOUR = int(os.getenv("CP_JWT_TOKEN_EXPIRATION_CHECK_TIMEOUT_HOUR", 1)) * 60 * 60
 GLOBAL_REFRESH_THRESHOLD = "launch.jwt.token.expiration.refresh.threshold"
 API_URL = os.environ['API']
 LOG_DIR = os.environ.get('LOG_DIR', 'logs')
 
 
 def read_env_src():
+    if not os.path.isfile(ENV_SRC):
+        return []
     with open(ENV_SRC, 'r') as f:
         return f.readlines()
 
@@ -35,7 +38,7 @@ def get_token_from_env_src():
     token = None
     for line in lines:
         if line.startswith(API_TOKEN_PREFIX):
-            token = line[len(API_TOKEN_PREFIX):].strip()
+            token = line[len(API_TOKEN_PREFIX):].strip().strip('"')
     return token
 
 
@@ -46,39 +49,18 @@ def get_global_token_refresh_threshold(api):
     return preference.get('value')
 
 
-def load_contextual_preference(api, user_id):
-    try:
-        query = '/contextual/preference/load?name=%s&level=USER&resourceId=%d' % (GLOBAL_REFRESH_THRESHOLD, user_id)
-        result = api.execute_request(str(API_URL) + query)
-        return {} if result is None else result
-    except BaseException as error:
-        print("Failed to load user refresh threshold from contextual preferences. Error message: %s" % error.message)
-        return None
-
-
 def get_user_token_refresh_threshold(api, user_id):
-    preference = load_contextual_preference(api, user_id)
+    preference = api.get_contextual_preference(GLOBAL_REFRESH_THRESHOLD, 'USER', user_id)
     if not preference or not preference.get('value'):
         return None
     return preference.get('value')
 
 
-def load_user_token(api, user_name, duration=None):
-    try:
-        query = '/user/token?name=%s' % user_name
-        if duration:
-            query = '&expiration='.join([query, str(duration)])
-        result = api.execute_request(str(API_URL) + query)
-        return {} if result is None else result
-    except BaseException as e:
-        raise RuntimeError("Failed to load user token. Error message: %s" % e.message)
-
-
 def get_user_token(api, user_name, duration=None):
-    token_response = load_user_token(api, user_name, duration)
+    token_response = api.generate_user_token(user_name, duration)
     token = token_response.get('token', None)
     if not token:
-        raise RuntimeError('User token is empty')
+        raise RuntimeError('[ERROR] User token is empty')
     return token
 
 
@@ -87,7 +69,7 @@ def get_refresh_threshold(api, user_id):
     if not refresh_threshold:
         refresh_threshold = get_global_token_refresh_threshold(api)
     if not refresh_threshold:
-        raise RuntimeError("Token refresh threshold was not specified")
+        raise RuntimeError("[INFO] Token refresh threshold was not specified")
     return refresh_threshold
 
 
@@ -104,11 +86,11 @@ def refresh_token():
         token_from_file = False
         api_token = os.getenv("API_TOKEN")
     if not api_token:
-        raise RuntimeError("API_TOKEN was not provided")
+        raise RuntimeError("[ERROR] API_TOKEN was not provided")
     token_payload = jwt.decode(api_token, verify=False)
     token_expiration_date = token_payload.get('exp', None)
     if not token_expiration_date:
-        raise RuntimeError("Cannot determine expiration date for current token")
+        raise RuntimeError("[ERROR] Cannot determine expiration date for current token")
 
     api = PipelineAPI(API_URL, LOG_DIR)
     user = api.load_current_user()
@@ -116,7 +98,7 @@ def refresh_token():
     user_id = user.get("id", None)
 
     if not token_refresh_required(api, user_id, token_expiration_date):
-        print("No token refresh required")
+        # No token refresh required
         return
 
     new_token = get_user_token(api, username)
@@ -124,6 +106,7 @@ def refresh_token():
         os.system("sed -i 's|API_TOKEN=.*|API_TOKEN=%s|g' %s" % (new_token, ENV_SRC))
     else:
         os.system('echo "export API_TOKEN=%s" >> %s' % (new_token, ENV_SRC))
+    print("[INFO] Token has been refreshed on {}".format(datetime.now()))
 
 
 if __name__ == '__main__':
@@ -132,5 +115,4 @@ if __name__ == '__main__':
             refresh_token()
         except BaseException as e:
             print(e)
-        delay = os.getenv("CP_JWT_TOKEN_EXPIRATION_CHECK_TIMEOUT_HOUR", MONITORING_DELAY)
-        sleep(int(delay) * 60 * 60)
+        sleep(MONITORING_DELAY_HOUR)

--- a/workflows/pipe-common/setup.py
+++ b/workflows/pipe-common/setup.py
@@ -61,6 +61,7 @@ setup(name='pipeline',
             'psutil==5.8.0',
             'pywin32==300; platform_system == "Windows"',
             'watchdog==0.10.4',
-            'psutil==5.8.0'
+            'psutil==5.8.0',
+            'PyJWT==1.7.1'
       ],
       zip_safe=False)


### PR DESCRIPTION
The current PR provides implementation for issue #2678 

- a new system preference `launch.jwt.token.expiration.refresh.threshold` were added. Default value: 172800 (2 days in seconds).
- `CP_JWT_TOKEN_EXPIRATION_CHECK_TIMEOUT_HOUR` can be used to regulate token monitoring frequency
-  `CP_API_TOKEN_REFRESHER_DISABLED=true` can be used to disable token monitoring