### PR TITLE
Issue 2713 sync blocked users with LDAP with new approach

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/ldap/LdapBlockedUsersManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/ldap/LdapBlockedUsersManager.java
@@ -16,6 +16,7 @@
 
 package com.epam.pipeline.manager.ldap;
 
+import com.epam.pipeline.entity.ldap.LdapBlockedUserSearchMethod;
 import com.epam.pipeline.entity.ldap.LdapEntity;
 import com.epam.pipeline.entity.ldap.LdapEntityType;
 import com.epam.pipeline.entity.ldap.LdapSearchRequest;
@@ -39,6 +40,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -63,36 +65,61 @@ public class LdapBlockedUsersManager {
      */
     public List<PipelineUser> filterBlockedUsers(final List<PipelineUser> users) {
         final Integer pageSize = preferenceManager.getPreference(SystemPreferences.LDAP_BLOCKED_USERS_FILTER_PAGE_SIZE);
-        final String filter = preferenceManager.getPreference(SystemPreferences.LDAP_BLOCKED_USER_FILTER);
+        final String filterTemplate = preferenceManager.getPreference(SystemPreferences.LDAP_BLOCKED_USER_FILTER);
         final String nameAttribute = preferenceManager.getPreference(
                 SystemPreferences.LDAP_BLOCKED_USER_NAME_ATTRIBUTE);
+        final LdapBlockedUserSearchMethod ldapSearchMethod = chooseLdapSearchMethod();
+
+        log.debug(String.format("LDAP search method: %s, filterTemplate: %s, nameAttribute: %s",
+                ldapSearchMethod.name(), filterTemplate, nameAttribute));
 
         final List<List<PipelineUser>> userPatches = Lists.partition(users, pageSize);
         return userPatches.stream()
-                .flatMap(patch -> findLdapBlockedUsers(patch, filter, nameAttribute).stream())
+                .flatMap(patch -> findLdapBlockedUsers(patch, ldapSearchMethod, filterTemplate, nameAttribute).stream())
                 .collect(Collectors.toList());
     }
 
-    private List<PipelineUser> findLdapBlockedUsers(final List<PipelineUser> patch, final String filterTemplate,
+    private List<PipelineUser> findLdapBlockedUsers(final List<PipelineUser> patch,
+                                                    final LdapBlockedUserSearchMethod searchMethod,
+                                                    final String filterTemplate,
                                                     final String nameAttribute) {
         final String filter = buildFilter(filterTemplate, patch, nameAttribute);
 
-        final List<LdapEntity> ldapUsers = queryLdap(patch.size(), filter, nameAttribute);
-        if (CollectionUtils.isEmpty(ldapUsers)) {
-            return Collections.emptyList();
-        }
-
-        final Map<String, PipelineUser> usersByName = patch.stream()
-                .collect(Collectors.toMap(user -> StringUtils.upperCase(user.getUserName()),
-                        Function.identity()));
-        return ldapUsers.stream()
+        final Set<String> userNamesFromLdap = ListUtils.emptyIfNull(
+                queryLdap(patch.size(), filter, nameAttribute)
+                ).stream()
                 .filter(Objects::nonNull)
                 .map(LdapEntity::getName)
                 .filter(StringUtils::isNotBlank)
                 .map(StringUtils::upperCase)
-                .filter(usersByName::containsKey)
-                .map(usersByName::get)
-                .collect(Collectors.toList());
+                .collect(Collectors.toSet());
+
+        final Map<String, PipelineUser> usersByName = patch.stream()
+                .collect(Collectors.toMap(user -> StringUtils.upperCase(user.getUserName()),
+                        Function.identity()));
+
+        switch (searchMethod) {
+            case LOAD_BLOCKED:
+                return userNamesFromLdap.stream()
+                        .filter(usersByName::containsKey)
+                        .map(usersByName::get)
+                        .collect(Collectors.toList());
+            case LOAD_ACTIVE_AND_INTERCEPT:
+                return usersByName.entrySet().stream()
+                        .filter(pu -> !userNamesFromLdap.contains(pu.getKey()))
+                        .map(Map.Entry::getValue).collect(Collectors.toList());
+            default:
+                throw new IllegalArgumentException("Unsupported search method: " + searchMethod.name());
+        }
+    }
+
+    private LdapBlockedUserSearchMethod chooseLdapSearchMethod() {
+        final String ldapSearchMethodPref = preferenceManager.getPreference(
+                SystemPreferences.LDAP_BLOCKED_USER_SEARCH_METHOD
+        );
+        return StringUtils.isEmpty(ldapSearchMethodPref)
+                ? LdapBlockedUserSearchMethod.LOAD_BLOCKED
+                : LdapBlockedUserSearchMethod.valueOf(ldapSearchMethodPref);
     }
 
     private String buildLdapTodayFilter() {

--- a/api/src/main/java/com/epam/pipeline/manager/ldap/LdapBlockedUsersManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/ldap/LdapBlockedUsersManager.java
@@ -78,6 +78,9 @@ public class LdapBlockedUsersManager {
                 .collect(Collectors.toList());
     }
 
+    // We need to make sure, when configure SystemPreference, that we are consistent between `searchMethod`
+    // and `filterTemplate`. e.g. if we have LOAD_ACTIVE_AND_INTERCEPT then we also should have `filterTemplate`
+    // that actually will search users that are active.
     private List<PipelineUser> findLdapBlockedUsers(final List<PipelineUser> patch,
                                                     final LdapBlockedUserSearchMethod searchMethod,
                                                     final String filterTemplate,

--- a/api/src/main/java/com/epam/pipeline/manager/ldap/LdapBlockedUsersManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/ldap/LdapBlockedUsersManager.java
@@ -29,7 +29,6 @@ import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.google.common.collect.Lists;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -32,6 +32,7 @@ import com.epam.pipeline.entity.datastorage.DataStorageConvertRequestAction;
 import com.epam.pipeline.entity.datastorage.StorageQuotaAction;
 import com.epam.pipeline.entity.datastorage.nfs.NFSMountPolicy;
 import com.epam.pipeline.entity.git.GitlabVersion;
+import com.epam.pipeline.entity.ldap.LdapBlockedUserSearchMethod;
 import com.epam.pipeline.entity.monitoring.IdleRunAction;
 import com.epam.pipeline.entity.monitoring.LongPausedRunAction;
 import com.epam.pipeline.entity.notification.filter.NotificationFilter;
@@ -1003,6 +1004,11 @@ public class SystemPreferences {
             "ldap.response.timeout", 60000, LDAP_GROUP, isGreaterThanOrEquals(0));
     public static final StringPreference LDAP_BLOCKED_USER_FILTER = new StringPreference(
             "ldap.blocked.user.filter", "", LDAP_GROUP, pass);
+
+    public static final StringPreference LDAP_BLOCKED_USER_SEARCH_METHOD = new StringPreference(
+            "ldap.blocked.user.search.method",
+            LdapBlockedUserSearchMethod.LOAD_BLOCKED.name(), LDAP_GROUP,
+            isValidEnum(LdapBlockedUserSearchMethod.class));
     public static final StringPreference LDAP_BLOCKED_USER_NAME_ATTRIBUTE = new StringPreference(
             "ldap.blocked.user.name.attribute", "sAMAccountName", LDAP_GROUP, pass);
     public static final IntPreference LDAP_BLOCKED_USERS_FILTER_PAGE_SIZE = new IntPreference(

--- a/core/src/main/java/com/epam/pipeline/entity/ldap/LdapBlockedUserSearchMethod.java
+++ b/core/src/main/java/com/epam/pipeline/entity/ldap/LdapBlockedUserSearchMethod.java
@@ -16,14 +16,7 @@
 
 package com.epam.pipeline.entity.ldap;
 
-import lombok.Value;
-
-import java.util.List;
-import java.util.Map;
-
-@Value
-public class LdapEntity {
-    String name;
-    LdapEntityType type;
-    Map<String, List<String>> attributes;
+public enum LdapBlockedUserSearchMethod {
+    LOAD_BLOCKED,
+    LOAD_ACTIVE_AND_INTERCEPT
 }


### PR DESCRIPTION
related to #2713 
Implementation of new possibly way to get blocked user from LDAP:
 - Try to load users from LDAP
    - These users who were successfully loaded - active ones
    - These users who can't be loaded - blocked
 - Filter list of users based on LDAP user list (filter user out if he/she in LDAP list)
 - Block remain users