### PR TITLE
Implement nodes graceful scale down support in deployment autoscaler

### DIFF
--- a/deploy/contents/k8s/cp-api-srv/cp-api-srv-dpl.yaml
+++ b/deploy/contents/k8s/cp-api-srv/cp-api-srv-dpl.yaml
@@ -11,7 +11,6 @@ spec:
       labels:
         cloud-pipeline/cp-api-srv: "true"
     spec:
-      terminationGracePeriodSeconds: 40
       nodeSelector:
         cloud-pipeline/cp-api-srv: "true"
       tolerations:
@@ -97,6 +96,7 @@ spec:
             - name: cp-cluster-ssh-key
               mountPath: "/etc/cp_ssh"
               readOnly: true
+          terminationGracePeriodSeconds: 50
           readinessProbe:
             httpGet:
               path: /pipeline/launch.sh
@@ -113,6 +113,10 @@ spec:
             initialDelaySeconds: 150
             periodSeconds: 15
             failureThreshold: 4
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "10"]
       dnsConfig:
         options:
           - name: ndots

--- a/deploy/contents/k8s/cp-deployment-autoscaler/README.md
+++ b/deploy/contents/k8s/cp-deployment-autoscaler/README.md
@@ -206,7 +206,13 @@ Deployment autoscaler parameter descriptions can be found in the following code 
     "scale_up_instance_timeout": 60,
     
     // Specifies instances scaling ↑ polling delay.
-    "scale_up_instance_delay": 10
+    "scale_up_instance_delay": 10,
+    
+    // Specifies node scaling ↓ polling timeout.
+    "scale_down_node_timeout": 120,
+    
+    // Specifies node scaling ↓ polling delay.
+    "scale_down_node_delay": 10
   },
   "misc": {
     "boto3_retry_count": 10

--- a/deploy/contents/k8s/cp-deployment-autoscaler/config.json
+++ b/deploy/contents/k8s/cp-deployment-autoscaler/config.json
@@ -83,7 +83,9 @@
     "scale_up_node_timeout": 900,
     "scale_up_node_delay": 10,
     "scale_up_instance_timeout": 60,
-    "scale_up_instance_delay": 10
+    "scale_up_instance_delay": 10,
+    "scale_down_node_timeout": 120,
+    "scale_down_node_delay": 10
   },
   "misc": {
     "boto3_retry_count": 10

--- a/deploy/docker/cp-deployment-autoscaler/autoscaler/cluster/provider.py
+++ b/deploy/docker/cp-deployment-autoscaler/autoscaler/cluster/provider.py
@@ -38,7 +38,7 @@ class NodeProvider(ABC):
         pass
 
     @abstractmethod
-    def cordon_node(self, node: Node):
+    def drain_node(self, node: Node):
         pass
 
     @abstractmethod

--- a/deploy/docker/cp-deployment-autoscaler/autoscaler/config.py
+++ b/deploy/docker/cp-deployment-autoscaler/autoscaler/config.py
@@ -56,7 +56,8 @@ KubeNodeConfiguration = collections.namedtuple('KubeNodeConfiguration',
                                                'kube_token, kube_ip, kube_port, kube_dns_ip, aws_fs_url')
 TimeoutConfiguration = collections.namedtuple('TimeoutConfiguration',
                                               'scale_up_node_timeout, scale_up_node_delay, '
-                                              'scale_up_instance_timeout, scale_up_instance_delay')
+                                              'scale_up_instance_timeout, scale_up_instance_delay, '
+                                              'scale_down_node_timeout, scale_down_node_delay')
 MiscConfiguration = collections.namedtuple('MiscConfiguration',
                                            'boto3_retry_count')
 
@@ -223,7 +224,9 @@ class LocalFileAutoscalingConfiguration(AutoscalingConfiguration, RefreshableCon
             scale_up_node_timeout=self._get_number(configuration, 'timeout.scale_up_node_timeout', 15 * 60),
             scale_up_node_delay=self._get_number(configuration, 'timeout.scale_up_node_delay', 10),
             scale_up_instance_timeout=self._get_number(configuration, 'timeout.scale_up_instance_timeout', 60),
-            scale_up_instance_delay=self._get_number(configuration, 'timeout.scale_up_instance_delay', 10))
+            scale_up_instance_delay=self._get_number(configuration, 'timeout.scale_up_instance_delay', 10),
+            scale_down_node_timeout=self._get_number(configuration, 'timeout.scale_down_node_timeout', 2 * 60),
+            scale_down_node_delay=self._get_number(configuration, 'timeout.scale_down_node_delay', 10))
         self._misc = MiscConfiguration(
             boto3_retry_count=self._get_number(configuration, 'misc.boto3_retry_count', 10))
 

--- a/deploy/docker/cp-deployment-autoscaler/autoscaler/exception.py
+++ b/deploy/docker/cp-deployment-autoscaler/autoscaler/exception.py
@@ -17,6 +17,10 @@ class NodeScaleUpTimeoutError(RuntimeError):
     pass
 
 
+class NodeEvictionTimeoutError(RuntimeError):
+    pass
+
+
 class ForbiddenNodeScaleDownError(RuntimeError):
     pass
 

--- a/deploy/docker/cp-deployment-autoscaler/autoscaler/rule.py
+++ b/deploy/docker/cp-deployment-autoscaler/autoscaler/rule.py
@@ -68,6 +68,6 @@ class LostTransientNodesRule(AutoscalingRule):
             if self._configuration.rules.on_lost_nodes == OnLostNodesStrategy.STOP:
                 logging.warning('Deleting lost transient nodes...')
                 for node in transient_lost_nodes:
-                    self._node_provider.cordon_node(node)
+                    self._node_provider.drain_node(node)
                     self._node_provider.delete_node(node)
                 raise AbortScalingError()

--- a/deploy/docker/cp-deployment-autoscaler/autoscaler/trigger.py
+++ b/deploy/docker/cp-deployment-autoscaler/autoscaler/trigger.py
@@ -21,6 +21,7 @@ import sys
 from abc import ABC, abstractmethod
 
 from autoscaler.cluster.provider import NodeProvider
+from autoscaler.config import AutoscalingConfiguration
 from autoscaler.model import Condition
 
 
@@ -161,7 +162,8 @@ class TargetReplicasPerTargetNodesCoefficientTrigger(CoefficientTrigger):
 
 class NodeConditionTrigger(AutoscalingTrigger):
 
-    def __init__(self, node_provider, condition, condition_name, condition_target):
+    def __init__(self, configuration, node_provider, condition, condition_name, condition_target):
+        self._configuration: AutoscalingConfiguration = configuration
         self._node_provider: NodeProvider = node_provider
         self._condition: Condition = condition
         self._condition_name: str = condition_name
@@ -196,21 +198,21 @@ class NodeConditionTrigger(AutoscalingTrigger):
 class NodeDiskPressureTrigger(NodeConditionTrigger):
 
     def __init__(self, configuration, node_provider):
-        super().__init__(node_provider, Condition.DISK_PRESSURE, 'disk pressured nodes',
+        super().__init__(configuration, node_provider, Condition.DISK_PRESSURE, 'disk pressured nodes',
                          configuration.trigger.disk_pressured_nodes)
 
 
 class NodeMemoryPressureTrigger(NodeConditionTrigger):
 
     def __init__(self, configuration, node_provider):
-        super().__init__(node_provider, Condition.MEMORY_PRESSURE, 'memory pressured nodes',
+        super().__init__(configuration, node_provider, Condition.MEMORY_PRESSURE, 'memory pressured nodes',
                          configuration.trigger.memory_pressured_nodes)
 
 
 class NodePidPressureTrigger(NodeConditionTrigger):
 
     def __init__(self, configuration, node_provider):
-        super().__init__(node_provider, Condition.PID_PRESSURE, 'pid pressured nodes',
+        super().__init__(configuration, node_provider, Condition.PID_PRESSURE, 'pid pressured nodes',
                          configuration.trigger.pid_pressured_nodes)
 
 


### PR DESCRIPTION
Relates to #2639 and improves changes introduced in #2685.

The pull request brings support for nodes graceful scale down to deployment autoscaler.

### Graceful pod termination

In order to avoid race condition between pod termination and pod service endpoint deletion a small 10 seconds delay is added to API deployment container. The delay happens after pod is deleted and before the corresponding container receives termination signal.

### Enhanced node draining

Deployment autoscaler node draining process is enhanced in order to allow pods to gracefully terminate. The process waits for all pods to complete before proceeding with node deletion.
