### PR TITLE
Issue 2721 tagging files while uploading (pipe cli / RestAPI)

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
@@ -563,7 +563,7 @@ public class DataStorageManager implements SecuredEntityManager {
 
     public DataStorageDownloadFileUrl generateDataStorageItemUploadUrl(Long id, String path) {
         AbstractDataStorage dataStorage = load(id);
-        return storageProviderManager.generateDataStorageItemUploadUrl(dataStorage, path);
+        return storageProviderManager.generateDataStorageItemUploadUrl(dataStorage, path, matchObjectTagsForItem(path));
     }
 
     public List<DataStorageDownloadFileUrl> generateDataStorageItemUploadUrl(Long id, List<String> paths) {
@@ -572,7 +572,8 @@ public class DataStorageManager implements SecuredEntityManager {
         if (paths == null) {
             return urls;
         }
-        paths.forEach(path -> urls.add(storageProviderManager.generateDataStorageItemUploadUrl(dataStorage, path)));
+        paths.forEach(path -> urls.add(storageProviderManager.generateDataStorageItemUploadUrl(dataStorage, path,
+                matchObjectTagsForItem(path))));
         return urls;
     }
 
@@ -1114,7 +1115,8 @@ public class DataStorageManager implements SecuredEntityManager {
     private DataStorageFile createDataStorageFile(final AbstractDataStorage storage,
                                                   final String path,
                                                   final byte[] contents) throws DataStorageException {
-        final DataStorageFile file = storageProviderManager.createFile(storage, path, contents);
+        final DataStorageFile file = storageProviderManager.createFile(storage, path, contents,
+                matchObjectTagsForItem(path));
         tagProviderManager.createFileTags(storage, path, file.getVersion());
         return file;
     }
@@ -1122,7 +1124,8 @@ public class DataStorageManager implements SecuredEntityManager {
     private DataStorageFile createDataStorageFile(final AbstractDataStorage storage, 
                                                   final String path, 
                                                   final InputStream contentStream) {
-        final DataStorageFile file = storageProviderManager.createFile(storage, path, contentStream);
+        final DataStorageFile file = storageProviderManager.createFile(storage, path, contentStream,
+                matchObjectTagsForItem(path));
         tagProviderManager.createFileTags(storage, path, file.getVersion());
         return file;
     }
@@ -1167,6 +1170,14 @@ public class DataStorageManager implements SecuredEntityManager {
         Assert.isTrue(storageProviderManager.findFile(dataStorage, path, version).isPresent(),
                 messageHelper.getMessage(MessageConstants.ERROR_DATASTORAGE_PATH_NOT_FOUND,
                         path, dataStorage.getRoot()));
+    }
+
+    private List<String> matchObjectTagsForItem(final String path) {
+        final Map<String, List<String>> objectTagsSchema = MapUtils.emptyIfNull(
+                preferenceManager.getPreference(SystemPreferences.STORAGE_OBJECT_TAGS_SCHEMA));
+        final String filename = Paths.get(path).getFileName().toString();
+        return objectTagsSchema.entrySet().stream().filter(e -> filename.matches(e.getKey()))
+                .flatMap(e -> e.getValue().stream()).collect(Collectors.toList());
     }
 
     private void assertToolsToMount(final DataStorageVO dataStorageVO) {

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
@@ -561,12 +561,12 @@ public class DataStorageManager implements SecuredEntityManager {
         return hours > 0 ? Duration.ofHours(hours) : Duration.ZERO;
     }
 
-    public DataStorageDownloadFileUrl generateDataStorageItemUploadUrl(Long id, String path) {
+    public DataStorageDownloadFileUrl generateDataStorageItemUploadUrl(final Long id, final String path) {
         AbstractDataStorage dataStorage = load(id);
         return storageProviderManager.generateDataStorageItemUploadUrl(dataStorage, path, matchObjectTagsForItem(path));
     }
 
-    public List<DataStorageDownloadFileUrl> generateDataStorageItemUploadUrl(Long id, List<String> paths) {
+    public List<DataStorageDownloadFileUrl> generateDataStorageItemUploadUrl(final Long id, final List<String> paths) {
         AbstractDataStorage dataStorage = load(id);
         List<DataStorageDownloadFileUrl> urls = new ArrayList<>();
         if (paths == null) {

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageProviderManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageProviderManager.java
@@ -126,9 +126,11 @@ public class StorageProviderManager {
     }
 
     @StorageWriteOperation
-    public DataStorageDownloadFileUrl generateDataStorageItemUploadUrl(AbstractDataStorage dataStorage,
-                                                                       String path) {
-        return getStorageProvider(dataStorage).generateDataStorageItemUploadUrl(dataStorage, path);
+    public DataStorageDownloadFileUrl generateDataStorageItemUploadUrl(final AbstractDataStorage dataStorage,
+                                                                       final String path,
+                                                                       final List<String> objectTags) {
+        return getStorageProvider(dataStorage).generateDataStorageItemUploadUrl(dataStorage, path,
+                objectTags);
     }
 
     @SensitiveStorageOperation
@@ -140,15 +142,18 @@ public class StorageProviderManager {
     }
 
     @StorageWriteOperation
-    public DataStorageFile createFile(AbstractDataStorage dataStorage, String path, byte[] contents)
+    public DataStorageFile createFile(final AbstractDataStorage dataStorage, final String path,
+                                      final byte[] contents, final List<String> objectTags)
             throws DataStorageException {
-        return getStorageProvider(dataStorage).createFile(dataStorage, path, contents);
+        return getStorageProvider(dataStorage).createFile(dataStorage, path, contents, objectTags);
     }
 
     @StorageWriteOperation
-    public DataStorageFile createFile(AbstractDataStorage dataStorage, String path, InputStream contentStream)
+    public DataStorageFile createFile(final AbstractDataStorage dataStorage, final String path,
+                                      final InputStream contentStream, final List<String> objectTags)
             throws DataStorageException {
-        return getStorageProvider(dataStorage).createFile(dataStorage, path, contentStream);
+        return getStorageProvider(dataStorage).createFile(dataStorage, path, contentStream,
+                objectTags);
     }
 
     @StorageWriteOperation

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/StorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/StorageProvider.java
@@ -63,14 +63,14 @@ public interface StorageProvider<T extends AbstractDataStorage> {
     DataStorageDownloadFileUrl generateDownloadURL(T dataStorage, String path, String version,
                                                    ContentDisposition contentDisposition);
 
-    DataStorageDownloadFileUrl generateDataStorageItemUploadUrl(T dataStorage, String path);
+    DataStorageDownloadFileUrl generateDataStorageItemUploadUrl(T dataStorage, String path, List<String> objectTags);
 
     DataStorageDownloadFileUrl generateUrl(T dataStorage, String path, List<String> permissions, Duration duration);
 
-    DataStorageFile createFile(T dataStorage, String path, byte[] contents)
+    DataStorageFile createFile(T dataStorage, String path, byte[] contents, List<String> objectTags)
             throws DataStorageException;
 
-    DataStorageFile createFile(T dataStorage, String path, InputStream dataStream)
+    DataStorageFile createFile(T dataStorage, String path, InputStream dataStream, List<String> objectTags)
         throws DataStorageException;
 
     DataStorageFolder createFolder(T dataStorage, String path)

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureBlobStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureBlobStorageProvider.java
@@ -119,7 +119,7 @@ public class AzureBlobStorageProvider implements StorageProvider<AzureBlobStorag
 
     @Override
     public DataStorageDownloadFileUrl generateDataStorageItemUploadUrl(final AzureBlobStorage dataStorage,
-                                                                       final String path) {
+                                                                       final String path, List<String> objectTags) {
         final BlobSASPermission permission = new BlobSASPermission()
                 .withRead(true)
                 .withAdd(true)
@@ -172,7 +172,8 @@ public class AzureBlobStorageProvider implements StorageProvider<AzureBlobStorag
     }
 
     @Override
-    public DataStorageFile createFile(final AzureBlobStorage dataStorage, final String path, final byte[] contents) {
+    public DataStorageFile createFile(final AzureBlobStorage dataStorage, final String path, final byte[] contents,
+                                      List<String> objectTags) {
         return getAzureStorageHelper(dataStorage)
                 .createFile(dataStorage, path, contents, authManager.getAuthorizedUser());
     }
@@ -180,7 +181,7 @@ public class AzureBlobStorageProvider implements StorageProvider<AzureBlobStorag
     @Override
     public DataStorageFile createFile(final AzureBlobStorage dataStorage,
                                       final String path,
-                                      final InputStream dataStream) {
+                                      final InputStream dataStream, List<String> objectTags) {
         return getAzureStorageHelper(dataStorage)
                 .createFile(dataStorage, path, dataStream, authManager.getAuthorizedUser());
     }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageProvider.java
@@ -115,7 +115,7 @@ public class GSBucketStorageProvider implements StorageProvider<GSBucketStorage>
 
     @Override
     public DataStorageDownloadFileUrl generateDataStorageItemUploadUrl(final GSBucketStorage dataStorage,
-                                                                       final String path) {
+                                                                       final String path, List<String> objectTags) {
         return null;
     }
 
@@ -128,14 +128,15 @@ public class GSBucketStorageProvider implements StorageProvider<GSBucketStorage>
     }
 
     @Override
-    public DataStorageFile createFile(final GSBucketStorage dataStorage, final String path, final byte[] contents)
-            throws DataStorageException {
+    public DataStorageFile createFile(final GSBucketStorage dataStorage, final String path, final byte[] contents,
+                                      List<String> objectTags) throws DataStorageException {
         return getHelper(dataStorage).createFile(dataStorage, path, contents, authManager.getAuthorizedUser());
     }
 
     @Override
     public DataStorageFile createFile(final GSBucketStorage dataStorage, final String path,
-                                      final InputStream dataStream) throws DataStorageException {
+                                      final InputStream dataStream, List<String> objectTags)
+            throws DataStorageException {
         return getHelper(dataStorage).createFile(dataStorage, path, dataStream, authManager.getAuthorizedUser());
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProvider.java
@@ -277,7 +277,8 @@ public class NFSStorageProvider implements StorageProvider<NFSDataStorage> {
     }
 
     @Override
-    public DataStorageDownloadFileUrl generateDataStorageItemUploadUrl(NFSDataStorage dataStorage, String path) {
+    public DataStorageDownloadFileUrl generateDataStorageItemUploadUrl(NFSDataStorage dataStorage, String path,
+                                                                       List<String> objectTags) {
         throw new UnsupportedOperationException();
     }
 
@@ -290,17 +291,18 @@ public class NFSStorageProvider implements StorageProvider<NFSDataStorage> {
     }
 
     @Override
-    public DataStorageFile createFile(NFSDataStorage dataStorage, String path, byte[] contents)
+    public DataStorageFile createFile(NFSDataStorage dataStorage, String path, byte[] contents, List<String> objectTags)
         throws DataStorageException {
         try (ByteArrayInputStream dataStream = new ByteArrayInputStream(contents)) {
-            return createFile(dataStorage, path, dataStream);
+            return createFile(dataStorage, path, dataStream, objectTags);
         } catch (IOException e) {
             throw new DataStorageException(e);
         }
     }
 
     @Override
-    public DataStorageFile createFile(NFSDataStorage dataStorage, String path, InputStream dataStream)
+    public DataStorageFile createFile(NFSDataStorage dataStorage, String path, InputStream dataStream,
+                                      List<String> objectTags)
         throws DataStorageException {
         File dataStorageDir = nfsStorageMounter.mount(dataStorage);
         File file = new File(dataStorageDir, path);

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -269,6 +269,14 @@ public class SystemPreferences {
             DATA_STORAGE_GROUP,
             PreferenceValidators.isValidGraceConfiguration);
 
+    public static final ObjectPreference<Map<String, List<String>>> STORAGE_OBJECT_TAGS_SCHEMA =
+            new ObjectPreference<>(
+                    "storage.object.tags.schema",
+                    Collections.emptyMap(),
+                    new TypeReference<Map<String, List<String>>>() {},
+                    DATA_STORAGE_GROUP,
+                    isNullOrValidJson(new TypeReference<Map<String, List<String>>>() {}));
+
     // GIT_GROUP
     public static final StringPreference GIT_HOST = new StringPreference("git.host", null, GIT_GROUP, null);
     public static final StringPreference GIT_READER_HOST =

--- a/api/src/test/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProviderTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProviderTest.java
@@ -25,6 +25,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -243,7 +244,7 @@ public class NFSStorageProviderTest extends AbstractSpringTest {
         dataStorage.setFileShareMountId(awsFileShareMount.getId());
         nfsProvider.createStorage(dataStorage);
         String testFileName = "testFile.txt";
-        nfsProvider.createFile(dataStorage, testFileName, "testContent".getBytes());
+        nfsProvider.createFile(dataStorage, testFileName, "testContent".getBytes(), Collections.emptyList());
 
         File dataStorageRoot = new File(testMountPoint, TEST_PATH + "/test");
         File testFile = new File(dataStorageRoot, testFileName);
@@ -293,7 +294,8 @@ public class NFSStorageProviderTest extends AbstractSpringTest {
         final Path rootPath = Paths.get(testMountPoint.toString(), TEST_PATH,  "test");
         final Path oldPath = rootPath.resolve("oldFilePath");
         final Path newPath = rootPath.resolve("newFilePath");
-        nfsProvider.createFile(storage, oldPath.getFileName().toString(), CommonCreatorConstants.TEST_BYTES);
+        nfsProvider.createFile(storage, oldPath.getFileName().toString(), CommonCreatorConstants.TEST_BYTES,
+                Collections.emptyList());
 
         nfsProvider.copyFile(storage, oldPath.getFileName().toString(), newPath.getFileName().toString());
 
@@ -345,7 +347,7 @@ public class NFSStorageProviderTest extends AbstractSpringTest {
         String testFileName = "testFile.txt";
         String testFolderName = "testFolder";
         String testFolder2Name = "testFolder2";
-        nfsProvider.createFile(dataStorage, testFileName, "testContent".getBytes());
+        nfsProvider.createFile(dataStorage, testFileName, "testContent".getBytes(), Collections.emptyList());
         nfsProvider.createFolder(dataStorage, testFolderName);
         nfsProvider.createFolder(dataStorage, testFolder2Name);
 
@@ -388,14 +390,15 @@ public class NFSStorageProviderTest extends AbstractSpringTest {
         byte[] testContent = "testContent".getBytes();
         byte[] newContent = "new content".getBytes();
 
-        DataStorageFile file = nfsProvider.createFile(dataStorage, testFileName, testContent);
+        DataStorageFile file = nfsProvider.createFile(dataStorage, testFileName, testContent, Collections.emptyList());
 
         Assert.assertArrayEquals(
                 testContent,
                 nfsProvider.getFile(dataStorage, testFileName, file.getVersion(), Long.MAX_VALUE).getContent()
         );
 
-        DataStorageFile updatedFile = nfsProvider.createFile(dataStorage, testFileName, newContent);
+        DataStorageFile updatedFile = nfsProvider.createFile(dataStorage, testFileName, newContent,
+                Collections.emptyList());
 
         Assert.assertArrayEquals(
                 newContent,

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1133,6 +1133,11 @@ def storage_remove_item(path, yes, version, hard_delete, recursive, exclude, inc
 @click.option('-l', '--file-list', required=False, help="Path to the file with file paths that should be moved. This file "
                                                         "should be tab delimited and consist of two columns: "
                                                         "relative path to a file and size")
+@click.option('-tm', '--tags-map', required=False, help="Path to file that contains 'tags map' - json-like "
+                                                        "structured file describes how files should be tagged "
+                                                        "while copying. Basically it has format of an array of object "
+                                                        "with two fields: mask - file name mask to match, tags - string with tags "
+                                                        "in format 'key1=value1;key2=value2'")
 @click.option('-sl', '--symlinks', required=False, default='follow',
               type=click.Choice(['follow', 'filter', 'skip']),
               help='Describe symlinks processing strategy for local sources. '
@@ -1171,14 +1176,14 @@ def storage_remove_item(path, yes, version, hard_delete, recursive, exclude, inc
 @click.option('-vd', '--verify-destination', is_flag=True, required=False,
               help=STORAGE_VERIFY_DESTINATION_OPTION_DESCRIPTION)
 @common_options
-def storage_move_item(source, destination, recursive, force, exclude, include, quiet, skip_existing, tags, file_list,
-                      symlinks, threads, io_threads, on_unsafe_chars, on_unsafe_chars_replacement, on_failures,
-                      verify_destination):
+def storage_move_item(source, destination, recursive, force, exclude, include, quiet, skip_existing, tags, tags_map,
+                      file_list, symlinks, threads, io_threads, on_unsafe_chars, on_unsafe_chars_replacement,
+                      on_failures, verify_destination):
     """
     Moves files/directories between data storages or between a local filesystem and a data storage.
     """
-    DataStorageOperations.cp(source, destination, recursive, force, exclude, include, quiet, tags, file_list,
-                             symlinks, threads, io_threads,
+    DataStorageOperations.cp(source, destination, recursive, force, exclude, include, quiet, tags, tags_map,
+                             file_list, symlinks, threads, io_threads,
                              on_unsafe_chars, on_unsafe_chars_replacement, on_failures,
                              clean=True, skip_existing=skip_existing, verify_destination=verify_destination)
 
@@ -1197,6 +1202,11 @@ def storage_move_item(source, destination, recursive, force, exclude, include, q
                                                                   "as single KEY=VALUE pair or a list of them. "
                                                                   "If --tags option specified all existent tags will "
                                                                   "be overwritten.")
+@click.option('-tm', '--tags-map', required=False, help="Path to file that contains 'tags map' - json-like "
+                                                        "structured file describes how files should be tagged "
+                                                        "while copying. Basically it has format of an array of object "
+                                                        "with two fields: mask - file name mask to match, tags - string with tags "
+                                                        "in format 'key1=value1;key2=value2'")
 @click.option('-l', '--file-list', required=False, help="Path to the file with file paths that should be copied. This file "
                                                         "should be tab delimited and consist of two columns: "
                                                         "relative path to a file and size")
@@ -1240,14 +1250,14 @@ def storage_move_item(source, destination, recursive, force, exclude, include, q
 @click.option('-vd', '--verify-destination', is_flag=True, required=False,
               help=STORAGE_VERIFY_DESTINATION_OPTION_DESCRIPTION)
 @common_options
-def storage_copy_item(source, destination, recursive, force, exclude, include, quiet, tags, file_list,
+def storage_copy_item(source, destination, recursive, force, exclude, include, quiet, tags, tags_map, file_list,
                       symlinks, threads, io_threads, on_unsafe_chars, on_unsafe_chars_replacement, on_failures,
                       skip_existing, verify_destination):
     """
     Copies files/directories between data storages or between a local filesystem and a data storage.
     """
     DataStorageOperations.cp(source, destination, recursive, force,
-                             exclude, include, quiet, tags, file_list, symlinks, threads, io_threads,
+                             exclude, include, quiet, tags, tags_map, file_list, symlinks, threads, io_threads,
                              on_unsafe_chars, on_unsafe_chars_replacement, on_failures,
                              clean=False, skip_existing=skip_existing, verify_destination=verify_destination)
 

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1133,11 +1133,11 @@ def storage_remove_item(path, yes, version, hard_delete, recursive, exclude, inc
 @click.option('-l', '--file-list', required=False, help="Path to the file with file paths that should be moved. This file "
                                                         "should be tab delimited and consist of two columns: "
                                                         "relative path to a file and size")
-@click.option('-tm', '--tags-map', required=False, help="Path to file that contains 'tags map' - json-like "
-                                                        "structured file describes how files should be tagged "
-                                                        "while copying. Basically it has format of an array of object "
-                                                        "with two fields: mask - file name mask to match, tags - string with tags "
-                                                        "in format 'key1=value1;key2=value2'")
+@click.option('-ts', '--tags-schema', required=False, help="Path to file that contains 'tags map' - json-like "
+                                                           "structured file describes how files should be tagged "
+                                                           "while copying. Basically it has format of an array of object "
+                                                           "with two fields: mask - file name mask to match, tags - array of strings with tags "
+                                                           "in format '['key1=value1', 'key2=value2']")
 @click.option('-sl', '--symlinks', required=False, default='follow',
               type=click.Choice(['follow', 'filter', 'skip']),
               help='Describe symlinks processing strategy for local sources. '
@@ -1176,13 +1176,13 @@ def storage_remove_item(path, yes, version, hard_delete, recursive, exclude, inc
 @click.option('-vd', '--verify-destination', is_flag=True, required=False,
               help=STORAGE_VERIFY_DESTINATION_OPTION_DESCRIPTION)
 @common_options
-def storage_move_item(source, destination, recursive, force, exclude, include, quiet, skip_existing, tags, tags_map,
+def storage_move_item(source, destination, recursive, force, exclude, include, quiet, skip_existing, tags, tags_schema,
                       file_list, symlinks, threads, io_threads, on_unsafe_chars, on_unsafe_chars_replacement,
                       on_failures, verify_destination):
     """
     Moves files/directories between data storages or between a local filesystem and a data storage.
     """
-    DataStorageOperations.cp(source, destination, recursive, force, exclude, include, quiet, tags, tags_map,
+    DataStorageOperations.cp(source, destination, recursive, force, exclude, include, quiet, tags, tags_schema,
                              file_list, symlinks, threads, io_threads,
                              on_unsafe_chars, on_unsafe_chars_replacement, on_failures,
                              clean=True, skip_existing=skip_existing, verify_destination=verify_destination)
@@ -1202,11 +1202,11 @@ def storage_move_item(source, destination, recursive, force, exclude, include, q
                                                                   "as single KEY=VALUE pair or a list of them. "
                                                                   "If --tags option specified all existent tags will "
                                                                   "be overwritten.")
-@click.option('-tm', '--tags-map', required=False, help="Path to file that contains 'tags map' - json-like "
-                                                        "structured file describes how files should be tagged "
-                                                        "while copying. Basically it has format of an array of object "
-                                                        "with two fields: mask - file name mask to match, tags - string with tags "
-                                                        "in format 'key1=value1;key2=value2'")
+@click.option('-ts', '--tags-schema', required=False, help="Path to file that contains 'tags map' - json-like "
+                                                           "structured file describes how files should be tagged "
+                                                           "while copying. Basically it has format of an array of object "
+                                                           "with two fields: mask - file name mask to match, tags - array of strings with tags "
+                                                           "in format '['key1=value1', 'key2=value2']")
 @click.option('-l', '--file-list', required=False, help="Path to the file with file paths that should be copied. This file "
                                                         "should be tab delimited and consist of two columns: "
                                                         "relative path to a file and size")
@@ -1250,14 +1250,14 @@ def storage_move_item(source, destination, recursive, force, exclude, include, q
 @click.option('-vd', '--verify-destination', is_flag=True, required=False,
               help=STORAGE_VERIFY_DESTINATION_OPTION_DESCRIPTION)
 @common_options
-def storage_copy_item(source, destination, recursive, force, exclude, include, quiet, tags, tags_map, file_list,
+def storage_copy_item(source, destination, recursive, force, exclude, include, quiet, tags, tags_schema, file_list,
                       symlinks, threads, io_threads, on_unsafe_chars, on_unsafe_chars_replacement, on_failures,
                       skip_existing, verify_destination):
     """
     Copies files/directories between data storages or between a local filesystem and a data storage.
     """
     DataStorageOperations.cp(source, destination, recursive, force,
-                             exclude, include, quiet, tags, tags_map, file_list, symlinks, threads, io_threads,
+                             exclude, include, quiet, tags, tags_schema, file_list, symlinks, threads, io_threads,
                              on_unsafe_chars, on_unsafe_chars_replacement, on_failures,
                              clean=False, skip_existing=skip_existing, verify_destination=verify_destination)
 

--- a/pipe-cli/src/model/tags_map.py
+++ b/pipe-cli/src/model/tags_map.py
@@ -17,7 +17,7 @@ class TagsMap:
         ]
 
     @classmethod
-    def read_tags_map(cls, storage_tags_schema_file_path, storage_tags_schema_preference_value=None):
+    def read_tags_schema(cls, storage_tags_schema_file_path, storage_tags_schema_preference_value=None):
 
         def load_storage_tags_schema_content():
             if storage_tags_schema_file_path and os.path.exists(storage_tags_schema_file_path):

--- a/pipe-cli/src/model/tags_map.py
+++ b/pipe-cli/src/model/tags_map.py
@@ -1,0 +1,47 @@
+import json
+import os.path
+import re
+
+
+class TagsMap:
+
+    def __init__(self, masks_to_tags):
+        self.masks_to_tags = masks_to_tags
+        self.mask_to_pattern = {mask: re.compile(mask) for mask in masks_to_tags.keys()}
+
+    def find_tags(self, file_item):
+        return [
+            tag
+            for mask, tags in self.masks_to_tags.items() if self.mask_to_pattern[mask].match(file_item[1])
+            for tag in tags
+        ]
+
+    @classmethod
+    def read_tags_map(cls, storage_tags_schema_file_path, storage_tags_schema_preference_value=None):
+
+        def load_storage_tags_schema_content():
+            if storage_tags_schema_file_path and os.path.exists(storage_tags_schema_file_path):
+                with open(storage_tags_schema_file_path) as tf:
+                    return json.load(tf)
+            elif storage_tags_schema_preference_value:
+                return json.loads(storage_tags_schema_preference_value)
+            return {}
+
+        # TODO fix [0] - should check that dict of the mask-tag entry valid
+        data = {
+            file_mask: cls.__parse_tags_from_list_of_string(tags)
+            for file_mask, tags in load_storage_tags_schema_content().items()
+        }
+        tags_map = TagsMap(data)
+        return tags_map
+
+    @classmethod
+    def __parse_tags_from_list_of_string(cls, _tags):
+        if not isinstance(_tags, list):
+            _tags = [_tags]
+
+        for _tag in _tags:
+            if "=" not in _tag:
+                raise RuntimeError("Wrong tag format, should be 'key=value', but was: " + _tag)
+
+        return _tags


### PR DESCRIPTION
Related to #2721 
This PR adds ability to specify tags for datastorage files through `SystemPreference` (`storage.object.tags.schema`) or `json` file, in format:
```
{
	".*html": ["tag-key=tag-value", "tag-key-2=tag-value-2"],
	".*txt": "tag-key=value"
}
```
**key** - Regexp for file name
**value** - List of strings, each string is a tag for object in format `key=value`

- For pipe CLI it is possible to specify it with `-ts/--tag-schema` option, and with `SystemPreference` (`-ts` option has higher priority)
- For Rest API methods only  `SystemPreference` is suitable