### PR TITLE
Enrich billing documents in elasticsearch

### DIFF
--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/EntityContainer.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/EntityContainer.java
@@ -16,6 +16,7 @@
 
 package com.epam.pipeline.billingreportagent.model;
 
+import com.epam.pipeline.entity.region.AbstractCloudRegion;
 import com.epam.pipeline.entity.user.PipelineUser;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -30,4 +31,5 @@ public class EntityContainer<T> {
 
     private T entity;
     private EntityWithMetadata<PipelineUser> owner;
+    private AbstractCloudRegion region;
 }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/PipelineRunWithType.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/PipelineRunWithType.java
@@ -17,7 +17,9 @@
 package com.epam.pipeline.billingreportagent.model;
 
 import com.epam.pipeline.entity.cluster.NodeDisk;
+import com.epam.pipeline.entity.pipeline.Pipeline;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.pipeline.Tool;
 import lombok.Value;
 
 import java.util.List;
@@ -26,6 +28,9 @@ import java.util.List;
 public class PipelineRunWithType {
 
     PipelineRun pipelineRun;
+    ToolAddress toolAddress;
+    EntityContainer<Tool> tool;
+    EntityContainer<Pipeline> pipeline;
     List<NodeDisk> disks;
     ComputeType runType;
 }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/ToolAddress.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/ToolAddress.java
@@ -1,0 +1,44 @@
+package com.epam.pipeline.billingreportagent.model;
+
+import lombok.Value;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+
+@Value
+public class ToolAddress {
+
+    private static final String COMMON_DELIMITER = "/";
+    private static final String VERSION_DELIMITER = ":";
+    private static final String EMPTY = "";
+
+    String registry;
+    String group;
+    String tool;
+    String version;
+
+    public static ToolAddress from(final String image) {
+        final String[] imageItems = image.split(COMMON_DELIMITER);
+        final String registry = imageItems.length > 0 ? imageItems[0] : null;
+        final String group = imageItems.length > 1 ? imageItems[1] : null;
+        final String toolAndVersion = imageItems.length > 2 ? join(imageItems, 2) : null;
+        final String[] toolAndVersionItems = toolAndVersion != null ? toolAndVersion.split(VERSION_DELIMITER) : new String[0];
+        final String tool = toolAndVersionItems.length > 0 ? toolAndVersionItems[0] : null;
+        final String version = toolAndVersionItems.length > 1 ? join(toolAndVersionItems, 1) : null;
+        return new ToolAddress(registry, group, tool, version);
+    }
+
+    private static String join(final String[] elements, final int startInclusive) {
+        return String.join(COMMON_DELIMITER, ArrayUtils.subarray(elements, startInclusive, elements.length));
+    }
+
+    public static ToolAddress empty() {
+        return new ToolAddress(null, null, null, null);
+    }
+
+    public String getPathWithoutVersion() {
+        return String.join(COMMON_DELIMITER,
+                StringUtils.defaultIfBlank(registry, EMPTY),
+                StringUtils.defaultIfBlank(group, EMPTY),
+                StringUtils.defaultIfBlank(tool, EMPTY));
+    }
+}

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/ToolAddress.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/ToolAddress.java
@@ -9,7 +9,6 @@ public class ToolAddress {
 
     private static final String COMMON_DELIMITER = "/";
     private static final String VERSION_DELIMITER = ":";
-    private static final String EMPTY = "";
 
     String registry;
     String group;
@@ -21,7 +20,9 @@ public class ToolAddress {
         final String registry = imageItems.length > 0 ? imageItems[0] : null;
         final String group = imageItems.length > 1 ? imageItems[1] : null;
         final String toolAndVersion = imageItems.length > 2 ? join(imageItems, 2) : null;
-        final String[] toolAndVersionItems = toolAndVersion != null ? toolAndVersion.split(VERSION_DELIMITER) : new String[0];
+        final String[] toolAndVersionItems = toolAndVersion != null
+                ? toolAndVersion.split(VERSION_DELIMITER)
+                : new String[0];
         final String tool = toolAndVersionItems.length > 0 ? toolAndVersionItems[0] : null;
         final String version = toolAndVersionItems.length > 1 ? join(toolAndVersionItems, 1) : null;
         return new ToolAddress(registry, group, tool, version);
@@ -37,8 +38,8 @@ public class ToolAddress {
 
     public String getPathWithoutVersion() {
         return String.join(COMMON_DELIMITER,
-                StringUtils.defaultIfBlank(registry, EMPTY),
-                StringUtils.defaultIfBlank(group, EMPTY),
-                StringUtils.defaultIfBlank(tool, EMPTY));
+                StringUtils.defaultIfBlank(registry, StringUtils.EMPTY),
+                StringUtils.defaultIfBlank(group, StringUtils.EMPTY),
+                StringUtils.defaultIfBlank(tool, StringUtils.EMPTY));
     }
 }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/StorageBillingInfo.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/StorageBillingInfo.java
@@ -31,14 +31,14 @@ public class StorageBillingInfo extends AbstractBillingInfo<AbstractDataStorage>
 
     private Long usageBytes;
     private StorageType storageType;
-    private Long regionId;
+    private String storageKind;
 
     @Builder
     public StorageBillingInfo(final LocalDate date, final AbstractDataStorage storage, final Long cost,
-                              final Long usageBytes, final StorageType storageType, final Long regionId) {
+                              final Long usageBytes, final StorageType storageType, final String storageKind) {
         super(date, storage, cost, ResourceType.STORAGE);
         this.usageBytes = usageBytes;
         this.storageType = storageType;
-        this.regionId = regionId;
+        this.storageKind = storageKind;
     }
 }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/StorageBillingInfo.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/StorageBillingInfo.java
@@ -19,6 +19,8 @@ package com.epam.pipeline.billingreportagent.model.billing;
 import com.epam.pipeline.billingreportagent.model.ResourceType;
 import com.epam.pipeline.billingreportagent.model.StorageType;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
+import com.epam.pipeline.entity.datastorage.DataStorageType;
+import com.epam.pipeline.entity.datastorage.MountType;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -30,15 +32,18 @@ import java.time.LocalDate;
 public class StorageBillingInfo extends AbstractBillingInfo<AbstractDataStorage> {
 
     private Long usageBytes;
-    private StorageType storageType;
-    private String storageKind;
+    private StorageType resourceStorageType;
+    private DataStorageType objectStorageType;
+    private MountType fileStorageType;
 
     @Builder
     public StorageBillingInfo(final LocalDate date, final AbstractDataStorage storage, final Long cost,
-                              final Long usageBytes, final StorageType storageType, final String storageKind) {
+                              final Long usageBytes, final StorageType resourceStorageType,
+                              final DataStorageType objectStorageType, final MountType fileStorageType) {
         super(date, storage, cost, ResourceType.STORAGE);
         this.usageBytes = usageBytes;
-        this.storageType = storageType;
-        this.storageKind = storageKind;
+        this.resourceStorageType = resourceStorageType;
+        this.objectStorageType = objectStorageType;
+        this.fileStorageType = fileStorageType;
     }
 }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/AbstractEntityMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/AbstractEntityMapper.java
@@ -19,10 +19,12 @@ package com.epam.pipeline.billingreportagent.service;
 import com.epam.pipeline.billingreportagent.model.EntityContainer;
 import com.epam.pipeline.billingreportagent.model.EntityWithMetadata;
 import com.epam.pipeline.entity.user.PipelineUser;
-import org.apache.commons.collections4.MapUtils;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
 
 public abstract class AbstractEntityMapper<T> {
 
@@ -30,18 +32,17 @@ public abstract class AbstractEntityMapper<T> {
 
     public abstract String getBillingCenterKey();
 
-    protected XContentBuilder buildUserContent(final EntityWithMetadata<PipelineUser> user,
+    protected XContentBuilder buildUserContent(final EntityWithMetadata<PipelineUser> owner,
                                                final XContentBuilder jsonBuilder) throws IOException {
-        if (user != null) {
-            final PipelineUser entity = user.getEntity();
-            if (entity != null) {
-                jsonBuilder
-                        .field("owner", entity.getUserName())
-                        .field("groups", entity.getGroups())
-                        .field("billing_center", MapUtils.emptyIfNull(user.getMetadata())
-                                .get(getBillingCenterKey()));
-            }
-        }
-        return jsonBuilder;
+        final Optional<PipelineUser> user = Optional.ofNullable(owner)
+                .map(EntityWithMetadata::getEntity);
+        final Map<String, String> metadata = Optional.ofNullable(owner)
+                .map(EntityWithMetadata::getMetadata)
+                .orElseGet(Collections::emptyMap);
+        return jsonBuilder
+                .field("owner", user.map(PipelineUser::getUserName).orElse(null))
+                .field("owner_user_id", user.map(PipelineUser::getId).orElse(null))
+                .field("groups", user.map(PipelineUser::getGroups).orElse(null))
+                .field("billing_center", metadata.get(getBillingCenterKey()));
     }
 }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/AbstractEntityMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/AbstractEntityMapper.java
@@ -18,15 +18,20 @@ package com.epam.pipeline.billingreportagent.service;
 
 import com.epam.pipeline.billingreportagent.model.EntityContainer;
 import com.epam.pipeline.billingreportagent.model.EntityWithMetadata;
+import com.epam.pipeline.config.Constants;
 import com.epam.pipeline.entity.user.PipelineUser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.text.SimpleDateFormat;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
 
 public abstract class AbstractEntityMapper<T> {
+
+    private static final SimpleDateFormat SIMPLE_DATE_FORMAT = new SimpleDateFormat(Constants.FMT_ISO_LOCAL_DATE);
 
     public abstract XContentBuilder map(EntityContainer<T> doc);
 
@@ -41,8 +46,12 @@ public abstract class AbstractEntityMapper<T> {
                 .orElseGet(Collections::emptyMap);
         return jsonBuilder
                 .field("owner", user.map(PipelineUser::getUserName).orElse(null))
-                .field("owner_user_id", user.map(PipelineUser::getId).orElse(null))
+                .field("owner_id", user.map(PipelineUser::getId).orElse(null))
                 .field("groups", user.map(PipelineUser::getGroups).orElse(null))
                 .field("billing_center", metadata.get(getBillingCenterKey()));
+    }
+
+    protected String asString(final Date date) {
+        return Optional.ofNullable(date).map(SIMPLE_DATE_FORMAT::format).orElse(null);
     }
 }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/AbstractEntityMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/AbstractEntityMapper.java
@@ -31,7 +31,7 @@ import java.util.Optional;
 
 public abstract class AbstractEntityMapper<T> {
 
-    private static final SimpleDateFormat SIMPLE_DATE_FORMAT = new SimpleDateFormat(Constants.FMT_ISO_LOCAL_DATE);
+    public static final SimpleDateFormat SIMPLE_DATE_FORMAT = new SimpleDateFormat(Constants.FMT_ISO_LOCAL_DATE);
 
     public abstract XContentBuilder map(EntityContainer<T> doc);
 

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/EntityLoader.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/EntityLoader.java
@@ -20,18 +20,23 @@ import com.epam.pipeline.billingreportagent.model.EntityContainer;
 import com.epam.pipeline.billingreportagent.model.EntityWithMetadata;
 import com.epam.pipeline.billingreportagent.service.impl.CloudPipelineAPIClient;
 import com.epam.pipeline.entity.BaseEntity;
+import com.epam.pipeline.entity.docker.DockerRegistryList;
 import com.epam.pipeline.entity.metadata.MetadataEntry;
 import com.epam.pipeline.entity.metadata.PipeConfValue;
+import com.epam.pipeline.entity.pipeline.Pipeline;
+import com.epam.pipeline.entity.pipeline.Tool;
 import com.epam.pipeline.entity.region.AbstractCloudRegion;
 import com.epam.pipeline.entity.security.acl.AclClass;
 import com.epam.pipeline.entity.user.PipelineUser;
 import com.epam.pipeline.vo.EntityVO;
 import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -90,5 +95,35 @@ public interface EntityLoader<T> {
         return apiClient.loadAllCloudRegions()
                 .stream()
                 .collect(Collectors.toMap(BaseEntity::getId, Function.identity()));
+    }
+
+    default Map<Long, Pipeline> preparePipelines(final CloudPipelineAPIClient apiClient) {
+        return apiClient.loadAllPipelines()
+                .stream()
+                .collect(Collectors.toMap(BaseEntity::getId, Function.identity()));
+    }
+
+    default Map<String, Tool> prepareTools(final CloudPipelineAPIClient apiClient) {
+        return Optional.ofNullable(apiClient.loadAllRegistries())
+                .map(DockerRegistryList::getRegistries)
+                .map(List::stream)
+                .orElseGet(Stream::empty)
+                .filter(Objects::nonNull)
+                .flatMap(registry -> Optional.ofNullable(registry.getGroups())
+                        .map(List::stream)
+                        .orElseGet(Stream::empty)
+                        .filter(Objects::nonNull)
+                        .flatMap(group -> Optional.ofNullable(group.getTools())
+                                .map(List::stream)
+                                .orElseGet(Stream::empty)
+                                .filter(Objects::nonNull)
+                                .peek(tool -> {
+                                    tool.setRegistryId(registry.getId());
+                                    tool.setRegistry(registry.getName());
+                                    tool.setToolGroupId(group.getId());
+                                    tool.setToolGroup(group.getName());
+                                })))
+                .filter(tool -> StringUtils.isNotBlank(tool.getRegistry()) && StringUtils.isNotBlank(tool.getImage()))
+                .collect(Collectors.toMap(tool -> tool.getRegistry() + "/" + tool.getImage(), Function.identity()));
     }
 }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/EntityLoader.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/EntityLoader.java
@@ -19,8 +19,10 @@ package com.epam.pipeline.billingreportagent.service;
 import com.epam.pipeline.billingreportagent.model.EntityContainer;
 import com.epam.pipeline.billingreportagent.model.EntityWithMetadata;
 import com.epam.pipeline.billingreportagent.service.impl.CloudPipelineAPIClient;
+import com.epam.pipeline.entity.BaseEntity;
 import com.epam.pipeline.entity.metadata.MetadataEntry;
 import com.epam.pipeline.entity.metadata.PipeConfValue;
+import com.epam.pipeline.entity.region.AbstractCloudRegion;
 import com.epam.pipeline.entity.security.acl.AclClass;
 import com.epam.pipeline.entity.user.PipelineUser;
 import com.epam.pipeline.vo.EntityVO;
@@ -82,5 +84,11 @@ public interface EntityLoader<T> {
                         map.put(entry.getKey(), value);
                     },
                     HashMap::putAll);
+    }
+
+    default Map<Long, AbstractCloudRegion> prepareRegions(final CloudPipelineAPIClient apiClient) {
+        return apiClient.loadAllCloudRegions()
+                .stream()
+                .collect(Collectors.toMap(BaseEntity::getId, Function.identity()));
     }
 }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/CloudPipelineAPIClient.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/CloudPipelineAPIClient.java
@@ -22,9 +22,12 @@ import com.epam.pipeline.client.pipeline.RetryingCloudPipelineApiExecutor;
 import com.epam.pipeline.entity.cluster.InstanceType;
 import com.epam.pipeline.entity.cluster.NodeDisk;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
+import com.epam.pipeline.entity.docker.DockerRegistryList;
 import com.epam.pipeline.entity.metadata.MetadataEntry;
+import com.epam.pipeline.entity.pipeline.Pipeline;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 
+import com.epam.pipeline.entity.pipeline.Tool;
 import com.epam.pipeline.entity.region.AbstractCloudRegion;
 import com.epam.pipeline.entity.security.acl.AclClass;
 import com.epam.pipeline.entity.user.PipelineUser;
@@ -33,6 +36,7 @@ import com.epam.pipeline.vo.EntityVO;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -80,6 +84,14 @@ public class CloudPipelineAPIClient {
 
     public List<AbstractCloudRegion> loadAllCloudRegions() {
         return retryingApiExecutor.execute(cloudPipelineAPI.loadAllRegions());
+    }
+
+    public List<Pipeline> loadAllPipelines() {
+        return retryingApiExecutor.execute(cloudPipelineAPI.loadAllPipelines());
+    }
+
+    public DockerRegistryList loadAllRegistries() {
+        return retryingApiExecutor.execute(cloudPipelineAPI.loadAllRegistries());
     }
 
     public List<EntityVO> searchEntriesByMetadata(final AclClass entityClass, final String key, final String value) {

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/CloudPipelineAPIClient.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/CloudPipelineAPIClient.java
@@ -26,8 +26,6 @@ import com.epam.pipeline.entity.docker.DockerRegistryList;
 import com.epam.pipeline.entity.metadata.MetadataEntry;
 import com.epam.pipeline.entity.pipeline.Pipeline;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
-
-import com.epam.pipeline.entity.pipeline.Tool;
 import com.epam.pipeline.entity.region.AbstractCloudRegion;
 import com.epam.pipeline.entity.security.acl.AclClass;
 import com.epam.pipeline.entity.user.PipelineUser;
@@ -36,7 +34,6 @@ import com.epam.pipeline.vo.EntityVO;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/loader/PipelineRunLoader.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/loader/PipelineRunLoader.java
@@ -27,6 +27,7 @@ import com.epam.pipeline.entity.cluster.NodeDisk;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.run.parameter.PipelineRunParameter;
+import com.epam.pipeline.entity.region.AbstractCloudRegion;
 import com.epam.pipeline.entity.user.PipelineUser;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.ListUtils;
@@ -70,7 +71,7 @@ public class PipelineRunLoader implements EntityLoader<PipelineRunWithType> {
     public List<EntityContainer<PipelineRunWithType>> loadAllEntitiesActiveInPeriod(final LocalDateTime from,
                                                                                     final LocalDateTime to) {
         final Map<String, EntityWithMetadata<PipelineUser>> usersWithMetadata = prepareUsers(apiClient);
-
+        final Map<Long, AbstractCloudRegion> regions = prepareRegions(apiClient);
         final List<PipelineRun> runs = getRuns(from, to);
 
         final Map<Long, List<InstanceType>> regionOffers = runs.stream()
@@ -85,6 +86,7 @@ public class PipelineRunLoader implements EntityLoader<PipelineRunWithType> {
                 .map(run -> EntityContainer.<PipelineRunWithType>builder()
                         .entity(new PipelineRunWithType(run, loadDisks(run), getRunType(run, regionOffers)))
                         .owner(getOwner(run, usersWithMetadata))
+                        .region(regions.get(run.getInstance().getCloudRegionId()))
                         .build())
                 .collect(Collectors.toList());
     }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/loader/PipelineRunLoader.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/loader/PipelineRunLoader.java
@@ -20,17 +20,22 @@ import com.epam.pipeline.billingreportagent.model.ComputeType;
 import com.epam.pipeline.billingreportagent.model.EntityContainer;
 import com.epam.pipeline.billingreportagent.model.EntityWithMetadata;
 import com.epam.pipeline.billingreportagent.model.PipelineRunWithType;
+import com.epam.pipeline.billingreportagent.model.ToolAddress;
 import com.epam.pipeline.billingreportagent.service.EntityLoader;
 import com.epam.pipeline.billingreportagent.service.impl.CloudPipelineAPIClient;
+import com.epam.pipeline.entity.AbstractSecuredEntity;
 import com.epam.pipeline.entity.cluster.InstanceType;
 import com.epam.pipeline.entity.cluster.NodeDisk;
+import com.epam.pipeline.entity.pipeline.Pipeline;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.RunInstance;
+import com.epam.pipeline.entity.pipeline.Tool;
 import com.epam.pipeline.entity.pipeline.run.parameter.PipelineRunParameter;
 import com.epam.pipeline.entity.region.AbstractCloudRegion;
 import com.epam.pipeline.entity.user.PipelineUser;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -72,6 +77,8 @@ public class PipelineRunLoader implements EntityLoader<PipelineRunWithType> {
                                                                                     final LocalDateTime to) {
         final Map<String, EntityWithMetadata<PipelineUser>> usersWithMetadata = prepareUsers(apiClient);
         final Map<Long, AbstractCloudRegion> regions = prepareRegions(apiClient);
+        final Map<Long, Pipeline> pipelines = preparePipelines(apiClient);
+        final Map<String, Tool> tools = prepareTools(apiClient);
         final List<PipelineRun> runs = getRuns(from, to);
 
         final Map<Long, List<InstanceType>> regionOffers = runs.stream()
@@ -83,12 +90,40 @@ public class PipelineRunLoader implements EntityLoader<PipelineRunWithType> {
 
         return runs
                 .stream()
-                .map(run -> EntityContainer.<PipelineRunWithType>builder()
-                        .entity(new PipelineRunWithType(run, loadDisks(run), getRunType(run, regionOffers)))
-                        .owner(getOwner(run, usersWithMetadata))
-                        .region(regions.get(run.getInstance().getCloudRegionId()))
-                        .build())
+                .map(run -> {
+                    final ToolAddress toolAddress = Optional.ofNullable(run.getDockerImage())
+                            .map(ToolAddress::from)
+                            .orElseGet(ToolAddress::empty);
+                    return EntityContainer.<PipelineRunWithType>builder()
+                            .entity(new PipelineRunWithType(run, toolAddress,
+                                    loadEntity(toolAddress.getPathWithoutVersion(), tools, usersWithMetadata),
+                                    loadEntity(run.getPipelineId(), pipelines, usersWithMetadata),
+                                    loadDisks(run),
+                                    getRunType(run, regionOffers)))
+                            .owner(getRunOwner(run, usersWithMetadata))
+                            .region(regions.get(run.getInstance().getCloudRegionId()))
+                            .build();
+                })
                 .collect(Collectors.toList());
+    }
+
+    private <E extends AbstractSecuredEntity, I> EntityContainer<E> loadEntity(
+            final I id,
+            final Map<I, E> entities,
+            final Map<String, EntityWithMetadata<PipelineUser>> users) {
+        return Optional.ofNullable(id)
+                .map(entities::get)
+                .map(entity -> toContainer(entity, users))
+                .orElse(null);
+    }
+
+    private <E extends AbstractSecuredEntity> EntityContainer<E> toContainer(
+            final E entity,
+            final Map<String, EntityWithMetadata<PipelineUser>> user) {
+        return EntityContainer.<E>builder()
+                .entity(entity)
+                .owner(getOwner(entity, user))
+                .build();
     }
 
     private List<PipelineRun> getRuns(final LocalDateTime from, final LocalDateTime to) {
@@ -125,10 +160,10 @@ public class PipelineRunLoader implements EntityLoader<PipelineRunWithType> {
                 .orElse(ComputeType.CPU);
     }
 
-    private EntityWithMetadata<PipelineUser> getOwner(final PipelineRun run,
-                                                      final Map<String, EntityWithMetadata<PipelineUser>> users) {
+    private EntityWithMetadata<PipelineUser> getRunOwner(final PipelineRun run,
+                                                         final Map<String, EntityWithMetadata<PipelineUser>> users) {
         return getBillingOwner(run, users)
-                .orElseGet(() -> getRunOwner(run, users));
+                .orElseGet(() -> getOwner(run, users));
     }
 
     private Optional<EntityWithMetadata<PipelineUser>> getBillingOwner(
@@ -149,9 +184,9 @@ public class PipelineRunLoader implements EntityLoader<PipelineRunWithType> {
                 .findFirst();
     }
 
-    private EntityWithMetadata<PipelineUser> getRunOwner(final PipelineRun run,
-                                                         final Map<String, EntityWithMetadata<PipelineUser>> users) {
-        return users.get(run.getOwner());
+    private EntityWithMetadata<PipelineUser> getOwner(final AbstractSecuredEntity entity,
+                                                      final Map<String, EntityWithMetadata<PipelineUser>> users) {
+        return Optional.ofNullable(users.get(entity.getOwner()))
+                .orElseGet(() -> users.get(StringUtils.upperCase(entity.getOwner())));
     }
-
 }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/loader/StorageLoader.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/loader/StorageLoader.java
@@ -19,7 +19,13 @@ import com.epam.pipeline.billingreportagent.model.EntityContainer;
 import com.epam.pipeline.billingreportagent.model.EntityWithMetadata;
 import com.epam.pipeline.billingreportagent.service.EntityLoader;
 import com.epam.pipeline.billingreportagent.service.impl.CloudPipelineAPIClient;
+import com.epam.pipeline.billingreportagent.service.impl.converter.FileShareMountsService;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
+import com.epam.pipeline.entity.datastorage.AzureBlobStorage;
+import com.epam.pipeline.entity.datastorage.GSBucketStorage;
+import com.epam.pipeline.entity.datastorage.NFSDataStorage;
+import com.epam.pipeline.entity.datastorage.S3bucketDataStorage;
+import com.epam.pipeline.entity.region.AbstractCloudRegion;
 import com.epam.pipeline.entity.security.acl.AclClass;
 import com.epam.pipeline.entity.user.PipelineUser;
 import com.epam.pipeline.vo.EntityVO;
@@ -30,6 +36,7 @@ import org.springframework.stereotype.Component;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -37,15 +44,18 @@ import java.util.stream.Collectors;
 public class StorageLoader implements EntityLoader<AbstractDataStorage> {
 
     private final CloudPipelineAPIClient apiClient;
+    private final Optional<FileShareMountsService> fileshareMountsService;
     private final String storageExcludeKey;
     private final String storageExcludeValue;
 
     public StorageLoader(final CloudPipelineAPIClient apiClient,
+                         final FileShareMountsService fileshareMountsService,
                          @Value("${sync.storage.billing.exclude.metadata.key:Billing status}")
                          final String storageExcludeKey,
                          @Value("${sync.storage.billing.exclude.metadata.value:Exclude}")
                          final String storageExcludeValue) {
         this.apiClient = apiClient;
+        this.fileshareMountsService = Optional.ofNullable(fileshareMountsService);
         this.storageExcludeKey = storageExcludeKey;
         this.storageExcludeValue = storageExcludeValue;
     }
@@ -53,15 +63,36 @@ public class StorageLoader implements EntityLoader<AbstractDataStorage> {
     @Override
     public List<EntityContainer<AbstractDataStorage>> loadAllEntities() {
         final Map<String, EntityWithMetadata<PipelineUser>> usersWithMetadata = prepareUsers(apiClient);
+        final Map<Long, AbstractCloudRegion> regions = prepareRegions(apiClient);
         final Set<Long> storageIdsToIgnore = loadStorageIdsToIgnoreByTag();
+        fileshareMountsService.ifPresent(FileShareMountsService::updateSharesRegions);
         return apiClient.loadAllDataStorages()
                 .stream()
                 .filter(storage -> isStorageBillable(storage, storageIdsToIgnore))
                 .map(storage -> EntityContainer.<AbstractDataStorage>builder()
                         .entity(storage)
                         .owner(usersWithMetadata.get(storage.getOwner()))
+                        .region(regions.get(getRegionId(storage)))
                         .build())
                 .collect(Collectors.toList());
+    }
+
+    private Long getRegionId(final AbstractDataStorage storage) {
+        if (storage instanceof S3bucketDataStorage) {
+            return ((S3bucketDataStorage) storage).getRegionId();
+        } else if (storage instanceof AzureBlobStorage) {
+            return ((AzureBlobStorage) storage).getRegionId();
+        } else if (storage instanceof GSBucketStorage) {
+            return ((GSBucketStorage) storage).getRegionId();
+        } else if (storage instanceof NFSDataStorage) {
+            return fileshareMountsService
+                    .map(fileShareMountsService -> fileShareMountsService.getRegionIdForShare(
+                            storage.getFileShareMountId()))
+                    .orElseThrow(() -> new IllegalStateException(
+                            "FileShareMountService is not available for NFSSynchronizer!"));
+        } else {
+            throw new IllegalArgumentException("Unknown storage type!");
+        }
     }
 
     @Override

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapper.java
@@ -26,6 +26,7 @@ import com.epam.pipeline.entity.BaseEntity;
 import com.epam.pipeline.entity.pipeline.Pipeline;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.Tool;
+import com.epam.pipeline.entity.region.AbstractCloudRegion;
 import com.epam.pipeline.entity.search.SearchDocumentType;
 import com.epam.pipeline.entity.user.PipelineUser;
 import lombok.Getter;
@@ -58,21 +59,27 @@ public class RunBillingMapper extends AbstractEntityMapper<PipelineRunBillingInf
             final PipelineRunBillingInfo billingInfo = container.getEntity();
             final PipelineRun run = billingInfo.getEntity().getPipelineRun();
 
-            final Optional<EntityContainer<Pipeline>> pipelineEntity = Optional.ofNullable(billingInfo.getEntity().getPipeline());
+            final Optional<AbstractCloudRegion> region = Optional.ofNullable(container.getRegion());
+
+            final Optional<EntityContainer<Pipeline>> pipelineEntity = Optional.ofNullable(
+                    billingInfo.getEntity().getPipeline());
             final Optional<Pipeline> pipeline = pipelineEntity.map(EntityContainer::getEntity);
             final Optional<PipelineUser> pipelineOwner = pipelineEntity.map(EntityContainer::getOwner)
                     .map(EntityWithMetadata::getEntity);
-            final Optional<EntityContainer<Tool>> toolEntity = Optional.ofNullable(billingInfo.getEntity().getTool());
+
+            final Optional<EntityContainer<Tool>> toolEntity = Optional.ofNullable(
+                    billingInfo.getEntity().getTool());
+            final Optional<Tool> tool = toolEntity.map(EntityContainer::getEntity);
             final Optional<PipelineUser> toolOwner = toolEntity.map(EntityContainer::getOwner)
                     .map(EntityWithMetadata::getEntity);
-            final Optional<Tool> tool = toolEntity.map(EntityContainer::getEntity);
+
             jsonBuilder.startObject()
                 .field(DOC_TYPE_FIELD, SearchDocumentType.PIPELINE_RUN.name())
                 .field("created_date", billingInfo.getDate()) // Document creation date: 2022-07-22
                 .field("resource_type", billingInfo.getResourceType()) // Document resource type: COMPUTE / STORAGE
-                .field("cloudRegionId", container.getRegion().getId())
-                .field("cloud_region_name", container.getRegion().getName())
-                .field("cloud_region_provider", container.getRegion().getProvider())
+                .field("cloudRegionId", region.map(AbstractCloudRegion::getId).orElse(null))
+                .field("cloud_region_name", region.map(AbstractCloudRegion::getName).orElse(null))
+                .field("cloud_region_provider", region.map(AbstractCloudRegion::getProvider).orElse(null))
 
                 .field("run_id", run.getId())
                 .field("compute_type", billingInfo.getEntity().getRunType())

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapper.java
@@ -69,7 +69,8 @@ public class RunBillingMapper extends AbstractEntityMapper<PipelineRunBillingInf
             jsonBuilder.startObject()
                 .field(DOC_TYPE_FIELD, SearchDocumentType.PIPELINE_RUN.name())
                 .field("resource_type", billingInfo.getResourceType())
-                .field("cloudRegionId", run.getInstance().getCloudRegionId())
+                .field("cloudRegionId", container.getRegion().getId())
+                .field("cloud_region_name", container.getRegion().getName())
 
                 .field("run_id", run.getId())
                 .field("compute_type", billingInfo.getEntity().getRunType())

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapper.java
@@ -20,7 +20,7 @@ import com.epam.pipeline.billingreportagent.model.EntityContainer;
 import com.epam.pipeline.billingreportagent.model.billing.StorageBillingInfo;
 import com.epam.pipeline.billingreportagent.service.AbstractEntityMapper;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
-import com.epam.pipeline.entity.datastorage.DataStorageType;
+import com.epam.pipeline.entity.region.AbstractCloudRegion;
 import com.epam.pipeline.entity.search.SearchDocumentType;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +28,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import static com.epam.pipeline.billingreportagent.service.ElasticsearchSynchronizer.DOC_TYPE_FIELD;
 
@@ -44,13 +45,15 @@ public class StorageBillingMapper extends AbstractEntityMapper<StorageBillingInf
             final StorageBillingInfo billingInfo = container.getEntity();
             final AbstractDataStorage storage = billingInfo.getEntity();
 
+            final Optional<AbstractCloudRegion> region = Optional.ofNullable(container.getRegion());
+
             jsonBuilder.startObject()
                 .field(DOC_TYPE_FIELD, documentType.name())
                 .field("created_date", billingInfo.getDate()) // Document creation date: 2022-07-22
                 .field("resource_type", billingInfo.getResourceType()) // Document resource type: COMPUTE / STORAGE
-                .field("cloudRegionId", container.getRegion().getId())
-                .field("cloud_region_name", container.getRegion().getName())
-                .field("cloud_region_provider", container.getRegion().getProvider())
+                .field("cloudRegionId", region.map(AbstractCloudRegion::getId).orElse(null))
+                .field("cloud_region_name", region.map(AbstractCloudRegion::getName).orElse(null))
+                .field("cloud_region_provider", region.map(AbstractCloudRegion::getProvider).orElse(null))
 
                 .field("storage_id", storage.getId())
                 .field("storage_name", storage.getName())

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapper.java
@@ -16,8 +16,6 @@
 
 package com.epam.pipeline.billingreportagent.service.impl.mapper;
 
-import static com.epam.pipeline.billingreportagent.service.ElasticsearchSynchronizer.DOC_TYPE_FIELD;
-
 import com.epam.pipeline.billingreportagent.model.EntityContainer;
 import com.epam.pipeline.billingreportagent.model.billing.StorageBillingInfo;
 import com.epam.pipeline.billingreportagent.service.AbstractEntityMapper;
@@ -29,6 +27,8 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 
 import java.io.IOException;
+
+import static com.epam.pipeline.billingreportagent.service.ElasticsearchSynchronizer.DOC_TYPE_FIELD;
 
 @RequiredArgsConstructor
 @Getter
@@ -42,20 +42,26 @@ public class StorageBillingMapper extends AbstractEntityMapper<StorageBillingInf
         try (XContentBuilder jsonBuilder = XContentFactory.jsonBuilder()) {
             final StorageBillingInfo billingInfo = container.getEntity();
             final AbstractDataStorage storage = billingInfo.getEntity();
-            jsonBuilder
-                .startObject()
+
+            jsonBuilder.startObject()
                 .field(DOC_TYPE_FIELD, documentType.name())
-                .field("storage_id", storage.getId())
                 .field("resource_type", billingInfo.getResourceType())
                 .field("cloudRegionId", billingInfo.getRegionId())
-                .field("provider", storage.getType())
+
+                .field("storage_id", storage.getId())
+                .field("storage_name", storage.getName())
+                .field("storage_path", storage.getPath())
                 .field("storage_type", billingInfo.getStorageType())
+                .field("provider", storage.getType())
+
                 .field("usage_bytes", billingInfo.getUsageBytes())
+                .field("usage_bytes_avg", billingInfo.getUsageBytes())
                 .field("cost", billingInfo.getCost())
+
                 .field("created_date", billingInfo.getDate());
-            buildUserContent(container.getOwner(), jsonBuilder);
-            jsonBuilder.endObject();
-            return jsonBuilder;
+
+            return buildUserContent(container.getOwner(), jsonBuilder)
+                    .endObject();
         } catch (IOException e) {
             throw new IllegalArgumentException("Failed to create elasticsearch document for data storage: ", e);
         }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapper.java
@@ -20,6 +20,7 @@ import com.epam.pipeline.billingreportagent.model.EntityContainer;
 import com.epam.pipeline.billingreportagent.model.billing.StorageBillingInfo;
 import com.epam.pipeline.billingreportagent.service.AbstractEntityMapper;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
+import com.epam.pipeline.entity.datastorage.DataStorageType;
 import com.epam.pipeline.entity.search.SearchDocumentType;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -46,12 +47,17 @@ public class StorageBillingMapper extends AbstractEntityMapper<StorageBillingInf
             jsonBuilder.startObject()
                 .field(DOC_TYPE_FIELD, documentType.name())
                 .field("resource_type", billingInfo.getResourceType())
-                .field("cloudRegionId", billingInfo.getRegionId())
+                .field("cloudRegionId", container.getRegion().getId())
+                .field("cloud_region_name", container.getRegion().getName())
 
                 .field("storage_id", storage.getId())
+                .field("storage_title", storage.getType() != DataStorageType.NFS
+                        ? storage.getPath()
+                        : storage.getName())
                 .field("storage_name", storage.getName())
                 .field("storage_path", storage.getPath())
                 .field("storage_type", billingInfo.getStorageType())
+                .field("storage_kind", billingInfo.getStorageKind())
                 .field("provider", storage.getType())
 
                 .field("usage_bytes", billingInfo.getUsageBytes())

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapper.java
@@ -46,25 +46,24 @@ public class StorageBillingMapper extends AbstractEntityMapper<StorageBillingInf
 
             jsonBuilder.startObject()
                 .field(DOC_TYPE_FIELD, documentType.name())
-                .field("resource_type", billingInfo.getResourceType())
+                .field("created_date", billingInfo.getDate()) // Document creation date: 2022-07-22
+                .field("resource_type", billingInfo.getResourceType()) // Document resource type: COMPUTE / STORAGE
                 .field("cloudRegionId", container.getRegion().getId())
                 .field("cloud_region_name", container.getRegion().getName())
+                .field("cloud_region_provider", container.getRegion().getProvider())
 
                 .field("storage_id", storage.getId())
-                .field("storage_title", storage.getType() != DataStorageType.NFS
-                        ? storage.getPath()
-                        : storage.getName())
                 .field("storage_name", storage.getName())
                 .field("storage_path", storage.getPath())
-                .field("storage_type", billingInfo.getStorageType())
-                .field("storage_kind", billingInfo.getStorageKind())
-                .field("provider", storage.getType())
+                .field("storage_type", billingInfo.getResourceStorageType()) // Storage resource type: OBJECT_STORAGE / FILE_STORAGE
+                .field("provider", storage.getType()) // Storage common type: S3 / AZ / GS / NFS
+                .field("object_storage_type", billingInfo.getObjectStorageType()) // Object storage type: S3 / AZ / GS
+                .field("file_storage_type", billingInfo.getFileStorageType()) // File storage type: NFS / SMB / LUSTRE
+                .field("storage_created_date", asString(storage.getCreatedDate()))
 
                 .field("usage_bytes", billingInfo.getUsageBytes())
                 .field("usage_bytes_avg", billingInfo.getUsageBytes())
-                .field("cost", billingInfo.getCost())
-
-                .field("created_date", billingInfo.getDate());
+                .field("cost", billingInfo.getCost());
 
             return buildUserContent(container.getOwner(), jsonBuilder)
                     .endObject();

--- a/billing-report-agent/src/main/resources/templates/pipeline_run_billing.json
+++ b/billing-report-agent/src/main/resources/templates/pipeline_run_billing.json
@@ -6,6 +6,7 @@
         "resource_type": { "type": "keyword" },
         "cloudRegionId": { "type": "keyword" },
         "cloud_region_id": { "type": "alias", "path": "cloudRegionId" },
+        "cloud_region_name": { "type": "keyword" },
 
         "run_id": { "type": "keyword", "store": true },
         "compute_type": { "type": "keyword" },

--- a/billing-report-agent/src/main/resources/templates/pipeline_run_billing.json
+++ b/billing-report-agent/src/main/resources/templates/pipeline_run_billing.json
@@ -3,26 +3,34 @@
     "_doc": {
       "properties": {
         "doc_type": { "type": "keyword", "store": true },
+        "created_date": { "type": "date" },
         "resource_type": { "type": "keyword" },
         "cloudRegionId": { "type": "keyword" },
-        "cloud_region_id": { "type": "alias", "path": "cloudRegionId" },
         "cloud_region_name": { "type": "keyword" },
+        "cloud_region_provider": { "type": "keyword" },
 
         "run_id": { "type": "keyword", "store": true },
         "compute_type": { "type": "keyword" },
         "instance_type":  { "type": "keyword" },
 
         "pipeline": { "type": "keyword" },
-        "pipeline_id": { "type": "alias", "path": "pipeline" },
         "pipeline_name": { "type": "keyword" },
         "pipeline_version": { "type": "keyword" },
+        "pipeline_owner_id": { "type": "keyword" },
+        "pipeline_owner_name": { "type": "keyword" },
+        "pipeline_created_date": { "type": "date", "format": "yyyy-MM-dd HH:mm:ss.SSS" },
 
         "tool": { "type": "keyword" },
-        "tool_image": { "type": "alias", "path": "tool" },
-        "tool_registry": { "type": "keyword" },
-        "tool_group": { "type": "keyword" },
+        "tool_registry_id": { "type": "keyword" },
+        "tool_registry_name": { "type": "keyword" },
+        "tool_group_id": { "type": "keyword" },
+        "tool_group_name": { "type": "keyword" },
+        "tool_id": { "type": "keyword" },
         "tool_name": { "type": "keyword" },
         "tool_version": { "type": "keyword" },
+        "tool_owner_id": { "type": "keyword" },
+        "tool_owner_name": { "type": "keyword" },
+        "tool_created_date": { "type": "date", "format": "yyyy-MM-dd HH:mm:ss.SSS" },
 
         "usage_minutes": { "type": "long" },
         "paused_minutes": { "type": "long" },
@@ -31,15 +39,11 @@
         "disk_price": { "type": "long" },
         "cost": { "type": "long" },
 
-        "owner_user_id": { "type": "keyword" },
         "owner": { "type": "keyword" },
-        "owner_user_name": { "type": "alias", "path": "owner" },
+        "owner_id": { "type": "keyword" },
         "groups": { "type": "keyword" },
-        "owner_user_groups": { "type": "alias", "path": "groups" },
         "billing_center":  { "type": "keyword" },
-        "owner_billing_center":  { "type": "alias", "path": "billing_center" },
 
-        "created_date": { "type": "date" },
         "started_date": { "type": "date", "format": "yyyy-MM-dd HH:mm:ss.SSS" },
         "finished_date": { "type": "date", "format": "yyyy-MM-dd HH:mm:ss.SSS" }
       }

--- a/billing-report-agent/src/main/resources/templates/pipeline_run_billing.json
+++ b/billing-report-agent/src/main/resources/templates/pipeline_run_billing.json
@@ -3,20 +3,41 @@
     "_doc": {
       "properties": {
         "doc_type": { "type": "keyword", "store": true },
-        "run_id": { "type": "keyword", "store": true },
-        "pipeline": { "type": "keyword" },
-        "pipeline_name": { "type": "keyword" },
         "resource_type": { "type": "keyword" },
-        "compute_type": { "type": "keyword" },
-        "cost": {"type": "long"},
-        "run_price": {"type": "long"},
-        "usage_minutes": {"type": "long"},
-        "owner": { "type": "keyword" },
-        "groups": { "type": "keyword" },
-        "tool": {"type": "keyword"},
-        "instance_type":  { "type": "keyword" },
-        "billing_center":  { "type": "keyword" },
         "cloudRegionId": { "type": "keyword" },
+        "cloud_region_id": { "type": "alias", "path": "cloudRegionId" },
+
+        "run_id": { "type": "keyword", "store": true },
+        "compute_type": { "type": "keyword" },
+        "instance_type":  { "type": "keyword" },
+
+        "pipeline": { "type": "keyword" },
+        "pipeline_id": { "type": "alias", "path": "pipeline" },
+        "pipeline_name": { "type": "keyword" },
+        "pipeline_version": { "type": "keyword" },
+
+        "tool": { "type": "keyword" },
+        "tool_image": { "type": "alias", "path": "tool" },
+        "tool_registry": { "type": "keyword" },
+        "tool_group": { "type": "keyword" },
+        "tool_name": { "type": "keyword" },
+        "tool_version": { "type": "keyword" },
+
+        "usage_minutes": { "type": "long" },
+        "paused_minutes": { "type": "long" },
+        "run_price": { "type": "long" },
+        "compute_price": { "type": "long" },
+        "disk_price": { "type": "long" },
+        "cost": { "type": "long" },
+
+        "owner_user_id": { "type": "keyword" },
+        "owner": { "type": "keyword" },
+        "owner_user_name": { "type": "alias", "path": "owner" },
+        "groups": { "type": "keyword" },
+        "owner_user_groups": { "type": "alias", "path": "groups" },
+        "billing_center":  { "type": "keyword" },
+        "owner_billing_center":  { "type": "alias", "path": "billing_center" },
+
         "created_date": { "type": "date" },
         "started_date": { "type": "date", "format": "yyyy-MM-dd HH:mm:ss.SSS" },
         "finished_date": { "type": "date", "format": "yyyy-MM-dd HH:mm:ss.SSS" }

--- a/billing-report-agent/src/main/resources/templates/storage_billing.json
+++ b/billing-report-agent/src/main/resources/templates/storage_billing.json
@@ -3,33 +3,29 @@
     "_doc": {
       "properties": {
         "doc_type": { "type": "keyword", "store": true },
+        "created_date": { "type": "date" },
         "resource_type": { "type": "keyword" },
         "cloudRegionId": { "type": "keyword" },
-        "cloud_region_id": { "type": "alias", "path": "cloudRegionId" },
         "cloud_region_name": { "type": "keyword" },
+        "cloud_region_provider": { "type": "keyword" },
 
         "storage_id": { "type": "keyword", "store": true },
-        "storage_title": { "type": "keyword" },
         "storage_name": { "type": "keyword" },
         "storage_path": { "type": "keyword" },
         "storage_type": { "type": "keyword" },
-        "storage_kind": { "type": "keyword" },
         "provider": { "type": "keyword" },
-        "storage_provider": { "type": "alias", "path": "provider" },
+        "object_storage_type": { "type": "keyword" },
+        "file_storage_type": { "type": "keyword" },
+        "storage_created_date": { "type": "date", "format": "yyyy-MM-dd HH:mm:ss.SSS" },
 
         "usage_bytes": { "type": "long" },
         "usage_bytes_avg": { "type": "long" },
         "cost": { "type": "long" },
 
         "owner": { "type": "keyword" },
-        "owner_user_id": { "type": "keyword" },
-        "owner_user_name": { "type": "alias", "path": "owner" },
+        "owner_id": { "type": "keyword" },
         "groups": { "type": "keyword" },
-        "owner_groups": { "type": "alias", "path": "groups" },
-        "billing_center":  { "type": "keyword" },
-        "owner_billing_center": { "type": "alias", "path": "billing_center" },
-
-        "created_date": { "type": "date" }
+        "billing_center":  { "type": "keyword" }
       }
     }
   },

--- a/billing-report-agent/src/main/resources/templates/storage_billing.json
+++ b/billing-report-agent/src/main/resources/templates/storage_billing.json
@@ -6,11 +6,14 @@
         "resource_type": { "type": "keyword" },
         "cloudRegionId": { "type": "keyword" },
         "cloud_region_id": { "type": "alias", "path": "cloudRegionId" },
+        "cloud_region_name": { "type": "keyword" },
 
         "storage_id": { "type": "keyword", "store": true },
+        "storage_title": { "type": "keyword" },
         "storage_name": { "type": "keyword" },
         "storage_path": { "type": "keyword" },
         "storage_type": { "type": "keyword" },
+        "storage_kind": { "type": "keyword" },
         "provider": { "type": "keyword" },
         "storage_provider": { "type": "alias", "path": "provider" },
 

--- a/billing-report-agent/src/main/resources/templates/storage_billing.json
+++ b/billing-report-agent/src/main/resources/templates/storage_billing.json
@@ -3,17 +3,30 @@
     "_doc": {
       "properties": {
         "doc_type": { "type": "keyword", "store": true },
-        "storage_id": { "type": "keyword", "store": true },
         "resource_type": { "type": "keyword" },
         "cloudRegionId": { "type": "keyword" },
-        "provider": { "type": "keyword" },
+        "cloud_region_id": { "type": "alias", "path": "cloudRegionId" },
+
+        "storage_id": { "type": "keyword", "store": true },
+        "storage_name": { "type": "keyword" },
+        "storage_path": { "type": "keyword" },
         "storage_type": { "type": "keyword" },
+        "provider": { "type": "keyword" },
+        "storage_provider": { "type": "alias", "path": "provider" },
+
+        "usage_bytes": { "type": "long" },
+        "usage_bytes_avg": { "type": "long" },
+        "cost": { "type": "long" },
+
         "owner": { "type": "keyword" },
+        "owner_user_id": { "type": "keyword" },
+        "owner_user_name": { "type": "alias", "path": "owner" },
         "groups": { "type": "keyword" },
+        "owner_groups": { "type": "alias", "path": "groups" },
         "billing_center":  { "type": "keyword" },
-        "usage_bytes": {"type": "long"},
-        "cost": {"type": "long"},
-        "created_date": {"type": "date"}
+        "owner_billing_center": { "type": "alias", "path": "billing_center" },
+
+        "created_date": { "type": "date" }
       }
     }
   },

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/TestUtils.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/TestUtils.java
@@ -20,6 +20,8 @@ import com.epam.pipeline.billingreportagent.service.EntityToBillingRequestConver
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
+import com.epam.pipeline.entity.region.AbstractCloudRegion;
+import com.epam.pipeline.entity.region.AwsRegion;
 import com.fasterxml.jackson.core.JsonFactory;
 import org.apache.commons.collections.CollectionUtils;
 import org.elasticsearch.common.Strings;
@@ -82,6 +84,12 @@ public final class TestUtils {
         instance.setCloudRegionId(regionId);
         instance.setNodeType(nodeType);
         return instance;
+    }
+
+    public static AbstractCloudRegion createTestRegion(final Long regionId) {
+        final AwsRegion region = new AwsRegion();
+        region.setId(regionId);
+        return region;
     }
 
     public static String buildBillingIndex(final String prefix, final LocalDateTime syncDate) {

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverterImplTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverterImplTest.java
@@ -21,6 +21,7 @@ import com.epam.pipeline.billingreportagent.model.EntityContainer;
 import com.epam.pipeline.billingreportagent.model.EntityWithMetadata;
 import com.epam.pipeline.billingreportagent.model.PipelineRunWithType;
 import com.epam.pipeline.billingreportagent.model.ResourceType;
+import com.epam.pipeline.billingreportagent.model.ToolAddress;
 import com.epam.pipeline.billingreportagent.model.billing.PipelineRunBillingInfo;
 import com.epam.pipeline.billingreportagent.service.impl.TestUtils;
 import com.epam.pipeline.billingreportagent.service.impl.mapper.RunBillingMapper;
@@ -96,7 +97,8 @@ public class RunToBillingRequestConverterImplTest {
         run.setPricePerHour(BigDecimal.valueOf(4, 2));
 
         final EntityContainer<PipelineRunWithType> runContainer = EntityContainer.<PipelineRunWithType>builder()
-                .entity(new PipelineRunWithType(run, Collections.emptyList(), ComputeType.CPU)).build();
+                .entity(runEntity(run, Collections.emptyList()))
+                .build();
         final Collection<PipelineRunBillingInfo> billings =
                 converter.convertRunToBillings(runContainer,
                         LocalDate.of(2019, 12, 4).atStartOfDay(),
@@ -117,7 +119,8 @@ public class RunToBillingRequestConverterImplTest {
         run.setPricePerHour(BigDecimal.valueOf(4, 2));
 
         final EntityContainer<PipelineRunWithType> runContainer = EntityContainer.<PipelineRunWithType>builder()
-            .entity(new PipelineRunWithType(run, Collections.emptyList(), ComputeType.CPU)).build();
+                .entity(runEntity(run, Collections.emptyList()))
+                .build();
         final Collection<PipelineRunBillingInfo> billings =
             converter.convertRunToBillings(runContainer,
                                            LocalDate.of(2019, 12, 1).atStartOfDay(),
@@ -144,7 +147,8 @@ public class RunToBillingRequestConverterImplTest {
         final PipelineRun run = run();
         run.setPricePerHour(BigDecimal.valueOf(4, 2));
         final EntityContainer<PipelineRunWithType> runContainer = EntityContainer.<PipelineRunWithType>builder()
-            .entity(new PipelineRunWithType(run, Collections.emptyList(), ComputeType.CPU)).build();
+                .entity(runEntity(run, Collections.emptyList()))
+                .build();
 
         final Collection<PipelineRunBillingInfo> billings =
             converter.convertRunToBillings(runContainer,
@@ -166,8 +170,9 @@ public class RunToBillingRequestConverterImplTest {
 
         final EntityContainer<PipelineRunWithType> runContainer =
             EntityContainer.<PipelineRunWithType>builder()
-                .entity(new PipelineRunWithType(run, Collections.emptyList(), ComputeType.CPU))
+                .entity(runEntity(run, Collections.emptyList()))
                 .owner(testUserWithMetadata)
+                .region(TestUtils.createTestRegion(REGION_ID))
                 .build();
 
         final LocalDateTime prevSync = LocalDate.of(2019, 12, 4).atStartOfDay();
@@ -215,7 +220,8 @@ public class RunToBillingRequestConverterImplTest {
                 disk(40L, LocalDateTime.of(2020, 5, 21, 22, 30)),
                 disk(60L, LocalDateTime.of(2020, 5, 24, 14, 0)));
         final EntityContainer<PipelineRunWithType> runContainer = EntityContainer.<PipelineRunWithType>builder()
-                .entity(new PipelineRunWithType(run, disks, ComputeType.CPU)).build();
+                .entity(runEntity(run, disks))
+                .build();
         final Collection<PipelineRunBillingInfo> billings =
                 converter.convertRunToBillings(runContainer,
                         LocalDate.of(2020, 5, 21).atStartOfDay(),
@@ -253,7 +259,8 @@ public class RunToBillingRequestConverterImplTest {
         disks.add(disk(20L, LocalDateTime.of(2020, 5, 21, 12, 0)));
         disks.add(disk(20L, LocalDateTime.of(2020, 5, 21, 12, 0)));
         final EntityContainer<PipelineRunWithType> runContainer = EntityContainer.<PipelineRunWithType>builder()
-                .entity(new PipelineRunWithType(run, disks, ComputeType.CPU)).build();
+                .entity(runEntity(run, disks))
+                .build();
         final Collection<PipelineRunBillingInfo> billings =
                 converter.convertRunToBillings(runContainer,
                         LocalDate.of(2020, 5, 21).atStartOfDay(),
@@ -280,7 +287,8 @@ public class RunToBillingRequestConverterImplTest {
         disks.add(disk(20L, LocalDateTime.of(2020, 5, 21, 12, 0)));
         disks.add(disk(20L, LocalDateTime.of(2020, 5, 21, 12, 0)));
         final EntityContainer<PipelineRunWithType> runContainer = EntityContainer.<PipelineRunWithType>builder()
-                .entity(new PipelineRunWithType(run, disks, ComputeType.CPU)).build();
+                .entity(runEntity(run, disks))
+                .build();
         final Collection<PipelineRunBillingInfo> billings =
                 converter.convertRunToBillings(runContainer,
                         LocalDate.of(2020, 5, 21).atStartOfDay(),
@@ -742,5 +750,9 @@ public class RunToBillingRequestConverterImplTest {
 
     private RunStatus status(final TaskStatus status, final LocalDateTime date) {
         return new RunStatus(RUN_ID, status, date);
+    }
+
+    private PipelineRunWithType runEntity(final PipelineRun run, final List<NodeDisk> disks) {
+        return new PipelineRunWithType(run, ToolAddress.empty(), null, null, disks, ComputeType.CPU);
     }
 }

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapperTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapperTest.java
@@ -21,11 +21,22 @@ import com.epam.pipeline.billingreportagent.model.EntityContainer;
 import com.epam.pipeline.billingreportagent.model.EntityWithMetadata;
 import com.epam.pipeline.billingreportagent.model.PipelineRunWithType;
 import com.epam.pipeline.billingreportagent.model.ResourceType;
+import com.epam.pipeline.billingreportagent.model.ToolAddress;
 import com.epam.pipeline.billingreportagent.model.billing.PipelineRunBillingInfo;
+import com.epam.pipeline.billingreportagent.service.AbstractEntityMapper;
+import com.epam.pipeline.billingreportagent.service.ElasticsearchSynchronizer;
+import com.epam.pipeline.billingreportagent.service.EntityToBillingRequestConverter;
 import com.epam.pipeline.billingreportagent.service.impl.TestUtils;
 import com.epam.pipeline.config.Constants;
+import com.epam.pipeline.entity.pipeline.Pipeline;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.pipeline.Tool;
+import com.epam.pipeline.entity.region.AbstractCloudRegion;
+import com.epam.pipeline.entity.region.AwsRegion;
+import com.epam.pipeline.entity.region.CloudProvider;
+import com.epam.pipeline.entity.search.SearchDocumentType;
 import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.entity.utils.DateUtils;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
@@ -46,18 +57,35 @@ public class RunBillingMapperTest {
 
     private static final String BILLING_CENTER_KEY = "billing";
     private static final Long TEST_PIPELINE_ID = 1L;
+    private static final String TEST_PIPELINE_NAME = "pipeline_name";
+    private static final String TEST_PIPELINE_VERSION = "pipeline_version";
+    private static final Long TEST_USER_ID = 1L;
     private static final String TEST_USER_NAME = "User";
     private static final String TEST_TOOL_IMAGE = "cp/tool:latest";
+    private static final Long TEST_TOOL_REGISTRY_ID = 1L;
+    private static final String TEST_TOOL_REGISTRY_NAME = "registry_name";
+    private static final Long TEST_TOOL_GROUP_ID = 1L;
+    private static final String TEST_TOOL_GROUP_NAME = "group_name";
+    private static final Long TEST_TOOL_ID = 1L;
+    private static final String TEST_TOOL_NAME = "tool_name";
+    private static final String TEST_TOOL_VERSION = "tool_version";
     private static final String TEST_NODE_TYPE = "nodetype.medium";
     private static final String TEST_GROUP_1 = "TestGroup1";
     private static final String TEST_GROUP_2 = "TestGroup2";
     private static final Long TEST_COST = 10L;
     private static final Long TEST_RUN_ID = 1L;
+    private static final ComputeType TEST_RUN_COMPUTE_TYPE = ComputeType.CPU;
     private static final Long TEST_REGION_ID = 1L;
+    private static final String TEST_REGION_NAME = "test-region";
+    private static final CloudProvider TEST_REGION_PROVIDER = CloudProvider.AWS;
     private static final BigDecimal TEST_PRICE = BigDecimal.ONE;
+    private static final int TEST_PRICES_MULTIPLIER = 100_000;
     private static final Long TEST_USAGE_MINUTES = 600L;
+    private static final Long TEST_PAUSED_MINUTES = 400L;
     private static final List<String> TEST_GROUPS = Arrays.asList(TEST_GROUP_1, TEST_GROUP_2);
-    private static final LocalDate TEST_DATE = LocalDate.of(2021, 11, 18);
+
+    private static final Date TEST_JAVA_DATE = DateUtils.now();
+    private static final LocalDate TEST_DATE = DateUtils.toLocalDateTime(TEST_JAVA_DATE).toLocalDate();
     private static final Date TEST_STARTED_DATE = toDate(TEST_DATE.atStartOfDay());
     private static final String TEST_STARTED_DATE_STR = toString(TEST_STARTED_DATE);
     private static final Date TEST_FINISHED_DATE = toDate(TEST_DATE.plusDays(1L).atStartOfDay());
@@ -73,6 +101,7 @@ public class RunBillingMapperTest {
 
     private final RunBillingMapper mapper = new RunBillingMapper(BILLING_CENTER_KEY);
     private final PipelineUser testUser = PipelineUser.builder()
+        .id(TEST_USER_ID)
         .userName(TEST_USER_NAME)
         .groups(TEST_GROUPS)
         .attributes(Collections.emptyMap())
@@ -87,36 +116,108 @@ public class RunBillingMapperTest {
         final PipelineRun run =
             TestUtils.createTestPipelineRun(TEST_RUN_ID, TEST_PIPELINE_ID, TEST_TOOL_IMAGE, TEST_PRICE,
                                             TestUtils.createTestInstance(TEST_REGION_ID, TEST_NODE_TYPE));
+        run.setPipelineId(TEST_PIPELINE_ID);
+        run.setPipelineName(TEST_PIPELINE_NAME);
+        run.setVersion(TEST_PIPELINE_VERSION);
         run.setStartDate(TEST_STARTED_DATE);
         run.setEndDate(TEST_FINISHED_DATE);
+        run.setPricePerHour(TEST_PRICE);
+        run.setComputePricePerHour(TEST_PRICE);
+        run.setDiskPricePerHour(TEST_PRICE);
+        final Tool tool = new Tool();
+        tool.setId(TEST_TOOL_ID);
+        tool.setRegistryId(TEST_TOOL_REGISTRY_ID);
+        tool.setRegistry(TEST_TOOL_REGISTRY_NAME);
+        tool.setToolGroupId(TEST_TOOL_GROUP_ID);
+        tool.setToolGroup(TEST_TOOL_GROUP_NAME);
+        tool.setCreatedDate(TEST_JAVA_DATE);
+        final EntityContainer<Tool> toolEntity = EntityContainer.<Tool>builder()
+                .entity(tool)
+                .owner(testUserWithMetadata)
+                .build();
+        final Pipeline pipeline = new Pipeline();
+        pipeline.setId(TEST_PIPELINE_ID);
+        pipeline.setName(TEST_PIPELINE_NAME);
+        pipeline.setCreatedDate(TEST_JAVA_DATE);
+        final EntityContainer<Pipeline> pipelineEntity = EntityContainer.<Pipeline>builder()
+                .entity(pipeline)
+                .owner(testUserWithMetadata)
+                .build();
         final PipelineRunBillingInfo billing = PipelineRunBillingInfo.builder()
-            .run(new PipelineRunWithType(run, Collections.emptyList(), ComputeType.CPU))
+            .run(new PipelineRunWithType(run,
+                    ToolAddress.from(TEST_TOOL_REGISTRY_NAME + "/"
+                            + TEST_TOOL_GROUP_NAME + "/"
+                            + TEST_TOOL_NAME + ":" + TEST_TOOL_VERSION),
+                    toolEntity, pipelineEntity, Collections.emptyList(),
+                    TEST_RUN_COMPUTE_TYPE))
             .date(TEST_DATE)
             .cost(TEST_COST)
             .usageMinutes(TEST_USAGE_MINUTES)
+            .pausedMinutes(TEST_PAUSED_MINUTES)
             .build();
+        final AbstractCloudRegion region = new AwsRegion();
+        region.setId(TEST_REGION_ID);
+        region.setName(TEST_REGION_NAME);
         final EntityContainer<PipelineRunBillingInfo> billingContainer =
             EntityContainer.<PipelineRunBillingInfo>builder()
             .entity(billing)
             .owner(testUserWithMetadata)
+            .region(region)
             .build();
 
         final XContentBuilder mappedBilling = mapper.map(billingContainer);
 
         final Map<String, Object> mappedFields = TestUtils.getPuttedObject(mappedBilling);
 
-        Assert.assertEquals(TEST_RUN_ID.intValue(), mappedFields.get("run_id"));
+        Assert.assertEquals(SearchDocumentType.PIPELINE_RUN.name(),
+                mappedFields.get(ElasticsearchSynchronizer.DOC_TYPE_FIELD));
+        Assert.assertEquals(EntityToBillingRequestConverter.SIMPLE_DATE_FORMAT.format(TEST_DATE),
+                mappedFields.get("created_date"));
         Assert.assertEquals(ResourceType.COMPUTE.toString(), mappedFields.get("resource_type"));
-        Assert.assertEquals(TEST_PIPELINE_ID.intValue(), mappedFields.get("pipeline"));
-        Assert.assertEquals(TEST_TOOL_IMAGE, mappedFields.get("tool"));
-        Assert.assertEquals(TEST_NODE_TYPE, mappedFields.get("instance_type"));
-        Assert.assertEquals(TEST_COST.intValue(), mappedFields.get("cost"));
-        Assert.assertEquals(TEST_USAGE_MINUTES.intValue(), mappedFields.get("usage_minutes"));
-        Assert.assertEquals(run.getPricePerHour().intValue(), mappedFields.get("run_price"));
         Assert.assertEquals(TEST_REGION_ID.intValue(), mappedFields.get("cloudRegionId"));
-        Assert.assertEquals(TEST_USER_NAME, mappedFields.get("owner"));
+        Assert.assertEquals(TEST_REGION_NAME, mappedFields.get("cloud_region_name"));
+        Assert.assertEquals(TEST_REGION_PROVIDER.toString(), mappedFields.get("cloud_region_provider"));
+
+        Assert.assertEquals(TEST_RUN_ID.intValue(), mappedFields.get("run_id"));
+        Assert.assertEquals(TEST_RUN_COMPUTE_TYPE.toString(), mappedFields.get("compute_type"));
+        Assert.assertEquals(TEST_NODE_TYPE, mappedFields.get("instance_type"));
+
+        Assert.assertEquals(TEST_PIPELINE_ID.intValue(), mappedFields.get("pipeline"));
+        Assert.assertEquals(TEST_PIPELINE_NAME, mappedFields.get("pipeline_name"));
+        Assert.assertEquals(TEST_PIPELINE_VERSION, mappedFields.get("pipeline_version"));
+        Assert.assertEquals(TEST_USER_ID.intValue(), mappedFields.get("pipeline_owner_id"));
+        Assert.assertEquals(TEST_USER_NAME, mappedFields.get("pipeline_owner_name"));
+        Assert.assertEquals(AbstractEntityMapper.SIMPLE_DATE_FORMAT.format(TEST_JAVA_DATE),
+                mappedFields.get("pipeline_created_date"));
+
+        Assert.assertEquals(TEST_TOOL_IMAGE, mappedFields.get("tool"));
+        Assert.assertEquals(TEST_TOOL_REGISTRY_ID.intValue(), mappedFields.get("tool_registry_id"));
+        Assert.assertEquals(TEST_TOOL_REGISTRY_NAME, mappedFields.get("tool_registry_name"));
+        Assert.assertEquals(TEST_TOOL_GROUP_ID.intValue(), mappedFields.get("tool_group_id"));
+        Assert.assertEquals(TEST_TOOL_GROUP_NAME, mappedFields.get("tool_group_name"));
+        Assert.assertEquals(TEST_TOOL_ID.intValue(), mappedFields.get("tool_id"));
+        Assert.assertEquals(TEST_TOOL_NAME, mappedFields.get("tool_name"));
+        Assert.assertEquals(TEST_TOOL_VERSION, mappedFields.get("tool_version"));
+        Assert.assertEquals(TEST_USER_ID.intValue(), mappedFields.get("tool_owner_id"));
+        Assert.assertEquals(TEST_USER_NAME, mappedFields.get("tool_owner_name"));
+        Assert.assertEquals(AbstractEntityMapper.SIMPLE_DATE_FORMAT.format(TEST_JAVA_DATE),
+                mappedFields.get("tool_created_date"));
+
+        Assert.assertEquals(TEST_USAGE_MINUTES.intValue(), mappedFields.get("usage_minutes"));
+        Assert.assertEquals(TEST_PAUSED_MINUTES.intValue(), mappedFields.get("paused_minutes"));
+        Assert.assertEquals(run.getPricePerHour().intValue(), mappedFields.get("run_price"));
+        Assert.assertEquals(run.getComputePricePerHour().intValue() * TEST_PRICES_MULTIPLIER,
+                mappedFields.get("compute_price"));
+        Assert.assertEquals(run.getDiskPricePerHour().intValue() * TEST_PRICES_MULTIPLIER,
+                mappedFields.get("disk_price"));
+        Assert.assertEquals(TEST_COST.intValue(), mappedFields.get("cost"));
+
         Assert.assertEquals(TEST_STARTED_DATE_STR, mappedFields.get("started_date"));
         Assert.assertEquals(TEST_FINISHED_DATE_STR, mappedFields.get("finished_date"));
+
+        Assert.assertEquals(TEST_USER_ID.intValue(), mappedFields.get("owner_id"));
+        Assert.assertEquals(TEST_USER_NAME, mappedFields.get("owner"));
         TestUtils.verifyStringArray(TEST_GROUPS, mappedFields.get("groups"));
     }
+
 }

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapperTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapperTest.java
@@ -72,7 +72,6 @@ public class StorageBillingMapperTest {
         final StorageBillingInfo billing = StorageBillingInfo.builder()
             .storage(s3Storage)
             .storageType(StorageType.OBJECT_STORAGE)
-            .regionId(TEST_REGION_ID)
             .usageBytes(TEST_USAGE_BYTES)
             .cost(TEST_COST)
             .date(TEST_DATE)
@@ -108,7 +107,6 @@ public class StorageBillingMapperTest {
         final StorageBillingInfo billing = StorageBillingInfo.builder()
             .storage(efsStorage)
             .storageType(StorageType.FILE_STORAGE)
-            .regionId(TEST_REGION_ID)
             .usageBytes(TEST_USAGE_BYTES)
             .cost(TEST_COST)
             .build();
@@ -126,7 +124,6 @@ public class StorageBillingMapperTest {
                             mappedFields.get(ElasticsearchSynchronizer.DOC_TYPE_FIELD));
         Assert.assertEquals(efsStorage.getId(), mappedFields.get("storage_id"));
         Assert.assertEquals(ResourceType.STORAGE.toString(), mappedFields.get("resource_type"));
-        Assert.assertEquals(billing.getRegionId().intValue(), mappedFields.get("cloudRegionId"));
         Assert.assertEquals(efsStorage.getType().toString(), mappedFields.get("provider"));
         Assert.assertEquals(StorageType.FILE_STORAGE.toString(), mappedFields.get("storage_type"));
         Assert.assertEquals(testUser.getUserName(), mappedFields.get("owner"));

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapperTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapperTest.java
@@ -21,13 +21,20 @@ import com.epam.pipeline.billingreportagent.model.EntityWithMetadata;
 import com.epam.pipeline.billingreportagent.model.ResourceType;
 import com.epam.pipeline.billingreportagent.model.StorageType;
 import com.epam.pipeline.billingreportagent.model.billing.StorageBillingInfo;
+import com.epam.pipeline.billingreportagent.service.AbstractEntityMapper;
 import com.epam.pipeline.billingreportagent.service.ElasticsearchSynchronizer;
 import com.epam.pipeline.billingreportagent.service.EntityToBillingRequestConverter;
 import com.epam.pipeline.billingreportagent.service.impl.TestUtils;
+import com.epam.pipeline.entity.datastorage.DataStorageType;
+import com.epam.pipeline.entity.datastorage.MountType;
 import com.epam.pipeline.entity.datastorage.NFSDataStorage;
 import com.epam.pipeline.entity.datastorage.S3bucketDataStorage;
+import com.epam.pipeline.entity.region.AbstractCloudRegion;
+import com.epam.pipeline.entity.region.AwsRegion;
+import com.epam.pipeline.entity.region.CloudProvider;
 import com.epam.pipeline.entity.search.SearchDocumentType;
 import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.entity.utils.DateUtils;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
@@ -36,20 +43,27 @@ import java.io.IOException;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
 public class StorageBillingMapperTest {
 
     private static final String BILLING_CENTER_KEY = "billing";
+    private static final long TEST_USER_ID = 1L;
     private static final String TEST_USER_NAME = "User";
     private static final String TEST_GROUP_1 = "TestGroup1";
     private static final String TEST_GROUP_2 = "TestGroup2";
     private static final long TEST_REGION_ID = 1L;
+    private static final String TEST_REGION_NAME = "test-region";
+    private static final CloudProvider TEST_REGION_PROVIDER = CloudProvider.AWS;
     private static final long TEST_COST = 10;
     private static final long TEST_USAGE_BYTES = 600;
     private static final List<String> TEST_GROUPS = Arrays.asList(TEST_GROUP_1, TEST_GROUP_2);
-    private static final LocalDate TEST_DATE = LocalDate.now();
+    private static final Date TEST_JAVA_DATE = DateUtils.now();
+    private static final LocalDate TEST_DATE = DateUtils.toLocalDateTime(TEST_JAVA_DATE).toLocalDate();
+    private static final String TEST_STORAGE_NAME = "storage_name";
+    private static final String TEST_STORAGE_PATH = "storage_path";
 
     private final StorageBillingMapper s3Mapper = new StorageBillingMapper(
             SearchDocumentType.S3_STORAGE, BILLING_CENTER_KEY);
@@ -57,6 +71,7 @@ public class StorageBillingMapperTest {
             SearchDocumentType.NFS_STORAGE, BILLING_CENTER_KEY);
 
     private final PipelineUser testUser = PipelineUser.builder()
+        .id(TEST_USER_ID)
         .userName(TEST_USER_NAME)
         .groups(TEST_GROUPS)
         .attributes(Collections.emptyMap())
@@ -68,18 +83,26 @@ public class StorageBillingMapperTest {
 
     @Test
     public void testStorageMapperMapS3Storage() throws IOException {
-        final S3bucketDataStorage s3Storage = new S3bucketDataStorage();
+        final S3bucketDataStorage storage = new S3bucketDataStorage();
+        storage.setName(TEST_STORAGE_NAME);
+        storage.setName(TEST_STORAGE_PATH);
+        storage.setCreatedDate(TEST_JAVA_DATE);
         final StorageBillingInfo billing = StorageBillingInfo.builder()
-            .storage(s3Storage)
-            .storageType(StorageType.OBJECT_STORAGE)
+            .storage(storage)
+            .resourceStorageType(StorageType.OBJECT_STORAGE)
+            .objectStorageType(DataStorageType.S3)
+            .fileStorageType(null)
             .usageBytes(TEST_USAGE_BYTES)
             .cost(TEST_COST)
             .date(TEST_DATE)
             .build();
-
+        final AbstractCloudRegion region = new AwsRegion();
+        region.setId(TEST_REGION_ID);
+        region.setName(TEST_REGION_NAME);
         final EntityContainer<StorageBillingInfo> billingContainer = EntityContainer.<StorageBillingInfo>builder()
             .entity(billing)
             .owner(testUserWithMetadata)
+            .region(region)
             .build();
 
         final XContentBuilder mappedBilling = s3Mapper.map(billingContainer);
@@ -88,32 +111,55 @@ public class StorageBillingMapperTest {
 
         Assert.assertEquals(SearchDocumentType.S3_STORAGE.name(),
                             mappedFields.get(ElasticsearchSynchronizer.DOC_TYPE_FIELD));
-        Assert.assertEquals(s3Storage.getId(), mappedFields.get("storage_id"));
+        Assert.assertEquals(EntityToBillingRequestConverter.SIMPLE_DATE_FORMAT.format(TEST_DATE),
+                mappedFields.get("created_date"));
         Assert.assertEquals(ResourceType.STORAGE.toString(), mappedFields.get("resource_type"));
         Assert.assertEquals((int) TEST_REGION_ID, mappedFields.get("cloudRegionId"));
-        Assert.assertEquals(s3Storage.getType().toString(), mappedFields.get("provider"));
+        Assert.assertEquals(TEST_REGION_NAME, mappedFields.get("cloud_region_name"));
+        Assert.assertEquals(TEST_REGION_PROVIDER.toString(), mappedFields.get("cloud_region_provider"));
+
+        Assert.assertEquals(storage.getId(), mappedFields.get("storage_id"));
+        Assert.assertEquals(storage.getName(), mappedFields.get("storage_name"));
+        Assert.assertEquals(storage.getPath(), mappedFields.get("storage_path"));
         Assert.assertEquals(StorageType.OBJECT_STORAGE.toString(), mappedFields.get("storage_type"));
-        Assert.assertEquals(TEST_USER_NAME, mappedFields.get("owner"));
+        Assert.assertEquals(storage.getType().toString(), mappedFields.get("provider"));
+        Assert.assertEquals(null, mappedFields.get("file_storage_type"));
+        Assert.assertEquals(storage.getType().toString(), mappedFields.get("object_storage_type"));
+        Assert.assertEquals(AbstractEntityMapper.SIMPLE_DATE_FORMAT.format(TEST_JAVA_DATE),
+                mappedFields.get("storage_created_date"));
+
         Assert.assertEquals((int) TEST_USAGE_BYTES, mappedFields.get("usage_bytes"));
+        Assert.assertEquals((int) TEST_USAGE_BYTES, mappedFields.get("usage_bytes_avg"));
         Assert.assertEquals((int) TEST_COST, mappedFields.get("cost"));
-        Assert.assertEquals(EntityToBillingRequestConverter.SIMPLE_DATE_FORMAT.format(TEST_DATE),
-                            mappedFields.get("created_date"));
+
+        Assert.assertEquals((int) TEST_USER_ID, mappedFields.get("owner_id"));
+        Assert.assertEquals(TEST_USER_NAME, mappedFields.get("owner"));
         TestUtils.verifyStringArray(TEST_GROUPS, mappedFields.get("groups"));
     }
 
     @Test
     public void testStorageMapperMapEFSStorage() throws IOException {
-        final NFSDataStorage efsStorage = new NFSDataStorage();
+        final NFSDataStorage storage = new NFSDataStorage();
+        storage.setName(TEST_STORAGE_NAME);
+        storage.setName(TEST_STORAGE_PATH);
+        storage.setCreatedDate(TEST_JAVA_DATE);
         final StorageBillingInfo billing = StorageBillingInfo.builder()
-            .storage(efsStorage)
-            .storageType(StorageType.FILE_STORAGE)
+            .storage(storage)
+            .resourceStorageType(StorageType.FILE_STORAGE)
+            .objectStorageType(null)
+            .fileStorageType(MountType.NFS)
             .usageBytes(TEST_USAGE_BYTES)
             .cost(TEST_COST)
+            .date(TEST_DATE)
             .build();
+        final AbstractCloudRegion region = new AwsRegion();
+        region.setId(TEST_REGION_ID);
+        region.setName(TEST_REGION_NAME);
 
         final EntityContainer<StorageBillingInfo> billingContainer = EntityContainer.<StorageBillingInfo>builder()
             .entity(billing)
             .owner(testUserWithMetadata)
+            .region(region)
             .build();
 
         final XContentBuilder mappedBilling = efsMapper.map(billingContainer);
@@ -121,14 +167,29 @@ public class StorageBillingMapperTest {
         final Map<String, Object> mappedFields = TestUtils.getPuttedObject(mappedBilling);
 
         Assert.assertEquals(SearchDocumentType.NFS_STORAGE.name(),
-                            mappedFields.get(ElasticsearchSynchronizer.DOC_TYPE_FIELD));
-        Assert.assertEquals(efsStorage.getId(), mappedFields.get("storage_id"));
+                mappedFields.get(ElasticsearchSynchronizer.DOC_TYPE_FIELD));
+        Assert.assertEquals(EntityToBillingRequestConverter.SIMPLE_DATE_FORMAT.format(TEST_DATE),
+                mappedFields.get("created_date"));
         Assert.assertEquals(ResourceType.STORAGE.toString(), mappedFields.get("resource_type"));
-        Assert.assertEquals(efsStorage.getType().toString(), mappedFields.get("provider"));
+        Assert.assertEquals((int) TEST_REGION_ID, mappedFields.get("cloudRegionId"));
+        Assert.assertEquals(TEST_REGION_NAME, mappedFields.get("cloud_region_name"));
+        Assert.assertEquals(TEST_REGION_PROVIDER.toString(), mappedFields.get("cloud_region_provider"));
+
+        Assert.assertEquals(storage.getId(), mappedFields.get("storage_id"));
+        Assert.assertEquals(storage.getName(), mappedFields.get("storage_name"));
+        Assert.assertEquals(storage.getPath(), mappedFields.get("storage_path"));
         Assert.assertEquals(StorageType.FILE_STORAGE.toString(), mappedFields.get("storage_type"));
-        Assert.assertEquals(testUser.getUserName(), mappedFields.get("owner"));
-        Assert.assertEquals(billing.getUsageBytes().intValue(), mappedFields.get("usage_bytes"));
-        Assert.assertEquals(billing.getCost().intValue(), mappedFields.get("cost"));
+        Assert.assertEquals(storage.getType().toString(), mappedFields.get("provider"));
+        Assert.assertEquals(MountType.NFS.toString(), mappedFields.get("file_storage_type"));
+        Assert.assertEquals(null, mappedFields.get("object_storage_type"));
+        Assert.assertEquals(AbstractEntityMapper.SIMPLE_DATE_FORMAT.format(TEST_JAVA_DATE),
+                mappedFields.get("storage_created_date"));
+
+        Assert.assertEquals((int) TEST_USAGE_BYTES, mappedFields.get("usage_bytes"));
+        Assert.assertEquals((int) TEST_USAGE_BYTES, mappedFields.get("usage_bytes_avg"));
+        Assert.assertEquals((int) TEST_COST, mappedFields.get("cost"));
+
+        Assert.assertEquals(TEST_USER_NAME, mappedFields.get("owner"));
         TestUtils.verifyStringArray(TEST_GROUPS, mappedFields.get("groups"));
     }
 }

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
@@ -27,6 +27,7 @@ import com.epam.pipeline.entity.datastorage.DataStorageAction;
 import com.epam.pipeline.entity.datastorage.DataStorageTag;
 import com.epam.pipeline.entity.datastorage.FileShareMount;
 import com.epam.pipeline.entity.datastorage.TemporaryCredentials;
+import com.epam.pipeline.entity.docker.DockerRegistryList;
 import com.epam.pipeline.entity.docker.ToolDescription;
 import com.epam.pipeline.entity.dts.submission.DtsRegistry;
 import com.epam.pipeline.entity.git.GitRepositoryEntry;
@@ -216,6 +217,9 @@ public interface CloudPipelineAPI {
 
     @GET("tool/{toolId}/attributes ")
     Call<Result<ToolDescription>> loadToolAttributes(@Path(TOOL_ID) Long toolId);
+
+    @GET("dockerRegistry/loadTree")
+    Call<Result<DockerRegistryList>> loadAllRegistries();
 
     @GET("dockerRegistry/{id}/load")
     Call<Result<DockerRegistry>> loadDockerRegistry(@Path(ID) Long dockerRegistryId);

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/docker/DockerRegistryList.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/docker/DockerRegistryList.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /**
@@ -34,6 +35,7 @@ import lombok.Setter;
  */
 @Getter
 @Setter
+@NoArgsConstructor
 public class DockerRegistryList extends AbstractHierarchicalEntity {
     private List<DockerRegistry> registries;
 


### PR DESCRIPTION
Relates to #2739.

The pull request bring a lot of new fields to billing documents in elasticsearch. Such explicit entities indexing allows to store deleted entities details as well as reduce a number of database calls on subsequent billing data aggregations.

Check the following mapping files to find out which fields are indexed:
- `resources/templates/pipeline_run_billing.json`
- `resources/templates/storage_billing.json`
