### PR TITLE
Cellprofiler web api tool: parallel runs execution

### DIFF
--- a/deploy/docker/cp-tools/research/cellprofiler-web-api/app/src/hcs_modules_factory.py
+++ b/deploy/docker/cp-tools/research/cellprofiler-web-api/app/src/hcs_modules_factory.py
@@ -557,11 +557,7 @@ class DefineResultsModuleProcessor(ExportToSpreadsheetModuleProcessor):
         return settings
 
     def generated_params(self):
-        if Config.BATCH_ENABLED and Config.RESULTS_DIR:
-            results_location = 'Elsewhere...|' + Config.RESULTS_DIR
-        else:
-            results_location = self._output_location()
-        return {'Output file location': results_location,
+        return {'Output file location': self._output_location(),
                 'Add a prefix to file names?': 'No',
                 'Overwrite existing files without warning?': 'Yes',
                 'Add image metadata columns to your object data file?': 'Yes'}

--- a/deploy/docker/cp-tools/research/cellprofiler-web-api/start.sh
+++ b/deploy/docker/cp-tools/research/cellprofiler-web-api/start.sh
@@ -12,74 +12,132 @@ nohup python3.8 $CELLPROFILER_API_HOME/hcs.py --host=${CELLPROFILER_API_HOST:-0.
                                             --process_count=${CELLPROFILER_API_PROCESSES:-2} > "$CELLPROFILER_API_LOGS_DIR/serve_cp_api.log" 2>&1 &
 
 function run_pipeline() {
-    run_pipeline_response="$(curl -k -s -X POST "http://localhost:$CELLPROFILER_API_PORT/hcs/run/pipelines?pipelineId=$pipeline_id" | jq -r './/""')"
+    id=$1
+    run_pipeline_response="$(curl -k -s -X POST "http://localhost:$CELLPROFILER_API_PORT/hcs/run/pipelines?pipelineId=$id" | jq -r './/""')"
     run_pipeline_status="$(echo "$run_pipeline_response" | jq -r .status)"
     if [ "$run_pipeline_status" != "OK" ]; then
       run_pipeline_error="$(echo "$run_pipeline_response" | jq -r .message)"
-      echo "[ERROR] Failed to run pipeline. $run_pipeline_error"
+      echo "[ERROR] Failed to run pipeline '$id'. $run_pipeline_error"
       exit 1
     fi
+}
+
+function add_input_files() {
+    local pipeline_id=$1
+    local inputs_file=$2
+    add_files_response="$(curl -k -s -H 'Content-Type: application/json' -X POST "http://localhost:$CELLPROFILER_API_PORT/hcs/pipelines/files?pipelineId=$pipeline_id" -d @$inputs_file | jq -r './/""')"
+    add_files_status="$(echo $add_files_response | jq -r .status)"
+    if [ "$add_files_status" != "OK" ]; then
+      add_files_error="$(echo "$add_files_response" | jq -r .message)"
+      echo "[ERROR] Failed to add input files to pipeline '$pipeline_id'. $add_files_error"
+      exit 1
+    fi
+}
+
+function prepare_modules() {
+    local modules_count=$1
+    for i in $(seq $modules_count);
+    do
+      module_index=$(expr $i - 1)
+      tmp_module_file=$CELLPROFILER_API_TMP_DIR/.module-$module_index.json
+      jq -r .modules[$module_index] $CELLPROFILER_API_BATCH_SPEC_FILE > $tmp_module_file
+    done
+}
+
+function add_modules() {
+    local pipeline_id=$1
+    local modules_count=$2
+    for i in $(seq $modules_count);
+    do
+      module_index=$(expr $i - 1)
+      module_file=$CELLPROFILER_API_TMP_DIR/.module-$module_index.json
+      add_module_response="$(curl -k -s  -H 'Content-Type: application/json' -X POST "http://localhost:$CELLPROFILER_API_PORT/hcs/modules?pipelineId=$pipeline_id" -d @$module_file | jq -r './/""')"
+      add_module_status="$(echo "$add_module_response" | jq -r .status)"
+      if [ "$add_module_status" != "OK" ]; then
+        add_module_error="$(echo "$add_module_response" | jq -r .message)"
+        echo "[ERROR] Failed to add module '$pipeline_id'. $add_module_error"
+        exit 1
+      fi
+    done
 }
 
 if [ -z "$CELLPROFILER_API_BATCH_SPEC_FILE" ] ; then
     tail -f "$CELLPROFILER_API_LOGS_DIR/serve_cp_api.log"
 else
-    CELLPROFILER_API_TMP_DIR=$(mktemp -d)
     if [ -z "$CELLPROFILER_API_BATCH_RESULTS_DIR" ] ; then
       echo "[ERROR] No result directory provided. Parameter 'CELLPROFILER_API_BATCH_RESULTS_DIR' shall be specified."
       exit 1
     fi
+
     mkdir -p "$CELLPROFILER_API_BATCH_RESULTS_DIR"
     timeout $CELLPROFILER_API_STARTUP_TIMEOUT bash -c 'until printf "" 2>>/dev/null >>/dev/tcp/$0/$1; do sleep 2; done' "$CELLPROFILER_API_HOST" "${CELLPROFILER_API_PORT}"
     if [ "$?" -ne 0 ]; then
       echo "[ERROR] Exceeded max retries count for waiting Cellprofiler API startup"
       exit 1
     fi
+
+    CELLPROFILER_API_TMP_DIR=$(mktemp -d)
     measurement_uuid=$(jq -r .measurementUUID $CELLPROFILER_API_BATCH_SPEC_FILE)
-    pipeline_id="$(curl -k -s -H 'Content-Type: application/json' -X POST "http://localhost:$CELLPROFILER_API_PORT/hcs/pipelines?measurementUUID=$measurement_uuid" | jq -r '.payload.pipelineId//""')"
-    if [ -z "$pipeline_id" ]; then
-        echo "[ERROR] Failed to create pipeline"
-        exit 1
-    fi
-    tmp_inputs_file=$CELLPROFILER_API_TMP_DIR/.inputs.json
-    jq -r '.inputs' $CELLPROFILER_API_BATCH_SPEC_FILE > $tmp_inputs_file
-    add_files_response="$(curl -k -s -H 'Content-Type: application/json' -X POST "http://localhost:$CELLPROFILER_API_PORT/hcs/pipelines/files?pipelineId=$pipeline_id" -d @$tmp_inputs_file | jq -r './/""')"
-    add_files_status="$(echo $add_files_response | jq -r .status)"
-    if [ "$add_files_status" != "OK" ]; then
-      add_files_error="$(echo "$add_files_response" | jq -r .message)"
-      echo "[ERROR] Failed to add input files to pipeline. $add_files_error"
-      exit 1
-    fi
     modules_count=$(jq '.modules | length' $CELLPROFILER_API_BATCH_SPEC_FILE)
-    for i in $(seq $modules_count);
+    prepare_modules "$modules_count"
+
+    pipelines=()
+    tmp_inputs_dir="$CELLPROFILER_API_TMP_DIR/inputs"
+    mkdir "$tmp_inputs_dir"
+    inputs_by_well="[$(jq -r '.inputs | [ group_by(.x, .y)[] | [{"x": .[0].x, "y": .[0].y, "data": .}] | add | tojson ] | join(",")' $CELLPROFILER_API_BATCH_SPEC_FILE)]"
+    inputs_count=$(echo "$inputs_by_well" | jq '. | length')
+    for i in $(seq "$inputs_count");
     do
-      module_index=$(expr $i - 1)
-      tmp_module_file=$CELLPROFILER_API_TMP_DIR/.module-$module_index.json
-      jq -r .modules[$module_index] $CELLPROFILER_API_BATCH_SPEC_FILE > $tmp_module_file
-      add_module_response="$(curl -k -s  -H 'Content-Type: application/json' -X POST "http://localhost:$CELLPROFILER_API_PORT/hcs/modules?pipelineId=$pipeline_id" -d @$tmp_module_file | jq -r './/""')"
-      add_module_status="$(echo "$add_module_response" | jq -r .status)"
-      if [ "$add_module_status" != "OK" ]; then
-        add_module_error="$(echo "$add_module_response" | jq -r .message)"
-        echo "[ERROR] Failed to add module. $add_module_error"
+        index=$(expr $i - 1)
+        well=$(echo "$inputs_by_well" | jq ".[$index]")
+        well_x=$(echo "$well" | jq -r '.x//""')
+        well_y=$(echo "$well" | jq -r '.y//""')
+        tmp_well_inputs_file="$tmp_inputs_dir/well-$well_x$well_y.json"
+        echo "$well" | jq -r '.data//""' > "$tmp_well_inputs_file"
+
+        pipeline_id="$(curl -k -s -H 'Content-Type: application/json' -X POST "http://localhost:$CELLPROFILER_API_PORT/hcs/pipelines?measurementUUID=$measurement_uuid" | jq -r '.payload.pipelineId//""')"
+        if [ -z "$pipeline_id" ]; then
+            echo "[ERROR] Failed to create pipeline."
+            exit 1
+        fi
+        add_input_files "$pipeline_id" "$tmp_well_inputs_file"
+        add_modules "$pipeline_id" "$modules_count"
+        run_pipeline "$pipeline_id"
+        pipelines+=("$pipeline_id")
+    done
+
+    for pipeline_id in "${pipelines[@]}"
+    do
+      pipeline_state="$(curl -k -s -X GET "http://localhost:$CELLPROFILER_API_PORT/hcs/pipelines?pipelineId=$pipeline_id" | jq -r '.payload.pipelineId.state//""')"
+      while [ "$pipeline_state" == "CONFIGURING" ] || [ "$pipeline_state" == "RUNNING" ];
+      do
+        echo "[DEBUG] Pipeline '$pipeline_id' in non terminal state '$pipeline_state'. Wait for the end of execution."
+        sleep 5
+        pipeline_state="$(curl -k -s -X GET "http://localhost:$CELLPROFILER_API_PORT/hcs/pipelines?pipelineId=$pipeline_id" | jq -r '.payload.pipelineId.state//""')"
+        if [ "$pipeline_state" == "FINISHED" ] || [ "$pipeline_state" == "FAILED" ]; then
+            break
+        fi
+      done
+      pipeline_run_message="$(curl -k -s -X GET "http://localhost:$CELLPROFILER_API_PORT/hcs/pipelines?pipelineId=$pipeline_id" | jq -r '.payload.pipelineId.message//""')"
+      if [ "$pipeline_state" == "FINISHED" ]; then
+        echo "[INFO] Run completed for pipeline '$pipeline_id'. $pipeline_run_message"
+      else
+        echo "[ERROR] Run failed for pipeline '$pipeline_id'. $pipeline_run_message"
         exit 1
       fi
     done
-    run_pipeline
-    pipeline_state="$(curl -k -s -X GET "http://localhost:$CELLPROFILER_API_PORT/hcs/pipelines?pipelineId=$pipeline_id" | jq -r '.payload.pipelineId.state//""')"
-    while [ "$pipeline_state" == "CONFIGURING" ] || [ "$pipeline_state" == "RUNNING" ];
+
+    # merge results
+    common_define_results_file="$CELLPROFILER_API_BATCH_RESULTS_DIR/Results.csv"
+    first_pipeline_id="${pipelines[0]}"
+    for pipeline_id in "${pipelines[@]}"
     do
-      echo "Non terminal pipeline state '$pipeline_state'. Wait for the end of execution."
-      sleep 5
-      pipeline_state="$(curl -k -s -X GET "http://localhost:$CELLPROFILER_API_PORT/hcs/pipelines?pipelineId=$pipeline_id" | jq -r '.payload.pipelineId.state//""')"
-      if [ "$pipeline_state" == "FINISHED" ] || [ "$pipeline_state" == "FAILED" ]; then
-          break
-      fi
+        module_id="$(curl -k -s -X GET "http://localhost:$CELLPROFILER_API_PORT/hcs/pipelines?pipelineId=$pipeline_id" | jq -r '.payload.pipelineId.modules | map(select(.name=="DefineResults"))[] | .id//""')"
+        define_results_pipeline_file="$CELLPROFILER_API_COMMON_RESULTS_DIR/$measurement_uuid/$pipeline_id/$module_id/Results.csv"
+        if [ "$pipeline_id" == "$first_pipeline_id" ]; then
+            cat "$define_results_pipeline_file" > "$common_define_results_file"
+        else
+            tail -n +2 "$define_results_pipeline_file" >> "$common_define_results_file"
+        fi
     done
-    pipeline_run_message="$(curl -k -s -X GET "http://localhost:$CELLPROFILER_API_PORT/hcs/pipelines?pipelineId=$pipeline_id" | jq -r '.payload.pipelineId.message//""')"
-    if [ "$pipeline_state" == "FINISHED" ]; then
-      echo "[INFO] Run completed. $pipeline_run_message"
-      exit 0
-    fi
-    echo "[ERROR] Run failed. $pipeline_run_message"
-    exit 1
 fi

--- a/deploy/docker/cp-tools/research/cellprofiler-web-api/start.sh
+++ b/deploy/docker/cp-tools/research/cellprofiler-web-api/start.sh
@@ -66,7 +66,6 @@ else
     done
     run_pipeline
     pipeline_state="$(curl -k -s -X GET "http://localhost:$CELLPROFILER_API_PORT/hcs/pipelines?pipelineId=$pipeline_id" | jq -r '.payload.pipelineId.state//""')"
-    retry_count=0
     while [ "$pipeline_state" == "CONFIGURING" ] || [ "$pipeline_state" == "RUNNING" ];
     do
       echo "Non terminal pipeline state '$pipeline_state'. Wait for the end of execution."
@@ -74,15 +73,6 @@ else
       pipeline_state="$(curl -k -s -X GET "http://localhost:$CELLPROFILER_API_PORT/hcs/pipelines?pipelineId=$pipeline_id" | jq -r '.payload.pipelineId.state//""')"
       if [ "$pipeline_state" == "FINISHED" ] || [ "$pipeline_state" == "FAILED" ]; then
           break
-      fi
-      if [ "$pipeline_state" == "CONFIGURING" ]; then
-          if [ "$retry_count" -gt 10 ]; then
-              echo "[ERROR] Exceeded max retries count for configuring pipeline run."
-              exit 1
-          fi
-          retry_count=$((retry_count+1))
-          echo "Stuck in 'CONFIGURING' state. Try to rerun pipeline."
-          run_pipeline
       fi
     done
     pipeline_run_message="$(curl -k -s -X GET "http://localhost:$CELLPROFILER_API_PORT/hcs/pipelines?pipelineId=$pipeline_id" | jq -r '.payload.pipelineId.message//""')"


### PR DESCRIPTION
The current PR provides an ability to launch pipelines in separate process. The process count can be managed via `CELLPROFILER_API_PROCESSES ` parameter. 

Such approach requires changes for batch mode:
- split `inputs` by well 
- merge results from each `DefineResults` module run into one output