### PR TITLE
GUI cluster nodes labels filters

### DIFF
--- a/client/src/components/cluster/node-roles.js
+++ b/client/src/components/cluster/node-roles.js
@@ -90,12 +90,27 @@ export function getRoles (labels) {
 export function matchesPlatformCoreNodes (node) {
   if (node.labels) {
     return Object.keys(node.labels).some(key => {
-      const result = parseLabel(key, node.labels[key]);
-      return (
-        testRole(result.role, nodeRoles.cloudPipelineRole) ||
-        testRole(result.role, nodeRoles.master)
-      );
+      const {role, value} = parseLabel(key, node.labels[key]);
+      const exec = /^CLOUD-PIPELINE\/(.+)$/i.exec(key);
+      const cloudPipelineRole = testRole(role, nodeRoles.cloudPipelineRole);
+      const master = testRole(role, nodeRoles.master);
+      const cpLabel = (() => {
+        if (exec && exec[1]) {
+          return exec[1].toLowerCase().search(value.trim().toLowerCase()) > -1;
+        }
+        return null;
+      })();
+      return (cloudPipelineRole || master || cpLabel);
     });
   }
   return false;
 }
+
+export function matchesLabelValue (node, label) {
+  if (node.labels) {
+    return Object.keys(node.labels).some(key => {
+      const {value} = parseLabel(key, node.labels[key]);
+      return value.includes(label.toLowerCase());
+    });
+  }
+};

--- a/client/src/components/cluster/node-roles.js
+++ b/client/src/components/cluster/node-roles.js
@@ -106,11 +106,23 @@ export function matchesPlatformCoreNodes (node) {
   return false;
 }
 
-export function matchesLabelValue (node, label) {
+export function matchesLabelValue (node, inputValue) {
   if (node.labels) {
     return Object.keys(node.labels).some(key => {
-      const {value} = parseLabel(key, node.labels[key]);
-      return value.includes(label.toLowerCase());
+      const labelValue = node.labels[key];
+      // if string includes only number, find equal runId
+      if (/^\d+$/.test(inputValue)) {
+        return labelValue === inputValue;
+      }
+      let value;
+      // if label's value equal true, get label's key and replace 'cloud-pipeline/'
+      if (labelValue === 'true') {
+        value = parseLabel(key, labelValue).value;
+      // rest cases, filter by substring
+      } else {
+        value = labelValue;
+      }
+      return value.includes(inputValue.toLowerCase());
     });
   }
 };

--- a/client/src/components/cluster/node-roles.js
+++ b/client/src/components/cluster/node-roles.js
@@ -86,3 +86,16 @@ export function getRoles (labels) {
   }
   return roles;
 }
+
+export function matchesPlatformCoreNodes (node) {
+  if (node.labels) {
+    return Object.keys(node.labels).some(key => {
+      const result = parseLabel(key, node.labels[key]);
+      return (
+        testRole(result.role, nodeRoles.cloudPipelineRole) ||
+        testRole(result.role, nodeRoles.master)
+      );
+    });
+  }
+  return false;
+}


### PR DESCRIPTION
This PR changes cluster nodes labels and address filters:
- removed "No run id" filter
- added "Platform core nodes" filter
- changed "Run id" input to "Label value"
- "Label value" input filters by equal run id if value is a number, by substring otherwise
- checkboxes and input are mutually exclusive
- moved address filter to FE, changed to filtering by substring