### PR TITLE
Issue 2749: [HCS Analysis] Ability to merge Z-stack in a single projection

### DIFF
--- a/deploy/docker/cp-tools/research/cellprofiler-web-api/app/hcs.py
+++ b/deploy/docker/cp-tools/research/cellprofiler-web-api/app/hcs.py
@@ -159,7 +159,7 @@ def run_pipeline():
         pipeline_id = flask.request.args.get("pipelineId")
         if not pipeline_id:
             raise RuntimeError("Parameter 'pipelineId' must be specified.")
-        manager.run_pipeline(pipeline_id)
+        manager.launch_pipeline(pipeline_id)
         return jsonify({"status": "OK"})
     except Exception as e:
         print(traceback.format_exc())

--- a/deploy/docker/cp-tools/research/cellprofiler-web-api/app/src/hcs_manager.py
+++ b/deploy/docker/cp-tools/research/cellprofiler-web-api/app/src/hcs_manager.py
@@ -133,6 +133,7 @@ class HCSManager:
             return
         self.run_pipeline(projection_pipeline_id)
         parent_pipeline.set_pipeline_files(self._collect_parent_pipeline_inputs(parent_pipeline, projection_pipeline))
+        parent_pipeline.set_input_sets()
 
     def _parse_inputs(self, coordinates):
         x = int(self._get_required_field(coordinates, 'x'))

--- a/deploy/docker/cp-tools/research/cellprofiler-web-api/app/src/hcs_modules_factory.py
+++ b/deploy/docker/cp-tools/research/cellprofiler-web-api/app/src/hcs_modules_factory.py
@@ -584,7 +584,6 @@ class SaveImagesModuleProcessor(OutputModuleProcessor):
     def generated_params(self):
         return {'Overwrite existing files without warning?': 'Yes',
                 'Save with lossless compression?': 'No',
-                'Append a suffix to the image file name?': 'Yes',
                 'Output file location': self._output_location()}
 
 

--- a/deploy/docker/cp-tools/research/cellprofiler-web-api/app/src/hcs_modules_factory.py
+++ b/deploy/docker/cp-tools/research/cellprofiler-web-api/app/src/hcs_modules_factory.py
@@ -530,8 +530,9 @@ class DefineResultsModuleProcessor(ExportToSpreadsheetModuleProcessor):
         grouping = module_config['grouping'] if 'grouping' in module_config else None
         fields_by_well = \
             module_config[DefineResults.FIELDS_BY_WELL] if DefineResults.FIELDS_BY_WELL in module_config else {}
+        z_planes = module_config[DefineResults.Z_PLANES] if DefineResults.Z_PLANES in module_config else None
         self._validate_configuration(specs, grouping)
-        self.module.set_calculation_spec(specs, grouping, fields_by_well)
+        self.module.set_calculation_spec(specs, grouping, fields_by_well, z_planes)
         self.set_required_data_to_module_config(module_config, specs)
         ExportToSpreadsheetModuleProcessor.configure_module(self, module_config)
         return self.module

--- a/deploy/docker/cp-tools/research/cellprofiler-web-api/app/src/hcs_pipeline.py
+++ b/deploy/docker/cp-tools/research/cellprofiler-web-api/app/src/hcs_pipeline.py
@@ -198,12 +198,12 @@ class HcsPipeline(object):
 
     def set_input(self, image_coords_list: List[ImageCoords]):
         self.set_pipeline_state(PipelineState.CONFIGURING)
-        self.set_pipeline_files([self._map_to_file_name(image) for image in image_coords_list])
+        self.set_pipeline_files([self.map_to_file_name(image) for image in image_coords_list])
         self._set_fields_by_well(image_coords_list)
         self._channels_map = {image.channel_name: image.channel for image in image_coords_list}
         self.set_input_sets()
 
-    def _map_to_file_name(self, coords: ImageCoords):
+    def map_to_file_name(self, coords: ImageCoords):
         well_full_name = "r{:02d}c{:02d}".format(coords.well_x, coords.well_y)
         image_relative_path = 'images/{well}/{well}f{field:02d}p{plane:02d}-ch{channel:02d}t{timepoint:02d}.tiff' \
             .format(well=well_full_name, field=coords.field, plane=coords.z_plane,

--- a/deploy/docker/cp-tools/research/cellprofiler-web-api/app/src/hcs_pipeline.py
+++ b/deploy/docker/cp-tools/research/cellprofiler-web-api/app/src/hcs_pipeline.py
@@ -63,14 +63,29 @@ class HcsPipeline(object):
         self._pipeline_state_message = ''
         self._input_sets = set()
         self._fields_by_well = dict()
+        self._measurement_uuid = measurement_id
+        self._pre_processing_pipeline_id = None
+        self._z_planes = None  # z-planes to squash
         cellprofiler_core.preferences.set_headless()
 
     def set_pipeline_state(self, status: PipelineState, message: str = ''):
         self._pipeline_state = status
         self._pipeline_state_message = message
 
+    def set_pre_processing_pipeline(self, pipeline_id):
+        self._pre_processing_pipeline_id = pipeline_id
+
+    def get_pre_processing_pipeline(self):
+        return self._pre_processing_pipeline_id
+
     def get_id(self):
         return self._pipeline_id
+
+    def get_measurement(self):
+        return self._measurement_uuid
+
+    def set_z_planes(self, z_planes):
+        self._z_planes = z_planes
 
     def get_module_outputs(self, module):
         module_id = str(module.id)
@@ -95,6 +110,8 @@ class HcsPipeline(object):
         data['state'] = self._pipeline_state.name
         data['message'] = self._pipeline_state_message
         data['inputs'] = list(self._input_sets)
+        if self.get_pre_processing_pipeline():
+            data['pre_process_pipeline'] = self.get_pre_processing_pipeline()
         return data
 
     def get_module_status(self):
@@ -145,6 +162,7 @@ class HcsPipeline(object):
             module_name = module.module_name
         if module_name == DefineResults.MODULE_NAME:
             module_config.update({DefineResults.FIELDS_BY_WELL: self._fields_by_well})
+            module_config.update({DefineResults.Z_PLANES: self._z_planes})
         processor = self._modules_factory.get_module_processor(module, module_name)
         module = processor.configure_module(module_config)
         return module

--- a/deploy/docker/cp-tools/research/cellprofiler-web-api/app/src/hcs_pipeline.py
+++ b/deploy/docker/cp-tools/research/cellprofiler-web-api/app/src/hcs_pipeline.py
@@ -208,7 +208,10 @@ class HcsPipeline(object):
         image_relative_path = 'images/{well}/{well}f{field:02d}p{plane:02d}-ch{channel:02d}t{timepoint:02d}.tiff' \
             .format(well=well_full_name, field=coords.field, plane=coords.z_plane,
                     channel=coords.channel, timepoint=coords.timepoint)
-        return os.path.join(self._pipeline_input_dir, image_relative_path)
+        image_full_path = os.path.join(self._pipeline_input_dir, image_relative_path)
+        if not os.path.exists(image_full_path):
+            raise FileNotFoundError("The file '%s' does not exist." % image_full_path)
+        return image_full_path
 
     def _verify_module_num(self, module_num: int):
         modules = self._pipeline.modules()

--- a/deploy/docker/cp-tools/research/cellprofiler-web-api/app/src/z_planes_pipeline.py
+++ b/deploy/docker/cp-tools/research/cellprofiler-web-api/app/src/z_planes_pipeline.py
@@ -1,0 +1,94 @@
+from typing import List
+
+from cellprofiler_core.setting import Binary, SettingsGroup
+from cellprofiler_core.setting.choice import Choice
+
+from .hcs_pipeline import HcsPipeline, ImageCoords
+
+
+class ZPlanesPipeline(HcsPipeline):
+    METADATA_CATEGORY_CHOICES = ['WellRow', 'WellColumn', 'Field', 'Timepoint']
+    DEFAULT_BIT_DEPTH = '16-bit integer'
+
+    def __init__(self, measurements_uuid, bit_depth=DEFAULT_BIT_DEPTH):
+        HcsPipeline.__init__(self, measurements_uuid)
+        self.parent_pipeline_inputs = list()
+        self.pipeline_inputs = list()
+        self.bit_depth = bit_depth
+
+    def set_input(self, coordinates_list: List[ImageCoords]):
+        z_planes_map = self._construct_z_plane_groups(coordinates_list)
+        self._filter_pipeline_inputs(z_planes_map)
+
+        if not self.pipeline_inputs or len(self.pipeline_inputs) == 0:
+            return
+
+        super().set_input(self.pipeline_inputs)
+        self._construct_grouping_module()
+        self._construct_extra_modules()
+
+    def _filter_pipeline_inputs(self, z_planes_map: dict):
+        for group_key, planes in z_planes_map.items():
+            if not planes or len(planes) == 0:
+                continue
+            # groups with single z-plane shall not be squashed and no processing required
+            if len(planes) == 1:
+                self.parent_pipeline_inputs.append(planes[0])
+                continue
+            for image_coordinates in planes:
+                self.pipeline_inputs.append(image_coordinates)
+
+    def _construct_grouping_module(self):
+        self._pipeline.modules()[3].wants_groups = Binary('Do you want to group your images?', True)
+        self._pipeline.modules()[3].grouping_metadata.clear()
+        for metadata_category in self.METADATA_CATEGORY_CHOICES:
+            self._pipeline.modules()[3].grouping_metadata.append(self._groups_setting_group(metadata_category))
+
+    def _construct_extra_modules(self):
+        channels_map = {image.channel_name: image.channel for image in self.pipeline_inputs}
+
+        module_id = 0
+        for channel_name in channels_map.keys():
+            module_id += 1
+            self.add_module('MakeProjection', module_id, self._make_projection_module_config(channel_name))
+            module_id += 1
+            self.add_module('SaveImages', module_id,
+                            self._save_projection_images_module_config(channel_name, self.bit_depth))
+
+    def _construct_z_plane_groups(self, coordinates_list: List[ImageCoords]):
+        z_planes_map = dict()
+        for coordinates in coordinates_list:
+            current_z_plane = coordinates.z_plane
+            if current_z_plane not in self._z_planes:
+                self.parent_pipeline_inputs.append(coordinates)
+                continue
+            z_planes_group_key = (coordinates.well_x, coordinates.well_y, coordinates.timepoint,
+                                  coordinates.field, coordinates.channel, coordinates.channel_name)
+            if z_planes_map.get(z_planes_group_key) is None:
+                z_planes_map.update({z_planes_group_key: list()})
+            z_planes_map.get(z_planes_group_key).append(coordinates)
+        return z_planes_map
+
+    @staticmethod
+    def _make_projection_module_config(channel_name):
+        return {
+            'Select the input image': channel_name,
+            'Type of projection': 'Maximum',
+            'Name of the output image': '%s-projection' % channel_name
+        }
+
+    @staticmethod
+    def _save_projection_images_module_config(channel_name, bit_depth=DEFAULT_BIT_DEPTH):
+        return {
+            'Select the type of image to save': 'Image',
+            'Select the image to save': '%s-projection' % channel_name,
+            'Select method for constructing file names': 'From image filename',
+            'Image bit depth': bit_depth or ZPlanesPipeline.DEFAULT_BIT_DEPTH,
+            'When to save': 'Last cycle'
+        }
+
+    @staticmethod
+    def _groups_setting_group(metadata_category):
+        group = SettingsGroup()
+        group.metadata_choice = Choice('Metadata category', [metadata_category], value=metadata_category)
+        return group

--- a/deploy/docker/cp-tools/research/cellprofiler-web-api/app/src/z_planes_pipeline.py
+++ b/deploy/docker/cp-tools/research/cellprofiler-web-api/app/src/z_planes_pipeline.py
@@ -47,7 +47,7 @@ class ZPlanesPipeline(HcsPipeline):
     def _construct_extra_modules(self):
         channels_map = {image.channel_name: image.channel for image in self.pipeline_inputs}
 
-        module_id = 0
+        module_id = 4
         for channel_name in channels_map.keys():
             module_id += 1
             self.add_module('MakeProjection', module_id, self._make_projection_module_config(channel_name))
@@ -74,7 +74,7 @@ class ZPlanesPipeline(HcsPipeline):
         return {
             'Select the input image': channel_name,
             'Type of projection': 'Maximum',
-            'Name of the output image': '%s-projection' % channel_name
+            'Name the output image': '%s-projection' % channel_name
         }
 
     @staticmethod
@@ -84,7 +84,10 @@ class ZPlanesPipeline(HcsPipeline):
             'Select the image to save': '%s-projection' % channel_name,
             'Select method for constructing file names': 'From image filename',
             'Image bit depth': bit_depth or ZPlanesPipeline.DEFAULT_BIT_DEPTH,
-            'When to save': 'Last cycle'
+            'When to save': 'Last cycle',
+            'Select image name for file prefix': channel_name,
+            'Record the file and path information to the saved image?': 'No',
+            'Create subfolders in the output folder?': 'No'
         }
 
     @staticmethod

--- a/deploy/docker/cp-tools/research/cellprofiler-web-api/app/src/z_planes_pipeline.py
+++ b/deploy/docker/cp-tools/research/cellprofiler-web-api/app/src/z_planes_pipeline.py
@@ -20,12 +20,15 @@ class ZPlanesPipeline(HcsPipeline):
         z_planes_map = self._construct_z_plane_groups(coordinates_list)
         self._filter_pipeline_inputs(z_planes_map)
 
-        if not self.pipeline_inputs or len(self.pipeline_inputs) == 0:
+        if self.is_empty():
             return
 
         super().set_input(self.pipeline_inputs)
         self._construct_grouping_module()
         self._construct_extra_modules()
+
+    def is_empty(self):
+        return not self.pipeline_inputs or len(self.pipeline_inputs) == 0
 
     def _filter_pipeline_inputs(self, z_planes_map: dict):
         for group_key, planes in z_planes_map.items():


### PR DESCRIPTION
The current PR provides implementation for issue #2749 

The following changes were added:
- `POST /hcs/pipelines/files` method request body was changed. A new body shall have the following structure:
```
{
    "files": [
    {
      "x": 2,
      "y": 2,
      "timepoint": 1,
      "z": 1,
      "fieldId": 1,
      "channel": 1,
      "channelName": "DAPI"
    },
    .... 
  ],
  "zPlanes": [1, 2, 3, ...]  # optional; shall be used if squash z-planes required
  "bitDepth": "16-bit integer" # optional (Default: "16-bit integer"); possible values: "8-bit integer", "16-bit integer", "32-bit floating point" (required by SaveImages module)
}
``` 
- added a new field `pre_process_pipeline` for `GET /hcs/piplines` response if projection pipeline execution required