### PR TITLE
Issue 2721 change lifecycle notification object and process

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/user/RoleApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/user/RoleApiService.java
@@ -47,12 +47,13 @@ public class RoleApiService {
     }
 
     @PreAuthorize(ADMIN_ONLY + OR_USER_READER)
-    public Role loadRole(final String id) {
-        if (StringUtils.isNumeric(id)) {
-            return roleManager.loadRoleWithUsers(Long.parseLong(id));
-        } else {
-            return roleManager.loadRoleByNameWithUsers(id);
-        }
+    public Role loadRole(final Long id) {
+        return roleManager.loadRoleWithUsers(id);
+    }
+
+    @PreAuthorize(ADMIN_ONLY + OR_USER_READER)
+    public Role loadRoleByName(final String name) {
+        return roleManager.loadRoleByNameWithUsers(name);
     }
 
     @PreAuthorize(ADMIN_ONLY)
@@ -79,5 +80,4 @@ public class RoleApiService {
     public ExtendedRole removeRole(Long roleId, List<Long> userIds) {
         return roleManager.removeRole(roleId, userIds);
     }
-
 }

--- a/api/src/main/java/com/epam/pipeline/acl/user/RoleApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/user/RoleApiService.java
@@ -20,6 +20,7 @@ import com.epam.pipeline.controller.vo.user.RoleVO;
 import com.epam.pipeline.entity.user.ExtendedRole;
 import com.epam.pipeline.entity.user.Role;
 import com.epam.pipeline.manager.user.RoleManager;
+import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
@@ -46,8 +47,12 @@ public class RoleApiService {
     }
 
     @PreAuthorize(ADMIN_ONLY + OR_USER_READER)
-    public Role loadRole(Long id) {
-        return roleManager.loadRoleWithUsers(id);
+    public Role loadRole(final String id) {
+        if (StringUtils.isNumeric(id)) {
+            return roleManager.loadRoleWithUsers(Long.parseLong(id));
+        } else {
+            return roleManager.loadRoleByNameWithUsers(id);
+        }
     }
 
     @PreAuthorize(ADMIN_ONLY)

--- a/api/src/main/java/com/epam/pipeline/controller/user/RoleController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/user/RoleController.java
@@ -129,7 +129,7 @@ public class RoleController extends AbstractRestController {
     @ApiResponses(
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
             })
-    public Result<Role> getRole(@PathVariable Long id) {
+    public Result<Role> getRole(@PathVariable String id) {
         return Result.success(roleApiService.loadRole(id));
     }
 

--- a/api/src/main/java/com/epam/pipeline/controller/user/RoleController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/user/RoleController.java
@@ -129,8 +129,21 @@ public class RoleController extends AbstractRestController {
     @ApiResponses(
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
             })
-    public Result<Role> getRole(@PathVariable String id) {
+    public Result<Role> getRole(@PathVariable Long id) {
         return Result.success(roleApiService.loadRole(id));
+    }
+
+    @RequestMapping(method = RequestMethod.GET)
+    @ResponseBody
+    @ApiOperation(
+            value = "Gets a role specified by name.",
+            notes = "Gets a role specified by name.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public Result<Role> getRoleByName(@RequestParam final String name) {
+        return Result.success(roleApiService.loadRoleByName(name));
     }
 
     @RequestMapping(value = "/{id}", method = RequestMethod.DELETE)

--- a/api/src/main/java/com/epam/pipeline/manager/user/RoleManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/RoleManager.java
@@ -156,6 +156,9 @@ public class RoleManager {
                 .collect(Collectors.toList());
     }
 
+    public Role loadRoleByNameWithUsers(final String name) {
+        return roleDao.loadExtendedRole(loadRole(name).getId());
+    }
 
     public Role loadRole(Long roleId) {
         return roleDao.loadRole(roleId)

--- a/api/src/test/java/com/epam/pipeline/acl/user/RoleApiServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/acl/user/RoleApiServiceTest.java
@@ -86,7 +86,7 @@ public class RoleApiServiceTest extends AbstractAclTest {
     public void shouldLoadRoleForAdmin() {
         doReturn(extendedRole).when(mockRoleManager).loadRoleWithUsers(ID);
 
-        assertThat(roleApiService.loadRole(ID)).isEqualTo(extendedRole);
+        assertThat(roleApiService.loadRole(String.valueOf(ID))).isEqualTo(extendedRole);
     }
 
     @Test
@@ -94,7 +94,7 @@ public class RoleApiServiceTest extends AbstractAclTest {
     public void shouldLoadRoleForUserReader() {
         doReturn(extendedRole).when(mockRoleManager).loadRoleWithUsers(ID);
 
-        assertThat(roleApiService.loadRole(ID)).isEqualTo(extendedRole);
+        assertThat(roleApiService.loadRole(String.valueOf(ID))).isEqualTo(extendedRole);
     }
 
     @Test
@@ -102,7 +102,7 @@ public class RoleApiServiceTest extends AbstractAclTest {
     public void shouldDenyLoadRoleForNotUserReader() {
         doReturn(extendedRole).when(mockRoleManager).loadRoleWithUsers(ID);
 
-        assertThrows(AccessDeniedException.class, () -> roleApiService.loadRole(ID));
+        assertThrows(AccessDeniedException.class, () -> roleApiService.loadRole(String.valueOf(ID)));
     }
 
     @Test

--- a/api/src/test/java/com/epam/pipeline/acl/user/RoleApiServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/acl/user/RoleApiServiceTest.java
@@ -86,7 +86,7 @@ public class RoleApiServiceTest extends AbstractAclTest {
     public void shouldLoadRoleForAdmin() {
         doReturn(extendedRole).when(mockRoleManager).loadRoleWithUsers(ID);
 
-        assertThat(roleApiService.loadRole(String.valueOf(ID))).isEqualTo(extendedRole);
+        assertThat(roleApiService.loadRole(ID)).isEqualTo(extendedRole);
     }
 
     @Test
@@ -94,7 +94,7 @@ public class RoleApiServiceTest extends AbstractAclTest {
     public void shouldLoadRoleForUserReader() {
         doReturn(extendedRole).when(mockRoleManager).loadRoleWithUsers(ID);
 
-        assertThat(roleApiService.loadRole(String.valueOf(ID))).isEqualTo(extendedRole);
+        assertThat(roleApiService.loadRole(ID)).isEqualTo(extendedRole);
     }
 
     @Test
@@ -102,7 +102,7 @@ public class RoleApiServiceTest extends AbstractAclTest {
     public void shouldDenyLoadRoleForNotUserReader() {
         doReturn(extendedRole).when(mockRoleManager).loadRoleWithUsers(ID);
 
-        assertThrows(AccessDeniedException.class, () -> roleApiService.loadRole(String.valueOf(ID)));
+        assertThrows(AccessDeniedException.class, () -> roleApiService.loadRole(ID));
     }
 
     @Test

--- a/api/src/test/java/com/epam/pipeline/controller/user/RoleControllerTest.java
+++ b/api/src/test/java/com/epam/pipeline/controller/user/RoleControllerTest.java
@@ -163,11 +163,11 @@ public class RoleControllerTest extends AbstractControllerTest {
     @Test
     @WithMockUser
     public void shouldGetRole() {
-        doReturn(role).when(mockRoleApiService).loadRole(ID);
+        doReturn(role).when(mockRoleApiService).loadRole(String.valueOf(ID));
 
         final MvcResult mvcResult = performRequest(get(String.format(ROLE_ID_URL, ID)));
 
-        verify(mockRoleApiService).loadRole(ID);
+        verify(mockRoleApiService).loadRole(String.valueOf(ID));
         assertResponse(mvcResult, role, UserCreatorUtils.ROLE_INSTANCE_TYPE);
     }
 

--- a/api/src/test/java/com/epam/pipeline/controller/user/RoleControllerTest.java
+++ b/api/src/test/java/com/epam/pipeline/controller/user/RoleControllerTest.java
@@ -163,11 +163,11 @@ public class RoleControllerTest extends AbstractControllerTest {
     @Test
     @WithMockUser
     public void shouldGetRole() {
-        doReturn(role).when(mockRoleApiService).loadRole(String.valueOf(ID));
+        doReturn(role).when(mockRoleApiService).loadRole(ID);
 
         final MvcResult mvcResult = performRequest(get(String.format(ROLE_ID_URL, ID)));
 
-        verify(mockRoleApiService).loadRole(String.valueOf(ID));
+        verify(mockRoleApiService).loadRole(ID);
         assertResponse(mvcResult, role, UserCreatorUtils.ROLE_INSTANCE_TYPE);
     }
 

--- a/core/src/main/java/com/epam/pipeline/dto/datastorage/lifecycle/StorageLifecycleNotification.java
+++ b/core/src/main/java/com/epam/pipeline/dto/datastorage/lifecycle/StorageLifecycleNotification.java
@@ -16,6 +16,7 @@
 
 package com.epam.pipeline.dto.datastorage.lifecycle;
 
+import com.epam.pipeline.entity.user.SidImpl;
 import lombok.Builder;
 import lombok.Value;
 
@@ -29,9 +30,7 @@ import java.util.List;
 public class StorageLifecycleNotification {
     Long notifyBeforeDays;
     Long prolongDays;
-    List<Long> informedUserIds;
-    Boolean keepInformedAdmins;
-    Boolean keepInformedOwner;
+    List<SidImpl> recipients;
     Boolean enabled;
     String subject;
     String body;

--- a/storage-lifecycle-service/integrational_tests/decorator/cp_api_decator.py
+++ b/storage-lifecycle-service/integrational_tests/decorator/cp_api_decator.py
@@ -53,6 +53,9 @@ class MockedNotificationRESTApiCloudPipelineDataSource(CloudPipelineDataSource):
     def load_role(self, role_id):
         return self.cp_source.load_role(role_id)
 
+    def load_role_by_name(self, role_name):
+        return self.cp_source.load_role_by_name(role_name)
+
     def load_user_by_name(self, username):
         return self.cp_source.load_user_by_name(username)
 
@@ -61,6 +64,9 @@ class MockedNotificationRESTApiCloudPipelineDataSource(CloudPipelineDataSource):
 
     def load_preference(self, preference_name):
         return self.cp_source.load_preference(preference_name)
+
+    def load_regions(self):
+        return self.cp_source.load_regions()
 
     def _load_default_lifecycle_rule_notification(self):
         return self.cp_source._load_default_lifecycle_rule_notification()

--- a/storage-lifecycle-service/integrational_tests/integration_test_runner.py
+++ b/storage-lifecycle-service/integrational_tests/integration_test_runner.py
@@ -72,7 +72,7 @@ class IntegrationTestsRunner(unittest.TestCase):
         self.assert_platform_state(actual.platform, expected.platform)
 
         logger.log(logging.INFO, "Finish test case: {}\n\n".format(case_file))
-        time.sleep(5)
+        time.sleep(30)
 
     def assertCloudState(self, actual, expected):
         self.assertEqual(expected is None, actual is None)

--- a/storage-lifecycle-service/integrational_tests/processor/test_case_execution.py
+++ b/storage-lifecycle-service/integrational_tests/processor/test_case_execution.py
@@ -35,7 +35,7 @@ class TestCaseExecutor(TestCaseProcessor):
         logger = AppLogger()
         data_source = cp_api_decator.MockedNotificationRESTApiCloudPipelineDataSource(
             sls.datasorce.cp_data_source.configure_cp_data_source(
-                self.config.get("CP_API_URL"), self.config.get("CP_API_TOKEN"), "/tmp")
+                self.config.get("CP_API_URL"), self.config.get("CP_API_TOKEN"), "/tmp", logger)
         )
 
         storage_lifecycle_service_config = self.fetch_storage_lifecycle_service_config(data_source)

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_10_removing_files_action_complete.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_10_removing_files_action_complete.json
@@ -32,8 +32,7 @@
             "notification": {
               "notifyBeforeDays": 10,
               "prolongDays": 10,
-              "keepInformedAdmins": false,
-              "keepInformedOwner": true,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
               "enabled": true,
               "subject": "Lifecycle rule is about to be applied!",
               "body": "Lifecycle rule is about to be applied!"

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_11_several_directories_only_one_eligable_eligable_for_notification.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_11_several_directories_only_one_eligable_eligable_for_notification.json
@@ -40,8 +40,7 @@
             "notification": {
               "notifyBeforeDays": 10,
               "prolongDays": 10,
-              "keepInformedAdmins": false,
-              "keepInformedOwner": true,
+             "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
               "enabled": true,
               "subject": "Lifecycle rule is about to be applied!",
               "body": "Lifecycle rule is about to be applied!"

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_12_files_not_eligable_for_action_because_of_prolongation.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_12_files_not_eligable_for_action_because_of_prolongation.json
@@ -43,8 +43,7 @@
             "notification": {
               "notifyBeforeDays": 5,
               "prolongDays": 10,
-              "keepInformedAdmins": false,
-              "keepInformedOwner": true,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
               "enabled": true,
               "subject": "Lifecycle rule is about to be applied!",
               "body": "Lifecycle rule is about to be applied!"

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_13_files_eligable_for_action_with_prolongation.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_13_files_eligable_for_action_with_prolongation.json
@@ -43,8 +43,7 @@
             "notification": {
               "notifyBeforeDays": 5,
               "prolongDays": 10,
-              "keepInformedAdmins": false,
-              "keepInformedOwner": true,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
               "enabled": true,
               "subject": "Lifecycle rule is about to be applied!",
               "body": "Lifecycle rule is about to be applied!"

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_14_transition_criterion_MATCHING_FILES_with_prolongation_not_eligable_to_action.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_14_transition_criterion_MATCHING_FILES_with_prolongation_not_eligable_to_action.json
@@ -47,8 +47,7 @@
             "notification": {
               "notifyBeforeDays": 10,
               "prolongDays": 10,
-              "keepInformedAdmins": false,
-              "keepInformedOwner": true,
+             "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
               "enabled": true,
               "subject": "Lifecycle rule is about to be applied!",
               "body": "Lifecycle rule is about to be applied!"

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_15_several_directories_deep_in_hierarcy.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_15_several_directories_deep_in_hierarcy.json
@@ -40,8 +40,7 @@
             "notification": {
               "notifyBeforeDays": 10,
               "prolongDays": 10,
-              "keepInformedAdmins": false,
-              "keepInformedOwner": true,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
               "enabled": true,
               "subject": "Lifecycle rule is about to be applied!",
               "body": "Lifecycle rule is about to be applied!"

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_16_transition_method_earliest_file_files_not_eligable.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_16_transition_method_earliest_file_files_not_eligable.json
@@ -37,8 +37,7 @@
             "notification": {
               "notifyBeforeDays": 5,
               "prolongDays": 10,
-              "keepInformedAdmins": false,
-              "keepInformedOwner": true,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
               "enabled": true,
               "subject": "Lifecycle rule is about to be applied!",
               "body": "Lifecycle rule is about to be applied!"

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_17_transition_method_earliest_files_eligable_for_notification.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_17_transition_method_earliest_files_eligable_for_notification.json
@@ -37,8 +37,7 @@
             "notification": {
               "notifyBeforeDays": 5,
               "prolongDays": 10,
-              "keepInformedAdmins": false,
-              "keepInformedOwner": true,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
               "enabled": true,
               "subject": "Lifecycle rule is about to be applied!",
               "body": "Lifecycle rule is about to be applied!"

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_18_transition_method_earliest_files_eligable_for_action.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_18_transition_method_earliest_files_eligable_for_action.json
@@ -37,8 +37,7 @@
             "notification": {
               "notifyBeforeDays": 5,
               "prolongDays": 10,
-              "keepInformedAdmins": false,
-              "keepInformedOwner": true,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
               "enabled": true,
               "subject": "Lifecycle rule is about to be applied!",
               "body": "Lifecycle rule is about to be applied!"

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_1_nothing_eligable_to_do.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_1_nothing_eligable_to_do.json
@@ -37,8 +37,7 @@
             "notification": {
               "notifyBeforeDays": 10,
               "prolongDays": 10,
-              "keepInformedAdmins": false,
-              "keepInformedOwner": true,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
               "enabled": true,
               "subject": "Lifecycle rule is about to be applied!",
               "body": "Lifecycle rule is about to be applied!"

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_21_previous_run_failed_should_rerun_action.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_21_previous_run_failed_should_rerun_action.json
@@ -37,8 +37,7 @@
             "notification": {
               "notifyBeforeDays": 5,
               "prolongDays": 10,
-              "keepInformedAdmins": false,
-              "keepInformedOwner": true,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
               "enabled": true,
               "subject": "Lifecycle rule is about to be applied!",
               "body": "Lifecycle rule is about to be applied!"

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_22_storage_from_bucket_folder_files_eligable_for_action.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_22_storage_from_bucket_folder_files_eligable_for_action.json
@@ -37,8 +37,7 @@
             "notification": {
               "notifyBeforeDays": 5,
               "prolongDays": 10,
-              "keepInformedAdmins": false,
-              "keepInformedOwner": true,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
               "enabled": true,
               "subject": "Lifecycle rule is about to be applied!",
               "body": "Lifecycle rule is about to be applied!"

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_23_storage_from_bucket_folder_files_eligable_for_notification.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_23_storage_from_bucket_folder_files_eligable_for_notification.json
@@ -37,8 +37,7 @@
             "notification": {
               "notifyBeforeDays": 10,
               "prolongDays": 10,
-              "keepInformedAdmins": false,
-              "keepInformedOwner": true,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
               "enabled": true,
               "subject": "Lifecycle rule is about to be applied!",
               "body": "Lifecycle rule is about to be applied!"

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_24_storage_from_bucket_folder_files_not_eligable_for_action_because_of_prolongation.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_24_storage_from_bucket_folder_files_not_eligable_for_action_because_of_prolongation.json
@@ -43,8 +43,7 @@
             "notification": {
               "notifyBeforeDays": 5,
               "prolongDays": 10,
-              "keepInformedAdmins": false,
-              "keepInformedOwner": true,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
               "enabled": true,
               "subject": "Lifecycle rule is about to be applied!",
               "body": "Lifecycle rule is about to be applied!"

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_25_wide_glob_from_root_several_directories_deep_in_hierarcy.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_25_wide_glob_from_root_several_directories_deep_in_hierarcy.json
@@ -40,8 +40,7 @@
             "notification": {
               "notifyBeforeDays": 10,
               "prolongDays": 10,
-              "keepInformedAdmins": false,
-              "keepInformedOwner": true,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
               "enabled": true,
               "subject": "Lifecycle rule is about to be applied!",
               "body": "Lifecycle rule is about to be applied!"

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_26_rule_without_object_glob_eligable_for_notification.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_26_rule_without_object_glob_eligable_for_notification.json
@@ -37,8 +37,7 @@
             "notification": {
               "notifyBeforeDays": 10,
               "prolongDays": 10,
-              "keepInformedAdmins": false,
-              "keepInformedOwner": true,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
               "enabled": true,
               "subject": "Lifecycle rule is about to be applied!",
               "body": "Lifecycle rule is about to be applied!"

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_27_rule_without_object_glob_files_eligable_for_action.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_27_rule_without_object_glob_files_eligable_for_action.json
@@ -36,8 +36,7 @@
             "notification": {
               "notifyBeforeDays": 5,
               "prolongDays": 10,
-              "keepInformedAdmins": false,
-              "keepInformedOwner": true,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
               "enabled": true,
               "subject": "Lifecycle rule is about to be applied!",
               "body": "Lifecycle rule is about to be applied!"

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_28_rule_without_object_glob_with_wide_path_glob_files_eligable_for_action.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_28_rule_without_object_glob_with_wide_path_glob_files_eligable_for_action.json
@@ -36,8 +36,7 @@
             "notification": {
               "notifyBeforeDays": 5,
               "prolongDays": 10,
-              "keepInformedAdmins": false,
-              "keepInformedOwner": true,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
               "enabled": true,
               "subject": "Lifecycle rule is about to be applied!",
               "body": "Lifecycle rule is about to be applied!"

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_2_files_eligable_for_notification.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_2_files_eligable_for_notification.json
@@ -37,8 +37,7 @@
             "notification": {
               "notifyBeforeDays": 10,
               "prolongDays": 10,
-              "keepInformedAdmins": false,
-              "keepInformedOwner": true,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
               "enabled": true,
               "subject": "Lifecycle rule is about to be applied!",
               "body": "Lifecycle rule is about to be applied!"

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_3_files_eligable_for_action.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_3_files_eligable_for_action.json
@@ -37,8 +37,7 @@
             "notification": {
               "notifyBeforeDays": 5,
               "prolongDays": 10,
-              "keepInformedAdmins": false,
-              "keepInformedOwner": true,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
               "enabled": true,
               "subject": "Lifecycle rule is about to be applied!",
               "body": "Lifecycle rule is about to be applied!"

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_4_files_action_completed.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_4_files_action_completed.json
@@ -37,8 +37,7 @@
             "notification": {
               "notifyBeforeDays": 5,
               "prolongDays": 10,
-              "keepInformedAdmins": false,
-              "keepInformedOwner": true,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
               "enabled": true,
               "subject": "Lifecycle rule is about to be applied!",
               "body": "Lifecycle rule is about to be applied!"

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_5_files_action_completed_and_eligable_for_next_notification.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_5_files_action_completed_and_eligable_for_next_notification.json
@@ -41,8 +41,7 @@
             "notification": {
               "notifyBeforeDays": 5,
               "prolongDays": 10,
-              "keepInformedAdmins": false,
-              "keepInformedOwner": true,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
               "enabled": true,
               "subject": "Lifecycle rule is about to be applied!",
               "body": "Lifecycle rule is about to be applied!"

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_6_files_action_completed_and_eligable_for_next_action.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_6_files_action_completed_and_eligable_for_next_action.json
@@ -41,8 +41,7 @@
             "notification": {
               "notifyBeforeDays": 5,
               "prolongDays": 10,
-              "keepInformedAdmins": false,
-              "keepInformedOwner": true,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
               "enabled": true,
               "subject": "Lifecycle rule is about to be applied!",
               "body": "Lifecycle rule is about to be applied!"

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_7_two_rules_one_to_notify_one_to_perform_action.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_7_two_rules_one_to_notify_one_to_perform_action.json
@@ -40,8 +40,7 @@
             "notification": {
               "notifyBeforeDays": 5,
               "prolongDays": 10,
-              "keepInformedAdmins": false,
-              "keepInformedOwner": true,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
               "enabled": true,
               "subject": "Lifecycle rule is about to be applied!",
               "body": "Lifecycle rule is about to be applied!"

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_7_two_rules_one_to_notify_one_to_perform_action.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_7_two_rules_one_to_notify_one_to_perform_action.json
@@ -64,8 +64,7 @@
             "notification": {
               "notifyBeforeDays": 1,
               "prolongDays": 10,
-              "keepInformedAdmins": false,
-              "keepInformedOwner": true,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
               "enabled": true,
               "subject": "Lifecycle rule is about to be applied!",
               "body": "Lifecycle rule is about to be applied!"

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_8_transition_criterion_MATCHING_FILES_eligable_to_notify.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_8_transition_criterion_MATCHING_FILES_eligable_to_notify.json
@@ -41,8 +41,7 @@
             "notification": {
               "notifyBeforeDays": 10,
               "prolongDays": 10,
-              "keepInformedAdmins": false,
-              "keepInformedOwner": true,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
               "enabled": true,
               "subject": "Lifecycle rule is about to be applied!",
               "body": "Lifecycle rule is about to be applied!"

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_9_transition_criterion_MATCHING_FILES_eligable_to_action.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_9_transition_criterion_MATCHING_FILES_eligable_to_action.json
@@ -41,8 +41,7 @@
             "notification": {
               "notifyBeforeDays": 10,
               "prolongDays": 10,
-              "keepInformedAdmins": false,
-              "keepInformedOwner": true,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
               "enabled": true,
               "subject": "Lifecycle rule is about to be applied!",
               "body": "Lifecycle rule is about to be applied!"

--- a/storage-lifecycle-service/sls/app.py
+++ b/storage-lifecycle-service/sls/app.py
@@ -40,7 +40,7 @@ def main():
 
 
 def run_application(args, logger):
-    data_source = configure_cp_data_source(args.cp_api_url, args.cp_api_token, args.log_dir, args.data_source)
+    data_source = configure_cp_data_source(args.cp_api_url, args.cp_api_token, args.log_dir, logger, args.data_source)
 
     if not re.match("\\d\\d:\\d\\d", args.at):
         raise RuntimeError("Wrong format of 'at' argument: {}, please specify it in format: 00:00".format(args.at))

--- a/storage-lifecycle-service/sls/app/storage_synchronizer.py
+++ b/storage-lifecycle-service/sls/app/storage_synchronizer.py
@@ -387,22 +387,17 @@ class StorageLifecycleSynchronizer:
 
     def _send_notification(self, storage, rule, notification_properties):
         def _prepare_massage():
-            cc_users = [
-                self.cp_data_source.load_user(user_id)["userName"]
-                for user_id in (rule.notification.user_to_notify_ids if rule.notification.user_to_notify_ids else [])
-            ]
-            if rule.notification.keep_informed_admins:
-                role_admin = self.cp_data_source.load_role(ROLE_ADMIN_ID)
-                if role_admin and "users" in role_admin:
-                    cc_users.extend([user["userName"] for user in role_admin["users"]])
+            cc_users = []
+            for recipient in rule.notification.recipients:
+                if recipient["principal"]:
+                    cc_users.append(recipient["name"])
+                else:
+                    # TODO add method to load role with users by name, not id
+                    loaded_role = self.cp_data_source.load_role(recipient["name"])
+                    if loaded_role and "users" in loaded_role:
+                        cc_users.extend([user["userName"] for user in loaded_role["users"]])
 
-            _to_user = None
-            if rule.notification.keep_informed_owner:
-                loaded = self.cp_data_source.load_user_by_name(storage.owner)
-                _to_user = loaded["userName"]
-            if not _to_user:
-                _to_user = next(iter(cc_users), None)
-
+            _to_user = next(iter(cc_users), None)
             notification_parameters = {
                 "storageName": storage.name,
                 "storageId": storage.id,

--- a/storage-lifecycle-service/sls/app/storage_synchronizer.py
+++ b/storage-lifecycle-service/sls/app/storage_synchronizer.py
@@ -392,8 +392,7 @@ class StorageLifecycleSynchronizer:
                 if recipient["principal"]:
                     cc_users.append(recipient["name"])
                 else:
-                    # TODO add method to load role with users by name, not id
-                    loaded_role = self.cp_data_source.load_role(recipient["name"])
+                    loaded_role = self.cp_data_source.load_role_by_name(recipient["name"])
                     if loaded_role and "users" in loaded_role:
                         cc_users.extend([user["userName"] for user in loaded_role["users"]])
 

--- a/storage-lifecycle-service/sls/datasorce/cp_data_source.py
+++ b/storage-lifecycle-service/sls/datasorce/cp_data_source.py
@@ -64,6 +64,9 @@ class CloudPipelineDataSource:
     def load_role(self, role_id):
         pass
 
+    def load_role_by_name(self, role_name):
+        pass
+
     def load_user_by_name(self, username):
         pass
 
@@ -71,6 +74,9 @@ class CloudPipelineDataSource:
         pass
 
     def load_preference(self, preference_name):
+        pass
+
+    def load_regions(self):
         pass
 
     def _load_default_lifecycle_rule_notification(self):
@@ -124,6 +130,9 @@ class RESTApiCloudPipelineDataSource(CloudPipelineDataSource):
 
     def load_role(self, role_id):
         return self.api.load_role(role_id)
+
+    def load_role_by_name(self, role_name):
+        return self.api.load_role_by_name(role_name)
 
     def load_regions(self):
         return self.api.get_regions()

--- a/storage-lifecycle-service/sls/model/rule_model.py
+++ b/storage-lifecycle-service/sls/model/rule_model.py
@@ -86,7 +86,6 @@ class StorageLifecycleRuleExecution:
 class LifecycleRuleParser:
 
     def __init__(self, default_lifecycle_notification):
-        # TODO Test this palace
         self.default_lifecycle_notification = default_lifecycle_notification
 
     def parse_rule(self, rule_json_dict):

--- a/storage-lifecycle-service/sls/model/rule_model.py
+++ b/storage-lifecycle-service/sls/model/rule_model.py
@@ -41,13 +41,10 @@ class StorageLifecycleRuleProlongation:
 
 class StorageLifecycleNotification:
 
-    def __init__(self, notify_before_days, prolong_days, user_to_notify_ids,
-                 keep_informed_admins, keep_informed_owner, enabled, subject, body):
+    def __init__(self, notify_before_days, prolong_days, recipients, enabled, subject, body):
         self.notify_before_days = notify_before_days
         self.prolong_days = prolong_days
-        self.user_to_notify_ids = user_to_notify_ids
-        self.keep_informed_admins = keep_informed_admins
-        self.keep_informed_owner = keep_informed_owner
+        self.recipients = recipients
         self.enabled = enabled
         self.subject = subject
         self.body = body
@@ -88,8 +85,9 @@ class StorageLifecycleRuleExecution:
 
 class LifecycleRuleParser:
 
-    def __init__(self, default_lifecycle_notification_json):
-        self.default_lifecycle_notification = self._parse_notification(default_lifecycle_notification_json)
+    def __init__(self, default_lifecycle_notification):
+        # TODO Test this palace
+        self.default_lifecycle_notification = default_lifecycle_notification
 
     def parse_rule(self, rule_json_dict):
         if not rule_json_dict:
@@ -187,15 +185,9 @@ class LifecycleRuleParser:
             prolong_days=notification_json["prolongDays"]
             if "prolongDays" in notification_json
             else None,
-            user_to_notify_ids=notification_json["informedUserIds"]
-            if "informedUserIds" in notification_json
+            recipients=notification_json["recipients"]
+            if "recipients" in notification_json
             else [],
-            keep_informed_admins=notification_json["keepInformedAdmins"]
-            if "keepInformedAdmins" in notification_json
-            else False,
-            keep_informed_owner=notification_json["keepInformedOwner"]
-            if "keepInformedOwner" in notification_json
-            else False,
             enabled=notification_json["enabled"]
             if "enabled" in notification_json
             else True,

--- a/storage-lifecycle-service/tests/test_notification.py
+++ b/storage-lifecycle-service/tests/test_notification.py
@@ -22,7 +22,7 @@ from sls.model.rule_model import StorageLifecycleNotification, StorageLifecycleR
 
 class TestNotificationPositive(unittest.TestCase):
 
-    enabled_notification = StorageLifecycleNotification(7, 7, [], False, False, True, "", "")
+    enabled_notification = StorageLifecycleNotification(7, 7, [], True, "", "")
     completed_execution = StorageLifecycleRuleExecution(1, 1, sls.app.storage_synchronizer.EXECUTION_SUCCESS_STATUS, "/", "GLACIER", datetime.datetime.now())
     failed_execution = StorageLifecycleRuleExecution(1, 1, sls.app.storage_synchronizer.EXECUTION_FAILED_STATUS, "/", "GLACIER", datetime.datetime.now())
 
@@ -66,8 +66,8 @@ class TestNotificationPositive(unittest.TestCase):
 
 class TestNotificationNegative(unittest.TestCase):
 
-    enabled_notification = StorageLifecycleNotification(7, 7, [], False, False, True, "", "")
-    disabled_notification = StorageLifecycleNotification(None, None, None, False, False, False, None, None)
+    enabled_notification = StorageLifecycleNotification(7, 7, [], True, "", "")
+    disabled_notification = StorageLifecycleNotification(None, None, None, False, None, None)
     running_execution = StorageLifecycleRuleExecution(1, 1, sls.app.storage_synchronizer.EXECUTION_RUNNING_STATUS, "/", "GLACIER", datetime.datetime.now())
     notification_execution = StorageLifecycleRuleExecution(1, 1, sls.app.storage_synchronizer.EXECUTION_NOTIFICATION_SENT_STATUS, "/", "GLACIER", datetime.datetime.now())
     today = datetime.datetime.now().date()

--- a/workflows/pipe-common/pipeline/api/api.py
+++ b/workflows/pipe-common/pipeline/api/api.py
@@ -228,6 +228,7 @@ class PipelineAPI:
     LOAD_CURRENT_USER = 'whoami'
     LOAD_ROLES = 'role/loadAll?loadUsers={}'
     LOAD_ROLE = 'role/{}'
+    LOAD_ROLE_BY_NAME = 'role?name={}'
     LOAD_USER_BY_NAME = 'user?name={}'
     LOAD_USER = 'user/{}'
     RUN_CONFIGURATION = '/runConfiguration'
@@ -1020,7 +1021,7 @@ class PipelineAPI:
 
     def load_role_by_name(self, name):
         try:
-            return self.execute_request(str(self.api_url) + self.LOAD_ROLE.format(name))
+            return self.execute_request(str(self.api_url) + self.LOAD_ROLE_BY_NAME.format(name))
         except Exception as e:
             raise RuntimeError("Failed to load role by name '{}'.", "Error message: {}".format(str(name),
                                                                                                str(e.message)))

--- a/workflows/pipe-common/pipeline/api/api.py
+++ b/workflows/pipe-common/pipeline/api/api.py
@@ -1018,6 +1018,13 @@ class PipelineAPI:
             raise RuntimeError("Failed to load user by id '{}'.", "Error message: {}".format(str(user_id),
                                                                                              str(e.message)))
 
+    def load_role_by_name(self, name):
+        try:
+            return self.execute_request(str(self.api_url) + self.LOAD_ROLE.format(name))
+        except Exception as e:
+            raise RuntimeError("Failed to load role by name '{}'.", "Error message: {}".format(str(name),
+                                                                                               str(e.message)))
+
     def run_configuration(self, data):
         try:
             result = self.execute_request(str(self.api_url) + self.RUN_CONFIGURATION, method='post',


### PR DESCRIPTION
This PR changes the way how Lifecycle Notification object is processed and notifications are sent.
In short now it is possible to specify as `recipients` not only users but also roles or groups.