### PR TITLE
Create user local accounts with predefined uids and gids

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -86,6 +86,7 @@ import java.util.stream.Collectors;
 import static com.epam.pipeline.manager.preference.PreferenceValidators.isGreaterThan;
 import static com.epam.pipeline.manager.preference.PreferenceValidators.isGreaterThanOrEquals;
 import static com.epam.pipeline.manager.preference.PreferenceValidators.isLessThan;
+import static com.epam.pipeline.manager.preference.PreferenceValidators.isNotBlank;
 import static com.epam.pipeline.manager.preference.PreferenceValidators.isNotLessThanValueOrNull;
 import static com.epam.pipeline.manager.preference.PreferenceValidators.isNullOrGreaterThan;
 import static com.epam.pipeline.manager.preference.PreferenceValidators.isNullOrValidEnum;
@@ -581,6 +582,8 @@ public class SystemPreferences {
             "pods", LAUNCH_GROUP, pass);
     public static final StringPreference KUBE_POD_SEARCH_PATH = new StringPreference("launch.kube.pod.search.path",
             "pods.default.svc.cluster.local", LAUNCH_GROUP, pass);
+    public static final IntPreference  LAUNCH_UID_SEED = new IntPreference("launch.uid.seed", 70000,
+            LAUNCH_GROUP, pass, true);
 
 
     //DTS submission

--- a/scripts/pipeline-launch/launch.py
+++ b/scripts/pipeline-launch/launch.py
@@ -185,7 +185,7 @@ try:
 
     from pipeline.api import PipelineAPI
     from pipeline.log.logger import LocalLogger, RunLogger, TaskLogger
-    from pipeline.utils.ssh import HostSSH, LogSSH, UserSSH
+    from pipeline.utils.ssh import RemoteHostExecutor, LoggingExecutor, UserExecutor
     from pipeline.utils.path import add_to_path
 
     logging.getLogger('paramiko').setLevel(logging.WARNING)
@@ -214,9 +214,9 @@ try:
     node_ip = _extract_parameter(
         'NODE_IP',
         default_provider=lambda: api.load_run_efficiently(run_id).get('instance', {}).get('nodeIP', ''))
-    node_ssh = HostSSH(host=node_ip, private_key_path=node_private_key_path)
-    node_ssh = LogSSH(logger=logger, inner=node_ssh)
-    node_ssh = UserSSH(user=node_owner, inner=node_ssh)
+    node_ssh = RemoteHostExecutor(host=node_ip, private_key_path=node_private_key_path)
+    node_ssh = LoggingExecutor(logger=logger, inner=node_ssh)
+    node_ssh = UserExecutor(user=node_owner, inner=node_ssh)
 
     logger.info('Installing pipe common on the node...')
     node_ssh.execute(f'{python_dir}\\python.exe -m pip install -q {common_repo_dir}')
@@ -273,7 +273,7 @@ try:
     if requires_storage_mount:
         task_name = 'MountDataStorages'
         task_logger = TaskLogger(task=task_name, inner=run_logger)
-        task_ssh = LogSSH(logger=task_logger, inner=node_ssh)
+        task_ssh = LoggingExecutor(logger=task_logger, inner=node_ssh)
         task_logger.info('Mounting data storages...')
         # Invocation of WmiMethod is required in order to keep background processes running after ssh session is over
         task_ssh.execute(f'Invoke-WmiMethod -Path \'Win32_Process\' -Name Create -ArgumentList \''
@@ -290,7 +290,7 @@ try:
 
     if requires_cloud_data:
         task_logger = TaskLogger(task='InstallCloudData', inner=run_logger)
-        task_ssh = LogSSH(logger=task_logger, inner=node_ssh)
+        task_ssh = LoggingExecutor(logger=task_logger, inner=node_ssh)
         task_logger.info('Installing Cloud-Data application...')
         task_logger.info('Downloading Cloud-Data App...')
         _download_file(cloud_data_distribution_url, os.path.join(run_dir, 'cloud-data.zip'))
@@ -323,7 +323,7 @@ try:
 
     if requires_drive_mount:
         task_logger = TaskLogger(task='NetworkStorageMapping', inner=run_logger)
-        task_ssh = LogSSH(logger=task_logger, inner=node_ssh)
+        task_ssh = LoggingExecutor(logger=task_logger, inner=node_ssh)
         task_logger.info('Adding EDGE root certificate to trusted...')
         edge_root_cert_path = os.path.join(host_root, 'edge_root.cer')
         from urllib.parse import urlparse
@@ -361,11 +361,10 @@ try:
     sys.exit(exit_code)
 except BaseException as e:
     if _extract_boolean_parameter('CP_CAP_ZOMBIE'):
-        traceback.print_exc()
-        stacktrace = traceback.format_exc()
         try:
-            logger.error('Switching to zombie mode because the error occurred: {} {}'.format(e, stacktrace))
+            logger.error('Switching to zombie mode because the error occurred.', trace=True)
         except:
+            traceback.print_exc()
             print('Switching to zombie mode because the error occurred...')
         import time
 

--- a/scripts/pipeline-launch/launch.sh
+++ b/scripts/pipeline-launch/launch.sh
@@ -635,14 +635,15 @@ function add_self_to_no_proxy() {
 }
 
 function configure_owner_account() {
+    OWNER_ID="$(resolve_owner_id)"
+    export OWNER_ID
+
     if [ "$OWNER" ]; then
         # Crop OWNER account by @ if present
         IFS='@' read -r -a owner_info <<< "$OWNER"
         export OWNER="${owner_info[0]}"
         export OWNER_HOME="${OWNER_HOME:-/home/$OWNER}"
         export OWNER_GROUPS="${OWNER_GROUPS:-root}"
-        OWNER_ID="$(resolve_owner_id)"
-        export OWNER_ID
         if check_cp_cap "CP_CAP_UID_SEED_DISABLED"; then
             if check_user_created "$OWNER"; then
                 return 0

--- a/scripts/pipeline-launch/launch.sh
+++ b/scripts/pipeline-launch/launch.sh
@@ -634,6 +634,106 @@ function add_self_to_no_proxy() {
       export no_proxy="${_self_no_proxy},${_kube_no_proxy}"
 }
 
+function configure_owner_account() {
+    if [ "$OWNER" ]; then
+        # Crop OWNER account by @ if present
+        IFS='@' read -r -a owner_info <<< "$OWNER"
+        export OWNER="${owner_info[0]}"
+        export OWNER_HOME="${OWNER_HOME:-/home/$OWNER}"
+        export OWNER_GROUPS="${OWNER_GROUPS:-root}"
+        UID_SEED="$(get_pipe_preference_low_level "launch.uid.seed" "${CP_CAP_UID_SEED:-70000}")"
+        export UID_SEED
+        OWNER_ID="$(resolve_owner_id)"
+        export OWNER_ID
+        export OWNER_UID=$(( UID_SEED + OWNER_ID ))
+        export OWNER_GID="$OWNER_UID"
+        if check_user_created "$OWNER" "$OWNER_UID" "$OWNER_GID"; then
+            return 0
+        else
+            create_user "$OWNER" "$OWNER" "$OWNER_UID" "$OWNER_GID" "$OWNER_HOME" "$OWNER_GROUPS"
+            return "$?"
+        fi
+    else
+        echo "OWNER is not set - skipping owner account configuration"
+        return 1
+    fi
+}
+
+function get_pipe_preference_low_level() {
+    # Returns Cloud Pipeline preference value similarly to get_pipe_preference
+    # but doesn't require pipe commons to be installed. Therefore can be used
+    # safely anywhere in launch.sh.
+    local _preference="$1"
+    local _default_value="$2"
+
+    _value="$(curl -X GET \
+                   --insecure \
+                   -s \
+                   --max-time 30 \
+                   --header "Accept: application/json" \
+                   --header "Authorization: Bearer $API_TOKEN" \
+                   "$API/preferences/$_preference" \
+        | jq -r '.payload.value')"
+
+    if [[ "$?" == "0" && "$_value" ]]; then
+        echo "$_value"
+    else
+        echo "$_default_value"
+    fi
+}
+
+function resolve_owner_id() {
+    # Returns current cloud pipeline user id
+    curl -X GET \
+         --insecure \
+         -s \
+         --max-time 30 \
+         --header "Accept: application/json" \
+         --header "Authorization: Bearer $API_TOKEN" \
+         "$API/whoami" \
+        | jq -r '.payload.id // 0'
+}
+
+function check_user_created() {
+    local _user_name="$1"
+    local _user_uid="$2"
+    local _user_gid="$3"
+
+    if id "$OWNER" >/dev/null 2>&1; then
+        _existing_user_uid="$(id "$_user_name" -u)"
+        _existing_user_gid="$(id "$_user_name" -g)"
+        echo "User $_user_name (uid: $_existing_user_uid, gid: $_existing_user_gid) already exists"
+        if [[ "$_user_uid" != "$_existing_user_uid" ]] || [[ "$_user_gid" != "$_existing_user_gid" ]]; then
+            echo "Existing user $_user_name (uid: $_existing_user_uid, gid: $_existing_user_gid) configuration is different from the expected one (uid: $_user_uid, gid: $_user_gid)"
+        fi
+        return 0
+    else
+        return 1
+    fi
+}
+
+function create_user() {
+    local _user_name="$1"
+    local _user_pass="$2"
+    local _user_uid="$3"
+    local _user_gid="$4"
+    local _user_home="$5"
+    local _user_groups="$6"
+
+    echo "Creating user $_user_name..."
+    if check_installed "useradd"; then
+        useradd -s "/bin/bash" "$_user_name" -u "$_user_uid" -g "$_user_gid" -G "$_user_groups" -d "$_user_home"
+    elif check_installed "adduser"; then
+        adduser -s "/bin/bash" "$_user_name" -u "$_user_uid" -g "$_user_gid" -G "$_user_groups" -d "$_user_home" -D
+    else
+        echo "Cannot create user $_user_name: useradd and adduser commands not installed"
+        return 1
+    fi
+    echo "$_user_name:$_user_pass" | chpasswd
+    echo "User ${OWNER} (uid: $OWNER_UID, gid: $OWNER_GID) has been created"
+    return 0
+}
+
 function configureHyperThreading() {
     mount -o rw,remount /sys
     if [ "${CP_DISABLE_HYPER_THREADING:-false}" == 'true' ]; then
@@ -1051,35 +1151,9 @@ echo
 echo Configure owner account
 echo "-"
 ######################################################
-if [ "$OWNER" ]
-then
 
-      # Crop OWNER account by @ if present
-	IFS='@' read -r -a owner_info <<< "$OWNER"
-	export OWNER="${owner_info[0]}"
-	export OWNER_HOME="/home/$OWNER"
-
-      export _OWNER_CONFIGURED=1
-
-      # Create OWNER account if not exists
-	if id "$OWNER" >/dev/null 2>&1
-	then
-		echo "User ${OWNER} already exists"
-	else
-            if check_installed "useradd"; then
-                  useradd -s "/bin/bash" "$OWNER" -G root -d $OWNER_HOME
-            elif check_installed "adduser"; then
-                  adduser -s "/bin/bash" $OWNER -d $OWNER_HOME -D -G root
-            else
-                  echo "Cannot add user $OWNER. useradd and adduser commands not installed"
-                  export _OWNER_CONFIGURED=0
-            fi
-		echo "$OWNER:$OWNER" | chpasswd
-	fi
-else
-	echo "OWNER is not set - skipping owner account configuration"
-fi
-
+configure_owner_account
+export _OWNER_CONFIGURED="$?"
 
 echo "------"
 echo
@@ -1434,9 +1508,9 @@ if [ "${OWNER}" ] && [ -d /root/.ssh ]; then
     cp /root/.ssh/* /home/${OWNER}/.ssh/ && \
     chown -R ${OWNER} /home/${OWNER}/.ssh
     ssh_fix_permissions /home/${OWNER}/.ssh
-    echo "Passworldess SSH for ${OWNER} is configured"
+    echo "Passwordless SSH for ${OWNER} is configured"
 else
-    echo "[ERROR] Failed to configure passworldess SSH for \"${OWNER}\""
+    echo "[ERROR] Failed to configure passwordless SSH for \"${OWNER}\""
 fi
 # Double check that root's SSH permissions are correct
 ssh_fix_permissions /root/.ssh
@@ -1710,7 +1784,7 @@ echo Symlink common locations for OWNER and root
 echo "-"
 ######################################################
 
-if [ "$OWNER" ] && [ "$OWNER_HOME" ] && [ $_OWNER_CONFIGURED -ne 0 ]
+if [ "$OWNER" ] && [ "$OWNER_HOME" ] && [ $_OWNER_CONFIGURED -eq 0 ]
 then
       symlink_common_locations "$OWNER" "$OWNER_HOME"
       # Just double check the permissions for the OWNER on the OWNER_HOME

--- a/workflows/pipe-common/pipeline/api/api.py
+++ b/workflows/pipe-common/pipeline/api/api.py
@@ -303,6 +303,9 @@ class PipelineAPI:
             'date': date
         })
 
+    def get_preference_efficiently(self, name):
+        return self._request('GET', 'preferences/' + name) or ''
+
     def _request(self, http_method, endpoint, data=None):
         url = '{}/{}'.format(self.api_url, endpoint)
         count = 0
@@ -1025,6 +1028,10 @@ class PipelineAPI:
         except Exception as e:
             raise RuntimeError("Failed to load role by name '{}'.", "Error message: {}".format(str(name),
                                                                                                str(e.message)))
+
+    def load_users(self):
+        return self._request('GET', 'users') or []
+
 
     def run_configuration(self, data):
         try:

--- a/workflows/pipe-common/pipeline/api/api.py
+++ b/workflows/pipe-common/pipeline/api/api.py
@@ -1032,7 +1032,6 @@ class PipelineAPI:
     def load_users(self):
         return self._request('GET', 'users') or []
 
-
     def run_configuration(self, data):
         try:
             result = self.execute_request(str(self.api_url) + self.RUN_CONFIGURATION, method='post',

--- a/workflows/pipe-common/pipeline/common/common.py
+++ b/workflows/pipe-common/pipeline/common/common.py
@@ -22,10 +22,10 @@ class CmdError(RuntimeError):
 
 def execute(command, logger=None):
     exit_code, out, err = execute_cmd_command_and_get_stdout_stderr(command, silent=True)
-    if out:
-        logger.info(out)
-    if err:
-        logger.warning(err)
+    if out and logger:
+        logger.debug(out)
+    if err and logger:
+        logger.debug(err)
     if exit_code:
         raise CmdError('Command has finished with exit code ' + str(exit_code))
     return out, err

--- a/workflows/pipe-common/pipeline/log/logger.py
+++ b/workflows/pipe-common/pipeline/log/logger.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datetime
 import logging
 import os
+import traceback
 from abc import ABCMeta, abstractmethod
+
+import datetime
 
 from pipeline.api import LogEntry, TaskStatus, PipelineAPI
 
@@ -151,23 +153,23 @@ class CloudPipelineLogger:
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def info(self, message, task=None):
+    def info(self, message, task=None, trace=False):
         pass
 
     @abstractmethod
-    def debug(self, message, task=None):
+    def debug(self, message, task=None, trace=False):
         pass
 
     @abstractmethod
-    def warning(self, message, task=None):
+    def warning(self, message, task=None, trace=False):
         pass
 
     @abstractmethod
-    def success(self, message, task=None):
+    def success(self, message, task=None, trace=False):
         pass
 
     @abstractmethod
-    def error(self, message, task=None):
+    def error(self, message, task=None, trace=False):
         pass
 
 
@@ -176,30 +178,30 @@ class LocalLogger(CloudPipelineLogger):
     def __init__(self, inner=None):
         self._inner = inner
 
-    def info(self, message, task=None):
-        logging.info(message)
+    def info(self, message, task=None, trace=False):
+        logging.info(message, exc_info=trace)
         if self._inner:
-            self._inner.info(message, task)
+            self._inner.info(message, task=task, trace=trace)
 
-    def debug(self, message, task=None):
-        logging.debug(message)
+    def debug(self, message, task=None, trace=False):
+        logging.debug(message, exc_info=trace)
         if self._inner:
-            self._inner.debug(message, task)
+            self._inner.debug(message, task=task, trace=trace)
 
-    def warning(self, message, task=None):
-        logging.warning(message)
+    def warning(self, message, task=None, trace=False):
+        logging.warning(message, exc_info=trace)
         if self._inner:
-            self._inner.warning(message, task)
+            self._inner.warning(message, task=task, trace=trace)
 
-    def success(self, message, task=None):
-        logging.info(message)
+    def success(self, message, task=None, trace=False):
+        logging.info(message, exc_info=trace)
         if self._inner:
-            self._inner.success(message, task)
+            self._inner.success(message, task=task, trace=trace)
 
-    def error(self, message, task=None):
-        logging.error(message)
+    def error(self, message, task=None, trace=False):
+        logging.error(message, exc_info=trace)
         if self._inner:
-            self._inner.error(message, task)
+            self._inner.error(message, task=task, trace=trace)
 
 
 class LevelLogger(CloudPipelineLogger):
@@ -214,25 +216,25 @@ class LevelLogger(CloudPipelineLogger):
         self._level_idx = self._levels.index(level)
         self._inner = inner
 
-    def info(self, message, task=None):
+    def info(self, message, task=None, trace=False):
         if self._applies(self._info_idx):
-            self._inner.info(message, task)
+            self._inner.info(message, task=task, trace=trace)
 
-    def debug(self, message, task=None):
+    def debug(self, message, task=None, trace=False):
         if self._applies(self._debug_idx):
-            self._inner.debug(message, task)
+            self._inner.debug(message, task=task, trace=trace)
 
-    def warning(self, message, task=None):
+    def warning(self, message, task=None, trace=False):
         if self._applies(self._warn_idx):
-            self._inner.warning(message, task)
+            self._inner.warning(message, task=task, trace=trace)
 
-    def success(self, message, task=None):
+    def success(self, message, task=None, trace=False):
         if self._applies(self._info_idx):
-            self._inner.success(message, task)
+            self._inner.success(message, task=task, trace=trace)
 
-    def error(self, message, task=None):
+    def error(self, message, task=None, trace=False):
         if self._applies(self._error_idx):
-            self._inner.error(message, task)
+            self._inner.error(message, task=task, trace=trace)
 
     def _applies(self, level_idx):
         return self._level_idx >= level_idx
@@ -244,20 +246,20 @@ class TaskLogger(CloudPipelineLogger):
         self._task = task
         self._inner = inner
 
-    def info(self, message, task=None):
-        self._inner.info(message, task or self._task)
+    def info(self, message, task=None, trace=False):
+        self._inner.info(message, task=task or self._task, trace=trace)
 
-    def debug(self, message, task=None):
-        self._inner.debug(message, task or self._task)
+    def debug(self, message, task=None, trace=False):
+        self._inner.debug(message, task=task or self._task, trace=trace)
 
-    def warning(self, message, task=None):
-        self._inner.warning(message, task or self._task)
+    def warning(self, message, task=None, trace=False):
+        self._inner.warning(message, task=task or self._task, trace=trace)
 
-    def success(self, message, task=None):
-        self._inner.success(message, task or self._task)
+    def success(self, message, task=None, trace=False):
+        self._inner.success(message, task=task or self._task, trace=trace)
 
-    def error(self, message, task=None):
-        self._inner.error(message, task or self._task)
+    def error(self, message, task=None, trace=False):
+        self._inner.error(message, task=task or self._task, trace=trace)
 
 
 class RunLogger(CloudPipelineLogger):
@@ -270,32 +272,35 @@ class RunLogger(CloudPipelineLogger):
         self._run_id = run_id
         self._inner = inner
 
-    def info(self, message, task=None):
-        self._log(message=message, task=task, status='RUNNING')
+    def info(self, message, task=None, trace=False):
+        self._log(message=message, task=task, status='RUNNING', trace=trace)
         if self._inner:
-            self._inner.info(message, task)
+            self._inner.info(message, task=task, trace=trace)
 
-    def debug(self, message, task=None):
-        self._log(message=message, task=task, status='RUNNING')
+    def debug(self, message, task=None, trace=False):
+        self._log(message=message, task=task, status='RUNNING', trace=trace)
         if self._inner:
-            self._inner.debug(message, task)
+            self._inner.debug(message, task=task, trace=trace)
 
-    def warning(self, message, task=None):
-        self._log(message=message, task=task, status='RUNNING')
+    def warning(self, message, task=None, trace=False):
+        self._log(message=message, task=task, status='RUNNING', trace=trace)
         if self._inner:
-            self._inner.warning(message, task)
+            self._inner.warning(message, task=task, trace=trace)
 
-    def success(self, message, task=None):
-        self._log(message=message, task=task, status='SUCCESS')
+    def success(self, message, task=None, trace=False):
+        self._log(message=message, task=task, status='SUCCESS', trace=trace)
         if self._inner:
-            self._inner.success(message, task)
+            self._inner.success(message, task=task, trace=trace)
 
-    def error(self, message, task=None):
-        self._log(message=message, task=task, status='FAILURE')
+    def error(self, message, task=None, trace=False):
+        self._log(message=message, task=task, status='FAILURE', trace=trace)
         if self._inner:
-            self._inner.error(message, task)
+            self._inner.error(message, task=task, trace=trace)
 
-    def _log(self, message, task, status):
+    def _log(self, message, task, status, trace):
         now_utc = datetime.datetime.utcnow()
         formatted_dt = self._DATE_WITH_MILLISECONDS % (now_utc.strftime(self._DATE_FORMAT), now_utc.microsecond / 1000)
+        if trace:
+            stacktrace = traceback.format_exc()
+            message += ' ' + stacktrace
         self._api.log_efficiently(run_id=self._run_id, message=message, task=task, status=status, date=formatted_dt)

--- a/workflows/pipe-common/pipeline/utils/account.py
+++ b/workflows/pipe-common/pipeline/utils/account.py
@@ -66,7 +66,7 @@ def _create_lin_user(executor, username, password, uid=None, gid=None, home_dir=
         if _is_command_available('useradd', executor) and _is_command_available('groupadd', executor):
             if gid:
                 executor.execute('groupadd "{groupname}" '.format(groupname=username) + gid_arg)
-            executor.execute('useradd -s "/bin/bash" "{username}" '.format(username=username)
+            executor.execute('useradd -m -s "/bin/bash" "{username}" '.format(username=username)
                              + uid_arg + gid_arg + home_dir_arg + groups_arg)
             executor.execute('echo "{username}:{password}" | chpasswd'
                              .format(username=username, password=password))
@@ -74,7 +74,7 @@ def _create_lin_user(executor, username, password, uid=None, gid=None, home_dir=
         if _is_command_available('adduser', executor) and _is_command_available('addgroup', executor):
             if gid:
                 executor.execute('addgroup "{groupname}" '.format(groupname=username) + gid_arg)
-            executor.execute('adduser -s "/bin/bash" "{username}" '.format(username=username)
+            executor.execute('adduser -m -s "/bin/bash" "{username}" '.format(username=username)
                              + uid_arg + gid_arg + home_dir_arg + groups_arg)
             executor.execute('echo "{username}:{password}" | chpasswd'
                              .format(username=username, password=password))

--- a/workflows/pipe-common/pipeline/utils/account.py
+++ b/workflows/pipe-common/pipeline/utils/account.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import platform
 
 from pipeline.common.common import execute
-from pipeline.utils.path import mkdir
+from pipeline.utils.plat import is_windows
 
 _USER_ALREADY_EXISTS_WIN_ERROR = 2224
 _USER_ALREADY_IN_GROUP_WIN_ERROR = 1378
@@ -54,27 +53,56 @@ def _add_win_user_to_group(username, domain, group, skip_existing=False):
             raise
 
 
-def _create_lin_user(username, password, home_dir=None, skip_existing=False, logger=None):
+def _create_lin_user(username, password, uid=None, gid=None, home_dir=None, groups=None, skip_existing=False,
+                     logger=None):
     try:
         execute('id -u {username}'.format(username=username))
         if not skip_existing:
             raise RuntimeError('User {} already exists.'.format(username))
-    except:
-        if home_dir:
-            mkdir(os.path.dirname(home_dir))
-            home_dir_arg = '-d "{home_dir}" '.format(home_dir=home_dir)
-        else:
-            home_dir_arg = ''
-        execute(('useradd -m -s /bin/bash ' + home_dir_arg + ' -p $(openssl passwd -1 "{password}") "{username}"')
-                .format(username=username, password=password),
-                logger=logger)
+    except Exception:
+        uid_arg = '-u "{uid}" '.format(uid=uid) if uid else ''
+        gid_arg = '-g "{gid}" '.format(gid=gid) if gid else ''
+        groups_arg = '-G "{groups}" '.format(groups=groups) if groups else ''
+        home_dir_arg = '-d "{home_dir}" '.format(home_dir=home_dir) if home_dir else ''
+        if _is_command_available('useradd', logger) and _is_command_available('groupadd', logger):
+            if gid:
+                execute(('groupadd "{groupname}" -p $(openssl passwd -1 "{password}") '
+                        + gid_arg)
+                        .format(groupname=username, password=password))
+            execute(('useradd -s "/bin/bash" "{username}" -p $(openssl passwd -1 "{password}") '
+                     + uid_arg + gid_arg + home_dir_arg + groups_arg)
+                    .format(username=username, password=password),
+                    logger=logger)
+            return
+        if _is_command_available('adduser', logger) and _is_command_available('addgroup', logger):
+            if gid:
+                execute(('addgroup "{groupname}" -p $(openssl passwd -1 "{password}") '
+                        + gid_arg)
+                        .format(groupname=username, password=password))
+            execute(('adduser -s "/bin/bash" "{username}" -p $(openssl passwd -1 "{password}") '
+                     + uid_arg + gid_arg + home_dir_arg + groups_arg)
+                    .format(username=username, password=password),
+                    logger=logger)
+            return
+        raise RuntimeError('User {username} cannot be created because both useradd/groupadd and adduser/addgroup '
+                           'commands are not available.'
+                           .format(username=username))
 
 
-def create_user(username, password, groups='', home_dir=None, skip_existing=False, logger=None):
-    current_platform = platform.system()
-    if current_platform == 'Windows':
+def _is_command_available(command, logger):
+    try:
+        execute('command -v %s' % command, logger=logger)
+        return True
+    except Exception:
+        logger.warning('Command %s is not available' % command)
+        return False
+
+
+def create_user(username, password, uid=None, gid=None, groups='', home_dir=None, skip_existing=False, logger=None):
+    if is_windows():
         _create_win_user(username, password, skip_existing=skip_existing)
         for group in groups.split(','):
             _add_win_user_to_group(username, platform.node(), group, skip_existing=skip_existing)
     else:
-        _create_lin_user(username, password, home_dir=home_dir, skip_existing=skip_existing, logger=logger)
+        _create_lin_user(username, password, uid=uid, gid=gid, groups=groups, home_dir=home_dir,
+                         skip_existing=skip_existing, logger=logger)

--- a/workflows/pipe-common/pipeline/utils/account.py
+++ b/workflows/pipe-common/pipeline/utils/account.py
@@ -56,7 +56,7 @@ def _add_win_user_to_group(username, domain, group, skip_existing=False):
 def _create_lin_user(username, password, uid=None, gid=None, home_dir=None, groups=None, skip_existing=False,
                      logger=None):
     try:
-        execute('id -u {username}'.format(username=username))
+        execute('id {username}'.format(username=username))
         if not skip_existing:
             raise RuntimeError('User {} already exists.'.format(username))
     except Exception:

--- a/workflows/pipe-common/pipeline/utils/ssh.py
+++ b/workflows/pipe-common/pipeline/utils/ssh.py
@@ -12,16 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import subprocess
 from abc import ABCMeta, abstractmethod
 
 import paramiko
 
+from pipeline.utils.plat import is_windows
 
-class SSHError(RuntimeError):
+
+class ExecutorError(RuntimeError):
     pass
 
 
-class CloudPipelineSSH:
+class SSHError(ExecutorError):
+    pass
+
+
+class CloudPipelineExecutor:
     __metaclass__ = ABCMeta
 
     @abstractmethod
@@ -29,7 +37,7 @@ class CloudPipelineSSH:
         pass
 
 
-class LogSSH(CloudPipelineSSH):
+class LoggingExecutor(CloudPipelineExecutor):
 
     def __init__(self, logger, inner):
         self._logger = logger
@@ -39,7 +47,7 @@ class LogSSH(CloudPipelineSSH):
         self._inner.execute(command, user=user, logger=logger or self._logger)
 
 
-class UserSSH(CloudPipelineSSH):
+class UserExecutor(CloudPipelineExecutor):
 
     def __init__(self, user, inner):
         self._user = user
@@ -49,7 +57,7 @@ class UserSSH(CloudPipelineSSH):
         self._inner.execute(command, user=user or self._user, logger=logger)
 
 
-class HostSSH(CloudPipelineSSH):
+class RemoteHostExecutor(CloudPipelineExecutor):
 
     def __init__(self, host, private_key_path):
         self._host = host
@@ -71,3 +79,42 @@ class HostSSH(CloudPipelineSSH):
         if exit_code != 0:
             raise SSHError('Command has finished with exit code ' + str(exit_code))
         client.close()
+
+
+class LocalExecutor(CloudPipelineExecutor):
+
+    def __init__(self):
+        pass
+
+    def execute(self, command, user=None, logger=None):
+        exit_code, out, err = self._execute(command, user=user)
+        if out:
+            logger.debug(out)
+        if err:
+            logger.debug(err)
+        if exit_code != 0:
+            raise ExecutorError('Command has finished with exit code ' + str(exit_code))
+
+    def _execute(self, command, user=None):
+        stdout, stderr = self._get_stdout_and_stderr()
+        p = subprocess.Popen(command, shell=True, stdout=stdout, stderr=stderr,
+                             preexec_fn=self._execute_as_fn(user))
+        out, err = p.communicate()
+        return p.returncode, out, err
+
+    def _get_stdout_and_stderr(self):
+        return (None, None) if is_windows() else (subprocess.PIPE, subprocess.PIPE)
+
+    def _execute_as_fn(self, user):
+        if not user:
+            return None
+        if is_windows():
+            return None
+
+        user_uid, user_gid = user
+
+        def _execute_as():
+            os.setgid(user_gid)
+            os.setuid(user_uid)
+
+        return _execute_as

--- a/workflows/pipe-common/pipeline/utils/ssh.py
+++ b/workflows/pipe-common/pipeline/utils/ssh.py
@@ -88,9 +88,9 @@ class LocalExecutor(CloudPipelineExecutor):
 
     def execute(self, command, user=None, logger=None):
         exit_code, out, err = self._execute(command, user=user)
-        if out:
+        if out and logger:
             logger.debug(out)
-        if err:
+        if err and logger:
             logger.debug(err)
         if exit_code != 0:
             raise ExecutorError('Command has finished with exit code ' + str(exit_code))

--- a/workflows/pipe-common/scripts/configure_shared_users.py
+++ b/workflows/pipe-common/scripts/configure_shared_users.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,13 +14,12 @@
 
 import logging
 import os
-import traceback
 
 from pipeline.api import PipelineAPI
-from pipeline.common.common import execute
 from pipeline.log.logger import LocalLogger, RunLogger, TaskLogger, LevelLogger
 from pipeline.utils.package import install_package
 from pipeline.utils.path import mkdir
+from pipeline.utils.ssh import LocalExecutor, LoggingExecutor
 
 _MANAGER_CLUSTER_ROLE = 'master'
 _ETC_DIRECTORY = '/etc'
@@ -51,6 +50,9 @@ def configure_shared_users():
     logger = LevelLogger(level=logging_level, inner=logger)
     logger = LocalLogger(inner=logger)
 
+    executor = LocalExecutor()
+    executor = LoggingExecutor(logger=logger, inner=executor)
+
     try:
         logger.info('Configuring shared users and groups management...')
 
@@ -73,24 +75,20 @@ def configure_shared_users():
 
         logger.info('Mounting etc directory from manager node...')
         mkdir(_ETC_DIRECTORY_SHARED)
-        execute('sshfs -o ro,allow_other root@{parent_run_host}:{etc_directory} {etc_directory_shared}'
-                .format(parent_run_host=parent_run_host,
-                        etc_directory=_ETC_DIRECTORY, etc_directory_shared=_ETC_DIRECTORY_SHARED),
-                logger=logger)
+        executor.execute('sshfs -o ro,allow_other root@{parent_run_host}:{etc_directory} {etc_directory_shared}'
+                         .format(parent_run_host=parent_run_host,
+                                 etc_directory=_ETC_DIRECTORY, etc_directory_shared=_ETC_DIRECTORY_SHARED))
 
         logger.info('Mounting users and groups from manager node etc directory...')
         for etc_file_path in _ETC_FILE_PATHS:
             file_path = os.path.join(_ETC_DIRECTORY, etc_file_path)
             file_path_shared = os.path.join(_ETC_DIRECTORY_SHARED, etc_file_path)
-            execute('mount -o ro,bind,allow_other {file_path_shared} {file_path}'
-                    .format(file_path=file_path, file_path_shared=file_path_shared),
-                    logger=logger)
+            executor.execute('mount -o ro,bind,allow_other {file_path_shared} {file_path}'
+                             .format(file_path=file_path, file_path_shared=file_path_shared))
 
         logger.success('Shared users and groups management was successfully configured.')
-    except BaseException as e:
-        traceback.print_exc()
-        stacktrace = traceback.format_exc()
-        logger.error('Shared users and groups management configuration has failed: {} {}'.format(e, stacktrace))
+    except BaseException:
+        logger.error('Shared users and groups management configuration has failed.', trace=True)
         raise
 
 

--- a/workflows/pipe-common/scripts/serve_desktop.py
+++ b/workflows/pipe-common/scripts/serve_desktop.py
@@ -29,7 +29,7 @@ except:
 from pipeline.api import PipelineAPI
 from pipeline.log.logger import LocalLogger
 from pipeline.utils.plat import is_windows
-from pipeline.utils.ssh import HostSSH, LogSSH, UserSSH
+from pipeline.utils.ssh import RemoteHostExecutor, UserExecutor, LoggingExecutor
 
 NXS = 'nxs'
 DCV = 'dcv'
@@ -210,9 +210,9 @@ def _resolve_executor(run_id, api, logger):
         host_root = _extract_parameter('CP_HOST_ROOT_DIR', default='c:\\host')
         node_private_key_path = _extract_parameter('CP_NODE_PRIVATE_KEY',
                                                    default=os.path.join(host_root, '.ssh', 'id_rsa'))
-        executor = HostSSH(host=node_ip, private_key_path=node_private_key_path)
-        executor = LogSSH(logger=logger, inner=executor)
-        return UserSSH(user='Administrator', inner=executor)
+        executor = RemoteHostExecutor(host=node_ip, private_key_path=node_private_key_path)
+        executor = LoggingExecutor(logger=logger, inner=executor)
+        return UserExecutor(user='Administrator', inner=executor)
 
 
 def _scramble_pass(user_pass):

--- a/workflows/pipe-common/scripts/sync_users.py
+++ b/workflows/pipe-common/scripts/sync_users.py
@@ -106,7 +106,8 @@ def sync_users():
                     if not user_id:
                         logger.warning('Skipping {} user creation since the corresponding details have not been found.')
                         continue
-                    user_uid, user_gid, user_home_dir = _create_account(user, user_id, uid_seed, root_home_dir, logger)
+                    user_uid, user_gid, user_home_dir = _create_account(user, user_id, uid_seed, root_home_dir,
+                                                                        executor, logger)
                     _configure_bash_profile(user, user_uid, user_gid, user_home_dir, logger)
                     _configure_ssh_keys(user, user_uid, user_gid, user_home_dir, executor, logger)
                 except KeyboardInterrupt:
@@ -154,14 +155,14 @@ def _get_local_users():
             yield stripped_line.split(':')[0]
 
 
-def _create_account(user, user_id, uid_seed, root_home_dir, logger):
+def _create_account(user, user_id, uid_seed, root_home_dir, executor, logger):
     logger.debug('Creating {} user account...'.format(user))
     user_uid, user_gid = _resolve_uid_gid(user_id, uid_seed)
     user_home_dir = os.path.join(root_home_dir, user)
     mkdir(user_home_dir)
     _set_permissions(user_home_dir, user_uid, user_gid)
     create_user(user, user, uid=user_uid, gid=user_gid, home_dir=user_home_dir,
-                skip_existing=True, logger=logger)
+                skip_existing=True, executor=executor)
     logger.info('User {} account has been created.'.format(user))
     return user_uid, user_gid, user_home_dir
 

--- a/workflows/pipe-common/shell/env_setup_user_profile
+++ b/workflows/pipe-common/shell/env_setup_user_profile
@@ -39,20 +39,7 @@ if [ -f "$_OWNER_ATTRIBUTES_ENV_FILE" ]; then
     rm -f "$_OWNER_ATTRIBUTES_ENV_FILE"
 fi
 
-echo "Getting owner ($OWNER) user id"
-_OWNER_ID=$(curl -s \
-            --max-time 30 \
-            -X GET \
-            --insecure \
-            --header "Accept: application/json" \
-            --header "Authorization: Bearer $API_TOKEN" \
-            "$API/whoami" | jq -r '.payload.id // 0')
-
-if [ "$_OWNER_ID" == 0 ]; then
-    echo "Cannot determine owner's user id (current owner is $OWNER)"
-    exit 1
-fi
-echo "Owner ($OWNER) user id is: $_OWNER_ID"
+echo "Resolving $OWNER user (id: $OWNER_ID) attributes..."
 
 _OWNER_ATTRIBUTES="$(curl -s \
                     --max-time 30 \
@@ -61,7 +48,7 @@ _OWNER_ATTRIBUTES="$(curl -s \
                     --header 'Content-Type: application/json' \
                     --header 'Accept: application/json' \
                     --header "Authorization: Bearer $API_TOKEN" \
-                    -d "[ { \"entityId\": $_OWNER_ID, \"entityClass\": \"PIPELINE_USER\" } ]" \
+                    -d "[ { \"entityId\": $OWNER_ID, \"entityClass\": \"PIPELINE_USER\" } ]" \
                     "$API/metadata/load")"
 
 

--- a/workflows/pipe-common/shell/ssh_setup_personal_keys
+++ b/workflows/pipe-common/shell/ssh_setup_personal_keys
@@ -50,21 +50,8 @@ OWNER_SSH_CONFIG_LOCATION=$OWNER_SSH_DIR/config
 mkdir -p $(dirname $OWNER_SSH_PRV_LOCATION)
 
 ## SSH keys configuration
-### Setup user id
-echo "Getting owner ($OWNER) user id"
-OWNER_ID=$(curl -s \
-            --max-time 30 \
-            -X GET \
-            --insecure \
-            --header "Accept: application/json" \
-            --header "Authorization: Bearer $API_TOKEN" \
-            "$API/whoami" | jq -r '.payload.id // 0')
 
-if [ "$OWNER_ID" == 0 ]; then
-    echo "Cannot determine owner's user id (current owner is $OWNER)"
-    exit 1
-fi
-echo "Owner ($OWNER) user id is: $OWNER_ID"
+echo "Resolving $OWNER user (id: $OWNER_ID) attributes..."
 
 ### Setup user's keys values
 OWNER_ATTRIBUTES="$(curl -s \


### PR DESCRIPTION
Relates to #2802.

The pull request brings support for user local accounts creation with predefined uids and gids. The functionality works for both owner account and syncing user accounts. From now on Cloud Pipeline user local account uid will be a sum of Cloud Pipeline user id and local accounts uid seed.

The following system preference is introduced:
- `launch.uid.seed` specifies local accounts uid seed. Defaults to `70000`.

Additionally, the following run parameters are introduced:
- `CP_CAP_UID_SEED` specifies local accounts uid seed only if the corresponding system preference is not set. Defaults to `70000`.
- `CP_CAP_UID_SEED_DISABLED` disables local account uids calculation. Instead it enables previously used random local account uids usage. Defaults to `false`.