### PR TITLE
Restrict passwordless ssh access in pipe tunnel

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1668,8 +1668,8 @@ def start_tunnel_options(decorating_func):
                   help='Path to .ssh directory for passwordless ssh configuration on Linux.')
     @click.option('-sh', '--ssh-host', required=False, type=str,
                   help='Host name for passwordless ssh configuration.')
-    @click.option('-su', '--ssh-user', required=False, type=str,
-                  help='User name for passwordless ssh configuration.')
+    @click.option('-su', '--ssh-user', required=False, type=str, multiple=True,
+                  help='User name for passwordless ssh configuration. Multiple options supported.')
     @click.option('-sk', '--ssh-keep', required=False, is_flag=True, default=False,
                   help='Keeps passwordless ssh configuration after tunnel stopping.')
     @click.option('-d', '--direct', required=False, is_flag=True, default=False,

--- a/pipe-cli/src/utilities/ssh_operations.py
+++ b/pipe-cli/src/utilities/ssh_operations.py
@@ -66,10 +66,12 @@ class TunnelError(Exception):
 
 class PasswordlessSSHConfig:
 
-    def __init__(self, run_id, conn_info, ssh_user=None, ssh_path=None):
+    def __init__(self, run_id, conn_info, ssh_users=None, ssh_path=None):
         self.run_ssh_mode = resolve_run_ssh_mode(conn_info)
         self.run_owner = conn_info.owner.split('@')[0]
-        self.user = ssh_user or resolve_run_ssh_user(self.run_ssh_mode, self.run_owner)
+        _non_unique_users = ssh_users or [resolve_run_ssh_user(self.run_ssh_mode, self.run_owner)]
+        self.users = list(set(_non_unique_users))
+        self.user = _non_unique_users[0]
         self.key_name = 'pipeline-{}-{}-{}'.format(run_id, int(time.time()), random.randint(0, sys.maxsize))
 
         self.remote_keys_path = '/root/.pipe/.keys'
@@ -78,7 +80,7 @@ class PasswordlessSSHConfig:
         self.remote_ppk_key_path = '{}.ppk'.format(self.remote_private_key_path)
         self.remote_host_rsa_public_key_path = '/etc/ssh/ssh_host_rsa_key.pub'
         self.remote_host_ed25519_public_key_path = '/etc/ssh/ssh_host_ed25519_key.pub'
-        self.remote_authorized_users = list({DEFAULT_SSH_USER, self.run_owner, self.user})
+        self.remote_authorized_users = self.users
 
         self.local_keys_path = os.path.join(os.path.expanduser('~'), '.pipe', '.keys')
         self.local_private_key_path = os.path.join(self.local_keys_path, self.key_name)
@@ -100,7 +102,7 @@ class PasswordlessSSHConfig:
 class TunnelArgs:
 
     def __init__(self, host_id=None, local_ports=None, remote_ports=None,
-                 ssh=None, ssh_path=None, ssh_host=None,
+                 ssh=None, ssh_path=None, ssh_host=None, ssh_users=None,
                  direct=None):
         self.host_id = str(host_id) if host_id else None
         self.local_ports = local_ports
@@ -112,6 +114,7 @@ class TunnelArgs:
         self.ssh = ssh
         self.ssh_path = str(ssh_path) if ssh_path else None
         self.ssh_host = str(ssh_host) if ssh_host else None
+        self.ssh_users = ssh_users
         self.direct = direct
 
     @staticmethod
@@ -123,6 +126,7 @@ class TunnelArgs:
             ssh=parsed_args.get('ssh'),
             ssh_path=parsed_args.get('ssh_path'),
             ssh_host=parsed_args.get('ssh_host'),
+            ssh_users=parsed_args.get('ssh_user'),
             direct=parsed_args.get('direct'),
         )
 
@@ -477,7 +481,7 @@ def parse_scp_location(location):
 
 
 def create_tunnel(host_id, local_ports_str, remote_ports_str, connection_timeout,
-                  ssh, ssh_path, ssh_host, ssh_user, ssh_keep, direct, log_file, log_level,
+                  ssh, ssh_path, ssh_host, ssh_users, ssh_keep, direct, log_file, log_level,
                   timeout, timeout_stop, foreground,
                   keep_existing, keep_same, replace_existing, replace_different, ignore_owner, ignore_existing,
                   retries, region, parse_tunnel_args):
@@ -502,13 +506,13 @@ def create_tunnel(host_id, local_ports_str, remote_ports_str, connection_timeout
         raise RuntimeError('Option -s/--ssh can be used only for run tunnels.')
     if not ignore_existing:
         check_existing_tunnels(host_id, local_ports, remote_ports,
-                               ssh, ssh_path, ssh_host, ssh_user, direct, log_file, timeout_stop,
+                               ssh, ssh_path, ssh_host, ssh_users, direct, log_file, timeout_stop,
                                keep_existing, keep_same, replace_existing, replace_different, ignore_owner,
                                region, retries, parse_tunnel_args)
         check_local_ports(local_ports)
     if run_id:
         create_tunnel_to_run(run_id, local_ports, remote_ports, connection_timeout,
-                             ssh, ssh_path, ssh_host, ssh_user, ssh_keep, direct, log_file, log_level,
+                             ssh, ssh_path, ssh_host, ssh_users, ssh_keep, direct, log_file, log_level,
                              timeout, foreground, retries, region)
     else:
         create_tunnel_to_host(host_id, local_ports, remote_ports, connection_timeout,
@@ -533,13 +537,14 @@ def parse_ports(port_str):
 
 
 def check_existing_tunnels(host_id, local_ports, remote_ports,
-                           ssh, ssh_path, ssh_host, ssh_user, direct, log_file, timeout_stop,
+                           ssh, ssh_path, ssh_host, ssh_users, direct, log_file, timeout_stop,
                            keep_existing, keep_same, replace_existing, replace_different, ignore_owner,
                            region, retries, parse_tunnel_args):
     for existing_tunnel in find_tunnels(parse_tunnel_args):
         existing_tunnel_args = TunnelArgs.from_args(existing_tunnel.parsed_args)
         creating_tunnel_args = TunnelArgs(host_id=host_id, local_ports=local_ports, remote_ports=remote_ports,
-                                          ssh=ssh, ssh_path=ssh_path, ssh_host=ssh_host, direct=direct)
+                                          ssh=ssh, ssh_path=ssh_path, ssh_host=ssh_host, ssh_users=ssh_users,
+                                          direct=direct)
         if not any(local_port in creating_tunnel_args.local_ports for local_port in existing_tunnel_args.local_ports):
             logging.debug('Skipping tunnel process #%s '
                           'because it has %s local ports but %s local ports are required...',
@@ -589,7 +594,7 @@ def check_existing_tunnels(host_id, local_ports, remote_ports,
             if existing_tunnel_args.ssh and has_different_owner(existing_tunnel.owner):
                 configure_ssh(existing_tunnel_run_id,
                               existing_tunnel_args.local_ports[0], existing_tunnel_args.remote_ports[0],
-                              existing_tunnel_args.ssh_path, ssh_user, existing_tunnel_remote_host,
+                              existing_tunnel_args.ssh_path, ssh_users, existing_tunnel_remote_host,
                               log_file, retries)
             sys.exit(0)
         if replace_different and not is_same_tunnel:
@@ -614,7 +619,7 @@ def check_existing_tunnels(host_id, local_ports, remote_ports,
             if existing_tunnel_args.ssh and has_different_owner(existing_tunnel.owner):
                 configure_ssh(existing_tunnel_run_id,
                               existing_tunnel_args.local_ports[0], existing_tunnel_args.remote_ports[0],
-                              existing_tunnel_args.ssh_path, ssh_user, existing_tunnel_remote_host,
+                              existing_tunnel_args.ssh_path, ssh_users, existing_tunnel_remote_host,
                               log_file, retries)
             sys.exit(0)
         if has_different_owner(existing_tunnel.owner):
@@ -723,7 +728,7 @@ def get_current_user():
 
 
 def configure_ssh(run_id, local_port, remote_port,
-                  ssh_path, ssh_user, remote_host,
+                  ssh_path, ssh_users, remote_host,
                   log_file, retries):
     def _establish_tunnel():
         pass
@@ -731,11 +736,11 @@ def configure_ssh(run_id, local_port, remote_port,
     ssh_keep = True
     if is_windows():
         configure_ssh_and_execute_on_windows(run_id, local_port, remote_port, conn_info,
-                                             ssh_user, ssh_keep, remote_host,
+                                             ssh_users, ssh_keep, remote_host,
                                              retries, _establish_tunnel)
     else:
         configure_ssh_and_execute_on_linux(run_id, local_port, remote_port, conn_info,
-                                           ssh_path, ssh_user, ssh_keep, remote_host, log_file,
+                                           ssh_path, ssh_users, ssh_keep, remote_host, log_file,
                                            retries, _establish_tunnel)
 
 
@@ -748,7 +753,7 @@ def get_flag_value(proc_args, arg_index, arg_names):
 
 
 def create_tunnel_to_run(run_id, local_ports, remote_ports, connection_timeout,
-                         ssh, ssh_path, ssh_host, ssh_user, ssh_keep, direct, log_file, log_level,
+                         ssh, ssh_path, ssh_host, ssh_users, ssh_keep, direct, log_file, log_level,
                          timeout, foreground, retries, region=None):
     conn_info = get_conn_info(run_id, region)
     if conn_info.sensitive:
@@ -757,7 +762,7 @@ def create_tunnel_to_run(run_id, local_ports, remote_ports, connection_timeout,
     if foreground:
         if ssh:
             create_foreground_tunnel_with_ssh(run_id, local_ports, remote_ports, connection_timeout, conn_info,
-                                              ssh_path, ssh_user, ssh_keep,
+                                              ssh_path, ssh_users, ssh_keep,
                                               remote_host, direct, log_file, log_level, retries)
         else:
             create_foreground_tunnel(run_id, local_ports, remote_ports, connection_timeout, conn_info,
@@ -911,25 +916,25 @@ def is_tunnel_listen_all_ports(tunnel_pid, local_ports, serving_procs):
 
 
 def create_foreground_tunnel_with_ssh(run_id, local_ports, remote_ports, connection_timeout, conn_info,
-                                      ssh_path, ssh_user, ssh_keep, remote_host, direct, log_file, log_level, retries):
+                                      ssh_path, ssh_users, ssh_keep, remote_host, direct, log_file, log_level, retries):
     def _establish_tunnel():
         create_foreground_tunnel(run_id, local_ports, remote_ports, connection_timeout, conn_info,
                                  remote_host, direct, log_level, retries)
     if is_windows():
         configure_ssh_and_execute_on_windows(run_id, local_ports[0], remote_ports[0], conn_info,
-                                             ssh_user, ssh_keep, remote_host,
+                                             ssh_users, ssh_keep, remote_host,
                                              retries, _establish_tunnel)
     else:
         configure_ssh_and_execute_on_linux(run_id, local_ports[0], remote_ports[0], conn_info,
-                                           ssh_path, ssh_user, ssh_keep, remote_host, log_file,
+                                           ssh_path, ssh_users, ssh_keep, remote_host, log_file,
                                            retries, _establish_tunnel)
 
 
 def configure_ssh_and_execute_on_windows(run_id, local_port, remote_port, conn_info,
-                                         ssh_user, ssh_keep, remote_host,
+                                         ssh_users, ssh_keep, remote_host,
                                          retries, func):
     logging.info('Configuring putty and openssh passwordless ssh...')
-    passwordless_config = PasswordlessSSHConfig(run_id, conn_info, ssh_user)
+    passwordless_config = PasswordlessSSHConfig(run_id, conn_info, ssh_users)
     if not os.path.exists(passwordless_config.local_openssh_path):
         os.makedirs(passwordless_config.local_openssh_path, mode=stat.S_IRWXU)
     if not os.path.exists(passwordless_config.local_keys_path):
@@ -960,10 +965,10 @@ def configure_ssh_and_execute_on_windows(run_id, local_port, remote_port, conn_i
 
 
 def configure_ssh_and_execute_on_linux(run_id, local_port, remote_port, conn_info,
-                                       ssh_path, ssh_user, ssh_keep, remote_host, log_file,
+                                       ssh_path, ssh_users, ssh_keep, remote_host, log_file,
                                        retries, func):
     logging.info('Configuring openssh passwordless ssh...')
-    passwordless_config = PasswordlessSSHConfig(run_id, conn_info, ssh_user, ssh_path)
+    passwordless_config = PasswordlessSSHConfig(run_id, conn_info, ssh_users, ssh_path)
     if not os.path.exists(passwordless_config.local_openssh_path):
         os.makedirs(passwordless_config.local_openssh_path, mode=stat.S_IRWXU)
     if not os.path.exists(passwordless_config.local_keys_path):


### PR DESCRIPTION
Resolves #2806.

The pull request restricts passwordless ssh access to only default and explicitly specified users in pipe tunnel.
