### PR TITLE
issue 2721 allow to not to specify subject and body for storage lifecycle notification

### DIFF
--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -332,6 +332,8 @@ public final class MessageConstants {
             "error.datastirage.lifecycle.rule.one.by.one.has.default.criterion";
     public static final String ERROR_DATASTORAGE_LIFECYCLE_RULE_ONE_BY_ONE_NOTIFICATION_ENABLED =
             "error.datastirage.lifecycle.rule.one.by.one.notification.enabled";
+    public static final String ERROR_DATASTORAGE_LIFECYCLE_RULE_NOTIFICATION_RECIPIENTS_NOT_PROVIDED =
+            "error.datastorage.lifecycle.rule.notification.recipients.not.provided";
 
     // Git messages
     public static final String ERROR_REPOSITORY_FILE_WAS_UPDATED = "error.repository.file.was.updated";

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/lifecycle/DataStorageLifecycleManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/lifecycle/DataStorageLifecycleManager.java
@@ -398,14 +398,13 @@ public class DataStorageLifecycleManager {
             return;
         }
 
+        Assert.notEmpty(notification.getRecipients(),
+                messageHelper.getMessage(
+                        MessageConstants.ERROR_DATASTORAGE_LIFECYCLE_RULE_NOTIFICATION_RECIPIENTS_NOT_PROVIDED));
         Assert.isTrue(notification.getProlongDays() == null || notification.getProlongDays() > 0,
                 messageHelper.getMessage(MessageConstants.ERROR_DATASTORAGE_LIFECYCLE_RULE_WRONG_DAYS_TO_PROLONG));
         Assert.isTrue(notification.getNotifyBeforeDays() == null || notification.getNotifyBeforeDays() > 0,
                 messageHelper.getMessage(MessageConstants.ERROR_DATASTORAGE_LIFECYCLE_WRONG_NOTIFY_BEFORE_DAYS));
-        Assert.hasLength(notification.getSubject(),
-                messageHelper.getMessage(MessageConstants.ERROR_NOTIFICATION_SUBJECT_NOT_SPECIFIED));
-        Assert.hasLength(notification.getBody(),
-                messageHelper.getMessage(MessageConstants.ERROR_NOTIFICATION_BODY_NOT_SPECIFIED));
     }
 
     private void validatePathIsAbsolute(final String path) {

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -293,6 +293,7 @@ error.datastirage.lifecycle.rule.transition.criterion.value.is.not.provided=Tran
 error.datastirage.lifecycle.path.is.not.absolute=Please provide absolute path from root of the storage starting with /
 error.datastirage.lifecycle.rule.one.by.one.has.default.criterion=When transition method ONE_BY_ONE is used only DEFAULT transition criterion is valid.
 error.datastirage.lifecycle.rule.one.by.one.notification.enabled=When transition method ONE_BY_ONE is used notification must be disabled.
+error.datastirage.lifecycle.rule.notification.recipients.not.provided=Recipients should be provided!
 
 # Git messages
 

--- a/storage-lifecycle-service/sls/model/rule_model.py
+++ b/storage-lifecycle-service/sls/model/rule_model.py
@@ -101,7 +101,7 @@ class LifecycleRuleParser:
         transition_criterion = self._parse_transition_criterion(rule_json_dict["transitionCriterion"]) \
             if "transitionCriterion" in rule_json_dict \
             else StorageLifecycleTransitionCriterion("DEFAULT", None)
-        notification = self._parse_notification(rule_json_dict["notification"]) \
+        notification = self._parse_notification(rule_json_dict["notification"], self.default_lifecycle_notification) \
             if "notification" in rule_json_dict \
             else self.default_lifecycle_notification
 
@@ -176,24 +176,15 @@ class LifecycleRuleParser:
         return [_parse_prolongation(prolongation) for prolongation in prolongations_json]
 
     @staticmethod
-    def _parse_notification(notification_json):
+    def _parse_notification(notification_json, default_notification):
         return StorageLifecycleNotification(
             notify_before_days=notification_json["notifyBeforeDays"]
-            if "notifyBeforeDays" in notification_json
-            else None,
+            if "notifyBeforeDays" in notification_json else default_notification.notify_before_days,
             prolong_days=notification_json["prolongDays"]
-            if "prolongDays" in notification_json
-            else None,
+            if "prolongDays" in notification_json else default_notification.prolong_days,
             recipients=notification_json["recipients"]
-            if "recipients" in notification_json
-            else [],
-            enabled=notification_json["enabled"]
-            if "enabled" in notification_json
-            else True,
-            subject=notification_json["subject"]
-            if "subject" in notification_json
-            else None,
-            body=notification_json["body"]
-            if "body" in notification_json
-            else None
+            if "recipients" in notification_json else notification_json.recipients,
+            enabled=notification_json["enabled"] if "enabled" in notification_json else default_notification.enabled,
+            subject=notification_json["subject"] if "subject" in notification_json else default_notification.subject,
+            body=notification_json["body"] if "body" in notification_json else default_notification.body
         )


### PR DESCRIPTION
This PR changes way how lifecycle notification is handled.
 1) It is possible now to not specify subject and body for notification even if `enabled` is `true` - we will use subject and body from default notification object
 2) `sls` service now will merge default notification with notification object from rule - it allows to implement (1)
 3) `recipients` - is mandatory if `enabled` is true