### PR TITLE
Add "per-component" versioning

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -45,6 +45,13 @@ task copyLocalDtsStartupScripts(type: Copy) {
     into "$rootDir/api/src/main/resources/static/"
 }
 
+task generateComponentsVersions(type: Exec) {
+    commandLine "bash", 
+                "$project.rootDir/scripts/pipeline-scripts/generate_components_versions.sh",
+                "$project.rootDir",
+                "$rootDir/api/src/main/resources/static/components_versions.json"
+}
+
 jar {
     archiveName "pipeline.jar"
     manifest {
@@ -246,4 +253,4 @@ dependencies {
 
 // >>>>> processes profiles
 processResources.dependsOn.addAll([copyConfiguration, copyLaunchScripts, copyCommitRunScripts, copyFsAutoscalerScripts,
-                                   copyLocalDtsStartupScripts])
+                                   copyLocalDtsStartupScripts, generateComponentsVersions])

--- a/cloud-pipeline-webdav-client/build_linux.sh
+++ b/cloud-pipeline-webdav-client/build_linux.sh
@@ -27,8 +27,8 @@ cat >$_BUILD_SCRIPT_NAME <<'EOL'
 cd /cloud-data
 
 version_file="scripts/PublishVersionPlugin.js"
-cp \$version_file /tmp/version.bkp
-sed -i "s/1111111111111111111111111111111111111111/\$CLOUD_DATA_COMMIT_HASH/g" \$version_file
+cp $version_file /tmp/version.bkp
+sed -i "s/1111111111111111111111111111111111111111/$CLOUD_DATA_COMMIT_HASH/g" $version_file
 
 npm install
 npm run package:linux

--- a/cloud-pipeline-webdav-client/build_linux.sh
+++ b/cloud-pipeline-webdav-client/build_linux.sh
@@ -26,11 +26,16 @@ cat >$_BUILD_SCRIPT_NAME <<'EOL'
 
 cd /cloud-data
 
+version_file="scripts/PublishVersionPlugin.js"
+cp \$version_file /tmp/version.bkp
+sed -i "s/1111111111111111111111111111111111111111/\$CLOUD_DATA_COMMIT_HASH/g" \$version_file
+
 npm install
 npm run package:linux
 
 if [ $? -ne 0 ]; then
     echo "Unable to build UI for Linux"
+    cp /tmp/version.bkp \$version_file 
     exit 1
 fi
 
@@ -39,13 +44,19 @@ tar -zcf /cloud-data/out/cloud-data-linux.tar.gz \
         cloud-data-linux-x64
 
 chmod -R 777 /cloud-data/out
+cp /tmp/version.bkp \$version_file 
 
 EOL
+
+cd $CP_CLOUD_DATA_SOURCES_DIR
+CLOUD_DATA_COMMIT_HASH=$(git log --pretty=tformat:"%H" -n1 .)
+cd -
 
 docker run -i --rm \
            -v $CP_CLOUD_DATA_SOURCES_DIR:/cloud-data \
            -v $_BUILD_SCRIPT_NAME:$_BUILD_SCRIPT_NAME \
            --env CLOUD_DATA_APP_VERSION=$CLOUD_DATA_APP_VERSION \
+           --env CLOUD_DATA_COMMIT_HASH=$CLOUD_DATA_COMMIT_HASH \
            $CP_NODE_DOCKER \
            bash $_BUILD_SCRIPT_NAME
 

--- a/cloud-pipeline-webdav-client/build_win.sh
+++ b/cloud-pipeline-webdav-client/build_win.sh
@@ -26,11 +26,16 @@ cat >$_BUILD_SCRIPT_NAME <<'EOL'
 
 cd /cloud-data
 
+version_file="scripts/PublishVersionPlugin.js"
+cp \$version_file /tmp/version.bkp
+sed -i "s/1111111111111111111111111111111111111111/\$CLOUD_DATA_COMMIT_HASH/g" \$version_file
+
 npm install
 npm run package:win64
 
 if [ $? -ne 0 ]; then
     echo "Unable to build UI for Windows"
+    cp /tmp/version.bkp \$version_file 
     exit 1
 fi
 
@@ -39,8 +44,13 @@ cd out
 zip -r -q /cloud-data/out/cloud-data-win64.zip cloud-data-win32-x64/
 
 chmod -R 777 /cloud-data/out
+cp /tmp/version.bkp \$version_file 
 
 EOL
+
+cd $CP_CLOUD_DATA_SOURCES_DIR
+CLOUD_DATA_COMMIT_HASH=$(git log --pretty=tformat:"%H" -n1 .)
+cd -
 
 docker run -i --rm \
            -v $CP_CLOUD_DATA_SOURCES_DIR:/cloud-data \

--- a/cloud-pipeline-webdav-client/build_win.sh
+++ b/cloud-pipeline-webdav-client/build_win.sh
@@ -27,8 +27,8 @@ cat >$_BUILD_SCRIPT_NAME <<'EOL'
 cd /cloud-data
 
 version_file="scripts/PublishVersionPlugin.js"
-cp \$version_file /tmp/version.bkp
-sed -i "s/1111111111111111111111111111111111111111/\$CLOUD_DATA_COMMIT_HASH/g" \$version_file
+cp $version_file /tmp/version.bkp
+sed -i "s/1111111111111111111111111111111111111111/$CLOUD_DATA_COMMIT_HASH/g" $version_file
 
 npm install
 npm run package:win64

--- a/cloud-pipeline-webdav-client/scripts/PublishVersionPlugin.js
+++ b/cloud-pipeline-webdav-client/scripts/PublishVersionPlugin.js
@@ -2,11 +2,17 @@ class PublishVersionPlugin {
   apply(compiler) {
     compiler.hooks.emit.tapPromise('PublishVersionPlugin', async compilation => {
       const version = process.env.CLOUD_DATA_APP_VERSION || '';
+      const component_version = '1111111111111111111111111111111111111111';
       console.log();
       console.log(`Cloud Data App Version: "${version}"`);
+      console.log(`Cloud Data App Component Version: "${component_version}"`);
       compilation.assets['VERSION'] = {
         source: () => Buffer.from(version),
         size: () => Buffer.from(version).length
+      };
+      compilation.assets['COMPONENT_VERSION'] = {
+        source: () => Buffer.from(component_version),
+        size: () => Buffer.from(component_version).length
       };
     });
   }

--- a/cloud-pipeline-webdav-client/src/read-webdav-configuration.js
+++ b/cloud-pipeline-webdav-client/src/read-webdav-configuration.js
@@ -22,14 +22,22 @@ function readCustomConfiguration () {
   return undefined;
 }
 
-function getAppVersion() {
+function readCompilationAsset(assetName) {
   try {
-    const versionFile = path.join(__dirname, 'VERSION');
-    if (fs.existsSync(versionFile)) {
-      return fs.readFileSync(versionFile).toString();
+    const assetFile = path.join(__dirname, assetName);
+    if (fs.existsSync(assetFile)) {
+      return fs.readFileSync(assetFile).toString();
     }
   } catch (_) {}
   return undefined;
+}
+
+function getAppVersion() {
+  return readCompilationAsset('VERSION')
+}
+
+function getComponentVersion() {
+  return readCompilationAsset('COMPONENT_VERSION')
 }
 
 function readCertificates (root) {

--- a/pipe-cli/build_linux.sh
+++ b/pipe-cli/build_linux.sh
@@ -122,6 +122,9 @@ function build_pipe {
 
     echo "__bundle_info__ = { 'bundle_type': '\$bundle_type', 'build_os_id': '\$build_os_id', 'build_os_version_id': '\$build_os_version_id' }" >> \$version_file
 
+    sed -i '/__component_version__/d' \$version_file
+    echo "__component_version__='\${PIPE_COMMIT_HASH}'" >> \$version_file
+
     cd $PIPE_CLI_SOURCES_DIR
     python2 $PYINSTALLER_PATH/pyinstaller/pyinstaller.py \
                                     --add-data "$PIPE_CLI_SOURCES_DIR/res/effective_tld_names.dat.txt:tld/res/" \
@@ -158,6 +161,10 @@ tar -zcf $PIPE_CLI_LINUX_DIST_DIR/dist/dist-folder/pipe.tar.gz \
 
 EOL
 
+cd $PIPE_CLI_SOURCES_DIR
+PIPE_COMMIT_HASH=$(git log --pretty=tformat:"%H" -n1 .)
+cd -
+
 docker pull $_BUILD_DOCKER_IMAGE &> /dev/null
 docker run -i --rm \
            -v $PIPE_CLI_SOURCES_DIR:$PIPE_CLI_SOURCES_DIR \
@@ -168,6 +175,7 @@ docker run -i --rm \
            --env PIPE_CLI_LINUX_DIST_DIR=$PIPE_CLI_LINUX_DIST_DIR \
            --env PIPE_CLI_RUNTIME_TMP_DIR="'"$PIPE_CLI_RUNTIME_TMP_DIR"'" \
            --env PYINSTALLER_PATH=$PYINSTALLER_PATH \
+           --env PIPE_COMMIT_HASH=$PIPE_COMMIT_HASH \
            $_BUILD_DOCKER_IMAGE \
            bash $_BUILD_SCRIPT_NAME
 

--- a/pipe-cli/build_mac.sh
+++ b/pipe-cli/build_mac.sh
@@ -97,6 +97,10 @@ function build_pipe {
     echo "__bundle_info__ = { 'bundle_type': '$bundle_type', 'build_os_id': 'macos', 'build_os_version_id': '$build_os_version_id' }" >> $version_file
 
     cd $PIPE_CLI_SOURCES_DIR
+    sed -i '/__component_version__/d' $version_file
+    local pipe_commit_hash=$(git log --pretty=tformat:"%H" -n1 .)
+    echo "__component_version__='$pipe_commit_hash'" >> $version_file
+
     python2 $PYINSTALLER_PATH/pyinstaller/pyinstaller.py \
                                     --add-data "$PIPE_CLI_SOURCES_DIR/res/effective_tld_names.dat.txt:tld/res/" \
                                     --hidden-import=UserList \

--- a/pipe-cli/build_windows.sh
+++ b/pipe-cli/build_windows.sh
@@ -78,6 +78,10 @@ _BUILD_SCRIPT_NAME=/tmp/build_pytinstaller_win64_$(date +%s).sh
 
 cat >$_BUILD_SCRIPT_NAME <<'EOL'
 
+version_file="${PIPE_CLI_SOURCES_DIR}/src/version.py"
+sed -i '/__component_version__/d' \$version_file
+echo "__component_version__='\${PIPE_COMMIT_HASH}'" >> \$version_file
+
 cat > /tmp/pipe-win-version-info.txt <<< "$(envsubst < /pipe-cli/res/pipe-win-version-info.txt)" && \
 pip install --upgrade 'setuptools<=45.1.0' && \
 pip install -r /pipe-cli/requirements.txt && \
@@ -144,6 +148,10 @@ cd /pipe-cli/dist/win64 && \
 zip -r -q pipe.zip pipe
 EOL
 
+cd $PIPE_CLI_SOURCES_DIR
+PIPE_COMMIT_HASH=$(git log --pretty=tformat:"%H" -n1 .)
+cd -
+
 docker run -i --rm \
            -v $PIPE_CLI_SOURCES_DIR:/pipe-cli \
            -v $PIPE_CLI_WIN_DIST_DIR:/pipe-cli/dist/win64 \
@@ -152,6 +160,7 @@ docker run -i --rm \
            -e PIPE_CLI_MINOR_VERSION=$PIPE_CLI_MINOR_VERSION \
            -e PIPE_CLI_PATCH_VERSION=$PIPE_CLI_PATCH_VERSION \
            -e PIPE_CLI_BUILD_VERSION=$(cut -d. -f1 <<< "$PIPE_CLI_BUILD_VERSION") \
+           -e PIPE_COMMIT_HASH=$PIPE_COMMIT_HASH \
            $CP_PYINSTALL_WIN64_DOCKER \
            bash $_BUILD_SCRIPT_NAME
 

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -49,7 +49,7 @@ from src.utilities.update_cli_version import UpdateCLIVersionManager
 from src.utilities.user_operations_manager import UserOperationsManager
 from src.utilities.user_token_operations import UserTokenOperations
 from src.utilities.dts_operations_manager import DtsOperationsManager
-from src.version import __version__, __bundle_info__
+from src.version import __version__, __bundle_info__, __component_version__
 
 MAX_INSTANCE_COUNT = 1000
 MAX_CORES_COUNT = 10000
@@ -86,7 +86,7 @@ def print_version(ctx, param, value):
     if value is False:
         return
     silent_print_api_version()
-    click.echo('Cloud Pipeline CLI, version {}'.format(__version__))
+    click.echo('Cloud Pipeline CLI, version {} ({})'.format(__version__, __component_version__))
     silent_print_creds_info()
     ctx.exit()
 

--- a/pipe-cli/src/version.py
+++ b/pipe-cli/src/version.py
@@ -14,3 +14,4 @@
 
 __version__='0.17'
 __bundle_info__ = { 'bundle_type': 'source', 'build_os_id': 'generic', 'build_os_version_id': 'generic' }
+__component_version__='1111111111111111111111111111111111111111'

--- a/scripts/pipeline-scripts/generate_components_versions.sh
+++ b/scripts/pipeline-scripts/generate_components_versions.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project_root_dir="$1"
+versions_file_path="$2"
+
+components_list="pipe-cli data-transfer-service cloud-pipeline-webdav-client"
+components_json=""
+for component in $components_list; do
+    echo $component
+    component_commit_hash=$(git log --pretty=tformat:"%H" -n1 "${project_root_dir}/$component")
+    components_json="${components_json}, \"$component\": \"$component_commit_hash\""
+done
+
+components_json=$(echo "$components_json" | sed 's/,//')
+echo "{ $components_json }" > "$versions_file_path"


### PR DESCRIPTION
* API: contains a `components_versions.json` file with all client utilities' versions in a "static" directory:
```
{ 
  "pipe-cli": "44ff0f9470f5e8bd43c3db9bb5c63af2e8cacaa2", 
  "data-transfer-service": "6287fc35542997b2d5b1a49a8d60e63b81bcd434", 
  "cloud-pipeline-webdav-client": "44ff0f9470f5e8bd43c3db9bb5c63af2e8cacaa2" 
}
```

* `pipe` CLI: 
  * Contains a `__component_version__` constant in a `version.py`
  * Prints a component version in a `--version` output (in brackets)
```
$ pipe --version
Cloud Pipeline CLI, version 0.17.0.123.123123123123123123123123 (44ff0f9470f5e8bd43c3db9bb5c63af2e8cacaa2)
```

* `Cloud Data` app:
  * Contains component version in the resources (`COMPONENT_VERSION` file)
  * Exposes a component version via `getComponentVersion()`
