### PR TITLE
Issue #2821: INACTIVE_USERS notification enhancements

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/notification/NotificationService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/notification/NotificationService.java
@@ -86,8 +86,7 @@ public interface NotificationService {
 
     }
 
-    default void notifyInactiveUsers(final List<PipelineUser> inactiveUsers,
-                                     final List<PipelineUser> ldapBlockedUsers) {
+    default void notifyPipelineUsers(final List<PipelineUser> inactiveUsers, final NotificationType type) {
     }
 
     default void notifyOnBillingQuotaExceeding(final AppliedQuota appliedQuota) {

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -800,16 +800,18 @@ public class SystemPreferences {
      */
     public static final StringPreference SYSTEM_OOM_EXCLUDE_EVENTS = new StringPreference(
             "system.oom.exclude.events", "flanneld|iptables|canal|kube-proxy|calico", SYSTEM_GROUP, pass);
-    public static final IntPreference SYSTEM_USER_MONITOR_DELAY = new IntPreference(
-            "system.user.monitor.delay", Constants.MILLISECONDS_IN_DAY, SYSTEM_GROUP, isGreaterThan(0));
-    public static final BooleanPreference SYSTEM_USER_MONITOR_ENABLED = new BooleanPreference(
-            "system.user.monitor.enable", false, SYSTEM_GROUP, pass);
+    public static final IntPreference SYSTEM_INACTIVE_USER_MONITOR_DELAY = new IntPreference(
+            "system.inactive.user.monitor.delay", Constants.MILLISECONDS_IN_DAY, SYSTEM_GROUP, isGreaterThan(0));
+    public static final BooleanPreference SYSTEM_INACTIVE_USER_MONITOR_ENABLED = new BooleanPreference(
+            "system.inactive.user.monitor.enable", false, SYSTEM_GROUP, pass);
+    public static final IntPreference SYSTEM_INACTIVE_USER_MONITOR_BLOCKED_DAYS = new IntPreference(
+            "system.inactive.user.monitor.blocked.days", 365, SYSTEM_GROUP, pass);
+    public static final IntPreference SYSTEM_INACTIVE_USER_MONITOR_IDLE_DAYS = new IntPreference(
+            "system.inactive.user.monitor.idle.days", 365, SYSTEM_GROUP, pass);
     public static final BooleanPreference SYSTEM_LDAP_USER_BLOCK_MONITOR_ENABLED = new BooleanPreference(
             "system.ldap.user.block.monitor.enable", false, SYSTEM_GROUP, pass);
-    public static final IntPreference SYSTEM_USER_MONITOR_BLOCKED_DAYS = new IntPreference(
-            "system.user.monitor.blocked.days", 365, SYSTEM_GROUP, pass);
-    public static final IntPreference SYSTEM_USER_MONITOR_IDLE_DAYS = new IntPreference(
-            "system.user.monitor.idle.days", 365, SYSTEM_GROUP, pass);
+    public static final IntPreference SYSTEM_LDAP_USER_BLOCK_MONITOR_DELAY = new IntPreference(
+            "system.ldap.user.block.monitor.delay", Constants.MILLISECONDS_IN_DAY, SYSTEM_GROUP, isGreaterThan(0));
     public static final IntPreference SYSTEM_NODE_POOL_MONITOR_DELAY = new IntPreference(
             "system.node.pool.monitor.delay", 30000, SYSTEM_GROUP, pass);
     /**

--- a/api/src/main/java/com/epam/pipeline/manager/user/BlockedUsersMonitoringService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/BlockedUsersMonitoringService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,13 +25,13 @@ import javax.annotation.PostConstruct;
 
 @Service
 @RequiredArgsConstructor
-public class InactiveUsersMonitoringService extends AbstractSchedulingManager {
+public class BlockedUsersMonitoringService extends AbstractSchedulingManager {
 
-    private final InactiveUsersMonitoringServiceCore core;
+    private final BlockedUsersMonitoringServiceCore core;
 
     @PostConstruct
     public void init() {
-        scheduleFixedDelaySecured(core::monitor, SystemPreferences.SYSTEM_INACTIVE_USER_MONITOR_DELAY,
-                "InactiveUsersMonitor");
+        scheduleFixedDelaySecured(core::monitor, SystemPreferences.SYSTEM_LDAP_USER_BLOCK_MONITOR_DELAY,
+                "BlockedUsersMonitor");
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/user/BlockedUsersMonitoringServiceCore.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/BlockedUsersMonitoringServiceCore.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.user;
+
+import com.epam.pipeline.entity.notification.NotificationType;
+import com.epam.pipeline.entity.user.DefaultRoles;
+import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.entity.user.Role;
+import com.epam.pipeline.manager.ldap.LdapBlockedUsersManager;
+import com.epam.pipeline.manager.notification.NotificationManager;
+import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.epam.pipeline.manager.preference.SystemPreferences;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.core.SchedulerLock;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.ListUtils;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class BlockedUsersMonitoringServiceCore {
+    private final UserManager userManager;
+    private final NotificationManager notificationManager;
+    private final PreferenceManager preferenceManager;
+    private final LdapBlockedUsersManager ldapBlockedUsersManager;
+
+    /**
+     * Finds LDAP blocked non-admin users, blocks them into Cloud Pipeline system and
+     * notifies about them.
+     */
+    @SchedulerLock(name = "BlockedUsersMonitoringService_monitor", lockAtMostForString = "PT10M")
+    public void monitor() {
+        if (monitoringDisabled()) {
+            log.debug("Blocked users monitoring is not enabled");
+            return;
+        }
+
+        log.debug("Started blocked users monitoring");
+        final Collection<PipelineUser> allUsers = userManager.loadAllUsers();
+        if (CollectionUtils.isEmpty(allUsers)) {
+            log.debug("No users found to monitor");
+            return;
+        }
+
+        final List<PipelineUser> ldapBlockedUsers = findAndBlockLdapBlockedUsers(allUsers);
+        notificationManager.notifyPipelineUsers(ldapBlockedUsers, NotificationType.LDAP_BLOCKED_USERS);
+        log.debug("Finished blocked users monitoring");
+    }
+
+    private boolean monitoringDisabled() {
+        final Boolean monitoringEnabled = preferenceManager.getPreference(
+                SystemPreferences.SYSTEM_LDAP_USER_BLOCK_MONITOR_ENABLED);
+        return Objects.isNull(monitoringEnabled) || !monitoringEnabled;
+    }
+
+    private List<PipelineUser> findAndBlockLdapBlockedUsers(final Collection<PipelineUser> allUsers) {
+        final List<PipelineUser> activeNonAdmins = allUsers.stream()
+                .filter(pipelineUser -> !pipelineUser.isBlocked())
+                .filter(pipelineUser -> !userIsAdmin(pipelineUser))
+                .filter(pipelineUser -> !hasRole(pipelineUser, DefaultRoles.ROLE_SERVICE_ACCOUNT.getName()))
+                .collect(Collectors.toList());
+
+        log.debug("Fetch from DB {} active non admin users. " +
+                "Will query LDAP with this list and sync blocking status.", activeNonAdmins.size());
+
+        final List<PipelineUser> blockedUsers = ldapBlockedUsersManager.filterBlockedUsers(activeNonAdmins);
+        log.debug("Found {} new blocked user in total.", blockedUsers.size());
+        return blockedUsers.stream()
+                .map(user -> userManager.updateUserBlockingStatus(user.getId(), true))
+                .collect(Collectors.toList());
+    }
+
+    private boolean userIsAdmin(final PipelineUser pipelineUser) {
+        return pipelineUser.isAdmin() || hasRole(pipelineUser, DefaultRoles.ROLE_ADMIN.getName());
+    }
+
+    private boolean hasRole(final PipelineUser pipelineUser, final String roleName) {
+        return ListUtils.emptyIfNull(pipelineUser.getRoles())
+                .stream()
+                .map(Role::getName)
+                .anyMatch(roleName::equals);
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/user/InactiveUsersMonitoringServiceCore.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/InactiveUsersMonitoringServiceCore.java
@@ -16,12 +16,10 @@
 
 package com.epam.pipeline.manager.user;
 
-import com.epam.pipeline.entity.user.DefaultRoles;
+import com.epam.pipeline.entity.notification.NotificationType;
 import com.epam.pipeline.entity.user.GroupStatus;
 import com.epam.pipeline.entity.user.PipelineUser;
-import com.epam.pipeline.entity.user.Role;
 import com.epam.pipeline.entity.utils.DateUtils;
-import com.epam.pipeline.manager.ldap.LdapBlockedUsersManager;
 import com.epam.pipeline.manager.notification.NotificationManager;
 import com.epam.pipeline.manager.preference.AbstractSystemPreference;
 import com.epam.pipeline.manager.preference.PreferenceManager;
@@ -36,7 +34,6 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -50,7 +47,6 @@ public class InactiveUsersMonitoringServiceCore {
     private final UserManager userManager;
     private final NotificationManager notificationManager;
     private final PreferenceManager preferenceManager;
-    private final LdapBlockedUsersManager ldapBlockedUsersManager;
 
     /**
      * Finds inactive users and notifies about them. Inactive user is a user who meets at least one of the
@@ -59,9 +55,6 @@ public class InactiveUsersMonitoringServiceCore {
      * - user belongs to the group that was blocked for a long period of time
      * - user have never login
      * - user have not login for a long period of time
-     *
-     * Also, this method finds LDAP blocked non-admin users, blocks them into Cloud Pipeline system and
-     * adds them to notification.
      */
     @SchedulerLock(name = "InactiveUsersMonitoringService_monitor", lockAtMostForString = "PT10M")
     public void monitor() {
@@ -78,44 +71,19 @@ public class InactiveUsersMonitoringServiceCore {
         }
 
         final List<PipelineUser> inactiveUsers = findInactivePipelineUsers(allUsers);
-        final List<PipelineUser> ldapBlockedUsers = findAndBlockLdapBlockedUsers(allUsers);
-        notificationManager.notifyInactiveUsers(inactiveUsers, ldapBlockedUsers);
+        notificationManager.notifyPipelineUsers(inactiveUsers, NotificationType.INACTIVE_USERS);
         log.debug("Finished inactive users monitoring");
     }
 
     private boolean monitoringDisabled() {
         final Boolean monitoringEnabled = preferenceManager.getPreference(
-                SystemPreferences.SYSTEM_USER_MONITOR_ENABLED);
+                SystemPreferences.SYSTEM_INACTIVE_USER_MONITOR_ENABLED);
         return Objects.isNull(monitoringEnabled) || !monitoringEnabled;
     }
 
-    private List<PipelineUser> findAndBlockLdapBlockedUsers(final Collection<PipelineUser> allUsers) {
-        final Boolean monitoringEnabled = preferenceManager.getPreference(
-                SystemPreferences.SYSTEM_LDAP_USER_BLOCK_MONITOR_ENABLED);
-        if (Objects.isNull(monitoringEnabled) || !monitoringEnabled) {
-            log.debug("Ldap blocked users monitoring is not enabled");
-            return Collections.emptyList();
-        }
-
-        final List<PipelineUser> activeNonAdmins = allUsers.stream()
-                .filter(pipelineUser -> !pipelineUser.isBlocked())
-                .filter(pipelineUser -> !userIsAdmin(pipelineUser))
-                .filter(pipelineUser -> !hasRole(pipelineUser, DefaultRoles.ROLE_SERVICE_ACCOUNT.getName()))
-                .collect(Collectors.toList());
-
-        log.debug("Fetch from DB {} active non admin users. " +
-                "Will query LDAP with this list and sync blocking status.", activeNonAdmins.size());
-
-        final List<PipelineUser> blockedUsers = ldapBlockedUsersManager.filterBlockedUsers(activeNonAdmins);
-        log.debug("Found {} new blocked user in total.", blockedUsers.size());
-        return blockedUsers.stream()
-                .map(user -> userManager.updateUserBlockingStatus(user.getId(), true))
-                .collect(Collectors.toList());
-    }
-
     private List<PipelineUser> findInactivePipelineUsers(final Collection<PipelineUser> allUsers) {
-        final Integer userBlockedDays = parseIntPreference(SystemPreferences.SYSTEM_USER_MONITOR_BLOCKED_DAYS);
-        final Integer userIdleDays = parseIntPreference(SystemPreferences.SYSTEM_USER_MONITOR_IDLE_DAYS);
+        final Integer userBlockedDays = parseIntPreference(SystemPreferences.SYSTEM_INACTIVE_USER_MONITOR_BLOCKED_DAYS);
+        final Integer userIdleDays = parseIntPreference(SystemPreferences.SYSTEM_INACTIVE_USER_MONITOR_IDLE_DAYS);
 
         final LocalDateTime now = DateUtils.nowUTC();
         final Map<String, GroupStatus> blockedGroups = ListUtils.emptyIfNull(
@@ -135,17 +103,6 @@ public class InactiveUsersMonitoringServiceCore {
             return null;
         }
         return result < 0 ? null : result;
-    }
-
-    private boolean userIsAdmin(final PipelineUser pipelineUser) {
-        return pipelineUser.isAdmin() || hasRole(pipelineUser, DefaultRoles.ROLE_ADMIN.getName());
-    }
-
-    private boolean hasRole(final PipelineUser pipelineUser, final String roleName) {
-        return ListUtils.emptyIfNull(pipelineUser.getRoles())
-                .stream()
-                .map(Role::getName)
-                .anyMatch(roleName::equals);
     }
 
     private boolean shouldNotify(final PipelineUser user, final LocalDateTime now, final Integer userBlockedDays,

--- a/api/src/test/java/com/epam/pipeline/manager/user/BlockedUsersMonitoringServiceCoreTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/user/BlockedUsersMonitoringServiceCoreTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.user;
+
+import com.epam.pipeline.entity.user.DefaultRoles;
+import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.manager.ldap.LdapBlockedUsersManager;
+import com.epam.pipeline.manager.notification.NotificationManager;
+import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.epam.pipeline.manager.preference.SystemPreferences;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static com.epam.pipeline.test.creator.user.UserCreatorUtils.getPipelineUser;
+import static com.epam.pipeline.util.CustomAssertions.notInvoked;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class BlockedUsersMonitoringServiceCoreTest {
+    private static final String USER_NAME_1 = "name1";
+    private static final String USER_NAME_2 = "name2";
+    private static final String USER_NAME_3 = "name3";
+    private static final Long ID_1 = 1L;
+    private static final Long ID_2 = 2L;
+    private static final Long ID_3 = 3L;
+
+    private final UserManager userManager = mock(UserManager.class);
+    private final NotificationManager notificationManager = mock(NotificationManager.class);
+    private final PreferenceManager preferenceManager = mock(PreferenceManager.class);
+    private final LdapBlockedUsersManager ldapManager = mock(LdapBlockedUsersManager.class);
+    private final BlockedUsersMonitoringServiceCore monitoringService = new BlockedUsersMonitoringServiceCore(
+            userManager, notificationManager, preferenceManager, ldapManager);
+
+    @Before
+    public void setup() {
+        doReturn(true).when(preferenceManager).getPreference(
+                SystemPreferences.SYSTEM_LDAP_USER_BLOCK_MONITOR_ENABLED);
+    }
+
+    @Test
+    public void shouldBlockAndNotifyBlockedLdapUser() {
+        final PipelineUser blockedUser = activeUser(USER_NAME_1, ID_1);
+        final PipelineUser activeUser1 = activeUser(USER_NAME_2, ID_2);
+        final PipelineUser activeUser2 = activeUser(USER_NAME_3, ID_3);
+        final List<PipelineUser> allUsers = Arrays.asList(blockedUser, activeUser1, activeUser2);
+
+        doReturn(allUsers).when(userManager).loadAllUsers();
+        doReturn(blockedUser).when(userManager).updateUserBlockingStatus(ID_1, true);
+        doReturn(Collections.singletonList(blockedUser)).when(ldapManager).filterBlockedUsers(allUsers);
+
+        monitoringService.monitor();
+
+        verify(userManager).updateUserBlockingStatus(ID_1, true);
+        verify(ldapManager).filterBlockedUsers(allUsers);
+        final ArgumentCaptor<List<PipelineUser>> usersCaptor = argumentCaptor();
+        verify(notificationManager).notifyPipelineUsers(usersCaptor.capture(), any());
+        final List<PipelineUser> resultUsers = usersCaptor.getValue();
+
+        assertThat(resultUsers).hasSize(1);
+        assertThat(resultUsers.get(0)).isEqualTo(blockedUser);
+    }
+
+    @Test
+    public void shouldNotBlockAndNotifyLdapBlockedAdmin() {
+        final PipelineUser blockedAdmin = activeUser(USER_NAME_1, ID_1);
+        blockedAdmin.setRoles(Collections.singletonList(DefaultRoles.ROLE_ADMIN.getRole()));
+
+        doReturn(Collections.singletonList(blockedAdmin)).when(userManager).loadAllUsers();
+
+        monitoringService.monitor();
+
+        notInvoked(userManager).updateUserBlockingStatus(ID_1, true);
+        final ArgumentCaptor<List<PipelineUser>> captor = argumentCaptor();
+        verify(notificationManager).notifyPipelineUsers(captor.capture(), any());
+        final List<PipelineUser> resultUsers = captor.getValue();
+
+        assertThat(resultUsers).hasSize(0);
+    }
+
+    private static PipelineUser activeUser(final String userName, final Long id) {
+        final PipelineUser pipelineUser = getPipelineUser(userName, id);
+        pipelineUser.setBlocked(false);
+        pipelineUser.setLastLoginDate(LocalDateTime.now());
+        return pipelineUser;
+    }
+
+    private ArgumentCaptor argumentCaptor() {
+        return ArgumentCaptor.forClass((Class) List.class);
+    }
+}

--- a/core/src/main/java/com/epam/pipeline/entity/notification/NotificationType.java
+++ b/core/src/main/java/com/epam/pipeline/entity/notification/NotificationType.java
@@ -66,7 +66,9 @@ public enum NotificationType {
     DATASTORAGE_LIFECYCLE_ACTION(17, -1L, -1L, Collections.emptyList(), true,
             NotificationGroup.DATASTORAGE_LIFECYCLE),
     DATASTORAGE_LIFECYCLE_RESTORE_ACTION(18, -1L, -1L, Collections.emptyList(), true,
-            NotificationGroup.DATASTORAGE_LIFECYCLE);
+            NotificationGroup.DATASTORAGE_LIFECYCLE),
+    LDAP_BLOCKED_USERS(19, -1L, -1L, Collections.emptyList(), true,
+            NotificationGroup.USER);
 
     private static final Map<Long, NotificationType> BY_ID;
 

--- a/deploy/contents/install/email-templates/contents/INACTIVE_USERS.html
+++ b/deploy/contents/install/email-templates/contents/INACTIVE_USERS.html
@@ -39,29 +39,6 @@
         #end
     </table>
     #end
-    #if( ${CP_DOLLAR}templateParameters["ldapUsers"] )
-    <p>The following users were blocked since they are blocked into LDAP.</p>
-    <table>
-        <tr>
-            <th>User ID</th>
-            <th>Email</th>
-            <th>Storage Name</th>
-            <th>Creation Date</th>
-            <th>Last Login Date</th>
-            <th>Blocked Date</th>
-        </tr>
-        #foreach( ${CP_DOLLAR}user in ${CP_DOLLAR}templateParameters["ldapUsers"] )
-        <tr>
-            <td>${CP_DOLLAR}user.name</td>
-            #if( ${CP_DOLLAR}user.email )<td>${CP_DOLLAR}user.email</td>#else<td></td>#end
-            #if( ${CP_DOLLAR}user.storage_name )<td>${CP_DOLLAR}user.storage_name</td>#else<td></td>#end
-            ${CP_DOLLAR}calendar.setTime(${CP_DOLLAR}dateFormat.parse(${CP_DOLLAR}user.registration_date))<td>${CP_DOLLAR}calendar.getTime().toString()</td>
-            #if( ${CP_DOLLAR}user.last_login_date ) ${CP_DOLLAR}calendar.setTime(${CP_DOLLAR}dateFormat.parse(${CP_DOLLAR}user.last_login_date))<td>${CP_DOLLAR}calendar.getTime().toString()</td>#else<td></td>#end
-            #if( ${CP_DOLLAR}user.block_date ) ${CP_DOLLAR}calendar.setTime(${CP_DOLLAR}dateFormat.parse(${CP_DOLLAR}user.block_date))<td>${CP_DOLLAR}calendar.getTime().toString()</td>#else<td></td>#end
-        </tr>
-        #end
-    </table>
-    #end
 
     <p>Best regards,</p>
     <p>$CP_PREF_UI_PIPELINE_DEPLOYMENT_NAME Platform</p>

--- a/deploy/contents/install/email-templates/contents/LDAP_BLOCKED_USERS.html
+++ b/deploy/contents/install/email-templates/contents/LDAP_BLOCKED_USERS.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <style>
+        table,
+        td {
+            border: 1px solid black;
+            border-collapse: collapse;
+            padding: 5px;
+        }
+    </style>
+</head>
+
+<body>
+<p>Dear user,</p>
+<p>*** This is a system generated email, do not reply to this email ***</p>
+#if( ${CP_DOLLAR}templateParameters["pipelineUsers"] )
+<p>The following users were blocked since they are blocked into LDAP.</p>
+<table>
+    <tr>
+        <th>User ID</th>
+        <th>Email</th>
+        <th>Storage Name</th>
+        <th>Creation Date</th>
+        <th>Last Login Date</th>
+        <th>Blocked Date</th>
+    </tr>
+    #foreach( ${CP_DOLLAR}user in ${CP_DOLLAR}templateParameters["pipelineUsers"] )
+    <tr>
+        <td>${CP_DOLLAR}user.name</td>
+        #if( ${CP_DOLLAR}user.email )<td>${CP_DOLLAR}user.email</td>#else<td></td>#end
+        #if( ${CP_DOLLAR}user.storage_name )<td>${CP_DOLLAR}user.storage_name</td>#else<td></td>#end
+        ${CP_DOLLAR}calendar.setTime(${CP_DOLLAR}dateFormat.parse(${CP_DOLLAR}user.registration_date))<td>${CP_DOLLAR}calendar.getTime().toString()</td>
+        #if( ${CP_DOLLAR}user.last_login_date ) ${CP_DOLLAR}calendar.setTime(${CP_DOLLAR}dateFormat.parse(${CP_DOLLAR}user.last_login_date))<td>${CP_DOLLAR}calendar.getTime().toString()</td>#else<td></td>#end
+        #if( ${CP_DOLLAR}user.block_date ) ${CP_DOLLAR}calendar.setTime(${CP_DOLLAR}dateFormat.parse(${CP_DOLLAR}user.block_date))<td>${CP_DOLLAR}calendar.getTime().toString()</td>#else<td></td>#end
+    </tr>
+    #end
+</table>
+#end
+
+<p>Best regards,</p>
+<p>$CP_PREF_UI_PIPELINE_DEPLOYMENT_NAME Platform</p>
+</body>
+
+</html>


### PR DESCRIPTION
The current PR provide implementation for issue #2821. The following changes were added:
- a new notification type `LDAP_BLOCKED_USERS` and corresponding template were added
- freshly blocked users were removed from `INACTIVE_USERS` notification and template was changed