### PR TITLE
Support basic ssh pretty urls

### DIFF
--- a/api/src/main/java/com/epam/pipeline/controller/vo/PipelineRunFilterVO.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/PipelineRunFilterVO.java
@@ -47,6 +47,7 @@ public class PipelineRunFilterVO implements AclSecuredFilter {
     private List<Long> configurationIds;
     private List<Long> projectIds;
     private List<String> dockerImages;
+    private String prettyUrl;
 
     private boolean userModified = true;
     private Map<String, String> tags;
@@ -79,7 +80,8 @@ public class PipelineRunFilterVO implements AclSecuredFilter {
                 && parentId == null && CollectionUtils.isEmpty(owners)
                 && CollectionUtils.isEmpty(configurationIds) && CollectionUtils.isEmpty(entitiesIds)
                 && CollectionUtils.isEmpty(projectIds)
-                && MapUtils.isEmpty(tags);
+                && MapUtils.isEmpty(tags)
+                && prettyUrl == null;
     }
 
     @Data

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
@@ -627,7 +627,8 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
         if (StringUtils.isNotBlank(filter.getPrettyUrl())) {
             appendAnd(whereBuilder, clausesCount);
             whereBuilder.append(String.format(" r.pretty_url like :%s", PipelineRunParameters.PRETTY_URL.name()));
-            params.addValue(PipelineRunParameters.PRETTY_URL.name(), filter.getPrettyUrl());
+            params.addValue(PipelineRunParameters.PRETTY_URL.name(),
+                    String.format("%%\"path\":\"%s\"%%", filter.getPrettyUrl()));
             clausesCount++;
         }
 

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
@@ -624,6 +624,13 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
             whereBuilder.append(tagsFilterConditions);
         }
 
+        if (StringUtils.isNotBlank(filter.getPrettyUrl())) {
+            appendAnd(whereBuilder, clausesCount);
+            whereBuilder.append(String.format(" r.pretty_url like :%s", PipelineRunParameters.PRETTY_URL.name()));
+            params.addValue(PipelineRunParameters.PRETTY_URL.name(), filter.getPrettyUrl());
+            clausesCount++;
+        }
+
         appendProjectFilter(projectFilter, params, whereBuilder, clausesCount);
         appendAclFilters(filter, params, whereBuilder, clausesCount);
 

--- a/api/src/main/java/com/epam/pipeline/entity/cluster/PrettyUrl.java
+++ b/api/src/main/java/com/epam/pipeline/entity/cluster/PrettyUrl.java
@@ -2,28 +2,6 @@ package com.epam.pipeline.entity.cluster;
 
 import lombok.Value;
 
-/**
- * Pretty url support three formats:
- *
- * 1. If only path is specified
- *      - path = prettypath
- *    Then resulting urls are
- *      - https://cloud.pipeline.egde.domain.com/prettypath
- *      - https://cloud.pipeline.egde.domain.com/ssh/pipeline/prettypath
- *
- * 2. If both domain and path are specified
- *      - path = prettypath
- *      - domain = pretty.domain.com
- *    Then resulting urls are
- *      - https://pretty.domain.com/prettypath
- *      - https://pretty.domain.com/ssh/pipeline/prettypath
- *
- * 3. If only domain is specified
- *      - domain = pretty.domain.com
- *    Then resulting urls are
- *      - https://pretty.domain.com/runpath
- *      - https://pretty.domain.com/ssh/pipeline/runpath
- */
 @Value
 public class PrettyUrl {
     String path;

--- a/api/src/main/java/com/epam/pipeline/entity/cluster/PrettyUrl.java
+++ b/api/src/main/java/com/epam/pipeline/entity/cluster/PrettyUrl.java
@@ -1,0 +1,31 @@
+package com.epam.pipeline.entity.cluster;
+
+import lombok.Value;
+
+/**
+ * Pretty url support three formats:
+ *
+ * 1. If only path is specified
+ *      - path = prettypath
+ *    Then resulting urls are
+ *      - https://cloud.pipeline.egde.domain.com/prettypath
+ *      - https://cloud.pipeline.egde.domain.com/ssh/pipeline/prettypath
+ *
+ * 2. If both domain and path are specified
+ *      - path = prettypath
+ *      - domain = pretty.domain.com
+ *    Then resulting urls are
+ *      - https://pretty.domain.com/prettypath
+ *      - https://pretty.domain.com/ssh/pipeline/prettypath
+ *
+ * 3. If only domain is specified
+ *      - domain = pretty.domain.com
+ *    Then resulting urls are
+ *      - https://pretty.domain.com/runpath
+ *      - https://pretty.domain.com/ssh/pipeline/runpath
+ */
+@Value
+public class PrettyUrl {
+    String path;
+    String domain;
+}

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/EdgeServiceManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/EdgeServiceManager.java
@@ -19,10 +19,14 @@ package com.epam.pipeline.manager.cluster;
 
 import com.epam.pipeline.common.MessageConstants;
 import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.config.JsonMapper;
+import com.epam.pipeline.entity.cluster.PrettyUrl;
 import com.epam.pipeline.entity.cluster.ServiceDescription;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.manager.pipeline.PipelineRunCRUDService;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
+import com.fasterxml.jackson.core.type.TypeReference;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServicePort;
 import lombok.extern.slf4j.Slf4j;
@@ -31,6 +35,7 @@ import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -47,8 +52,8 @@ import java.util.stream.Collectors;
 public class EdgeServiceManager {
     private static final String DEFAULT_SVC_SCHEME = "http";
     private static final String BASE_URL_TEMPLATE = "%s://%s:%d";
-    private static final String SSH_URL_TEMPLATE = "%s://%s:%d/ssh/pipeline/%d";
-    private static final String FSBROWSER_URL_TEMPLATE = "%s://%s:%d/fsbrowser/%d";
+    private static final String SSH_URL_TEMPLATE = "%s://%s:%d/ssh/pipeline/%s";
+    private static final String FSBROWSER_URL_TEMPLATE = "%s://%s:%d/fsbrowser/%s";
 
     private final KubernetesManager kubernetesManager;
     private final MessageHelper messageHelper;
@@ -83,7 +88,23 @@ public class EdgeServiceManager {
     }
 
     public Map<String, String> buildSshUrl(final Long runId) {
-        return buildServiceUrl(runId, SSH_URL_TEMPLATE);
+        return buildServiceUrl(SSH_URL_TEMPLATE, toPrettyUrlPath(runId).orElse(ObjectUtils.toString(runId)));
+    }
+
+    private Optional<String> toPrettyUrlPath(final Long runId) {
+        return runCRUDService.findRunByRunId(runId)
+                .map(PipelineRun::getPrettyUrl)
+                .flatMap(this::toPrettyUrl)
+                .map(PrettyUrl::getPath);
+    }
+
+    private Optional<PrettyUrl> toPrettyUrl(final String prettyUrlJson) {
+        try {
+            return Optional.ofNullable(JsonMapper.parseData(prettyUrlJson, new TypeReference<PrettyUrl>() {}));
+        } catch (IllegalArgumentException e) {
+            log.warn("Pretty url parsing has failed: {}", prettyUrlJson, e);
+            return Optional.empty();
+        }
     }
 
     public String getEdgeDomainNameOrIP() {
@@ -98,7 +119,7 @@ public class EdgeServiceManager {
 
     public Map<String, String> buildFSBrowserUrl(final Long runId) {
         if (isFSBrowserEnabled() && runIsNotSensitive(runId)) {
-            return buildServiceUrl(runId, FSBROWSER_URL_TEMPLATE);
+            return buildServiceUrl(FSBROWSER_URL_TEMPLATE, ObjectUtils.toString(runId));
         } else {
             throw new IllegalArgumentException("Storage fsbrowser is not enabled.");
         }
@@ -177,10 +198,6 @@ public class EdgeServiceManager {
                 .orElse(false);
     }
 
-    private String buildUrl(final ServiceDescription service, final String template, final Long runId) {
-        return String.format(template, service.getScheme(), service.getIp(), service.getPort(), runId);
-    }
-
     private String buildEdgeExternalUrl(final ServiceDescription edgeService) {
         return String.format(BASE_URL_TEMPLATE, edgeService.getScheme(), edgeService.getIp(), edgeService.getPort());
     }
@@ -193,11 +210,15 @@ public class EdgeServiceManager {
         return labels;
     }
 
-    private Map<String, String> buildServiceUrl(final Long runId, final String template) {
+    private Map<String, String> buildServiceUrl(final String template, final String path) {
         return kubernetesManager.getServicesByLabel(edgeLabel).stream()
                 .map(this::getServiceDescription)
                 .collect(Collectors.toMap(ServiceDescription::getRegion, serviceDescription ->
-                        buildUrl(serviceDescription, template, runId)));
+                        buildUrl(template, path, serviceDescription)));
+    }
+
+    private String buildUrl(final String template, final String path, final ServiceDescription service) {
+        return String.format(template, service.getScheme(), service.getIp(), service.getPort(), path);
     }
 
     private String getEdgeRegion(final String region) {

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunCRUDService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunCRUDService.java
@@ -21,17 +21,17 @@ import com.epam.pipeline.dao.pipeline.PipelineRunDao;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 //TODO: Move all CRUD and DB persistence methods from PipelineRunManager to this class
@@ -51,7 +51,7 @@ public class PipelineRunCRUDService {
 
     @Transactional(propagation = Propagation.REQUIRED)
     public void updatePrettyUrlForFinishedRun(PipelineRun run) {
-        if (run.getStatus().isFinal() && StringUtils.hasText(run.getPrettyUrl())) {
+        if (run.getStatus().isFinal() && StringUtils.isNotBlank(run.getPrettyUrl())) {
             run.setPrettyUrl(null);
             pipelineRunDao.updateRun(run);
         }
@@ -71,9 +71,12 @@ public class PipelineRunCRUDService {
     }
 
     public PipelineRun loadRunById(final Long id) {
-        final PipelineRun pipelineRun = pipelineRunDao.loadPipelineRun(id);
-        Assert.notNull(pipelineRun, messageHelper.getMessage(MessageConstants.ERROR_RUN_PIPELINES_NOT_FOUND, id));
-        return pipelineRun;
+        return findRunByRunId(id).orElseThrow(() -> new IllegalArgumentException(messageHelper.getMessage(
+                MessageConstants.ERROR_RUN_PIPELINES_NOT_FOUND, id)));
+    }
+
+    public Optional<PipelineRun> findRunByRunId(final Long id) {
+        return Optional.ofNullable(pipelineRunDao.loadPipelineRun(id));
     }
 
     public List<PipelineRun> loadRunsForNodeName(final String nodeName) {

--- a/deploy/docker/cp-edge/Dockerfile
+++ b/deploy/docker/cp-edge/Dockerfile
@@ -44,7 +44,8 @@ RUN yum install -y python \
                    zlib-devel \
                    cronie \
                    sshpass \
-                   perl && \
+                   perl \
+                   netcat && \
     yum group install -y "Development Tools" && \
     curl https://cloud-pipeline-oss-builds.s3.amazonaws.com/tools/pip/2.7/get-pip.py | python - && \
     pip install rsa==4.0 \

--- a/deploy/docker/cp-edge/wetty/app.js
+++ b/deploy/docker/cp-edge/wetty/app.js
@@ -9,53 +9,127 @@ var child_process = require('child_process');
 const checkMaintenanceMode = require('./maintenance');
 
 // Constants
-var ENV_TAG_RUNID_NAME = 'CP_ENV_TAG_RUNID';
-var CONN_QUOTA_PER_PIPELINE_ID = process.env.CP_EDGE_MAX_SSH_CONNECTIONS || 25;
+const ENV_TAG_RUNID_NAME = 'CP_ENV_TAG_RUNID';
+const CONN_QUOTA_PER_RUN_ID = process.env.CP_EDGE_MAX_SSH_CONNECTIONS || 25;
 
 const CP_MAINTENANCE_SKIP_ROLES = (process.env.CP_MAINTENANCE_SKIP_ROLES || '')
     .split(',')
     .map(o => o.trim().toUpperCase())
     .filter(o => o.length);
 
+function console_log(message) {
+    console.log((new Date()) + ' ' + message);
+}
+
+function console_error(message) {
+    console.error((new Date()) + ' ' + message);
+}
+
 function call_api(api_method, auth_key, httpMethod = 'GET', payload = undefined) {
-    var options = {
+    const options = {
         'headers': {
             'Authorization': 'Bearer ' + auth_key
         },
         json: payload
     };
-    var response = request(httpMethod, process.env.API + api_method, options);
+    const response = request(httpMethod, process.env.API + api_method, options);
     if (response.statusCode == 200) {
         return JSON.parse(response.getBody()).payload;
     }
     return null;
 }
 
-function get_pipe_details(pipeline_id, auth_key) {
-    payload = call_api('/run/' + pipeline_id, auth_key);
-    if (payload) {
-        var parameters = {};
-        if (payload.pipelineRunParameters) {
-            parameters = payload.pipelineRunParameters.reduce(function(parameters, parameter) {
-                parameters[parameter.name] = parameter.value;
-                return parameters;
-            }, {});
+function load_run(run_id, auth_key) {
+    return call_api('/run/' + run_id, auth_key);
+}
+
+function load_runs(pretty_url_path, auth_key) {
+    return call_api(
+        '/run/filter',
+         auth_key,
+        'POST',
+        {
+            'page': 0,
+            'pageSize': 100,
+            'prettyUrl': '*"path":"' + pretty_url_path + '"*'
         }
-        return {
-            'ip': payload.podIP,
-            'pass': payload.sshPassword,
-            'owner': payload.owner,
-            'pod_id': payload.podId,
-            'platform': payload.platform,
-            'parameters': parameters
-        };
+    );
+}
+
+function extract_run_details(payload) {
+    if (!payload) {
+        return null;
+    }
+    const parameters = payload.pipelineRunParameters
+        ? payload.pipelineRunParameters.reduce(function(parameters, parameter) {
+            parameters[parameter.name] = parameter.value;
+            return parameters;
+        }, {})
+        : {};
+    return {
+        'id': payload.id,
+        'ip': payload.podIP,
+        'pass': payload.sshPassword,
+        'owner': payload.owner,
+        'pod_id': payload.podId,
+        'platform': payload.platform,
+        'parameters': parameters
+    };
+}
+
+function get_run_details_by_run_id(run_id, auth_key) {
+    const payload = load_run(run_id, auth_key);
+    return extract_run_details(payload);
+}
+
+function get_run_details_by_pretty_url_path(pretty_url_path, auth_key) {
+    const payload = load_runs(pretty_url_path, auth_key);
+    if (payload && payload.length && payload[0]) {
+        return extract_run_details(payload[0]);
+    }
+    return null;
+}
+
+function get_run_details(referer, auth_key) {
+    if (!referer) {
+        return null;
+    }
+    if (match = referer.match('/ssh/pipeline/(\\d+)$')) {
+        const run_id = match[1];
+        if (!run_id) {
+            console_log('Could not find run id in referer url: ' + referer + '.');
+            return null;
+        }
+
+        const run_details = get_run_details_by_run_id(run_id, auth_key);
+        if (!run_details) {
+            console_log('Could not find run #' + run_id + '.');
+            return null;
+        }
+
+        return run_details;
+    } else if (match = referer.match('/ssh/pipeline/(.+)$')) {
+        const run_pretty_url_path = match[1];
+        if (!run_pretty_url_path) {
+            console_log('Could not find ssh pretty url in referer url: ' + referer + '.');
+            return null;
+        }
+
+        const run_details = get_run_details_by_pretty_url_path(run_pretty_url_path, auth_key);
+        if (!run_details) {
+            console_log('Could not find run with ' + run_pretty_url_path + ' ssh pretty url.');
+            return null;
+        }
+
+        return run_details;
     } else {
-        return payload;
+        console_log('Could not find run id or ssh pretty url in referer url: ' + referer + '.');
+        return null;
     }
 }
 
 function get_current_user(auth_key) {
-    payload = call_api('/whoami', auth_key);
+    const payload = call_api('/whoami', auth_key);
     if (payload) {
         return {
             'id': payload.id,
@@ -63,9 +137,8 @@ function get_current_user(auth_key) {
             'admin': payload.admin,
             'roles': (payload.groups || []).concat((payload.roles || []).map(function (role) { return role.name; }))
         };
-    } else {
-        return payload;
     }
+    return null;
 }
 
 function get_platform_name(auth_key) {
@@ -109,7 +182,7 @@ function get_boolean(value) {
 }
 
 function get_preference(preference, auth_key) {
-    payload = call_api('/preferences/' + preference, auth_key);
+    const payload = call_api('/preferences/' + preference, auth_key);
     return payload && payload.value;
 }
 
@@ -117,18 +190,18 @@ function get_boolean_preference(preference, auth_key) {
     return get_boolean(get_preference(preference, auth_key));
 }
 
-function conn_quota_available(pipeline_id) {
+function conn_quota_available(run_id) {
     // This command:
     // 1. Searches for the processes with "ssh" command (grep -wl ssh /proc/*/comm) and prints the file name (e.g. /proc/123/comm)
     // 2. Replaces the "comm" with "environ" file name (it will be searched for a "tag")
     // 3. Searches the resulting list of "ssh" processes, that are "tagged" with the RUN ID
     var running_pids_command = 'ssh_pids=$(grep -wl ssh /proc/*/comm | sed -e "s/comm/environ/g") && \
                                 [ "$ssh_pids" ] && \
-                                grep -l "\\b' + ENV_TAG_RUNID_NAME + '=' + pipeline_id + '\\b" $ssh_pids';
+                                grep -l "\\b' + ENV_TAG_RUNID_NAME + '=' + run_id + '\\b" $ssh_pids';
 
-    var running_pids_count = 0;
+    let running_pids_count = 0;
     try {
-        var stdout = child_process.execSync(running_pids_command).toString();
+        const stdout = child_process.execSync(running_pids_command).toString();
         running_pids_count = stdout.split(/\r\n|\r|\n/).filter(item => item).length;
     }
     catch (err) {
@@ -137,12 +210,12 @@ function conn_quota_available(pipeline_id) {
         // https://www.unix.com/man-page/posix/1P/grep/
         if (err.status != 1) {
             // If something went wrong - we'll be optimists and allow the connection, but drop a log line on the error
-            console.log((new Date()) + ' Cannot get running connections for a run #' + pipeline_id + ' (exit code: ' + err.status + ', stderr: ' + err.stderr + ')');
+            console_log('Cannot get running connections for a run #' + run_id + ' (exit code: ' + err.status + ', stderr: ' + err.stderr + ')');
         }
     }
 
-    console.log('Already running "' + running_pids_count + '" PIDs for #' + pipeline_id);
-    return running_pids_count < CONN_QUOTA_PER_PIPELINE_ID;;
+    console_log('Already running "' + running_pids_count + '/' + CONN_QUOTA_PER_RUN_ID + '" PIDs for run #' + run_id);
+    return running_pids_count < CONN_QUOTA_PER_RUN_ID;
 }
 
 function get_owner_user_name(owner) {
@@ -151,17 +224,17 @@ function get_owner_user_name(owner) {
 }
 
 function get_run_sshpass(run_details, auth_key) {
-    parent_run_id = run_details.parameters['parent-id'];
-    run_shared_users_enabled = get_boolean(run_details.parameters['CP_CAP_SHARE_USERS']);
+    const parent_run_id = run_details.parameters['parent-id'];
+    const run_shared_users_enabled = get_boolean(run_details.parameters['CP_CAP_SHARE_USERS']);
     if (run_shared_users_enabled && parent_run_id) {
-        parent_run_details = get_pipe_details(parent_run_id, auth_key);
+        const parent_run_details = get_run_details_by_run_id(parent_run_id, auth_key);
         return parent_run_details.pass;
     } else {
         return run_details.pass;
     }
 }
 
-var opts = require('optimist')
+const opts = require('optimist')
     .options({
         sshport: {
             demand: false,
@@ -182,127 +255,107 @@ var opts = require('optimist')
         },
     }).boolean('allow_discovery').argv;
 
-var sshport = 22;
-var sshuser = 'root';
-var sshpass = null;
-
-if (opts.sshport) {
-    sshport = opts.sshport;
-}
-
-if (opts.sshuser) {
-    sshuser = opts.sshuser;
-}
-if (opts.sshpass) {
-    sshpass = opts.sshpass;
-}
+const sshport = opts.sshport ? opts.sshport : 22;
 
 process.on('uncaughtException', function(e) {
-    console.error('Error: ' + e);
+    console_error('Error: ' + e);
+    if (e.stack) {
+        console_error('Error: ' + e.stack);
+    }
 });
 
-var httpserv;
-
-var app = express();
+const app = express();
 app.get('/ssh/pipeline/:pipeline', function(req, res) {
-    res.sendfile(__dirname + '/public/ssh/index.html');
-});
-app.get('/ssh/container/:pipeline', function(req, res) {
     res.sendfile(__dirname + '/public/ssh/index.html');
 });
 app.use('/', express.static(path.join(__dirname, 'public')));
 
 
-httpserv = http.createServer(app).listen(opts.port, function() {
-    console.log('http on port ' + opts.port);
+const httpserv = http.createServer(app).listen(opts.port, function() {
+    console_log('http on port ' + opts.port);
 });
 
 const {addListener} = checkMaintenanceMode();
 
-var io = server(httpserv,{path: '/ssh/socket.io'});
+const io = server(httpserv,{path: '/ssh/socket.io'});
 io.on('connection', function(socket) {
-    var sshhost = 'localhost';
-    var pipeline_id = 0
-    var request = socket.request;
-    console.log((new Date()) + ' Connection accepted for ' + request.headers.referer);
-    var term;
-    let current_user;
-    let platformName = 'Cloud Pipeline';
-    let theme = 'default';
-    if (match = request.headers.referer.match('/ssh/(pipeline|container)/(.+)$')) {
-        pipeline_id = match[2];
-        if (!pipeline_id) {
-            socket.disconnect();
-            return;
-        }
+    const auth_key = socket.handshake.headers['token'];
+    const referer = socket.request.headers.referer;
+    console_log('Connection accepted for ' + referer);
 
-        if (!conn_quota_available(pipeline_id)) {
-            var conn_err_msg = ' SSH connection quota exceeded for the run #' + pipeline_id + ' (Max connections: ' + CONN_QUOTA_PER_PIPELINE_ID + ')';
-            console.log((new Date()) + conn_err_msg);
-            socket.emit('output', conn_err_msg);
-            socket.disconnect();
-            return;
-        }
-
-        var auth_key = socket.handshake.headers['token'];
-        pipe_details = get_pipe_details(pipeline_id, auth_key);
-        if (!pipe_details || !pipe_details.ip || !pipe_details.pass || !pipe_details.owner) {
-            console.log((new Date()) + " Cannot get ip/pass/owner for a run #" + pipeline_id);
-            socket.disconnect();
-            return;
-        }
-
-        if(match[1] == 'pipeline') {
-            sshhost = pipe_details.ip;
-            run_ssh_mode = pipe_details.parameters['CP_CAP_SSH_MODE'];
-            owner_user_name = get_owner_user_name(pipe_details.owner);
-            if (!run_ssh_mode) {
-                if (pipe_details.platform == 'windows') {
-                    run_ssh_mode = 'owner-sshpass';
-                } else {
-                    run_ssh_mode = get_boolean_preference('system.ssh.default.root.user.enabled', auth_key) ? 'root' : 'owner';
-                }
-            }
-            current_user = get_current_user(auth_key);
-            platformName = get_platform_name(auth_key);
-            const userDefinedTheme = current_user
-                ? get_user_attributes_theme(current_user.id, auth_key)
-                : undefined;
-            theme = userDefinedTheme || get_ssh_theme(auth_key);
-            switch (run_ssh_mode) {
-                case 'user':
-                    user = current_user;
-                    sshuser = user.name;
-                    sshpass = user.name;
-                    break
-                case 'owner':
-                    sshuser = owner_user_name;
-                    sshpass = owner_user_name;
-                    break
-                case 'owner-sshpass':
-                    sshuser = owner_user_name;
-                    sshpass = get_run_sshpass(pipe_details, auth_key);
-                    break
-                default:
-                    sshuser = 'root';
-                    sshpass = get_run_sshpass(pipe_details, auth_key);
-                    break
-            }
-            term = pty.spawn('sshpass', ['-p', sshpass, 'ssh', sshuser + '@' + sshhost, '-p', sshport, '-o', 'StrictHostKeyChecking=no', '-o', 'GlobalKnownHostsFile=/dev/null', '-o', 'UserKnownHostsFile=/dev/null', '-q'], {
-                    name: 'xterm-256color',
-                    cols: 80,
-                    rows: 30,
-                    env: { [ENV_TAG_RUNID_NAME]: pipeline_id }
-            });
-        } else {
-            socket.disconnect();
-            return;
-        }
-    }
-    else {
+    const run_details = get_run_details(referer, auth_key);
+    if (!run_details) {
+        console_log('Aborting SSH connection because run details haven\'t been retrieved for ' + referer + '...');
         socket.disconnect();
         return;
     }
+    if (!run_details.id || !run_details.ip || !run_details.pass || !run_details.owner) {
+        console_log('Aborting SSH connection because run details don\'t have id/ip/pass/owner for ' + referer + '...');
+        socket.disconnect();
+        return;
+    }
+
+    const run_id = run_details.id;
+    console_log('Establishing SSH connection to run #' + run_id + '...');
+
+    if (!conn_quota_available(run_id)) {
+        const conn_err_msg = 'Aborting SSH connection because quota exceeded for run #' + run_id + '. '
+                             + 'Max connections: ' + CONN_QUOTA_PER_RUN_ID + '.';
+        console_log(conn_err_msg);
+        socket.emit('output', conn_err_msg);
+        socket.disconnect();
+        return;
+    }
+
+    const sshhost = run_details.ip;
+    const owner_user_name = get_owner_user_name(run_details.owner);
+    let run_ssh_mode = run_details.parameters['CP_CAP_SSH_MODE'];
+    if (!run_ssh_mode) {
+        if (run_details.platform == 'windows') {
+            run_ssh_mode = 'owner-sshpass';
+        } else {
+            run_ssh_mode = get_boolean_preference('system.ssh.default.root.user.enabled', auth_key) ? 'root' : 'owner';
+        }
+    }
+    const current_user = get_current_user(auth_key);
+    const platformName = get_platform_name(auth_key);
+    const userDefinedTheme = current_user
+        ? get_user_attributes_theme(current_user.id, auth_key)
+        : undefined;
+    const theme = userDefinedTheme || get_ssh_theme(auth_key);
+    let sshuser;
+    let sshpass;
+    switch (run_ssh_mode) {
+        case 'user':
+            sshuser = current_user.name;
+            sshpass = current_user.name;
+            break
+        case 'owner':
+            sshuser = owner_user_name;
+            sshpass = owner_user_name;
+            break
+        case 'owner-sshpass':
+            sshuser = owner_user_name;
+            sshpass = get_run_sshpass(run_details, auth_key);
+            break
+        default:
+            sshuser = 'root';
+            sshpass = get_run_sshpass(run_details, auth_key);
+            break
+    }
+    console_log('Establishing SSH connection to run #' + run_id + ' as ' + sshuser + ' (' + run_ssh_mode + ' mode)...');
+    const term = pty.spawn('sshpass', ['-p', sshpass, 'ssh', sshuser + '@' + sshhost,
+                                       '-p', sshport,
+                                       '-o', 'StrictHostKeyChecking=no',
+                                       '-o', 'GlobalKnownHostsFile=/dev/null',
+                                       '-o', 'UserKnownHostsFile=/dev/null',
+                                       '-q'], {
+            name: 'xterm-256color',
+            cols: 80,
+            rows: 30,
+            env: { [ENV_TAG_RUNID_NAME]: run_id }
+    });
+
     const currentUserIsAdmin = current_user &&
         (
             current_user.admin ||
@@ -318,18 +371,19 @@ io.on('connection', function(socket) {
             socket.emit('output', `\r\n\n\u001b[32m${platformName}\u001b[0m is back from the \u001b[31mmaintenance mode\u001b[0m.\n\r\n`);
         }
         if (!currentUserIsAdmin && active) {
+            console_log('Aborting SSH connection because platform maintenance has started for run #' + run_id + '...');
             socket.disconnect();
         }
     }
 
     const stopListeningMaintenanceModeChange = addListener(onMaintenanceModeChange);
 
-    console.log((new Date()) + " PID=" + term.pid + " STARTED to IP=" + sshhost + ", RUNNO=" + pipeline_id + " on behalf of user=" + sshuser);
+    console_log("PID=" + term.pid + " STARTED to IP=" + sshhost + ", RUNNO=" + run_id + " on behalf of user=" + sshuser);
     term.on('data', function(data) {
         socket.emit('output', data);
     });
     term.on('exit', function(code) {
-        console.log((new Date()) + " PID=" + term.pid + " ENDED")
+        console_log("PID=" + term.pid + " ENDED")
     });
     socket.on('resize', function(data) {
         term.resize(data.col, data.row);
@@ -339,13 +393,13 @@ io.on('connection', function(socket) {
     });
     socket.on('disconnect', function() {
         stopListeningMaintenanceModeChange();
-        console.log((new Date()) + " Disconnecting PID=" + term.pid);
+        console_log("Disconnecting PID=" + term.pid);
         term.end();
         try {
             process.kill(term.pid);
         }
         catch(ex) {
-            console.log(ex);
+            console_log('Error: ' + ex);
         }
     });
     socket.emit('term.theme', theme);

--- a/deploy/docker/cp-edge/wetty/app.js
+++ b/deploy/docker/cp-edge/wetty/app.js
@@ -51,7 +51,7 @@ function load_runs(pretty_url_path, auth_key) {
         {
             'page': 1,
             'pageSize': 1,
-            'prettyUrl': '%"path":"' + pretty_url_path + '"%'
+            'prettyUrl': pretty_url_path
         }
     );
 }


### PR DESCRIPTION
Resolves #2850.

The pull request brings support for ssh pretty urls. From now on all runs with pretty url paths or friendly urls specified have ssh pretty url as well.

1. If only path is specified in pretty url
     - path = prettypath
     - ssh url = https://cloud.pipeline.egde.domain.com/ssh/pipeline/prettypath
     - ssh url = https://cloud.pipeline.egde.domain.com/ssh/pipeline/runid
 
2. If both domain and path are specified in pretty url
     - path = prettypath
     - domain = pretty.domain.com
     - ssh url = https://pretty.domain.com/ssh/pipeline/prettypath
     - ssh url = https://cloud.pipeline.egde.domain.com/ssh/pipeline/prettypath
     - ssh url = https://cloud.pipeline.egde.domain.com/ssh/pipeline/runid
 
3. If only domain is specified in pretty url
     - domain = pretty.domain.com
     - ssh url = https://pretty.domain.com/ssh/pipeline/runid
     - ssh url = https://cloud.pipeline.egde.domain.com/ssh/pipeline/runid