### PR TITLE
issue 2721 SLS: changing transition chain

### DIFF
--- a/storage-lifecycle-service/integrational_tests/decorator/cloud_decator.py
+++ b/storage-lifecycle-service/integrational_tests/decorator/cloud_decator.py
@@ -44,3 +44,6 @@ class AttributesChangingStorageOperations(StorageOperations):
 
     def tag_files_to_transit(self, region, storage_container, files, storage_class, transit_id):
         return self.cloud_operations.tag_files_to_transit(region, storage_container, files, storage_class, transit_id)
+
+    def get_storage_class_transition_map(self, storage_classes):
+        return self.cloud_operations.get_storage_class_transition_map(storage_classes)

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_29_files_action_completed_and_eligable_for_several_next_actions.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_29_files_action_completed_and_eligable_for_several_next_actions.json
@@ -1,0 +1,105 @@
+{
+  "cloud": {
+    "storages": [
+      {
+        "storageProvider": "S3",
+        "storage": "cp-lifecycle-storage-policy-test-storage",
+        "files": [
+          {"key": "data/file1.txt", "creationDateShift": 11, "storageClass": "STANDARD"},
+          {"key": "data/file2.txt", "creationDateShift": 20, "storageClass": "GLACIER"},
+          {"key": "data/file3.txt", "creationDateShift": 20, "storageClass": "GLACIER"}
+        ]
+      }
+    ]
+  },
+  "platform": {
+    "storages": [
+      {
+        "id": 1,
+        "storageProvider": "S3",
+        "storage": "cp-lifecycle-storage-policy-test-storage",
+        "rules": [
+          {
+            "id": 1,
+            "datastorageId": 1,
+            "pathGlob": "/data",
+            "objectGlob": "*.txt",
+            "transitionMethod": "LATEST_FILE",
+            "transitionCriterion": {
+              "type": "DEFAULT"
+            },
+            "transitions": [
+              {
+                "transitionAfterDays": 10,
+                "storageClass": "GLACIER"
+              },
+              {
+                "transitionAfterDays": 20,
+                "storageClass": "DEEP_ARCHIVE"
+              }
+            ],
+            "notification": {
+              "notifyBeforeDays": 5,
+              "prolongDays": 10,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
+              "enabled": true,
+              "subject": "Lifecycle rule is about to be applied!",
+              "body": "Lifecycle rule is about to be applied!"
+            }
+          }
+        ],
+        "executions": [
+          {
+            "ruleId": 1,
+            "path": "/data",
+            "status": "SUCCESS",
+            "storageClass": "GLACIER"
+          },
+          {
+            "ruleId": 1,
+            "path": "/data",
+            "status": "NOTIFICATION_SENT",
+            "storageClass": "DEEP_ARCHIVE"
+          }
+        ]
+      }
+    ]
+  },
+  "result": {
+    "cloud": {
+      "storages": [
+        {
+          "storage": "cp-lifecycle-storage-policy-test-storage",
+          "storageProvider": "S3",
+          "files": [
+            {"key": "data/file1.txt", "tags": {"DESTINATION_STORAGE_CLASS":  "GLACIER"}},
+            {"key": "data/file2.txt", "tags": {"DESTINATION_STORAGE_CLASS":  "DEEP_ARCHIVE"}},
+            {"key": "data/file3.txt", "tags": {"DESTINATION_STORAGE_CLASS":  "DEEP_ARCHIVE"}}
+          ]
+        }
+      ]
+    },
+    "platform": {
+      "storages": [
+        {
+          "id": 1,
+          "storage": "cp-lifecycle-storage-policy-test-storage",
+          "executions": [
+            {
+              "ruleId": 1,
+              "path": "/data",
+              "status": "RUNNING",
+              "storageClass": "GLACIER"
+            },
+            {
+              "ruleId": 1,
+              "path": "/data",
+              "status": "RUNNING",
+              "storageClass": "DEEP_ARCHIVE"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_30_files_action_completed_and_new_files_eligable_for_action.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_30_files_action_completed_and_new_files_eligable_for_action.json
@@ -1,0 +1,93 @@
+{
+  "cloud": {
+    "storages": [
+      {
+        "storageProvider": "S3",
+        "storage": "cp-lifecycle-storage-policy-test-storage",
+        "files": [
+          {"key": "data/file1.txt", "creationDateShift": 11, "storageClass": "STANDARD"},
+          {"key": "data/file2.txt", "creationDateShift": 14, "storageClass": "GLACIER"},
+          {"key": "data/file3.txt", "creationDateShift": 14, "storageClass": "GLACIER"}
+        ]
+      }
+    ]
+  },
+  "platform": {
+    "storages": [
+      {
+        "id": 1,
+        "storageProvider": "S3",
+        "storage": "cp-lifecycle-storage-policy-test-storage",
+        "rules": [
+          {
+            "id": 1,
+            "datastorageId": 1,
+            "pathGlob": "/data",
+            "objectGlob": "*.txt",
+            "transitionMethod": "LATEST_FILE",
+            "transitionCriterion": {
+              "type": "DEFAULT"
+            },
+            "transitions": [
+              {
+                "transitionAfterDays": 10,
+                "storageClass": "GLACIER"
+              },
+              {
+                "transitionAfterDays": 20,
+                "storageClass": "DEEP_ARCHIVE"
+              }
+            ],
+            "notification": {
+              "notifyBeforeDays": 5,
+              "prolongDays": 10,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
+              "enabled": true,
+              "subject": "Lifecycle rule is about to be applied!",
+              "body": "Lifecycle rule is about to be applied!"
+            }
+          }
+        ],
+        "executions": [
+          {
+            "ruleId": 1,
+            "path": "/data",
+            "status": "SUCCESS",
+            "storageClass": "GLACIER"
+          }
+        ]
+      }
+    ]
+  },
+  "result": {
+    "cloud": {
+      "storages": [
+        {
+          "storage": "cp-lifecycle-storage-policy-test-storage",
+          "storageProvider": "S3",
+          "files": [
+            {"key": "data/file1.txt", "tags": {"DESTINATION_STORAGE_CLASS":  "GLACIER"}},
+            {"key": "data/file2.txt"},
+            {"key": "data/file3.txt"}
+          ]
+        }
+      ]
+    },
+    "platform": {
+      "storages": [
+        {
+          "id": 1,
+          "storage": "cp-lifecycle-storage-policy-test-storage",
+          "executions": [
+            {
+              "ruleId": 1,
+              "path": "/data",
+              "status": "RUNNING",
+              "storageClass": "GLACIER"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_31_files_action_completed_and_new_files_not_eligable_for_action.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_31_files_action_completed_and_new_files_not_eligable_for_action.json
@@ -1,0 +1,93 @@
+{
+  "cloud": {
+    "storages": [
+      {
+        "storageProvider": "S3",
+        "storage": "cp-lifecycle-storage-policy-test-storage",
+        "files": [
+          {"key": "data/file1.txt", "creationDateShift": 7, "storageClass": "STANDARD"},
+          {"key": "data/file2.txt", "creationDateShift": 14, "storageClass": "GLACIER"},
+          {"key": "data/file3.txt", "creationDateShift": 14, "storageClass": "GLACIER"}
+        ]
+      }
+    ]
+  },
+  "platform": {
+    "storages": [
+      {
+        "id": 1,
+        "storageProvider": "S3",
+        "storage": "cp-lifecycle-storage-policy-test-storage",
+        "rules": [
+          {
+            "id": 1,
+            "datastorageId": 1,
+            "pathGlob": "/data",
+            "objectGlob": "*.txt",
+            "transitionMethod": "LATEST_FILE",
+            "transitionCriterion": {
+              "type": "DEFAULT"
+            },
+            "transitions": [
+              {
+                "transitionAfterDays": 10,
+                "storageClass": "GLACIER"
+              },
+              {
+                "transitionAfterDays": 20,
+                "storageClass": "DEEP_ARCHIVE"
+              }
+            ],
+            "notification": {
+              "notifyBeforeDays": 5,
+              "prolongDays": 10,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
+              "enabled": true,
+              "subject": "Lifecycle rule is about to be applied!",
+              "body": "Lifecycle rule is about to be applied!"
+            }
+          }
+        ],
+        "executions": [
+          {
+            "ruleId": 1,
+            "path": "/data",
+            "status": "SUCCESS",
+            "storageClass": "GLACIER"
+          }
+        ]
+      }
+    ]
+  },
+  "result": {
+    "cloud": {
+      "storages": [
+        {
+          "storage": "cp-lifecycle-storage-policy-test-storage",
+          "storageProvider": "S3",
+          "files": [
+            {"key": "data/file1.txt"},
+            {"key": "data/file2.txt"},
+            {"key": "data/file3.txt"}
+          ]
+        }
+      ]
+    },
+    "platform": {
+      "storages": [
+        {
+          "id": 1,
+          "storage": "cp-lifecycle-storage-policy-test-storage",
+          "executions": [
+            {
+              "ruleId": 1,
+              "path": "/data",
+              "status": "NOTIFICATION_SENT",
+              "storageClass": "GLACIER"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_32_files_eligable_for_all_action_but_first_will_be_piked_up.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_32_files_eligable_for_all_action_but_first_will_be_piked_up.json
@@ -1,0 +1,85 @@
+{
+  "cloud": {
+    "storages": [
+      {
+        "storageProvider": "S3",
+        "storage": "cp-lifecycle-storage-policy-test-storage",
+        "files": [
+          {"key": "data/file1.txt", "creationDateShift": 21, "storageClass": "STANDARD"},
+          {"key": "data/file2.txt", "creationDateShift": 23, "storageClass": "STANDARD"},
+          {"key": "data/file3.txt", "creationDateShift": 21, "storageClass": "STANDARD"}
+        ]
+      }
+    ]
+  },
+  "platform": {
+    "storages": [
+      {
+        "id": 1,
+        "storageProvider": "S3",
+        "storage": "cp-lifecycle-storage-policy-test-storage",
+        "rules": [
+          {
+            "id": 1,
+            "datastorageId": 1,
+            "pathGlob": "/data",
+            "objectGlob": "*.txt",
+            "transitionMethod": "LATEST_FILE",
+            "transitionCriterion": {
+              "type": "DEFAULT"
+            },
+            "transitions": [
+              {
+                "transitionAfterDays": 10,
+                "storageClass": "GLACIER"
+              },
+              {
+                "transitionAfterDays": 20,
+                "storageClass": "DEEP_ARCHIVE"
+              }
+            ],
+            "notification": {
+              "notifyBeforeDays": 5,
+              "prolongDays": 10,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
+              "enabled": true,
+              "subject": "Lifecycle rule is about to be applied!",
+              "body": "Lifecycle rule is about to be applied!"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "result": {
+    "cloud": {
+      "storages": [
+        {
+          "storage": "cp-lifecycle-storage-policy-test-storage",
+          "storageProvider": "S3",
+          "files": [
+            {"key": "data/file1.txt", "tags": {"DESTINATION_STORAGE_CLASS":  "GLACIER"}},
+            {"key": "data/file2.txt", "tags": {"DESTINATION_STORAGE_CLASS":  "GLACIER"}},
+            {"key": "data/file3.txt", "tags": {"DESTINATION_STORAGE_CLASS":  "GLACIER"}}
+          ]
+        }
+      ]
+    },
+    "platform": {
+      "storages": [
+        {
+          "id": 1,
+          "storage": "cp-lifecycle-storage-policy-test-storage",
+          "executions": [
+            {
+              "ruleId": 1,
+              "path": "/data",
+              "status": "RUNNING",
+              "storageClass": "GLACIER"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_33_transition_criterion_MATCHING_FILES_several_file_groups_eligable_to_action.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_33_transition_criterion_MATCHING_FILES_several_file_groups_eligable_to_action.json
@@ -1,0 +1,94 @@
+{
+  "cloud": {
+    "storages": [
+      {
+        "storageProvider": "S3",
+        "storage": "cp-lifecycle-storage-policy-test-storage",
+        "files": [
+          {"key": "data/file1.txt", "creationDateShift": 5, "storageClass": "STANDARD"},
+          {"key": "data/file2.txt", "creationDateShift": 10, "storageClass": "GLACIER"},
+          {"key": "data/file3.txt", "creationDateShift": 10, "storageClass": "GLACIER"},
+          {"key": "data/file2.pdf", "creationDateShift": 21, "storageClass": "STANDARD"}
+        ]
+      }
+    ]
+  },
+  "platform": {
+    "storages": [
+      {
+        "id": 1,
+        "storageProvider": "S3",
+        "storage": "cp-lifecycle-storage-policy-test-storage",
+        "rules": [
+          {
+            "id": 1,
+            "datastorageId": 1,
+            "pathGlob": "/data",
+            "objectGlob": "*.txt",
+            "transitionMethod": "LATEST_FILE",
+            "transitionCriterion": {
+              "type": "MATCHING_FILES",
+              "value": "*.pdf"
+            },
+            "transitions": [
+              {
+                "transitionAfterDays": 10,
+                "storageClass": "GLACIER"
+              },
+               {
+                "transitionAfterDays": 20,
+                "storageClass": "DEEP_ARCHIVE"
+              }
+            ],
+            "notification": {
+              "notifyBeforeDays": 10,
+              "prolongDays": 10,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
+              "enabled": true,
+              "subject": "Lifecycle rule is about to be applied!",
+              "body": "Lifecycle rule is about to be applied!"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "result": {
+    "cloud": {
+      "storages": [
+        {
+          "storage": "cp-lifecycle-storage-policy-test-storage",
+          "storageProvider": "S3",
+          "files": [
+            {"key": "data/file1.txt", "tags": {"DESTINATION_STORAGE_CLASS":  "GLACIER"}},
+            {"key": "data/file2.txt", "tags": {"DESTINATION_STORAGE_CLASS":  "DEEP_ARCHIVE"}},
+            {"key": "data/file3.txt", "tags": {"DESTINATION_STORAGE_CLASS":  "DEEP_ARCHIVE"}},
+            {"key": "data/file2.pdf"}
+          ]
+        }
+      ]
+    },
+    "platform": {
+      "storages": [
+        {
+          "id": 1,
+          "storage": "cp-lifecycle-storage-policy-test-storage",
+          "executions": [
+            {
+              "ruleId": 1,
+              "path": "/data",
+              "status": "RUNNING",
+              "storageClass": "GLACIER"
+            },
+             {
+              "ruleId": 1,
+              "path": "/data",
+              "status": "RUNNING",
+              "storageClass": "DEEP_ARCHIVE"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_34_eligable_for_several_notifications.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_34_eligable_for_several_notifications.json
@@ -1,0 +1,99 @@
+{
+  "cloud": {
+    "storages": [
+      {
+        "storageProvider": "S3",
+        "storage": "cp-lifecycle-storage-policy-test-storage",
+        "files": [
+          {"key": "data/file1.txt", "creationDateShift": 7, "storageClass": "STANDARD"},
+          {"key": "data/file2.txt", "creationDateShift": 16, "storageClass": "GLACIER"},
+          {"key": "data/file3.txt", "creationDateShift": 17, "storageClass": "GLACIER"}
+        ]
+      }
+    ]
+  },
+  "platform": {
+    "storages": [
+      {
+        "id": 1,
+        "storageProvider": "S3",
+        "storage": "cp-lifecycle-storage-policy-test-storage",
+        "rules": [
+          {
+            "id": 1,
+            "datastorageId": 1,
+            "pathGlob": "/data",
+            "objectGlob": "*.txt",
+            "transitionMethod": "LATEST_FILE",
+            "transitionCriterion": {
+              "type": "DEFAULT"
+            },
+            "transitions": [
+              {
+                "transitionAfterDays": 10,
+                "storageClass": "GLACIER"
+              },
+              {
+                "transitionAfterDays": 20,
+                "storageClass": "DEEP_ARCHIVE"
+              }
+            ],
+            "notification": {
+              "notifyBeforeDays": 5,
+              "prolongDays": 10,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
+              "enabled": true,
+              "subject": "Lifecycle rule is about to be applied!",
+              "body": "Lifecycle rule is about to be applied!"
+            }
+          }
+        ],
+        "executions": [
+          {
+            "ruleId": 1,
+            "path": "/data",
+            "status": "SUCCESS",
+            "storageClass": "GLACIER"
+          }
+        ]
+      }
+    ]
+  },
+  "result": {
+    "cloud": {
+      "storages": [
+        {
+          "storage": "cp-lifecycle-storage-policy-test-storage",
+          "storageProvider": "S3",
+          "files": [
+            {"key": "data/file1.txt"},
+            {"key": "data/file2.txt"},
+            {"key": "data/file3.txt"}
+          ]
+        }
+      ]
+    },
+    "platform": {
+      "storages": [
+        {
+          "id": 1,
+          "storage": "cp-lifecycle-storage-policy-test-storage",
+          "executions": [
+            {
+              "ruleId": 1,
+              "path": "/data",
+              "status": "NOTIFICATION_SENT",
+              "storageClass": "GLACIER"
+            },
+            {
+              "ruleId": 1,
+              "path": "/data",
+              "status": "NOTIFICATION_SENT",
+              "storageClass": "DEEP_ARCHIVE"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/storage-lifecycle-service/sls/app/cloud_storage_adapter.py
+++ b/storage-lifecycle-service/sls/app/cloud_storage_adapter.py
@@ -167,6 +167,10 @@ class PlatformToCloudOperationsAdapter:
                 "value": None
             }
 
+    def get_storage_class_transition_map(self, storage, rule):
+        storage_classes = [transition.storage_class for transition in rule.transitions]
+        return self.cloud_operations[storage.storage_type].get_storage_class_transition_map(storage_classes)
+
     @staticmethod
     def _parse_storage_path(storage):
         split_storage_path = storage.path.rsplit("/", 1)

--- a/storage-lifecycle-service/sls/app/synchronizer/archiving_synchronizer_impl.py
+++ b/storage-lifecycle-service/sls/app/synchronizer/archiving_synchronizer_impl.py
@@ -400,11 +400,10 @@ class StorageLifecycleArchivingSynchronizer(StorageLifecycleSynchronizer):
                 date=today - datetime.timedelta(days=notification.notify_before_days),
                 to_check=execution.updated.date()
             )
-            if execution.status == EXECUTION_RUNNING_STATUS:
+            if execution.status == EXECUTION_RUNNING_STATUS or execution.status == EXECUTION_FAILED_STATUS:
                 return False
-            if execution.status == EXECUTION_NOTIFICATION_SENT_STATUS or execution.status == EXECUTION_FAILED_STATUS:
-                if was_updated_before:
-                    return False
+            if execution.status == EXECUTION_NOTIFICATION_SENT_STATUS and was_updated_before:
+                return False
         return True
 
     @staticmethod

--- a/storage-lifecycle-service/sls/cloud/cloud.py
+++ b/storage-lifecycle-service/sls/cloud/cloud.py
@@ -29,6 +29,9 @@ class StorageOperations:
     def check_files_restore(self, region, storage_container, files, restore_timestamp, restore_mode):
         pass
 
+    def get_storage_class_transition_map(self, storage_classes):
+        pass
+
 
 class CloudPipelineStorageContainer:
 

--- a/storage-lifecycle-service/sls/cloud/s3_cloud.py
+++ b/storage-lifecycle-service/sls/cloud/s3_cloud.py
@@ -237,6 +237,18 @@ class S3StorageOperations(StorageOperations):
                 "reason": "All files are ready!"
             }
 
+    def get_storage_class_transition_map(self, transition_storage_classes):
+        possible_storage_classes = ["GLACIER_IR", "GLACIER", "DEEP_ARCHIVE", "DELETION"]
+        storage_class_road_map = {}
+        source_storage_classes = ["STANDARD"]
+        for storage_class in possible_storage_classes:
+            if storage_class not in transition_storage_classes:
+                source_storage_classes.append(storage_class)
+            else:
+                storage_class_road_map[storage_class] = source_storage_classes
+                source_storage_classes = [storage_class]
+        return storage_class_road_map
+
     def _run_s3_batch_operation(self, region, storage_container, files, operation_obj, operation_id):
         bucket = storage_container.bucket
         sls_properties = region.storage_lifecycle_service_properties.properties

--- a/storage-lifecycle-service/tests/test_notification.py
+++ b/storage-lifecycle-service/tests/test_notification.py
@@ -61,7 +61,7 @@ class TestNotificationPositive(unittest.TestCase):
         )
 
     def test_notification_will_be_sent_if_files_are_eligible_for_week_after_and_execution_with_failed_status(self):
-        self.assertTrue(
+        self.assertFalse(
             StorageLifecycleArchivingSynchronizer._notification_should_be_sent(
                 self.enabled_notification, self.failed_execution, self.today + datetime.timedelta(days=7), self.today
             )

--- a/storage-lifecycle-service/tests/test_synchronizer.py
+++ b/storage-lifecycle-service/tests/test_synchronizer.py
@@ -66,110 +66,6 @@ class TestSynchronizerBuildsActionsForFiles(unittest.TestCase):
         )
 
 
-class TestSynchronizerGetEligibleTransition(unittest.TestCase):
-
-    folder = "/datastorage"
-    now = datetime.datetime.now(datetime.timezone.utc)
-    today = now.date()
-    synchronizer = StorageLifecycleArchivingSynchronizer(None, None, None, None)
-
-    def test_get_eligible_transition_when_no_execution(self):
-        criterion_file = CloudObject(os.path.join(self.folder, "file2.txt"), self.now - datetime.timedelta(days=1), None)
-        subject_files = [
-            criterion_file,
-            CloudObject(os.path.join(self.folder, "file1.txt"), self.now, None)
-        ]
-        transitions = [
-            StorageLifecycleRuleTransition("GLACIER", transition_after_days=1),
-            StorageLifecycleRuleTransition("DEEP_ARCHIVE", transition_after_days=3)
-        ]
-        transition_class, transition_date, transition_execution, trn_subject_file = \
-            self.synchronizer._get_eligible_transition(criterion_file, transitions, [], subject_files, self.today)
-        self.assertEqual(transition_class, "GLACIER")
-        self.assertEqual(transition_date, self.today)
-        self.assertEqual(transition_execution, None)
-        self.assertEqual(len(trn_subject_file), len(subject_files))
-
-    def test_get_eligible_transition_when_execution_notification(self):
-        criterion_file = CloudObject(os.path.join(self.folder, "file2.txt"), self.now - datetime.timedelta(days=1), "STANDARD")
-        subject_files = [
-            criterion_file,
-            CloudObject(os.path.join(self.folder, "file1.txt"), self.now, None)
-        ]
-        transitions = [
-            StorageLifecycleRuleTransition("GLACIER", transition_after_days=1),
-            StorageLifecycleRuleTransition("DEEP_ARCHIVE", transition_after_days=3)
-        ]
-        executions = [
-            StorageLifecycleRuleExecution(
-                1, 1, archiving_synchronizer_impl.EXECUTION_NOTIFICATION_SENT_STATUS,
-                self.folder, "GLACIER", None)
-        ]
-        transition_class, transition_date, transition_execution, trn_subject_file = \
-            self.synchronizer._get_eligible_transition(
-                criterion_file, transitions,
-                executions,
-                subject_files, self.today)
-        self.assertEqual("GLACIER", transition_class)
-        self.assertEqual(self.today, transition_date)
-        self.assertEqual(
-            archiving_synchronizer_impl.EXECUTION_NOTIFICATION_SENT_STATUS, transition_execution.status)
-        self.assertEqual(len(subject_files), len(trn_subject_file))
-
-    def test_get_eligible_transition_when_execution_running(self):
-        criterion_file = CloudObject(os.path.join(self.folder, "file2.txt"), self.now - datetime.timedelta(days=1),
-                                     "STANDARD")
-        subject_files = [
-            criterion_file,
-            CloudObject(os.path.join(self.folder, "file1.txt"), self.now, None)
-        ]
-        transitions = [
-            StorageLifecycleRuleTransition("GLACIER", transition_after_days=1),
-            StorageLifecycleRuleTransition("DEEP_ARCHIVE", transition_after_days=3)
-        ]
-        executions = [
-            StorageLifecycleRuleExecution(
-                1, 1, archiving_synchronizer_impl.EXECUTION_RUNNING_STATUS,
-                self.folder, "GLACIER", None)
-        ]
-        transition_class, transition_date, transition_execution, trn_subject_file = \
-            self.synchronizer._get_eligible_transition(
-                criterion_file, transitions,
-                executions,
-                subject_files, self.today)
-        self.assertEqual("GLACIER", transition_class)
-        self.assertEqual(self.today, transition_date)
-        self.assertEqual(
-            archiving_synchronizer_impl.EXECUTION_RUNNING_STATUS, transition_execution.status)
-        self.assertEqual(len(subject_files), len(trn_subject_file))
-
-    def test_get_eligible_transition_when_execution_complete(self):
-        criterion_file = CloudObject(os.path.join(self.folder, "file2.txt"), self.now - datetime.timedelta(days=2),
-                                     "GLACIER")
-        subject_files = [
-            criterion_file,
-            CloudObject(os.path.join(self.folder, "file1.txt"), self.now, "GLACIER")
-        ]
-        transitions = [
-            StorageLifecycleRuleTransition("GLACIER", transition_after_days=1),
-            StorageLifecycleRuleTransition("DEEP_ARCHIVE", transition_after_days=3)
-        ]
-        executions = [
-            StorageLifecycleRuleExecution(
-                1, 1, archiving_synchronizer_impl.EXECUTION_SUCCESS_STATUS, self.folder,
-                "GLACIER", self.now - datetime.timedelta(days=1))
-        ]
-        transition_class, transition_date, transition_execution, trn_subject_file = \
-            self.synchronizer._get_eligible_transition(
-                criterion_file, transitions,
-                executions,
-                subject_files, self.today)
-        self.assertEqual("DEEP_ARCHIVE", transition_class)
-        self.assertEqual(criterion_file.creation_date.date() + datetime.timedelta(days=3), transition_date)
-        self.assertEqual(None, transition_execution)
-        self.assertEqual(len(subject_files), len(trn_subject_file))
-
-
 class TestSynchronizerCheckRuleExecutionProgress(unittest.TestCase):
 
     folder = "/datastorage"
@@ -179,10 +75,13 @@ class TestSynchronizerCheckRuleExecutionProgress(unittest.TestCase):
             SynchronizerConfig(command="archive"), MockCloudPipelineDataSource(), None, AppLogger("archive"))
 
     def test_check_rule_execution_progress_still_running(self):
-        subject_files = [
-            CloudObject(os.path.join(self.folder, "file1.txt"), self.now, "STANDARD"),
-            CloudObject(os.path.join(self.folder, "file2.txt"), self.now, "STANDARD")
-        ]
+        subject_files = {
+            "GLACIER":
+            [
+                CloudObject(os.path.join(self.folder, "file1.txt"), self.now - datetime.timedelta(days=3), "STANDARD"),
+                CloudObject(os.path.join(self.folder, "file2.txt"), self.now - datetime.timedelta(days=3), "STANDARD")
+            ]
+        }
         execution = StorageLifecycleRuleExecution(
             1, 1, archiving_synchronizer_impl.EXECUTION_RUNNING_STATUS, self.folder,
             "GLACIER", self.now
@@ -190,28 +89,43 @@ class TestSynchronizerCheckRuleExecutionProgress(unittest.TestCase):
         self.assertIsNone(self.synchronizer._check_rule_execution_progress(1, subject_files, execution))
 
     def test_check_rule_execution_progress_running_overdue(self):
-        subject_files = [
-            CloudObject(os.path.join(self.folder, "file1.txt"), self.now, "STANDARD"),
-            CloudObject(os.path.join(self.folder, "file2.txt"), self.now, "STANDARD")
-        ]
+        subject_files = {
+            "GLACIER":
+            [
+                CloudObject(os.path.join(self.folder, "file1.txt"), self.now - datetime.timedelta(days=4), "STANDARD"),
+                CloudObject(os.path.join(self.folder, "file2.txt"), self.now - datetime.timedelta(days=4), "STANDARD")
+            ]
+        }
         execution = StorageLifecycleRuleExecution(
             1, 1, archiving_synchronizer_impl.EXECUTION_RUNNING_STATUS, self.folder,
             "GLACIER", self.now - datetime.timedelta(days=3)
         )
         updated_execution = self.synchronizer._check_rule_execution_progress(1, subject_files, execution)
-        self.assertEqual(updated_execution.status, archiving_synchronizer_impl.EXECUTION_FAILED_STATUS)
+        self.assertEqual(archiving_synchronizer_impl.EXECUTION_FAILED_STATUS, updated_execution.status)
 
     def test_check_rule_execution_progress_running_should_succeed(self):
-        subject_files = [
-            CloudObject(os.path.join(self.folder, "file1.txt"), self.now, "GLACIER"),
-            CloudObject(os.path.join(self.folder, "file2.txt"), self.now, "GLACIER")
-        ]
+        subject_files = {"GLACIER": []}
         execution = StorageLifecycleRuleExecution(
             1, 1, archiving_synchronizer_impl.EXECUTION_RUNNING_STATUS, self.folder,
             "GLACIER", self.now - datetime.timedelta(days=2)
         )
         updated_execution = self.synchronizer._check_rule_execution_progress(1, subject_files, execution)
-        self.assertEqual(updated_execution.status, archiving_synchronizer_impl.EXECUTION_SUCCESS_STATUS)
+        self.assertEqual(archiving_synchronizer_impl.EXECUTION_SUCCESS_STATUS, updated_execution.status)
+
+    def test_check_rule_execution_progress_running_should_succeed_if_new_file_appear_after_execution(self):
+        subject_files = {
+            "GLACIER":
+            [
+                CloudObject(os.path.join(self.folder, "file1.txt"), self.now, "STANDARD"),
+                CloudObject(os.path.join(self.folder, "file2.txt"), self.now, "STANDARD")
+            ]
+        }
+        execution = StorageLifecycleRuleExecution(
+            1, 1, archiving_synchronizer_impl.EXECUTION_RUNNING_STATUS, self.folder,
+            "GLACIER", self.now - datetime.timedelta(days=2)
+        )
+        updated_execution = self.synchronizer._check_rule_execution_progress(1, subject_files, execution)
+        self.assertEqual(archiving_synchronizer_impl.EXECUTION_SUCCESS_STATUS, updated_execution.status)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Related to https://github.com/epam/cloud-pipeline/issues/2759#issuecomment-1259323777

This PR changes algorithm to process transitions of a rule.
Now `sls` will process files in different storage classes as separate groups.

f.e.:
If we have directory with transition rule like:
 - after 30 days -> move to GLACIER
 - after 60 days -> move to DEEP_ARCHIVE

And:
 - at time point (1) this folder had files (subject of this rule)
 - at time point (2) this rule moved this files to GLACIER
 - at time point (3) new files arrived 

In this case `sls` will do:
 - separately will move files from time point (1) to DEEP_ARCHIVE and (3) to GLACIER when time will come accordingly 