### PR TITLE
Issue 2721 prolongation check and transition date alg changes

### DIFF
--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -296,6 +296,8 @@ public final class MessageConstants {
             "error.datastorage.lifecycle.rule.cant.define.days.to.prolong";
     public static final String ERROR_DATASTORAGE_LIFECYCLE_RULE_WRONG_DAYS_TO_PROLONG =
             "error.datastorage.lifecycle.rule.wrong.days.to.prolong";
+    public static final String ERROR_DATASTORAGE_LIFECYCLE_RULE_CANT_BE_PROLONGED =
+        "error.datastorage.lifecycle.rule.cant.be.prolonged";
     public static final String ERROR_DATASTORAGE_LIFECYCLE_RULE_WAS_PROLONGED_BEFORE =
             "error.datastorage.lifecycle.rule.was.prolong.before";
     public static final String ERROR_DATASTORAGE_LIFECYCLE_DATASTORAGE_ID_NOT_SPECIFIED =

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/lifecycle/DataStorageLifecycleManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/lifecycle/DataStorageLifecycleManager.java
@@ -148,6 +148,17 @@ public class DataStorageLifecycleManager {
         Assert.isTrue(effectiveDaysToProlong > 0,
                 messageHelper.getMessage(MessageConstants.ERROR_DATASTORAGE_LIFECYCLE_RULE_WRONG_DAYS_TO_PROLONG));
 
+        if (!force) {
+            final List<StorageLifecycleRuleExecution> executionsWithNotificationSent =
+                    listStorageLifecycleRuleExecutionsForRuleAndPath(
+                            ruleId, path, StorageLifecycleRuleExecutionStatus.NOTIFICATION_SENT);
+            Assert.notEmpty(
+                    executionsWithNotificationSent,
+                    messageHelper.getMessage(
+                            MessageConstants.ERROR_DATASTORAGE_LIFECYCLE_RULE_CANT_BE_PROLONGED, ruleId, path)
+            );
+        }
+
         final StorageLifecycleRuleProlongationEntity lastProlongation =
                 ListUtils.emptyIfNull(lifecycleRuleEntity.getProlongations())
                         .stream().filter(p -> p.getPath().equals(path))

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -275,6 +275,7 @@ error.datastorage.mirror.deletion=Deletion of a linked storage is not allowed. U
 error.datastorage.lifecycle.rule.not.found=Lifecycle rule with id ''{0}'' cannot be found!
 error.datastorage.lifecycle.rule.cant.define.days.to.prolong=Cannot define days to prolong, please explicitly specify this value.
 error.datastorage.lifecycle.rule.wrong.days.to.prolong=Days to prolong should be > 0.
+error.datastorage.lifecycle.rule.cant.be.prolonged=Lifecycle rule with id ''{0}'' for path ''{1}'' cannot be prolonged due to its state, if you still want to do it, use flag force!
 error.datastorage.lifecycle.rule.was.prolong.before=This Rule was prolonged less than {0} days. Will not prolonged again.
 error.datastorage.lifecycle.rule.datastorage.id.not.specified=datastorageId should be specified!
 error.datastorage.lifecycle.root.path.not.specified=Root path should be provided!

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_35_not_all_files_eligable_to_action.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_35_not_all_files_eligable_to_action.json
@@ -1,0 +1,89 @@
+{
+  "cloud": {
+    "storages": [
+      {
+        "storageProvider": "S3",
+        "storage": "cp-lifecycle-storage-policy-test-storage",
+        "files": [
+          {"key": "data/file1.txt", "creationDateShift": 0, "storageClass": "STANDARD"},
+          {"key": "data/file2.txt", "creationDateShift": 26, "storageClass": "STANDARD"},
+          {"key": "data/file3.txt", "creationDateShift": 27, "storageClass": "STANDARD"}
+        ]
+      }
+    ]
+  },
+  "platform": {
+    "storages": [
+      {
+        "id": 1,
+        "storageProvider": "S3",
+        "storage": "cp-lifecycle-storage-policy-test-storage",
+        "rules": [
+          {
+            "id": 1,
+            "datastorageId": 1,
+            "pathGlob": "/data",
+            "objectGlob": "*.txt",
+            "transitionMethod": "LATEST_FILE",
+            "transitionCriterion": {
+              "type": "DEFAULT"
+            },
+            "transitions": [
+              {
+                "transitionDate": 20,
+                "storageClass": "GLACIER"
+              }
+            ],
+            "notification": {
+              "notifyBeforeDays": 10,
+              "prolongDays": 10,
+             "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
+              "enabled": true,
+              "subject": "Lifecycle rule is about to be applied!",
+              "body": "Lifecycle rule is about to be applied!"
+            }
+          }
+        ],
+        "executions": [
+            {
+              "ruleId": 1,
+              "path": "/data",
+              "status": "NOTIFICATION_SENT",
+              "storageClass": "GLACIER"
+            }
+          ]
+      }
+    ]
+  },
+  "result": {
+    "cloud": {
+      "storages": [
+        {
+          "storage": "cp-lifecycle-storage-policy-test-storage",
+          "storageProvider": "S3",
+          "files": [
+            {"key": "data/file1.txt"},
+            {"key": "data/file2.txt", "tags": {"DESTINATION_STORAGE_CLASS":  "GLACIER"}},
+            {"key": "data/file3.txt", "tags": {"DESTINATION_STORAGE_CLASS":  "GLACIER"}}
+          ]
+        }
+      ]
+    },
+    "platform": {
+      "storages": [
+        {
+          "id": 1,
+          "storage": "cp-lifecycle-storage-policy-test-storage",
+          "executions": [
+            {
+              "ruleId": 1,
+              "path": "/data",
+              "status": "RUNNING",
+              "storageClass": "GLACIER"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_36_MATCHING_FILES_not_all_files_eligable_to_action.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_36_MATCHING_FILES_not_all_files_eligable_to_action.json
@@ -1,0 +1,82 @@
+{
+  "cloud": {
+    "storages": [
+      {
+        "storageProvider": "S3",
+        "storage": "cp-lifecycle-storage-policy-test-storage",
+        "files": [
+          {"key": "data/file1.txt", "creationDateShift": 0, "storageClass": "STANDARD"},
+          {"key": "data/file2.txt", "creationDateShift": 11, "storageClass": "STANDARD"},
+          {"key": "data/file2.pdf", "creationDateShift": 9, "storageClass": "STANDARD"}
+        ]
+      }
+    ]
+  },
+  "platform": {
+    "storages": [
+      {
+        "id": 1,
+        "storageProvider": "S3",
+        "storage": "cp-lifecycle-storage-policy-test-storage",
+        "rules": [
+          {
+            "id": 1,
+            "datastorageId": 1,
+            "pathGlob": "/data",
+            "objectGlob": "*.txt",
+            "transitionMethod": "LATEST_FILE",
+            "transitionCriterion": {
+              "type": "MATCHING_FILES",
+              "value": "*.pdf"
+            },
+            "transitions": [
+              {
+                "transitionDate": 10,
+                "storageClass": "GLACIER"
+              }
+            ],
+            "notification": {
+              "notifyBeforeDays": 10,
+              "prolongDays": 10,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
+              "enabled": true,
+              "subject": "Lifecycle rule is about to be applied!",
+              "body": "Lifecycle rule is about to be applied!"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "result": {
+    "cloud": {
+      "storages": [
+        {
+          "storage": "cp-lifecycle-storage-policy-test-storage",
+          "storageProvider": "S3",
+          "files": [
+            {"key": "data/file1.txt"},
+            {"key": "data/file2.txt", "tags": {"DESTINATION_STORAGE_CLASS":  "GLACIER"}},
+            {"key": "data/file2.pdf"}
+          ]
+        }
+      ]
+    },
+    "platform": {
+      "storages": [
+        {
+          "id": 1,
+          "storage": "cp-lifecycle-storage-policy-test-storage",
+          "executions": [
+            {
+              "ruleId": 1,
+              "path": "/data",
+              "status": "RUNNING",
+              "storageClass": "GLACIER"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_37_with_transition_date_action_completed_even_if_file_in_standard_exists_because_was_added_after.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_37_with_transition_date_action_completed_even_if_file_in_standard_exists_because_was_added_after.json
@@ -1,0 +1,89 @@
+{
+  "cloud": {
+    "storages": [
+      {
+        "storageProvider": "S3",
+        "storage": "cp-lifecycle-storage-policy-test-storage",
+        "files": [
+          {"key": "data/file1.txt", "creationDateShift": 5, "storageClass": "STANDARD"},
+          {"key": "data/file2.txt", "creationDateShift": 16, "storageClass": "GLACIER"},
+          {"key": "data/file3.txt", "creationDateShift": 16, "storageClass": "GLACIER"}
+        ]
+      }
+    ]
+  },
+  "platform": {
+    "storages": [
+      {
+        "id": 1,
+        "storageProvider": "S3",
+        "storage": "cp-lifecycle-storage-policy-test-storage",
+        "rules": [
+          {
+            "id": 1,
+            "datastorageId": 1,
+            "pathGlob": "/data",
+            "objectGlob": "*.txt",
+            "transitionMethod": "LATEST_FILE",
+            "transitionCriterion": {
+              "type": "DEFAULT"
+            },
+            "transitions": [
+              {
+                "transitionDate": 10,
+                "storageClass": "GLACIER"
+              }
+            ],
+            "notification": {
+              "notifyBeforeDays": 5,
+              "prolongDays": 10,
+              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
+              "enabled": true,
+              "subject": "Lifecycle rule is about to be applied!",
+              "body": "Lifecycle rule is about to be applied!"
+            }
+          }
+        ],
+        "executions": [
+          {
+            "ruleId": 1,
+            "path": "/data",
+            "status": "RUNNING",
+            "storageClass": "GLACIER"
+          }
+        ]
+      }
+    ]
+  },
+  "result": {
+    "cloud": {
+      "storages": [
+        {
+          "storage": "cp-lifecycle-storage-policy-test-storage",
+          "storageProvider": "S3",
+          "files": [
+            {"key": "data/file1.txt"},
+            {"key": "data/file2.txt"},
+            {"key": "data/file3.txt"}
+          ]
+        }
+      ]
+    },
+    "platform": {
+      "storages": [
+        {
+          "id": 1,
+          "storage": "cp-lifecycle-storage-policy-test-storage",
+          "executions": [
+            {
+              "ruleId": 1,
+              "path": "/data",
+              "status": "SUCCESS",
+              "storageClass": "GLACIER"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/storage-lifecycle-service/sls/util/date_utils.py
+++ b/storage-lifecycle-service/sls/util/date_utils.py
@@ -33,3 +33,7 @@ def parse_timestamp(timestamp_string):
 
 def parse_date(date_string):
     return datetime.datetime.strptime(date_string, ISO_DATE_FORMAT).date()
+
+
+def str_date(date):
+    return date.strftime(ISO_DATE_FORMAT)

--- a/storage-lifecycle-service/tests/test_synchronizer.py
+++ b/storage-lifecycle-service/tests/test_synchronizer.py
@@ -82,11 +82,12 @@ class TestSynchronizerCheckRuleExecutionProgress(unittest.TestCase):
                 CloudObject(os.path.join(self.folder, "file2.txt"), self.now - datetime.timedelta(days=3), "STANDARD")
             ]
         }
+        transition = StorageLifecycleRuleTransition("GLACIER", transition_after_days=0)
         execution = StorageLifecycleRuleExecution(
             1, 1, archiving_synchronizer_impl.EXECUTION_RUNNING_STATUS, self.folder,
             "GLACIER", self.now
         )
-        self.assertIsNone(self.synchronizer._check_rule_execution_progress(1, subject_files, execution))
+        self.assertIsNone(self.synchronizer._check_rule_execution_progress(1, transition, subject_files, execution))
 
     def test_check_rule_execution_progress_running_overdue(self):
         subject_files = {
@@ -96,20 +97,22 @@ class TestSynchronizerCheckRuleExecutionProgress(unittest.TestCase):
                 CloudObject(os.path.join(self.folder, "file2.txt"), self.now - datetime.timedelta(days=4), "STANDARD")
             ]
         }
+        transition = StorageLifecycleRuleTransition("GLACIER", transition_after_days=0)
         execution = StorageLifecycleRuleExecution(
             1, 1, archiving_synchronizer_impl.EXECUTION_RUNNING_STATUS, self.folder,
             "GLACIER", self.now - datetime.timedelta(days=3)
         )
-        updated_execution = self.synchronizer._check_rule_execution_progress(1, subject_files, execution)
+        updated_execution = self.synchronizer._check_rule_execution_progress(1, transition, subject_files, execution)
         self.assertEqual(archiving_synchronizer_impl.EXECUTION_FAILED_STATUS, updated_execution.status)
 
     def test_check_rule_execution_progress_running_should_succeed(self):
         subject_files = {"GLACIER": []}
+        transition = StorageLifecycleRuleTransition("GLACIER", transition_after_days=0)
         execution = StorageLifecycleRuleExecution(
             1, 1, archiving_synchronizer_impl.EXECUTION_RUNNING_STATUS, self.folder,
             "GLACIER", self.now - datetime.timedelta(days=2)
         )
-        updated_execution = self.synchronizer._check_rule_execution_progress(1, subject_files, execution)
+        updated_execution = self.synchronizer._check_rule_execution_progress(1, transition, subject_files, execution)
         self.assertEqual(archiving_synchronizer_impl.EXECUTION_SUCCESS_STATUS, updated_execution.status)
 
     def test_check_rule_execution_progress_running_should_succeed_if_new_file_appear_after_execution(self):
@@ -120,11 +123,12 @@ class TestSynchronizerCheckRuleExecutionProgress(unittest.TestCase):
                 CloudObject(os.path.join(self.folder, "file2.txt"), self.now, "STANDARD")
             ]
         }
+        transition = StorageLifecycleRuleTransition("GLACIER", transition_after_days=0)
         execution = StorageLifecycleRuleExecution(
             1, 1, archiving_synchronizer_impl.EXECUTION_RUNNING_STATUS, self.folder,
             "GLACIER", self.now - datetime.timedelta(days=2)
         )
-        updated_execution = self.synchronizer._check_rule_execution_progress(1, subject_files, execution)
+        updated_execution = self.synchronizer._check_rule_execution_progress(1, transition, subject_files, execution)
         self.assertEqual(archiving_synchronizer_impl.EXECUTION_SUCCESS_STATUS, updated_execution.status)
 
 

--- a/workflows/pipe-common/pipeline/api/api.py
+++ b/workflows/pipe-common/pipeline/api/api.py
@@ -199,7 +199,7 @@ class PipelineAPI:
     LOAD_AVAILABLE_STORAGES = "/datastorage/available"
     LOAD_LIFECYCLE_RULE_FOR_STORAGE_URL = "/datastorage/{id}/lifecycle/rule/{rule_id}"
     LIFECYCLE_RULES_FOR_STORAGE_URL = "/datastorage/{id}/lifecycle/rule"
-    PROLONG_LIFECYCLE_RULES_URL = "/datastorage/{id}/lifecycle/rule/{rule_id}/prolong?path={path}&days={days}"
+    PROLONG_LIFECYCLE_RULES_URL = "/datastorage/{id}/lifecycle/rule/{rule_id}/prolong?path={path}&days={days}&force={force}"
     LIFECYCLE_RULES_EXECUTION_FOR_STORAGE_URL = "/datastorage/{id}/lifecycle/rule/{rule_id}/execution"
     LOAD_LIFECYCLE_RULES_EXECUTION_FOR_STORAGE_URL = "/datastorage/{id}/lifecycle/rule/{rule_id}/execution{filter}"
     UPDATE_STATUS_LIFECYCLE_RULES_EXECUTION_FOR_STORAGE_URL = "/datastorage/{id}/lifecycle/rule/execution/{execution_id}/status?status={status}"
@@ -1132,10 +1132,10 @@ class PipelineAPI:
             raise RuntimeError("Failed to delete lifecycle rule execution by ID '{}'.",
                                "Error message: {}".format(str(execution_id), str(e.message)))
 
-    def prolong_lifecycle_rule(self, datastorage_id, rule_id, path, days):
+    def prolong_lifecycle_rule(self, datastorage_id, rule_id, path, days, force=False):
         try:
             return self.execute_request(str(self.api_url) + self.PROLONG_LIFECYCLE_RULES_URL.format(
-                                            id=datastorage_id, rule_id=rule_id, path=path, days=days))
+                                            id=datastorage_id, rule_id=rule_id, path=path, days=days, force=force))
         except Exception as e:
             raise RuntimeError("Failed to prolong lifecycle rule '{}'.",
                                "Error message: {}".format(str(rule_id), str(e.message)))


### PR DESCRIPTION
Couple of fixes for SLS:
 - Allow to prolong path only if there is execution with NOTIFICATION_SENT status
 - Do not transit files that were uploaded to a storage after transitionDate (if transition was configured with transitionDate property)