### PR TITLE
Use proper error codes for webdav operations in pipe fuse

### DIFF
--- a/pipe-cli/mount/pipe-fuse.py
+++ b/pipe-cli/mount/pipe-fuse.py
@@ -64,7 +64,7 @@ from pipefuse.storage import StorageHighLevelFileSystemClient
 from pipefuse.trunc import CopyOnDownTruncateFileSystemClient, \
     WriteNullsOnUpTruncateFileSystemClient, \
     WriteLastNullOnUpTruncateFileSystemClient
-from pipefuse.webdav import CPWebDavClient
+from pipefuse.webdav import WebDavClient, WebDavAdapterFileSystemClient
 from pipefuse.xattr import ExtendedAttributesCache, ThreadSafeExtendedAttributesCache, \
     ExtendedAttributesCachingFileSystemClient, RestrictingExtendedAttributesFS
 
@@ -104,7 +104,8 @@ def start(mountpoint, webdav, bucket,
     if not bearer:
         raise RuntimeError('Cloud Pipeline API_TOKEN should be specified.')
     if webdav:
-        client = CPWebDavClient(webdav_url=webdav, bearer=bearer)
+        client = WebDavClient(webdav_url=webdav, bearer=bearer)
+        client = WebDavAdapterFileSystemClient(client)
     else:
         if not api:
             raise RuntimeError('Cloud Pipeline API should be specified.')

--- a/pipe-cli/mount/pipefuse/fsclient.py
+++ b/pipe-cli/mount/pipefuse/fsclient.py
@@ -20,7 +20,27 @@ from pipefuse.chain import ChainingService
 File = namedtuple('File', ['name', 'size', 'mtime', 'ctime', 'contenttype', 'is_dir'])
 
 
-class UnsupportedOperationException(RuntimeError):
+class FileSystemOperationException(RuntimeError):
+    pass
+
+
+class UnsupportedOperationException(FileSystemOperationException):
+    pass
+
+
+class ForbiddenOperationException(FileSystemOperationException):
+    pass
+
+
+class NotFoundOperationException(FileSystemOperationException):
+    pass
+
+
+class NoDataOperationException(FileSystemOperationException):
+    pass
+
+
+class InvalidOperationException(FileSystemOperationException):
     pass
 
 

--- a/pipe-cli/mount/pipefuse/pipefs.py
+++ b/pipe-cli/mount/pipefuse/pipefs.py
@@ -12,24 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datetime
-import errno
 import functools
 import io
 import logging
 import os
 import platform
 import stat
-import time
 from threading import RLock
 
-import easywebdav
+import datetime
+import errno
+import time
 from dateutil.tz import tzlocal
-from fuse import FuseOSError, Operations, ENOTSUP
+from fuse import FuseOSError, Operations
 
 from pipefuse import fuseutils
 from pipefuse.chain import ChainingService
-from pipefuse.fsclient import UnsupportedOperationException
+from pipefuse.fsclient import FileSystemOperationException, \
+    UnsupportedOperationException, ForbiddenOperationException, \
+    NotFoundOperationException, NoDataOperationException, InvalidOperationException
 
 
 class FileHandleContainer(object):
@@ -78,7 +79,7 @@ def errorlogged(func):
         path = args[1]
         try:
             return func(*args, **kwargs)
-        except FuseOSError:
+        except FileSystemOperationException:
             raise
         except Exception:
             logging.exception('Error occurred while %s for %s', func.__name__, path)
@@ -128,7 +129,7 @@ class PipeFS(Operations, ChainingService):
         if path == self._root:
             return
         if self._is_skipped_mac_files(path) or not self._client.exists(path):
-            raise FuseOSError(errno.EACCES)
+            raise ForbiddenOperationException()
 
     def chmod(self, path, mode):
         pass
@@ -138,31 +139,28 @@ class PipeFS(Operations, ChainingService):
 
     @errorlogged
     def getattr(self, path, fh=None):
-        try:
-            if self._is_skipped_mac_files(path):
-                raise FuseOSError(errno.ENOENT)
-            props = self._client.attrs(path)
-            if not props:
-                raise FuseOSError(errno.ENOENT)
-            if path == self._root or props.is_dir:
-                mode = stat.S_IFDIR
-            else:
-                mode = stat.S_IFREG
-            attrs = {
-                'st_size': props.size,
-                'st_nlink': 1,
-                'st_mode': mode | self._mode,
-                'st_gid': self._gid,
-                'st_uid': self._uid,
-                'st_atime': time.mktime(datetime.datetime.now(tz=tzlocal()).timetuple())
-            }
-            if props.mtime:
-                attrs['st_mtime'] = props.mtime
-            if props.ctime:
-                attrs['st_ctime'] = props.ctime
-            return attrs
-        except easywebdav.OperationFailed:
-            raise FuseOSError(errno.ENOENT)
+        if self._is_skipped_mac_files(path):
+            raise NotFoundOperationException()
+        props = self._client.attrs(path)
+        if not props:
+            raise NotFoundOperationException()
+        if path == self._root or props.is_dir:
+            mode = stat.S_IFDIR
+        else:
+            mode = stat.S_IFREG
+        attrs = {
+            'st_size': props.size,
+            'st_nlink': 1,
+            'st_mode': mode | self._mode,
+            'st_gid': self._gid,
+            'st_uid': self._uid,
+            'st_atime': time.mktime(datetime.datetime.now(tz=tzlocal()).timetuple())
+        }
+        if props.mtime:
+            attrs['st_mtime'] = props.mtime
+        if props.ctime:
+            attrs['st_ctime'] = props.ctime
+        return attrs
 
     @errorlogged
     def readdir(self, path, fh):
@@ -178,10 +176,10 @@ class PipeFS(Operations, ChainingService):
             yield f
 
     def readlink(self, path):
-        raise FuseOSError(ENOTSUP)
+        raise UnsupportedOperationException()
 
     def mknod(self, path, mode, dev):
-        raise FuseOSError(ENOTSUP)
+        raise UnsupportedOperationException()
 
     @syncronized
     @errorlogged
@@ -191,10 +189,7 @@ class PipeFS(Operations, ChainingService):
     @syncronized
     @errorlogged
     def mkdir(self, path, mode):
-        try:
-            self._client.mkdir(path)
-        except easywebdav.OperationFailed:
-            raise FuseOSError(errno.EACCES)
+        self._client.mkdir(path)
 
     @errorlogged
     def statfs(self, path):
@@ -226,7 +221,7 @@ class PipeFS(Operations, ChainingService):
         self._client.delete(path)
 
     def symlink(self, name, target):
-        raise FuseOSError(ENOTSUP)
+        raise UnsupportedOperationException()
 
     @syncronized
     @errorlogged
@@ -234,7 +229,7 @@ class PipeFS(Operations, ChainingService):
         self._client.mv(old, new)
 
     def link(self, target, name):
-        raise FuseOSError(ENOTSUP)
+        raise UnsupportedOperationException()
 
     @errorlogged
     def utimens(self, path, times=None):
@@ -248,7 +243,7 @@ class PipeFS(Operations, ChainingService):
     def open(self, path, flags):
         if self._client.exists(path):
             return self._container.get()
-        raise FuseOSError(errno.ENOENT)
+        raise NotFoundOperationException()
 
     @syncronized
     @errorlogged
@@ -294,7 +289,7 @@ class PipeFS(Operations, ChainingService):
     def fallocate(self, path, mode, offset, length, fh):
         props = self._client.attrs(path)
         if not props:
-            raise FuseOSError(errno.ENOENT)
+            raise NotFoundOperationException()
         if mode:
             # See http://man7.org/linux/man-pages/man2/fallocate.2.html.
             # https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/falloc.h
@@ -313,7 +308,7 @@ class PipeFS(Operations, ChainingService):
         xattrs = self._client.download_xattrs(path) or {}
         xattr = xattrs.get(name)
         if xattr is None:
-            raise FuseOSError(errno.ENODATA)
+            raise NoDataOperationException()
         return xattr
 
     @errorlogged
@@ -362,11 +357,19 @@ class SupportedOperationsFS(ChainingService):
             method_name = name or args[0]
             if method_name in self._exclude:
                 logging.debug('Aborting excluded operation %s processing...', method_name)
-                raise FuseOSError(ENOTSUP)
+                raise FuseOSError(errno.ENOTSUP)
             try:
                 return attr(*args, **kwargs)
             except UnsupportedOperationException:
-                raise FuseOSError(ENOTSUP)
+                raise FuseOSError(errno.ENOTSUP)
+            except ForbiddenOperationException:
+                raise FuseOSError(errno.EACCES)
+            except NotFoundOperationException:
+                raise FuseOSError(errno.ENOENT)
+            except NoDataOperationException:
+                raise FuseOSError(errno.ENODATA)
+            except InvalidOperationException:
+                raise FuseOSError(errno.EINVAL)
         return _wrapped_attr
 
     def parameters(self):


### PR DESCRIPTION
Relates to #2859.

The pull request brings proper error codes to multiple webdav operations. For instance from now on an access denied error is shown on any writes if a storage is mounted as read only in webdav.
