### PR TITLE
Issue 2843 fix for renaming folder in storage

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3Helper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3Helper.java
@@ -137,6 +137,7 @@ public class S3Helper {
     private static final CannedAccessControlList DEFAULT_CANNED_ACL = CannedAccessControlList.BucketOwnerFullControl;
     private static final String FOLDER_GLOB_SUFFIX = "/**";
     private static final String EMPTY_STRING = "";
+    public static final String STANDARD_STORAGE_CLASS = "STANDARD";
 
     private final MessageHelper messageHelper;
 
@@ -629,7 +630,7 @@ public class S3Helper {
         return client.getObjectMetadata(request).getContentLength() > COPYING_FILE_SIZE_LIMIT;
     }
 
-    public DataStorageFolder moveFolder(String bucket, String rawOldPath, String rawNewPath)
+    public DataStorageFolder moveFolder(final String bucket, final String rawOldPath, final String rawNewPath)
             throws DataStorageException {
         if (StringUtils.isNullOrEmpty(rawOldPath) || StringUtils.isNullOrEmpty(rawNewPath)) {
             throw new DataStorageException(PATH_SHOULD_NOT_BE_EMPTY_MESSAGE);
@@ -637,24 +638,30 @@ public class S3Helper {
         final String oldPath = ProviderUtils.withTrailingDelimiter(rawOldPath);
         final String newPath = ProviderUtils.withTrailingDelimiter(rawNewPath);
         final String folderFullPath = newPath.substring(0, newPath.length() - 1);
-        String[] parts = newPath.split(ProviderUtils.DELIMITER);
+        final String[] parts = newPath.split(ProviderUtils.DELIMITER);
         final String folderName = parts[parts.length - 1];
-        AmazonS3 client = getDefaultS3Client();
+        final AmazonS3 client = getDefaultS3Client();
         checkItemExists(client, bucket, oldPath, true);
         checkItemDoesNotExist(client, bucket, newPath, true);
-        ListObjectsRequest req = new ListObjectsRequest();
+        final ListObjectsRequest req = new ListObjectsRequest();
         req.setBucketName(bucket);
         ObjectListing listing = client.listObjects(req);
         boolean listingFinished = false;
-        List<String> oldKeys = new ArrayList<>();
+        final List<String> oldKeys = new ArrayList<>();
         while (!listingFinished) {
-            for (S3ObjectSummary s3ObjectSummary : listing.getObjectSummaries()) {
+            for (final S3ObjectSummary s3ObjectSummary : listing.getObjectSummaries()) {
                 if (s3ObjectSummary.getSize() > COPYING_FILE_SIZE_LIMIT) {
                     throw new DataStorageException(String.format("Moving folder '%s' was aborted because " +
                                     "some of its files '%s' size exceeds the limit of %s bytes",
                             oldPath, s3ObjectSummary.getKey(), COPYING_FILE_SIZE_LIMIT));
                 }
-                String relativePath = s3ObjectSummary.getKey();
+                final String itemStorageClass = s3ObjectSummary.getStorageClass();
+                if(!STANDARD_STORAGE_CLASS.equals(itemStorageClass)) {
+                    throw new DataStorageException(String.format("Moving folder '%s' was aborted because " +
+                                    "some of its files '%s' located in %s storage class",
+                            oldPath, s3ObjectSummary.getKey(), itemStorageClass));
+                }
+                final String relativePath = s3ObjectSummary.getKey();
                 if (relativePath.startsWith(oldPath)) {
                     oldKeys.add(relativePath);
                 }
@@ -669,7 +676,7 @@ public class S3Helper {
                 .map(oldKey -> new MoveObjectRequest(oldKey, newPath + oldKey.substring(oldPath.length())))
                 .collect(Collectors.toList());
         moveS3Objects(client, bucket, moveRequests);
-        DataStorageFolder folder = new DataStorageFolder();
+        final DataStorageFolder folder = new DataStorageFolder();
         folder.setName(folderName);
         folder.setPath(folderFullPath);
         return folder;

--- a/api/src/test/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3HelperTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3HelperTest.java
@@ -204,8 +204,10 @@ public class S3HelperTest {
         final ObjectListing bucketListing = spy(new ObjectListing());
         final S3ObjectSummary firstFileSummary = new S3ObjectSummary();
         firstFileSummary.setKey(firstFileOldPath);
+        firstFileSummary.setStorageClass(S3Helper.STANDARD_STORAGE_CLASS);
         final S3ObjectSummary secondFileSummary = new S3ObjectSummary();
         secondFileSummary.setKey(secondFileOldPath);
+        secondFileSummary.setStorageClass(S3Helper.STANDARD_STORAGE_CLASS);
         when(bucketListing.getObjectSummaries()).thenReturn(Arrays.asList(firstFileSummary, secondFileSummary));
         when(amazonS3.listObjects(any(ListObjectsRequest.class)))
                 .thenReturn(sourceListing, destinationListing, bucketListing);


### PR DESCRIPTION
This PR provides fix for storage renaming procedure:
 - If folder contains files in non-standard storage class - it will fail before any action will be performed.