### PR TITLE
issue 2721 bug fixing: Long restore action creation, false positive matches for parent actions

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3StorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3StorageProvider.java
@@ -413,12 +413,7 @@ public class S3StorageProvider implements StorageProvider<S3bucketDataStorage> {
 
     @Override
     public Pair<Boolean, String> isRestoreActionEligible(final S3bucketDataStorage dataStorage, final String path) {
-        final String storagePathPrefix = path.startsWith(dataStorage.getDelimiter())
-                ? path.substring(dataStorage.getDelimiter().length())
-                : path;
-        final boolean result = listDataStorageFiles(dataStorage, storagePathPrefix).findAny().isPresent();
-        final String reason = !result ? "Path not found!" : "";
-        return Pair.of(result, reason);
+        return Pair.of(true, StringUtils.EMPTY);
     }
 
     @Override

--- a/api/src/test/java/com/epam/pipeline/manager/datastorage/lifecycle/DataStorageLifecycleManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/datastorage/lifecycle/DataStorageLifecycleManagerTest.java
@@ -41,6 +41,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -219,11 +220,12 @@ public class DataStorageLifecycleManagerTest {
 
     @Test
     public void shouldSuccessfullyUpdateStatusForLifecycleRuleExecution() {
-        final LocalDateTime startPoint = DateUtils.nowUTC();
+        final LocalDateTime startPoint = DateUtils.nowUTC().minus(1, ChronoUnit.SECONDS);
         final StorageLifecycleRuleExecutionEntity execution = StorageLifecycleRuleExecutionEntity.builder()
                 .ruleId(ID).path("/data/1/dataset1")
                 .storageClass(STORAGE_CLASS)
                 .status(StorageLifecycleRuleExecutionStatus.RUNNING)
+                .updated(DateUtils.nowUTC())
                 .build();
         Mockito.doReturn(execution).when(lifecycleRuleExecutionRepository).findOne(eq(ID));
         Mockito.doReturn(execution).when(lifecycleRuleExecutionRepository)

--- a/core/src/main/java/com/epam/pipeline/dto/datastorage/lifecycle/restore/StorageRestoreActionSearchFilter.java
+++ b/core/src/main/java/com/epam/pipeline/dto/datastorage/lifecycle/restore/StorageRestoreActionSearchFilter.java
@@ -45,6 +45,14 @@ public class StorageRestoreActionSearchFilter {
 
     private List<StorageRestoreStatus> statuses;
 
+    /**
+     * SEARCH_PARENT - will search for all action that has path type == FOLDER and include path from filter,
+     *                 also will include actions with the same path
+     * SEARCH_CHILD - if path from filter is a folder, will search for all action under this path
+     *                (one hierarchy level only), also will include actions with the same path
+     * SEARCH_CHILD_RECURSIVELY - if path from filter is a folder, will search for all action under this path
+     *                            (all hierarchy levels), also will include actions with the same path
+     * */
     public enum SearchType {
         SEARCH_PARENT, SEARCH_CHILD, SEARCH_CHILD_RECURSIVELY
     }


### PR DESCRIPTION
This PR fix couple of problems:
 - Long restore action creation,
 - Bug with false matching path as parent - previously even if path is a file it could be matched as a parent for other path