### PR TITLE
Dedicated instances for AWS

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/cloud/commands/ClusterCommandService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/commands/ClusterCommandService.java
@@ -59,6 +59,7 @@ public class ClusterCommandService {
                 .cloud(cloud)
                 .availabilityZone(instance.getAvailabilityZone())
                 .networkInterface(instance.getNetworkInterfaceId())
+                .isDedicated(instance.isDedicated())
                 .prePulledImages(instance.getPrePulledDockerImages())
                 .region(region.getRegionCode());
     }

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/commands/NodeUpCommand.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/commands/NodeUpCommand.java
@@ -52,6 +52,8 @@ public class NodeUpCommand extends AbstractClusterCommand {
     private final Set<String> prePulledImages;
     private final String availabilityZone;
     private final String networkInterface;
+    private final boolean isDedicated;
+
 
     @Override
     protected List<String> buildCommandArguments() {
@@ -109,6 +111,10 @@ public class NodeUpCommand extends AbstractClusterCommand {
         if (StringUtils.isNotBlank(networkInterface)) {
             commands.add("--network_interface");
             commands.add(networkInterface);
+        }
+        if (isDedicated) {
+            commands.add("--dedicated");
+            commands.add("True");
         }
         return commands;
     }

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/AutoscaleManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/AutoscaleManager.java
@@ -98,6 +98,7 @@ public class AutoscaleManager extends AbstractSchedulingManager {
 
         private static final String TARGET_AZ_PARAMETER_NAME = "CP_CAP_TARGET_AVAILABILITY_ZONE";
         private static final String TARGET_NETWORK_INTERFACE_PARAMETER_NAME = "CP_CAP_TARGET_NETWORK_INTERFACE";
+        private static final String DEDICATED_INSTANCE_PARAMETER_NAME = "CP_CAP_DEDICATED_INSTANCE";
 
         private final PipelineRunManager pipelineRunManager;
         private final ParallelExecutorService executorService;
@@ -558,6 +559,7 @@ public class AutoscaleManager extends AbstractSchedulingManager {
             instanceRequest.setRequestedImage(run.getActualDockerImage());
             setAvailabilityZoneIfSpecified(instanceRequest, run);
             setNetworkInterfaceIfSpecified(instanceRequest, run);
+            setDedicatedFlagIfSpecified(instanceRequest, run);
             return instanceRequest;
         }
 
@@ -571,6 +573,12 @@ public class AutoscaleManager extends AbstractSchedulingManager {
             run.getParameterValue(TARGET_NETWORK_INTERFACE_PARAMETER_NAME)
                     .filter(StringUtils::isNotBlank)
                     .ifPresent(ni -> requiredInstance.getInstance().setNetworkInterfaceId(ni));
+        }
+
+        private void setDedicatedFlagIfSpecified(final InstanceRequest requiredInstance, final PipelineRun run) {
+            run.getParameterValue(DEDICATED_INSTANCE_PARAMETER_NAME)
+                    .filter(Boolean.TRUE.toString()::equalsIgnoreCase)
+                    .ifPresent(ni -> requiredInstance.getInstance().setDedicated(true));
         }
 
         private int getPoolNodeUpTasksCount() {

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/ReassignHandler.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/ReassignHandler.java
@@ -49,6 +49,7 @@ import java.util.function.BiFunction;
 @Slf4j
 public class ReassignHandler {
     private static final String CP_CREATE_NEW_NODE = "CP_CREATE_NEW_NODE";
+    private static final String CP_CAP_DEDICATED_INSTANCE = "CP_CAP_DEDICATED_INSTANCE";
 
     private final AutoscalerService autoscalerService;
     private final CloudFacade cloudFacade;
@@ -200,7 +201,13 @@ public class ReassignHandler {
                                      && isValueTrue(parameter.getValue()))
                 .findAny())
             .isPresent();
-        return !(isWindowsRun || requiresNewNode);
+        final boolean dedicatedNode = pipelineRun
+                .flatMap(run -> run.getPipelineRunParameters().stream()
+                        .filter(parameter -> Objects.equals(parameter.getName(), CP_CAP_DEDICATED_INSTANCE)
+                                && isValueTrue(parameter.getValue()))
+                        .findAny())
+                .isPresent();
+        return !(isWindowsRun || requiresNewNode || dedicatedNode);
     }
 
     private boolean isValueTrue(final String value) {

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -392,7 +392,7 @@ public class PipelineRunManager {
                 messageHelper.getMessage(
                         MessageConstants.ERROR_SENSITIVE_RUN_NOT_ALLOWED_FOR_TOOL, tool.getImage()));
 
-        PipelineRun run = createPipelineRun(version, configuration, pipeline, tool, toolVersion.orElse(null), region, 
+        PipelineRun run = createPipelineRun(version, configuration, pipeline, tool, toolVersion.orElse(null), region,
                 parentRun.orElse(null), entityIds, configurationId, sensitive);
         if (parentNodeId != null && !parentNodeId.equals(run.getId())) {
             setParentInstance(run, parentNodeId);

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/RunInstance.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/RunInstance.java
@@ -63,6 +63,13 @@ public class RunInstance {
     private String availabilityZone;
     private String networkInterfaceId;
 
+    /**
+     * Defines if instance should be created as dedicated,
+     * can be useful in case of BYOL (Bring Your Own License) case
+     */
+    private boolean dedicated;
+
+
     public RunInstance(final String nodeType,
                        final Integer nodeDisk,
                        final Integer effectiveNodeDisk,

--- a/deploy/contents/install/preferences/launch.system.parameters.json
+++ b/deploy/contents/install/preferences/launch.system.parameters.json
@@ -496,7 +496,7 @@
     },
     {
         "name": "CP_LOCALIZE_FROM_FILES_KEEP_JOB_ON_FAILURE",
-        "type": "boolen",
+        "type": "boolean",
         "description": "Whether fail or keep a job running if a config file based localization fails",
         "defaultValue": "true",
         "passToWorkers": false
@@ -513,6 +513,13 @@
         "type": "string",
         "description": "Specifies the target ENI to be attached to the node for run",
         "defaultValue": "",
+        "passToWorkers": false
+    },
+    {
+        "name": "CP_CAP_DEDICATED_INSTANCE",
+        "type": "boolean",
+        "description": "Specifies if the instance should be dedicated (has a dedicated hardware)",
+        "defaultValue": "false",
         "passToWorkers": false
     }
 ]

--- a/scripts/autoscaling/nodeup.py
+++ b/scripts/autoscaling/nodeup.py
@@ -41,6 +41,7 @@ def main():
     parser.add_argument("--kms_encyr_key_id", type=str, required=False)
     parser.add_argument("--region_id", type=str, default=None)
     parser.add_argument("--cloud", type=str, default=None)
+    parser.add_argument("--dedicated", type=bool, required=False)
     parser.add_argument("--label", type=str, default=[], required=False, action='append')
     parser.add_argument("--image", type=str, default=[], required=False, action='append')
 
@@ -67,6 +68,7 @@ def main():
     pre_pull_images = args.image
     additional_labels = map_labels_to_dict(args.label)
     pool_id = additional_labels.get('pool_id')
+    is_dedicated = args.dedicated if args.dedicated else False
 
     if not kube_ip or not kubeadm_token:
         raise RuntimeError('Kubernetes configuration is required to create a new node')
@@ -121,7 +123,7 @@ def main():
             ins_id, ins_ip = cloud_provider.run_instance(is_spot, bid_price, ins_type, ins_hdd, ins_img, ins_platform, ins_key, run_id,
                                                          pool_id, kms_encyr_key_id, num_rep, time_rep, kube_ip,
                                                          kubeadm_token, kubeadm_cert_hash, kube_node_token,
-                                                         pre_pull_images)
+                                                         pre_pull_images, is_dedicated)
 
         cloud_provider.check_instance(ins_id, run_id, num_rep, time_rep)
         nodename, nodename_full = cloud_provider.get_instance_names(ins_id)

--- a/workflows/pipe-common/pipeline/autoscaling/azureprovider.py
+++ b/workflows/pipe-common/pipeline/autoscaling/azureprovider.py
@@ -54,7 +54,7 @@ class AzureInstanceProvider(AbstractInstanceProvider):
         self.resource_group_name = os.environ["AZURE_RESOURCE_GROUP"]
 
     def run_instance(self, is_spot, bid_price, ins_type, ins_hdd, ins_img, ins_platform, ins_key, run_id, pool_id, kms_encyr_key_id,
-                     num_rep, time_rep, kube_ip, kubeadm_token, kubeadm_cert_hash, kube_node_token, pre_pull_images=[]):
+                     num_rep, time_rep, kube_ip, kubeadm_token, kubeadm_cert_hash, kube_node_token, pre_pull_images=[], is_dedicated=False):
         try:
             ins_key = utils.read_ssh_key(ins_key)
             swap_size = utils.get_swap_size(self.zone, ins_type, is_spot, "AZURE")

--- a/workflows/pipe-common/pipeline/autoscaling/gcpprovider.py
+++ b/workflows/pipe-common/pipeline/autoscaling/gcpprovider.py
@@ -49,7 +49,7 @@ class GCPInstanceProvider(AbstractInstanceProvider):
         self.client = discovery.build('compute', 'v1')
 
     def run_instance(self, is_spot, bid_price, ins_type, ins_hdd, ins_img, ins_platform, ins_key, run_id, pool_id, kms_encyr_key_id,
-                     num_rep, time_rep, kube_ip, kubeadm_token, kubeadm_cert_hash, kube_node_token, pre_pull_images=[]):
+                     num_rep, time_rep, kube_ip, kubeadm_token, kubeadm_cert_hash, kube_node_token, pre_pull_images=[], is_dedicated=False):
         ssh_pub_key = utils.read_ssh_key(ins_key)
         swap_size = utils.get_swap_size(self.cloud_region, ins_type, is_spot, "GCP")
         user_data_script = utils.get_user_data_script(self.cloud_region, ins_type, ins_img, ins_platform,


### PR DESCRIPTION
This PR brings possibility to run dedicated instances within AWS infrastructure.
Other cloud providers will ignore this configuration for now, but it will be quite easy to implement it in a future, since all infrastructure is ready, only changes in `nodeup` scripts would be needed.