### PR TITLE
Issue 2897: Allow to get number of layers for a run - fix empty output

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerContainerLayersCommand.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerContainerLayersCommand.java
@@ -23,7 +23,7 @@ import java.util.List;
 @Builder
 public class DockerContainerLayersCommand extends AbstractDockerCommand {
     private static final String LAYERS_COMMAND_TEMPLATE = "curl -k -s \"%s\" | sudo -E /bin/bash " +
-            "--login /dev/stdin %s &> ~/container_layers.log &";
+            "--login /dev/stdin %s";
 
     private final String containerId;
 


### PR DESCRIPTION
[Disable commit and pause operations for runs exceeding layers number #2897](https://github.com/epam/cloud-pipeline/issues/2897)