### PR TITLE
Issue 2918: Persist docker image history and cmd during image scan

### DIFF
--- a/api/src/main/java/com/epam/pipeline/dao/tool/ToolVulnerabilityDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/tool/ToolVulnerabilityDao.java
@@ -156,21 +156,20 @@ public class ToolVulnerabilityDao extends NamedParameterJdbcDaoSupport {
     @Transactional(propagation = Propagation.MANDATORY)
     public void insertToolVersionScan(long toolId, String version, ToolOSVersion toolOSVersion, String layerRef,
                                       String digest, ToolScanStatus newStatus, Date scanDate,
-                                      Map<VulnerabilitySeverity, Integer> vulnerabilitiesCount) {
-
-        MapSqlParameterSource params = ToolVulnerabilityColumns.getParams(
-                toolId, version, toolOSVersion, layerRef, digest, newStatus, scanDate, false, vulnerabilitiesCount
-        );
+                                      Map<VulnerabilitySeverity, Integer> vulnerabilitiesCount, String defaultCmd,
+                                      Integer layersCount) {
+        MapSqlParameterSource params = ToolVulnerabilityColumns.getParams(toolId, version, toolOSVersion, layerRef,
+                digest, newStatus, scanDate, false, vulnerabilitiesCount, defaultCmd, layersCount);
         getNamedParameterJdbcTemplate().update(insertToolVersionScanQuery, params);
     }
 
     @Transactional(propagation = Propagation.MANDATORY)
     public void updateToolVersionScan(long toolId, String version, ToolOSVersion toolOSVersion, String layerRef,
                                       String digest, ToolScanStatus newStatus, Date scanDate, boolean whiteList,
-                                      Map<VulnerabilitySeverity, Integer> vulnerabilitiesCount) {
-        MapSqlParameterSource params = ToolVulnerabilityColumns.getParams(
-                toolId, version, toolOSVersion, layerRef, digest, newStatus, scanDate, whiteList, vulnerabilitiesCount
-        );
+                                      Map<VulnerabilitySeverity, Integer> vulnerabilitiesCount, String defaultCmd,
+                                      Integer layersCount) {
+        MapSqlParameterSource params = ToolVulnerabilityColumns.getParams(toolId, version, toolOSVersion, layerRef,
+                digest, newStatus, scanDate, whiteList, vulnerabilitiesCount, defaultCmd, layersCount);
         if (newStatus == ToolScanStatus.COMPLETED) {
             getNamedParameterJdbcTemplate().update(updateToolVersionScanWithSuccessQuery, params);
         } else {
@@ -188,8 +187,7 @@ public class ToolVulnerabilityDao extends NamedParameterJdbcDaoSupport {
     }
 
     @Transactional(propagation = Propagation.MANDATORY)
-    public void updateWhiteListWithToolVersion(long toolId, String version,
-                                                                boolean fromWhiteList) {
+    public void updateWhiteListWithToolVersion(long toolId, String version, boolean fromWhiteList) {
         MapSqlParameterSource params = new MapSqlParameterSource();
         params.addValue(ToolVersionColumns.TOOL_ID.name(), toolId);
         params.addValue(ToolVersionColumns.VERSION.name(), version);
@@ -422,7 +420,8 @@ public class ToolVulnerabilityDao extends NamedParameterJdbcDaoSupport {
                                                        final ToolOSVersion toolOSVersion, final String layerRef,
                                                        final String digest, final ToolScanStatus newStatus,
                                                        final Date scanDate, final boolean whiteList,
-                                                       final Map<VulnerabilitySeverity, Integer> vulnerabilitiesCount) {
+                                                       final Map<VulnerabilitySeverity, Integer> vulnerabilitiesCount,
+                                                       final String defaultCmd, final Integer layersCount) {
             MapSqlParameterSource params = new MapSqlParameterSource();
             params.addValue(ToolVersionColumns.TOOL_ID.name(), toolId);
             params.addValue(ToolVersionColumns.VERSION.name(), version);
@@ -441,6 +440,8 @@ public class ToolVulnerabilityDao extends NamedParameterJdbcDaoSupport {
                     Optional.ofNullable(vulnerabilitiesCount)
                             .map(count -> JsonMapper.convertDataToJsonStringForQuery(vulnerabilitiesCount))
                             .orElse(null));
+            params.addValue(ToolVersionColumns.DEFAULT_CMD.name(), defaultCmd);
+            params.addValue(ToolVersionColumns.LAYERS_COUNT.name(), layersCount);
             return params;
         }
 
@@ -488,7 +489,9 @@ public class ToolVulnerabilityDao extends NamedParameterJdbcDaoSupport {
         WHITE_LIST,
         OS_NAME,
         OS_VERSION,
-        VULNERABILITIES_COUNT;
+        VULNERABILITIES_COUNT,
+        DEFAULT_CMD,
+        LAYERS_COUNT;
 
         private static RowMapper<ToolVersionScanResult> getRowMapper() {
             return (rs, rowNum) -> {
@@ -525,9 +528,10 @@ public class ToolVulnerabilityDao extends NamedParameterJdbcDaoSupport {
                     versionScan.setVulnerabilitiesCount(JsonMapper.parseData(vulnerabilitiesCount,
                             new TypeReference<Map<VulnerabilitySeverity, Integer>>() {}));
                 }
+                versionScan.setDefaultCmd(rs.getString(ToolVersionColumns.DEFAULT_CMD.name()));
+                versionScan.setLayersCount(rs.getInt(ToolVersionColumns.LAYERS_COUNT.name()));
                 return versionScan;
             };
         }
-
     }
 }

--- a/api/src/main/java/com/epam/pipeline/entity/scan/ToolVersionScanResult.java
+++ b/api/src/main/java/com/epam/pipeline/entity/scan/ToolVersionScanResult.java
@@ -47,6 +47,8 @@ public class ToolVersionScanResult {
     private boolean isAllowedToExecute;
     private boolean fromWhiteList;
     private Date gracePeriod;
+    private String defaultCmd;
+    private Integer layersCount;
     private Map<VulnerabilitySeverity, Integer> vulnerabilitiesCount = new HashMap<>();
 
     @JsonIgnore
@@ -81,7 +83,7 @@ public class ToolVersionScanResult {
 
     public ToolVersionScanResult(String version,  ToolOSVersion toolOSVersion, List<Vulnerability> vulnerabilities,
                                  List<ToolDependency> dependencies, ToolScanStatus status,
-                                 String lastLayerRef, String digest) {
+                                 String lastLayerRef, String digest, String defaultCmd, Integer layersCount) {
         this.version = version;
         this.vulnerabilities = new ArrayList<>(vulnerabilities);
         this.lastLayerRef = lastLayerRef;
@@ -93,5 +95,7 @@ public class ToolVersionScanResult {
         if (status == ToolScanStatus.COMPLETED) {
             this.successScanDate = scanDate;
         }
+        this.defaultCmd = defaultCmd;
+        this.layersCount = layersCount;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/entity/scan/ToolVersionScanResultView.java
+++ b/api/src/main/java/com/epam/pipeline/entity/scan/ToolVersionScanResultView.java
@@ -42,6 +42,8 @@ public class ToolVersionScanResultView {
     private boolean isAllowedToExecute;
     private boolean fromWhiteList;
     private Date gracePeriod;
+    private String defaultCmd;
+    private Integer layersCount;
     private Map<VulnerabilitySeverity, Integer> vulnerabilitiesCount;
 
     public static ToolVersionScanResultView from(final ToolVersionScanResult scanResult, final boolean isOSAllowed) {
@@ -59,6 +61,8 @@ public class ToolVersionScanResultView {
                     .fromWhiteList(scan.isFromWhiteList())
                     .gracePeriod(scan.getGracePeriod())
                     .vulnerabilitiesCount(scan.getVulnerabilitiesCount())
+                    .defaultCmd(scan.getDefaultCmd())
+                    .layersCount(scan.getLayersCount())
                     .build()
         ).orElse(null);
     }

--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerClient.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerClient.java
@@ -207,11 +207,6 @@ public class DockerClient {
             }).collect(Collectors.toList());
     }
 
-    public int getLayersCount(final DockerRegistry registry, final String imageName, final String tag) {
-        final RawImageDescription rawImage = getRawImageDescription(registry, imageName, tag, getAuthHeaders());
-        return rawImage.getHistory().size();
-    }
-
     private Map<String, Long> getLayersSize(final DockerRegistry registry, final String imageName, final String tag) {
         return getManifest(registry, imageName, tag)
             .map(ManifestV2::getLayers)

--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerClient.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerClient.java
@@ -207,6 +207,11 @@ public class DockerClient {
             }).collect(Collectors.toList());
     }
 
+    public int getLayersCount(final DockerRegistry registry, final String imageName, final String tag) {
+        final RawImageDescription rawImage = getRawImageDescription(registry, imageName, tag, getAuthHeaders());
+        return rawImage.getHistory().size();
+    }
+
     private Map<String, Long> getLayersSize(final DockerRegistry registry, final String imageName, final String tag) {
         return getManifest(registry, imageName, tag)
             .map(ManifestV2::getLayers)

--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerRegistryManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerRegistryManager.java
@@ -498,7 +498,7 @@ public class DockerRegistryManager implements SecuredEntityManager {
                     toolGroup.getName()));
             toolManager.updateToolVersionScanStatus(toolInGroup.get().getId(),
                     ToolScanStatus.NOT_SCANNED, DateUtils.now(), event.getTarget().getTag(),
-                    null, event.getTarget().getDigest(), new HashMap<>());
+                    null, event.getTarget().getDigest(), new HashMap<>(), null, null);
             return toolInGroup;
         }
         if (!permissionManager.isActionAllowedForUser(toolGroup, actor, AclPermission.WRITE)) {

--- a/api/src/main/java/com/epam/pipeline/manager/docker/scan/AggregatingToolScanManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/scan/AggregatingToolScanManager.java
@@ -18,6 +18,7 @@ package com.epam.pipeline.manager.docker.scan;
 
 import com.epam.pipeline.common.MessageConstants;
 import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.entity.docker.ImageHistoryLayer;
 import com.epam.pipeline.entity.docker.ManifestV2;
 import com.epam.pipeline.entity.docker.ToolVersion;
 import com.epam.pipeline.entity.docker.ToolVersionAttributes;
@@ -298,7 +299,7 @@ public class AggregatingToolScanManager implements ToolScanManager {
                 + ":" + UUID.randomUUID();
     }
 
-    private ToolVersionScanResult doScan(Tool tool, String tag, DockerRegistry registry)
+    private ToolVersionScanResult doScan(final Tool tool, final String tag, final DockerRegistry registry)
             throws ToolScanExternalServiceException {
 
         if (clairService == null) {
@@ -311,14 +312,17 @@ public class AggregatingToolScanManager implements ToolScanManager {
         }
 
         try {
-            String clairRef = scanLayers(tool, tag, registry);
-            String digest = getDockerClient(tool.getImage(), registry)
-                    .getVersionAttributes(registry, tool.getImage(), tag).getDigest();
+            final String clairRef = scanLayers(tool, tag, registry);
+            final DockerClient client = getDockerClient(tool.getImage(), registry);
+            final String digest = client.getVersionAttributes(registry, tool.getImage(), tag).getDigest();
+            final List<ImageHistoryLayer> imageHistory = client.getImageHistory(registry, tool.getImage(), tag);
+            final String defaultCmd = toolManager.loadToolDefaultCommand(imageHistory);
+            final int layersCount = client.getLayersCount(registry, tool.getImage(), tag);
 
-            ClairScanResult clairResult = getScanResult(tool, clairService.getScanResult(clairRef));
-            DockerComponentScanResult dockerScanResult = dockerComponentService == null ? null :
+            final ClairScanResult clairResult = getScanResult(tool, clairService.getScanResult(clairRef));
+            final DockerComponentScanResult dockerScanResult = dockerComponentService == null ? null :
                     getScanResult(tool, dockerComponentService.getScanResult(clairRef));
-            return convertResults(clairResult, dockerScanResult, tool, tag, digest);
+            return convertResults(clairResult, dockerScanResult, tool, tag, digest, defaultCmd, layersCount);
         } catch (IOException e) {
             throw new ToolScanExternalServiceException(tool, e);
         }
@@ -431,7 +435,9 @@ public class AggregatingToolScanManager implements ToolScanManager {
                                                  final DockerComponentScanResult compScanResult,
                                                  final Tool tool,
                                                  final String tag,
-                                                 final String digest) {
+                                                 final String digest,
+                                                 final String defaultCmd,
+                                                 final int layersCount) {
         final Map<VulnerabilitySeverity, Integer> vulnerabilitiesCount = new HashMap<>();
         final List<Vulnerability> vulnerabilities = Optional.ofNullable(clairScanResult)
                 .map(result -> ListUtils.emptyIfNull(result.getFeatures()).stream())
@@ -477,7 +483,7 @@ public class AggregatingToolScanManager implements ToolScanManager {
                 .orElseGet(() -> createEmptyToolOsVersion(tool, tag));
 
         final ToolVersionScanResult result = new ToolVersionScanResult(tag, osVersion, vulnerabilities,
-                dependencies, ToolScanStatus.COMPLETED, clairScanResult.getName(), digest);
+                dependencies, ToolScanStatus.COMPLETED, clairScanResult.getName(), digest, defaultCmd, layersCount);
         result.setVulnerabilitiesCount(vulnerabilitiesCount);
         return result;
     }

--- a/api/src/main/java/com/epam/pipeline/manager/docker/scan/AggregatingToolScanManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/scan/AggregatingToolScanManager.java
@@ -317,12 +317,11 @@ public class AggregatingToolScanManager implements ToolScanManager {
             final String digest = client.getVersionAttributes(registry, tool.getImage(), tag).getDigest();
             final List<ImageHistoryLayer> imageHistory = client.getImageHistory(registry, tool.getImage(), tag);
             final String defaultCmd = toolManager.loadToolDefaultCommand(imageHistory);
-            final int layersCount = client.getLayersCount(registry, tool.getImage(), tag);
 
             final ClairScanResult clairResult = getScanResult(tool, clairService.getScanResult(clairRef));
             final DockerComponentScanResult dockerScanResult = dockerComponentService == null ? null :
                     getScanResult(tool, dockerComponentService.getScanResult(clairRef));
-            return convertResults(clairResult, dockerScanResult, tool, tag, digest, defaultCmd, layersCount);
+            return convertResults(clairResult, dockerScanResult, tool, tag, digest, defaultCmd, imageHistory.size());
         } catch (IOException e) {
             throw new ToolScanExternalServiceException(tool, e);
         }

--- a/api/src/main/java/com/epam/pipeline/manager/docker/scan/ToolScanSchedulerCore.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/scan/ToolScanSchedulerCore.java
@@ -111,19 +111,20 @@ class ToolScanSchedulerCore {
                     toolManager.updateToolDependencies(result.getDependencies(), tool.getId(), version);
                     toolManager.updateToolVersionScanStatus(tool.getId(), ToolScanStatus.COMPLETED, new Date(),
                             version, result.getToolOSVersion(),
-                            result.getLastLayerRef(), result.getDigest(), result.getVulnerabilitiesCount());
+                            result.getLastLayerRef(), result.getDigest(), result.getVulnerabilitiesCount(),
+                            result.getDefaultCmd(), result.getLayersCount());
                     updateToolVersion(tool, version, registry, dockerClient);
                 } catch (ToolScanExternalServiceException e) {
                     log.error(messageHelper.getMessage(MessageConstants.ERROR_TOOL_SCAN_FAILED,
                             tool.getImage(), version), e);
                     toolManager.updateToolVersionScanStatus(tool.getId(), ToolScanStatus.FAILED, new Date(),
-                            version, null, null, new HashMap<>());
+                            version, null, null, new HashMap<>(), null, null);
                 }
             }
         } catch (Exception e) {
             log.error(messageHelper.getMessage(MessageConstants.ERROR_TOOL_SCAN_FAILED, tool.getImage()), e);
             toolManager.updateToolVersionScanStatus(tool.getId(), ToolScanStatus.FAILED, new Date(),
-                    "latest", null, null, new HashMap<>());
+                    "latest", null, null, new HashMap<>(), null, null);
         }
     }
 
@@ -152,8 +153,14 @@ class ToolScanSchedulerCore {
             final Map<VulnerabilitySeverity, Integer> vulnerabilitiesCount = toolVersionScanResult
                     .map(ToolVersionScanResult::getVulnerabilitiesCount)
                     .orElse(new HashMap<>());
+            final String defaultCmd = toolVersionScanResult
+                    .map(ToolVersionScanResult::getDefaultCmd)
+                    .orElse(null);
+            final Integer layersCount = toolVersionScanResult
+                    .map(ToolVersionScanResult::getLayersCount)
+                    .orElse(null);
             toolManager.updateToolVersionScanStatus(tool.getId(), ToolScanStatus.PENDING, null,
-                    version, layerRef, digest, vulnerabilitiesCount);
+                    version, layerRef, digest, vulnerabilitiesCount, defaultCmd, layersCount);
             return forceScanExecutor.submit(new DelegatingSecurityContextCallable<>(() -> {
                 log.info(messageHelper.getMessage(
                         MessageConstants.INFO_TOOL_FORCE_SCAN_STARTED, tool.getImage()));
@@ -166,11 +173,11 @@ class ToolScanSchedulerCore {
                     toolManager.updateToolVersionScanStatus(tool.getId(), ToolScanStatus.COMPLETED,
                             scanResult.getScanDate(), version, scanResult.getToolOSVersion(),
                             scanResult.getLastLayerRef(), scanResult.getDigest(),
-                            scanResult.getVulnerabilitiesCount());
+                            scanResult.getVulnerabilitiesCount(), scanResult.getDefaultCmd(), scanResult.getLayersCount());
                     return scanResult;
                 } catch (Exception e) {
                     toolManager.updateToolVersionScanStatus(tool.getId(), ToolScanStatus.FAILED, new Date(),
-                            version, null, null, new HashMap<>());
+                            version, null, null, new HashMap<>(), null, null);
                     log.error(messageHelper.getMessage(
                             MessageConstants.ERROR_TOOL_SCAN_FAILED, tool.getImage()), e);
                     throw new PipelineException(e);

--- a/api/src/main/java/com/epam/pipeline/manager/docker/scan/ToolScanSchedulerCore.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/scan/ToolScanSchedulerCore.java
@@ -172,8 +172,8 @@ class ToolScanSchedulerCore {
                     toolManager.updateToolDependencies(scanResult.getDependencies(), tool.getId(), version);
                     toolManager.updateToolVersionScanStatus(tool.getId(), ToolScanStatus.COMPLETED,
                             scanResult.getScanDate(), version, scanResult.getToolOSVersion(),
-                            scanResult.getLastLayerRef(), scanResult.getDigest(),
-                            scanResult.getVulnerabilitiesCount(), scanResult.getDefaultCmd(), scanResult.getLayersCount());
+                            scanResult.getLastLayerRef(), scanResult.getDigest(), scanResult.getVulnerabilitiesCount(),
+                            scanResult.getDefaultCmd(), scanResult.getLayersCount());
                     return scanResult;
                 } catch (Exception e) {
                     toolManager.updateToolVersionScanStatus(tool.getId(), ToolScanStatus.FAILED, new Date(),

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/ToolManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/ToolManager.java
@@ -182,7 +182,7 @@ public class ToolManager implements SecuredEntityManager {
                 String digest = dockerRegistryManager.getDockerClient(registry, tool.getImage())
                         .getVersionAttributes(registry, tool.getImage(), tag).getDigest();
                 updateToolVersionScanStatus(tool.getId(), ToolScanStatus.NOT_SCANNED,
-                        DateUtils.now(), tag, null, digest, new HashMap<>());
+                        DateUtils.now(), tag, null, digest, new HashMap<>(), null, null);
             }
         } catch (DockerConnectionException e) {
             throw new IllegalArgumentException(
@@ -521,7 +521,18 @@ public class ToolManager implements SecuredEntityManager {
     }
 
     public String loadToolDefaultCommand(final Long id, final String tag) {
-        final List<String> commands = loadToolHistory(id, tag)
+        final String command = toolVulnerabilityDao.loadToolVersionScan(id, tag)
+                .map(ToolVersionScanResult::getDefaultCmd)
+                .orElse(null);
+        if (command != null) {
+            return command;
+        }
+        final List<ImageHistoryLayer> imageHistory = loadToolHistory(id, tag);
+        return loadToolDefaultCommand(imageHistory);
+    }
+
+    public String loadToolDefaultCommand(final List<ImageHistoryLayer> imageHistory) {
+        final List<String> commands = imageHistory
             .stream()
             .map(ImageHistoryLayer::getCommand)
             .collect(Collectors.toList());
@@ -603,7 +614,8 @@ public class ToolManager implements SecuredEntityManager {
     public void updateToolVersionScanStatus(long toolId, ToolScanStatus newStatus, Date scanDate,
                                             String version, ToolOSVersion toolOSVersion,
                                             String layerRef, String digest,
-                                            Map<VulnerabilitySeverity, Integer> vulnerabilityCount) {
+                                            Map<VulnerabilitySeverity, Integer> vulnerabilityCount,
+                                            String defaultCmd, Integer layersCount) {
         final Tool tool = load(toolId);
         validateToolNotNull(tool, toolId);
         validateToolCanBeModified(tool);
@@ -616,19 +628,20 @@ public class ToolManager implements SecuredEntityManager {
                 whiteList = false;
             }
             toolVulnerabilityDao.updateToolVersionScan(toolId, version, toolOSVersion, layerRef, digest, newStatus,
-                    scanDate, whiteList, vulnerabilityCount);
+                    scanDate, whiteList, vulnerabilityCount, defaultCmd, layersCount);
         } else {
             toolVulnerabilityDao.insertToolVersionScan(toolId, version, toolOSVersion, layerRef,
-                    digest, newStatus, scanDate, vulnerabilityCount);
+                    digest, newStatus, scanDate, vulnerabilityCount, defaultCmd, layersCount);
         }
     }
 
     @Transactional(propagation = Propagation.REQUIRED)
     public void updateToolVersionScanStatus(long toolId, ToolScanStatus newStatus, Date scanDate,
                                             String version, String layerRef, String digest,
-                                            Map<VulnerabilitySeverity, Integer> vulnerabilityCount) {
+                                            Map<VulnerabilitySeverity, Integer> vulnerabilityCount,
+                                            String defaultCmd, Integer layersCount) {
         updateToolVersionScanStatus(toolId, newStatus, scanDate, version, null, layerRef, digest,
-                vulnerabilityCount);
+                vulnerabilityCount, defaultCmd, layersCount);
     }
 
     @Transactional(propagation = Propagation.REQUIRED)
@@ -640,7 +653,7 @@ public class ToolManager implements SecuredEntityManager {
         Optional<ToolVersionScanResult> toolVersionScanResult = loadToolVersionScan(tool, version);
         if (!toolVersionScanResult.isPresent()) {
             toolVulnerabilityDao.insertToolVersionScan(toolId, version, null, null, null, ToolScanStatus.NOT_SCANNED,
-                    DateUtils.now(), new HashMap<>());
+                    DateUtils.now(), new HashMap<>(), null, null);
         }
         toolVulnerabilityDao.updateWhiteListWithToolVersion(toolId, version, fromWhiteList);
         return loadToolVersionScan(tool, version).orElse(null);

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/ToolManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/ToolManager.java
@@ -521,14 +521,9 @@ public class ToolManager implements SecuredEntityManager {
     }
 
     public String loadToolDefaultCommand(final Long id, final String tag) {
-        final String command = toolVulnerabilityDao.loadToolVersionScan(id, tag)
+        return toolVulnerabilityDao.loadToolVersionScan(id, tag)
                 .map(ToolVersionScanResult::getDefaultCmd)
-                .orElse(null);
-        if (command != null) {
-            return command;
-        }
-        final List<ImageHistoryLayer> imageHistory = loadToolHistory(id, tag);
-        return loadToolDefaultCommand(imageHistory);
+                .orElseGet(() -> loadToolDefaultCommand(loadToolHistory(id, tag)));
     }
 
     public String loadToolDefaultCommand(final List<ImageHistoryLayer> imageHistory) {

--- a/api/src/main/resources/dao/tool-vulnerability-dao.xml
+++ b/api/src/main/resources/dao/tool-vulnerability-dao.xml
@@ -192,7 +192,9 @@
                         success_scan_date,
                         os_name,
                         os_version,
-                        vulnerabilities_count
+                        vulnerabilities_count,
+                        default_cmd,
+                        layers_count
                     ) VALUES (
                         :TOOL_ID,
                         :VERSION,
@@ -203,7 +205,9 @@
                         :SUCCESS_SCAN_DATE,
                         :OS_NAME,
                         :OS_VERSION,
-                        :VULNERABILITIES_COUNT
+                        :VULNERABILITIES_COUNT,
+                        :DEFAULT_CMD,
+                        :LAYERS_COUNT
                     )
                 ]]>
             </value>
@@ -220,7 +224,9 @@
                         white_list=:WHITE_LIST,
                         os_name=:OS_NAME,
                         os_version=:OS_VERSION,
-                        vulnerabilities_count=:VULNERABILITIES_COUNT
+                        vulnerabilities_count=:VULNERABILITIES_COUNT,
+                        default_cmd=:DEFAULT_CMD,
+                        layers_count=:LAYERS_COUNT
                     WHERE
                         tool_id=:TOOL_ID
                         AND version=:VERSION
@@ -252,7 +258,9 @@
                         white_list=:WHITE_LIST,
                         os_name=:OS_NAME,
                         os_version=:OS_VERSION,
-                        vulnerabilities_count=:VULNERABILITIES_COUNT
+                        vulnerabilities_count=:VULNERABILITIES_COUNT,
+                        default_cmd=:DEFAULT_CMD,
+                        layers_count=:LAYERS_COUNT
                     WHERE
                         tool_id=:TOOL_ID
                         AND version=:VERSION
@@ -273,7 +281,9 @@
                         white_list,
                         os_name,
                         os_version,
-                        vulnerabilities_count
+                        vulnerabilities_count,
+                        default_cmd,
+                        layers_count
                     FROM
                         pipeline.tool_version_scan
                     WHERE
@@ -296,7 +306,9 @@
                         white_list,
                         os_name,
                         os_version,
-                        vulnerabilities_count
+                        vulnerabilities_count,
+                        default_cmd,
+                        layers_count
                     FROM
                         pipeline.tool_version_scan
                     WHERE
@@ -318,7 +330,9 @@
                         white_list,
                         os_name,
                         os_version,
-                        vulnerabilities_count
+                        vulnerabilities_count,
+                        default_cmd,
+                        layers_count
                     FROM
                         pipeline.tool_version_scan
                     WHERE

--- a/api/src/main/resources/db/migration/v2022.11.14_12.00__issue_2918_tool_requests_performance.sql
+++ b/api/src/main/resources/db/migration/v2022.11.14_12.00__issue_2918_tool_requests_performance.sql
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ALTER TABLE tool_version_scan ADD COLUMN default_cmd TEXT NULL;
+ALTER TABLE tool_version_scan ADD COLUMN layers_count BIGINT NULL;

--- a/api/src/test/java/com/epam/pipeline/dao/tool/ToolVulnerabilityDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/tool/ToolVulnerabilityDaoTest.java
@@ -124,11 +124,35 @@ public class ToolVulnerabilityDaoTest extends AbstractJdbcTest {
         vulnerabilitiesCount.put(VulnerabilitySeverity.Medium, 2);
         toolVulnerabilityDao.insertToolVersionScan(tool.getId(), LATEST_VERSION,
                 new ToolOSVersion("centos", "7"), "", "digest",
-                ToolScanStatus.COMPLETED, new Date(), vulnerabilitiesCount);
+                ToolScanStatus.COMPLETED, new Date(), vulnerabilitiesCount, null, null);
         final Optional<ToolVersionScanResult> result = toolVulnerabilityDao
                 .loadToolVersionScan(tool.getId(), LATEST_VERSION);
         Assert.assertTrue(result.isPresent());
         Assert.assertEquals(vulnerabilitiesCount, result.get().getVulnerabilitiesCount());
+    }
+
+    @Test
+    public void shouldSaveAndLoadVersionWithLayersCount() {
+        final Integer layersCount = 10;
+        toolVulnerabilityDao.insertToolVersionScan(tool.getId(), LATEST_VERSION,
+                new ToolOSVersion("centos", "7"), "", "digest",
+                ToolScanStatus.COMPLETED, new Date(), new HashMap<>(), null, layersCount);
+        final Optional<ToolVersionScanResult> result = toolVulnerabilityDao
+                .loadToolVersionScan(tool.getId(), LATEST_VERSION);
+        Assert.assertTrue(result.isPresent());
+        Assert.assertEquals(layersCount, result.get().getLayersCount());
+    }
+
+    @Test
+    public void shouldSaveAndLoadVersionWithDefaultCmd() {
+        final String defaultCmd = "defaultCmd";
+        toolVulnerabilityDao.insertToolVersionScan(tool.getId(), LATEST_VERSION,
+                new ToolOSVersion("centos", "7"), "", "digest",
+                ToolScanStatus.COMPLETED, new Date(), new HashMap<>(), defaultCmd, null);
+        final Optional<ToolVersionScanResult> result = toolVulnerabilityDao
+                .loadToolVersionScan(tool.getId(), LATEST_VERSION);
+        Assert.assertTrue(result.isPresent());
+        Assert.assertEquals(defaultCmd, result.get().getDefaultCmd());
     }
 
     @Test

--- a/api/src/test/java/com/epam/pipeline/manager/docker/scan/ToolScanSchedulerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/docker/scan/ToolScanSchedulerTest.java
@@ -74,6 +74,8 @@ public class ToolScanSchedulerTest extends AbstractSpringTest {
     private static final String TEST_LAYER_DIGEST = "testDigest";
     public static final long DOCKER_SIZE = 123456L;
     public static final String PREFERENCE_MANAGER = "preferenceManager";
+    private static final String DEFAULT_COMMAND = "default_command";
+    private static final int LAYERS_COUNT = 10;
 
     private ToolScanScheduler toolScanScheduler;
 
@@ -156,7 +158,7 @@ public class ToolScanSchedulerTest extends AbstractSpringTest {
             .thenReturn(new ToolVersionScanResult(LATEST_VERSION, new ToolOSVersion("test", "0.1"),
                     Collections.singletonList(vulnerability),
                     Collections.singletonList(dependency),
-                    ToolScanStatus.COMPLETED, TEST_LAYER_REF, TEST_LAYER_DIGEST));
+                    ToolScanStatus.COMPLETED, TEST_LAYER_REF, TEST_LAYER_DIGEST, DEFAULT_COMMAND, LAYERS_COUNT));
 
         doNothing().when(toolVersionManager).updateOrCreateToolVersion(Mockito.anyLong(), Mockito.anyString(),
                 Mockito.anyString(), Mockito.any(DockerRegistry.class), Mockito.any(DockerClient.class));
@@ -280,7 +282,8 @@ public class ToolScanSchedulerTest extends AbstractSpringTest {
         @Override
         public void updateToolVersionScanStatus(long toolId, ToolScanStatus newStatus, Date scanDate, String version,
                                                 ToolOSVersion toolOSVersion, String layerRef, String digest,
-                                                Map<VulnerabilitySeverity, Integer> vulnerabilityCount) {
+                                                Map<VulnerabilitySeverity, Integer> vulnerabilityCount,
+                                                String defaultCmd, Integer layersCount) {
             Assert.assertNotNull(version);
 
             ToolVersionScanResult versionScan = new ToolVersionScanResult();
@@ -304,9 +307,10 @@ public class ToolScanSchedulerTest extends AbstractSpringTest {
         @Override
         public void updateToolVersionScanStatus(long toolId, ToolScanStatus newStatus, Date scanDate, String version,
                                                 String layerRef, String digest,
-                                                Map<VulnerabilitySeverity, Integer> vulnerabilityCount) {
+                                                Map<VulnerabilitySeverity, Integer> vulnerabilityCount,
+                                                String defaultCmd, Integer layersCount) {
             updateToolVersionScanStatus(toolId, newStatus, scanDate, version, null, layerRef,
-                    digest, vulnerabilityCount);
+                    digest, vulnerabilityCount, defaultCmd, layersCount);
         }
 
         @Override
@@ -344,6 +348,5 @@ public class ToolScanSchedulerTest extends AbstractSpringTest {
                     .computeIfAbsent(toolId, key -> new HashMap<>());
             return Optional.ofNullable(versionScanMap.get(version));
         }
-
     }
 }

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/ToolManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/ToolManagerTest.java
@@ -565,7 +565,8 @@ public class ToolManagerTest extends AbstractManagerTest {
         toolManager.create(tool, true);
 
         toolManager.updateToolVersionScanStatus(tool.getId(), ToolScanStatus.COMPLETED, scanDate,
-                latestVersion, new ToolOSVersion(CENTOS, CENTOS_VERSION), testRef, testRef, new HashMap<>(), null, null);
+                latestVersion, new ToolOSVersion(CENTOS, CENTOS_VERSION), testRef, testRef, new HashMap<>(),
+                null, null);
 
         ToolScanResult loaded = toolManager.loadToolScanResult(tool);
         ToolOSVersion toolOSVersion = loaded.getToolVersionScanResults().get(LATEST_TAG).getToolOSVersion();

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/ToolManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/ToolManagerTest.java
@@ -477,8 +477,7 @@ public class ToolManagerTest extends AbstractManagerTest {
 
         toolManager.updateToolVersionScanStatus(
                 tool.getId(), ToolScanStatus.COMPLETED, new Date(), LATEST_TAG,
-                new ToolOSVersion(TEST, TEST), LAYER_REF, DIGEST, new HashMap<>()
-        );
+                new ToolOSVersion(TEST, TEST), LAYER_REF, DIGEST, new HashMap<>(), null, null);
         toolManager.updateToolVulnerabilities(Collections.emptyList(), tool.getId(), LATEST_TAG);
         toolManager.updateToolDependencies(Collections.emptyList(), tool.getId(), LATEST_TAG);
         Assert.assertNotNull(toolManager.load(tool.getId()));
@@ -525,7 +524,7 @@ public class ToolManagerTest extends AbstractManagerTest {
         ToolScanStatus status = ToolScanStatus.COMPLETED;
 
         toolManager.updateToolVersionScanStatus(tool.getId(), status, now, LATEST_TAG, new ToolOSVersion(TEST, TEST),
-                layerRef, digest, new HashMap<>());
+                layerRef, digest, new HashMap<>(), null, null);
         toolManager.updateWhiteListWithToolVersionStatus(tool.getId(), LATEST_TAG, true);
         ToolVersionScanResult versionScan = toolManager.loadToolVersionScan(
                 tool.getId(), LATEST_TAG).get();
@@ -539,7 +538,7 @@ public class ToolManagerTest extends AbstractManagerTest {
         now = new Date();
 
         toolManager.updateToolVersionScanStatus(tool.getId(), status, now, LATEST_TAG, new ToolOSVersion(TEST, TEST),
-                layerRef, digest, new HashMap<>());
+                layerRef, digest, new HashMap<>(), null, null);
         Assert.assertEquals(1, toolManager.loadToolScanResult(tool).getToolVersionScanResults().values().size());
         versionScan = toolManager.loadToolVersionScan(tool.getId(), LATEST_TAG).get();
         Assert.assertEquals(now, versionScan.getScanDate());
@@ -566,7 +565,7 @@ public class ToolManagerTest extends AbstractManagerTest {
         toolManager.create(tool, true);
 
         toolManager.updateToolVersionScanStatus(tool.getId(), ToolScanStatus.COMPLETED, scanDate,
-                latestVersion, new ToolOSVersion(CENTOS, CENTOS_VERSION), testRef, testRef, new HashMap<>());
+                latestVersion, new ToolOSVersion(CENTOS, CENTOS_VERSION), testRef, testRef, new HashMap<>(), null, null);
 
         ToolScanResult loaded = toolManager.loadToolScanResult(tool);
         ToolOSVersion toolOSVersion = loaded.getToolVersionScanResults().get(LATEST_TAG).getToolOSVersion();
@@ -598,7 +597,7 @@ public class ToolManagerTest extends AbstractManagerTest {
         toolManager.create(tool, true);
 
         toolManager.updateToolVersionScanStatus(tool.getId(), ToolScanStatus.COMPLETED, scanDate,
-                latestVersion, new ToolOSVersion(TEST, TEST), testRef, testRef, new HashMap<>());
+                latestVersion, new ToolOSVersion(TEST, TEST), testRef, testRef, new HashMap<>(), null, null);
 
         ToolScanResult loaded = toolManager.loadToolScanResult(tool);
         Assert.assertEquals(
@@ -674,7 +673,7 @@ public class ToolManagerTest extends AbstractManagerTest {
         ToolScanStatus status = ToolScanStatus.FAILED;
 
         toolManager.updateToolVersionScanStatus(tool.getId(), status, now, LATEST_TAG, layerRef,
-                digest, new HashMap<>());
+                digest, new HashMap<>(), null, null);
         ToolVersionScanResult versionScan = toolManager.loadToolVersionScan(
                 tool.getId(), LATEST_TAG).get();
         Assert.assertEquals(status, versionScan.getStatus());
@@ -699,7 +698,7 @@ public class ToolManagerTest extends AbstractManagerTest {
 
         toolManager.updateToolVersionScanStatus(
                 tool.getId(), status, scanDate, LATEST_TAG, new ToolOSVersion(TEST, TEST), layerRef, digest,
-                new HashMap<>());
+                new HashMap<>(), null, null);
         ToolVersionScanResult versionScan =
                 toolManager.loadToolVersionScan(tool.getId(), LATEST_TAG).get();
         Assert.assertEquals(status, versionScan.getStatus());
@@ -712,7 +711,7 @@ public class ToolManagerTest extends AbstractManagerTest {
         Date newScanDate = new Date();
 
         toolManager.updateToolVersionScanStatus(
-                tool.getId(), status, newScanDate, LATEST_TAG, layerRef, digest, new HashMap<>());
+                tool.getId(), status, newScanDate, LATEST_TAG, layerRef, digest, new HashMap<>(), null, null);
         Assert.assertEquals(1, toolManager.loadToolScanResult(tool).getToolVersionScanResults().values().size());
         versionScan = toolManager.loadToolVersionScan(tool.getId(), LATEST_TAG).get();
         Assert.assertEquals(newScanDate, versionScan.getScanDate());
@@ -795,10 +794,10 @@ public class ToolManagerTest extends AbstractManagerTest {
         assertThrows(IllegalArgumentException.class, 
             () -> toolManager.updateToolVersionScanStatus(symlink.getId(), ToolScanStatus.COMPLETED, 
                     DateUtils.now(), LATEST_TAG, new ToolOSVersion(CENTOS, CENTOS_VERSION), LAYER_REF, DIGEST,
-                    new HashMap<>()));
+                    new HashMap<>(), null, null));
         assertThrows(IllegalArgumentException.class, 
             () -> toolManager.updateToolVersionScanStatus(symlink.getId(), ToolScanStatus.COMPLETED, 
-                    DateUtils.now(), LATEST_TAG, LAYER_REF, DIGEST, new HashMap<>()));
+                    DateUtils.now(), LATEST_TAG, LAYER_REF, DIGEST, new HashMap<>(), null, null));
         assertThrows(IllegalArgumentException.class, 
             () -> toolManager.updateToolDependencies(Collections.emptyList(), symlink.getId(), LATEST_TAG));
         assertThrows(IllegalArgumentException.class, 
@@ -863,5 +862,4 @@ public class ToolManagerTest extends AbstractManagerTest {
         tool.setToolGroup(toolGroupName);
         return tool;
     }
-
 }


### PR DESCRIPTION
**Background**
[Persist docker image history and cmd during image scan #2918](https://github.com/epam/cloud-pipeline/issues/2918)