### PR TITLE
Gitlab upgrade: fix for gitlab-reader service

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/git/GitProjectStorage.java
+++ b/api/src/main/java/com/epam/pipeline/entity/git/GitProjectStorage.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.git;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode
+public class GitProjectStorage {
+
+    @JsonProperty("project_id")
+    private Long projectId;
+
+    @JsonProperty("disk_path")
+    private String diskPath;
+}

--- a/api/src/main/java/com/epam/pipeline/manager/git/GitLabApi.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/GitLabApi.java
@@ -25,6 +25,7 @@ import com.epam.pipeline.entity.git.GitProject;
 import com.epam.pipeline.entity.git.GitProjectMember;
 import com.epam.pipeline.entity.git.GitProjectMemberRequest;
 import com.epam.pipeline.entity.git.GitProjectRequest;
+import com.epam.pipeline.entity.git.GitProjectStorage;
 import com.epam.pipeline.entity.git.GitPushCommitEntry;
 import com.epam.pipeline.entity.git.GitRepositoryEntry;
 import com.epam.pipeline.entity.git.GitTagEntry;
@@ -332,4 +333,13 @@ public interface GitLabApi {
     Call<GitProject> forkProject(@Path(API_VERSION) String apiVersion,
                                  @Path(PROJECT) String project,
                                  @Query("namespace") String namespace);
+
+    /**
+     * Get the path to repository storage for specified project. Available for administrators only.
+     * NOTE: Introduced in GitLab 14.0.
+     *
+     * @param project The ID or URL-encoded path of the project
+     */
+    @GET("api/v4/projects/{project}/storage")
+    Call<GitProjectStorage> getProjectStorage(@Path(PROJECT) String project);
 }

--- a/api/src/main/java/com/epam/pipeline/manager/git/GitReaderClient.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/GitReaderClient.java
@@ -19,7 +19,6 @@ package com.epam.pipeline.manager.git;
 import com.epam.pipeline.controller.Result;
 import com.epam.pipeline.controller.ResultStatus;
 import com.epam.pipeline.entity.git.GitCommitsFilter;
-import com.epam.pipeline.entity.git.GitRepositoryUrl;
 import com.epam.pipeline.entity.git.gitreader.GitReaderDiff;
 import com.epam.pipeline.entity.git.gitreader.GitReaderDiffEntry;
 import com.epam.pipeline.entity.git.gitreader.GitReaderEntryIteratorListing;
@@ -65,7 +64,7 @@ public class GitReaderClient {
         this.gitReaderApi = buildGitLabApi(gitReaderUrlRoot);
     }
 
-    public GitReaderEntryIteratorListing<GitReaderRepositoryCommit> getRepositoryCommits(final GitRepositoryUrl repo,
+    public GitReaderEntryIteratorListing<GitReaderRepositoryCommit> getRepositoryCommits(final String gitlabRepoPath,
                                                                                          final Long page,
                                                                                          final Integer pageSize,
                                                                                          final GitCommitsFilter filter,
@@ -73,17 +72,17 @@ public class GitReaderClient {
         throws GitClientException {
         return callAndCheckResult(
                 gitReaderApi.listCommits(
-                        getRepositoryPath(repo), page, pageSize, toGitReaderRequestFilter(filter, ignored)
+                        gitlabRepoPath, page, pageSize, toGitReaderRequestFilter(filter, ignored)
                 )
         ).getPayload();
     }
 
-    public GitReaderDiff getRepositoryCommitDiffs(final GitRepositoryUrl repo,
+    public GitReaderDiff getRepositoryCommitDiffs(final String gitlabRepoPath,
                                                   final Boolean includeDiff,
                                                   final GitCommitsFilter filter,
                                                   final List<String> filesToIgnore) throws GitClientException {
         final Result<GitReaderRepositoryCommitDiff> result = callAndCheckResult(
-                gitReaderApi.listCommitDiffs(getRepositoryPath(repo), includeDiff,
+                gitReaderApi.listCommitDiffs(gitlabRepoPath, includeDiff,
                         toGitReaderRequestFilter(filter, filesToIgnore))
         );
         return GitReaderDiff.builder()
@@ -94,39 +93,39 @@ public class GitReaderClient {
                 .build();
     }
 
-    public GitReaderDiffEntry getRepositoryCommitDiff(final GitRepositoryUrl repo,
+    public GitReaderDiffEntry getRepositoryCommitDiff(final String gitlabRepoPath,
                                                       final String commit,
                                                       final GitReaderLogsPathFilter paths) throws GitClientException {
         return callAndCheckResult(
-                gitReaderApi.getCommitDiff(getRepositoryPath(repo), commit, paths)
+                gitReaderApi.getCommitDiff(gitlabRepoPath, commit, paths)
         ).getPayload();
     }
 
-    public GitReaderEntryListing<GitReaderObject> getRepositoryTree(final GitRepositoryUrl repo,
+    public GitReaderEntryListing<GitReaderObject> getRepositoryTree(final String gitlabRepoPath,
                                                                     final GitReaderLogsPathFilter paths,
                                                                     final String ref, final Long page,
                                                                     final Integer pageSize) throws GitClientException {
         return callAndCheckResult(
-                gitReaderApi.getRepositoryTree(getRepositoryPath(repo), ref, page, pageSize, paths)
+                gitReaderApi.getRepositoryTree(gitlabRepoPath, ref, page, pageSize, paths)
         ).getPayload();
     }
 
-    public GitReaderEntryListing<GitReaderRepositoryLogEntry> getRepositoryTreeLogs(final GitRepositoryUrl repo,
+    public GitReaderEntryListing<GitReaderRepositoryLogEntry> getRepositoryTreeLogs(final String gitlabRepoPath,
                                                                                     final GitReaderLogsPathFilter paths,
                                                                                     final String ref, final Long page,
                                                                                     final Integer pageSize)
             throws GitClientException {
         return callAndCheckResult(
-                gitReaderApi.getRepositoryLogsTree(getRepositoryPath(repo), ref, page, pageSize, paths)
+                gitReaderApi.getRepositoryLogsTree(gitlabRepoPath, ref, page, pageSize, paths)
         ).getPayload();
     }
 
-    public GitReaderEntryListing<GitReaderRepositoryLogEntry> getRepositoryTreeLogs(final GitRepositoryUrl repo,
+    public GitReaderEntryListing<GitReaderRepositoryLogEntry> getRepositoryTreeLogs(final String gitlabRepoPath,
                                                                                     final String ref,
                                                                                     final GitReaderLogsPathFilter paths)
             throws GitClientException {
         return callAndCheckResult(
-                gitReaderApi.getRepositoryLogsTree(getRepositoryPath(repo), ref, paths)
+                gitReaderApi.getRepositoryLogsTree(gitlabRepoPath, ref, paths)
         ).getPayload();
     }
 
@@ -136,14 +135,6 @@ public class GitReaderClient {
             throw new GitClientException(result.getMessage());
         }
         return result;
-    }
-
-    private String getRepositoryPath(final GitRepositoryUrl gitRepositoryUrl) {
-        final String namespace = gitRepositoryUrl.getNamespace()
-                .orElseThrow(() -> new IllegalArgumentException("Invalid repository URL format"));
-        final String project = gitRepositoryUrl.getProject()
-                .orElseThrow(() -> new IllegalArgumentException("Invalid repository URL format"));
-        return Paths.get(namespace, project + ".git").toString();
     }
 
     private GitReaderApi buildGitLabApi(final String gitReaderUrlRoot) {

--- a/api/src/main/java/com/epam/pipeline/manager/git/GitlabClient.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/GitlabClient.java
@@ -24,6 +24,7 @@ import com.epam.pipeline.entity.git.GitGroupRequest;
 import com.epam.pipeline.entity.git.GitHookRequest;
 import com.epam.pipeline.entity.git.GitProject;
 import com.epam.pipeline.entity.git.GitProjectRequest;
+import com.epam.pipeline.entity.git.GitProjectStorage;
 import com.epam.pipeline.entity.git.GitPushCommitEntry;
 import com.epam.pipeline.entity.git.GitRepositoryEntry;
 import com.epam.pipeline.entity.git.GitRepositoryUrl;
@@ -433,6 +434,10 @@ public class GitlabClient {
             }
         }
         return gitlabUser;
+    }
+
+    public GitProjectStorage getProjectStorage(final String project) throws GitClientException {
+        return execute(gitLabApi.getProjectStorage(makeProjectId(namespace, project)));
     }
 
     private GitProject createRepo(String repoName, String description) throws GitClientException {

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -305,7 +305,8 @@ public class SystemPreferences {
             new StringPreference("bitbucket.user.name", null, GIT_GROUP, pass);
     public static final StringPreference GITLAB_API_VERSION = new StringPreference(
             "git.gitlab.api.version", "v3", GIT_GROUP, pass);
-
+    public static final BooleanPreference GITLAB_HASHED_REPO_SUPPORT = new BooleanPreference(
+            "git.gitlab.hashed.repo.support", false, GIT_GROUP, pass);
 
     // DOCKER_SECURITY_GROUP
     /**


### PR DESCRIPTION
The current PR provides fix for gitlab-reader service for a newest gitlab versions.

Since gitlab started to support [hashed storages](https://docs.gitlab.com/ee/administration/repository_storage_types.html#hashed-storage) a new approach shall be implemented for Versioned Storages and in particular gitlab-reader service. 

To find a path to gitlab repository we can use a gitlab rest api method: `GET api/v4/projects/<project_id>/storage `

A new system preference added to support new storages approach.