### PR TITLE
EDGE: support stubs for broken location configurations

### DIFF
--- a/deploy/contents/k8s/cp-edge/cp-edge-dpl.yaml
+++ b/deploy/contents/k8s/cp-edge/cp-edge-dpl.yaml
@@ -65,6 +65,8 @@ spec:
             - mountPath: /etc/nginx/ext/external-apps
               name: edge-external-apps
               readOnly: true
+            - mountPath: /etc/nginx/static
+              name: edge-static
             - mountPath: /opt/share-srv/pki
               name: share-pki
               readOnly: true
@@ -97,6 +99,9 @@ spec:
         - name: edge-external-apps
           hostPath:
             path: /opt/edge/external-apps
+        - name: edge-static
+          hostPath:
+            path: /opt/edge/static
         - name: share-pki
           hostPath:
             path: /opt/share-srv/pki

--- a/deploy/contents/k8s/cp-edge/cp-edge-dpl.yaml
+++ b/deploy/contents/k8s/cp-edge/cp-edge-dpl.yaml
@@ -67,6 +67,7 @@ spec:
               readOnly: true
             - mountPath: /etc/nginx/static
               name: edge-static
+              readOnly: true
             - mountPath: /opt/share-srv/pki
               name: share-pki
               readOnly: true

--- a/deploy/docker/cp-edge/Dockerfile
+++ b/deploy/docker/cp-edge/Dockerfile
@@ -90,6 +90,7 @@ RUN touch /var/log/sync-routes.log && \
 ## Main config file
 ADD	nginx.conf /etc/nginx/nginx.conf
 ADD endpoints-config /etc/nginx/endpoints-config
+ADD static /etc/nginx/static
 ADD mime.types /etc/nginx/mime.types
 
 ## Logs dir

--- a/deploy/docker/cp-edge/endpoints-config/error.html
+++ b/deploy/docker/cp-edge/endpoints-config/error.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Cloud Pipeline - Error occured...</title>
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      html, body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: #fff;
+        height: 100vh;
+        width: 100vw;
+        padding: 25px;
+        font-family: sans-serif;
+        color: rgba(0, 0, 0, .65);
+        font-size: 12px;
+      }
+      .container {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        padding: 25px;
+        width: 100%;
+        height: 100%;
+        background-color: #efefef;
+        border: 1px dashed #ccc;
+        border-radius: 10px;
+      }
+      .exclamation-icon {
+        display: inline-block;
+        position: relative;
+        width: 25px;
+        height: 25px;
+        margin: 0 10px;
+        border-radius: 50%;
+        background-color: rgba(0, 0, 0, .65);
+      }
+      .exclamation-icon::before {
+        content: "!";
+        font-size: large;
+        display: block;
+        color: #fff;
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+      }
+      .row {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: larger;
+        margin-bottom: 5px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+        <div class="row" style="font-size: large;">
+          <span class="exclamation-icon"></span>
+          <span>
+            An error occurred in the tool endpoints settings.
+          </span>
+        </div>
+        <p class="row">
+          Please fix the endpoint configuration and restart run. 
+        <p class="row">
+          In case of any questions please contact administrator or mail to
+          <a style="margin-left: 5px" href="mailto:${CP_ERROR_SUPPORT_EMAIL}?Subject=${CP_ERROR_PLATFORM_NAME} tool endpoint settings request">
+            ${CP_ERROR_PLATFORM_NAME} support team
+          </a>
+          .
+        </p>
+    </div>
+  </body>
+</html>

--- a/deploy/docker/cp-edge/endpoints-config/error.html
+++ b/deploy/docker/cp-edge/endpoints-config/error.html
@@ -21,6 +21,14 @@
         color: rgba(0, 0, 0, .65);
         font-size: 12px;
       }
+      a, a:visited {
+        color: #108ee9;
+        text-decoration: none;
+        transition: color .3s ease;
+      }
+      a:hover {
+        color: #49a9ee;
+      }
       .container {
         display: flex;
         flex-direction: column;

--- a/deploy/docker/cp-edge/endpoints-config/route.template.stub.loc.conf
+++ b/deploy/docker/cp-edge/endpoints-config/route.template.stub.loc.conf
@@ -2,6 +2,7 @@ location {edge_route_location} {
     set $username "{edge_route_owner}";
     set $shared_with_users "{edge_route_shared_users}";
     set $shared_with_groups "{edge_route_shared_groups}";
+    set $route_location_root "{edge_route_location}";
     root /etc/nginx/static/;
     rewrite ^ /error.html break;
 }

--- a/deploy/docker/cp-edge/endpoints-config/route.template.stub.loc.conf
+++ b/deploy/docker/cp-edge/endpoints-config/route.template.stub.loc.conf
@@ -1,0 +1,7 @@
+location {edge_route_location} {
+    set $username "{edge_route_owner}";
+    set $shared_with_users "{edge_route_shared_users}";
+    set $shared_with_groups "{edge_route_shared_groups}";
+    root /etc/nginx/endpoints-config/;
+    rewrite ^ /error.html break;
+}

--- a/deploy/docker/cp-edge/endpoints-config/route.template.stub.loc.conf
+++ b/deploy/docker/cp-edge/endpoints-config/route.template.stub.loc.conf
@@ -2,6 +2,6 @@ location {edge_route_location} {
     set $username "{edge_route_owner}";
     set $shared_with_users "{edge_route_shared_users}";
     set $shared_with_groups "{edge_route_shared_groups}";
-    root /etc/nginx/endpoints-config/;
+    root /etc/nginx/static/;
     rewrite ^ /error.html break;
 }

--- a/deploy/docker/cp-edge/static/error.html
+++ b/deploy/docker/cp-edge/static/error.html
@@ -73,14 +73,17 @@
         <div class="row" style="font-size: large;">
           <span class="exclamation-icon"></span>
           <span>
-            An error occurred in the tool endpoints settings.
+            An error occurred in the tool endpoint settings.
           </span>
         </div>
         <p class="row">
-          Please fix the endpoint configuration and restart run. 
+          Please fix the endpoint configuration and refresh this page.
         </p>
         <p class="row">
-          In case of any questions please contact administrator or mail to support team.
+          Most likely this is caused by a an error (typo or duplicate) in the "Additional" section of the endpoint configuration.
+        </p>
+        <p class="row">
+          In case of any questions please contact the Platform Support Team.
         </p>
     </div>
   </body>

--- a/deploy/docker/cp-edge/static/error.html
+++ b/deploy/docker/cp-edge/static/error.html
@@ -79,11 +79,7 @@
         <p class="row">
           Please fix the endpoint configuration and restart run. 
         <p class="row">
-          In case of any questions please contact administrator or mail to
-          <a style="margin-left: 5px" href="mailto:${CP_ERROR_SUPPORT_EMAIL}?Subject=${CP_ERROR_PLATFORM_NAME} tool endpoint settings request">
-            ${CP_ERROR_PLATFORM_NAME} support team
-          </a>
-          .
+          In case of any questions please contact administrator or mail to support team.
         </p>
     </div>
   </body>

--- a/deploy/docker/cp-edge/static/error.html
+++ b/deploy/docker/cp-edge/static/error.html
@@ -78,6 +78,7 @@
         </div>
         <p class="row">
           Please fix the endpoint configuration and restart run. 
+        </p>
         <p class="row">
           In case of any questions please contact administrator or mail to support team.
         </p>

--- a/deploy/docker/cp-edge/sync-routes.py
+++ b/deploy/docker/cp-edge/sync-routes.py
@@ -792,7 +792,6 @@ def find_preference(api_preference_query, preference_name):
 
 
 def write_stub_location_configuration(path_to_route, service_location, service_spec, has_custom_domain):
-        route_location = service_location if service_location == '/' else service_location[:-1]
         nginx_route_definition = nginx_loc_module_stub_template_contents \
                 .replace('{edge_route_location}', route_location) \
                 .replace('{edge_route_owner}', service_spec["pod_owner"]) \

--- a/deploy/docker/cp-edge/sync-routes.py
+++ b/deploy/docker/cp-edge/sync-routes.py
@@ -18,7 +18,7 @@ import json
 import glob
 import re
 import requests
-from subprocess import check_output
+from subprocess import check_output, CalledProcessError
 import urllib3
 from time import sleep
 import time
@@ -54,6 +54,7 @@ API_GET_HOSTED_ZONE_BASE_PREF = 'preferences/instance.dns.hosted.zone.base'
 API_GET_DEFAULT_EDGE_REGION_PREF = 'preferences/default.edge.region'
 NUMBER_OF_RETRIES = 10
 SECS_TO_WAIT_BEFORE_RETRY = 15
+STUB_LOCATION_CONFIG_EXTENSION = '.stub.loc.conf'
 
 EDGE_SVC_ROLE_LABEL = 'cloud-pipeline/role'
 EDGE_SVC_ROLE_LABEL_VALUE = 'EDGE'
@@ -72,6 +73,7 @@ api_domain_path = '/etc/nginx/ingress/cp-api-srv.conf'
 nginx_loc_module_template = '/etc/nginx/endpoints-config/route.template.loc.conf'
 nginx_srv_module_template = '/etc/nginx/endpoints-config/route.template' + nginx_custom_domain_config_ext
 nginx_sensitive_loc_module_template = '/etc/nginx/endpoints-config/sensitive.template.loc.conf'
+nginx_loc_module_stub_template = '/etc/nginx/endpoints-config/route.template.stub.loc.conf'
 nginx_sensitive_routes_config_path = '/etc/nginx/endpoints-config/sensitive.routes.json'
 nginx_system_endpoints_config_path = '/etc/nginx/endpoints-config/system_endpoints.json'
 edge_service_port = 31000
@@ -739,6 +741,9 @@ def create_service_location(service_spec, added_route, service_url_dict):
                 if nginx_sensitive_route_definitions:
                         for nginx_sensitive_route_definition in nginx_sensitive_route_definitions:
                                 added_route_file.write(nginx_sensitive_route_definition)
+
+        path_to_route = check_route(path_to_route, service_location, service_spec)
+
         if has_custom_domain:
                 do_log('Adding {} route to the server block {}'.format(path_to_route, service_hostname))
                 add_custom_domain(service_hostname, path_to_route, is_external_app=service_spec['external_app'])
@@ -784,6 +789,36 @@ def find_preference(api_preference_query, preference_name):
                 return response["payload"]["value"]
         return None
 
+
+def write_stub_location_configuration(path_to_route, service_location, service_spec):
+        route_location = service_location if service_location == '/' else service_location[:-1]
+        nginx_route_definition = nginx_loc_module_stub_template_contents \
+                .replace('{edge_route_location}', route_location) \
+                .replace('{edge_route_owner}', service_spec["pod_owner"]) \
+                .replace('{edge_route_shared_users}', service_spec["shared_users_sids"]) \
+                .replace('{edge_route_shared_groups}', service_spec["shared_groups_sids"])
+
+        path_to_stub = path_to_route.replace(".loc.conf", STUB_LOCATION_CONFIG_EXTENSION)
+        with open(path_to_stub, "w") as stub_file:
+                stub_file.write(nginx_route_definition)
+        do_log('Creating stub route: ' + path_to_stub)
+        return path_to_stub
+
+
+def check_route(path_to_route, service_location, service_spec):
+        test_config_command = "nginx -c %s -t" % nginx_root_config_path
+
+        try:
+                check_output(test_config_command, shell=True)
+                return path_to_route
+        except CalledProcessError as e:
+                error_message = e.output
+                error_code = e.returncode
+                do_log("Nginx configuration test failed with exit code '%s': %s" % (error_code, error_message))
+                path_to_stub = write_stub_location_configuration(path_to_route, service_location, service_spec)
+                os.remove(path_to_route)
+                do_log('Deleting invalid route: ' + path_to_route)
+                return path_to_stub
 
 do_log('============ Started iteration ============')
 
@@ -866,7 +901,13 @@ routes_kube = set([x for x in services_list])
 # Find out existing routes from /etc/nginx/sites-enabled
 nginx_modules_list = {}
 for x in os.listdir(nginx_sites_path):
-        if '.conf' in x and os.path.isfile(os.path.join(nginx_sites_path, x)):
+        location_config_path = os.path.join(nginx_sites_path, x)
+        if '.loc.conf' in x and os.path.isfile(location_config_path):
+                if location_config_path.endswith(STUB_LOCATION_CONFIG_EXTENSION):
+                        os.remove(location_config_path)
+                        do_log('Deleting stub route: ' + location_config_path)
+                        remove_custom_domain_all(location_config_path)
+                        continue
                 nginx_modules_list[x.replace('.conf', '')] = x
 routes_current = set([x for x in nginx_modules_list])
 
@@ -939,6 +980,10 @@ with open(nginx_sensitive_loc_module_template, 'r') as nginx_sensitive_loc_modul
 sensitive_routes = []
 with open(nginx_sensitive_routes_config_path, 'r') as sensitive_routes_file:
     sensitive_routes = json.load(sensitive_routes_file)
+
+nginx_loc_module_stub_template_contents = ''
+with open(nginx_loc_module_stub_template, 'r') as stub_template_file:
+    nginx_loc_module_stub_template_contents = stub_template_file.read()
 
 
 # loop through all routes that we need to create, if this route doesn't have option to create custom DNS record

--- a/deploy/docker/cp-edge/sync-routes.py
+++ b/deploy/docker/cp-edge/sync-routes.py
@@ -55,6 +55,7 @@ API_GET_DEFAULT_EDGE_REGION_PREF = 'preferences/default.edge.region'
 NUMBER_OF_RETRIES = 10
 SECS_TO_WAIT_BEFORE_RETRY = 15
 STUB_LOCATION_CONFIG_EXTENSION = '.stub.loc.conf'
+STUB_CUSTOM_DOMAIN_EXTENSION = '.stub.conf'
 
 EDGE_SVC_ROLE_LABEL = 'cloud-pipeline/role'
 EDGE_SVC_ROLE_LABEL_VALUE = 'EDGE'
@@ -742,12 +743,12 @@ def create_service_location(service_spec, added_route, service_url_dict):
                         for nginx_sensitive_route_definition in nginx_sensitive_route_definitions:
                                 added_route_file.write(nginx_sensitive_route_definition)
 
-        path_to_route = check_route(path_to_route, service_location, service_spec)
-
         if has_custom_domain:
                 do_log('Adding {} route to the server block {}'.format(path_to_route, service_hostname))
                 add_custom_domain(service_hostname, path_to_route, is_external_app=service_spec['external_app'])
-                
+
+        check_route(path_to_route, service_location, service_spec, has_custom_domain, service_hostname)
+
         service_url = SVC_URL_TMPL.format(external_ip=service_hostname,
                                           edge_location=service_spec["edge_location"] if service_spec[
                                                   "edge_location"] else "",
@@ -790,7 +791,7 @@ def find_preference(api_preference_query, preference_name):
         return None
 
 
-def write_stub_location_configuration(path_to_route, service_location, service_spec):
+def write_stub_location_configuration(path_to_route, service_location, service_spec, has_custom_domain):
         route_location = service_location if service_location == '/' else service_location[:-1]
         nginx_route_definition = nginx_loc_module_stub_template_contents \
                 .replace('{edge_route_location}', route_location) \
@@ -798,27 +799,35 @@ def write_stub_location_configuration(path_to_route, service_location, service_s
                 .replace('{edge_route_shared_users}', service_spec["shared_users_sids"]) \
                 .replace('{edge_route_shared_groups}', service_spec["shared_groups_sids"])
 
-        path_to_stub = path_to_route.replace(".loc.conf", STUB_LOCATION_CONFIG_EXTENSION)
+        path_to_route_extension = ".conf" if has_custom_domain else ".loc.conf"
+        stub_extension = STUB_CUSTOM_DOMAIN_EXTENSION if has_custom_domain else STUB_LOCATION_CONFIG_EXTENSION
+
+        path_to_stub = path_to_route.replace(path_to_route_extension, stub_extension)
         with open(path_to_stub, "w") as stub_file:
                 stub_file.write(nginx_route_definition)
         do_log('Creating stub route: ' + path_to_stub)
         return path_to_stub
 
 
-def check_route(path_to_route, service_location, service_spec):
+def check_route(path_to_route, service_location, service_spec, has_custom_domain, service_hostname):
         test_config_command = "nginx -c %s -t" % nginx_root_config_path
 
         try:
                 check_output(test_config_command, shell=True)
-                return path_to_route
         except CalledProcessError as e:
-                error_message = e.output
-                error_code = e.returncode
-                do_log("Nginx configuration test failed with exit code '%s': %s" % (error_code, error_message))
-                path_to_stub = write_stub_location_configuration(path_to_route, service_location, service_spec)
-                os.remove(path_to_route)
+                do_log("Nginx configuration test failed with exit code '%s'" % e.returncode)
+                path_to_stub = write_stub_location_configuration(path_to_route,
+                                                                 service_location,
+                                                                 service_spec,
+                                                                 has_custom_domain)
                 do_log('Deleting invalid route: ' + path_to_route)
-                return path_to_stub
+                os.remove(path_to_route)
+                if has_custom_domain:
+                        do_log('Deleting invalid custom domain route: ' + path_to_route)
+                        remove_custom_domain_all(path_to_route)
+                        do_log('Adding {} route stub to the server block {}'.format(path_to_stub, service_hostname))
+                        add_custom_domain(service_hostname, path_to_stub, is_external_app=service_spec['external_app'])
+
 
 do_log('============ Started iteration ============')
 
@@ -902,10 +911,14 @@ routes_kube = set([x for x in services_list])
 nginx_modules_list = {}
 for x in os.listdir(nginx_sites_path):
         location_config_path = os.path.join(nginx_sites_path, x)
-        if '.loc.conf' in x and os.path.isfile(location_config_path):
+        if '.conf' in x and os.path.isfile(location_config_path):
                 if location_config_path.endswith(STUB_LOCATION_CONFIG_EXTENSION):
                         os.remove(location_config_path)
                         do_log('Deleting stub route: ' + location_config_path)
+                        continue
+                if location_config_path.endswith(STUB_CUSTOM_DOMAIN_EXTENSION):
+                        os.remove(location_config_path)
+                        do_log('Deleting custom domain stub route: ' + location_config_path)
                         remove_custom_domain_all(location_config_path)
                         continue
                 nginx_modules_list[x.replace('.conf', '')] = x


### PR DESCRIPTION
The current PR provides support for broken location configurations: if endpoint's configuration contains a syntax error a predefined page shall be shown.