### PR TITLE
Datastorage object: Search by tag refactoring

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/datastorage/DataStorageApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/datastorage/DataStorageApiService.java
@@ -383,7 +383,7 @@ public class DataStorageApiService {
         return dataStorageManager.getItemType(id, path, version);
     }
 
-    @PostFilter(AclExpressions.FILTER_TAG_SEARCH_RESULT_BY_STORAGE_ID)
+    @PostFilter(AclExpressions.ADMIN_OR_GENERAL_USER)
     public List<DataStorageTagSearchResult> searchDataStorageItemByTag(
             final DataStorageObjectSearchByTagRequest request) {
         return dataStorageManager.searchDataStorageItemByTag(request);

--- a/api/src/main/java/com/epam/pipeline/controller/datastorage/tag/DataStorageTagBatchController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/datastorage/tag/DataStorageTagBatchController.java
@@ -43,7 +43,9 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import java.util.List;
 
 @Controller
-@Api(value = "Data storage object tag batch methods")
+@Api(value = "Data storage object tag batch methods. " +
+        "NOTE: all these methods assume that client provide absolute path for a storage object " +
+        "(path from datastorage root object and not from storage itself) within BatchRequest")
 public class DataStorageTagBatchController extends AbstractRestController {
 
     private static final String ID = "id";

--- a/api/src/main/java/com/epam/pipeline/entity/datastorage/nfs/NFSDataStorage.java
+++ b/api/src/main/java/com/epam/pipeline/entity/datastorage/nfs/NFSDataStorage.java
@@ -59,6 +59,7 @@ public class NFSDataStorage extends AbstractDataStorage {
         return false;
     }
 
+    // TODO: related to storage object tagging, see https://github.com/epam/cloud-pipeline/issues/2943
     @Override
     public String getRoot() {
         return NFSHelper.getNfsRootPath(getPath());

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
@@ -765,47 +765,42 @@ public class DataStorageManager implements SecuredEntityManager {
         return dataStorageFile;
     }
 
-    public List<DataStorageTagSearchResult> searchDataStorageItemByTag(
-            final DataStorageObjectSearchByTagRequest request) {
-        final Set<Long> storageIdsToFilter = new HashSet<>(CollectionUtils.emptyIfNull(request.getDatastorageIds()));
-        final List<AbstractDataStorage> storagesToSearch = CollectionUtils.isNotEmpty(request.getDatastorageIds())
-                ? getDatastoragesByIds(request.getDatastorageIds())
-                : Collections.emptyList();
-        final Map<Long, List<DataStorageTag>> rootSearchResult =
-                tagProviderManager.search(storagesToSearch, request.getTags());
-        if (MapUtils.isNotEmpty(rootSearchResult)) {
+    public List<DataStorageTagSearchResult> searchDataStorageItemByTag(final DataStorageObjectSearchByTagRequest req) {
+        final Set<Long> requestedStorageIds = new HashSet<>(CollectionUtils.emptyIfNull(req.getDatastorageIds()));
+        final Map<Long, List<DataStorageTag>> searchTagsResult =
+                tagProviderManager.search(getDatastoragesByIds(req.getDatastorageIds()), req.getTags());
+
+        if (MapUtils.isNotEmpty(searchTagsResult)) {
             // by tagProviderManager.search we found tags for datastorage_root, and now we need to map it on
-            // actual datastorages
+            // actual storages
+            final Map<Long, List<AbstractDataStorage>> storagesByRootId = dataStorageDao
+                .loadDataStoragesByRootIds(searchTagsResult.keySet()).stream()
+                .filter(dataStorage -> checkStoragePermissions(dataStorage, READ_PERMISSION))
+                .filter(ds -> CollectionUtils.isEmpty(requestedStorageIds) || requestedStorageIds.contains(ds.getId()))
+                .collect(Collectors.groupingBy(AbstractDataStorage::getRootId));
+
             final Map<Long, List<DataStorageTag>> results = new HashMap<>();
-            final Map<Long, List<AbstractDataStorage>> storagesByRootId = dataStorageDao.loadDataStoragesByRootIds(
-                    rootSearchResult.keySet()
-            ).stream()
-                    .filter(dataStorage -> permissionManager.storagePermission(dataStorage, READ_PERMISSION))
-                    .filter(
-                            ds -> CollectionUtils.isEmpty(storageIdsToFilter) || storageIdsToFilter.contains(ds.getId())
-                    ).collect(Collectors.groupingBy(AbstractDataStorage::getRootId));
-
-            rootSearchResult.forEach((rootId, rootStorageTags) ->
-                rootStorageTags.forEach(dataStorageTag -> {
-                    final List<AbstractDataStorage> storages = storagesByRootId
-                            .getOrDefault(rootId, Collections.emptyList());
-                    storages.stream().filter(
-                        dataStorage -> dataStorageTag.getObject().getPath().startsWith(dataStorage.getPrefix())
-                    ).max(Comparator.comparingInt(s -> s.getPrefix().length())).ifPresent(dataStorage -> {
-                        final DataStorageTag storageObjectTag = new DataStorageTag(
-                            new DataStorageObject(
-                                    dataStorage.resolveRelativePath(dataStorageTag.getObject().getPath()),
-                                    dataStorageTag.getObject().getVersion()
-                            ),
-                            dataStorageTag.getKey(), dataStorageTag.getValue()
-                        );
-                        results.computeIfAbsent(dataStorage.getId(), (id) -> new ArrayList<>()).add(storageObjectTag);
-                    });
-                })
+            searchTagsResult.forEach(
+                (rootId, tags) -> tags.forEach(
+                    rootTag -> storagesByRootId.getOrDefault(rootId, Collections.emptyList())
+                        .stream()
+                        .filter(dataStorage -> rootTag.getObject().getPath().startsWith(dataStorage.getPrefix()))
+                        .max(Comparator.comparingInt(s -> s.getPrefix().length()))
+                        .ifPresent(dataStorage -> {
+                            final DataStorageTag storageTag = new DataStorageTag(
+                                new DataStorageObject(
+                                        dataStorage.resolveRelativePath(rootTag.getObject().getPath()),
+                                        rootTag.getObject().getVersion()
+                                ),
+                                rootTag.getKey(), rootTag.getValue()
+                            );
+                            results.computeIfAbsent(dataStorage.getId(), (id) -> new ArrayList<>()).add(storageTag);
+                        })
+                )
             );
-
             return results.entrySet().stream()
-                    .map(e -> new DataStorageTagSearchResult(e.getKey(), e.getValue())).collect(Collectors.toList());
+                    .map(e -> new DataStorageTagSearchResult(e.getKey(), e.getValue()))
+                    .collect(Collectors.toList());
         } else {
             return Collections.emptyList();
         }
@@ -956,6 +951,10 @@ public class DataStorageManager implements SecuredEntityManager {
             default:
                 return false;
         }
+    }
+
+    private boolean checkStoragePermissions(final AbstractDataStorage dataStorage, final String permission) {
+        return permissionManager.storagePermission(dataStorage, permission);
     }
 
     private Long getCloudRegionId(final AbstractDataStorage dataStorage) {

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
@@ -786,8 +786,8 @@ public class DataStorageManager implements SecuredEntityManager {
                 rootStorageTags.forEach(dataStorageTag -> {
                     final List<AbstractDataStorage> storages = storagesByRootId.get(rootId);
                     storages.stream().filter(
-                        dataStorage -> dataStorageTag.getObject().getPath().startsWith(dataStorage.getPrefix())
-                    ).findFirst().ifPresent(dataStorage -> {
+                            dataStorage -> dataStorageTag.getObject().getPath().startsWith(dataStorage.getPrefix())
+                    ).max(Comparator.comparingInt(s -> s.getPrefix().length())).ifPresent(dataStorage -> {
                         final DataStorageTag storageObjectTag = new DataStorageTag(
                             new DataStorageObject(
                                     dataStorage.resolveRelativePath(dataStorageTag.getObject().getPath()),

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProvider.java
@@ -89,6 +89,7 @@ public class NFSStorageProvider implements StorageProvider<NFSDataStorage> {
     private static final Set<PosixFilePermission> PERMISSIONS = Arrays.stream(PosixFilePermission.values())
                                                                       .filter(p -> !p.name().startsWith("OTHERS"))
                                                                       .collect(Collectors.toSet());
+    private static final int DEFAULT_PAGE_SIZE = 1000;
 
     private final MessageHelper messageHelper;
     private final PreferenceManager preferenceManager;
@@ -211,7 +212,7 @@ public class NFSStorageProvider implements StorageProvider<NFSDataStorage> {
 
         long offset = StringUtils.isNumeric(marker) ? Long.parseLong(marker) : 1;
         try (Stream<Path> dirStream = Files.walk(startingPath.toPath(), 1)) {
-            final int effectivePageSize = Optional.ofNullable(pageSize).orElse(Integer.MAX_VALUE);
+            final int effectivePageSize = Optional.ofNullable(pageSize).orElse(DEFAULT_PAGE_SIZE);
             List<AbstractDataStorageItem> dataStorageItems = dirStream
                 .sorted()
                 .skip(offset) // First element is a directory itself

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/tag/DataStorageTagBatchManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/tag/DataStorageTagBatchManager.java
@@ -44,6 +44,17 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/**
+ * Performs batch operations with storage objects to insert, update, list and delete tags for these objects.
+ *
+ * @implNote All these operations expects from client to provide full paths of the storage object
+ *           (full path is a path from datastorage_root of storage and not from storage itself) with in BatchRequests
+ *           for example:
+ *           @see DataStorageTagBatchManager#upsert(Long, DataStorageTagUpsertBatchRequest) and
+ *           @see DataStorageTagDao to get more information on actual logic
+ *  TODO: Maybe it is good idea to expand API to allow to specify flag 'relative' on BatchRequest level,
+ *  TODO: to be able to automatically performs such resolving of paths on server side rather that client side
+ * */
 @Service
 @RequiredArgsConstructor
 public class DataStorageTagBatchManager {

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -685,6 +685,9 @@ public class SystemPreferences {
             "faceted.filter.dictionaries", null, new TypeReference<Map<String, Object>>() {},
             FACETED_FILTER_GROUP, isNullOrValidJson(new TypeReference<Map<String, Object>>() {}));
 
+    public static final StringPreference FACETED_FILTER_DISPLAY_NAME_TAG = new StringPreference(
+            "faceted.filter.display.name.tag", null, FACETED_FILTER_GROUP, pass, true);
+
     // BASE_URLS_GROUP
     public static final StringPreference BASE_API_HOST = new StringPreference("base.api.host", null,
                                                                   BASE_URLS_GROUP, PreferenceValidators.isValidUrl);

--- a/api/src/main/java/com/epam/pipeline/manager/security/storage/StoragePermissionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/storage/StoragePermissionManager.java
@@ -23,7 +23,6 @@ import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.DataStorageWithShareMount;
 import com.epam.pipeline.entity.datastorage.NFSStorageMountStatus;
 import com.epam.pipeline.entity.datastorage.nfs.NFSDataStorage;
-import com.epam.pipeline.entity.datastorage.tag.DataStorageTagSearchResult;
 import com.epam.pipeline.entity.security.acl.AclClass;
 import com.epam.pipeline.manager.EntityManager;
 import com.epam.pipeline.manager.datastorage.DataStoragePathLoader;
@@ -150,13 +149,5 @@ public class StoragePermissionManager {
         return permissions.stream()
                 .anyMatch(permission -> permissionsService.isMaskBitSet(storage.getMask(),
                         permission.getSimpleMask()));
-    }
-
-    public boolean checkTagSearchResultPermission(final DataStorageTagSearchResult searchResultEntry,
-                                                  final String permissionName) {
-        return grantPermissionManager.storagePermission(
-                entityManager.load(AclClass.DATA_STORAGE, searchResultEntry.getDatastorageId()),
-                permissionName
-        );
     }
 }

--- a/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
+++ b/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
@@ -83,9 +83,6 @@ public final class AclExpressions {
     public static final String STORAGE_PATHS_READ = ADMIN_ONLY + OR +
             "@grantPermissionManager.hasDataStoragePathsPermission(returnObject, 'READ')";
 
-    public static final String FILTER_TAG_SEARCH_RESULT_BY_STORAGE_ID = ADMIN_ONLY + OR +
-            "@storagePermissionManager.checkTagSearchResultPermission(filterObject, 'READ')";
-
     public static final String RUN_COMMIT_EXECUTE =
         "hasRole('ADMIN') OR (@runPermissionManager.runPermission(#runId, 'EXECUTE')"
             + " AND hasPermission(#registryId, 'com.epam.pipeline.entity.pipeline.DockerRegistry', 'WRITE'))";

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/NFSSynchronizer.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/NFSSynchronizer.java
@@ -256,11 +256,11 @@ public class NFSSynchronizer implements ElasticsearchSynchronizer {
                 dataStorage.getId(),
                 new DataStorageTagLoadBatchRequest(
                         files.stream()
-                                .map(DataStorageFile::getPath)
+                                .map(file -> dataStorage.resolveAbsolutePath(file.getPath()))
                                 .map(DataStorageTagLoadRequest::new)
                                 .collect(Collectors.toList())));
         return files.stream()
-                .peek(file -> file.setTags(tags.get(file.getPath())));
+                .peek(file -> file.setTags(tags.get(dataStorage.resolveAbsolutePath(file.getPath()))));
     }
 
     protected IndexRequest createIndexRequest(final DataStorageFile file,


### PR DESCRIPTION
This PR includes:
 - Changes to load bounded number of entries in NFSProvider if pageSize isn't specified
 - Link to issue about enchantment regarding NFS storage object tagging
 - Changes regarding permission checking (should increase performance because we don't load storage several times)
 - Fix bug with NFSSynchronizer in elastichsearch-agent - now tags are indexed in a right way