### PR TITLE
Issue #2942: Allow to specify security groups and subnet while launching run

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacade.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacade.java
@@ -34,7 +34,7 @@ import java.util.Map;
 import java.util.Optional;
 
 public interface CloudFacade {
-    RunInstance scaleUpNode(Long runId, RunInstance instance);
+    RunInstance scaleUpNode(Long runId, RunInstance instance, Map<String, String> runtimeParameters);
 
     RunInstance scaleUpPoolNode(String nodeId, NodePool node);
 

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacadeImpl.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacadeImpl.java
@@ -85,9 +85,11 @@ public class CloudFacadeImpl implements CloudFacade {
     }
 
     @Override
-    public RunInstance scaleUpNode(final Long runId, final RunInstance instance) {
+    public RunInstance scaleUpNode(final Long runId, final RunInstance instance,
+                                   final Map<String, String> runtimeParameters) {
         final AbstractCloudRegion region = regionManager.loadOrDefault(instance.getCloudRegionId());
-        final RunInstance scaledUpInstance = getInstanceService(region).scaleUpNode(region, runId, instance);
+        final RunInstance scaledUpInstance = getInstanceService(region)
+                .scaleUpNode(region, runId, instance, runtimeParameters);
         kubernetesManager.createNodeService(scaledUpInstance);
         return scaledUpInstance;
     }

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/CloudInstanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/CloudInstanceService.java
@@ -58,7 +58,7 @@ public interface CloudInstanceService<T extends AbstractCloudRegion>
      * @param instance
      * @return
      */
-    RunInstance scaleUpNode(T region, Long runId, RunInstance instance);
+    RunInstance scaleUpNode(T region, Long runId, RunInstance instance, Map<String, String> runtimeParameters);
 
     RunInstance scaleUpPoolNode(T region, String nodeId, NodePool node);
 

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSInstanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSInstanceService.java
@@ -112,8 +112,10 @@ public class AWSInstanceService implements CloudInstanceService<AwsRegion> {
     @Override
     public RunInstance scaleUpNode(final AwsRegion region,
                                    final Long runId,
-                                   final RunInstance instance) {
-        final String command = buildNodeUpCommand(region, String.valueOf(runId), instance, Collections.emptyMap());
+                                   final RunInstance instance,
+                                   final Map<String, String> runtimeParameters) {
+        final String command = buildNodeUpCommand(region, String.valueOf(runId), instance,
+                Collections.emptyMap(), runtimeParameters);
         return instanceService.runNodeUpScript(cmdExecutor, runId, instance, command, buildScriptEnvVars(region));
     }
 
@@ -122,7 +124,8 @@ public class AWSInstanceService implements CloudInstanceService<AwsRegion> {
                                        final String nodeIdLabel,
                                        final NodePool node) {
         final RunInstance instance = node.toRunInstance();
-        final String command = buildNodeUpCommand(region, nodeIdLabel, instance, getPoolLabels(node));
+        final String command = buildNodeUpCommand(region, nodeIdLabel, instance, getPoolLabels(node),
+                Collections.emptyMap());
         return instanceService.runNodeUpScript(cmdExecutor, null, instance, command, buildScriptEnvVars(region));
     }
 
@@ -318,10 +321,11 @@ public class AWSInstanceService implements CloudInstanceService<AwsRegion> {
     private String buildNodeUpCommand(final AwsRegion region,
                                       final String nodeLabel,
                                       final RunInstance instance,
-                                      final Map<String, String> labels) {
-        final NodeUpCommand.NodeUpCommandBuilder commandBuilder =
-                commandService.buildNodeUpCommand(nodeUpScript, region, nodeLabel, instance, getProviderName())
-                               .sshKey(region.getSshKeyName());
+                                      final Map<String, String> labels,
+                                      final Map<String, String> runtimeParameters) {
+        final NodeUpCommand.NodeUpCommandBuilder commandBuilder = commandService
+                .buildNodeUpCommand(nodeUpScript, region, nodeLabel, instance, getProviderName(), runtimeParameters)
+                .sshKey(region.getSshKeyName());
 
         if (StringUtils.isNotBlank(region.getKmsKeyId())) {
             commandBuilder.encryptionKey(region.getKmsKeyId());

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzureInstanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzureInstanceService.java
@@ -100,8 +100,10 @@ public class AzureInstanceService implements CloudInstanceService<AzureRegion> {
     @Override
     public RunInstance scaleUpNode(final AzureRegion region,
                                    final Long runId,
-                                   final RunInstance instance) {
-        final String command = buildNodeUpCommand(region, String.valueOf(runId), instance, Collections.emptyMap());
+                                   final RunInstance instance,
+                                   final Map<String, String> runtimeParameters) {
+        final String command = buildNodeUpCommand(region, String.valueOf(runId), instance, Collections.emptyMap(),
+                runtimeParameters);
         return instanceService.runNodeUpScript(cmdExecutor, runId, instance, command, buildScriptAzureEnvVars(region));
     }
 
@@ -110,8 +112,10 @@ public class AzureInstanceService implements CloudInstanceService<AzureRegion> {
                                        final String nodeId,
                                        final NodePool nodePool) {
         final RunInstance instance = nodePool.toRunInstance();
-        final String command = buildNodeUpCommand(region, nodeId, instance, getPoolLabels(nodePool));
-        return instanceService.runNodeUpScript(cmdExecutor, null, instance, command, buildScriptAzureEnvVars(region));
+        final String command = buildNodeUpCommand(region, nodeId, instance, getPoolLabels(nodePool),
+                Collections.emptyMap());
+        return instanceService.runNodeUpScript(cmdExecutor, null, instance, command,
+                buildScriptAzureEnvVars(region));
     }
 
     @Override
@@ -285,12 +289,11 @@ public class AzureInstanceService implements CloudInstanceService<AzureRegion> {
     }
 
     private String buildNodeUpCommand(final AzureRegion region, final String nodeLabel, final RunInstance instance,
-                                      final Map<String, String> labels) {
-
-        final NodeUpCommand.NodeUpCommandBuilder commandBuilder =
-                commandService.buildNodeUpCommand(nodeUpScript, region, nodeLabel, instance, getProviderName())
-                        .sshKey(region.getSshPublicKeyPath())
-                        .additionalLabels(labels);
+                                      final Map<String, String> labels, final Map<String, String> runtimeParameters) {
+        final NodeUpCommand.NodeUpCommandBuilder commandBuilder = commandService
+                .buildNodeUpCommand(nodeUpScript, region, nodeLabel, instance, getProviderName(), runtimeParameters)
+                .sshKey(region.getSshPublicKeyPath())
+                .additionalLabels(labels);
 
         final Boolean clusterSpotStrategy = instance.getSpot() == null
                 ? preferenceManager.getPreference(SystemPreferences.CLUSTER_SPOT)

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/commands/ClusterCommandService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/commands/ClusterCommandService.java
@@ -20,6 +20,7 @@ import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.region.AbstractCloudRegion;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import java.util.Map;
 
 @Service
 public class ClusterCommandService {
@@ -43,7 +44,8 @@ public class ClusterCommandService {
                                                                  final AbstractCloudRegion region,
                                                                  final String nodeLabel,
                                                                  final RunInstance instance,
-                                                                 final String cloud) {
+                                                                 final String cloud,
+                                                                 final Map<String, String> runtimeParameters) {
         return NodeUpCommand.builder()
                 .executable(AbstractClusterCommand.EXECUTABLE)
                 .script(nodeUpScript)
@@ -57,9 +59,7 @@ public class ClusterCommandService {
                 .kubeCertHash(kubeCertHash)
                 .kubeNodeToken(kubeNodeToken)
                 .cloud(cloud)
-                .availabilityZone(instance.getAvailabilityZone())
-                .networkInterface(instance.getNetworkInterfaceId())
-                .isDedicated(instance.isDedicated())
+                .runtimeParameters(runtimeParameters)
                 .prePulledImages(instance.getPrePulledDockerImages())
                 .region(region.getRegionCode());
     }

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/commands/NodeUpCommand.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/commands/NodeUpCommand.java
@@ -50,10 +50,7 @@ public class NodeUpCommand extends AbstractClusterCommand {
     private final String cloud;
     private final Map<String, String> additionalLabels;
     private final Set<String> prePulledImages;
-    private final String availabilityZone;
-    private final String networkInterface;
-    private final boolean isDedicated;
-
+    private final Map<String, String> runtimeParameters;
 
     @Override
     protected List<String> buildCommandArguments() {
@@ -104,18 +101,10 @@ public class NodeUpCommand extends AbstractClusterCommand {
             commands.add("--image");
             commands.add(image);
         });
-        if (StringUtils.isNotBlank(availabilityZone)) {
-            commands.add("--availability_zone");
-            commands.add(availabilityZone);
-        }
-        if (StringUtils.isNotBlank(networkInterface)) {
-            commands.add("--network_interface");
-            commands.add(networkInterface);
-        }
-        if (isDedicated) {
-            commands.add("--dedicated");
-            commands.add("True");
-        }
+        MapUtils.emptyIfNull(runtimeParameters).forEach((argName, argValue) -> {
+            commands.add(argName);
+            commands.add(argValue);
+        });
         return commands;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPInstanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPInstanceService.java
@@ -89,17 +89,20 @@ public class GCPInstanceService implements CloudInstanceService<GCPRegion> {
     }
 
     @Override
-    public RunInstance scaleUpNode(final GCPRegion region, final Long runId, final RunInstance instance) {
-
-        final String command = buildNodeUpCommand(region, String.valueOf(runId), instance, Collections.emptyMap());
+    public RunInstance scaleUpNode(final GCPRegion region, final Long runId, final RunInstance instance,
+                                   final Map<String, String> runtimeParameters) {
+        final String command = buildNodeUpCommand(region, String.valueOf(runId), instance, Collections.emptyMap(),
+                runtimeParameters);
         return instanceService.runNodeUpScript(cmdExecutor, runId, instance, command, buildScriptGCPEnvVars(region));
     }
 
     @Override
     public RunInstance scaleUpPoolNode(final GCPRegion region, final String nodeId, final NodePool node) {
         final RunInstance instance = node.toRunInstance();
-        final String command = buildNodeUpCommand(region, nodeId, instance, getPoolLabels(node));
-        return instanceService.runNodeUpScript(cmdExecutor, null, instance, command, buildScriptGCPEnvVars(region));
+        final String command = buildNodeUpCommand(region, nodeId, instance, getPoolLabels(node),
+                Collections.emptyMap());
+        return instanceService.runNodeUpScript(cmdExecutor, null, instance, command,
+                buildScriptGCPEnvVars(region));
     }
 
     @Override
@@ -270,9 +273,9 @@ public class GCPInstanceService implements CloudInstanceService<GCPRegion> {
     }
 
     private String buildNodeUpCommand(final GCPRegion region, final String nodeLabel, final RunInstance instance,
-                                      final Map<String, String> labels) {
+                                      final Map<String, String> labels, final Map<String, String> runtimeParameters) {
         return commandService
-            .buildNodeUpCommand(nodeUpScript, region, nodeLabel, instance, getProviderName())
+            .buildNodeUpCommand(nodeUpScript, region, nodeLabel, instance, getProviderName(), runtimeParameters)
             .sshKey(region.getSshPublicKeyPath())
             .isSpot(Optional.ofNullable(instance.getSpot())
                         .orElse(false))

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -36,6 +36,7 @@ import com.epam.pipeline.entity.ldap.LdapBlockedUserSearchMethod;
 import com.epam.pipeline.entity.monitoring.IdleRunAction;
 import com.epam.pipeline.entity.monitoring.LongPausedRunAction;
 import com.epam.pipeline.entity.notification.filter.NotificationFilter;
+import com.epam.pipeline.entity.pipeline.run.parameter.RuntimeParameter;
 import com.epam.pipeline.entity.preference.Preference;
 import com.epam.pipeline.entity.region.CloudProvider;
 import com.epam.pipeline.entity.search.StorageFileSearchMask;
@@ -503,10 +504,10 @@ public class SystemPreferences {
             "instance.dns.hosted.zone.base", null, CLUSTER_GROUP, pass);
     public static final StringPreference DEFAULT_EDGE_REGION = new StringPreference(
             "default.edge.region", "eu-central", CLUSTER_GROUP, pass);
-    public static final ObjectPreference<Map<String, String>> CLUSTER_RUN_PARAMETERS_MAPPING =
+    public static final ObjectPreference<Map<String, RuntimeParameter>> CLUSTER_RUN_PARAMETERS_MAPPING =
             new ObjectPreference<>("cluster.run.parameters.mapping", null,
-                    new TypeReference<Map<String, String>>() {}, CLUSTER_GROUP,
-                    isNullOrValidJson(new TypeReference<Map<String, String>>() {}));
+                    new TypeReference<Map<String, RuntimeParameter>>() {}, CLUSTER_GROUP,
+                    isNullOrValidJson(new TypeReference<Map<String, RuntimeParameter>>() {}));
 
     //LAUNCH_GROUP
     public static final StringPreference LAUNCH_CMD_TEMPLATE = new StringPreference("launch.cmd.template",

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -503,7 +503,10 @@ public class SystemPreferences {
             "instance.dns.hosted.zone.base", null, CLUSTER_GROUP, pass);
     public static final StringPreference DEFAULT_EDGE_REGION = new StringPreference(
             "default.edge.region", "eu-central", CLUSTER_GROUP, pass);
-
+    public static final ObjectPreference<Map<String, String>> CLUSTER_RUN_PARAMETERS_MAPPING =
+            new ObjectPreference<>("cluster.run.parameters.mapping", null,
+                    new TypeReference<Map<String, String>>() {}, CLUSTER_GROUP,
+                    isNullOrValidJson(new TypeReference<Map<String, String>>() {}));
 
     //LAUNCH_GROUP
     public static final StringPreference LAUNCH_CMD_TEMPLATE = new StringPreference("launch.cmd.template",

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/autoscale/AutoscaleManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/autoscale/AutoscaleManagerTest.java
@@ -198,16 +198,17 @@ public class AutoscaleManagerTest {
         when(kubernetesManager.isPodUnscheduled(any())).thenReturn(true);
 
         when(cloudFacade.scaleUpNode(eq(TEST_RUN_ID),
-                                    argThat(Matchers.hasProperty("spot", Matchers.is(true)))))
+                argThat(Matchers.hasProperty("spot", Matchers.is(true))), any()))
             .thenThrow(new CmdExecutionException("", 5, ""));
 
         autoscaleManagerCore.runAutoscaling(); // this time spot scheduling should fail
         verify(cloudFacade).scaleUpNode(eq(TEST_RUN_ID),
-                                       argThat(Matchers.hasProperty("spot", Matchers.is(true))));
+                argThat(Matchers.hasProperty("spot", Matchers.is(true))),
+                any());
 
         autoscaleManagerCore.runAutoscaling(); // this time it should be a on-demand request
         verify(cloudFacade, times(2))
             .scaleUpNode(eq(TEST_RUN_ID), argThat(
-                Matchers.hasProperty("spot", Matchers.is(false))));
+                Matchers.hasProperty("spot", Matchers.is(false))), any());
     }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/pool/InstanceRequest.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/pool/InstanceRequest.java
@@ -17,10 +17,12 @@ package com.epam.pipeline.entity.cluster.pool;
 
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import lombok.Data;
+import java.util.Map;
 
 
 @Data
 public class InstanceRequest {
     private RunInstance instance;
+    private Map<String, String> runtimeParameters;
     private String requestedImage;
 }

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
@@ -177,6 +177,14 @@ public class PipelineRun extends AbstractSecuredEntity {
                 .findFirst();
     }
 
+    @JsonIgnore
+    public Optional<PipelineRunParameter> getParameter(final String parameterName) {
+        return ListUtils.emptyIfNull(pipelineRunParameters)
+                .stream()
+                .filter(param -> parameterName.equals(param.getName()) && param.getValue() != null)
+                .findFirst();
+    }
+
     public void convertParamsToString(Map<String, PipeConfValueVO> parameters) {
         params = parameters
                 .entrySet().stream()

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
@@ -177,14 +177,6 @@ public class PipelineRun extends AbstractSecuredEntity {
                 .findFirst();
     }
 
-    @JsonIgnore
-    public Optional<PipelineRunParameter> getParameter(final String parameterName) {
-        return ListUtils.emptyIfNull(pipelineRunParameters)
-                .stream()
-                .filter(param -> parameterName.equals(param.getName()) && param.getValue() != null)
-                .findFirst();
-    }
-
     public void convertParamsToString(Map<String, PipeConfValueVO> parameters) {
         params = parameters
                 .entrySet().stream()

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/RunInstance.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/RunInstance.java
@@ -60,15 +60,6 @@ public class RunInstance {
      */
     private Set<String> prePulledDockerImages;
     private Long poolId;
-    private String availabilityZone;
-    private String networkInterfaceId;
-
-    /**
-     * Defines if instance should be created as dedicated,
-     * can be useful in case of BYOL (Bring Your Own License) case
-     */
-    private boolean dedicated;
-
 
     public RunInstance(final String nodeType,
                        final Integer nodeDisk,

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/run/parameter/RuntimeParameter.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/run/parameter/RuntimeParameter.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.pipeline.run.parameter;
+
+import lombok.Data;
+
+@Data
+public class RuntimeParameter {
+    private String argumentName;
+    private RuntimeParameterType type;
+}

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/run/parameter/RuntimeParameterType.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/run/parameter/RuntimeParameterType.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.pipeline.run.parameter;
+
+public enum RuntimeParameterType {
+    STRING, BOOLEAN
+}

--- a/scripts/autoscaling/aws/nodeup.py
+++ b/scripts/autoscaling/aws/nodeup.py
@@ -222,11 +222,15 @@ def get_networks_config(ec2, aws_region, instance_type):
 def get_instance_images_config(aws_region):
     return get_cloud_config_section(aws_region, "amis")
 
-def get_security_groups(aws_region):
+
+def get_security_groups(aws_region, security_groups):
+    if security_groups:
+        return security_groups.split(",")
     config = get_cloud_config_section(aws_region, "security_group_ids")
     if not config:
         raise RuntimeError('Security group setting is required to run an instance')
     return config
+
 
 def get_well_known_hosts(aws_region):
     return get_cloud_config_section(aws_region, "well_known_hosts")
@@ -379,22 +383,23 @@ def run_id_filter(run_id):
 
 def run_instance(api_url, api_token, api_user, bid_price, ec2, aws_region, ins_hdd, kms_encyr_key_id, ins_img, ins_platform, ins_key, ins_type,
                  is_spot, num_rep, run_id, pool_id, time_rep, kube_ip, kubeadm_token, kubeadm_cert_hash, kube_node_token, kube_client, pre_pull_images,
-                 instance_additional_spec, availability_zone, network_interface, is_dedicated):
+                 instance_additional_spec, availability_zone, security_groups, network_interface, is_dedicated):
     swap_size = get_swap_size(aws_region, ins_type, is_spot)
     user_data_script = get_user_data_script(api_url, api_token, api_user, aws_region, ins_type, ins_img, ins_platform, kube_ip,
                                             kubeadm_token, kubeadm_cert_hash, kube_node_token, swap_size, pre_pull_images)
     if is_spot:
         ins_id, ins_ip = find_spot_instance(ec2, aws_region, bid_price, run_id, pool_id, ins_img, ins_type, ins_key, ins_hdd, kms_encyr_key_id,
-                                            user_data_script, num_rep, time_rep, swap_size, kube_client, instance_additional_spec, availability_zone, network_interface, is_dedicated)
+                                            user_data_script, num_rep, time_rep, swap_size, kube_client, instance_additional_spec, availability_zone, security_groups, network_interface, is_dedicated)
     else:
         ins_id, ins_ip = run_on_demand_instance(ec2, aws_region, ins_img, ins_key, ins_type, ins_hdd, kms_encyr_key_id, run_id, pool_id, user_data_script,
-                                                num_rep, time_rep, swap_size, kube_client, instance_additional_spec, availability_zone, network_interface, is_dedicated)
+                                                num_rep, time_rep, swap_size, kube_client, instance_additional_spec, availability_zone, security_groups, network_interface, is_dedicated)
     return ins_id, ins_ip
 
 
 def run_on_demand_instance(ec2, aws_region, ins_img, ins_key, ins_type, ins_hdd,
                            kms_encyr_key_id, run_id, pool_id, user_data_script, num_rep, time_rep, swap_size,
-                           kube_client, instance_additional_spec, availability_zone, network_interface, is_dedicated):
+                           kube_client, instance_additional_spec, availability_zone, security_groups,
+                           network_interface, is_dedicated):
     pipe_log('Creating on demand instance')
     allowed_networks = get_networks_config(ec2, aws_region, ins_type)
     additional_args = instance_additional_spec if instance_additional_spec else {}
@@ -424,10 +429,13 @@ def run_on_demand_instance(ec2, aws_region, ins_img, ins_key, ins_type, ins_hdd,
             az_name = allowed_networks.items()[az_num][0]
             subnet_id = allowed_networks.items()[az_num][1]
         pipe_log('- Networks list found, subnet {} in AZ {} will be used'.format(subnet_id, az_name))
-        additional_args.update({ 'SubnetId': subnet_id, 'SecurityGroupIds': get_security_groups(aws_region)})
+        additional_args.update({
+            'SubnetId': subnet_id,
+            'SecurityGroupIds': get_security_groups(aws_region, security_groups)
+        })
     else:
         pipe_log('- Networks list NOT found, default subnet in random AZ will be used')
-        additional_args.update({ 'SecurityGroupIds': get_security_groups(aws_region)})
+        additional_args.update({'SecurityGroupIds': get_security_groups(aws_region, security_groups)})
     response = {}
 
     if is_dedicated:
@@ -1005,7 +1013,7 @@ def exit_if_spot_unavailable(run_id, last_status):
 
 def find_spot_instance(ec2, aws_region, bid_price, run_id, pool_id, ins_img, ins_type, ins_key,
                        ins_hdd, kms_encyr_key_id, user_data_script, num_rep, time_rep, swap_size, kube_client,
-                       instance_additional_spec, availability_zone, network_interface, is_dedicated):
+                       instance_additional_spec, availability_zone, security_groups, network_interface, is_dedicated):
     pipe_log('Creating spot request')
 
     pipe_log('- Checking spot prices for current region...')
@@ -1048,11 +1056,11 @@ def find_spot_instance(ec2, aws_region, bid_price, run_id, pool_id, ins_img, ins
         subnet_id = allowed_networks[cheapest_zone]
         pipe_log('- Networks list found, subnet {} in AZ {} will be used'.format(subnet_id, cheapest_zone))
         specifications['SubnetId'] = subnet_id
-        specifications['SecurityGroupIds'] = get_security_groups(aws_region)
+        specifications['SecurityGroupIds'] = get_security_groups(aws_region, security_groups)
         specifications['Placement'] = { 'AvailabilityZone': cheapest_zone }
     else:
         pipe_log('- Networks list NOT found or cheapest zone can not be determined, default subnet in a random AZ will be used')
-        specifications['SecurityGroupIds'] = get_security_groups(aws_region)
+        specifications['SecurityGroupIds'] = get_security_groups(aws_region, security_groups)
 
     if instance_additional_spec:
         specifications.update(instance_additional_spec)
@@ -1315,6 +1323,7 @@ def main():
     parser.add_argument("--region_id", type=str, default=None)
     parser.add_argument("--availability_zone", type=str, required=False)
     parser.add_argument("--network_interface", type=str, required=False)
+    parser.add_argument("--security_groups", type=str, required=False)
     parser.add_argument("--dedicated", type=bool, required=False)
     parser.add_argument("--label", type=str, default=[], required=False, action='append')
     parser.add_argument("--image", type=str, default=[], required=False, action='append')
@@ -1343,6 +1352,7 @@ def main():
     region_id = args.region_id
     availability_zone = args.availability_zone
     network_interface = args.network_interface
+    security_groups = args.security_groups
     is_dedicated = args.dedicated if args.dedicated else False
     pre_pull_images = args.image
     additional_labels = map_labels_to_dict(args.label)
@@ -1432,7 +1442,7 @@ def main():
             api_user = os.environ["API_USER"]
             ins_id, ins_ip = run_instance(api_url, api_token, api_user, bid_price, ec2, aws_region, ins_hdd, kms_encyr_key_id, ins_img, ins_platform, ins_key, ins_type, is_spot,
                                           num_rep, run_id, pool_id, time_rep, kube_ip, kubeadm_token, kubeadm_cert_hash, kube_node_token, api, pre_pull_images, instance_additional_spec,
-                                          availability_zone, network_interface, is_dedicated)
+                                          availability_zone, security_groups, network_interface, is_dedicated)
 
         check_instance(ec2, ins_id, run_id, num_rep, time_rep, api)
 


### PR DESCRIPTION
This PR implements issue #2942 

The following changes were added:
 - a new  aws`nodeup` script argument `--security_groups` added. This argument is optional and contains required security groups separated by a comma.
 - a new aws `nodeup` script argument `--subnet_id` added. This argument is optional and contains required subnet id.
 - a new system preferences `cluster.run.parameters.mapping` added. This value shall contain a dictionary with mapping <tun parameter name> to <nodeup script input arg>. For example:
```
{
  "CP_CAP_TARGET_AVAILABILITY_ZONE": {
    "argumentName": "--availability_zone"
  },
  "CP_CAP_TARGET_NETWORK_INTERFACE": {
    "argumentName": "--network_interface"
  },
  "CP_CAP_DEDICATED_INSTANCE": {
    "argumentName": "--dedicated",
    "type": "BOOLEAN"
  },
  "CP_CAP_TARGET_SECURITY_GROUPS": {
    "argumentName": "--security_groups"
  },
  "CP_CAP_TARGET_SUBNET_ID": {
    "argumentName": "--subnet_id"
  }
}
```