### PR TITLE
Issue #2946: Allow searching storage files by content

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/search/StorageFileSearchMask.java
+++ b/api/src/main/java/com/epam/pipeline/entity/search/StorageFileSearchMask.java
@@ -27,4 +27,5 @@ public class StorageFileSearchMask {
 
     private final String storageName;
     private final Set<String> hiddenFilePathGlobs;
+    private final Set<String> indexedContentPathGlobs;
 }

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -940,7 +940,7 @@ public class SystemPreferences {
             20, SEARCH_GROUP, pass);
 
     public static final ObjectPreference<List<StorageFileSearchMask>> FILE_SEARCH_MASK_RULES = new ObjectPreference<>(
-        "search.storage.elements.hide.mask",
+        "search.storage.elements.settings",
         Collections.emptyList(),
         new TypeReference<List<StorageFileSearchMask>>() {},
         SEARCH_GROUP,

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
@@ -24,6 +24,7 @@ import com.epam.pipeline.entity.cluster.pool.NodePool;
 import com.epam.pipeline.entity.configuration.RunConfiguration;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.DataStorageAction;
+import com.epam.pipeline.entity.datastorage.DataStorageDownloadFileUrl;
 import com.epam.pipeline.entity.datastorage.DataStorageFile;
 import com.epam.pipeline.entity.datastorage.DataStorageItemContent;
 import com.epam.pipeline.entity.datastorage.DataStorageTag;
@@ -191,6 +192,9 @@ public interface CloudPipelineAPI {
     @POST("datastorage/{id}/tags/batch/load")
     Call<Result<List<DataStorageTag>>> loadDataStorageObjectTags(@Path(ID) Long storageId,
                                                                  @Body DataStorageTagLoadBatchRequest request);
+
+    @GET("datastorage/{id}/generateUrl")
+    Call<Result<DataStorageDownloadFileUrl>> generateDownloadUrl(@Path(ID) Long storageId, @Query(PATH) String path);
 
     @GET("users")
     Call<Result<List<PipelineUser>>> loadAllUsers();

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/search/StorageFileSearchMask.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/search/StorageFileSearchMask.java
@@ -25,4 +25,5 @@ public class StorageFileSearchMask {
 
     private final String storageName;
     private final Set<String> hiddenFilePathGlobs;
+    private final Set<String> indexedContentPathGlobs;
 }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/CloudPipelineAPIClient.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/CloudPipelineAPIClient.java
@@ -22,6 +22,7 @@ import com.epam.pipeline.elasticsearchagent.model.PipelineRunWithLog;
 import com.epam.pipeline.entity.configuration.RunConfiguration;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.DataStorageAction;
+import com.epam.pipeline.entity.datastorage.DataStorageDownloadFileUrl;
 import com.epam.pipeline.entity.datastorage.DataStorageTag;
 import com.epam.pipeline.entity.datastorage.FileShareMount;
 import com.epam.pipeline.entity.datastorage.TemporaryCredentials;
@@ -70,7 +71,7 @@ public class CloudPipelineAPIClient {
 
     public CloudPipelineAPIClient(@Value("${cloud.pipeline.host}") String cloudPipelineHostUrl,
                                   @Value("${cloud.pipeline.token}") String cloudPipelineToken,
-                                  @Value("${sync.search.files.hidden.masks.preference.key}") String preferenceName,
+                                  @Value("${sync.search.files.elements.settings.preference.key}") String preferenceName,
                                   CloudPipelineApiExecutor cloudPipelineApiExecutor) {
         this.cloudPipelineAPI =
                 new CloudPipelineApiBuilder(0, 0, cloudPipelineHostUrl, cloudPipelineToken)
@@ -97,6 +98,10 @@ public class CloudPipelineAPIClient {
 
     public List<DataStorageTag> loadDataStorageTags(final Long id, final DataStorageTagLoadBatchRequest request) {
         return ListUtils.emptyIfNull(executor.execute(cloudPipelineAPI.loadDataStorageObjectTags(id, request)));
+    }
+
+    public DataStorageDownloadFileUrl generateDownloadUrl(final Long id, final String path) {
+        return executor.execute(cloudPipelineAPI.generateDownloadUrl(id, path));
     }
 
     public Map<String, Map<String, String>> loadDataStorageTagsMap(final Long id,

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/NFSSynchronizer.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/NFSSynchronizer.java
@@ -32,6 +32,7 @@ import com.epam.pipeline.vo.data.storage.DataStorageTagLoadRequest;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.elasticsearch.action.index.IndexRequest;
@@ -39,6 +40,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -156,7 +158,8 @@ public class NFSSynchronizer implements ElasticsearchSynchronizer {
                     .filter(path -> path.toFile().isFile())
                     .map(path -> convertToStorageFile(path, mountFolder));
             processFilesTagsInChunks(dataStorage, files)
-                    .map(file -> createIndexRequest(file, indexName, dataStorage, permissionsContainer))
+                    .map(file -> createIndexRequest(file, indexName, dataStorage, permissionsContainer,
+                            findFileContent(dataStorage.getName(), file.getName(), mountFolder.toString())))
                     .forEach(walker::add);
         } catch (IOException e) {
             throw new IllegalArgumentException("An error occurred during creating document.", e);
@@ -266,11 +269,26 @@ public class NFSSynchronizer implements ElasticsearchSynchronizer {
     protected IndexRequest createIndexRequest(final DataStorageFile file,
                                               final String indexName,
                                               final AbstractDataStorage dataStorage,
-                                              final PermissionsContainer permissionsContainer) {
+                                              final PermissionsContainer permissionsContainer,
+                                              final String content) {
         // TODO maybe we can use file path as _id instead of generating it
         //  on ES side to perform both create and update using this method
         return new IndexRequest(indexName, DOC_MAPPING_TYPE)
                 .source(fileMapper.fileToDocument(file, dataStorage, null, permissionsContainer,
-                        SearchDocumentType.NFS_FILE, tagDelimiter));
+                        SearchDocumentType.NFS_FILE, tagDelimiter, content));
+    }
+
+    protected String findFileContent(final String storageName, final String relativePath, final String mountFolder) {
+        if (fileMapper.isSkipContent(storageName, relativePath)) {
+            return null;
+        }
+        final File absolutePath = Paths.get(mountFolder, relativePath).toFile();
+        try {
+            return fileMapper.getFileContent(FileUtils.readFileToByteArray(absolutePath), relativePath, log);
+        } catch (IOException e) {
+            log.error("An error occurred during reading file '{}' content from storage '{}'",
+                    relativePath, storageName, e);
+            return null;
+        }
     }
 }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/ObjectStorageIndexImpl.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/ObjectStorageIndexImpl.java
@@ -21,12 +21,13 @@ import com.epam.pipeline.elasticsearchagent.service.ElasticsearchServiceClient;
 import com.epam.pipeline.elasticsearchagent.service.ObjectStorageFileManager;
 import com.epam.pipeline.elasticsearchagent.service.ObjectStorageIndex;
 import com.epam.pipeline.elasticsearchagent.service.impl.converter.storage.StorageFileMapper;
-import com.epam.pipeline.utils.StreamUtils;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.DataStorageAction;
+import com.epam.pipeline.entity.datastorage.DataStorageDownloadFileUrl;
 import com.epam.pipeline.entity.datastorage.DataStorageFile;
 import com.epam.pipeline.entity.datastorage.DataStorageType;
 import com.epam.pipeline.entity.datastorage.TemporaryCredentials;
+import com.epam.pipeline.utils.StreamUtils;
 import com.epam.pipeline.entity.search.SearchDocumentType;
 import com.epam.pipeline.vo.EntityPermissionVO;
 import com.epam.pipeline.vo.data.storage.DataStorageTagLoadBatchRequest;
@@ -35,13 +36,18 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.elasticsearch.action.index.IndexRequest;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -106,7 +112,7 @@ public class ObjectStorageIndexImpl implements ObjectStorageIndex {
                         .flatMap(filesChunk -> filesWithIncorporatedTags(dataStorage, filesChunk))
                         .peek(file -> file.setPath(dataStorage.resolveRelativePath(file.getPath())))
                         .map(file -> createIndexRequest(file, dataStorage, permissionsContainer, indexName,
-                                credentials.getRegion()))
+                                credentials.getRegion(), findFileContent(dataStorage, file.getPath())))
                         .forEach(requestContainer::add);
             }
 
@@ -153,11 +159,11 @@ public class ObjectStorageIndexImpl implements ObjectStorageIndex {
                                             final AbstractDataStorage dataStorage,
                                             final PermissionsContainer permissionsContainer,
                                             final String indexName,
-                                            final String region) {
+                                            final String region,
+                                            final String content) {
         return new IndexRequest(indexName, DOC_MAPPING_TYPE)
                 .source(fileMapper.fileToDocument(file, dataStorage, region,
-                        permissionsContainer,
-                        getDocumentType(), tagDelimiter));
+                        permissionsContainer, getDocumentType(), tagDelimiter, content));
     }
 
     private boolean isNotSharedOrChild(final AbstractDataStorage dataStorage,
@@ -179,5 +185,24 @@ public class ObjectStorageIndexImpl implements ObjectStorageIndex {
 
     private String withTrailingDelimiter(final String path, final String delimiter) {
         return StringUtils.isNotBlank(path) && !path.endsWith(delimiter) ? path + delimiter : path;
+    }
+
+    private String findFileContent(final AbstractDataStorage storage, final String filePath) {
+        if (fileMapper.isSkipContent(storage.getName(), filePath)) {
+            return null;
+        }
+        final DataStorageDownloadFileUrl downloadUrl = cloudPipelineAPIClient
+                .generateDownloadUrl(storage.getId(), filePath);
+        if (Objects.isNull(downloadUrl) || StringUtils.isBlank(downloadUrl.getUrl())) {
+            log.error("Cannot find download url for file '{}' from storage '{}'", filePath, storage.getName());
+            return null;
+        }
+        try (InputStream inputStream = new URL(downloadUrl.getUrl()).openStream()) {
+            return fileMapper.getFileContent(IOUtils.toByteArray(inputStream), filePath, log);
+        } catch (IOException e) {
+            log.error("An error occurred during reading file '{}' content from storage '{}'",
+                    filePath, storage.getName(), e);
+            return null;
+        }
     }
 }

--- a/elasticsearch-agent/src/main/resources/application.properties
+++ b/elasticsearch-agent/src/main/resources/application.properties
@@ -47,7 +47,7 @@ sync.run.bulk.insert.size=100
 sync.run.log.lines.size=1000
 
 # Common files settings
-sync.search.files.hidden.masks.preference.key=search.storage.elements.hide.mask
+sync.search.files.elements.settings.preference.key=search.storage.elements.settings
 
 #Azure blob storage Settings
 #sync.az-blob-storage.disable=false

--- a/elasticsearch-agent/src/main/resources/templates/storage_file.json
+++ b/elasticsearch-agent/src/main/resources/templates/storage_file.json
@@ -22,7 +22,8 @@
         "denied_users": { "type": "keyword" },
         "allowed_groups": { "type": "keyword" },
         "denied_groups": { "type": "keyword" },
-        "is_hidden": { "type":  "boolean" }
+        "is_hidden": { "type":  "boolean" },
+        "content": { "type": "text" }
       }
     }
   },


### PR DESCRIPTION
The current PR provides implementation for issue #2946 

- the system preference `search.storage.elements.hide.mask` renamed to `search.storage.elements.settings` and a new field `indexedContentPathGlobs ` added to interior object.
- a new field `content` added to ES `cp-file-*` index mapping.