### PR TITLE
Add support to export faceted search result to csv file

### DIFF
--- a/api/src/main/java/com/epam/pipeline/controller/search/SearchController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/search/SearchController.java
@@ -73,7 +73,7 @@ public class SearchController extends AbstractRestController {
         return Result.success(searchManager.facetedSearch(searchRequest));
     }
 
-    @PostMapping(value = "/search/export")
+    @PostMapping(value = "/search/facet/export")
     @ResponseBody
     @ApiOperation(
             value = "Export faceted search result as a csv file.",
@@ -82,9 +82,9 @@ public class SearchController extends AbstractRestController {
     @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
     public void export(@RequestBody final FacetedSearchExportRequest searchExportRequest,
                        final HttpServletResponse response) throws IOException {
-        final String csvFileName = StringUtils.isNotBlank(searchExportRequest.getCsvFileName())
+        final String reportFileName = StringUtils.isNotBlank(searchExportRequest.getCsvFileName())
                 ? searchExportRequest.getCsvFileName()
                 : String.format("facet_report_%s.csv", LocalDateTime.now());
-        writeFileToResponse(response, searchManager.export(searchExportRequest), csvFileName);
+        writeFileToResponse(response, searchManager.export(searchExportRequest), reportFileName);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/search/SearchController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/search/SearchController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package com.epam.pipeline.controller.search;
 import com.epam.pipeline.controller.AbstractRestController;
 import com.epam.pipeline.controller.Result;
 import com.epam.pipeline.controller.vo.search.ElasticSearchRequest;
+import com.epam.pipeline.controller.vo.search.FacetedSearchExportRequest;
 import com.epam.pipeline.controller.vo.search.FacetedSearchRequest;
 import com.epam.pipeline.entity.search.FacetedSearchResult;
 import com.epam.pipeline.entity.search.SearchResult;
@@ -27,6 +28,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -34,6 +36,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.LocalDateTime;
 
 @RestController
 @RequiredArgsConstructor
@@ -65,5 +71,20 @@ public class SearchController extends AbstractRestController {
             })
     public Result<FacetedSearchResult> facetedSearch(@RequestBody final FacetedSearchRequest searchRequest) {
         return Result.success(searchManager.facetedSearch(searchRequest));
+    }
+
+    @PostMapping(value = "/search/export")
+    @ResponseBody
+    @ApiOperation(
+            value = "Export faceted search result as a csv file.",
+            notes = "Export faceted search result as a csv file.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public void export(@RequestBody final FacetedSearchExportRequest searchExportRequest,
+                       final HttpServletResponse response) throws IOException {
+        final String csvFileName = StringUtils.isNotBlank(searchExportRequest.getCsvFileName())
+                ? searchExportRequest.getCsvFileName()
+                : String.format("facet_report_%s.csv", LocalDateTime.now());
+        writeFileToResponse(response, searchManager.export(searchExportRequest), csvFileName);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/vo/search/FacetedSearchExportRequest.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/search/FacetedSearchExportRequest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.epam.pipeline.controller.vo.search;
+
+import lombok.Data;
+
+@Data
+public class FacetedSearchExportRequest {
+    private FacetedSearchRequest facetedSearchRequest;
+    private FacetedSearchExportVO facetedSearchExportVO;
+    private String csvFileName;
+}

--- a/api/src/main/java/com/epam/pipeline/controller/vo/search/FacetedSearchExportVO.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/search/FacetedSearchExportVO.java
@@ -24,4 +24,5 @@ public class FacetedSearchExportVO {
     private boolean includeSize;
     private boolean includeOwner;
     private boolean includePath;
+    private String delimiter;
 }

--- a/api/src/main/java/com/epam/pipeline/controller/vo/search/FacetedSearchExportVO.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/search/FacetedSearchExportVO.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.epam.pipeline.controller.vo.search;
+
+import lombok.Data;
+
+@Data
+public class FacetedSearchExportVO {
+    private boolean includeName;
+    private boolean includeChanged;
+    private boolean includeSize;
+    private boolean includeOwner;
+    private boolean includePath;
+}

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -946,6 +946,9 @@ public class SystemPreferences {
             "search.elastic.denied.groups.field", null, SEARCH_GROUP, pass);
     public static final IntPreference SEARCH_AGGS_MAX_COUNT = new IntPreference("search.aggs.max.count",
             20, SEARCH_GROUP, pass);
+
+    public static final IntPreference SEARCH_EXPORT_PAGE_SIZE = new IntPreference("search.export.page.size",
+            5000, SEARCH_GROUP, isGreaterThan(0));
 
     public static final ObjectPreference<List<StorageFileSearchMask>> FILE_SEARCH_MASK_RULES = new ObjectPreference<>(
         "search.storage.elements.settings",

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -694,6 +694,9 @@ public class SystemPreferences {
     public static final StringPreference FACETED_FILTER_DISPLAY_NAME_TAG = new StringPreference(
             "faceted.filter.display.name.tag", null, FACETED_FILTER_GROUP, pass, true);
 
+    public static final IntPreference FACETED_FILTER_EXPORT_PAGE_SIZE = new IntPreference(
+            "faceted.filter.export.page.size", 5000, SEARCH_GROUP, isGreaterThan(0));
+
     // BASE_URLS_GROUP
     public static final StringPreference BASE_API_HOST = new StringPreference("base.api.host", null,
                                                                   BASE_URLS_GROUP, PreferenceValidators.isValidUrl);
@@ -946,9 +949,6 @@ public class SystemPreferences {
             "search.elastic.denied.groups.field", null, SEARCH_GROUP, pass);
     public static final IntPreference SEARCH_AGGS_MAX_COUNT = new IntPreference("search.aggs.max.count",
             20, SEARCH_GROUP, pass);
-
-    public static final IntPreference SEARCH_EXPORT_PAGE_SIZE = new IntPreference("search.export.page.size",
-            5000, SEARCH_GROUP, isGreaterThan(0));
 
     public static final ObjectPreference<List<StorageFileSearchMask>> FILE_SEARCH_MASK_RULES = new ObjectPreference<>(
         "search.storage.elements.settings",

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -694,9 +694,6 @@ public class SystemPreferences {
     public static final StringPreference FACETED_FILTER_DISPLAY_NAME_TAG = new StringPreference(
             "faceted.filter.display.name.tag", null, FACETED_FILTER_GROUP, pass, true);
 
-    public static final IntPreference FACETED_FILTER_EXPORT_PAGE_SIZE = new IntPreference(
-            "faceted.filter.export.page.size", 5000, SEARCH_GROUP, isGreaterThan(0));
-
     // BASE_URLS_GROUP
     public static final StringPreference BASE_API_HOST = new StringPreference("base.api.host", null,
                                                                   BASE_URLS_GROUP, PreferenceValidators.isValidUrl);
@@ -949,6 +946,9 @@ public class SystemPreferences {
             "search.elastic.denied.groups.field", null, SEARCH_GROUP, pass);
     public static final IntPreference SEARCH_AGGS_MAX_COUNT = new IntPreference("search.aggs.max.count",
             20, SEARCH_GROUP, pass);
+
+    public static final IntPreference SEARCH_EXPORT_PAGE_SIZE = new IntPreference(
+            "search.export.page.size", 5000, SEARCH_GROUP, isGreaterThan(0));
 
     public static final ObjectPreference<List<StorageFileSearchMask>> FILE_SEARCH_MASK_RULES = new ObjectPreference<>(
         "search.storage.elements.settings",

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchManager.java
@@ -120,10 +120,10 @@ public class SearchManager {
         Assert.notNull(request.getFacetedSearchRequest(), "Faceted search request is required");
         if (Objects.isNull(request.getFacetedSearchRequest().getPageSize())) {
             final Integer searchExportPageSize = Optional.ofNullable(
-                    preferenceManager.getPreference(SystemPreferences.FACETED_FILTER_EXPORT_PAGE_SIZE))
+                    preferenceManager.getPreference(SystemPreferences.SEARCH_EXPORT_PAGE_SIZE))
                     .orElseThrow(() -> new IllegalArgumentException(
                             String.format("System preference %s or page size are not provided",
-                                    SystemPreferences.FACETED_FILTER_EXPORT_PAGE_SIZE.getKey())));
+                                    SystemPreferences.SEARCH_EXPORT_PAGE_SIZE.getKey())));
             request.getFacetedSearchRequest().setPageSize(searchExportPageSize);
         }
         final FacetedSearchResult facetedSearchResult = facetedSearch(request.getFacetedSearchRequest());

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchManager.java
@@ -119,11 +119,11 @@ public class SearchManager {
     public byte[] export(final FacetedSearchExportRequest request) {
         Assert.notNull(request.getFacetedSearchRequest(), "Faceted search request is required");
         if (Objects.isNull(request.getFacetedSearchRequest().getPageSize())) {
-            final Integer searchExportPageSize = Optional.of(SystemPreferences.SEARCH_EXPORT_PAGE_SIZE)
-                    .map(preferenceManager::getPreference)
+            final Integer searchExportPageSize = Optional.ofNullable(
+                    preferenceManager.getPreference(SystemPreferences.FACETED_FILTER_EXPORT_PAGE_SIZE))
                     .orElseThrow(() -> new IllegalArgumentException(
-                            String.format("System preference %s is not specified or page size is not passed",
-                                    SystemPreferences.SEARCH_EXPORT_PAGE_SIZE.getKey())));
+                            String.format("System preference %s or page size are not provided",
+                                    SystemPreferences.FACETED_FILTER_EXPORT_PAGE_SIZE.getKey())));
             request.getFacetedSearchRequest().setPageSize(searchExportPageSize);
         }
         final FacetedSearchResult facetedSearchResult = facetedSearch(request.getFacetedSearchRequest());

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchResultExportManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchResultExportManager.java
@@ -152,7 +152,7 @@ public class SearchResultExportManager {
         switch (field) {
             case NAME: return "Name";
             case LAST_MODIFIED: return "Changed";
-            case SIZE: return "Size (byte(s))";
+            case SIZE: return "Size";
             case OWNER: return "Owner";
             case PATH: return "Path";
             default: throw new IllegalArgumentException(format("%s search source field is not supported", field));

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchResultExportManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchResultExportManager.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.epam.pipeline.manager.search;
+
+import com.epam.pipeline.config.Constants;
+import com.epam.pipeline.controller.vo.search.FacetedSearchExportRequest;
+import com.epam.pipeline.controller.vo.search.FacetedSearchExportVO;
+import com.epam.pipeline.entity.search.FacetedSearchResult;
+import com.epam.pipeline.entity.search.SearchDocument;
+import com.opencsv.CSVWriter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang.StringUtils;
+import org.springframework.stereotype.Service;
+
+import java.io.StringWriter;
+import java.nio.charset.Charset;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.epam.pipeline.manager.search.SearchSourceFields.LAST_MODIFIED;
+import static com.epam.pipeline.manager.search.SearchSourceFields.NAME;
+import static com.epam.pipeline.manager.search.SearchSourceFields.OWNER;
+import static com.epam.pipeline.manager.search.SearchSourceFields.PATH;
+import static com.epam.pipeline.manager.search.SearchSourceFields.SIZE;
+import static java.lang.String.format;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SearchResultExportManager {
+
+    private static final DateTimeFormatter EXPORT_DATE_FORMATTER = DateTimeFormatter.ofPattern(
+            Constants.EXPORT_DATE_TIME_FORMAT);
+    private static final DateTimeFormatter ISO_DATE_FORMATTER = DateTimeFormatter.ofPattern(
+            Constants.FMT_ISO_LOCAL_DATE);
+
+    public byte[] export(final FacetedSearchExportRequest searchExportRequest, final FacetedSearchResult searchResult) {
+        final StringWriter writer = new StringWriter();
+        final CSVWriter csvWriter = new CSVWriter(writer);
+
+        final String[] header = buildCsvHeader(searchExportRequest.getFacetedSearchRequest().getMetadataFields(),
+                searchExportRequest.getFacetedSearchExportVO());
+        csvWriter.writeNext(header, false);
+
+        CollectionUtils.emptyIfNull(searchResult.getDocuments()).stream()
+                .map(searchDocument -> createItem(searchDocument,
+                        searchExportRequest.getFacetedSearchExportVO(),
+                        searchExportRequest.getFacetedSearchRequest().getMetadataFields())
+                )
+                .forEach(item -> csvWriter.writeNext(item, false));
+        return writer.toString().getBytes(Charset.defaultCharset());
+    }
+
+    private String[] createItem(final SearchDocument searchDocument,
+                                final FacetedSearchExportVO facetedSearchExportVO,
+                                final List<String> metadataFields) {
+        final List<String> result = new ArrayList<>();
+        if (facetedSearchExportVO.isIncludeName()) {
+            result.add(getItem(searchDocument.getName()));
+        }
+        final Map<String, String> attributes = MapUtils.emptyIfNull(searchDocument.getAttributes());
+        if (facetedSearchExportVO.isIncludeChanged()) {
+            final String changedData = Optional.ofNullable(attributes.get(LAST_MODIFIED.getFieldName()))
+                    .map(field -> Optional.of(LocalDateTime.parse(getItem(field), ISO_DATE_FORMATTER))
+                            .map(date -> date.format(EXPORT_DATE_FORMATTER))
+                            .orElse(StringUtils.EMPTY))
+                    .orElse(StringUtils.EMPTY);
+            result.add(changedData);
+        }
+        if (facetedSearchExportVO.isIncludeSize()) {
+            final String docSize = Optional.ofNullable(attributes.get(SIZE.getFieldName()))
+                    .map(this::getItem)
+                    .orElse(StringUtils.EMPTY);
+            result.add(docSize);
+        }
+        final List<String> metadataValues = ListUtils.emptyIfNull(metadataFields)
+                .stream()
+                .map(field -> attributes.getOrDefault(field, StringUtils.EMPTY))
+                .collect(Collectors.toList());
+        result.addAll(metadataValues);
+        if (facetedSearchExportVO.isIncludeOwner()) {
+            result.add(getItem(searchDocument.getOwner()));
+        }
+        if (facetedSearchExportVO.isIncludePath()) {
+            final String docPath = Optional.ofNullable(attributes.get(PATH.getFieldName()))
+                    .map(this::getItem)
+                    .orElse(StringUtils.EMPTY);
+            result.add(docPath);
+        }
+        return result.toArray(new String[0]);
+    }
+
+    private String[] buildCsvHeader(final List<String> metadataFields,
+                                    final FacetedSearchExportVO facetedSearchExportVO) {
+        final List<String> header = new ArrayList<>();
+        if (facetedSearchExportVO.isIncludeName()) {
+            header.add(columnHeaderMapper(NAME));
+        }
+        if (facetedSearchExportVO.isIncludeChanged()) {
+            header.add(columnHeaderMapper(LAST_MODIFIED));
+        }
+        if (facetedSearchExportVO.isIncludeSize()) {
+            header.add(columnHeaderMapper(SIZE));
+        }
+        header.addAll(ListUtils.emptyIfNull(metadataFields));
+        if (facetedSearchExportVO.isIncludeOwner()) {
+            header.add(columnHeaderMapper(OWNER));
+        }
+        if (facetedSearchExportVO.isIncludePath()) {
+            header.add(columnHeaderMapper(PATH));
+        }
+        return header.toArray(new String[0]);
+    }
+
+    private String getItem(final String field) {
+        return StringUtils.isNotBlank(field) ? field : StringUtils.EMPTY;
+    }
+
+    private String columnHeaderMapper(final SearchSourceFields field) {
+        switch (field) {
+            case NAME: return "Name";
+            case LAST_MODIFIED: return "Changed";
+            case SIZE: return "Size (byte(s))";
+            case OWNER: return "Owner";
+            case PATH: return "Path";
+            default: throw new IllegalArgumentException(format("%s search source field is not supported", field));
+        }
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/controller/search/SearchControllerTest.java
+++ b/api/src/test/java/com/epam/pipeline/controller/search/SearchControllerTest.java
@@ -17,17 +17,21 @@
 package com.epam.pipeline.controller.search;
 
 import com.epam.pipeline.controller.vo.search.ElasticSearchRequest;
+import com.epam.pipeline.controller.vo.search.FacetedSearchExportRequest;
 import com.epam.pipeline.entity.search.SearchResult;
 import com.epam.pipeline.manager.search.SearchManager;
 import com.epam.pipeline.test.web.AbstractControllerTest;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
+import static com.epam.pipeline.test.creator.CommonCreatorConstants.TEST_STRING;
 import static com.epam.pipeline.test.creator.search.SearchCreatorUtils.SEARCH_RESULT_TYPE;
 import static com.epam.pipeline.test.creator.search.SearchCreatorUtils.getElasticSearchRequest;
+import static com.epam.pipeline.test.creator.search.SearchCreatorUtils.getFacetedSearchExportRequest;
 import static com.epam.pipeline.test.creator.search.SearchCreatorUtils.getSearchResult;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
@@ -37,8 +41,13 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 public class SearchControllerTest extends AbstractControllerTest {
 
     private static final String SEARCH_URL = SERVLET_PATH + "/search";
+    private static final String EXPORT_URL = SERVLET_PATH + "/search/export";
+    private static final String EXPORT_FILE_NAME = "test_search_export.csv";
+    private static final byte[] EXPORT_TEST_ARRAY = {1, 1, 1};
     private final SearchResult searchResult = getSearchResult();
     private final ElasticSearchRequest elasticSearchRequest = getElasticSearchRequest();
+    private final FacetedSearchExportRequest facetedSearchExportRequest =
+            getFacetedSearchExportRequest(EXPORT_FILE_NAME, TEST_STRING);
 
     @Autowired
     private SearchManager mockSearchManager;
@@ -58,5 +67,18 @@ public class SearchControllerTest extends AbstractControllerTest {
 
         verify(mockSearchManager).search(elasticSearchRequest);
         assertResponse(mvcResult, searchResult, SEARCH_RESULT_TYPE);
+    }
+
+    @Test
+    @WithMockUser
+    public void shouldExportSearchResults() throws Exception {
+        final String content = getObjectMapper().writeValueAsString(facetedSearchExportRequest);
+        doReturn(EXPORT_TEST_ARRAY).when(mockSearchManager).export(facetedSearchExportRequest);
+
+        final MvcResult mvcResult = performRequest(post(EXPORT_URL).content(content),
+                EXPECTED_CONTENT_TYPE, MediaType.APPLICATION_OCTET_STREAM_VALUE);
+
+        verify(mockSearchManager).export(facetedSearchExportRequest);
+        assertFileResponse(mvcResult, EXPORT_FILE_NAME, EXPORT_TEST_ARRAY);
     }
 }

--- a/api/src/test/java/com/epam/pipeline/controller/search/SearchControllerTest.java
+++ b/api/src/test/java/com/epam/pipeline/controller/search/SearchControllerTest.java
@@ -41,7 +41,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 public class SearchControllerTest extends AbstractControllerTest {
 
     private static final String SEARCH_URL = SERVLET_PATH + "/search";
-    private static final String EXPORT_URL = SERVLET_PATH + "/search/export";
+    private static final String EXPORT_URL = SERVLET_PATH + "/search/facet/export";
     private static final String EXPORT_FILE_NAME = "test_search_export.csv";
     private static final byte[] EXPORT_TEST_ARRAY = {1, 1, 1};
     private final SearchResult searchResult = getSearchResult();

--- a/api/src/test/java/com/epam/pipeline/manager/search/SearchManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/search/SearchManagerTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.epam.pipeline.manager.search;
+
+import com.epam.pipeline.AbstractSpringTest;
+import com.epam.pipeline.controller.vo.search.FacetedSearchExportRequest;
+import com.epam.pipeline.controller.vo.search.FacetedSearchRequest;
+import com.epam.pipeline.entity.search.FacetedSearchResult;
+import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.epam.pipeline.manager.preference.SystemPreferences;
+import com.epam.pipeline.test.creator.search.SearchCreatorUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Arrays;
+
+import static com.epam.pipeline.test.creator.search.SearchCreatorUtils.HEADER_WITH_ATTRIBUTE;
+import static com.epam.pipeline.test.creator.search.SearchCreatorUtils.HUMAN;
+import static com.epam.pipeline.test.creator.search.SearchCreatorUtils.ROLE_USER;
+import static com.epam.pipeline.test.creator.search.SearchCreatorUtils.SPECIES;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SearchManagerTest extends AbstractSpringTest {
+
+    private static final String EXPORT_FILE_NAME = "test_search_export.csv";
+    private static final int PAGE_SIZE = 5000;
+
+    @SpyBean
+    private SearchManager searchManager;
+
+    @SpyBean
+    private PreferenceManager preferenceManager;
+
+    @Before
+    public void setUpPreferenceManager() {
+        ReflectionTestUtils.setField(searchManager, "preferenceManager", preferenceManager);
+        when(preferenceManager.getPreference(SystemPreferences.SEARCH_EXPORT_PAGE_SIZE)).thenReturn(PAGE_SIZE);
+    }
+
+    @Test
+    public void shouldExportFacetedSearchResultWithPageSize() {
+        final FacetedSearchResult facetedSearchResult = SearchCreatorUtils.getFacetedSearchResult(HUMAN);
+        final FacetedSearchRequest facetedSearchRequest = SearchCreatorUtils.getFacetedSearchRequest(SPECIES);
+        doReturn(facetedSearchResult).when(searchManager).facetedSearch(facetedSearchRequest);
+        final FacetedSearchExportRequest facetedSearchExportRequest = SearchCreatorUtils
+                .getFacetedSearchExportRequest(EXPORT_FILE_NAME, SPECIES);
+        final String[] exportedCsv = new String(searchManager.export(facetedSearchExportRequest))
+                .split("\n");
+        Assert.assertNotNull(exportedCsv);
+        Assert.assertEquals(3, exportedCsv.length);
+        Assert.assertEquals(HEADER_WITH_ATTRIBUTE, exportedCsv[0]);
+        Assert.assertTrue(Arrays.stream(exportedCsv).anyMatch(s -> s.contains(ROLE_USER) && s.contains(HUMAN)));
+    }
+
+    @Test
+    public void shouldExportWithSearchExportPageSize() {
+        final FacetedSearchResult facetedSearchResult = SearchCreatorUtils.getFacetedSearchResult(HUMAN);
+        final FacetedSearchExportRequest facetedSearchExportRequest = SearchCreatorUtils
+                .getFacetedSearchExportRequest(EXPORT_FILE_NAME, SPECIES);
+        final FacetedSearchRequest facetedSearchRequest = facetedSearchExportRequest.getFacetedSearchRequest();
+        doReturn(facetedSearchResult).when(searchManager)
+                .facetedSearch(facetedSearchRequest);
+        facetedSearchRequest.setPageSize(null);
+        final String[] exportedCsv = new String(searchManager.export(facetedSearchExportRequest))
+                .split("\n");
+        verify(searchManager).facetedSearch(facetedSearchRequest);
+        verify(preferenceManager, atLeast(1)).getPreference(SystemPreferences.SEARCH_EXPORT_PAGE_SIZE);
+        Assert.assertNotNull(exportedCsv);
+        Assert.assertEquals(3, exportedCsv.length);
+        Assert.assertEquals(HEADER_WITH_ATTRIBUTE, exportedCsv[0]);
+        Assert.assertTrue(Arrays.stream(exportedCsv).anyMatch(s -> s.contains(ROLE_USER) && s.contains(HUMAN)));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailToExportWithoutPageSize() {
+        when(preferenceManager.getPreference(SystemPreferences.SEARCH_EXPORT_PAGE_SIZE)).thenReturn(null);
+        final FacetedSearchExportRequest facetedSearchExportRequest = SearchCreatorUtils
+                .getFacetedSearchExportRequest(EXPORT_FILE_NAME, SPECIES);
+        facetedSearchExportRequest.getFacetedSearchRequest().setPageSize(null);
+        searchManager.export(facetedSearchExportRequest);
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/manager/search/SearchManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/search/SearchManagerTest.java
@@ -53,7 +53,7 @@ public class SearchManagerTest extends AbstractSpringTest {
     @Before
     public void setUpPreferenceManager() {
         ReflectionTestUtils.setField(searchManager, "preferenceManager", preferenceManager);
-        when(preferenceManager.getPreference(SystemPreferences.SEARCH_EXPORT_PAGE_SIZE)).thenReturn(PAGE_SIZE);
+        when(preferenceManager.getPreference(SystemPreferences.FACETED_FILTER_EXPORT_PAGE_SIZE)).thenReturn(PAGE_SIZE);
     }
 
     @Test
@@ -83,7 +83,7 @@ public class SearchManagerTest extends AbstractSpringTest {
         final String[] exportedCsv = new String(searchManager.export(facetedSearchExportRequest))
                 .split("\n");
         verify(searchManager).facetedSearch(facetedSearchRequest);
-        verify(preferenceManager, atLeast(1)).getPreference(SystemPreferences.SEARCH_EXPORT_PAGE_SIZE);
+        verify(preferenceManager, atLeast(1)).getPreference(SystemPreferences.FACETED_FILTER_EXPORT_PAGE_SIZE);
         Assert.assertNotNull(exportedCsv);
         Assert.assertEquals(3, exportedCsv.length);
         Assert.assertEquals(HEADER_WITH_ATTRIBUTE, exportedCsv[0]);
@@ -92,7 +92,7 @@ public class SearchManagerTest extends AbstractSpringTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldFailToExportWithoutPageSize() {
-        when(preferenceManager.getPreference(SystemPreferences.SEARCH_EXPORT_PAGE_SIZE)).thenReturn(null);
+        when(preferenceManager.getPreference(SystemPreferences.FACETED_FILTER_EXPORT_PAGE_SIZE)).thenReturn(null);
         final FacetedSearchExportRequest facetedSearchExportRequest = SearchCreatorUtils
                 .getFacetedSearchExportRequest(EXPORT_FILE_NAME, SPECIES);
         facetedSearchExportRequest.getFacetedSearchRequest().setPageSize(null);

--- a/api/src/test/java/com/epam/pipeline/manager/search/SearchManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/search/SearchManagerTest.java
@@ -53,7 +53,7 @@ public class SearchManagerTest extends AbstractSpringTest {
     @Before
     public void setUpPreferenceManager() {
         ReflectionTestUtils.setField(searchManager, "preferenceManager", preferenceManager);
-        when(preferenceManager.getPreference(SystemPreferences.FACETED_FILTER_EXPORT_PAGE_SIZE)).thenReturn(PAGE_SIZE);
+        when(preferenceManager.getPreference(SystemPreferences.SEARCH_EXPORT_PAGE_SIZE)).thenReturn(PAGE_SIZE);
     }
 
     @Test
@@ -83,7 +83,7 @@ public class SearchManagerTest extends AbstractSpringTest {
         final String[] exportedCsv = new String(searchManager.export(facetedSearchExportRequest))
                 .split("\n");
         verify(searchManager).facetedSearch(facetedSearchRequest);
-        verify(preferenceManager, atLeast(1)).getPreference(SystemPreferences.FACETED_FILTER_EXPORT_PAGE_SIZE);
+        verify(preferenceManager, atLeast(1)).getPreference(SystemPreferences.SEARCH_EXPORT_PAGE_SIZE);
         Assert.assertNotNull(exportedCsv);
         Assert.assertEquals(3, exportedCsv.length);
         Assert.assertEquals(HEADER_WITH_ATTRIBUTE, exportedCsv[0]);
@@ -92,7 +92,7 @@ public class SearchManagerTest extends AbstractSpringTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldFailToExportWithoutPageSize() {
-        when(preferenceManager.getPreference(SystemPreferences.FACETED_FILTER_EXPORT_PAGE_SIZE)).thenReturn(null);
+        when(preferenceManager.getPreference(SystemPreferences.SEARCH_EXPORT_PAGE_SIZE)).thenReturn(null);
         final FacetedSearchExportRequest facetedSearchExportRequest = SearchCreatorUtils
                 .getFacetedSearchExportRequest(EXPORT_FILE_NAME, SPECIES);
         facetedSearchExportRequest.getFacetedSearchRequest().setPageSize(null);

--- a/api/src/test/java/com/epam/pipeline/manager/search/SearchResultExportManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/search/SearchResultExportManagerTest.java
@@ -35,7 +35,7 @@ import static com.epam.pipeline.test.creator.search.SearchCreatorUtils.getFacete
 public class SearchResultExportManagerTest extends AbstractSpringTest {
 
     private static final String EXPORT_FILE_NAME = "test_search_export.csv";
-    private static final String PLAIN_HEADER = "Name,Changed,Size (byte(s)),Owner,Path";
+    private static final String PLAIN_HEADER = "Name,Changed,Size,Owner,Path";
 
     @Autowired
     private SearchResultExportManager searchResultExportManager;

--- a/api/src/test/java/com/epam/pipeline/manager/search/SearchResultExportManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/search/SearchResultExportManagerTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.epam.pipeline.manager.search;
+
+import com.epam.pipeline.AbstractSpringTest;
+import com.epam.pipeline.controller.vo.search.FacetedSearchExportRequest;
+import com.epam.pipeline.entity.search.FacetedSearchResult;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Arrays;
+
+import static com.epam.pipeline.test.creator.CommonCreatorConstants.TEST_STRING;
+import static com.epam.pipeline.test.creator.search.SearchCreatorUtils.HEADER_WITH_ATTRIBUTE;
+import static com.epam.pipeline.test.creator.search.SearchCreatorUtils.HUMAN;
+import static com.epam.pipeline.test.creator.search.SearchCreatorUtils.ROLE_USER;
+import static com.epam.pipeline.test.creator.search.SearchCreatorUtils.SPECIES;
+import static com.epam.pipeline.test.creator.search.SearchCreatorUtils.getFacetedSearchExportRequest;
+import static com.epam.pipeline.test.creator.search.SearchCreatorUtils.getFacetedSearchResult;
+
+public class SearchResultExportManagerTest extends AbstractSpringTest {
+
+    private static final String EXPORT_FILE_NAME = "test_search_export.csv";
+    private static final String PLAIN_HEADER = "Name,Changed,Size (byte(s)),Owner,Path";
+
+    @Autowired
+    private SearchResultExportManager searchResultExportManager;
+
+    @Test
+    public void shouldExportFacetedSearchResult() {
+        final FacetedSearchResult facetedSearchResult = getFacetedSearchResult(null);
+        final FacetedSearchExportRequest facetedSearchExportRequest = getFacetedSearchExportRequest(EXPORT_FILE_NAME,
+                null);
+        final String[] exportedCsv = new String(
+                searchResultExportManager.export(facetedSearchExportRequest, facetedSearchResult)).split("\n");
+        Assert.assertNotNull(exportedCsv);
+        Assert.assertEquals(2, exportedCsv.length);
+        Assert.assertEquals(PLAIN_HEADER, exportedCsv[0]);
+        Assert.assertTrue(Arrays.stream(exportedCsv).anyMatch(s -> s.contains(TEST_STRING)));
+    }
+
+    @Test
+    public void shouldExportFacetedSearchResultWithAttributes() {
+        final FacetedSearchResult facetedSearchResult = getFacetedSearchResult(HUMAN);
+        final FacetedSearchExportRequest facetedSearchExportRequest = getFacetedSearchExportRequest(EXPORT_FILE_NAME,
+                SPECIES);
+        final String[] exportedCsv = new String(
+                searchResultExportManager.export(facetedSearchExportRequest, facetedSearchResult)).split("\n");
+        Assert.assertNotNull(exportedCsv);
+        Assert.assertEquals(3, exportedCsv.length);
+        Assert.assertEquals(HEADER_WITH_ATTRIBUTE, exportedCsv[0]);
+        Assert.assertTrue(Arrays.stream(exportedCsv).anyMatch(s -> s.contains(ROLE_USER) && s.contains(HUMAN)));
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/test/creator/search/SearchCreatorUtils.java
+++ b/api/src/test/java/com/epam/pipeline/test/creator/search/SearchCreatorUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,12 +18,21 @@ package com.epam.pipeline.test.creator.search;
 
 import com.epam.pipeline.controller.Result;
 import com.epam.pipeline.controller.vo.search.ElasticSearchRequest;
+import com.epam.pipeline.controller.vo.search.FacetedSearchExportRequest;
+import com.epam.pipeline.controller.vo.search.FacetedSearchExportVO;
+import com.epam.pipeline.controller.vo.search.FacetedSearchRequest;
+import com.epam.pipeline.entity.search.FacetedSearchResult;
 import com.epam.pipeline.entity.search.SearchDocument;
 import com.epam.pipeline.entity.search.SearchDocumentType;
 import com.epam.pipeline.entity.search.SearchResult;
 import com.fasterxml.jackson.core.type.TypeReference;
+import org.apache.commons.lang3.StringUtils;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static com.epam.pipeline.test.creator.CommonCreatorConstants.ID;
 import static com.epam.pipeline.test.creator.CommonCreatorConstants.TEST_INT;
@@ -34,6 +43,12 @@ public final class SearchCreatorUtils {
 
     public static final TypeReference<Result<SearchResult>> SEARCH_RESULT_TYPE =
             new TypeReference<Result<SearchResult>>() { };
+    public static final String ROLE_USER = "ROLE_USER";
+    public static final String SPECIES = "Species";
+    public static final String HUMAN = "human";
+    public static final String MOUSE = "mouse";
+    public static final String HEADER_WITH_ATTRIBUTE = "Name,Changed,Size (byte(s)),Species,Owner,Path";
+
     private static final SearchDocumentType SEARCH_DOCUMENT_TYPE = SearchDocumentType.AZ_BLOB_FILE;
 
     private SearchCreatorUtils() {
@@ -60,9 +75,69 @@ public final class SearchCreatorUtils {
         return elasticSearchRequest;
     }
 
+    public static FacetedSearchExportRequest getFacetedSearchExportRequest(final String exportFileName,
+                                                                           final String attribute) {
+        final FacetedSearchExportRequest exportRequest = new FacetedSearchExportRequest();
+        exportRequest.setFacetedSearchRequest(getFacetedSearchRequest(attribute));
+        exportRequest.setFacetedSearchExportVO(getFacetedSearchExportVO());
+        exportRequest.setCsvFileName(exportFileName);
+        return exportRequest;
+    }
+
+    public static FacetedSearchResult getFacetedSearchResult(final String facetValue) {
+        final FacetedSearchResult facetedSearchResult = new FacetedSearchResult();
+        facetedSearchResult.setTotalHits(ID);
+        if (StringUtils.isBlank(facetValue)) {
+            facetedSearchResult.setDocuments(Collections.singletonList(getSearchDocument()));
+            facetedSearchResult.setFacets(null);
+            return facetedSearchResult;
+        }
+        facetedSearchResult.setDocuments(Arrays.asList(getFacetedSearchDocument(HUMAN),
+                getFacetedSearchDocument(MOUSE)));
+        final Map<String, Map<String, Long>> facets = new HashMap<>();
+        final Map<String, Long> facetValues = new HashMap<>();
+        facetValues.put(facetValue, ID);
+        facets.put(SPECIES, facetValues);
+        facetedSearchResult.setFacets(facets);
+        return facetedSearchResult;
+    }
+
+    public static FacetedSearchRequest getFacetedSearchRequest(final String attribute) {
+        final FacetedSearchRequest facetedSearchRequest = new FacetedSearchRequest();
+        facetedSearchRequest.setQuery(TEST_STRING);
+        facetedSearchRequest.setPageSize(TEST_INT);
+        facetedSearchRequest.setOffset(TEST_INT);
+        facetedSearchRequest.setHighlight(true);
+        if (StringUtils.isNotBlank(attribute)) {
+            facetedSearchRequest.setMetadataFields(Collections.singletonList(attribute));
+        }
+        final Map<String, List<String>> filters = new HashMap<>();
+        filters.put(TEST_STRING, Collections.singletonList(TEST_STRING));
+        facetedSearchRequest.setFilters(filters);
+        return facetedSearchRequest;
+    }
+
+    private static FacetedSearchExportVO getFacetedSearchExportVO() {
+        final FacetedSearchExportVO facetedSearchExportVO = new FacetedSearchExportVO();
+        facetedSearchExportVO.setIncludeName(true);
+        facetedSearchExportVO.setIncludeChanged(true);
+        facetedSearchExportVO.setIncludeOwner(true);
+        facetedSearchExportVO.setIncludePath(true);
+        facetedSearchExportVO.setIncludeSize(true);
+        return facetedSearchExportVO;
+    }
+
     private static SearchDocument getSearchDocument() {
         return new SearchDocument(TEST_STRING, TEST_STRING, TEST_STRING, TEST_STRING, TEST_STRING, SEARCH_DOCUMENT_TYPE,
                 Collections.singletonList(new SearchDocument.HightLight(TEST_STRING, TEST_STRING_LIST)), TEST_INT,
                 TEST_STRING, null);
+    }
+
+    private static SearchDocument getFacetedSearchDocument(final String species) {
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put(SPECIES, species);
+        return new SearchDocument(TEST_STRING, TEST_STRING, TEST_STRING, TEST_STRING, TEST_STRING, SEARCH_DOCUMENT_TYPE,
+                Collections.singletonList(new SearchDocument.HightLight(SPECIES, Collections.singletonList(species))),
+                TEST_INT, ROLE_USER, attributes);
     }
 }

--- a/api/src/test/java/com/epam/pipeline/test/creator/search/SearchCreatorUtils.java
+++ b/api/src/test/java/com/epam/pipeline/test/creator/search/SearchCreatorUtils.java
@@ -47,7 +47,7 @@ public final class SearchCreatorUtils {
     public static final String SPECIES = "Species";
     public static final String HUMAN = "human";
     public static final String MOUSE = "mouse";
-    public static final String HEADER_WITH_ATTRIBUTE = "Name,Changed,Size (byte(s)),Species,Owner,Path";
+    public static final String HEADER_WITH_ATTRIBUTE = "Name,Changed,Size,Species,Owner,Path";
 
     private static final SearchDocumentType SEARCH_DOCUMENT_TYPE = SearchDocumentType.AZ_BLOB_FILE;
 


### PR DESCRIPTION
The pull request provides implementation of exporting faceted search result to CSV file:

- a new FacetedSearchExportRequest and FacetedSearchExportVO objects were added to serve export request:
   - `FacetedSearchExportRequest` contains fields to specify csv file name, FacetedSearchExportVO and FacetedSearchRequest objects
   - `FacetedSearchExportVO` contains fields to specify what attributes includes to result
- a new system preferences `search.export.page.size` was added to specify the default number of pages