### PR TITLE
Update api srv deployment livenessProbe and readinessProbe

### DIFF
--- a/deploy/contents/k8s/cp-api-srv/cp-api-srv-dpl.yaml
+++ b/deploy/contents/k8s/cp-api-srv/cp-api-srv-dpl.yaml
@@ -99,20 +99,28 @@ spec:
               readOnly: true
           readinessProbe:
             httpGet:
-              path: /pipeline/launch.sh
+              path: /pipeline/restapi/app/info
               port: 8080
               scheme: HTTPS
-            initialDelaySeconds: 5
+              httpHeaders:
+                - name: Authorization
+                  value: "Bearer ${CP_API_JWT_ADMIN}"
+            initialDelaySeconds: 180
             periodSeconds: 10
+            timeoutSeconds: 10
           livenessProbe:
             httpGet:
-              path: /pipeline/launch.sh
+              path: /pipeline/restapi/app/info
               port: 8080
               scheme: HTTPS
+              httpHeaders:
+                - name: Authorization
+                  value: "Bearer ${CP_API_JWT_ADMIN}"
             # 5 min delay to make sure API is up and running and drop pod after 60 seconds (4*15s) if API didn't respond
             initialDelaySeconds: 150
             periodSeconds: 15
             failureThreshold: 4
+            timeoutSeconds: 10
           lifecycle:
             preStop:
               exec:

--- a/deploy/contents/k8s/cp-api-srv/cp-api-srv-dpl.yaml
+++ b/deploy/contents/k8s/cp-api-srv/cp-api-srv-dpl.yaml
@@ -98,29 +98,23 @@ spec:
               mountPath: "/etc/cp_ssh"
               readOnly: true
           readinessProbe:
-            httpGet:
-              path: /pipeline/restapi/app/info
-              port: 8080
-              scheme: HTTPS
-              httpHeaders:
-                - name: Authorization
-                  value: "Bearer ${CP_API_JWT_ADMIN}"
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - /liveness-api-srv.sh
             initialDelaySeconds: 180
             periodSeconds: 10
-            timeoutSeconds: 10
           livenessProbe:
-            httpGet:
-              path: /pipeline/restapi/app/info
-              port: 8080
-              scheme: HTTPS
-              httpHeaders:
-                - name: Authorization
-                  value: "Bearer ${CP_API_JWT_ADMIN}"
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - /liveness-api-srv.sh
             # 5 min delay to make sure API is up and running and drop pod after 60 seconds (4*15s) if API didn't respond
-            initialDelaySeconds: 150
+            initialDelaySeconds: 180
             periodSeconds: 15
             failureThreshold: 4
-            timeoutSeconds: 10
           lifecycle:
             preStop:
               exec:

--- a/deploy/docker/cp-api-srv/Dockerfile
+++ b/deploy/docker/cp-api-srv/Dockerfile
@@ -128,6 +128,7 @@ ADD init-api /init-api
 ADD init-git-sync /init-git-sync
 ADD update-trust /update-trust
 ADD liveness-git-sync.sh /liveness-git-sync.sh
+ADD liveness-api-srv-template.sh /liveness-api-srv-template.sh
 
 RUN chmod +x /init* && \
     chmod +x /update-trust && \

--- a/deploy/docker/cp-api-srv/init-api
+++ b/deploy/docker/cp-api-srv/init-api
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -295,6 +295,21 @@ if [ "$CP_PREF_API_STATIC_DIRECTORY_EXT" ] && ! is_dir_empty "$CP_PREF_API_STATI
     echo "Importing static assets from $CP_PREF_API_STATIC_DIRECTORY_EXT to $CP_API_SRV_STATIC_DIR"
     \cp -r $CP_PREF_API_STATIC_DIRECTORY_EXT/* "$CP_API_SRV_STATIC_DIR/"
 fi
+
+# Prepare liveness check for api srv
+if [ -z "${CP_API_JWT_ADMIN}" ]; then
+    CP_API_JWT_ADMIN=$(java  -jar /opt/api/jwt-generator.jar \
+                             --private $CP_API_SRV_CERT_DIR/jwt.key.private \
+                             --expires 94608000 \
+                             --claim user_id=1 \
+                             --claim user_name=$CP_DEFAULT_ADMIN_NAME \
+                             --claim role=ROLE_ADMIN \
+                             --claim group=ADMIN)
+fi
+export CP_API_LIVENESS_JWT_TOKEN=${CP_API_JWT_ADMIN}
+export CP_REST_API_URL="https://127.0.0.1:8080/pipeline/restapi/"
+envsubst '$CP_API_LIVENESS_JWT_TOKEN,$CP_REST_API_URL' < /liveness-api-srv-template.sh > /liveness-api-srv.sh
+chmod +x /liveness-api-srv.sh
 
 # Configure logging and launch
 API_LOG_HOME="/var/log/cp-api/${CP_API_SRV_INSTANCE_NAME:-$CP_API_CURRENT_NODE_NAME}"

--- a/deploy/docker/cp-api-srv/init-api
+++ b/deploy/docker/cp-api-srv/init-api
@@ -307,8 +307,7 @@ if [ -z "${CP_API_JWT_ADMIN}" ]; then
                              --claim group=ADMIN)
 fi
 export CP_API_LIVENESS_JWT_TOKEN=${CP_API_JWT_ADMIN}
-export CP_REST_API_URL="https://127.0.0.1:8080/pipeline/restapi/"
-envsubst '$CP_API_LIVENESS_JWT_TOKEN,$CP_REST_API_URL' < /liveness-api-srv-template.sh > /liveness-api-srv.sh
+envsubst '$CP_API_LIVENESS_JWT_TOKEN' < /liveness-api-srv-template.sh > /liveness-api-srv.sh
 chmod +x /liveness-api-srv.sh
 
 # Configure logging and launch

--- a/deploy/docker/cp-api-srv/liveness-api-srv-template.sh
+++ b/deploy/docker/cp-api-srv/liveness-api-srv-template.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2019-2022 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,8 +19,13 @@ function die {
     exit 1
 }
 
-EDGE_HEALTH_ENDPOINT="http://127.0.0.1:8888/edge-health"
-WETTY_HEALTH_ENDPOINT="http://127.0.0.1:8888/wetty-health"
+LIVENESS_JWT_TOKEN=$CP_API_LIVENESS_JWT_TOKEN
+API_URL=$CP_REST_API_URL
 
-curl --fail "$EDGE_HEALTH_ENDPOINT" --max-time 60 > /dev/null 2>&1 || die "$EDGE_HEALTH_ENDPOINT"
-curl --fail "$WETTY_HEALTH_ENDPOINT" --max-time 60 > /dev/null 2>&1 || die "$WETTY_HEALTH_ENDPOINT"
+if [ -z "$LIVENESS_JWT_TOKEN" ] || [ -z "$API_URL" ]; then
+    echo "LIVENESS_JWT_TOKEN or API_URL was not specified. Exiting ..."
+    exit 1
+fi
+
+API_HEALTH_ENDPOINT="${API_URL}app/info"
+curl --fail -k -H "Authorization: Bearer $LIVENESS_JWT_TOKEN" "$API_HEALTH_ENDPOINT" --max-time 60 > /dev/null 2>&1 || die "$API_HEALTH_ENDPOINT"

--- a/deploy/docker/cp-api-srv/liveness-api-srv-template.sh
+++ b/deploy/docker/cp-api-srv/liveness-api-srv-template.sh
@@ -20,12 +20,11 @@ function die {
 }
 
 LIVENESS_JWT_TOKEN=$CP_API_LIVENESS_JWT_TOKEN
-API_URL=$CP_REST_API_URL
 
-if [ -z "$LIVENESS_JWT_TOKEN" ] || [ -z "$API_URL" ]; then
-    echo "LIVENESS_JWT_TOKEN or API_URL was not specified. Exiting ..."
+if [ -z "$LIVENESS_JWT_TOKEN" ]; then
+    echo "LIVENESS_JWT_TOKEN was not specified. Exiting ..."
     exit 1
 fi
 
-API_HEALTH_ENDPOINT="${API_URL}app/info"
+API_HEALTH_ENDPOINT="https://127.0.0.1:8080/pipeline/restapi/app/info"
 curl --fail -k -H "Authorization: Bearer $LIVENESS_JWT_TOKEN" "$API_HEALTH_ENDPOINT" --max-time 60 > /dev/null 2>&1 || die "$API_HEALTH_ENDPOINT"


### PR DESCRIPTION
The pull request provides the updates of the livenessProbe and the readinessProbe of the API srv deployment:
- **httpGet** was updated to `/pipeline/restapi/app/info`
- **initialDelaySeconds** was updated to avoid connection refused error
