### PR TITLE
Issue #2971: Static resources handling improvement

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/resource/StaticResourceApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/resource/StaticResourceApiService.java
@@ -28,7 +28,7 @@ public class StaticResourceApiService {
 
     private final StaticResourcesService resourcesService;
 
-    @PreAuthorize("hasRole('ADMIN') OR @storagePermissionManager.storagePermissionByPath(#path, 'READ')")
+    @PreAuthorize("hasRole('ADMIN') OR @storagePermissionManager.storagePermissionAndSharedByPath(#path, 'READ')")
     public DataStorageStreamingContent getContent(final String path) {
         return resourcesService.getContent(path);
     }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
@@ -725,6 +725,13 @@ public class DataStorageManager implements SecuredEntityManager {
         return storageProviderManager.getFile(dataStorage, path, version);
     }
 
+    public DataStorageItemContent getDataStorageItemContent(final Long id, final String path, final String version,
+                                                            final long maxDownloadSize) {
+        AbstractDataStorage dataStorage = load(id);
+        checkDataStorageVersioning(dataStorage, version);
+        return storageProviderManager.getFile(dataStorage, path, version, maxDownloadSize);
+    }
+
     @Transactional
     public Map<String, String> loadDataStorageObjectTags(Long id, String path, String version) {
         final AbstractDataStorage dataStorage = load(id);

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageProviderManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/StorageProviderManager.java
@@ -216,6 +216,12 @@ public class StorageProviderManager {
     @SensitiveStorageOperation
     public DataStorageItemContent getFile(AbstractDataStorage dataStorage, String path, String version) {
         long maxDownloadSize = preferenceManager.getPreference(SystemPreferences.DATA_STORAGE_MAX_DOWNLOAD_SIZE);
+        return getFile(dataStorage, path, version, maxDownloadSize);
+    }
+
+    @SensitiveStorageOperation
+    public DataStorageItemContent getFile(final AbstractDataStorage dataStorage, final String path,
+                                          final String version, final long maxDownloadSize) {
         return getStorageProvider(dataStorage).getFile(dataStorage, path, version, maxDownloadSize);
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -727,6 +727,9 @@ public class SystemPreferences {
     public static final StringPreference STATIC_RESOURCES_FOLDER_TEMPLATE_PATH =
             new StringPreference("data.sharing.static.resource.template.path", "classpath:views/folder.vm",
                     DATA_SHARING_GROUP, pass);
+    public static final LongPreference STATIC_RESOURCES_DOWNLOAD_LIMIT = new LongPreference(
+            "data.sharing.static.resources.download.limit", 1000L, DATA_SHARING_GROUP,
+            isGreaterThan(0L));
 
     // SYSTEM_GROUP
     /**

--- a/api/src/main/java/com/epam/pipeline/manager/resource/StaticResourcesService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/resource/StaticResourcesService.java
@@ -21,6 +21,7 @@ import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorageItem;
 import com.epam.pipeline.entity.datastorage.DataStorageFile;
+import com.epam.pipeline.entity.datastorage.DataStorageItemContent;
 import com.epam.pipeline.entity.datastorage.DataStorageItemType;
 import com.epam.pipeline.entity.datastorage.DataStorageStreamingContent;
 import com.epam.pipeline.exception.InvalidPathException;
@@ -77,7 +78,10 @@ public class StaticResourcesService {
             return new DataStorageStreamingContent(new ByteArrayInputStream(html.getBytes()),
                     ProviderUtils.withoutTrailingDelimiter(filePath) + HTML);
         }
-        return dataStorageManager.getStreamingContent(storage.getId(), filePath, null);
+        final long sizeLimit = preferenceManager.getPreference(SystemPreferences.STATIC_RESOURCES_DOWNLOAD_LIMIT);
+        final DataStorageItemContent content = dataStorageManager
+                .getDataStorageItemContent(storage.getId(), filePath, null, sizeLimit);
+        return new DataStorageStreamingContent(new ByteArrayInputStream(content.getContent()), filePath);
     }
 
     public static String buildHtml(final List<AbstractDataStorageItem> items,

--- a/api/src/main/java/com/epam/pipeline/manager/security/storage/StoragePermissionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/storage/StoragePermissionManager.java
@@ -102,7 +102,8 @@ public class StoragePermissionManager {
                                            final String permissionName) {
         try {
             final AbstractSecuredEntity storage = storagePathLoader.loadDataStorageByPathOrId(path);
-            return grantPermissionManager.storagePermission(storage, permissionName);
+            return grantPermissionManager.checkStorageShared(storage.getId())
+                    && grantPermissionManager.storagePermission(storage, permissionName);
         } catch (IllegalArgumentException e) {
             return false;
         }

--- a/api/src/main/java/com/epam/pipeline/manager/security/storage/StoragePermissionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/storage/StoragePermissionManager.java
@@ -98,8 +98,8 @@ public class StoragePermissionManager {
         return grantPermissionManager.storagePermission(storage, permissionName);
     }
 
-    public boolean storagePermissionByPath(final String path,
-                                           final String permissionName) {
+    public boolean storagePermissionAndSharedByPath(final String path,
+                                                    final String permissionName) {
         try {
             final AbstractSecuredEntity storage = storagePathLoader.loadDataStorageByPathOrId(path);
             return grantPermissionManager.checkStorageShared(storage.getId())


### PR DESCRIPTION
The current PR provides implementation for issue #2971 

- a new system preference `data.sharing.static.resources.download.limit` added to restrict file output content.
- storage shared verification added to `GET /static-resources/` method 