### PR TITLE
Issue #2972: Run notifications (long running, idle run) shall consider pause time

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/cluster/PodMonitor.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/PodMonitor.java
@@ -302,19 +302,8 @@ public class PodMonitor extends AbstractSchedulingManager {
         }
 
         private long toRunningDuration(final List<RunStatus> statuses) {
-            long duration = 0L;
-            for (int i = 0; i < statuses.size() - 1; i++) {
-                final RunStatus previous = statuses.get(i);
-                final RunStatus current = statuses.get(i + 1);
-                if (isRunning(previous)) {
-                    duration += secondsBetween(previous, current);
-                }
-            }
             final RunStatus last = statuses.get(statuses.size() - 1);
-            if (isRunning(last)) {
-                duration += secondsBetween(last.getTimestamp(), DateUtils.nowUTC());
-            }
-            return duration;
+            return isRunning(last) ? secondsBetween(last.getTimestamp(), DateUtils.nowUTC()) : 0;
         }
 
         private boolean isRunning(final RunStatus status) {

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -348,6 +348,7 @@ public class PipelineRunManager {
     public void prolongIdleRun(Long runId) {
         PipelineRun run = loadPipelineRun(runId);
         run.setLastIdleNotificationTime(null);
+        run.setLastNotificationTime(null);
         run.setProlongedAtTime(DateUtils.nowUTC());
         updateProlongIdleRunAndLastIdleNotificationTime(run);
     }

--- a/api/src/test/java/com/epam/pipeline/manager/notification/NotificationManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/notification/NotificationManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,6 +61,7 @@ import com.epam.pipeline.entity.region.CloudProvider;
 import com.epam.pipeline.manager.execution.EnvVarsBuilder;
 import com.epam.pipeline.manager.execution.EnvVarsBuilderTest;
 import com.epam.pipeline.manager.execution.SystemParams;
+import com.epam.pipeline.manager.pipeline.RunStatusManager;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -132,6 +133,7 @@ public class NotificationManagerTest extends AbstractManagerTest {
     private static final String NOT_EQUAL_PARAM_NAME = "notEqualParamName";
     private static final String INCLUDE_PARAM_VALUE = "includeParamValue";
     private static final String INCLUDE_PARAM_NAME = "includeParamName";
+    private static final long LONG_THRESHOLD = 2000L;
 
     @Autowired
     private NotificationManager notificationManager;
@@ -147,6 +149,9 @@ public class NotificationManagerTest extends AbstractManagerTest {
 
     @MockBean
     private KubernetesManager kubernetesManager;
+
+    @MockBean
+    private RunStatusManager runStatusManager;
 
     @Autowired
     private UserDao userDao;
@@ -223,6 +228,7 @@ public class NotificationManagerTest extends AbstractManagerTest {
 
         longRunnging = new PipelineRun();
         DateTime date = DateTime.now(DateTimeZone.UTC).minus(LONG_RUNNING_DURATION);
+        longRunnging.setId(1L);
         longRunnging.setStartDate(date.toDate());
         longRunnging.setStatus(TaskStatus.RUNNING);
         longRunnging.setOwner(admin.getUserName());
@@ -278,6 +284,41 @@ public class NotificationManagerTest extends AbstractManagerTest {
         notificationTemplateDao.deleteNotificationTemplate(longRunningTemplate.getId());
         podMonitor.updateStatus();
         List<NotificationMessage> messages = monitoringNotificationDao.loadAllNotifications();
+        Assert.assertEquals(0, messages.size());
+    }
+
+    @Test
+    public void testNotNotifyLongRunningAfterResume() {
+        NotificationSettings settings = notificationSettingsDao.loadNotificationSettings(1L);
+        // set threshold to 2 sec
+        settings.setThreshold(LONG_THRESHOLD);
+        notificationSettingsDao.updateNotificationSettings(settings);
+        final List<RunStatus> runStatuses = Arrays.asList(
+                RunStatus.builder()
+                        .runId(longRunnging.getId())
+                        .status(TaskStatus.PAUSING)
+                        .timestamp(DateUtils.nowUTC().minusHours(1))
+                        .build(),
+                RunStatus.builder()
+                        .runId(longRunnging.getId())
+                        .status(TaskStatus.PAUSED)
+                        .timestamp(DateUtils.nowUTC().minusMinutes(2))
+                        .build(),
+                RunStatus.builder()
+                        .runId(longRunnging.getId())
+                        .status(TaskStatus.RESUMING)
+                        .timestamp(DateUtils.nowUTC().minusMinutes(1))
+                        .build(),
+                RunStatus.builder()
+                        .runId(longRunnging.getId())
+                        .status(TaskStatus.RUNNING)
+                        .timestamp(DateUtils.nowUTC())
+                        .build());
+        when(runStatusManager.loadRunStatus(longRunnging.getId())).thenReturn(runStatuses);
+        longRunnging.setRunStatuses(runStatuses);
+        pipelineRunManager.updatePipelineStatus(longRunnging);
+        podMonitor.updateStatus();
+        final List<NotificationMessage> messages = monitoringNotificationDao.loadAllNotifications();
         Assert.assertEquals(0, messages.size());
     }
 


### PR DESCRIPTION
The current PR provides the fix of the run notifications for long-running run to consider pause time:
- prolongedAtTime is used instead of startDate for calculating notification time