### PR TITLE
Add support for grid engine autoscalers interactive configuration

### DIFF
--- a/workflows/pipe-common/pipeline/common/utils.py
+++ b/workflows/pipe-common/pipeline/common/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,16 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import os
-import re
 import subprocess
-
-_ENV_VAR_PLACEHOLDER = '${%s}'
-_ENV_VAR_PATTERN = r'\${(\w*|_)}'
-_ENV_VAR_NAME_PATTERN_GROUP = 1
-_PROFILE_PATTERN = '^({}(_\D+)*)_(\d+)$'
-_COMMON_PATTERN = '^({}(_\D+)*)(?!_\d+)$'
 
 
 def replace_all_system_variables_in_path(path):
@@ -53,59 +45,3 @@ def get_path_with_trailing_delimiter(path):
 
 def get_path_without_trailing_delimiter(path):
     return path if not path.endswith('/') else path[:-1]
-
-
-def build_environment_profiles(prefixes):
-    logging.info('Searching for environment profiles...')
-    common_profile = {}
-    profiles = {}
-    for key, value in os.environ.items():
-        prefix = None
-        for possible_prefix in prefixes:
-            if key.startswith(possible_prefix):
-                prefix = possible_prefix
-                break
-        if not prefix:
-            continue
-        profile_match = re.match(_PROFILE_PATTERN.format(prefix), key)
-        if profile_match:
-            profile_variable = profile_match.group(1)
-            profile_index = profile_match.group(3)
-            profile = profiles[profile_index] = profiles.get(profile_index) or {}
-            profile[profile_variable] = value
-            logging.info('Found profile %s variable: %s=%s', profile_index, profile_variable, value)
-            continue
-        common_match = re.match(_COMMON_PATTERN.format(prefix), key)
-        if common_match:
-            common_variable = common_match.group(1)
-            common_profile[common_variable] = value
-            logging.info('Found common variable: %s=%s', common_variable, value)
-            continue
-        logging.warn('Skipped variable: %s=%s', key, value)
-
-    logging.info('Building environment profiles...')
-    logging.info('Profile common environment:')
-    for key, value in common_profile.items():
-        logging.info('%s=%s', key, value)
-    complete_profiles = {}
-    for profile_index, profile in profiles.items():
-        complete_profile = complete_profiles[profile_index] = complete_profiles.get(profile_index) or {}
-        complete_profile.update(profile)
-        logging.info('Profile %s environment:', profile_index)
-        for key, value in complete_profile.items():
-            logging.info('%s=%s', key, value)
-
-    return common_profile, complete_profiles
-
-
-def suffix_non_unique(items, suffix_func=lambda item, suffix: item + suffix):
-    from collections import Counter
-    from itertools import tee, count
-    unique_items = list(items)
-    not_unique_items = [item for item, occurrences in Counter(items).items() if occurrences > 1]
-    item_suffix_generators = dict(zip(not_unique_items, tee(count(1), len(not_unique_items))))
-    for index, item in enumerate(items):
-        if item in item_suffix_generators:
-            suffix = str(next(item_suffix_generators[item]))
-            unique_items[index] = suffix_func(unique_items[index], suffix)
-    return unique_items

--- a/workflows/pipe-common/pipeline/utils/profile.py
+++ b/workflows/pipe-common/pipeline/utils/profile.py
@@ -1,0 +1,87 @@
+# Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import re
+
+_PROFILE_PATTERN = '^({}(_\D+)*)_(\d+)$'
+_COMMON_PATTERN = '^({}(_\D+)*)(?!_\d+)$'
+
+
+def build_environment_profiles(prefixes, logger):
+    common_profile, profiles = _build_profiles(prefixes, logger)
+    _log_profiles(common_profile, profiles, logger)
+    return common_profile, profiles
+
+
+def _build_profiles(prefixes, logger):
+    logger.debug('')
+    logger.debug('Building environment profiles...')
+    common_profile = {}
+    profiles = {}
+    for key, value in os.environ.items():
+        prefix = None
+        for possible_prefix in prefixes:
+            if key.startswith(possible_prefix):
+                prefix = possible_prefix
+                break
+        if not prefix:
+            continue
+        profile_match = re.match(_PROFILE_PATTERN.format(prefix), key)
+        if profile_match:
+            profile_variable = profile_match.group(1)
+            profile_index = profile_match.group(3)
+            profile = profiles[profile_index] = profiles.get(profile_index) or {}
+            profile[profile_variable] = value
+            logger.debug('Found profile {} variable: {}={}'.format(profile_index, profile_variable, value))
+            continue
+        common_match = re.match(_COMMON_PATTERN.format(prefix), key)
+        if common_match:
+            if key.endswith('_PARAM_TYPE'):
+                continue
+            common_variable = common_match.group(1)
+            common_profile[common_variable] = value
+            logger.debug('Found common variable: {}={}'.format(common_variable, value))
+            continue
+        logger.debug('Skipped variable: {}={}'.format(key, value))
+    return common_profile, profiles
+
+
+def _log_profiles(common_profile, profiles, logger):
+    logger.debug('')
+    logger.debug('Printing environment profiles...')
+    _log_profile('common', common_profile, logger)
+    for profile_index, profile in profiles.items():
+        _log_profile(profile_index, profile, logger)
+
+
+def _log_profile(profile_index, profile, logger):
+    logger.debug('')
+    logger.debug('Profile {} environment:'.format(profile_index))
+    for key in sorted(profile):
+        value = profile.get(key)
+        logger.debug('{}={}'.format(key, value))
+
+
+def suffix_non_unique(items, suffix_func=lambda item, suffix: item + suffix):
+    from collections import Counter
+    from itertools import tee, count
+    unique_items = list(items)
+    not_unique_items = [item for item, occurrences in Counter(items).items() if occurrences > 1]
+    item_suffix_generators = dict(zip(not_unique_items, tee(count(1), len(not_unique_items))))
+    for index, item in enumerate(items):
+        if item in item_suffix_generators:
+            suffix = str(next(item_suffix_generators[item]))
+            unique_items[index] = suffix_func(unique_items[index], suffix)
+    return unique_items

--- a/workflows/pipe-common/scripts/configure_sge_profiles_interactively.py
+++ b/workflows/pipe-common/scripts/configure_sge_profiles_interactively.py
@@ -1,0 +1,170 @@
+# Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import re
+import subprocess
+
+import psutil
+
+from pipeline.api import PipelineAPI
+from pipeline.log.logger import LocalLogger, RunLogger, TaskLogger, LevelLogger
+
+
+class SGEProfileConfigurationError(RuntimeError):
+    pass
+
+
+class Queue:
+
+    def __init__(self, name, profile_path):
+        self._name = name
+        self._profile_path = profile_path
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def profile_path(self):
+        return self._profile_path
+
+
+def configure_sge_profiles_interactively():
+    logging_dir = os.getenv('CP_CAP_SGE_PROFILE_CONFIGURATION_LOG_DIR', default=os.getenv('LOG_DIR', '/var/log'))
+    logging_level = os.getenv('CP_CAP_SGE_PROFILE_CONFIGURATION_LOGGING_LEVEL', default='INFO')
+    logging_level_local = os.getenv('CP_CAP_SGE_PROFILE_CONFIGURATION_LOGGING_LEVEL_LOCAL', default='DEBUG')
+    logging_format = os.getenv('CP_CAP_SGE_PROFILE_CONFIGURATION_LOGGING_FORMAT', default='%(asctime)s:%(levelname)s: %(message)s')
+    logging_task = os.getenv('CP_CAP_SGE_PROFILE_CONFIGURATION_LOGGING_TASK', default='ConfigureSGEProfiles')
+    logging_file = os.getenv('CP_CAP_SGE_PROFILE_CONFIGURATION_LOGGING_FILE', default='configure_sge_profiles_interactively.log')
+
+    api_url = os.environ['API']
+    run_id = os.environ['RUN_ID']
+    parent_run_id = os.getenv('parent_id')
+    runs_root = os.getenv('CP_RUNS_ROOT_DIR', default='/runs')
+    pipeline_name = os.getenv('PIPELINE_NAME', default='DefaultPipeline')
+    run_dir = os.getenv('RUN_DIR', default=os.path.join(runs_root, pipeline_name + '-' + run_id))
+    common_repo_dir = os.getenv('COMMON_REPO_DIR', default=os.path.join(run_dir, 'CommonRepo'))
+    cap_scripts_dir = os.getenv('CP_CAP_SCRIPTS_DIR', default='/common/cap_scripts')
+    sge_autoscale_script_path = os.path.join(common_repo_dir, 'scripts', 'autoscale_sge.py')
+    sge_profile_script_name_pattern = '^sge_profile_(.+)\\.sh$'
+    sge_profile_script_regexp = re.compile(sge_profile_script_name_pattern)
+
+    logging.basicConfig(level=logging_level_local, format=logging_format,
+                        filename=os.path.join(logging_dir, logging_file))
+
+    api = PipelineAPI(api_url=api_url, log_dir=logging_dir)
+    logger = RunLogger(api=api, run_id=run_id)
+    logger = TaskLogger(task=logging_task, inner=logger)
+    logger = LevelLogger(level=logging_level, inner=logger)
+    logger = LocalLogger(inner=logger)
+
+    try:
+        if parent_run_id:
+            logger.error('Please use the following node to configure grid engine profiles: '
+                         'pipeline-{}.'.format(parent_run_id))
+            raise SGEProfileConfigurationError()
+
+        logger.debug('Initiating grid engine profiles configuration...')
+        editor = _select_editor(logger)
+        queues = list(_collect_queues(cap_scripts_dir, sge_profile_script_regexp, logger))
+        _reconfigure_queues(queues, editor, logger)
+        _restart_autoscalers(queues, sge_autoscale_script_path, logger)
+    except SGEProfileConfigurationError:
+        exit(1)
+    except KeyboardInterrupt:
+        logger.warning('Interrupted.')
+
+
+def _select_editor(logger):
+    logger.debug('Selecting editor...')
+    default_editor = os.getenv('VISUAL', os.getenv('EDITOR'))
+    fallback_editors = ['nano', 'vi', 'vim']
+    editors = [default_editor] + fallback_editors if default_editor else fallback_editors
+    editor = None
+    for potential_editor in editors:
+        exit_code = subprocess.call(['command', '-v', potential_editor])
+        if not exit_code:
+            editor = potential_editor
+            break
+    if not editor:
+        logger.error('No suitable editor has been found. Exiting...')
+        raise SGEProfileConfigurationError()
+    logger.debug('Editor {} has been selected.'.format(editor))
+    return editor
+
+
+def _collect_queues(cap_scripts_dir, sge_profile_script_regexp, logger):
+    logger.debug('Collecting existing queues...')
+    for sge_profile_script_name in os.listdir(cap_scripts_dir):
+        sge_profile_script_match = sge_profile_script_regexp.match(sge_profile_script_name)
+        if not sge_profile_script_match:
+            continue
+        queue_name = sge_profile_script_match.group(1)
+        sge_profile_script_path = os.path.join(cap_scripts_dir, sge_profile_script_name)
+        yield Queue(name=queue_name, profile_path=sge_profile_script_path)
+        logger.debug('Queue {} has been collected.'.format(queue_name))
+
+
+def _reconfigure_queues(queues, editor, logger):
+    for queue in queues:
+        logger.debug('Reconfiguring queue {} by editing {}...'.format(queue.name, queue.profile_path))
+        subprocess.check_call([editor, queue.profile_path])
+        logger.info('Queue {} has been reconfigured.'.format(queue.name))
+
+
+def _restart_autoscalers(queues, sge_autoscale_script_path, logger):
+    for queue in queues:
+        _stop_autoscaler(queue, sge_autoscale_script_path, logger)
+        _launch_autoscaler(queue, sge_autoscale_script_path, logger)
+
+
+def _stop_autoscaler(queue, sge_autoscale_script_path, logger):
+    logger.debug('Searching for {} autoscaler processes...'.format(queue.name))
+    for proc in _get_processes(logger, sge_autoscale_script_path, CP_CAP_SGE_QUEUE_NAME=queue.name):
+        logger.debug('Stopping process #{}...'.format(proc.pid))
+        proc.terminate()
+
+
+def _get_processes(logger, *args, **kwargs):
+    for proc in psutil.process_iter():
+        try:
+            proc_cmdline = proc.cmdline()
+            proc_environ = proc.environ()
+        except KeyboardInterrupt:
+            raise
+        except Exception:
+            logger.error('Please use root account to configure grid engine profiles.')
+            raise SGEProfileConfigurationError()
+        if all(arg in proc_cmdline for arg in args) \
+                and all(proc_environ.get(k) == v for k, v in kwargs.items()):
+            yield proc
+
+
+def _launch_autoscaler(queue, sge_autoscale_script_path, logger):
+    logger.debug('Launching queue {} sge autoscaler process...', queue.name)
+    subprocess.check_call("""
+source "{sge_profile_script_path}"
+if check_cp_cap "CP_CAP_AUTOSCALE"; then
+    nohup "$CP_PYTHON2_PATH" "{sge_autoscale_script_path}" >"$LOG_DIR/.nohup.autoscaler.$CP_CAP_SGE_QUEUE_NAME.log" 2>&1 &
+fi
+    """.format(sge_profile_script_path=queue.profile_path,
+               sge_autoscale_script_path=sge_autoscale_script_path),
+                          shell=True)
+    logger.info('Queue {} sge autoscaler process has been launched.'.format(queue.name))
+
+
+if __name__ == '__main__':
+    configure_sge_profiles_interactively()

--- a/workflows/pipe-common/scripts/generate_sge_profiles.py
+++ b/workflows/pipe-common/scripts/generate_sge_profiles.py
@@ -1,14 +1,85 @@
+# Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import os
+import traceback
 
-from pipeline import suffix_non_unique, build_environment_profiles
-
-_LOGGING_FORMAT = '%(asctime)s:%(levelname)s: %(message)s'
+from pipeline.api import PipelineAPI
+from pipeline.log.logger import LocalLogger, RunLogger, TaskLogger, LevelLogger
+from pipeline.utils.profile import suffix_non_unique, build_environment_profiles
 
 
 def generate_sge_profiles():
-    common_profile, profiles = build_environment_profiles(prefixes=['CP_CAP_SGE', 'CP_CAP_AUTOSCALE'])
+    logging_dir = os.getenv('CP_CAP_SGE_PROFILE_GENERATION_LOG_DIR', default=os.getenv('LOG_DIR', '/var/log'))
+    logging_level = os.getenv('CP_CAP_SGE_PROFILE_GENERATION_LOGGING_LEVEL', default='INFO')
+    logging_level_local = os.getenv('CP_CAP_SGE_PROFILE_GENERATION_LOGGING_LEVEL_LOCAL', default='DEBUG')
+    logging_format = os.getenv('CP_CAP_SGE_PROFILE_GENERATION_LOGGING_FORMAT', default='%(asctime)s:%(levelname)s: %(message)s')
+    logging_task = os.getenv('CP_CAP_SGE_PROFILE_GENERATION_LOGGING_TASK', default='GenerateSGEProfiles')
+    logging_file = os.getenv('CP_CAP_SGE_PROFILE_GENERATION_LOGGING_FILE', default='generate_sge_profiles.log')
 
+    api_url = os.environ['API']
+    run_id = os.environ['RUN_ID']
+
+    cap_scripts_dir = os.getenv('CP_CAP_SCRIPTS_DIR', '/common/cap_scripts')
+    default_queue_disabled = os.getenv('CP_CAP_SGE_DISABLE_DEFAULT_QUEUE', 'false').lower() == 'true'
+
+    logging.basicConfig(level=logging_level_local, format=logging_format,
+                        filename=os.path.join(logging_dir, logging_file))
+
+    api = PipelineAPI(api_url=api_url, log_dir=logging_dir)
+    logger = RunLogger(api=api, run_id=run_id)
+    logger = TaskLogger(task=logging_task, inner=logger)
+    logger = LevelLogger(level=logging_level, inner=logger)
+    logger = LocalLogger(inner=logger)
+
+    profiles = _generate_profiles(default_queue_disabled, logger)
+    params = _get_parameters(logger)
+    _write_profiles(profiles, params, cap_scripts_dir, logger)
+
+
+def _get_parameters(logger):
+    try:
+        from scripts.autoscale_sge import GridEngineParameters
+        return GridEngineParameters().as_dict()
+    except KeyboardInterrupt:
+        raise
+    except Exception:
+        logger.warning('Grid engine parameter definitions retrieving has failed.')
+        logger.warning(traceback.format_exc())
+        return {}
+
+
+def _generate_profiles(default_queue_disabled, logger):
+    common_profile, secondary_profiles = build_environment_profiles(prefixes=['CP_CAP_SGE', 'CP_CAP_AUTOSCALE'],
+                                                                    logger=logger)
+    enhanced_secondary_profiles = _enhance_secondary_profiles(common_profile, secondary_profiles)
+    enhanced_common_profile = _enhance_common_profile(common_profile)
+    if default_queue_disabled:
+        return enhanced_secondary_profiles
+    return _merge_dicts({'common': enhanced_common_profile}, enhanced_secondary_profiles)
+
+
+def _enhance_common_profile(common_profile):
+    common_profile['CP_CAP_SGE_QUEUE_NAME'] = os.getenv('CP_CAP_SGE_QUEUE_NAME', 'main.q')
+    common_profile['CP_CAP_SGE_QUEUE_STATIC'] = 'true'
+    common_profile['CP_CAP_SGE_QUEUE_DEFAULT'] = 'true'
+    common_profile['CP_CAP_AUTOSCALE_TASK'] = 'GridEngineAutoscaling'
+    return common_profile
+
+
+def _enhance_secondary_profiles(common_profile, profiles):
     for profile_index, profile in profiles.items():
         if 'CP_CAP_SGE_QUEUE_NAME' not in profile:
             if 'CP_CAP_AUTOSCALE_INSTANCE_TYPE' in profile:
@@ -20,43 +91,69 @@ def generate_sge_profiles():
                 profile['CP_CAP_SGE_QUEUE_NAME'] = '{}.q'.format(os.environ['instance_size'])
         if 'CP_CAP_AUTOSCALE' not in profile:
             profile['CP_CAP_AUTOSCALE'] = 'false'
-
     profile_indexes = profiles.keys()
     profile_queues = [profiles[index]['CP_CAP_SGE_QUEUE_NAME'] for index in profile_indexes]
-
-    def append_suffix(item, suffix):
-        return '{}.{}.q'.format(item if not item.endswith('.q') else item[:-2], suffix)
-
-    unique_profile_queues = suffix_non_unique(profile_queues, suffix_func=append_suffix)
-
+    unique_profile_queues = suffix_non_unique(profile_queues, suffix_func=_append_suffix)
     for profile_index, profile in profiles.items():
         profile['CP_CAP_SGE_QUEUE_NAME'] = unique_profile_queues[profile_indexes.index(profile_index)]
         profile['CP_CAP_SGE_HOSTLIST_NAME'] = '@{}'.format(profile['CP_CAP_SGE_QUEUE_NAME'])
+    for profile_index in profiles.keys():
+        profile = dict(common_profile)
+        profile.update(profiles[profile_index])
+        profiles[profile_index] = profile
+    return profiles
 
-    common_profile['CP_CAP_SGE_QUEUE_STATIC'] = 'true'
-    common_profile['CP_CAP_SGE_QUEUE_DEFAULT'] = 'true'
-    common_profile['CP_CAP_AUTOSCALE_TASK'] = 'GridEngineAutoscaling'
 
-    logging.info('Generating sge profile scripts...')
-    profiles_directory = os.getenv('CP_CAP_SCRIPTS_DIR', '/common/cap_scripts')
-    complete_profiles = {}
-    if os.getenv('CP_CAP_SGE_DISABLE_DEFAULT_QUEUE', 'false').lower() not in ['true', 'yes']:
-        complete_profiles['common'] = common_profile
-    complete_profiles.update(profiles)
-    for profile_index, profile in complete_profiles.items():
-        logging.info('Profile %s environment:', profile_index)
-        for key, value in profile.items():
-            logging.info('%s=%s', key, value)
-        profile_script_name = 'sge_profile_{}.sh'.format(profile['CP_CAP_SGE_QUEUE_NAME'])
-        profile_script_path = os.path.join(profiles_directory, profile_script_name)
+def _append_suffix(item, suffix):
+    return '{}.{}.q'.format(item if not item.endswith('.q') else item[:-2], suffix)
+
+
+def _merge_dicts(left, right):
+    profiles = dict()
+    profiles.update(left)
+    profiles.update(right)
+    return profiles
+
+
+def _write_profiles(profiles, params, cap_scripts_dir, logger):
+    logger.debug('')
+    logger.debug('Writing grid engine profile scripts...')
+    for profile_index, profile in profiles.items():
+        logger.debug('')
+        logger.debug('Profile {} environment:'.format(profile_index))
+        for param_name in sorted(profile):
+            param_value = profile.get(param_name)
+            logger.debug('{}={}'.format(param_name, param_value))
+        profile_queue_name = profile.get('CP_CAP_SGE_QUEUE_NAME')
+        profile_script_name = 'sge_profile_{}.sh'.format(profile_queue_name)
+        profile_script_path = os.path.join(cap_scripts_dir, profile_script_name)
         with open(profile_script_path, 'w') as f:
-            for key, value in profile.items():
-                f.write('export {}="{}"\n'.format(key, value))
+            f.write("""# Grid Engine {} queue profile.
+# 
+# Please use this configuration file to modify 
+# the corresponding grid engine queue's autoscaling.
+# 
+# Below you can find all the available configuration parameters.
+# Change already existing parameters or configure additional ones 
+# by uncommenting the corresponding lines and setting proper values.
+
+""".format(profile_queue_name))
+            for param_name in sorted(params):
+                param = params.get(param_name)
+                param_help = param.help
+                param_value = profile.get(param_name)
+                if param_help:
+                    f.write('# ' + param_help.replace('\n', '\n# ') + '\n')
+                if param_value:
+                    f.write('export {}="{}"\n\n'.format(param_name, param_value))
+                else:
+                    f.write('# export {}=""\n\n'.format(param_name))
+            for param_name in sorted(profile):
+                if param_name in params:
+                    continue
+                param_value = profile.get(param_name)
+                f.write('export {}="{}"\n'.format(param_name, param_value))
 
 
 if __name__ == '__main__':
-    log_level = os.getenv('CP_CAP_SGE_PROFILE_GENERATION_LOGGING_LEVEL', logging.getLevelName(logging.ERROR))
-
-    logging.basicConfig(level=log_level, format=_LOGGING_FORMAT)
-
     generate_sge_profiles()

--- a/workflows/pipe-common/scripts/generate_sge_profiles.py
+++ b/workflows/pipe-common/scripts/generate_sge_profiles.py
@@ -14,6 +14,7 @@
 
 import logging
 import os
+import sys
 import traceback
 
 from pipeline.api import PipelineAPI
@@ -35,8 +36,19 @@ def generate_sge_profiles():
     cap_scripts_dir = os.getenv('CP_CAP_SCRIPTS_DIR', '/common/cap_scripts')
     default_queue_disabled = os.getenv('CP_CAP_SGE_DISABLE_DEFAULT_QUEUE', 'false').lower() == 'true'
 
-    logging.basicConfig(level=logging_level_local, format=logging_format,
-                        filename=os.path.join(logging_dir, logging_file))
+    logging_formatter = logging.Formatter(logging_format)
+
+    logging.getLogger().setLevel(logging_level_local)
+
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setLevel(logging_level_local)
+    console_handler.setFormatter(logging_formatter)
+    logging.getLogger().addHandler(console_handler)
+
+    file_handler = logging.FileHandler(os.path.join(logging_dir, logging_file))
+    file_handler.setLevel(logging_level_local)
+    file_handler.setFormatter(logging_formatter)
+    logging.getLogger().addHandler(file_handler)
 
     api = PipelineAPI(api_url=api_url, log_dir=logging_dir)
     logger = RunLogger(api=api, run_id=run_id)
@@ -129,12 +141,12 @@ def _write_profiles(profiles, params, cap_scripts_dir, logger):
         profile_script_path = os.path.join(cap_scripts_dir, profile_script_name)
         with open(profile_script_path, 'w') as f:
             f.write("""# Grid Engine {} queue profile.
-# 
-# Please use this configuration file to modify 
+#
+# Please use this configuration file to modify
 # the corresponding grid engine queue's autoscaling.
-# 
+#
 # Below you can find all the available configuration parameters.
-# Change already existing parameters or configure additional ones 
+# Change already existing parameters or configure additional ones
 # by uncommenting the corresponding lines and setting proper values.
 
 """.format(profile_queue_name))

--- a/workflows/pipe-common/shell/sge_configure
+++ b/workflows/pipe-common/shell/sge_configure
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"$CP_PYTHON2_PATH" "$COMMON_REPO_DIR/scripts/configure_sge_profiles_interactively.py"

--- a/workflows/pipe-common/shell/sge_setup_master
+++ b/workflows/pipe-common/shell/sge_setup_master
@@ -479,7 +479,7 @@ else
     pipe_log_success "All execution hosts are connected" "$SGE_MASTER_SETUP_TASK_WORKERS"
 fi
 
-for sge_profile_script in $CP_CAP_SCRIPTS_DIR/sge_profile_*.sh; do
+for sge_profile_script in "$CP_CAP_SCRIPTS_DIR"/sge_profile_*.sh; do
     (
         # shellcheck source=/dev/null
         [[ -e "$sge_profile_script" ]] && source "$sge_profile_script"

--- a/workflows/pipe-common/shell/sge_setup_worker
+++ b/workflows/pipe-common/shell/sge_setup_worker
@@ -267,7 +267,7 @@ fi
 export _CP_CAP_SGE_DEFAULT_QUEUE_NAME="$CP_CAP_SGE_QUEUE_NAME"
 export _CP_CAP_SGE_DEFAULT_HOSTLIST_NAME="$CP_CAP_SGE_HOSTLIST_NAME"
 
-for sge_profile_script in $CP_CAP_SCRIPTS_DIR/sge_profile_*.sh; do
+for sge_profile_script in "$CP_CAP_SCRIPTS_DIR"/sge_profile_*.sh; do
     (
         # shellcheck source=/dev/null
         [[ -e "$sge_profile_script" ]] && source "$sge_profile_script"


### PR DESCRIPTION
Resolves #2977 and depends on #2959.

The pull request brings support for grid engine autoscalers interactive configuration.

In order to configure any grid engine queue autoscaling the following command shall be executed. It opens a corresponding configuration file in a text editor. User can change existing parameters or add additional ones. Once the text editor is closed the corresponding grid engine autoscaler restarts and the added changes applies.

```bash
# Configures grid engine queues using one of the available text editors nano/vi/vim
sge_configure

# Configures grid engine queues using vi text editor
VISUAL=vi sge_configure
EDITOR=vi sge_configure
```
