### PR TITLE
Issue #2975: Allow to manage the pipelines code/docs repo structure - slash fixes

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/git/PipelineRepositoryService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/PipelineRepositoryService.java
@@ -35,6 +35,7 @@ import com.epam.pipeline.entity.pipeline.Revision;
 import com.epam.pipeline.entity.template.Template;
 import com.epam.pipeline.exception.git.GitClientException;
 import com.epam.pipeline.exception.git.UnexpectedResponseStatusException;
+import com.epam.pipeline.manager.datastorage.providers.ProviderUtils;
 import com.epam.pipeline.utils.GitUtils;
 import joptsimple.internal.Strings;
 import lombok.extern.slf4j.Slf4j;
@@ -173,7 +174,8 @@ public class PipelineRepositoryService {
                                                   final String path, final int byteLimit) throws GitClientException {
         Assert.isTrue(StringUtils.isNotBlank(path), "File path can't be null");
         Assert.isTrue(StringUtils.isNotBlank(revision), "Revision can't be null");
-        return providerService.getTruncatedFileContents(pipeline, path, GitUtils.getRevisionName(revision), byteLimit);
+        return providerService.getTruncatedFileContents(pipeline, GitUtils.withoutLeadingDelimiter(path),
+                GitUtils.getRevisionName(revision), byteLimit);
     }
 
     public GitCredentials getPipelineCloneCredentials(final Pipeline pipeline, final boolean useEnvVars,
@@ -208,8 +210,8 @@ public class PipelineRepositoryService {
     public List<GitRepositoryEntry> getRepositoryContents(final Pipeline pipeline, final String path,
                                                           final String version, final boolean recursive,
                                                           final boolean showHiddenFiles) {
-        return ListUtils.emptyIfNull(providerService
-                .getRepositoryContents(pipeline, path, GitUtils.getRevisionName(version), recursive)).stream()
+        return ListUtils.emptyIfNull(providerService.getRepositoryContents(pipeline,
+                GitUtils.withoutLeadingDelimiter(path), GitUtils.getRevisionName(version), recursive)).stream()
                 .filter(entry -> showHiddenFiles || !entry.getName().startsWith(Constants.DOT))
                 .collect(Collectors.toList());
     }
@@ -333,7 +335,9 @@ public class PipelineRepositoryService {
                 : String.format("Updating files %s", sourceItemVOList.getItems().stream()
                 .map(PipelineSourceItemVO::getPath)
                 .collect(Collectors.joining(", ")));
-        sourceItemVOList.getItems().forEach(sourceItemVO -> validateFilePath(sourceItemVO.getPath()));
+        sourceItemVOList.getItems().stream()
+                .peek(sourceItemVO -> sourceItemVO.setPath(GitUtils.withoutLeadingDelimiter(sourceItemVO.getPath())))
+                .forEach(sourceItemVO -> validateFilePath(sourceItemVO.getPath()));
 
         return providerService.updateFiles(pipeline, sourceItemVOList, message);
     }
@@ -374,7 +378,8 @@ public class PipelineRepositoryService {
                                    final String path, final String revision, final String token) {
         Assert.isTrue(StringUtils.isNotBlank(path), "File path can't be null");
         Assert.isTrue(StringUtils.isNotBlank(revision), "Revision can't be null");
-        return providerService.getFileContents(repositoryType, repository, path, revision, token);
+        return providerService
+                .getFileContents(repositoryType, repository, GitUtils.withoutLeadingDelimiter(path), revision, token);
     }
 
     private void uploadFolder(final RepositoryType repositoryType, final Template template,
@@ -507,7 +512,8 @@ public class PipelineRepositoryService {
         if (StringUtils.isBlank(folder) || folder.equals(Constants.PATH_DELIMITER)) {
             return fileName;
         }
-        return folder + Constants.PATH_DELIMITER + fileName;
+        final String folderPath = GitUtils.withoutLeadingDelimiter(ProviderUtils.withoutTrailingDelimiter(folder));
+        return folderPath + Constants.PATH_DELIMITER + fileName;
     }
 
     private void validateFilePath(final String path) {

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -310,9 +310,9 @@ public class SystemPreferences {
     public static final BooleanPreference GITLAB_HASHED_REPO_SUPPORT = new BooleanPreference(
             "git.gitlab.hashed.repo.support", false, GIT_GROUP, pass);
     public static final StringPreference GITLAB_DEFAULT_SRC_DIRECTORY = new StringPreference(
-            "gitlab.default.src.directory", "/src/", GIT_GROUP, pass);
+            "gitlab.default.src.directory", "src/", GIT_GROUP, pass);
     public static final StringPreference GITLAB_DEFAULT_DOC_DIRECTORY = new StringPreference(
-            "gitlab.default.doc.directory", "/docs/", GIT_GROUP, pass);
+            "gitlab.default.doc.directory", "docs/", GIT_GROUP, pass);
     public static final StringPreference BITBUCKET_DEFAULT_SRC_DIRECTORY = new StringPreference(
             "bitbucket.default.src.directory", "/", GIT_GROUP, pass);
     public static final StringPreference BITBUCKET_DEFAULT_DOC_DIRECTORY = new StringPreference(

--- a/api/src/main/java/com/epam/pipeline/utils/GitUtils.java
+++ b/api/src/main/java/com/epam/pipeline/utils/GitUtils.java
@@ -16,6 +16,7 @@
 
 package com.epam.pipeline.utils;
 
+import com.epam.pipeline.manager.datastorage.providers.ProviderUtils;
 import org.apache.commons.lang.StringUtils;
 
 import java.util.regex.Matcher;
@@ -78,5 +79,12 @@ public final class GitUtils {
 
     public static String getBranchRefOrDefault(final String branch) {
         return String.format(BRANCH_REF_PATTERN, StringUtils.isNotBlank(branch) ? branch : GIT_MASTER_REPOSITORY);
+    }
+
+    public static String withoutLeadingDelimiter(final String path) {
+        if (StringUtils.isBlank(path) || ProviderUtils.DELIMITER.equals(path)) {
+            return path;
+        }
+        return ProviderUtils.withoutLeadingDelimiter(path);
     }
 }


### PR DESCRIPTION
The current PR provides fixes for issue #2975 

The following changes were adde:
 - leading `/` shall be trimmed for all gitlab queries with file path
 - fixed string concatenation issue in `POST pipeline/<ID>/file/upload?path=<path with ending slash>` method 