### PR TITLE
Improve grid engine autoscalers interactive configuration

### DIFF
--- a/workflows/pipe-common/shell/sge_setup_master
+++ b/workflows/pipe-common/shell/sge_setup_master
@@ -424,7 +424,7 @@ create_execution_host
 
 "$CP_PYTHON2_PATH" "$COMMON_REPO_DIR/scripts/generate_sge_profiles.py"
 
-for sge_profile_script in "$CP_CAP_SCRIPTS_DIR"/sge_profile_*.sh; do
+for sge_profile_script in "$CP_CAP_SCRIPTS_DIR"/sge_profile_*_queue.sh; do
     (
         # shellcheck source=/dev/null
         [[ -e "$sge_profile_script" ]] && source "$sge_profile_script"
@@ -479,7 +479,7 @@ else
     pipe_log_success "All execution hosts are connected" "$SGE_MASTER_SETUP_TASK_WORKERS"
 fi
 
-for sge_profile_script in "$CP_CAP_SCRIPTS_DIR"/sge_profile_*.sh; do
+for sge_profile_script in "$CP_CAP_SCRIPTS_DIR"/sge_profile_*_queue.sh; do
     (
         # shellcheck source=/dev/null
         [[ -e "$sge_profile_script" ]] && source "$sge_profile_script"

--- a/workflows/pipe-common/shell/sge_setup_worker
+++ b/workflows/pipe-common/shell/sge_setup_worker
@@ -267,7 +267,7 @@ fi
 export _CP_CAP_SGE_DEFAULT_QUEUE_NAME="$CP_CAP_SGE_QUEUE_NAME"
 export _CP_CAP_SGE_DEFAULT_HOSTLIST_NAME="$CP_CAP_SGE_HOSTLIST_NAME"
 
-for sge_profile_script in "$CP_CAP_SCRIPTS_DIR"/sge_profile_*.sh; do
+for sge_profile_script in "$CP_CAP_SCRIPTS_DIR"/sge_profile_*_queue.sh; do
     (
         # shellcheck source=/dev/null
         [[ -e "$sge_profile_script" ]] && source "$sge_profile_script"


### PR DESCRIPTION
Relates to #2977.

The pull request brings several improvements to grid engine autoscalers interactive configuration:

1. Splits grid engine profiles into queue and autoscaling profiles. Only autoscaling profile is interactively configured.
2. Adds updated profile parameters logging.
3. Skips grid engine autoscaling restarts if the corresponding profile has not been changed.
