### PR TITLE
Issue 2995 Fix routing for wetty app

### DIFF
--- a/deploy/docker/cp-edge/wetty/app.js
+++ b/deploy/docker/cp-edge/wetty/app.js
@@ -259,7 +259,7 @@ process.on('uncaughtException', function(e) {
 });
 
 const app = express();
-app.get('/ssh/pipeline/:pipeline', function(req, res) {
+app.get('/ssh/pipeline/*', function(req, res) {
     res.sendfile(__dirname + '/public/ssh/index.html');
 });
 app.use('/', express.static(path.join(__dirname, 'public')));


### PR DESCRIPTION
This PR solves issue #2995 by simply changing routing.

Instead of mapping to 
`/ssh/pipeline/:pipeline` where `:pipeline` means only one part of the path
we will now map to
`/ssh/pipeline/*` where `*` means whole 'tail' of the url path
Such approach will allow to use pretty-ssh urls like: `some/pretty/url`

Since we actually doesn't use `:pipeline` named parameter, and calculate all necessary info by our self, we can safely make this changes 