### PR TITLE
Pipeline CLI: update operation fix

### DIFF
--- a/pipe-cli/build_windows.sh
+++ b/pipe-cli/build_windows.sh
@@ -146,7 +146,8 @@ pyinstaller --add-data "/pipe-cli/res/effective_tld_names.dat.txt;tld/res/" \
             --icon /pipe-cli/res/cloud-pipeline.ico \
             --name pipe-cli && \
 cd /pipe-cli/dist/win64 && \
-cp /pipe-cli/pipe.bat pipe/ && \
+cp /pipe-cli/pipe.bat pipe-cli/ && \
+mv pipe-cli pipe && \
 zip -r -q pipe.zip pipe
 EOL
 

--- a/pipe-cli/build_windows.sh
+++ b/pipe-cli/build_windows.sh
@@ -143,7 +143,8 @@ pyinstaller --add-data "/pipe-cli/res/effective_tld_names.dat.txt;tld/res/" \
             --add-data "/pipe-cli/ntlmaps;ntlmaps" \
             --add-data "/tmp/mount/dist/pipe-fuse;mount" \
             --version-file /tmp/pipe-win-version-info.txt \
-            --icon /pipe-cli/res/cloud-pipeline.ico && \
+            --icon /pipe-cli/res/cloud-pipeline.ico \
+            --name pipe-cli && \
 cd /pipe-cli/dist/win64 && \
 cp /pipe-cli/pipe.bat pipe/ && \
 zip -r -q pipe.zip pipe

--- a/pipe-cli/build_windows.sh
+++ b/pipe-cli/build_windows.sh
@@ -78,7 +78,7 @@ _BUILD_SCRIPT_NAME=/tmp/build_pytinstaller_win64_$(date +%s).sh
 
 cat >$_BUILD_SCRIPT_NAME <<'EOL'
 
-version_file="${PIPE_CLI_SOURCES_DIR}/src/version.py"
+version_file="/pipe-cli/src/version.py"
 sed -i '/__component_version__/d' \$version_file
 echo "__component_version__='\${PIPE_COMMIT_HASH}'" >> \$version_file
 
@@ -145,6 +145,7 @@ pyinstaller --add-data "/pipe-cli/res/effective_tld_names.dat.txt;tld/res/" \
             --version-file /tmp/pipe-win-version-info.txt \
             --icon /pipe-cli/res/cloud-pipeline.ico && \
 cd /pipe-cli/dist/win64 && \
+cp /pipe-cli/pipe.bat pipe/ && \
 zip -r -q pipe.zip pipe
 EOL
 

--- a/pipe-cli/pipe.bat
+++ b/pipe-cli/pipe.bat
@@ -1,0 +1,11 @@
+@echo off
+
+set all_args=%*
+set first_arg=%1
+
+if "%first_arg%" == "update" (
+	for /f "delims=" %%i in ('pipe.exe %all_args%') do set bat_file_path=%%i
+	bat_file_path
+) else (
+	pipe.exe %all_args%
+)

--- a/pipe-cli/pipe.bat
+++ b/pipe-cli/pipe.bat
@@ -17,12 +17,13 @@ SETLOCAL
 
 set all_args=%*
 set first_arg=%1
+set update_bat=pipe-cli-update.bat
 
 if "%first_arg%" == "update" (
     set "CP_CLI_UPDATE_WRAPPER=true"
 	pipe.exe %all_args%
-    if exist %CP_CLI_UPDATE_BAT% (
-	    %CP_CLI_UPDATE_BAT%
+    if exist %update_bat% (
+	    %update_bat%
 	)
 ) else (
 	pipe.exe %all_args%

--- a/pipe-cli/pipe.bat
+++ b/pipe-cli/pipe.bat
@@ -1,11 +1,29 @@
+:: Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+::
+:: Licensed under the Apache License, Version 2.0 (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+::
+::    http://www.apache.org/licenses/LICENSE-2.0
+::
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+
 @echo off
 
 set all_args=%*
 set first_arg=%1
 
 if "%first_arg%" == "update" (
-	for /f "delims=" %%i in ('pipe.exe %all_args%') do set bat_file_path=%%i
-	bat_file_path
+    setx CP_CLI_UPDATE_WRAPPER="true"
+	pipe.exe %all_args%'
+	set update_bat=%userprofile%\.pipe\tmp\pipe-cli-update.bat
+	if exist %update_bat% (
+	    %update_bat%
+	)
 ) else (
 	pipe.exe %all_args%
 )

--- a/pipe-cli/pipe.bat
+++ b/pipe-cli/pipe.bat
@@ -13,16 +13,16 @@
 :: limitations under the License.
 
 @echo off
+SETLOCAL
 
 set all_args=%*
 set first_arg=%1
 
 if "%first_arg%" == "update" (
-    setx CP_CLI_UPDATE_WRAPPER="true"
-	pipe.exe %all_args%'
-	set update_bat=%userprofile%\.pipe\tmp\pipe-cli-update.bat
-	if exist %update_bat% (
-	    %update_bat%
+    set "CP_CLI_UPDATE_WRAPPER=true"
+	pipe.exe %all_args%
+    if exist %CP_CLI_UPDATE_BAT% (
+	    %CP_CLI_UPDATE_BAT%
 	)
 ) else (
 	pipe.exe %all_args%

--- a/pipe-cli/pipe.bat
+++ b/pipe-cli/pipe.bat
@@ -21,10 +21,10 @@ set update_bat=pipe-cli-update.bat
 
 if "%first_arg%" == "update" (
     set "CP_CLI_UPDATE_WRAPPER=true"
-	pipe.exe %all_args%
+	pipe-cli.exe %all_args%
     if exist %update_bat% (
 	    %update_bat%
 	)
 ) else (
-	pipe.exe %all_args%
+	pipe-cli.exe %all_args%
 )

--- a/pipe-cli/src/utilities/update_cli_version.py
+++ b/pipe-cli/src/utilities/update_cli_version.py
@@ -206,6 +206,7 @@ class WindowsUpdater(CLIVersionUpdater):
             os.remove(path_to_update_bat)
         with open(path_to_update_bat, 'a') as bat_file:
             bat_file.write(bat_file_content)
+        os.environ['CP_CLI_UPDATE_BAT'] = path_to_update_bat
 
     def download_new_src(self, path, prefix):
         tmp_folder = self.get_tmp_folder()

--- a/pipe-cli/src/utilities/update_cli_version.py
+++ b/pipe-cli/src/utilities/update_cli_version.py
@@ -40,6 +40,7 @@ class UpdateCLIVersionManager(object):
         if not need_to_update_version():
             click.echo("The Cloud Pipeline CLI version is up-to-date")
             return
+
         updater = self.get_updater()
 
         if not path:
@@ -131,10 +132,10 @@ class WindowsUpdater(CLIVersionUpdater):
         random_prefix = str(uuid.uuid4()).replace("-", "")
 
         tmp_folder = self.get_tmp_folder()
-        self.check_write_permissions(tmp_folder)
+        self.check_write_permissions(tmp_folder, random_prefix)
 
         path_to_src_dir = os.path.dirname(sys.executable)
-        self.check_write_permissions(path_to_src_dir)
+        self.check_write_permissions(path_to_src_dir, random_prefix)
 
         tmp_src_dir = self.download_new_src(path, random_prefix)
         pipe_bat = os.path.join(tmp_src_dir, self.WRAPPER_BAT)
@@ -145,7 +146,8 @@ class WindowsUpdater(CLIVersionUpdater):
 
         log_file_path = os.path.join(tmp_folder, self.LOG_FILE)
         with open(log_file_path, 'a') as log_file:
-            log_file.write('[%s] Starting a new update operation\n' % (datetime.now().strftime("%d/%m/%Y %H:%M:%S")))
+            log_file.write('[%s] Starting a new update operation %s\n' % (datetime.now().strftime("%d/%m/%Y %H:%M:%S"),
+                                                                          random_prefix))
 
         bat_file_content = """@echo off
         for /L %%a in (1,1,{attempts_count}) do (
@@ -229,10 +231,9 @@ class WindowsUpdater(CLIVersionUpdater):
         return tmp_folder
 
     @staticmethod
-    def check_write_permissions(path):
-        random_prefix = str(uuid.uuid4()).replace("-", "")
+    def check_write_permissions(path, prefix):
         try:
-            path_to_tmp_file = os.path.join(path, "tmp-%s" % random_prefix)
+            path_to_tmp_file = os.path.join(path, "tmp-%s" % prefix)
             with open(path_to_tmp_file, 'a') as tmp_file:
                 tmp_file.write("")
             os.remove(path_to_tmp_file)

--- a/pipe-cli/src/utilities/update_cli_version.py
+++ b/pipe-cli/src/utilities/update_cli_version.py
@@ -22,6 +22,7 @@ import requests
 import platform
 import zipfile
 import uuid
+import shutil
 from datetime import datetime
 
 from src.config import Config
@@ -201,6 +202,8 @@ class WindowsUpdater(CLIVersionUpdater):
                    src_dir=path_to_src_dir,
                    tmp_dir=tmp_src_dir,
                    pipe_bat=self.WRAPPER_BAT)
+        if os.path.exists(path_to_update_bat):
+            os.remove(path_to_update_bat)
         with open(path_to_update_bat, 'a') as bat_file:
             bat_file.write(bat_file_content)
 
@@ -210,6 +213,8 @@ class WindowsUpdater(CLIVersionUpdater):
         request = requests.get(path, verify=False)
         open(path_to_zip, 'wb').write(request.content)
         tmp_src_dir = os.path.join(tmp_folder, prefix)
+        if os.path.exists(tmp_src_dir):
+            shutil.rmtree(tmp_src_dir)
         with zipfile.ZipFile(path_to_zip, 'r') as zip_ref:
             zip_ref.extractall(tmp_src_dir)
         os.remove(path_to_zip)

--- a/pipe-cli/src/utilities/update_cli_version.py
+++ b/pipe-cli/src/utilities/update_cli_version.py
@@ -158,18 +158,20 @@ class WindowsUpdater(CLIVersionUpdater):
                 echo The source subfolders were deleted >> "{log_file}"
                 for %%a in ("{src_dir}\\*") do (
 	                if /i not "%%~nxa" == "{pipe_bat}" (
-	                    del /q "%%a" >> "{log_file}" 2>>&1 || (
-                            echo Failed to delete src file "%%a" >> "{log_file}"
-                            goto fail
-                        )
+	                    if /i not "%%~nxa" == "{update_bat}" (
+                            del /q "%%a" >> "{log_file}" 2>>&1 || (
+                                echo Failed to delete src file "%%a" >> "{log_file}"
+                                goto fail
+                            )
+                        )    
 	                )
 	            )
                 echo The source files were deleted >> "{log_file}"
                 xcopy "{tmp_dir}\\pipe" "{src_dir}" /y /s /i > nul 2>> "{log_file}" || (
-                    echo Failed to copy files from "{tmp_dir}/pipe" to "{src_dir}" >> "{log_file}"
+                    echo Failed to copy files from "{tmp_dir}\\pipe" to "{src_dir}" >> "{log_file}"
                     goto fail
                 )
-                echo Files successfully copied from "{tmp_dir}/pipe" to "{src_dir}" >> "{log_file}"
+                echo Files successfully copied from "{tmp_dir}\\pipe" to "{src_dir}" >> "{log_file}"
                 rd /s /q "{tmp_dir}" || (
                     echo Failed to delete tmp directory '{tmp_dir}' >> "{log_file}"
                     goto fail
@@ -198,7 +200,8 @@ class WindowsUpdater(CLIVersionUpdater):
                    pipe_pid=os.getpid(),
                    src_dir=path_to_src_dir,
                    tmp_dir=tmp_src_dir,
-                   pipe_bat=self.WRAPPER_BAT)
+                   pipe_bat=self.WRAPPER_BAT,
+                   update_bat=self.UPDATE_SCRIPT)
         if os.path.exists(path_to_update_bat):
             os.remove(path_to_update_bat)
         with open(path_to_update_bat, 'a') as bat_file:

--- a/pipe-cli/src/utilities/update_cli_version.py
+++ b/pipe-cli/src/utilities/update_cli_version.py
@@ -37,7 +37,9 @@ class UpdateCLIVersionManager(object):
         pass
 
     def update(self, path=None):
-        # TODO: revert changes after debug
+        if not need_to_update_version():
+            click.echo("The Cloud Pipeline CLI version is up-to-date")
+            return
         updater = self.get_updater()
 
         if not path:


### PR DESCRIPTION
## Background 

Currently, `pipe update` operation for Windows OS takes a long time after releasing the console. Such behavior can lead to confusion and the user can start using the `pipe` before it is completely updated. This situation may result in an unexpected error.

The current PR provides fix for this issue.

## Approach

- a new static `pipe.bat` file shall be created in distribution directory. This file shall wrap currently existing Pipeline CLI.
- `pipe update` operation shall be possible from wrapper only (if envvar `CP_CLI_UPDATE_WRAPPER=true` specified)
- `pipe.exe` renamed to `pipe-cli.exe` to allow access to the Pipeline CLI via `pipe`