### PR TITLE
AWS EFA support

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/cluster/AMIConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/entity/cluster/AMIConfiguration.java
@@ -1,11 +1,10 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
- *
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,28 +21,22 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.util.List;
 import java.util.Map;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class NetworkConfiguration {
+public class AMIConfiguration {
 
-    private Long regionId;
-    private String name;
+    private String platform;
 
-    @JsonProperty("default")
-    private Boolean defaultRegion;
+    @JsonProperty("instance_mask")
+    private String instanceMask;
+    private String ami;
 
-    @JsonProperty("networks")
-    private Map<String, String> allowedNetworks;
+    @JsonProperty("run_parameters")
+    private Map<String, Object> runParameters;
 
-    @JsonProperty("security_group_ids")
-    private List<String> securityGroups;
 
-    private List<AMIConfiguration> amis;
-
-    private List<SwapConfiguration> swap;
 }

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineConfigurationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineConfigurationManager.java
@@ -18,6 +18,8 @@ package com.epam.pipeline.manager.pipeline;
 
 import com.epam.pipeline.common.MessageConstants;
 import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.entity.cluster.AMIConfiguration;
+import com.epam.pipeline.entity.cluster.CloudRegionsConfiguration;
 import com.epam.pipeline.entity.configuration.ConfigurationEntry;
 import com.epam.pipeline.entity.configuration.PipeConfValueVO;
 import com.epam.pipeline.entity.configuration.PipelineConfiguration;
@@ -28,12 +30,15 @@ import com.epam.pipeline.entity.pipeline.PipelineType;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.Tool;
 import com.epam.pipeline.entity.pipeline.run.PipelineStart;
+import com.epam.pipeline.entity.region.AbstractCloudRegion;
 import com.epam.pipeline.entity.utils.DefaultSystemParameter;
 import com.epam.pipeline.exception.git.GitClientException;
 import com.epam.pipeline.manager.docker.ToolVersionManager;
 import com.epam.pipeline.manager.git.GitManager;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
+import com.epam.pipeline.manager.region.CloudRegionManager;
+import com.epam.pipeline.manager.utils.RegExpUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
@@ -50,6 +55,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 @Service
 @Slf4j
@@ -83,6 +89,9 @@ public class PipelineConfigurationManager {
 
     @Autowired
     private PreferenceManager preferenceManager;
+
+    @Autowired
+    private CloudRegionManager regionManager;
 
     public PipelineConfiguration getPipelineConfigurationForPipeline(final Pipeline pipeline,
                                                                      final PipelineStart runVO) {
@@ -121,6 +130,13 @@ public class PipelineConfigurationManager {
         if (toolRun) {
             mergeParametersFromTool(configuration, tool);
         }
+
+        getParametersFromNetworkConfig(runVO.getInstanceType(), runVO.getCloudRegionId())
+                .forEach((key, parameter) -> {
+                    if(configuration.getParameters().containsKey(key)) {
+                        configuration.getParameters().put(key, parameter);
+                    }
+                });
 
         //client always sends actual node count value
         configuration.setNodeCount(Optional.ofNullable(runVO.getNodeCount()).orElse(0));
@@ -322,6 +338,42 @@ public class PipelineConfigurationManager {
         }
         configuration.buildEnvVariables();
         return configuration;
+    }
+
+    private Map<String, PipeConfValueVO> getParametersFromNetworkConfig(final String instanceType,
+                                                                        final Long cloudRegionId) {
+        final Map<String, PipeConfValueVO> parameters = new HashMap<>();
+        final AbstractCloudRegion runRegion = regionManager.loadOrDefault(cloudRegionId);
+        final CloudRegionsConfiguration cloudRegionsConfiguration = preferenceManager.getPreference(
+                SystemPreferences.CLUSTER_NETWORKS_CONFIG);
+
+        if (cloudRegionsConfiguration == null) {
+            return Collections.emptyMap();
+        }
+
+        ListUtils.emptyIfNull(cloudRegionsConfiguration.getRegions())
+                .stream()
+                .filter(r -> runRegion.getRegionCode().equals(r.getName()) || runRegion.getId().equals(r.getRegionId()))
+                .flatMap(networkConfiguration -> ListUtils.emptyIfNull(networkConfiguration.getAmis()).stream())
+                .filter(
+                        ami -> {
+                            final String instanceRegExp = RegExpUtils.getRegExpFormGlob(ami.getInstanceMask());
+                            return Pattern.compile(instanceRegExp).matcher(instanceType).find();
+                        }
+                ).findFirst()
+                .map(AMIConfiguration::getRunParameters)
+                .ifPresent(p -> p.forEach((k, v) -> parameters.put(k, buildPipeConfValue(v))));
+        return parameters;
+    }
+
+    private static PipeConfValueVO buildPipeConfValue(Object value) {
+        String type = PipeConfValueVO.DEFAULT_TYPE;
+        if (value instanceof Integer || value instanceof Long) {
+            type = "int";
+        } else if (value instanceof Boolean) {
+            type = "boolean";
+        }
+        return new PipeConfValueVO(value.toString(), type);
     }
 
     private static boolean hasBooleanParameter(PipelineConfiguration entry, String parameterName) {

--- a/api/src/main/java/com/epam/pipeline/manager/utils/RegExpUtils.java
+++ b/api/src/main/java/com/epam/pipeline/manager/utils/RegExpUtils.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.utils;
+
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@SuppressWarnings({"HideUtilityClassConstructor"})
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RegExpUtils {
+    public static String getRegExpFormGlob(final String glob) {
+        return glob.replace(".", "\\.")
+                .replace("*", ".*")
+                .replace("?", ".");
+    }
+}

--- a/deploy/contents/install/preferences/cluster.run.parameters.mapping.json
+++ b/deploy/contents/install/preferences/cluster.run.parameters.mapping.json
@@ -17,5 +17,9 @@
     },
     "CP_NODE_SSH_PORT": {
         "argumentName": "--node_ssh_port"
+    },
+    "CP_CAP_EFA_ENABLED": {
+        "argumentName": "--performance_network",
+        "type": "BOOLEAN"
     }
 }

--- a/deploy/contents/install/preferences/launch.system.parameters.json
+++ b/deploy/contents/install/preferences/launch.system.parameters.json
@@ -527,20 +527,34 @@
         "type": "string",
         "description": "Specifies which security groups shall be attached to the instance",
         "defaultValue": "",
-        "passToWorkers": false
+        "passToWorkers": true
     },
     {
         "name": "CP_CAP_TARGET_SUBNET_ID",
         "type": "string",
         "description": "Specifies which subnet shall be used for an instance",
         "defaultValue": "",
-        "passToWorkers": false
+        "passToWorkers": true
     },
     {
         "name": "CP_NODE_SSH_PORT",
         "type": "int",
         "description": "Sets SSH port, which is used by a host node of the job",
         "defaultValue": "22",
-        "passToWorkers": false
+        "passToWorkers": true
+    },
+    {
+        "name": "CP_CAP_EFA_ENABLED",
+        "type": "boolean",
+        "description": "Specifies if EFA should be enabled for this instance",
+        "defaultValue": "false",
+        "passToWorkers": true
+    },
+    {
+        "name": "CP_USE_HOST_NETWORK",
+        "type": "boolean",
+        "description": "Specifies if run pod should be run with host network capability",
+        "defaultValue": "false",
+        "passToWorkers": true
     }
 ]

--- a/scripts/autoscaling/aws/nodeup.py
+++ b/scripts/autoscaling/aws/nodeup.py
@@ -15,6 +15,7 @@
 import argparse
 import base64
 import socket
+import random
 from datetime import datetime, timedelta
 from time import sleep
 import boto3
@@ -388,50 +389,42 @@ def get_specified_subnet(subnet, availability_zone):
     return subnet
 
 
+def get_random_subnet(ec2):
+    subnets = ec2.describe_subnets()
+    if "Subnets" in subnets:
+        return random.choice(subnets['Subnets'])['SubnetId']
+    return None
+
+
 def run_instance(api_url, api_token, api_user, bid_price, ec2, aws_region, ins_hdd, kms_encyr_key_id, ins_img, ins_platform, ins_key, ins_type,
                  is_spot, num_rep, run_id, pool_id, time_rep, kube_ip, kubeadm_token, kubeadm_cert_hash, kube_node_token, kube_client,
                  global_distribution_url, pre_pull_images, instance_additional_spec,
-                 availability_zone, security_groups, subnet, network_interface, is_dedicated, node_ssh_port):
+                 availability_zone, security_groups, subnet, network_interface, is_dedicated, node_ssh_port, performance_network):
     swap_size = get_swap_size(aws_region, ins_type, is_spot)
     user_data_script = get_user_data_script(api_url, api_token, api_user, aws_region, ins_type, ins_img, ins_platform, kube_ip,
                                             kubeadm_token, kubeadm_cert_hash, kube_node_token,
                                             global_distribution_url, swap_size, pre_pull_images, node_ssh_port)
     if is_spot:
         ins_id, ins_ip = find_spot_instance(ec2, aws_region, bid_price, run_id, pool_id, ins_img, ins_type, ins_key, ins_hdd, kms_encyr_key_id,
-                                            user_data_script, num_rep, time_rep, swap_size, kube_client, instance_additional_spec, availability_zone, security_groups, subnet, network_interface, is_dedicated)
+                                            user_data_script, num_rep, time_rep, swap_size, kube_client, instance_additional_spec, availability_zone, security_groups, subnet, network_interface, is_dedicated, performance_network)
     else:
         ins_id, ins_ip = run_on_demand_instance(ec2, aws_region, ins_img, ins_key, ins_type, ins_hdd, kms_encyr_key_id, run_id, pool_id, user_data_script,
-                                                num_rep, time_rep, swap_size, kube_client, instance_additional_spec, availability_zone, security_groups, subnet, network_interface, is_dedicated)
+                                                num_rep, time_rep, swap_size, kube_client, instance_additional_spec, availability_zone, security_groups, subnet, network_interface, is_dedicated, performance_network)
     return ins_id, ins_ip
 
 
 def run_on_demand_instance(ec2, aws_region, ins_img, ins_key, ins_type, ins_hdd,
                            kms_encyr_key_id, run_id, pool_id, user_data_script, num_rep, time_rep, swap_size,
                            kube_client, instance_additional_spec, availability_zone, security_groups, subnet,
-                           network_interface, is_dedicated):
+                           network_interface, is_dedicated, performance_network):
     pipe_log('Creating on demand instance')
     allowed_networks = get_networks_config(ec2, aws_region, ins_type)
     additional_args = instance_additional_spec if instance_additional_spec else {}
 
     subnet_id = None
     az_name = None
-    if network_interface:
-        if subnet:
-            pipe_log('- Network interface specified. Desired subnet id {} will be ignored'.format(subnet))
-        network_interface, subnet_id, az_name = fetch_network_interface_info(ec2, network_interface, availability_zone, allowed_networks)
-        additional_args.update({
-            "NetworkInterfaces": [
-                {
-                    "DeviceIndex": 0,
-                    "NetworkInterfaceId": network_interface
-                }
-            ]
-        })
-    elif subnet:
-        additional_args.update({
-            'SubnetId': get_specified_subnet(subnet, availability_zone),
-            'SecurityGroupIds': get_security_groups(aws_region, security_groups)
-        })
+    if subnet:
+        subnet_id = get_specified_subnet(subnet, availability_zone)
     elif allowed_networks and len(allowed_networks) > 0:
         if availability_zone:
             pipe_log('- Desired availability zone {} was specified, trying to use it'.format(availability_zone))
@@ -445,6 +438,39 @@ def run_on_demand_instance(ec2, aws_region, ins_img, ins_key, ins_type, ins_hdd,
             az_name = allowed_networks.items()[az_num][0]
             subnet_id = allowed_networks.items()[az_num][1]
         pipe_log('- Networks list found, subnet {} in AZ {} will be used'.format(subnet_id, az_name))
+
+
+    if network_interface:
+        if subnet_id:
+            pipe_log('- Network interface specified. Desired subnet id {} and performance network config will be ignored.'.format(subnet_id))
+        network_interface, subnet_id, az_name = fetch_network_interface_info(ec2, network_interface, availability_zone, allowed_networks)
+        additional_args.update({
+            "NetworkInterfaces": [
+                {
+                    "DeviceIndex": 0,
+                    "NetworkInterfaceId": network_interface
+                }
+            ]
+        })
+    elif performance_network:
+        pipe_log('- Performance network requested.')
+        if not subnet or not subnet_id:
+            pipe_log('- Subnet is not specified, trying to get a random one...')
+            subnet_id = get_random_subnet(ec2)
+            pipe_log('- Subnet: {} will be used.'.format(subnet_id))
+
+        additional_args.update({
+            "NetworkInterfaces": [
+                {
+                    'DeleteOnTermination': True,
+                    'DeviceIndex': 0,
+                    'SubnetId': subnet_id if subnet_id else get_random_subnet(ec2),
+                    'Groups': get_security_groups(aws_region, security_groups),
+                    'InterfaceType': 'efa'
+                }
+            ]
+        })
+    elif subnet_id:
         additional_args.update({
             'SubnetId': subnet_id,
             'SecurityGroupIds': get_security_groups(aws_region, security_groups)
@@ -452,7 +478,6 @@ def run_on_demand_instance(ec2, aws_region, ins_img, ins_key, ins_type, ins_hdd,
     else:
         pipe_log('- Networks list NOT found, default subnet in random AZ will be used')
         additional_args.update({'SecurityGroupIds': get_security_groups(aws_region, security_groups)})
-    response = {}
 
     if is_dedicated:
         additional_args.update({
@@ -461,6 +486,7 @@ def run_on_demand_instance(ec2, aws_region, ins_img, ins_key, ins_type, ins_hdd,
             }
         })
 
+    response = {}
     try:
         response = ec2.run_instances(
             ImageId=ins_img,
@@ -1033,7 +1059,7 @@ def exit_if_spot_unavailable(run_id, last_status):
 def find_spot_instance(ec2, aws_region, bid_price, run_id, pool_id, ins_img, ins_type, ins_key,
                        ins_hdd, kms_encyr_key_id, user_data_script, num_rep, time_rep, swap_size, kube_client,
                        instance_additional_spec, availability_zone, security_groups, subnet, network_interface,
-                       is_dedicated):
+                       is_dedicated, performance_network):
     pipe_log('Creating spot request')
 
     pipe_log('- Checking spot prices for current region...')
@@ -1062,9 +1088,17 @@ def find_spot_instance(ec2, aws_region, bid_price, run_id, pool_id, ins_img, ins
             'UserData': base64.b64encode(user_data_script.encode('utf-8')).decode('utf-8'),
             'BlockDeviceMappings': get_block_devices(ec2, ins_img, ins_type, ins_hdd, kms_encyr_key_id, swap_size),
         }
+
+    subnet_id = None
+    if subnet:
+        subnet_id = get_specified_subnet(subnet, availability_zone)
+    elif allowed_networks and cheapest_zone in allowed_networks:
+        subnet_id = allowed_networks[cheapest_zone]
+        pipe_log('- Networks list found, subnet {} in AZ {} will be used'.format(subnet_id, cheapest_zone))
+
     if network_interface:
-        if subnet:
-            pipe_log('- Network interface specified. Desired subnet id {} will be ignored'.format(subnet))
+        if subnet_id:
+            pipe_log('- Network interface specified. Desired subnet id {} will be ignored'.format(subnet_id))
         network_interface, subnet_id, az_name = fetch_network_interface_info(ec2, network_interface, availability_zone, allowed_networks)
         specifications.update({
             "NetworkInterfaces": [
@@ -1074,17 +1108,31 @@ def find_spot_instance(ec2, aws_region, bid_price, run_id, pool_id, ins_img, ins
                 }
             ],
         })
-    elif subnet:
+    elif performance_network:
+        pipe_log('- Performance network requested.')
+        if not subnet or not subnet_id:
+            pipe_log('- Subnet is not specified, trying to get a random one...')
+            subnet_id = get_random_subnet(ec2)
+            pipe_log('- Subnet: {} will be used.'.format(subnet_id))
+
+        specifications.update({
+            "NetworkInterfaces": [
+                {
+                    'DeleteOnTermination': True,
+                    'DeviceIndex': 0,
+                    'SubnetId': subnet_id if subnet_id else get_random_subnet(ec2),
+                    'Groups': get_security_groups(aws_region, security_groups),
+                    'InterfaceType': 'efa'
+                }
+            ]
+        })
+    elif subnet_id:
         specifications.update({
             'SubnetId': get_specified_subnet(subnet, availability_zone),
             'SecurityGroupIds': get_security_groups(aws_region, security_groups)
         })
-    elif allowed_networks and cheapest_zone in allowed_networks:
-        subnet_id = allowed_networks[cheapest_zone]
-        pipe_log('- Networks list found, subnet {} in AZ {} will be used'.format(subnet_id, cheapest_zone))
-        specifications['SubnetId'] = subnet_id
-        specifications['SecurityGroupIds'] = get_security_groups(aws_region, security_groups)
-        specifications['Placement'] = { 'AvailabilityZone': cheapest_zone }
+        if cheapest_zone:
+            specifications['Placement'] = { 'AvailabilityZone': cheapest_zone }
     else:
         pipe_log('- Networks list NOT found or cheapest zone can not be determined, default subnet in a random AZ will be used')
         specifications['SecurityGroupIds'] = get_security_groups(aws_region, security_groups)
@@ -1350,6 +1398,7 @@ def main():
     parser.add_argument("--region_id", type=str, default=None)
     parser.add_argument("--availability_zone", type=str, required=False)
     parser.add_argument("--network_interface", type=str, required=False)
+    parser.add_argument("--performance_network", type=bool, required=False)
     parser.add_argument("--subnet_id", type=str, required=False)
     parser.add_argument("--security_groups", type=str, required=False)
     parser.add_argument("--dedicated", type=bool, required=False)
@@ -1381,6 +1430,7 @@ def main():
     region_id = args.region_id
     availability_zone = args.availability_zone
     network_interface = args.network_interface
+    performance_network = args.performance_network
     security_groups = args.security_groups
     subnet = args.subnet_id
     is_dedicated = args.dedicated if args.dedicated else False
@@ -1476,7 +1526,7 @@ def main():
             ins_id, ins_ip = run_instance(api_url, api_token, api_user, bid_price, ec2, aws_region, ins_hdd, kms_encyr_key_id, ins_img, ins_platform, ins_key, ins_type, is_spot,
                                           num_rep, run_id, pool_id, time_rep, kube_ip, kubeadm_token, kubeadm_cert_hash, kube_node_token, api,
                                           global_distribution_url, pre_pull_images, instance_additional_spec,
-                                          availability_zone, security_groups, subnet, network_interface, is_dedicated, node_ssh_port)
+                                          availability_zone, security_groups, subnet, network_interface, is_dedicated, node_ssh_port, performance_network)
 
         check_instance(ec2, ins_id, run_id, num_rep, time_rep, api)
 

--- a/scripts/pipeline-launch/launch.sh
+++ b/scripts/pipeline-launch/launch.sh
@@ -1997,6 +1997,28 @@ fi
 ######################################################
 
 ######################################################
+# Setup "EFA" support
+######################################################
+
+echo "Check if AWS EFA support is needed"
+echo "-"
+if [ "$CP_CAP_EFA_ENABLED" == "true" ]; then
+    echo "EFA support is requested, proceeding with installation..."
+    _LSPCI_INSTALL_COMMAND=
+    get_install_command_by_current_distr _LSPCI_INSTALL_COMMAND "pciutils"
+    eval "$_LSPCI_INSTALL_COMMAND"
+    if [ `lspci | grep -E "EFA|efa|Elastic Fabric Adapter" | wc -l` -gt 0 ]; then
+          efa_setup
+    else
+        echo "AWS EFA device cannot be found, drivers won't be installed"
+    fi
+else
+    echo "EFA support is not requested"
+fi
+
+######################################################
+
+######################################################
 # Setup "Singularity" support
 ######################################################
 

--- a/workflows/pipe-common/shell/efa_setup
+++ b/workflows/pipe-common/shell/efa_setup
@@ -40,9 +40,9 @@ fi
 EFA_SETUP_DIR="/opt/"
 
 cd $EFA_SETUP_DIR
-curl -O https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-latest.tar.gz \
-    && tar -xf aws-efa-installer-latest.tar.gz \
-    && rm -rf aws-efa-installer-latest.tar.gz \
+curl -O "${GLOBAL_DISTRIBUTION_URL}tools/efa/aws-efa-installer-1.21.0.tar.gz" \
+    && tar -xf aws-efa-installer-1.21.0.tar.gz \
+    && rm -rf aws-efa-installer-1.21.0.tar.gz \
     && cd aws-efa-installer \
     && ./efa_installer.sh -y --skip-kmod --skip-limit-conf --no-verify &> /dev/null
 

--- a/workflows/pipe-common/shell/efa_setup
+++ b/workflows/pipe-common/shell/efa_setup
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+EFA_SETUP_TASK=EFASupport
+
+pipe_log_info "Started AWS EFA Driver setup" "$EFA_SETUP_TASK"
+
+if [ -z "$CP_USE_HOST_NETWORK" ]; then
+  pipe_log_warn "CP_USE_HOST_NETWORK is not set. EFA capability may work unexpectedly or doesn't work at all!"
+fi
+
+if [ -z "$CP_NODE_SSH_PORT" ]; then
+  pipe_log_warn "CP_NODE_SSH_PORT is not set. EFA capability may work unexpectedly or doesn't work at all!"
+  if [ "$CP_USE_HOST_NETWORK" != "" ]; then
+    pipe_log_warn "CP_USE_HOST_NETWORK is set, but CP_NODE_SSH_PORT doesn't, so ssh to the run can be misconfigured and doesn't work!"
+  fi
+fi
+
+if [ -z "$CP_CAP_TARGET_SUBNET_ID" ]; then
+  pipe_log_warn "CP_CAP_TARGET_SUBNET_ID is not set. EFA capability may work unexpectedly or doesn't work at all!"
+fi
+
+if [ -z "$CP_CAP_TARGET_SECURITY_GROUPS" ]; then
+  pipe_log_warn "CP_CAP_TARGET_SECURITY_GROUPS is not set. EFA capability may work unexpectedly or doesn't work at all!"
+fi
+
+EFA_SETUP_DIR="/opt/"
+
+cd $EFA_SETUP_DIR
+curl -O https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-latest.tar.gz \
+    && tar -xf aws-efa-installer-latest.tar.gz \
+    && rm -rf aws-efa-installer-latest.tar.gz \
+    && cd aws-efa-installer \
+    && ./efa_installer.sh -y --skip-kmod --skip-limit-conf --no-verify &> /dev/null
+
+if [ $? -ne 0 ]; then
+  echo "Problems with installing EFA Driver"
+  exit 1
+fi
+
+export PATH="$PATH:/opt/amazon/efa/bin/"
+
+fi_info -p efa -t FI_EP_RDM
+if [ $? -ne 0 ]; then
+  echo "Problems with checking EFA Driver after installation"
+  exit 1
+fi
+
+pipe_log_success "AWS EFA successfully installed" "$EFA_SETUP_TASK"


### PR DESCRIPTION
This PR adds possibility to run ec2 nodes with EFA (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html) support.


As a side feature this request also includes possibility to specify list of `run parameter`s to be added to each run that will match specific `ami` entry  in `cluster.networks.config`.
f.e. if run need to be launched on `c5n.9xlarge` instance an we have:
```
{
     "platform": "linux",
     "instance_mask": "c5n.*",
     "run_parameters": {
      "CP_CAP_EFA_ENABLED": true,
      "CP_USE_HOST_NETWORK": true,
      "CP_NODE_SSH_PORT": 2022
     },
     ...
}
```
as an entry in `cluster.networks.config`, for such run these 3 parameters will be added to `PipelineRunConfiguration`