### PR TITLE
Invoking additional commands in the launch.sh

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2023 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -612,6 +612,9 @@ public class SystemPreferences {
     public static final IntPreference  LAUNCH_UID_SEED = new IntPreference("launch.uid.seed", 70000,
             LAUNCH_GROUP, pass, true);
 
+    public static final ObjectPreference<Map<String, Object>> LAUNCH_PRE_COMMON_COMMANDS = new ObjectPreference<>(
+            "launch.pre.common.commands", null, new TypeReference<Map<String, Object>>() {},
+            LAUNCH_GROUP, isNullOrValidJson(new TypeReference<Map<String, Object>>() {}));
 
     //DTS submission
     public static final StringPreference DTS_LAUNCH_CMD_TEMPLATE = new StringPreference("dts.launch.cmd",

--- a/workflows/pipe-common/shell/docker_setup_credentials
+++ b/workflows/pipe-common/shell/docker_setup_credentials
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2023 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ fi
 ############################
 # Setup docker client config
 ############################
-if [ "$http_proxy" ] || [ "$https_proxy" ] || [ "$no_proxy"]; then
+if [ "$http_proxy" ] || [ "$https_proxy" ] || [ "$no_proxy" ]; then
     echo "Setting Docker client proxies"
 
 _DIND_CLIENT_PROXIES="{


### PR DESCRIPTION
Add possibility to invoke additional commands from the `launch.pre.common.commands` preference in the **launch.sh**.
An example of the `launch.pre.common.commands` preference's value:
```json
{
  "linux": {
    "centos": {
      "default": {
        "common": ["echo \"This is default\"", "echo \"This is second priority\""],
        "python": ["echo \"Hello \""]
      },
      "7": {
        "common": ["echo \"This is 7 version\"", "echo \"This is first priority\""],
        "java": ["echo \"World \""]
      },
      "8": {
        "common": []
      }
    },
    "ubuntu": {
      "default": {},
      "16.04": {
        "java": [],
        "common": []
      },
      "18.04": {
        "common": []
      }
    }
  },
  "windows": {}
}
```

**Note**:  specific version of the distribution rewrites a command array declared in the `"default"` key.
When an empty command array is declared for specific version of the distribution (e.g. `"18.04": { "common": [] }`), it will ovewrite the `"default"` key value as empty value.