### PR TITLE
Stabilise edge endpoints generation mechanism

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -527,6 +527,9 @@ public class SystemPreferences {
 
     public static final StringPreference DEFAULT_EDGE_REGION = new StringPreference(
             "default.edge.region", "eu-central", CLUSTER_GROUP, pass);
+    public static final IntPreference DEFAULT_EDGE_REGION_ID = new IntPreference(
+            "default.edge.region.id", 1, CLUSTER_GROUP, isGreaterThan(0L), true);
+
     public static final ObjectPreference<Map<String, RuntimeParameter>> CLUSTER_RUN_PARAMETERS_MAPPING =
             new ObjectPreference<>("cluster.run.parameters.mapping", null,
                     new TypeReference<Map<String, RuntimeParameter>>() {}, CLUSTER_GROUP,


### PR DESCRIPTION
Relates #1615.

The pull request resolves several issues of edge service in regard to endpoints generation mechanism.

## What's been resolved

### Disappearing endpoints

Previously run endpoints were able to disappear if the corresponding tool endpoints configuration changed. From now on all existing run endpoints will be created from scratch if one of the run endpoints changes.

The following events cause regeneration of all endpoints of a single run:

- tool endpoint has been added to tool settings
- tool endpoint has been removed from tool settings
- tool endpoint port has been changed in tool settings
- share settings have been changed for run endpoints

### DNS records run failures

Previously a run failed if some of its endpoints were unable to create DNS records on first attempt. From now only a warning message will appear in case DNS record creation failed. Moreover edge service will try to reconfigure the missing endpoint until it is able to do so.

### Missing region id

Previously edge service was unable to configure custom dns records if region id was not configured explicitly for edge service. From now on edge service will fallback to a new system preference _default.edge.region.id_ in order to find default region id.

## What's not been resolved

### Impermanent endpoints

Currently run endpoints are not static. They depend on the corresponding tool's configuration. This may lead to tool endpoints reconfiguration affecting previously launched runs.
