### PR TITLE
Archived S3 files shall be excluded from pipe storage & pipe mount operations

### DIFF
--- a/pipe-cli/mount/pipe-fuse.py
+++ b/pipe-cli/mount/pipe-fuse.py
@@ -67,7 +67,7 @@ from pipefuse.trunc import CopyOnDownTruncateFileSystemClient, \
 from pipefuse.webdav import WebDavClient, ResilientWebDavFileSystemClient
 from pipefuse.xattr import ExtendedAttributesCache, ThreadSafeExtendedAttributesCache, \
     ExtendedAttributesCachingFileSystemClient, RestrictingExtendedAttributesFS
-from pipefuse.archived import ArchivedFilesFilterFileSystemClient
+from pipefuse.archived import ArchivedFilesFilterFileSystemClient, ArchivedAttributesFileSystemClient
 from pipefuse.storageclassfilter import StorageClassFilterFileSystemClient
 
 _allowed_logging_level_names = ['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'NOTSET']
@@ -124,6 +124,7 @@ def start(mountpoint, webdav, bucket,
             client = S3StorageLowLevelClient(bucket_name, pipe=pipe, chunk_size=chunk_size, storage_path=bucket)
             if not show_archived:
                 client = ArchivedFilesFilterFileSystemClient(client, pipe=pipe, bucket=client.bucket_object)
+            client = ArchivedAttributesFileSystemClient(client, pipe=pipe, bucket=client.bucket_object)
         elif bucket_type == CloudType.GS:
             client = GoogleStorageLowLevelFileSystemClient(bucket_name, pipe=pipe, chunk_size=chunk_size,
                                                            storage_path=bucket)

--- a/pipe-cli/mount/pipe-fuse.py
+++ b/pipe-cli/mount/pipe-fuse.py
@@ -67,6 +67,7 @@ from pipefuse.trunc import CopyOnDownTruncateFileSystemClient, \
 from pipefuse.webdav import WebDavClient, ResilientWebDavFileSystemClient
 from pipefuse.xattr import ExtendedAttributesCache, ThreadSafeExtendedAttributesCache, \
     ExtendedAttributesCachingFileSystemClient, RestrictingExtendedAttributesFS
+from pipefuse.archived import ArchivedFilesFilterFileSystemClient
 
 _allowed_logging_level_names = ['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'NOTSET']
 _allowed_logging_levels = future.utils.lfilter(lambda name: isinstance(name, str), _allowed_logging_level_names)
@@ -119,6 +120,7 @@ def start(mountpoint, webdav, bucket,
         bucket_type = bucket_object.type
         if bucket_type == CloudType.S3:
             client = S3StorageLowLevelClient(bucket_name, pipe=pipe, chunk_size=chunk_size, storage_path=bucket)
+            client = ArchivedFilesFilterFileSystemClient(client, pipe=pipe, bucket=client.bucket_object)
         elif bucket_type == CloudType.GS:
             client = GoogleStorageLowLevelFileSystemClient(bucket_name, pipe=pipe, chunk_size=chunk_size,
                                                            storage_path=bucket)

--- a/pipe-cli/mount/pipe-fuse.py
+++ b/pipe-cli/mount/pipe-fuse.py
@@ -346,7 +346,7 @@ if __name__ == '__main__':
     parser.add_argument("-th", "--threads", action='store_true', help="Enables multithreading.")
     parser.add_argument("-d", "--monitoring-delay", type=int, required=False, default=600,
                         help="Delay between path lock monitoring cycles.")
-    parser.add_argument("--show-archived", type=bool, default=False, help="Show archived files.")
+    parser.add_argument("--show-archived", action='store_true', help="Show archived files.")
     args = parser.parse_args()
 
     if args.xattrs_include_prefixes and args.xattrs_exclude_prefixes:

--- a/pipe-cli/mount/pipe-fuse.py
+++ b/pipe-cli/mount/pipe-fuse.py
@@ -86,7 +86,8 @@ def start(mountpoint, webdav, bucket,
           xattrs_include_prefixes, xattrs_exclude_prefixes,
           xattrs_cache_ttl, xattrs_cache_size,
           disabled_operations, default_mode,
-          mount_options, threads=False, monitoring_delay=600, recording=False):
+          mount_options, threads=False, monitoring_delay=600, recording=False,
+          show_archived=False):
     try:
         os.makedirs(mountpoint)
     except OSError as e:
@@ -120,7 +121,8 @@ def start(mountpoint, webdav, bucket,
         bucket_type = bucket_object.type
         if bucket_type == CloudType.S3:
             client = S3StorageLowLevelClient(bucket_name, pipe=pipe, chunk_size=chunk_size, storage_path=bucket)
-            client = ArchivedFilesFilterFileSystemClient(client, pipe=pipe, bucket=client.bucket_object)
+            if not show_archived:
+                client = ArchivedFilesFilterFileSystemClient(client, pipe=pipe, bucket=client.bucket_object)
         elif bucket_type == CloudType.GS:
             client = GoogleStorageLowLevelFileSystemClient(bucket_name, pipe=pipe, chunk_size=chunk_size,
                                                            storage_path=bucket)
@@ -344,6 +346,7 @@ if __name__ == '__main__':
     parser.add_argument("-th", "--threads", action='store_true', help="Enables multithreading.")
     parser.add_argument("-d", "--monitoring-delay", type=int, required=False, default=600,
                         help="Delay between path lock monitoring cycles.")
+    parser.add_argument("--show-archived", type=bool, default=False, help="Show archived files.")
     args = parser.parse_args()
 
     if args.xattrs_include_prefixes and args.xattrs_exclude_prefixes:
@@ -379,7 +382,8 @@ if __name__ == '__main__':
               xattrs_cache_ttl=args.xattrs_cache_ttl, xattrs_cache_size=args.xattrs_cache_size,
               disabled_operations=args.disabled_operations,
               default_mode=args.mode, mount_options=parse_mount_options(args.options),
-              threads=args.threads, monitoring_delay=args.monitoring_delay, recording=recording)
+              threads=args.threads, monitoring_delay=args.monitoring_delay, recording=recording,
+              show_archived=args.show_archived)
     except Exception:
         logging.exception('Unhandled error')
         traceback.print_exc()

--- a/pipe-cli/mount/pipe-fuse.py
+++ b/pipe-cli/mount/pipe-fuse.py
@@ -351,8 +351,8 @@ if __name__ == '__main__':
     parser.add_argument("-d", "--monitoring-delay", type=int, required=False, default=600,
                         help="Delay between path lock monitoring cycles.")
     parser.add_argument("--show-archived", action='store_true', help="Show archived files.")
-    parser.add_argument("--storage-class-exclude", type=str, required=False,
-                        help="Comma-separated values with storage classes shall be excluded.")
+    parser.add_argument("--storage-class-exclude", type=str, required=False, action="append", default=[],
+                        help="Storage classes that shall be excluded from listing.")
     args = parser.parse_args()
 
     if args.xattrs_include_prefixes and args.xattrs_exclude_prefixes:

--- a/pipe-cli/mount/pipefuse/api.py
+++ b/pipe-cli/mount/pipefuse/api.py
@@ -47,6 +47,22 @@ class TemporaryCredentials:
         return instance
 
 
+class StorageLifecycle:
+
+    def __init__(self):
+        self.path = None
+        self.status = None
+
+    @classmethod
+    def load(cls, json):
+        instance = StorageLifecycle()
+        if 'path' in json:
+            instance.path = json['path']
+        if 'status' in json:
+            instance.status = json['status']
+        return instance
+
+
 class DataStorage:
     _READ_MASK = 1
     _WRITE_MASK = 1 << 1
@@ -129,6 +145,21 @@ class CloudPipelineClient:
         }
         credentials = self._get_temporary_credentials([operation])
         return credentials
+
+    def get_storage_lifecycle(self, bucket, path):
+        logging.info('Getting storage lifecycle for data storage #%s' % bucket.id)
+        request_url = '/datastorage/%s/lifecycle/restore/effectiveHierarchy?path=%s&pathType=FOLDER&recursive=true' \
+                      % (str(bucket.id), path)
+        response_data = self._get(request_url)
+        if 'payload' in response_data:
+            items = []
+            for lifecycles_json in response_data['payload']:
+                lifecycle = StorageLifecycle.load(lifecycles_json)
+                items.append(lifecycle)
+            return items
+        if 'message' in response_data:
+            raise RuntimeError(response_data['message'])
+        return None
 
     def _check_write_allowed(self, bucket):
         try:

--- a/pipe-cli/mount/pipefuse/archived.py
+++ b/pipe-cli/mount/pipefuse/archived.py
@@ -64,13 +64,13 @@ class ArchivedFilesFilterFileSystemClient(FileSystemClientDecorator):
     def _get_restored_paths(self, path):
         try:
             response = self._pipe.get_storage_lifecycle(self._bucket, path)
-            items = set()
+            items = []
             if not response:
-                return items
+                return set()
             for item in response:
                 if item.status and item.status == 'SUCCEEDED':
-                    items.update(item.path)
-            return items
+                    items.append(item.path)
+            return set(items)
         except Exception as e:
             logging.info(e)
             return set()

--- a/pipe-cli/mount/pipefuse/archived.py
+++ b/pipe-cli/mount/pipefuse/archived.py
@@ -105,7 +105,7 @@ class ArchivedAttributesFileSystemClient(FileSystemClientDecorator):
             return tags if not source_file else self._add_lifecycle_status_attribute(tags, source_file,
                                                                                      self._get_storage_lifecycle(path))
         except Exception:
-            logging.debug('Download archived tags has failed')
+            logging.exception('Download archived tags has failed')
             return {}
 
     def _get_archived_file(self, path):

--- a/pipe-cli/mount/pipefuse/archived.py
+++ b/pipe-cli/mount/pipefuse/archived.py
@@ -16,7 +16,6 @@ import logging
 from pipefuse.fsclient import FileSystemClientDecorator
 
 PATH_SEPARATOR = '/'
-_ALL_ERRORS = Exception
 
 
 class ArchivedFilesFilterFileSystemClient(FileSystemClientDecorator):
@@ -72,8 +71,8 @@ class ArchivedFilesFilterFileSystemClient(FileSystemClientDecorator):
                 if item.is_restored():
                     items.append(item.path)
             return set(items)
-        except _ALL_ERRORS as e:
-            logging.info(e)
+        except Exception:
+            logging.exception('Storage lifecycle retrieving has failed')
             return set()
 
     @staticmethod
@@ -105,8 +104,8 @@ class ArchivedAttributesFileSystemClient(FileSystemClientDecorator):
             source_file = self._get_archived_file(path)
             return tags if not source_file else self._add_lifecycle_status_attribute(tags, source_file,
                                                                                      self._get_storage_lifecycle(path))
-        except _ALL_ERRORS as e:
-            logging.debug(e)
+        except Exception:
+            logging.debug('Download archived tags has failed')
             return {}
 
     def _get_archived_file(self, path):
@@ -132,6 +131,6 @@ class ArchivedAttributesFileSystemClient(FileSystemClientDecorator):
     def _get_storage_lifecycle(self, path, is_folder=False):
         try:
             return self._pipe.get_storage_last_lifecycle(self._bucket, path, is_folder)
-        except _ALL_ERRORS as e:
-            logging.info(e)
+        except Exception:
+            logging.exception('Storage last lifecycle retrieving has failed')
             return None

--- a/pipe-cli/mount/pipefuse/archived.py
+++ b/pipe-cli/mount/pipefuse/archived.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import collections
 import logging
+from future.utils import iteritems
 
 from pipefuse.fsclient import FileSystemClientDecorator
 
@@ -61,7 +62,7 @@ class ArchivedFilesFilterFileSystemClient(FileSystemClientDecorator):
 
     @staticmethod
     def _file_restored(file_path, storage_lifecycle):
-        for path, item in storage_lifecycle:
+        for path, item in iteritems(storage_lifecycle):
             if path == file_path or file_path.startswith(path):
                 if not item:
                     return False

--- a/pipe-cli/mount/pipefuse/archived.py
+++ b/pipe-cli/mount/pipefuse/archived.py
@@ -39,7 +39,7 @@ class ArchivedFilesFilterFileSystemClient(FileSystemClientDecorator):
         storage_lifecycle = None
         result = []
         for item in items:
-            if item.storage_class != 'STANDARD':
+            if item.storage_class is not None and item.storage_class != 'STANDARD':
                 path = self._normalize_path(path)
                 if storage_lifecycle is None:
                     storage_lifecycle = self._get_storage_lifecycle(path)

--- a/pipe-cli/mount/pipefuse/archived.py
+++ b/pipe-cli/mount/pipefuse/archived.py
@@ -1,0 +1,86 @@
+# Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import collections
+import logging
+
+from pipefuse.fsclient import FileSystemClientDecorator
+
+PATH_SEPARATOR = '/'
+
+
+class ArchivedFilesFilterFileSystemClient(FileSystemClientDecorator):
+
+    def __init__(self, inner, pipe, bucket):
+        """
+        Filters files that have GLACIER or DEEP_ARCHIVE storage class and not restored.
+
+        :param inner: Decorating file system client.
+        :param pipe: Cloud Pipeline API client.
+        :param bucket: Bucket object.
+        """
+        super(ArchivedFilesFilterFileSystemClient, self).__init__(inner)
+        self._inner = inner
+        self._pipe = pipe
+        self._bucket = bucket
+
+    def ls(self, path, depth=1):
+        items = self._inner.ls(path, depth)
+        storage_lifecycle = None
+        result = []
+        for item in items:
+            if item.storage_class != 'STANDARD':
+                path = self._normalize_path(path)
+                if storage_lifecycle is None:
+                    storage_lifecycle = self._get_storage_lifecycle(path)
+                file_path = path + item.name
+                if not self._file_restored(file_path, storage_lifecycle):
+                    continue
+            result.append(item)
+        return result
+
+    @staticmethod
+    def _normalize_path(path):
+        if not path:
+            return PATH_SEPARATOR
+        if not path.startswith(PATH_SEPARATOR):
+            path = PATH_SEPARATOR + path
+        if path != PATH_SEPARATOR and not path.endswith(PATH_SEPARATOR):
+            path = path + PATH_SEPARATOR
+        return path
+
+    @staticmethod
+    def _file_restored(file_path, storage_lifecycle):
+        for path, item in storage_lifecycle:
+            if path == file_path or file_path.startswith(path):
+                if not item:
+                    return False
+                return item.status == 'SUCCEEDED'
+        return False
+
+    def _get_storage_lifecycle(self, path):
+        try:
+            response = self._pipe.get_storage_lifecycle(self._bucket, path)
+            items = {}
+            if not response:
+                return {}
+            for item in response:
+                items.update({item.path: item})
+            sorted_paths = sorted([item.path for item in response], key=len, reverse=True)
+            sorted_results = collections.OrderedDict()
+            for path in sorted_paths:
+                sorted_results.update({path: items.get(path)})
+            return sorted_results
+        except Exception as e:
+            logging.info(e)
+            return {}

--- a/pipe-cli/mount/pipefuse/archived.py
+++ b/pipe-cli/mount/pipefuse/archived.py
@@ -78,6 +78,6 @@ class ArchivedFilesFilterFileSystemClient(FileSystemClientDecorator):
     @staticmethod
     def _folder_restored(folder_path, storage_lifecycle):
         for path in storage_lifecycle:
-            if path.startswith(folder_path):
+            if folder_path.startswith(path):
                 return True
         return False

--- a/pipe-cli/mount/pipefuse/archived.py
+++ b/pipe-cli/mount/pipefuse/archived.py
@@ -117,16 +117,20 @@ class ArchivedAttributesFileSystemClient(FileSystemClientDecorator):
             return None
         return source_file if source_file.storage_class != 'STANDARD' else None
 
+    def _add_lifecycle_status_attribute(self, tags, source_file, lifecycle):
+        tag_value = self._get_storage_class_tag_value(lifecycle, source_file.storage_class)
+        if tag_value:
+            tags.update({'user.system.lifecycle.status': tag_value})
+        return tags
+
     @staticmethod
-    def _add_lifecycle_status_attribute(tags, source_file, lifecycle):
-        if not lifecycle:
-            return tags
-        tag_value = source_file.storage_class
+    def _get_storage_class_tag_value(lifecycle, storage_class):
+        if not lifecycle or not storage_class:
+            return storage_class
         if lifecycle.is_restored():
             retired_till = (' till ' + lifecycle.restored_till) if lifecycle.restored_till else ''
-            tag_value = '%s (Restored%s)' % (source_file.storage_class, retired_till)
-        tags.update({'user.system.lifecycle.status': tag_value})
-        return tags
+            return '%s (Restored%s)' % (storage_class, retired_till)
+        return storage_class
 
     def _get_storage_lifecycle(self, path, is_folder=False):
         try:

--- a/pipe-cli/mount/pipefuse/archived.py
+++ b/pipe-cli/mount/pipefuse/archived.py
@@ -40,7 +40,7 @@ class ArchivedFilesFilterFileSystemClient(FileSystemClientDecorator):
         storage_lifecycle = None
         result = []
         for item in items:
-            if item.storage_class is not None and item.storage_class != 'STANDARD':
+            if not item.is_dir and item.storage_class != 'STANDARD':
                 path = self._normalize_path(path)
                 if storage_lifecycle is None:
                     storage_lifecycle = self._get_storage_lifecycle(path)

--- a/pipe-cli/mount/pipefuse/cache.py
+++ b/pipe-cli/mount/pipefuse/cache.py
@@ -193,7 +193,8 @@ class CachingListingFileSystemClient(FileSystemClientDecorator):
                     mtime=time.mktime(datetime.now(tz=tzlocal()).timetuple()),
                     ctime=None,
                     contenttype=None,
-                    is_dir=True)
+                    is_dir=True,
+                    storage_class=None)
 
     def ls(self, path, depth=1):
         return self._ls_as_dict(path, depth).values()

--- a/pipe-cli/mount/pipefuse/fsclient.py
+++ b/pipe-cli/mount/pipefuse/fsclient.py
@@ -17,7 +17,7 @@ from collections import namedtuple
 
 from pipefuse.chain import ChainingService
 
-File = namedtuple('File', ['name', 'size', 'mtime', 'ctime', 'contenttype', 'is_dir'])
+File = namedtuple('File', ['name', 'size', 'mtime', 'ctime', 'contenttype', 'is_dir', 'storage_class'])
 
 
 class FileSystemOperationException(RuntimeError):

--- a/pipe-cli/mount/pipefuse/gcp.py
+++ b/pipe-cli/mount/pipefuse/gcp.py
@@ -258,7 +258,8 @@ class GoogleStorageLowLevelFileSystemClient(StorageLowLevelFileSystemClient):
                     mtime=time.mktime(blob.updated.astimezone(tzlocal()).timetuple()),
                     ctime=None,
                     contenttype='',
-                    is_dir=False)
+                    is_dir=False,
+                    storage_class=None)
 
     def _get_folder_object(self, name, prefix, recursive):
         return File(name=self._get_object_name(name, prefix, recursive),
@@ -266,7 +267,8 @@ class GoogleStorageLowLevelFileSystemClient(StorageLowLevelFileSystemClient):
                     mtime=time.mktime(datetime.now(tz=tzlocal()).timetuple()),
                     ctime=None,
                     contenttype='',
-                    is_dir=True)
+                    is_dir=True,
+                    storage_class=None)
 
     def _get_object_name(self, name, prefix, recursive):
         return name if recursive else fuseutils.get_item_name(name, prefix=prefix)

--- a/pipe-cli/mount/pipefuse/pipefs.py
+++ b/pipe-cli/mount/pipefuse/pipefs.py
@@ -370,6 +370,7 @@ class ResilientFS(ChainingService):
                 err_msg = str(e)
                 if isinstance(e, ClientError) \
                         and err_msg and 'InvalidObjectState' in err_msg and 'storage class' in err_msg:
+                    logging.exception('Failed to access archived file. This file shall be restored first.')
                     raise FuseOSError(errno.EACCES)
                 logging.exception('Uncaught exception from underlying file system.')
                 raise FuseOSError(errno.EINVAL)

--- a/pipe-cli/mount/pipefuse/s3.py
+++ b/pipe-cli/mount/pipefuse/s3.py
@@ -299,9 +299,7 @@ class S3StorageLowLevelClient(StorageLowLevelFileSystemClient):
         logging.info('Downloading tags for %s...' % path)
         try:
             response = self._s3.get_object_tagging(Bucket=self.bucket, Key=path) or {}
-            tags = {tag.get('Key'): tag.get('Value') for tag in response.get('TagSet', [])}
-            source_file = self._get_archived_file(path)
-            return tags if not source_file else self._add_lifecycle_status_attribute(tags, source_file)
+            return {tag.get('Key'): tag.get('Value') for tag in response.get('TagSet', [])}
         except Exception:
             logging.debug('No tags have been found for %s' % path, exc_info=True)
             return {}
@@ -329,16 +327,3 @@ class S3StorageLowLevelClient(StorageLowLevelFileSystemClient):
             del tags[name]
         self.remove_xattrs(path)
         self.upload_xattrs(path, tags)
-
-    def _get_archived_file(self, path):
-        files = self.ls(path, depth=1)
-        if not files or len(files) != 1:
-            return None
-        source_file = files[0]
-        if not source_file or source_file.is_dir or not source_file.storage_class:
-            return None
-        return source_file if source_file.storage_class != 'STANDARD' else None
-
-    def _add_lifecycle_status_attribute(self, tags, source_file):
-        tags.update({'system.lifecycle.status': source_file.storage_class})
-        return tags

--- a/pipe-cli/mount/pipefuse/storageclassfilter.py
+++ b/pipe-cli/mount/pipefuse/storageclassfilter.py
@@ -26,7 +26,7 @@ class StorageClassFilterFileSystemClient(FileSystemClientDecorator):
         """
         super(StorageClassFilterFileSystemClient, self).__init__(inner)
         self._inner = inner
-        self._storage_classes = self._parse_storage_classes(classes)
+        self._storage_classes = classes
 
     def ls(self, path, depth=1):
         return filter(self._filter_storage_classes, self._inner.ls(path, depth))
@@ -35,9 +35,3 @@ class StorageClassFilterFileSystemClient(FileSystemClientDecorator):
         if item.is_dir:
             return True
         return item.storage_class not in self._storage_classes
-
-    @staticmethod
-    def _parse_storage_classes(classes):
-        if not classes:
-            return []
-        return [value.strip() for value in str(classes).split(',')]

--- a/pipe-cli/mount/pipefuse/storageclassfilter.py
+++ b/pipe-cli/mount/pipefuse/storageclassfilter.py
@@ -1,0 +1,43 @@
+# Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pipefuse.fsclient import FileSystemClientDecorator
+
+
+class StorageClassFilterFileSystemClient(FileSystemClientDecorator):
+
+    def __init__(self, inner, classes):
+        """
+        Filters files that have specific storage class.
+
+        :param inner: Decorating file system client.
+        :param classes: Storage classes that shall be filtered.
+        """
+        super(StorageClassFilterFileSystemClient, self).__init__(inner)
+        self._inner = inner
+        self._storage_classes = self._parse_storage_classes(classes)
+
+    def ls(self, path, depth=1):
+        return filter(self._filter_storage_classes, self._inner.ls(path, depth))
+
+    def _filter_storage_classes(self, item):
+        if item.is_dir:
+            return True
+        return item.storage_class not in self._storage_classes
+
+    @staticmethod
+    def _parse_storage_classes(classes):
+        if not classes:
+            return []
+        return [value.strip() for value in str(classes).split(',')]

--- a/pipe-cli/mount/pipefuse/webdav.py
+++ b/pipe-cli/mount/pipefuse/webdav.py
@@ -156,7 +156,8 @@ class WebDavClient(easywebdav.Client, FileSystemClient):
             self.parse_timestamp(self.prop_value(elem, 'getlastmodified', ''), self.M_DATE_FORMAT),
             self.parse_timestamp(self.prop_value(elem, 'creationdate', ''), self.C_DATE_FORMAT),
             self.prop_value(elem, 'getcontenttype', ''),
-            self.prop_exists(elem, 'collection')
+            self.prop_exists(elem, 'collection'),
+            storage_class=None
         )
 
     def download_range(self, fh, data, remote_path, offset=0, length=0):

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1340,9 +1340,10 @@ def storage_delete_object_tags(path, tags, version):
 @click.option('-m', '--mode', required=False, help='Default file permissions',  default=700, type=int)
 @click.option('-w', '--timeout', required=False, help='Waiting time in ms to check whether mount was successful',
               default=1000, type=int)
+@click.option('-g', '--show-archive', is_flag=True, help='Show archived files.')
 @common_options
 def mount_storage(mountpoint, file, bucket, options, custom_options, log_file, log_level, quiet, threads, mode,
-                  timeout):
+                  timeout, show_archive):
     """
     Mounts either all available network file systems or a single object storage to a local folder.
 
@@ -1367,7 +1368,8 @@ def mount_storage(mountpoint, file, bucket, options, custom_options, log_file, l
     """
     DataStorageOperations.mount_storage(mountpoint, file=file, log_file=log_file, log_level=log_level,
                                         bucket=bucket, options=options, custom_options=custom_options,
-                                        quiet=quiet, threading=threads, mode=mode, timeout=timeout)
+                                        quiet=quiet, threading=threads, mode=mode, timeout=timeout,
+                                        show_archive=show_archive)
 
 
 @storage.command('umount')

--- a/pipe-cli/src/utilities/datastorage_operations.py
+++ b/pipe-cli/src/utilities/datastorage_operations.py
@@ -644,8 +644,9 @@ class DataStorageOperations(object):
                 transfer_results = cls._flush_transfer_results(source_wrapper, destination_wrapper,
                                                                transfer_results, clean=clean)
         except Exception as e:
+            err_msg = str(e)
             if isinstance(e, ClientError) \
-                    and e.message and 'InvalidObjectState' in e.message and 'storage class' in e.message:
+                    and err_msg and 'InvalidObjectState' in err_msg and 'storage class' in err_msg:
                 if not quiet:
                     click.echo(u'File {} transferring has failed. Archived file shall be restored first.'
                                .format(full_path))

--- a/pipe-cli/src/utilities/datastorage_operations.py
+++ b/pipe-cli/src/utilities/datastorage_operations.py
@@ -550,14 +550,14 @@ class DataStorageOperations(object):
 
     @classmethod
     def mount_storage(cls, mountpoint, file=False, bucket=None, log_file=None, log_level=None, options=None,
-                      custom_options=None, quiet=False, threading=False, mode=700, timeout=1000):
+                      custom_options=None, quiet=False, threading=False, mode=700, timeout=1000, show_archive=False):
         if not file and not bucket:
             click.echo('Either file system mode should be enabled (-f/--file) '
                        'or bucket name should be specified (-b/--bucket BUCKET).', err=True)
             sys.exit(1)
         Mount().mount_storages(mountpoint, file, bucket, options, custom_options=custom_options, quiet=quiet,
                                log_file=log_file, log_level=log_level,  threading=threading,
-                               mode=mode, timeout=timeout)
+                               mode=mode, timeout=timeout, show_archive=show_archive)
 
     @classmethod
     def umount_storage(cls, mountpoint, quiet=False):

--- a/pipe-cli/src/utilities/storage/mount.py
+++ b/pipe-cli/src/utilities/storage/mount.py
@@ -37,20 +37,24 @@ class AbstractMount(object):
     __metaclass__ = ABCMeta
 
     def get_mount_webdav_cmd(self, config, mountpoint, options, custom_options, web_dav_url, mode, threading=False,
-                             log_level=None):
-        additional_args = self._append_arguments(['--webdav', web_dav_url], threading, log_level, custom_options)
+                             log_level=None, show_archive=False):
+        additional_args = self._append_arguments(['--webdav', web_dav_url], threading, log_level, custom_options,
+                                                 show_archive)
         return self._get_mount_cmd(config, mountpoint, options, additional_args, mode)
 
     def get_mount_storage_cmd(self, config, mountpoint, options, custom_options, bucket, mode, threading=False,
-                              log_level=None):
-        additional_args = self._append_arguments(['--bucket', bucket], threading, log_level, custom_options)
+                              log_level=None, show_archive=False):
+        additional_args = self._append_arguments(['--bucket', bucket], threading, log_level, custom_options,
+                                                 show_archive)
         return self._get_mount_cmd(config, mountpoint, options, additional_args, mode)
 
-    def _append_arguments(self, args, threading, log_level, custom_options):
+    def _append_arguments(self, args, threading, log_level, custom_options, show_archive):
         if threading:
             args.append('--threads')
         if log_level:
             args.extend(['--logging-level', log_level])
+        if show_archive:
+            args.append('--show-archive')
         if custom_options:
             args.extend(self._build_custom_option_arguments(custom_options))
         return args
@@ -134,7 +138,7 @@ class SourceMount(AbstractMount):
 class Mount(object):
 
     def mount_storages(self, mountpoint, file=False, bucket=None, options=None, custom_options=None, quiet=False,
-                       log_file=None, log_level=None, threading=False, mode=700, timeout=1000):
+                       log_file=None, log_level=None, threading=False, mode=700, timeout=1000, show_archive=False):
         config = Config.instance()
         username = self.normalize_username(config.get_current_user())
         mount = FrozenMount() if is_frozen() else SourceMount()
@@ -142,10 +146,12 @@ class Mount(object):
             web_dav_url = PreferenceAPI.get_preference('base.dav.auth.url').value
             web_dav_url = web_dav_url.replace('auth-sso/', username + '/')
             self.mount_dav(mount, config, mountpoint, options, custom_options, web_dav_url, mode,
-                           log_file=log_file, log_level=log_level, threading=threading, timeout=timeout)
+                           log_file=log_file, log_level=log_level, threading=threading, timeout=timeout,
+                           show_archive=show_archive)
         else:
             self.mount_storage(mount, config, mountpoint, options, custom_options, bucket, mode,
-                               log_file=log_file, log_level=log_level, threading=threading, timeout=timeout)
+                               log_file=log_file, log_level=log_level, threading=threading, timeout=timeout,
+                               show_archive=show_archive)
 
     # Split username by @ to get only first part of the user name,
     # because webdav trail user name as well to get get user folder name
@@ -153,15 +159,15 @@ class Mount(object):
         return username.split('@')[0]
 
     def mount_dav(self, mount, config, mountpoint, options, custom_options, web_dav_url, mode,
-                  log_file=None, log_level=None, threading=False, timeout=1000):
+                  log_file=None, log_level=None, threading=False, timeout=1000, show_archive=False):
         mount_cmd = mount.get_mount_webdav_cmd(config, mountpoint, options, custom_options, web_dav_url, mode,
-                                               log_level=log_level, threading=threading)
+                                               log_level=log_level, threading=threading, show_archive=show_archive)
         self.run(config, mount_cmd, log_file=log_file, mount_timeout=timeout)
 
     def mount_storage(self, mount, config, mountpoint, options, custom_options, bucket, mode,
-                      log_file=None, log_level=None, threading=False, timeout=1000):
+                      log_file=None, log_level=None, threading=False, timeout=1000, show_archive=False):
         mount_cmd = mount.get_mount_storage_cmd(config, mountpoint, options, custom_options, bucket, mode,
-                                                log_level=log_level, threading=threading)
+                                                log_level=log_level, threading=threading, show_archive=show_archive)
         self.run(config, mount_cmd, log_file=log_file, mount_timeout=timeout)
 
     def run(self, config, mount_cmd, mount_timeout=5*MS_IN_SEC, log_file=None):


### PR DESCRIPTION
The current PR provides additional implementation for issue #3020 

The following changes were added:
 - a new command line option `--show-archived (Default: false)` added to `pipe storage mount` command. If this flag enabled archived files (GLACIER, DEEP_ARCHIVE storage classes) shall be shown. Otherwise, not restored archived files shall be filtered out. 
 - a new command line option `--storage-class-exclude` added to pipe fuse. This option specifies a list of storage classes that shall be excluded from listing.
 - added storage class info for get attribute operation