### PR TITLE
E2E cli test: fix for TC-PIPE-TAG-28 test case since API response has been changed

### DIFF
--- a/e2e/cli/buckets/tag/test_tag.py
+++ b/e2e/cli/buckets/tag/test_tag.py
@@ -146,7 +146,7 @@ class TestTagging(object):
     test_case_for_non_existing = [
         ('cp://non_existing/{}'.format(test_file),
          "data storage with id: '{}/{}' was not found".format("non_existing", test_file)),
-        ('cp://{}/non_existing'.format(bucket), "Storage path 'non_existing' for bucket '%s' does not exist" % bucket)
+        ('cp://{}/non_existing'.format(bucket), "Error: API responded with http status 404.")
     ]
 
     @pytest.mark.parametrize("path,message", test_case_for_non_existing)


### PR DESCRIPTION
This PR provides fix for e2e cli test for non existent file tagging.

API response has changed since this commit: https://github.com/epam/cloud-pipeline/commit/ef6034dd153312fea4e5bb8420558acac61411c5

This commit brings changes in method `DataStorageManager#checkDataStorageObjectExists` that affects datastorage tagging API.