### PR TITLE
Issue 3028 Calculate size for all storage tiers

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSQuotasMonitor.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSQuotasMonitor.java
@@ -320,7 +320,7 @@ public class NFSQuotasMonitor {
 
     private boolean exceedsAbsoluteLimit(final Double originalLimit, final StorageUsage storageUsage) {
         final long limitBytes = (long) (originalLimit * GB_TO_BYTES);
-        return storageUsage.getEffectiveSize() > limitBytes;
+        return storageUsage.getTotalUsage().getEffectiveSize() > limitBytes;
     }
 
     private boolean exceedsPercentageLimit(final NFSDataStorage storage, final Double originalLimit,
@@ -332,7 +332,7 @@ public class NFSQuotasMonitor {
                 return lustreManager.findLustreFS(shareMount)
                     .map(LustreFS::getCapacityGb)
                     .map(maxSize -> convertLustrePercentageLimitToAbsoluteValue(originalLimit, maxSize) * GB_TO_BYTES)
-                    .map(limit -> storageUsage.getEffectiveSize() > limit)
+                    .map(limit -> storageUsage.getTotalUsage().getEffectiveSize() > limit)
                     .orElse(false);
             case NFS:
                 log.warn(messageHelper.getMessage(MessageConstants.STORAGE_QUOTA_NFS_PERCENTAGE_QUOTA_WARN,

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSQuotasMonitor.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSQuotasMonitor.java
@@ -78,6 +78,9 @@ public class NFSQuotasMonitor {
 
     private static final int GB_TO_BYTES = 1024 * 1024 * 1024;
     private static final int PERCENTS_MULTIPLIER = 100;
+    private static final String NFS_STORAGE_TIER = "STANDARD";
+    private static final StorageUsage.StorageUsageStats EMPTY_USAGE = new StorageUsage.StorageUsageStats(
+            NFS_STORAGE_TIER, 0L, 0L, 0L, 0L, 0L, 0L);
 
     private final DataStorageManager dataStorageManager;
     private final SearchManager searchManager;
@@ -320,7 +323,8 @@ public class NFSQuotasMonitor {
 
     private boolean exceedsAbsoluteLimit(final Double originalLimit, final StorageUsage storageUsage) {
         final long limitBytes = (long) (originalLimit * GB_TO_BYTES);
-        return storageUsage.getTotalUsage().getEffectiveSize() > limitBytes;
+        return storageUsage.getUsage()
+                .getOrDefault(NFS_STORAGE_TIER, EMPTY_USAGE).getEffectiveSize() > limitBytes;
     }
 
     private boolean exceedsPercentageLimit(final NFSDataStorage storage, final Double originalLimit,
@@ -332,7 +336,8 @@ public class NFSQuotasMonitor {
                 return lustreManager.findLustreFS(shareMount)
                     .map(LustreFS::getCapacityGb)
                     .map(maxSize -> convertLustrePercentageLimitToAbsoluteValue(originalLimit, maxSize) * GB_TO_BYTES)
-                    .map(limit -> storageUsage.getTotalUsage().getEffectiveSize() > limit)
+                    .map(limit -> storageUsage.getUsage()
+                            .getOrDefault(NFS_STORAGE_TIER, EMPTY_USAGE).getEffectiveSize() > limit)
                     .orElse(false);
             case NFS:
                 log.warn(messageHelper.getMessage(MessageConstants.STORAGE_QUOTA_NFS_PERCENTAGE_QUOTA_WARN,

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchManager.java
@@ -29,7 +29,6 @@ import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.manager.utils.GlobalSearchElasticHelper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.elasticsearch.action.search.MultiSearchRequest;

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchManager.java
@@ -86,11 +86,10 @@ public class SearchManager {
     public StorageUsage getStorageUsage(final AbstractDataStorage dataStorage, final String path,
                                         final boolean allowNoIndex, final Set<String> storageSizeMasks) {
         try (RestHighLevelClient client = globalSearchElasticHelper.buildClient()) {
-            final MultiSearchRequest request = requestBuilder.buildStorageSumRequest(
+            final MultiSearchRequest searchRequest = requestBuilder.buildStorageSumRequest(
                     dataStorage.getId(), dataStorage.getType(), path, allowNoIndex, storageSizeMasks);
-            final MultiSearchResponse searchResponse = client.msearch(request, RequestOptions.DEFAULT);
-            final int responsesExpected = CollectionUtils.isEmpty(storageSizeMasks) ? 1 : 2;
-            return resultConverter.buildStorageUsageResponse(searchResponse, dataStorage, path, responsesExpected);
+            final MultiSearchResponse searchResponse = client.msearch(searchRequest, RequestOptions.DEFAULT);
+            return resultConverter.buildStorageUsageResponse(searchRequest, searchResponse, dataStorage, path);
         } catch (IOException e) {
             log.error(e.getMessage(), e);
             throw new SearchException(e.getMessage(), e);

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchRequestBuilder.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchRequestBuilder.java
@@ -55,7 +55,6 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.QueryStringQueryBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
-import org.elasticsearch.search.aggregations.metrics.sum.SumAggregationBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.SortBuilder;
 import org.elasticsearch.search.sort.SortBuilders;
@@ -89,8 +88,9 @@ public class SearchRequestBuilder {
 
     private static final DateTimeFormatter DATE_TIME_FORMATTER =
             DateTimeFormatter.ofPattern(Constants.FMT_ISO_LOCAL_DATE);
-    private static final String STORAGE_SIZE_AGG_NAME = "sizeSumSearch";
-    private static final String SIZE_FIELD = "size";
+    private static final String STORAGE_SIZE_BY_TIER_AGG_NAME = "sizeSumByTier";
+    private static final String STORAGE_SIZE_AGG_NAME = "sizeSum";
+
     private static final String NAME_FIELD = "id";
     private static final String ES_FILE_INDEX_PATTERN = "cp-%s-file-%d";
     private static final String ES_DOC_ID_FIELD = "_id";
@@ -152,21 +152,39 @@ public class SearchRequestBuilder {
     public MultiSearchRequest buildStorageSumRequest(final Long storageId, final DataStorageType storageType,
                                                      final String path, final boolean allowNoIndex,
                                                      final Set<String> storageSizeMasks) {
+        final String searchIndex = String.format(
+                ES_FILE_INDEX_PATTERN, storageType.toString().toLowerCase(), storageId
+        );
         final MultiSearchRequest multiSearchRequest = new MultiSearchRequest();
-        multiSearchRequest.add(buildSumAggRequest(storageId, storageType, path, allowNoIndex, null));
-        if (CollectionUtils.isNotEmpty(storageSizeMasks)) {
-            multiSearchRequest.add(buildSumAggRequest(storageId, storageType, path, allowNoIndex, storageSizeMasks));
-        }
+        //requests to get size and effective size (if applicable) for current version of files across all storage tiers
+        populateMSearchRequest(path, allowNoIndex, storageSizeMasks, searchIndex, multiSearchRequest,
+                "storage_class", "size");
+        //requests to get size and effective size (if applicable) for old versions of files across all storage tiers
+        populateMSearchRequest(path, allowNoIndex, storageSizeMasks, searchIndex, multiSearchRequest,
+                "versions.storage_class", "versions.size");
         return multiSearchRequest;
     }
 
-    private SearchRequest buildSumAggRequest(final Long storageId, final DataStorageType storageType,
-                                             final String path, final boolean allowNoIndex,
+    private void populateMSearchRequest(final String path, final boolean allowNoIndex,
+                                        final Set<String> storageSizeMasks, final String searchIndex,
+                                        final MultiSearchRequest multiSearchRequest, final String groupBy,
+                                        final String aggregateBy) {
+        multiSearchRequest.add(
+                buildSumAggRequest(searchIndex, path, groupBy, aggregateBy, allowNoIndex, null));
+        if (CollectionUtils.isNotEmpty(storageSizeMasks)) {
+            multiSearchRequest.add(
+                    buildSumAggRequest(searchIndex, path, groupBy, aggregateBy, allowNoIndex, storageSizeMasks));
+        }
+    }
+
+    private SearchRequest buildSumAggRequest(final String searchIndex, final String path, final String groupedBy,
+                                             final String aggregateBy, final boolean allowNoIndex,
                                              final Set<String> storageSizeMasks) {
-        final String searchIndex =
-            String.format(ES_FILE_INDEX_PATTERN, storageType.toString().toLowerCase(), storageId);
-        final SumAggregationBuilder sizeSumAggregator = AggregationBuilders.sum(STORAGE_SIZE_AGG_NAME)
-                .field(SIZE_FIELD);
+
+
+        final TermsAggregationBuilder sizeSumAggregator = AggregationBuilders
+                .terms(STORAGE_SIZE_BY_TIER_AGG_NAME).field(groupedBy)
+                .subAggregation(AggregationBuilders.sum(STORAGE_SIZE_AGG_NAME).field(aggregateBy));
         final BoolQueryBuilder fileFilteringQuery = QueryBuilders.boolQuery();
         CollectionUtils.emptyIfNull(storageSizeMasks)
             .forEach(mask -> fileFilteringQuery.mustNot(QueryBuilders.wildcardQuery(NAME_FIELD, mask)));

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchResultConverter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchResultConverter.java
@@ -94,9 +94,13 @@ public class SearchResultConverter {
                 .name(dataStorage.getName())
                 .type(dataStorage.getType())
                 .path(path)
-                .size(totalSize)
-                .effectiveSize(effectiveSize)
-                .count(allDocsResponse.getHits().getTotalHits())
+                .totalUsage(
+                        StorageUsage.StorageUsageStats.builder()
+                                .size(totalSize)
+                                .effectiveSize(effectiveSize)
+                                .count(allDocsResponse.getHits().getTotalHits())
+                                .build()
+                )
                 .build();
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchResultConverter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchResultConverter.java
@@ -67,8 +67,6 @@ public class SearchResultConverter {
 
     private static final String STORAGE_SIZE_BY_TIER_AGG_NAME = "sizeSumByTier";
 
-    public static final String STANDARD_TIER = "STANDARD";
-
     public SearchResult buildResult(final SearchResponse searchResult,
                                     final String aggregation,
                                     final String typeFieldName,
@@ -288,7 +286,7 @@ public class SearchResultConverter {
 
     private MultiSearchResponse.Item[] tryExtractAllResponses(final MultiSearchResponse searchResponse,
                                                               final MultiSearchRequest searchRequest) {
-        int batchSize = searchRequest.requests().size();
+        final int batchSize = searchRequest.requests().size();
         final MultiSearchResponse.Item[] items = Optional.ofNullable(searchResponse)
             .map(MultiSearchResponse::getResponses)
             .filter(searchResponses -> ArrayUtils.getLength(searchResponses) > 0)

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchResultConverter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchResultConverter.java
@@ -95,7 +95,7 @@ public class SearchResultConverter {
     private Map<String, StorageUsage.StorageUsageStats> buildStorageUsageStatsByStorageTier(
             final MultiSearchResponse.Item[] responses) {
 
-        final List<String> storageTiers = Arrays.stream(responses).map(
+        final List<String> storageClasses = Arrays.stream(responses).map(
                 r -> Optional.ofNullable(r.getResponse())
                         .map(SearchResponse::getAggregations)
                         .map(aggregations -> aggregations.<ParsedTerms>get(STORAGE_SIZE_BY_TIER_AGG_NAME).getBuckets())
@@ -103,7 +103,7 @@ public class SearchResultConverter {
                 ).flatMap(Collection::stream).map(MultiBucketsAggregation.Bucket::getKeyAsString)
                 .distinct().collect(Collectors.toList());
 
-        return storageTiers.stream().map(tier -> {
+        return storageClasses.stream().map(storageClass -> {
             final StorageUsage.StorageUsageStats.StorageUsageStatsBuilder storageUsageStats =
                     StorageUsage.StorageUsageStats.builder();
 
@@ -112,18 +112,18 @@ public class SearchResultConverter {
             final Pair<Long, Long> effectiveCurrentSizeAndCount;
             final Pair<Long, Long> effectiveOldVersionSizeAndCount;
             if (responses.length > 2) {
-                totalCurrentSizeAndCount = extractSizeAndCountFromResponse(responses, tier, 0);
-                effectiveCurrentSizeAndCount = extractSizeAndCountFromResponse(responses, tier, 1);
-                totalOldVersionSizeAndCount = extractSizeAndCountFromResponse(responses, tier, 2);
-                effectiveOldVersionSizeAndCount = extractSizeAndCountFromResponse(responses, tier, 3);
+                totalCurrentSizeAndCount = extractSizeAndCountFromResponse(responses, storageClass, 0);
+                effectiveCurrentSizeAndCount = extractSizeAndCountFromResponse(responses, storageClass, 1);
+                totalOldVersionSizeAndCount = extractSizeAndCountFromResponse(responses, storageClass, 2);
+                effectiveOldVersionSizeAndCount = extractSizeAndCountFromResponse(responses, storageClass, 3);
             } else {
-                totalCurrentSizeAndCount = extractSizeAndCountFromResponse(responses, tier, 0);
+                totalCurrentSizeAndCount = extractSizeAndCountFromResponse(responses, storageClass, 0);
                 effectiveCurrentSizeAndCount = totalCurrentSizeAndCount;
-                totalOldVersionSizeAndCount = extractSizeAndCountFromResponse(responses, tier, 1);
+                totalOldVersionSizeAndCount = extractSizeAndCountFromResponse(responses, storageClass, 1);
                 effectiveOldVersionSizeAndCount = totalOldVersionSizeAndCount;
             }
             return storageUsageStats
-                    .storageClass(tier)
+                    .storageClass(storageClass)
                     .size(totalCurrentSizeAndCount.getRight()).count(totalCurrentSizeAndCount.getLeft())
                     .effectiveSize(effectiveCurrentSizeAndCount.getRight()).effectiveCount(effectiveCurrentSizeAndCount.getLeft())
                     .oldVersionsSize(totalOldVersionSizeAndCount.getRight())

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchResultConverter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchResultConverter.java
@@ -48,7 +48,14 @@ import org.elasticsearch.search.aggregations.metrics.sum.ParsedSum;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightField;
 import org.springframework.stereotype.Service;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -96,12 +103,12 @@ public class SearchResultConverter {
             final MultiSearchResponse.Item[] responses) {
 
         final List<String> storageClasses = Arrays.stream(responses).map(
-                r -> Optional.ofNullable(r.getResponse())
-                        .map(SearchResponse::getAggregations)
-                        .map(aggregations -> aggregations.<ParsedTerms>get(STORAGE_SIZE_BY_TIER_AGG_NAME).getBuckets())
-                        .orElse(Collections.emptyList())
-                ).flatMap(Collection::stream).map(MultiBucketsAggregation.Bucket::getKeyAsString)
-                .distinct().collect(Collectors.toList());
+            r -> Optional.ofNullable(r.getResponse())
+                    .map(SearchResponse::getAggregations)
+                    .map(aggregations -> aggregations.<ParsedTerms>get(STORAGE_SIZE_BY_TIER_AGG_NAME).getBuckets())
+                    .orElse(Collections.emptyList())
+            ).flatMap(Collection::stream).map(MultiBucketsAggregation.Bucket::getKeyAsString)
+            .distinct().collect(Collectors.toList());
 
         return storageClasses.stream().map(storageClass -> {
             final StorageUsage.StorageUsageStats.StorageUsageStatsBuilder storageUsageStats =
@@ -125,7 +132,8 @@ public class SearchResultConverter {
             return storageUsageStats
                     .storageClass(storageClass)
                     .size(totalCurrentSizeAndCount.getRight()).count(totalCurrentSizeAndCount.getLeft())
-                    .effectiveSize(effectiveCurrentSizeAndCount.getRight()).effectiveCount(effectiveCurrentSizeAndCount.getLeft())
+                    .effectiveSize(effectiveCurrentSizeAndCount.getRight())
+                    .effectiveCount(effectiveCurrentSizeAndCount.getLeft())
                     .oldVersionsSize(totalOldVersionSizeAndCount.getRight())
                     .oldVersionsEffectiveSize(effectiveOldVersionSizeAndCount.getRight()).build();
         }).collect(Collectors.toMap(StorageUsage.StorageUsageStats::getStorageClass, s -> s));

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchResultConverter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchResultConverter.java
@@ -31,6 +31,9 @@ import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.elasticsearch.action.search.MultiSearchRequest;
 import org.elasticsearch.action.search.MultiSearchResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.text.Text;
@@ -39,18 +42,13 @@ import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
+import org.elasticsearch.search.aggregations.bucket.terms.ParsedTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.metrics.sum.ParsedSum;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightField;
 import org.springframework.stereotype.Service;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -58,7 +56,11 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class SearchResultConverter {
 
-    private static final String STORAGE_SIZE_AGG_NAME = "sizeSumSearch";
+    private static final String STORAGE_SIZE_AGG_NAME = "sizeSum";
+
+    private static final String STORAGE_SIZE_BY_TIER_AGG_NAME = "sizeSumByTier";
+
+    public static final String STANDARD_TIER = "STANDARD";
 
     public SearchResult buildResult(final SearchResponse searchResult,
                                     final String aggregation,
@@ -75,33 +77,71 @@ public class SearchResultConverter {
                 .build();
     }
 
-    public StorageUsage buildStorageUsageResponse(final MultiSearchResponse searchResponse,
-                                                  final AbstractDataStorage dataStorage, final String path,
-                                                  final int responsesExpected) {
-        final MultiSearchResponse.Item[] responses = tryExtractAllResponses(searchResponse, responsesExpected);
-        final SearchResponse allDocsResponse = tryExtractResponse(responses, 0);
-        final Long totalSize = extractSizeAggregationFromResponse(allDocsResponse);
-        final Long effectiveSize;
-        if (responses.length != 1) {
-            final SearchResponse effectiveDocsResponse = tryExtractResponse(responses, 1);
-            effectiveSize = extractSizeAggregationFromResponse(effectiveDocsResponse);
-        } else {
-            effectiveSize = totalSize;
-        }
+    public StorageUsage buildStorageUsageResponse(final MultiSearchRequest searchRequest,
+                                                  final MultiSearchResponse searchResponse,
+                                                  final AbstractDataStorage dataStorage,
+                                                  final String path) {
+        final MultiSearchResponse.Item[] responses = tryExtractAllResponses(searchResponse, searchRequest);
+        final Map<String, StorageUsage.StorageUsageStats> statsByTiers = buildStorageUsageStatsByStorageTier(responses);
 
         return StorageUsage.builder()
                 .id(dataStorage.getId())
                 .name(dataStorage.getName())
                 .type(dataStorage.getType())
                 .path(path)
-                .totalUsage(
-                        StorageUsage.StorageUsageStats.builder()
-                                .size(totalSize)
-                                .effectiveSize(effectiveSize)
-                                .count(allDocsResponse.getHits().getTotalHits())
-                                .build()
-                )
-                .build();
+                .usage(statsByTiers).build();
+    }
+
+    private Map<String, StorageUsage.StorageUsageStats> buildStorageUsageStatsByStorageTier(
+            final MultiSearchResponse.Item[] responses) {
+
+        final List<String> storageTiers = Arrays.stream(responses).map(
+                r -> Optional.ofNullable(r.getResponse())
+                        .map(SearchResponse::getAggregations)
+                        .map(aggregations -> aggregations.<ParsedTerms>get(STORAGE_SIZE_BY_TIER_AGG_NAME).getBuckets())
+                        .orElse(Collections.emptyList())
+                ).flatMap(Collection::stream).map(MultiBucketsAggregation.Bucket::getKeyAsString)
+                .distinct().collect(Collectors.toList());
+
+        return storageTiers.stream().map(tier -> {
+            final StorageUsage.StorageUsageStats.StorageUsageStatsBuilder storageUsageStats =
+                    StorageUsage.StorageUsageStats.builder();
+
+            final Pair<Long, Long> totalCurrentSizeAndCount;
+            final Pair<Long, Long> totalOldVersionSizeAndCount;
+            final Pair<Long, Long> effectiveCurrentSizeAndCount;
+            final Pair<Long, Long> effectiveOldVersionSizeAndCount;
+            if (responses.length > 2) {
+                totalCurrentSizeAndCount = extractSizeAndCountFromResponse(responses, tier, 0);
+                effectiveCurrentSizeAndCount = extractSizeAndCountFromResponse(responses, tier, 1);
+                totalOldVersionSizeAndCount = extractSizeAndCountFromResponse(responses, tier, 2);
+                effectiveOldVersionSizeAndCount = extractSizeAndCountFromResponse(responses, tier, 3);
+            } else {
+                totalCurrentSizeAndCount = extractSizeAndCountFromResponse(responses, tier, 0);
+                effectiveCurrentSizeAndCount = totalCurrentSizeAndCount;
+                totalOldVersionSizeAndCount = extractSizeAndCountFromResponse(responses, tier, 1);
+                effectiveOldVersionSizeAndCount = totalOldVersionSizeAndCount;
+            }
+            return storageUsageStats
+                    .storageClass(tier)
+                    .size(totalCurrentSizeAndCount.getRight()).count(totalCurrentSizeAndCount.getLeft())
+                    .effectiveSize(effectiveCurrentSizeAndCount.getRight()).effectiveCount(effectiveCurrentSizeAndCount.getLeft())
+                    .oldVersionsSize(totalOldVersionSizeAndCount.getRight())
+                    .oldVersionsEffectiveSize(effectiveOldVersionSizeAndCount.getRight()).build();
+        }).collect(Collectors.toMap(StorageUsage.StorageUsageStats::getStorageClass, s -> s));
+    }
+
+    private ImmutablePair<Long, Long> extractSizeAndCountFromResponse(
+            final MultiSearchResponse.Item[] responses, final String tier, final int requestType) {
+        return Optional.ofNullable(tryExtractResponse(responses, requestType))
+                .map(SearchResponse::getAggregations).map(a -> a.<ParsedTerms>get(STORAGE_SIZE_BY_TIER_AGG_NAME))
+                .map(bkts -> bkts.getBucketByKey(tier))
+                .map(bucket -> ImmutablePair.of(
+                        bucket.getDocCount(),
+                        new Double(
+                                bucket.getAggregations().<ParsedSum>get(STORAGE_SIZE_AGG_NAME).getValue()
+                        ).longValue())
+                ).orElse(ImmutablePair.of(0L, 0L));
     }
 
     public FacetedSearchResult buildFacetedResult(final SearchResponse response, final String typeFieldName,
@@ -239,17 +279,18 @@ public class SearchResultConverter {
     }
 
     private MultiSearchResponse.Item[] tryExtractAllResponses(final MultiSearchResponse searchResponse,
-                                                              final int responsesExpected) {
+                                                              final MultiSearchRequest searchRequest) {
+        int batchSize = searchRequest.requests().size();
         final MultiSearchResponse.Item[] items = Optional.ofNullable(searchResponse)
             .map(MultiSearchResponse::getResponses)
             .filter(searchResponses -> ArrayUtils.getLength(searchResponses) > 0)
             .orElseThrow(() -> new SearchException(
                 "Empty multi-search response from ES, unable to calculate storage consumption."));
         final int responsesCount = items.length;
-        if (responsesExpected != items.length) {
+        if (batchSize != items.length) {
             throw new SearchException(String.format(
                 "Unexpected number of responses during storage size calculation: %d expected, but %d found.",
-                responsesExpected, responsesCount));
+                    batchSize, responsesCount));
         }
         return items;
     }
@@ -268,10 +309,4 @@ public class SearchResultConverter {
         return responseItem.getResponse();
     }
 
-    private Long extractSizeAggregationFromResponse(final SearchResponse searchResponse) {
-        return Optional.ofNullable(searchResponse.getAggregations())
-            .map(aggregations -> aggregations.<ParsedSum>get(STORAGE_SIZE_AGG_NAME))
-            .map(result -> new Double(result.getValue()).longValue())
-            .orElse(0L);
-    }
 }

--- a/api/src/test/java/com/epam/pipeline/test/creator/datastorage/DatastorageCreatorUtils.java
+++ b/api/src/test/java/com/epam/pipeline/test/creator/datastorage/DatastorageCreatorUtils.java
@@ -260,8 +260,7 @@ public final class DatastorageCreatorUtils {
     }
 
     public static StorageUsage getStorageUsage() {
-        return new StorageUsage(ID, TEST_STRING, DataStorageType.S3, TEST_PATH,
-                Collections.emptyMap(), new StorageUsage.StorageUsageStats(ID, ID, ID));
+        return new StorageUsage(ID, TEST_STRING, DataStorageType.S3, TEST_PATH, Collections.emptyMap());
     }
 
     public static StorageMountPath getDefaultStorageMountPath() {

--- a/api/src/test/java/com/epam/pipeline/test/creator/datastorage/DatastorageCreatorUtils.java
+++ b/api/src/test/java/com/epam/pipeline/test/creator/datastorage/DatastorageCreatorUtils.java
@@ -260,7 +260,8 @@ public final class DatastorageCreatorUtils {
     }
 
     public static StorageUsage getStorageUsage() {
-        return new StorageUsage(ID, TEST_STRING, DataStorageType.S3, TEST_PATH, ID, ID, ID);
+        return new StorageUsage(ID, TEST_STRING, DataStorageType.S3, TEST_PATH,
+                Collections.emptyMap(), new StorageUsage.StorageUsageStats(ID, ID, ID));
     }
 
     public static StorageMountPath getDefaultStorageMountPath() {

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/utils/GroupingIterator.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/utils/GroupingIterator.java
@@ -1,0 +1,41 @@
+package com.epam.pipeline.utils;
+
+import org.apache.commons.collections4.iterators.PeekingIterator;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+
+public class GroupingIterator<T> implements Iterator<List<T>> {
+
+    private final PeekingIterator<T> iterator;
+    private final Comparator<T> comparator;
+    private final List<T> group;
+
+    private T head;
+
+    public GroupingIterator(Iterator<T> iterator, Comparator<T> comparator) {
+        this.iterator = new PeekingIterator<>(iterator);
+        this.comparator = comparator;
+        this.group = new ArrayList<>();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return iterator.hasNext();
+    }
+
+    @Override
+    public List<T> next() {
+        group.clear();
+        if (hasNext()) {
+            head = iterator.next();
+            group.add(head);
+        }
+        while (iterator.hasNext() && comparator.compare(head, iterator.peek()) == 0) {
+            group.add(iterator.next());
+        }
+        return group;
+    }
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/utils/GroupingIterator.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/utils/GroupingIterator.java
@@ -12,7 +12,7 @@ public class GroupingIterator<T> implements Iterator<List<T>> {
     private final PeekingIterator<T> iterator;
     private final Comparator<T> comparator;
 
-    public GroupingIterator(Iterator<T> iterator, Comparator<T> comparator) {
+    public GroupingIterator(final Iterator<T> iterator, final Comparator<T> comparator) {
         this.iterator = new PeekingIterator<>(iterator);
         this.comparator = comparator;
     }
@@ -24,7 +24,7 @@ public class GroupingIterator<T> implements Iterator<List<T>> {
 
     @Override
     public List<T> next() {
-        List<T> group = new ArrayList<>();
+        final List<T> group = new ArrayList<>();
         T head = iterator.next();
         group.add(head);
         while (iterator.hasNext() && comparator.compare(head, iterator.peek()) == 0) {

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/utils/GroupingIterator.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/utils/GroupingIterator.java
@@ -11,14 +11,10 @@ public class GroupingIterator<T> implements Iterator<List<T>> {
 
     private final PeekingIterator<T> iterator;
     private final Comparator<T> comparator;
-    private final List<T> group;
-
-    private T head;
 
     public GroupingIterator(Iterator<T> iterator, Comparator<T> comparator) {
         this.iterator = new PeekingIterator<>(iterator);
         this.comparator = comparator;
-        this.group = new ArrayList<>();
     }
 
     @Override
@@ -28,11 +24,9 @@ public class GroupingIterator<T> implements Iterator<List<T>> {
 
     @Override
     public List<T> next() {
-        group.clear();
-        if (hasNext()) {
-            head = iterator.next();
-            group.add(head);
-        }
+        List<T> group = new ArrayList<>();
+        T head = iterator.next();
+        group.add(head);
         while (iterator.hasNext() && comparator.compare(head, iterator.peek()) == 0) {
             group.add(iterator.next());
         }

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/utils/IteratorUtils.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/utils/IteratorUtils.java
@@ -16,7 +16,7 @@ public final class IteratorUtils {
         return new ChunkedIterator<>(iterator, chunkSize);
     }
 
-    public static <T> Iterator<List<T>> grouped(Iterator<T> iterator, Comparator<T> comparator) {
+    public static <T> Iterator<List<T>> grouped(final Iterator<T> iterator, final Comparator<T> comparator) {
         return new GroupingIterator<>(iterator, comparator);
     }
 }

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/utils/IteratorUtils.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/utils/IteratorUtils.java
@@ -1,5 +1,6 @@
 package com.epam.pipeline.utils;
 
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 
@@ -13,5 +14,9 @@ public final class IteratorUtils {
 
     public static <T> Iterator<List<T>> chunked(final Iterator<T> iterator, final int chunkSize) {
         return new ChunkedIterator<>(iterator, chunkSize);
+    }
+
+    public static <T> Iterator<List<T>> grouped(Iterator<T> iterator, Comparator<T> comparator) {
+        return new GroupingIterator<>(iterator, comparator);
     }
 }

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/utils/StreamUtils.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/utils/StreamUtils.java
@@ -25,7 +25,7 @@ public final class StreamUtils {
         return from(IteratorUtils.chunked(stream.iterator(), chunkSize));
     }
 
-    public static <T> Stream<List<T>> grouped(final Stream<T> stream, Comparator<T> comparator) {
+    public static <T> Stream<List<T>> grouped(final Stream<T> stream, final Comparator<T> comparator) {
         return from(IteratorUtils.grouped(stream.iterator(), comparator));
     }
 

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/utils/StreamUtils.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/utils/StreamUtils.java
@@ -1,5 +1,6 @@
 package com.epam.pipeline.utils;
 
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Spliterator;
@@ -22,6 +23,10 @@ public final class StreamUtils {
 
     public static <T> Stream<List<T>> chunked(final Stream<T> stream, final int chunkSize) {
         return from(IteratorUtils.chunked(stream.iterator(), chunkSize));
+    }
+
+    public static <T> Stream<List<T>> grouped(final Stream<T> stream, Comparator<T> comparator) {
+        return from(IteratorUtils.grouped(stream.iterator(), comparator));
     }
 
     /**

--- a/cloud-pipeline-common/model/src/test/java/com/epam/pipeline/utils/GroupingIteratorTest.java
+++ b/cloud-pipeline-common/model/src/test/java/com/epam/pipeline/utils/GroupingIteratorTest.java
@@ -6,19 +6,22 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 
 @RunWith(Parameterized.class)
 public class GroupingIteratorTest {
 
     private final Integer[] data;
     private final Integer expectedSize;
-    private final Integer[] groupedSizes;
+    private final Integer[] groupSizes;
 
-    public GroupingIteratorTest(Integer[] data, Integer expectedSize, Integer[] groupedSizes) {
+    public GroupingIteratorTest(final Integer[] data, final Integer expectedSize, final Integer[] groupSizes) {
         this.data = data;
         this.expectedSize = expectedSize;
-        this.groupedSizes = groupedSizes;
+        this.groupSizes = groupSizes;
     }
 
     @Parameterized.Parameters
@@ -55,7 +58,7 @@ public class GroupingIteratorTest {
         groupingIterator.forEachRemaining(result::add);
         Assert.assertEquals(expectedSize.intValue(), result.size());
         for (int i = 0; i < result.size(); i++) {
-            Assert.assertEquals(groupedSizes[i].intValue(), result.get(i).size());
+            Assert.assertEquals(groupSizes[i].intValue(), result.get(i).size());
         }
     }
 

--- a/cloud-pipeline-common/model/src/test/java/com/epam/pipeline/utils/GroupingIteratorTest.java
+++ b/cloud-pipeline-common/model/src/test/java/com/epam/pipeline/utils/GroupingIteratorTest.java
@@ -1,0 +1,62 @@
+package com.epam.pipeline.utils;
+
+import org.apache.commons.collections4.IteratorUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.*;
+
+@RunWith(Parameterized.class)
+public class GroupingIteratorTest {
+
+    private final Integer[] data;
+    private final Integer expectedSize;
+    private final Integer[] groupedSizes;
+
+    public GroupingIteratorTest(Integer[] data, Integer expectedSize, Integer[] groupedSizes) {
+        this.data = data;
+        this.expectedSize = expectedSize;
+        this.groupedSizes = groupedSizes;
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                {
+                        new Integer[]{1, 1, 1, 2, 3},
+                        3,
+                        new Integer[]{3, 1, 1}
+                },
+                {
+                        new Integer[]{1, 2, 2, 3},
+                        3,
+                        new Integer[]{1, 2, 1}
+                },
+                {
+                        new Integer[]{1, 2, 3},
+                        3,
+                        new Integer[]{1, 1, 1}
+                },
+                {
+                        new Integer[]{},
+                        0,
+                        new Integer[]{0}
+                }
+        });
+    }
+
+    @Test
+    public void iteratorShouldGroupObjects() {
+        GroupingIterator<Integer> groupingIterator = new GroupingIterator<>(
+                IteratorUtils.arrayIterator(data), Integer::compareTo);
+        List<List<Integer>> result = new ArrayList<>();
+        groupingIterator.forEachRemaining(result::add);
+        Assert.assertEquals(expectedSize.intValue(), result.size());
+        for (int i = 0; i < result.size(); i++) {
+            Assert.assertEquals(groupedSizes[i].intValue(), result.get(i).size());
+        }
+    }
+
+}

--- a/cloud-pipeline-common/model/src/test/java/com/epam/pipeline/utils/GroupingIteratorTest.java
+++ b/cloud-pipeline-common/model/src/test/java/com/epam/pipeline/utils/GroupingIteratorTest.java
@@ -49,9 +49,9 @@ public class GroupingIteratorTest {
 
     @Test
     public void iteratorShouldGroupObjects() {
-        GroupingIterator<Integer> groupingIterator = new GroupingIterator<>(
+        final GroupingIterator<Integer> groupingIterator = new GroupingIterator<>(
                 IteratorUtils.arrayIterator(data), Integer::compareTo);
-        List<List<Integer>> result = new ArrayList<>();
+        final List<List<Integer>> result = new ArrayList<>();
         groupingIterator.forEachRemaining(result::add);
         Assert.assertEquals(expectedSize.intValue(), result.size());
         for (int i = 0; i < result.size(); i++) {

--- a/cloud-pipeline-common/model/src/test/java/com/epam/pipeline/utils/GroupingIteratorTest.java
+++ b/cloud-pipeline-common/model/src/test/java/com/epam/pipeline/utils/GroupingIteratorTest.java
@@ -22,28 +22,28 @@ public class GroupingIteratorTest {
     }
 
     @Parameterized.Parameters
-    public static Collection<Object[]> data() {
+    public static Collection<Object[]> provideData() {
         return Arrays.asList(new Object[][] {
-                {
-                        new Integer[]{1, 1, 1, 2, 3},
-                        3,
-                        new Integer[]{3, 1, 1}
-                },
-                {
-                        new Integer[]{1, 2, 2, 3},
-                        3,
-                        new Integer[]{1, 2, 1}
-                },
-                {
-                        new Integer[]{1, 2, 3},
-                        3,
-                        new Integer[]{1, 1, 1}
-                },
-                {
-                        new Integer[]{},
-                        0,
-                        new Integer[]{0}
-                }
+            {
+                new Integer[]{1, 1, 1, 2, 3},
+                3,
+                new Integer[]{3, 1, 1}
+            },
+            {
+                new Integer[]{1, 2, 2, 3},
+                3,
+                new Integer[]{1, 2, 1}
+            },
+            {
+                new Integer[]{1, 2, 3},
+                3,
+                new Integer[]{1, 1, 1}
+            },
+            {
+                new Integer[]{},
+                0,
+                new Integer[]{0}
+            }
         });
     }
 

--- a/core/src/main/java/com/epam/pipeline/entity/datastorage/StorageUsage.java
+++ b/core/src/main/java/com/epam/pipeline/entity/datastorage/StorageUsage.java
@@ -31,15 +31,18 @@ public class StorageUsage {
     private String name;
     private DataStorageType type;
     private String path;
-    private Map<String, StorageUsageStats> usageByStorageClass;
-    private StorageUsageStats totalUsage;
+    private Map<String, StorageUsageStats> usage;
 
     @Value
     @Builder
     @AllArgsConstructor
     public static class StorageUsageStats {
+        String storageClass;
         Long size;
         Long effectiveSize;
+        Long oldVersionsSize;
+        Long oldVersionsEffectiveSize;
         Long count;
+        Long effectiveCount;
     }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/datastorage/StorageUsage.java
+++ b/core/src/main/java/com/epam/pipeline/entity/datastorage/StorageUsage.java
@@ -19,6 +19,9 @@ package com.epam.pipeline.entity.datastorage;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.Value;
+
+import java.util.Map;
 
 @AllArgsConstructor
 @Builder
@@ -28,7 +31,15 @@ public class StorageUsage {
     private String name;
     private DataStorageType type;
     private String path;
-    private Long size;
-    private Long effectiveSize;
-    private Long count;
+    private Map<String, StorageUsageStats> usageByStorageClass;
+    private StorageUsageStats totalUsage;
+
+    @Value
+    @Builder
+    @AllArgsConstructor
+    public static class StorageUsageStats {
+        Long size;
+        Long effectiveSize;
+        Long count;
+    }
 }

--- a/deploy/docker/cp-search/config/application.properties
+++ b/deploy/docker/cp-search/config/application.properties
@@ -49,6 +49,7 @@ sync.run.bulk.insert.size=100
 sync.s3-file.disable=${CP_SEARCH_DISABLE_S3_FILE:false}
 sync.s3-file.index.mapping=file://${CP_SEARCH_MAPPINGS_LOCATION}/storage_file.json
 sync.s3-file.index.name=s3-file
+sync.s3-file.index.include.versions=${CP_SEARCH_S3_FILE_INCLUDE_VERSIONS:false}
 sync.s3-file.enable.tags=false
 sync.s3-file.bulk.insert.size=1000
 sync.s3-file.bulk.load.tags.size=100

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/app/AzureFileSyncConfiguration.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/app/AzureFileSyncConfiguration.java
@@ -69,6 +69,6 @@ public class AzureFileSyncConfiguration {
                 indexSettingsPath, bulkInsertSize, bulkLoadTagsSize,
                 DataStorageType.AZ,
                 SearchDocumentType.AZ_BLOB_FILE,
-                tagDelimiter);
+                tagDelimiter, false);
     }
 }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/app/GSFileSyncConfiguration.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/app/GSFileSyncConfiguration.java
@@ -65,7 +65,7 @@ public class GSFileSyncConfiguration {
                 indexSettingsPath, bulkInsertSize, bulkLoadTagsSize,
                 DataStorageType.GS,
                 SearchDocumentType.GS_FILE,
-                tagDelimiter);
+                tagDelimiter, false);
     }
 
 }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/app/S3FileSyncConfiguration.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/app/S3FileSyncConfiguration.java
@@ -40,6 +40,8 @@ public class S3FileSyncConfiguration {
     private String indexName;
     @Value("${sync.s3-file.index.mapping}")
     private String indexSettingsPath;
+    @Value("${sync.s3-file.index.include.versions:false}")
+    private Boolean includeVersions;
     @Value("${sync.s3-file.bulk.insert.size:1000}")
     private Integer bulkInsertSize;
     @Value("${sync.s3-file.bulk.load.tags.size:100}")
@@ -64,7 +66,8 @@ public class S3FileSyncConfiguration {
                 indexSettingsPath, bulkInsertSize, bulkLoadTagsSize,
                 DataStorageType.S3,
                 SearchDocumentType.S3_FILE,
-                tagDelimiter);
+                tagDelimiter,
+                includeVersions);
     }
 
 }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/ObjectStorageFileManager.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/ObjectStorageFileManager.java
@@ -35,6 +35,10 @@ public interface ObjectStorageFileManager {
                                   String path,
                                   Supplier<TemporaryCredentials> credentialsSupplier);
 
+    Stream<DataStorageFile> versions(String storage,
+                                     String path,
+                                     Supplier<TemporaryCredentials> credentialsSupplier);
+
     Stream<DataStorageFile> versionsWithNativeTags(String storage,
                                                    String path,
                                                    Supplier<TemporaryCredentials> credentialsSupplier);

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/AzureBlobManager.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/AzureBlobManager.java
@@ -84,8 +84,8 @@ public class AzureBlobManager implements ObjectStorageFileManager {
 
     @Override
     public Stream<DataStorageFile> versions(final String storage,
-                                                          final String path,
-                                                          final Supplier<TemporaryCredentials> credentialsSupplier) {
+                                            final String path,
+                                            final Supplier<TemporaryCredentials> credentialsSupplier) {
         return files(storage, path, credentialsSupplier);
     }
 

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/AzureBlobManager.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/AzureBlobManager.java
@@ -83,6 +83,13 @@ public class AzureBlobManager implements ObjectStorageFileManager {
     }
 
     @Override
+    public Stream<DataStorageFile> versions(final String storage,
+                                                          final String path,
+                                                          final Supplier<TemporaryCredentials> credentialsSupplier) {
+        return files(storage, path, credentialsSupplier);
+    }
+
+    @Override
     public Stream<DataStorageFile> versionsWithNativeTags(final String storage,
                                                           final String path,
                                                           final Supplier<TemporaryCredentials> credentialsSupplier) {

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/GsBucketFileManager.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/GsBucketFileManager.java
@@ -79,8 +79,8 @@ public class GsBucketFileManager implements ObjectStorageFileManager {
 
     @Override
     public Stream<DataStorageFile> versions(final String storage,
-                                                          final String path,
-                                                          final Supplier<TemporaryCredentials> credentialsSupplier) {
+                                            final String path,
+                                            final Supplier<TemporaryCredentials> credentialsSupplier) {
         return versionsWithNativeTags(storage, path, credentialsSupplier);
     }
 

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/GsBucketFileManager.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/GsBucketFileManager.java
@@ -78,6 +78,13 @@ public class GsBucketFileManager implements ObjectStorageFileManager {
     }
 
     @Override
+    public Stream<DataStorageFile> versions(final String storage,
+                                                          final String path,
+                                                          final Supplier<TemporaryCredentials> credentialsSupplier) {
+        return versionsWithNativeTags(storage, path, credentialsSupplier);
+    }
+
+    @Override
     public Stream<DataStorageFile> versionsWithNativeTags(final String storage,
                                                           final String path,
                                                           final Supplier<TemporaryCredentials> credentialsSupplier) {

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/ObjectStorageIndexImpl.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/ObjectStorageIndexImpl.java
@@ -22,6 +22,7 @@ import com.epam.pipeline.elasticsearchagent.service.ObjectStorageFileManager;
 import com.epam.pipeline.elasticsearchagent.service.ObjectStorageIndex;
 import com.epam.pipeline.elasticsearchagent.service.impl.converter.storage.StorageFileMapper;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
+import com.epam.pipeline.entity.datastorage.AbstractDataStorageItem;
 import com.epam.pipeline.entity.datastorage.DataStorageAction;
 import com.epam.pipeline.entity.datastorage.DataStorageDownloadFileUrl;
 import com.epam.pipeline.entity.datastorage.DataStorageFile;
@@ -35,6 +36,7 @@ import com.epam.pipeline.vo.data.storage.DataStorageTagLoadRequest;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -45,6 +47,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.time.LocalDateTime;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -104,16 +107,35 @@ public class ObjectStorageIndexImpl implements ObjectStorageIndex {
             final Supplier<TemporaryCredentials> credentialsSupplier = () -> getTemporaryCredentials(dataStorage);
             final TemporaryCredentials credentials = credentialsSupplier.get();
             try (IndexRequestContainer requestContainer = getRequestContainer(indexName, bulkInsertSize)) {
-                final Stream<DataStorageFile> files = fileManager
-                        .files(dataStorage.getRoot(),
-                                Optional.ofNullable(dataStorage.getPrefix()).orElse(StringUtils.EMPTY),
-                                credentialsSupplier);
-                StreamUtils.chunked(files, bulkLoadTagsSize)
-                        .flatMap(filesChunk -> filesWithIncorporatedTags(dataStorage, filesChunk))
-                        .peek(file -> file.setPath(dataStorage.resolveRelativePath(file.getPath())))
-                        .map(file -> createIndexRequest(file, dataStorage, permissionsContainer, indexName,
-                                credentials.getRegion(), findFileContent(dataStorage, file.getPath())))
-                        .forEach(requestContainer::add);
+
+                if (dataStorage.isVersioningEnabled()) {
+                    final Stream<DataStorageFile> files = fileManager.versions(
+                                    dataStorage.getRoot(),
+                                    Optional.ofNullable(dataStorage.getPrefix()).orElse(StringUtils.EMPTY),
+                                    credentialsSupplier
+                            );
+                    StreamUtils.grouped(
+                            StreamUtils.chunked(files, bulkLoadTagsSize)
+                                    .flatMap(filesChunk -> filesWithIncorporatedTags(dataStorage, filesChunk))
+                                    .peek(file -> file.setPath(dataStorage.resolveRelativePath(file.getPath()))),
+                            Comparator.comparing(AbstractDataStorageItem::getPath))
+                        .filter(CollectionUtils::isNotEmpty)
+                        .map(versions -> createIndexRequest(
+                                versions, dataStorage, permissionsContainer, indexName, credentials.getRegion())
+                        ).forEach(requestContainer::add);
+                } else {
+                    final Stream<DataStorageFile> files = fileManager
+                            .files(dataStorage.getRoot(),
+                                    Optional.ofNullable(dataStorage.getPrefix()).orElse(StringUtils.EMPTY),
+                                    credentialsSupplier);
+                    StreamUtils.chunked(files, bulkLoadTagsSize)
+                            .flatMap(filesChunk -> filesWithIncorporatedTags(dataStorage, filesChunk))
+                            .peek(file -> file.setPath(dataStorage.resolveRelativePath(file.getPath())))
+                            .map(file -> createIndexRequest(
+                                    file, dataStorage, permissionsContainer, indexName, credentials.getRegion(),
+                                    findFileContent(dataStorage, file.getPath()))
+                            ).forEach(requestContainer::add);
+                }
             }
 
             elasticsearchServiceClient.createIndexAlias(indexName, alias);
@@ -139,6 +161,9 @@ public class ObjectStorageIndexImpl implements ObjectStorageIndex {
         action.setBucketName(dataStorage.getPath());
         action.setId(dataStorage.getId());
         action.setList(true);
+        action.setListVersion(true);
+        action.setRead(true);
+        action.setReadVersion(true);
         return cloudPipelineAPIClient
                 .generateTemporaryCredentials(Collections.singletonList(action));
     }
@@ -164,6 +189,23 @@ public class ObjectStorageIndexImpl implements ObjectStorageIndex {
         return new IndexRequest(indexName, DOC_MAPPING_TYPE)
                 .source(fileMapper.fileToDocument(file, dataStorage, region,
                         permissionsContainer, getDocumentType(), tagDelimiter, content));
+    }
+
+    private IndexRequest createIndexRequest(final List<DataStorageFile> fileVersions,
+                                            final AbstractDataStorage dataStorage,
+                                            final PermissionsContainer permissionsContainer,
+                                            final String indexName,
+                                            final String region) {
+        final DataStorageFile file = fileVersions.get(0);
+        file.setVersions(
+                fileVersions.stream().skip(1).collect(Collectors.toMap(DataStorageFile::getVersion, v -> v))
+        );
+        return new IndexRequest(indexName, DOC_MAPPING_TYPE).source(
+                fileMapper.fileToDocument(
+                        file, dataStorage, region, permissionsContainer,
+                        getDocumentType(), tagDelimiter, findFileContent(dataStorage, file.getPath())
+                )
+        );
     }
 
     private boolean isNotSharedOrChild(final AbstractDataStorage dataStorage,

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/ObjectStorageIndexImpl.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/ObjectStorageIndexImpl.java
@@ -76,6 +76,8 @@ public class ObjectStorageIndexImpl implements ObjectStorageIndex {
     @Getter
     private final SearchDocumentType documentType;
     private final String tagDelimiter;
+    private final boolean includeVersions;
+
     private final StorageFileMapper fileMapper = new StorageFileMapper();
 
     @Override
@@ -108,7 +110,7 @@ public class ObjectStorageIndexImpl implements ObjectStorageIndex {
             final TemporaryCredentials credentials = credentialsSupplier.get();
             try (IndexRequestContainer requestContainer = getRequestContainer(indexName, bulkInsertSize)) {
 
-                final Stream<DataStorageFile> files = dataStorage.isVersioningEnabled()
+                final Stream<DataStorageFile> files = dataStorage.isVersioningEnabled() && includeVersions
                         ? loadFileWithVersions(dataStorage, credentialsSupplier)
                         : loadFiles(dataStorage, credentialsSupplier);
                 files.map(file -> createIndexRequest(

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/ObjectStorageIndexImpl.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/ObjectStorageIndexImpl.java
@@ -165,7 +165,7 @@ public class ObjectStorageIndexImpl implements ObjectStorageIndex {
                 });
     }
 
-    private IndexRequestContainer getRequestContainer(final String indexName, final int bulkInsertSize) {
+    IndexRequestContainer getRequestContainer(final String indexName, final int bulkInsertSize) {
         return new IndexRequestContainer(requests -> elasticsearchServiceClient.sendRequests(indexName, requests),
                 bulkInsertSize);
     }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/S3FileManager.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/S3FileManager.java
@@ -84,8 +84,8 @@ public class S3FileManager implements ObjectStorageFileManager {
 
     @Override
     public Stream<DataStorageFile> versions(final String storage,
-                                                          final String path,
-                                                          final Supplier<TemporaryCredentials> credentialsSupplier) {
+                                            final String path,
+                                            final Supplier<TemporaryCredentials> credentialsSupplier) {
         final AmazonS3 client = getS3Client(credentialsSupplier);
         return StreamUtils.from(new S3VersionPageIterator(client, storage, path))
                 .flatMap(List::stream)

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/S3FileManager.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/S3FileManager.java
@@ -83,6 +83,16 @@ public class S3FileManager implements ObjectStorageFileManager {
     }
 
     @Override
+    public Stream<DataStorageFile> versions(final String storage,
+                                                          final String path,
+                                                          final Supplier<TemporaryCredentials> credentialsSupplier) {
+        final AmazonS3 client = getS3Client(credentialsSupplier);
+        return StreamUtils.from(new S3VersionPageIterator(client, storage, path))
+                .flatMap(List::stream)
+                .filter(file -> !file.getDeleteMarker());
+    }
+
+    @Override
     public Stream<DataStorageFile> versionsWithNativeTags(final String storage,
                                                           final String path,
                                                           final Supplier<TemporaryCredentials> credentialsSupplier) {

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/storage/StorageFileMapper.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/storage/StorageFileMapper.java
@@ -96,10 +96,8 @@ public class StorageFileMapper {
                     .array("denied_users", permissions.getDeniedUsers().toArray())
                     .array("allowed_groups", permissions.getAllowedGroups().toArray())
                     .array("denied_groups", permissions.getDeniedGroups().toArray())
-                    .field("content", content);
-            if (labels.containsKey(ESConstants.STORAGE_CLASS_LABEL)) {
-                 jsonBuilder.field("storage_class", labels.get(ESConstants.STORAGE_CLASS_LABEL));
-            }
+                    .field("content", content)
+                    .field("storage_class", labels.getOrDefault(ESConstants.STORAGE_CLASS_LABEL, STANDARD_TIER));
 
             if (MapUtils.isNotEmpty(dataStorageFile.getVersions())) {
                 jsonBuilder.field("versions",
@@ -133,7 +131,7 @@ public class StorageFileMapper {
             final long totalSize = tierVersions.stream().collect(Collectors.summarizingLong(DataStorageFile::getSize)).getSum();
             HashMap<String, Object> result = new HashMap<>();
             result.put("size", totalSize);
-            result.put("tier", tier);
+            result.put("storage_class", tier);
             result.put("count", versions.size());
             return result;
         }).collect(Collectors.toList());

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/storage/StorageFileMapper.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/storage/StorageFileMapper.java
@@ -28,9 +28,6 @@ import com.epam.pipeline.entity.search.SearchDocumentType;
 import com.epam.pipeline.entity.search.StorageFileSearchMask;
 import com.epam.pipeline.utils.FileContentUtils;
 import com.epam.pipeline.utils.StreamUtils;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Value;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.MapUtils;
@@ -42,7 +39,6 @@ import org.springframework.util.AntPathMatcher;
 import org.springframework.util.StringUtils;
 
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.function.Function;

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/storage/StorageFileMapper.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/storage/StorageFileMapper.java
@@ -19,6 +19,7 @@ package com.epam.pipeline.elasticsearchagent.service.impl.converter.storage;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.epam.pipeline.elasticsearchagent.model.PermissionsContainer;
 import com.epam.pipeline.elasticsearchagent.service.impl.CloudPipelineAPIClient;
+import com.epam.pipeline.elasticsearchagent.utils.ESConstants;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.DataStorageFile;
 import com.epam.pipeline.entity.datastorage.DataStorageType;
@@ -64,6 +65,7 @@ public class StorageFileMapper {
                                           final String content) {
         try (XContentBuilder jsonBuilder = XContentFactory.jsonBuilder()) {
             final Map<String, String> tags = MapUtils.emptyIfNull(dataStorageFile.getTags());
+            final Map<String, String> labels = MapUtils.emptyIfNull(dataStorageFile.getLabels());
             jsonBuilder
                     .startObject()
                     .field("lastModified", dataStorageFile.getChanged())
@@ -88,6 +90,9 @@ public class StorageFileMapper {
                     .array("allowed_groups", permissions.getAllowedGroups().toArray())
                     .array("denied_groups", permissions.getDeniedGroups().toArray())
                     .field("content", content);
+            if (labels.containsKey(ESConstants.STORAGE_CLASS_LABEL)) {
+                 jsonBuilder.field("storage_class", labels.get(ESConstants.STORAGE_CLASS_LABEL));
+            }
             for (final Map.Entry<String, String> entry : tags.entrySet()) {
                 if (StringUtils.hasText(tagDelimiter) && StringUtils.hasText(entry.getValue())
                         && entry.getValue().contains(tagDelimiter)) {

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/storage/StorageFileMapper.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/converter/storage/StorageFileMapper.java
@@ -40,7 +40,12 @@ import org.springframework.util.StringUtils;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -112,7 +117,7 @@ public class StorageFileMapper {
         }
     }
 
-    private List<Map<String, Object>> calculateVersionSizes(Map<String, AbstractDataStorageItem> versions) {
+    private List<Map<String, Object>> calculateVersionSizes(final Map<String, AbstractDataStorageItem> versions) {
         return StreamUtils.grouped(
                 versions.values().stream().map(v -> (DataStorageFile) v),
                 Comparator.comparing(v -> MapUtils.emptyIfNull(v.getLabels())

--- a/elasticsearch-agent/src/main/resources/application.properties
+++ b/elasticsearch-agent/src/main/resources/application.properties
@@ -65,6 +65,7 @@ sync.az-blob.bulk.load.tags.size=100
 #sync.s3-file.disable=true
 sync.s3-file.index.mapping=classpath:/templates/storage_file.json
 sync.s3-file.index.name=s3-file
+sync.s3-file.index.include.versions=false
 sync.s3-file.enable.tags=false
 sync.s3-file.bulk.insert.size=1000
 sync.s3-file.bulk.load.tags.size=100

--- a/elasticsearch-agent/src/main/resources/templates/storage_file.json
+++ b/elasticsearch-agent/src/main/resources/templates/storage_file.json
@@ -12,6 +12,20 @@
         "name": { "type": "text", "store": true, "index": false, "fields": { "keyword": { "type": "keyword" } } },
         "lastModified": { "type": "date", "format": "yyyy-MM-dd HH:mm:ss.SSS" },
         "size": { "type": "long" },
+        "storage_class": {"type": "keyword", "store": true},
+        "versions": {
+          "properties": {
+            "tier": {
+              "type": "keyword"
+            },
+            "size": {
+              "type": "long"
+            },
+            "count": {
+              "type": "long"
+            }
+          }
+        },
         "path": { "type": "text", "analyzer": "file_path_analyzer", "fields": { "keyword": { "type": "keyword" } } },
         "cloud_path": { "type": "keyword", "index": false },
         "mount_path": { "type": "keyword", "index": false },

--- a/elasticsearch-agent/src/test/java/com/epam/pipeline/elasticsearchagent/service/impl/ObjectStorageIndexTest.java
+++ b/elasticsearch-agent/src/test/java/com/epam/pipeline/elasticsearchagent/service/impl/ObjectStorageIndexTest.java
@@ -17,19 +17,15 @@ package com.epam.pipeline.elasticsearchagent.service.impl;
 
 import com.epam.pipeline.elasticsearchagent.service.ElasticsearchServiceClient;
 import com.epam.pipeline.elasticsearchagent.service.ObjectStorageFileManager;
-import com.epam.pipeline.elasticsearchagent.service.ObjectStorageIndex;
 import com.epam.pipeline.entity.datastorage.*;
 import com.epam.pipeline.entity.search.SearchDocumentType;
 import com.epam.pipeline.vo.EntityPermissionVO;
 import org.apache.commons.io.FilenameUtils;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
@@ -45,9 +41,10 @@ import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 @ExtendWith(MockitoExtension.class)
 public class ObjectStorageIndexTest {
-    
+
     private static final String TEST_BLOB_NAME_1 = "1";
     private static final String TEST_BLOB_NAME_2 = "2";
+    public static final int BULK_SIZE = 1000;
 
     private final AbstractDataStorage dataStorage = new GSBucketStorage(
             1L, "storage", "storage", new StoragePolicy(), null
@@ -78,8 +75,8 @@ public class ObjectStorageIndexTest {
                 fileManager,
                 TEST_NAME,
                 TEST_NAME,
-                1000,
-                1000,
+                BULK_SIZE,
+                BULK_SIZE,
                 DataStorageType.GS,
                 SearchDocumentType.GS_FILE,
                 ";", false)

--- a/elasticsearch-agent/src/test/java/com/epam/pipeline/elasticsearchagent/service/impl/ObjectStorageIndexTest.java
+++ b/elasticsearch-agent/src/test/java/com/epam/pipeline/elasticsearchagent/service/impl/ObjectStorageIndexTest.java
@@ -74,7 +74,7 @@ public class ObjectStorageIndexTest {
             1000,
             DataStorageType.GS,
             SearchDocumentType.GS_FILE,
-            ";");
+            ";", false);
 
     @Test
     public void shouldAddZeroFilesToRequestContainer() {

--- a/elasticsearch-agent/src/test/java/com/epam/pipeline/elasticsearchagent/service/impl/ObjectStorageIndexVersionsTest.java
+++ b/elasticsearch-agent/src/test/java/com/epam/pipeline/elasticsearchagent/service/impl/ObjectStorageIndexVersionsTest.java
@@ -44,6 +44,7 @@ public class ObjectStorageIndexVersionsTest {
 
     private static final String TEST_BLOB_NAME_1 = "1";
     private static final String TEST_BLOB_NAME_2 = "2";
+    public static final int BULK_SIZE = 1000;
 
     private final Supplier<TemporaryCredentials> temporaryCredentials = () ->
             TemporaryCredentials.builder().region("").build();
@@ -71,8 +72,8 @@ public class ObjectStorageIndexVersionsTest {
                         fileManager,
                         TEST_NAME,
                         TEST_NAME,
-                        1000,
-                        1000,
+                        BULK_SIZE,
+                        BULK_SIZE,
                         DataStorageType.S3,
                         SearchDocumentType.S3_FILE,
                         ";", true)

--- a/elasticsearch-agent/src/test/resources/test-application.properties
+++ b/elasticsearch-agent/src/test/resources/test-application.properties
@@ -1,7 +1,7 @@
 #DB
 database.url=jdbc:postgresql://127.0.0.1:5432/pipeline_test
-database.username=pipeline
-database.password=pipeline
+database.username=postgres
+database.password=
 database.driverClass=org.postgresql.Driver
 database.max.pool.size=2
 database.initial.pool.size=1

--- a/elasticsearch-agent/src/test/resources/test-application.properties
+++ b/elasticsearch-agent/src/test/resources/test-application.properties
@@ -1,7 +1,7 @@
 #DB
 database.url=jdbc:postgresql://127.0.0.1:5432/pipeline_test
-database.username=postgres
-database.password=
+database.username=pipeline
+database.password=pipeline
 database.driverClass=org.postgresql.Driver
 database.max.pool.size=2
 database.initial.pool.size=1

--- a/pipe-cli/src/model/data_storage_usage_model.py
+++ b/pipe-cli/src/model/data_storage_usage_model.py
@@ -1,0 +1,55 @@
+class StorageUsage(object):
+
+    def __init__(self):
+        self.usage = {}
+
+    def add_item(self, tier, size):
+        if tier not in self.usage:
+            self.usage[tier] = StorageUsageItem(tier)
+        self.usage.get(tier).add_item(size)
+
+    def populate(self, tier, size, count, effective_size, effective_count,
+                 old_versions_size, old_versions_effective_size):
+        if tier not in self.usage:
+            self.usage[tier] = StorageUsageItem(tier)
+        self.usage.get(tier).populate(size, count, effective_size, effective_count,
+                                      old_versions_size, old_versions_effective_size)
+
+    def get_usage(self):
+        return self.usage
+
+    def get_tiers(self):
+        return self.usage.keys()
+
+    def get_total_count(self):
+        return sum([item.effective_count for item in self.usage.values()])
+
+    def get_total_size(self):
+        return sum([item.effective_size for item in self.usage.values()])
+
+
+class StorageUsageItem(object):
+
+    def __init__(self, tier="STANDARD"):
+        self.tier = tier
+        self.size = 0
+        self.effective_size = 0
+        self.count = 0
+        self.effective_count = 0
+        self.old_versions_size = 0
+        self.old_versions_effective_size = 0
+
+    def add_item(self, size):
+        self.size += size
+        self.count += 1
+        self.effective_size += size
+        self.effective_count += 1
+
+    def populate(self, size, count, effective_size, effective_count, old_versions_size, old_versions_effective_size):
+        self.size = size
+        self.count = count
+        self.effective_size = effective_size
+        self.effective_count = effective_count
+        self.old_versions_size = old_versions_size
+        self.old_versions_effective_size = old_versions_effective_size
+

--- a/pipe-cli/src/utilities/du_format_type.py
+++ b/pipe-cli/src/utilities/du_format_type.py
@@ -31,12 +31,16 @@ class DuFormatType(object):
             return 'Kb'
 
     @staticmethod
-    def pretty_value(value, type):
-        if type in DuFormatType.__gb():
+    def pretty_value(usage, measurement_type):
+        return DuFormatType.pretty_size_value(usage.get_total_size(), measurement_type)
+
+    @staticmethod
+    def pretty_size_value(value, measurement_type):
+        if measurement_type in DuFormatType.__gb():
             return DuFormatType.__to_string(value / float(1 << 30))
-        if type in DuFormatType.__mb():
+        if measurement_type in DuFormatType.__mb():
             return DuFormatType.__to_string(value / float(1 << 20))
-        if type in DuFormatType.__kb():
+        if measurement_type in DuFormatType.__kb():
             return DuFormatType.__to_string(value / float(1 << 10))
 
     @staticmethod

--- a/pipe-cli/src/utilities/storage/common.py
+++ b/pipe-cli/src/utilities/storage/common.py
@@ -297,6 +297,8 @@ class AbstractTransferManager:
 class AbstractListingManager:
     __metaclass__ = ABCMeta
 
+    STANDARD_TIER = "STANDARD"
+
     @abstractmethod
     def list_items(self, relative_path=None, recursive=False, page_size=StorageOperations.DEFAULT_PAGE_SIZE,
                    show_all=False, show_archive=False):

--- a/pipe-cli/src/utilities/storage/gs.py
+++ b/pipe-cli/src/utilities/storage/gs.py
@@ -24,6 +24,7 @@ from requests.adapters import HTTPAdapter
 from s3transfer import TransferConfig, MultipartUploader, OSUtils, MultipartDownloader
 from urllib3.connection import VerifiedHTTPSConnection
 
+from src.model.data_storage_usage_model import StorageUsage
 from src.utilities.encoding_utilities import to_string
 
 try:
@@ -432,12 +433,10 @@ class GsListingManager(GsManager, AbstractListingManager):
         bucket = self.client.bucket(self.bucket.path)
         blobs_iterator = bucket.list_blobs(prefix=prefix if relative_path else None)
 
-        size = 0
-        count = 0
+        storage_usage = StorageUsage()
         for blob in blobs_iterator:
-            size += blob.size
-            count += 1
-        return [StorageOperations.PATH_SEPARATOR.join([self.bucket.path, relative_path]), count, size]
+            storage_usage.add_item(AbstractListingManager.STANDARD_TIER, blob.size)
+        return [StorageOperations.PATH_SEPARATOR.join([self.bucket.path, relative_path]), storage_usage]
 
     def get_summary_with_depth(self, max_depth, relative_path=None):
         prefix = StorageOperations.get_prefix(relative_path)
@@ -449,7 +448,7 @@ class GsListingManager(GsManager, AbstractListingManager):
         for blob in blobs_iterator:
             size = blob.size
             name = blob.name
-            accumulator.add_path(name, size)
+            accumulator.add_path(name, AbstractListingManager.STANDARD_TIER, size)
         return accumulator.get_tree()
 
     def _to_storage_file(self, blob):

--- a/pipe-cli/src/utilities/storage/s3.py
+++ b/pipe-cli/src/utilities/storage/s3.py
@@ -15,6 +15,7 @@
 from boto3.s3.transfer import TransferConfig
 from botocore.endpoint import BotocoreHTTPSession, MAX_POOL_CONNECTIONS
 
+from src.model.data_storage_usage_model import StorageUsage
 from src.utilities.datastorage_lifecycle_manager import DataStorageLifecycleManager
 from src.utilities.encoding_utilities import to_string, to_ascii, is_safe_chars
 from src.utilities.storage.s3_proxy_utils import AwsProxyConnectWithHeadersHTTPSAdapter
@@ -642,7 +643,8 @@ class ListingManager(StorageItemManager, AbstractListingManager):
                 for file in page['Contents']:
                     name = self.get_file_name(file, prefix, True)
                     size = file['Size']
-                    accumulator.add_path(name, size)
+                    tier = file['StorageClass']
+                    accumulator.add_path(name, tier, size)
             if not page['IsTruncated']:
                 break
         return accumulator.get_tree()
@@ -660,18 +662,16 @@ class ListingManager(StorageItemManager, AbstractListingManager):
         paginator = client.get_paginator('list_objects_v2')
         page_iterator = paginator.paginate(**operation_parameters)
 
-        total_size = 0
-        total_objects = 0
+        storage_usage = StorageUsage()
 
         for page in page_iterator:
             if 'Contents' in page:
                 for file in page['Contents']:
                     if self.prefix_match(file, relative_path):
-                        total_size += file['Size']
-                        total_objects += 1
+                        storage_usage.add_item(file["StorageClass"], file['Size'])
             if not page['IsTruncated']:
                 break
-        return delimiter.join([self.bucket.bucket.path, relative_path]), total_objects, total_size
+        return delimiter.join([self.bucket.bucket.path, relative_path]), storage_usage
 
     @classmethod
     def prefix_match(cls, page_file, relative_path=None):

--- a/pipe-cli/src/utilities/storage/storage_usage.py
+++ b/pipe-cli/src/utilities/storage/storage_usage.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from treelib import Tree
+from src.model.data_storage_usage_model import StorageUsage
 
 
 class StorageUsageAccumulator(object):
@@ -27,15 +28,15 @@ class StorageUsageAccumulator(object):
         self.range_start = 1
         if relative_path:
             root_path = delimiter.join([bucket_name, relative_path])
-            self.root = self.result.create_node(root_path, root_path, data=StorageUsageItem())
+            self.root = self.result.create_node(root_path, root_path, data=StorageUsage())
             self.relative_path_len = len(relative_path.split(delimiter))
             self.range_start = self.relative_path_len + 1
         else:
-            self.root = self.result.create_node(bucket_name, bucket_name, data=StorageUsageItem())
+            self.root = self.result.create_node(bucket_name, bucket_name, data=StorageUsage())
 
-    def add_path(self, name, size):
+    def add_path(self, name, tier, size):
         tokens = name.split(self.delimiter)
-        self.root.data.add_item(size)
+        self.root.data.add_item(tier, size)
 
         if len(tokens) - self.relative_path_len > 1:
             if self.relative_path:
@@ -43,31 +44,15 @@ class StorageUsageAccumulator(object):
             else:
                 first_token = self.delimiter.join([self.bucket_name, tokens[0]])
             if not self.result.contains(first_token):
-                self.result.create_node(tokens[0], first_token, data=StorageUsageItem(), parent=self.root)
-            self.result[first_token].data.add_item(size)
+                self.result.create_node(tokens[0], first_token, data=StorageUsage(), parent=self.root)
+            self.result[first_token].data.add_item(tier, size)
             for i in range(self.range_start, min(self.max_depth, len(tokens) - 1)):
                 token = self.delimiter.join([self.bucket_name] + tokens[:i + 1])
                 parent_token = self.delimiter.join([self.bucket_name] + tokens[:i])
                 if not self.result.contains(token):
-                    self.result.create_node(tokens[i], token, parent=parent_token, data=StorageUsageItem())
-                self.result[token].data.add_item(size)
+                    self.result.create_node(tokens[i], token, parent=parent_token, data=StorageUsage())
+                self.result[token].data.add_item(tier, size)
 
     def get_tree(self):
         return self.result
 
-
-class StorageUsageItem(object):
-
-    def __init__(self):
-        self.size = 0
-        self.count = 0
-
-    def add_item(self, size):
-        self.size += size
-        self.count += 1
-
-    def get_size(self):
-        return self.size
-
-    def get_count(self):
-        return self.count


### PR DESCRIPTION
Related to #3028.

Changes:
 - ElasticSearch Agent is changed in a matter of building index for storage files. If storage is versioned and version indexing is enabled - agent will list all versions of files instead of just files, combine it and then process
 - Cloud-Pipeline API - The way how to query `elasticsearch` is changed, now we also query for old version information
 - `pipe du` command - was changed to support new model