### PR TITLE
Issue #3030: Data transition notifications shall be optionally sent to all users with R/W access to the storage

### DIFF
--- a/core/src/main/java/com/epam/pipeline/dto/datastorage/lifecycle/StorageLifecycleNotification.java
+++ b/core/src/main/java/com/epam/pipeline/dto/datastorage/lifecycle/StorageLifecycleNotification.java
@@ -34,4 +34,5 @@ public class StorageLifecycleNotification {
     Boolean enabled;
     String subject;
     String body;
+    Boolean notifyUsers;
 }

--- a/storage-lifecycle-service/sls/app/cp_api_interface.py
+++ b/storage-lifecycle-service/sls/app/cp_api_interface.py
@@ -56,5 +56,8 @@ class CloudPipelineDataSource:
     def load_regions(self):
         pass
 
+    def load_entity_permissions(self, entity_id, entity_class):
+        pass
+
     def _load_default_lifecycle_rule_notification(self):
         pass

--- a/storage-lifecycle-service/sls/app/storage_permissions_manager.py
+++ b/storage-lifecycle-service/sls/app/storage_permissions_manager.py
@@ -1,0 +1,66 @@
+# Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from sls.app.cp_api_interface import CloudPipelineDataSource
+
+DATA_STORAGE = 'DATA_STORAGE'
+
+
+class StoragePermissionsManager:
+
+    def __init__(self, api: CloudPipelineDataSource, storage_id: int):
+        self._api = api
+        self._storage_id = storage_id
+
+    def get_users(self):
+        users = []
+        for storage_permission in self._get_storage_permissions():
+            sid = storage_permission.get('sid')
+            mask = storage_permission.get('mask')
+            if not sid or not mask:
+                continue
+            if not self._has_read_or_write_permission(int(mask)):
+                continue
+            name = sid.get('name')
+            if not name:
+                continue
+            principal = sid.get('principal')
+            if principal:
+                users.append(name)
+                continue
+            role_name = str(name).upper()
+            for role_user in self._get_role_users(role_name):
+                user = role_user.get('userName')
+                if user:
+                    users.append(user)
+        return users
+
+    def _get_storage_permissions(self):
+        entity = self._api.load_entity_permissions(self._storage_id, DATA_STORAGE)
+        if not entity:
+            return []
+        return entity.get('permissions', []) or []
+
+    def _get_role_users(self, role_name):
+        response = self._api.load_role_by_name(role_name)
+        if not response:
+            return []
+        return response.get('users', []) or []
+
+    def _has_read_or_write_permission(self, mask):
+        return self._bit_enabled(1, mask) or self._bit_enabled(1 << 2, mask)
+
+    @staticmethod
+    def _bit_enabled(bit, mask):
+        return mask & bit == bit

--- a/storage-lifecycle-service/sls/app/synchronizer/archiving_synchronizer_impl.py
+++ b/storage-lifecycle-service/sls/app/synchronizer/archiving_synchronizer_impl.py
@@ -18,6 +18,7 @@ import datetime
 import os
 import re
 
+from sls.app.storage_permissions_manager import StoragePermissionsManager
 from sls.app.synchronizer.storage_synchronizer_interface import StorageLifecycleSynchronizer
 from sls.app.model.sync_event_model import StorageLifecycleRuleActionItems
 from sls.pipelineapi.model.archive_rule_model import StorageLifecycleRuleTransition, StorageLifecycleRuleProlongation
@@ -368,6 +369,9 @@ class StorageLifecycleArchivingSynchronizer(StorageLifecycleSynchronizer):
                     loaded_role = self.pipeline_api_client.load_role_by_name(recipient["name"])
                     if loaded_role and "users" in loaded_role:
                         cc_users.extend([user["userName"] for user in loaded_role["users"]])
+            if rule.notification.notify_users:
+                storage_users = StoragePermissionsManager(self.pipeline_api_client, storage.id).get_users()
+                cc_users.extend(storage_users)
 
             _to_user = next(iter(cc_users), None)
             is_date_expired = self._is_action_date_expired(notification_properties)

--- a/storage-lifecycle-service/sls/app/synchronizer/archiving_synchronizer_impl.py
+++ b/storage-lifecycle-service/sls/app/synchronizer/archiving_synchronizer_impl.py
@@ -371,7 +371,7 @@ class StorageLifecycleArchivingSynchronizer(StorageLifecycleSynchronizer):
                         cc_users.extend([user["userName"] for user in loaded_role["users"]])
             if rule.notification.notify_users:
                 storage_users = StoragePermissionsManager(self.pipeline_api_client, storage.id).get_users()
-                cc_users.extend(storage_users)
+                cc_users.extend([user_name for user_name in storage_users if not cc_users.__contains__(user_name)])
 
             _to_user = next(iter(cc_users), None)
             is_date_expired = self._is_action_date_expired(notification_properties)

--- a/storage-lifecycle-service/sls/pipelineapi/cp_api_interface_impl.py
+++ b/storage-lifecycle-service/sls/pipelineapi/cp_api_interface_impl.py
@@ -134,6 +134,9 @@ class RESTApiCloudPipelineDataSource(CloudPipelineDataSource):
 
         return CloudPipelineNotification.build_from_dicts(notification_template, notification_settings)
 
+    def load_entity_permissions(self, entity_id, entity_class):
+        return self.api.get_entity_permissions(entity_id, entity_class)
+
     def _load_default_lifecycle_rule_notification(self):
         notification = self.load_notification(self.DATASTORAGE_LIFECYCLE_ACTION_NOTIFICATION_TYPE)
         default_rule_prolong_days = self.load_preference("storage.lifecycle.prolong.days")
@@ -158,5 +161,6 @@ class RESTApiCloudPipelineDataSource(CloudPipelineDataSource):
             recipients=recipients,
             enabled=notification.settings.enabled,
             subject=notification.template.subject if notification.template.subject else "",
-            body=notification.template.body if notification.template.body else ""
+            body=notification.template.body if notification.template.body else "",
+            notify_users=False
         )

--- a/storage-lifecycle-service/sls/pipelineapi/model/archive_rule_model.py
+++ b/storage-lifecycle-service/sls/pipelineapi/model/archive_rule_model.py
@@ -41,13 +41,14 @@ class StorageLifecycleRuleProlongation:
 
 class StorageLifecycleNotification:
 
-    def __init__(self, notify_before_days, prolong_days, recipients, enabled, subject, body):
+    def __init__(self, notify_before_days, prolong_days, recipients, enabled, subject, body, notify_users):
         self.notify_before_days = notify_before_days
         self.prolong_days = prolong_days
         self.recipients = recipients
         self.enabled = enabled
         self.subject = subject
         self.body = body
+        self.notify_users = notify_users
 
 
 class StorageLifecycleRule:
@@ -183,5 +184,7 @@ class LifecycleRuleParser:
             if "recipients" in notification_json else default_notification.recipients,
             enabled=notification_json["enabled"] if "enabled" in notification_json else default_notification.enabled,
             subject=notification_json["subject"] if "subject" in notification_json else default_notification.subject,
-            body=notification_json["body"] if "body" in notification_json else default_notification.body
+            body=notification_json["body"] if "body" in notification_json else default_notification.body,
+            notify_users=notification_json["notifyUsers"]
+            if "notifyUsers" in notification_json else default_notification.notify_users
         )

--- a/storage-lifecycle-service/tests/test_notification.py
+++ b/storage-lifecycle-service/tests/test_notification.py
@@ -22,7 +22,7 @@ from sls.pipelineapi.model.archive_rule_model import StorageLifecycleNotificatio
 
 class TestNotificationPositive(unittest.TestCase):
 
-    enabled_notification = StorageLifecycleNotification(7, 7, [], True, "", "")
+    enabled_notification = StorageLifecycleNotification(7, 7, [], True, "", "", False)
     completed_execution = StorageLifecycleRuleExecution(
         1, 1, sls.app.synchronizer.archiving_synchronizer_impl.EXECUTION_SUCCESS_STATUS, "/",
         "GLACIER", datetime.datetime.now())
@@ -70,8 +70,8 @@ class TestNotificationPositive(unittest.TestCase):
 
 class TestNotificationNegative(unittest.TestCase):
 
-    enabled_notification = StorageLifecycleNotification(7, 7, [], True, "", "")
-    disabled_notification = StorageLifecycleNotification(None, None, None, False, None, None)
+    enabled_notification = StorageLifecycleNotification(7, 7, [], True, "", "", False)
+    disabled_notification = StorageLifecycleNotification(None, None, None, False, None, None, False)
     running_execution = StorageLifecycleRuleExecution(
         1, 1, sls.app.synchronizer.archiving_synchronizer_impl.EXECUTION_RUNNING_STATUS, "/",
         "GLACIER", datetime.datetime.now())

--- a/workflows/pipe-common/pipeline/api/api.py
+++ b/workflows/pipe-common/pipeline/api/api.py
@@ -247,6 +247,7 @@ class PipelineAPI:
     DATA_STORAGE_LOAD_URL = "/datastorage/{id}/load"
     CATEGORICAL_ATTRIBUTE_URL = "/categoricalAttribute"
     GRANT_PERMISSIONS_URL = "/grant"
+    PERMISSION_URL = "/permissions"
 
     # Pipeline API default header
 
@@ -1284,3 +1285,12 @@ class PipelineAPI:
             )
         except Exception as e:
             raise RuntimeError("Failed to grant permissions, object: {} error: {}".format(permissions_object, str(e.message)))
+
+    def get_entity_permissions(self, entity_id, entity_class):
+        request_url = '%s?id=%s&aclClass=%s' % (self.PERMISSION_URL, str(entity_id), entity_class)
+        try:
+            return self._request(endpoint=request_url, http_method="get")
+        except Exception as e:
+            raise RuntimeError("Failed to load permissions for entity '{}' with ID '{}', error: {}".format(
+                entity_class, str(entity_id), str(e)))
+


### PR DESCRIPTION
The current PR provides implementation for issue #3030 

The following changes were added:
-  a new boolean field `notifyUsers` added to storage lifecycle notification object
-  if `notifyUsers` enabled, users with read or write permissions shall be included to recipients