### PR TITLE
Pipeline CLI: update operation fix - fix for win pipe executable

### DIFF
--- a/deploy/docker/cp-api-srv/init-api
+++ b/deploy/docker/cp-api-srv/init-api
@@ -120,7 +120,7 @@ function sign_and_publish_pipe_win_distribution() {
     unzip -p "$jar_path" BOOT-INF/classes/static/pipe.zip >pipe.zip
     unzip -qq pipe.zip
     rm -f pipe.zip
-    sign_win_executable "pipe/pipe.bat" "$cert_path" "$cert_pass" "$cert_desc" "$cert_url"
+    sign_win_executable "pipe/pipe-cli.exe" "$cert_path" "$cert_pass" "$cert_desc" "$cert_url"
     sign_win_executable "pipe/ntlmaps/ntlmaps.exe" "$cert_path" "$cert_pass" "$cert_desc" "$cert_url"
     zip -q -r "$output_dir/pipe.zip" pipe
     rm -rf pipe

--- a/deploy/docker/cp-api-srv/init-api
+++ b/deploy/docker/cp-api-srv/init-api
@@ -120,7 +120,7 @@ function sign_and_publish_pipe_win_distribution() {
     unzip -p "$jar_path" BOOT-INF/classes/static/pipe.zip >pipe.zip
     unzip -qq pipe.zip
     rm -f pipe.zip
-    sign_win_executable "pipe/pipe.exe" "$cert_path" "$cert_pass" "$cert_desc" "$cert_url"
+    sign_win_executable "pipe/pipe.bat" "$cert_path" "$cert_pass" "$cert_desc" "$cert_url"
     sign_win_executable "pipe/ntlmaps/ntlmaps.exe" "$cert_path" "$cert_pass" "$cert_desc" "$cert_url"
     zip -q -r "$output_dir/pipe.zip" pipe
     rm -rf pipe

--- a/pipe-cli/res/pipe-win-version-info.txt
+++ b/pipe-cli/res/pipe-win-version-info.txt
@@ -34,7 +34,7 @@ VSVersionInfo(
         StringStruct(u'FileVersion', u'${PIPE_CLI_MAJOR_VERSION}.${PIPE_CLI_MINOR_VERSION}.${PIPE_CLI_PATCH_VERSION}.${PIPE_CLI_BUILD_VERSION}'),
         StringStruct(u'InternalName', u'pipe'),
         StringStruct(u'LegalCopyright', u'Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)'),
-        StringStruct(u'OriginalFilename', u'pipe.exe'),
+        StringStruct(u'OriginalFilename', u'pipe.bat'),
         StringStruct(u'ProductName', u'Cloud Pipeline CLI'),
         StringStruct(u'ProductVersion', u'${PIPE_CLI_MAJOR_VERSION}.${PIPE_CLI_MINOR_VERSION}.${PIPE_CLI_PATCH_VERSION}.${PIPE_CLI_BUILD_VERSION}')])
       ]), 

--- a/scripts/dts/DeployDts.ps1
+++ b/scripts/dts/DeployDts.ps1
@@ -76,7 +76,7 @@ if ($Install) {
 `$env:CP_API_JWT_KEY_PUBLIC = "$env:API_PUBLIC_KEY"
 `$env:DTS_LOCAL_NAME = "$env:DTS_NAME"
 `$env:DTS_IMPERSONATION_ENABLED = "false"
-`$env:DTS_PIPE_EXECUTABLE = "$env:DTS_DIR\pipe\pipe\pipe.exe"
+`$env:DTS_PIPE_EXECUTABLE = "$env:DTS_DIR\pipe\pipe\pipe.bat"
 "@ | Out-File -FilePath Environment.ps1 -Encoding ascii -Force -ErrorAction Stop
 
     Log "Loading environment..."

--- a/scripts/dts/DeployDts.ps1
+++ b/scripts/dts/DeployDts.ps1
@@ -76,7 +76,7 @@ if ($Install) {
 `$env:CP_API_JWT_KEY_PUBLIC = "$env:API_PUBLIC_KEY"
 `$env:DTS_LOCAL_NAME = "$env:DTS_NAME"
 `$env:DTS_IMPERSONATION_ENABLED = "false"
-`$env:DTS_PIPE_EXECUTABLE = "$env:DTS_DIR\pipe\pipe\pipe.bat"
+`$env:DTS_PIPE_EXECUTABLE = "$env:DTS_DIR\pipe\pipe\pipe"
 "@ | Out-File -FilePath Environment.ps1 -Encoding ascii -Force -ErrorAction Stop
 
     Log "Loading environment..."

--- a/scripts/pipeline-launch/launch.py
+++ b/scripts/pipeline-launch/launch.py
@@ -222,7 +222,7 @@ try:
     _extract_archive(os.path.join(pipe_dir, 'pipe.zip'), os.path.dirname(pipe_dir))
 
     logger.info('Configuring pipe...')
-    subprocess.check_call(f'powershell -Command "pipe.bat configure --api \'{api_url}\''
+    subprocess.check_call(f'powershell -Command "pipe configure --api \'{api_url}\''
                           f'                                        --auth-token \'{api_token}\''
                           f'                                        --timezone local'
                           f'                                        --proxy pac"')
@@ -334,7 +334,7 @@ try:
                      user=owner)
 
     logger.info('Configuring node SSH server proxy...')
-    subprocess.check_call(f'powershell -Command "pipe.bat tunnel start --direct -lp 22 -rp 22 --trace '
+    subprocess.check_call(f'powershell -Command "pipe tunnel start --direct -lp 22 -rp 22 --trace '
                           f'-l {_escape_backslashes(os.path.join(run_dir, "ssh_proxy.log"))} '
                           f'{node_ip}"')
 

--- a/scripts/pipeline-launch/launch.py
+++ b/scripts/pipeline-launch/launch.py
@@ -222,7 +222,7 @@ try:
     _extract_archive(os.path.join(pipe_dir, 'pipe.zip'), os.path.dirname(pipe_dir))
 
     logger.info('Configuring pipe...')
-    subprocess.check_call(f'powershell -Command "pipe.exe configure --api \'{api_url}\''
+    subprocess.check_call(f'powershell -Command "pipe.bat configure --api \'{api_url}\''
                           f'                                        --auth-token \'{api_token}\''
                           f'                                        --timezone local'
                           f'                                        --proxy pac"')
@@ -334,7 +334,7 @@ try:
                      user=owner)
 
     logger.info('Configuring node SSH server proxy...')
-    subprocess.check_call(f'powershell -Command "pipe.exe tunnel start --direct -lp 22 -rp 22 --trace '
+    subprocess.check_call(f'powershell -Command "pipe.bat tunnel start --direct -lp 22 -rp 22 --trace '
                           f'-l {_escape_backslashes(os.path.join(run_dir, "ssh_proxy.log"))} '
                           f'{node_ip}"')
 


### PR DESCRIPTION
The current PR provides fix for `pipe update` operation for windows OS: use `pipe.bat` wrapper instead of pipe.exe