### PR TITLE
Issue #3030: Data transition notifications shall be optionally sent to all users with R/W access to the storage 

### DIFF
--- a/api/src/test/java/com/epam/pipeline/manager/datastorage/lifecycle/DataStorageLifecycleRestoreManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/datastorage/lifecycle/DataStorageLifecycleRestoreManagerTest.java
@@ -79,7 +79,7 @@ public class DataStorageLifecycleRestoreManagerTest {
             .started(DateUtils.nowUTC().minus(ONE, ChronoUnit.DAYS)).build();
     public static final String STANDARD_RESTORE_MODE = "Standard";
     public static final StorageRestoreActionNotification DISABLED_NOTIFICATION =
-            new StorageRestoreActionNotification(false, Collections.emptyList());
+            new StorageRestoreActionNotification(false, Collections.emptyList(), false);
 
     private final PreferenceManager preferenceManager = Mockito.mock(PreferenceManager.class);
     private final DataStorageRestoreActionRepository dataStoragePathRestoreActionRepository =
@@ -140,7 +140,7 @@ public class DataStorageLifecycleRestoreManagerTest {
         lifecycleManager.buildStoragePathRestoreAction(dataStorage, StorageRestorePath.builder().path(PATH_1)
                         .type(StorageRestorePathType.FOLDER).build(),
                 STANDARD_RESTORE_MODE, DAYS_TO_RESTORE_10, false, false,
-                new StorageRestoreActionNotification(true, Collections.emptyList()));
+                new StorageRestoreActionNotification(true, Collections.emptyList(), false));
     }
 
     @Test(expected = IllegalStateException.class)

--- a/core/src/main/java/com/epam/pipeline/dto/datastorage/lifecycle/restore/StorageRestoreActionNotification.java
+++ b/core/src/main/java/com/epam/pipeline/dto/datastorage/lifecycle/restore/StorageRestoreActionNotification.java
@@ -30,4 +30,5 @@ import java.util.List;
 public class StorageRestoreActionNotification {
     private Boolean enabled;
     private List<SidImpl> recipients;
+    private Boolean notifyUsers;
 }

--- a/storage-lifecycle-service/sls/app/synchronizer/restoring_synchronizer_impl.py
+++ b/storage-lifecycle-service/sls/app/synchronizer/restoring_synchronizer_impl.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from collections import OrderedDict
 
+from sls.app.storage_permissions_manager import StoragePermissionsManager
 from sls.app.synchronizer.storage_synchronizer_interface import StorageLifecycleSynchronizer
 from sls.pipelineapi.model.restore_action_model import StorageLifecycleRestoreAction
 
@@ -193,6 +194,10 @@ class StorageLifecycleRestoringSynchronizer(StorageLifecycleSynchronizer):
                     loaded_role = self.pipeline_api_client.load_role_by_name(recipient["name"])
                     if loaded_role and "users" in loaded_role:
                         cc_users.extend([user["userName"] for user in loaded_role["users"]])
+
+            if action.notification.notify_users:
+                storage_users = StoragePermissionsManager(self.pipeline_api_client, storage.id).get_users()
+                cc_users.extend([user_name for user_name in storage_users if not cc_users.__contains__(user_name)])
 
             _to_user = next(iter(cc_users), None)
             return notification.template.subject, notification.template.body, _to_user, cc_users, \

--- a/storage-lifecycle-service/sls/pipelineapi/model/restore_action_model.py
+++ b/storage-lifecycle-service/sls/pipelineapi/model/restore_action_model.py
@@ -18,9 +18,10 @@ from sls.util.date_utils import parse_timestamp
 
 class StorageLifecycleRestoreNotification:
 
-    def __init__(self, enabled, recipients):
+    def __init__(self, enabled, recipients, notify_users):
         self.enabled = enabled
         self.recipients = recipients
+        self.notify_users = notify_users
 
     @staticmethod
     def parse_from_dict(obj_dict):
@@ -28,6 +29,7 @@ class StorageLifecycleRestoreNotification:
             raise RuntimeError("Lifecycle restore notification object doesn't have 'enabled' flag!")
         enabled = obj_dict["enabled"]
         recipients = None
+        notify_users = False
         if obj_dict["enabled"]:
             if "recipients" not in obj_dict or len(obj_dict["recipients"]) < 1:
                 raise RuntimeError("Lifecycle restore notification object with 'enabled' = true, "
@@ -36,7 +38,8 @@ class StorageLifecycleRestoreNotification:
                 if "name" not in recipient or "principal" not in recipient:
                     raise RuntimeError("Wrong format of 'recipient' object, should have 'name' and 'principal'")
             recipients = obj_dict["recipients"]
-        return StorageLifecycleRestoreNotification(enabled, recipients)
+            notify_users = obj_dict.get('notifyUsers', False)
+        return StorageLifecycleRestoreNotification(enabled, recipients, notify_users)
 
 
 class StorageLifecycleRestoreAction:


### PR DESCRIPTION
The current PR provides implementation for issue #3030  for restore notifications

The following changes were added:
 - a new flag `notifyUsers` added to restore action notification object
 - added `notifyUsers` flag support for restore action to `storage-lifecycle-service`