### PR TITLE
Introduce user metadata reader role

### DIFF
--- a/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
+++ b/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
@@ -102,7 +102,8 @@ public final class AclExpressions {
 
     public static final String METADATA_FILTER = ADMIN_ONLY + OR +
             "@metadataPermissionManager.metadataPermission(" +
-            "filterObject.entity.entityId, filterObject.entity.entityClass, 'READ')";
+            "filterObject.entity.entityId, filterObject.entity.entityClass, 'READ')" + OR +
+            "filterObject.entity.entityClass == 'PIPELINE_USER'" + AND + "hasRole('ROLE_USER_METADATA_READER')";
 
     public static final String ACL_ENTITY_OWNER =
             "hasRole('ADMIN') or @grantPermissionManager.ownerPermission(#id, #aclClass)";

--- a/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
+++ b/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
@@ -103,7 +103,7 @@ public final class AclExpressions {
     public static final String METADATA_FILTER = ADMIN_ONLY + OR +
             "@metadataPermissionManager.metadataPermission(" +
             "filterObject.entity.entityId, filterObject.entity.entityClass, 'READ')" + OR +
-            "filterObject.entity.entityClass == 'PIPELINE_USER'" + AND + "hasRole('ROLE_USER_METADATA_READER')";
+            "filterObject.entity.entityClass.name() == 'PIPELINE_USER'" + AND + "hasRole('USER_METADATA_READER')";
 
     public static final String ACL_ENTITY_OWNER =
             "hasRole('ADMIN') or @grantPermissionManager.ownerPermission(#id, #aclClass)";

--- a/api/src/test/java/com/epam/pipeline/acl/metadata/MetadataApiServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/acl/metadata/MetadataApiServiceTest.java
@@ -42,6 +42,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -78,10 +79,17 @@ public class MetadataApiServiceTest extends AbstractAclTest {
     private final MetadataEntryWithIssuesCount entry = MetadataCreatorUtils.getMetadataEntryWithIssuesCount(entityVO);
     private final MetadataEntryWithIssuesCount anotherEntry =
             MetadataCreatorUtils.getMetadataEntryWithIssuesCount(anotherEntityVO);
-    private final EntityVO pipelineUserEntityVO = SecurityCreatorUtils.getEntityVO(ID, PIPELINE_USER_ACL_CLASS);
+    private final EntityVO pipelineUserEntityVO =
+            SecurityCreatorUtils.getEntityVO(ID, PIPELINE_USER_ACL_CLASS);
+    private final EntityVO anotherPipelineUserEntityVO =
+            SecurityCreatorUtils.getEntityVO(ID_2, PIPELINE_USER_ACL_CLASS);
     private final EntityVO roleEntityVO = SecurityCreatorUtils.getEntityVO(ID, ROLE_ACL_CLASS);
-    private final PipelineUser pipelineUser = UserCreatorUtils.getPipelineUser(SIMPLE_USER);
-    private final MetadataEntry pipelineUserEntry = MetadataCreatorUtils.getMetadataEntry(pipelineUserEntityVO);
+    private final PipelineUser pipelineUser = UserCreatorUtils.getPipelineUser(SIMPLE_USER, ID);
+    private final PipelineUser anotherPipelineUser = UserCreatorUtils.getPipelineUser(ANOTHER_SIMPLE_USER, ID_2);
+    private final MetadataEntry pipelineUserEntry =
+            MetadataCreatorUtils.getMetadataEntry(pipelineUserEntityVO);
+    private final MetadataEntry anotherPipelineUserEntry =
+            MetadataCreatorUtils.getMetadataEntry(anotherPipelineUserEntityVO);
     private final MetadataEntry roleEntry = MetadataCreatorUtils.getMetadataEntry(roleEntityVO);
     private final MetadataEntryWithIssuesCount pipelineUserEntryWithIssuesCount =
             MetadataCreatorUtils.getMetadataEntryWithIssuesCount(pipelineUserEntityVO);
@@ -90,9 +98,10 @@ public class MetadataApiServiceTest extends AbstractAclTest {
     private final List<MetadataEntry> metadataEntries = new ArrayList<>(Collections.singletonList(metadataEntry));
     private final List<EntityVO> entityVOList = Collections.singletonList(entityVO);
     private final List<EntityVO> roleEntityVOList = Collections.singletonList(roleEntityVO);
-    private final List<EntityVO> pipelineUserEntityVOList = Collections.singletonList(pipelineUserEntityVO);
-    private final List<MetadataEntry> pipelineUserEntries = new ArrayList<>(
-            Collections.singletonList(pipelineUserEntry));
+    private final List<EntityVO> pipelineUserEntityVOList = Arrays.asList(pipelineUserEntityVO,
+            anotherPipelineUserEntityVO);
+    private final List<MetadataEntry> pipelineUserEntries = new ArrayList<>(Arrays.asList(pipelineUserEntry,
+            anotherPipelineUserEntry));
     private final List<MetadataEntry> roleEntries = new ArrayList<>(Collections.singletonList(roleEntry));
 
     @Autowired
@@ -324,19 +333,33 @@ public class MetadataApiServiceTest extends AbstractAclTest {
 
     @Test
     @WithMockUser(roles = ADMIN_ROLE)
-    public void shouldListPipelineUserMetadataItemsForAdmin() {
+    public void shouldListAllPipelineUserMetadataItemsForAdmin() {
         doReturn(pipelineUserEntries).when(mockMetadataManager).listMetadataItems(pipelineUserEntityVOList);
 
-        assertThat(metadataApiService.listMetadataItems(pipelineUserEntityVOList)).isEqualTo(pipelineUserEntries);
+        assertThat(metadataApiService.listMetadataItems(pipelineUserEntityVOList))
+                .isEqualTo(Arrays.asList(pipelineUserEntry, anotherPipelineUserEntry));
+    }
+
+    @Test
+    @WithMockUser(username = SIMPLE_USER, roles = "USER_METADATA_READER")
+    public void shouldListAllPipelineUserMetadataItemsForMetadataReader() {
+        doReturn(pipelineUserEntries).when(mockMetadataManager).listMetadataItems(pipelineUserEntityVOList);
+        mockUser();
+        mockEntityUser(anotherPipelineUser);
+
+        assertThat(metadataApiService.listMetadataItems(pipelineUserEntityVOList))
+                .isEqualTo(Arrays.asList(pipelineUserEntry, anotherPipelineUserEntry));
     }
 
     @Test
     @WithMockUser(username = SIMPLE_USER)
-    public void shouldListMetadataItemsForPipelineUser() {
+    public void shouldListOnlyPersonalMetadataItemsForUser() {
         doReturn(pipelineUserEntries).when(mockMetadataManager).listMetadataItems(pipelineUserEntityVOList);
         mockUser();
+        mockEntityUser(anotherPipelineUser);
 
-        assertThat(metadataApiService.listMetadataItems(pipelineUserEntityVOList)).isEqualTo(pipelineUserEntries);
+        assertThat(metadataApiService.listMetadataItems(pipelineUserEntityVOList))
+                .isEqualTo(Collections.singletonList(pipelineUserEntry));
     }
 
     @Test
@@ -834,7 +857,11 @@ public class MetadataApiServiceTest extends AbstractAclTest {
     }
 
     private void mockUser() {
-        mockAuthUser(SIMPLE_USER);
-        doReturn(pipelineUser).when(mockUserManager).loadUserById(ID);
+        mockAuthUser(pipelineUser.getUserName());
+        mockEntityUser(pipelineUser);
+    }
+
+    private void mockEntityUser(final PipelineUser user) {
+        doReturn(user).when(mockUserManager).loadUserById(user.getId());
     }
 }


### PR DESCRIPTION
Relates #3082.

The pull request brings support for `ROLE_USER_METADATA_READER` role which allows a user to be able to list metadata of other users.
