### PR TITLE
Issue #3056: Review archive operations permissions

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/datastorage/lifecycle/DataStorageLifecycleApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/datastorage/lifecycle/DataStorageLifecycleApiService.java
@@ -28,6 +28,7 @@ import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.manager.datastorage.DataStorageManager;
 import com.epam.pipeline.manager.datastorage.lifecycle.DataStorageLifecycleManager;
 import com.epam.pipeline.manager.datastorage.lifecycle.DataStorageLifecycleRestoreManager;
+import com.epam.pipeline.manager.security.storage.StoragePermissionManager;
 import com.epam.pipeline.security.acl.AclExpressions;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -44,6 +45,7 @@ public class DataStorageLifecycleApiService {
 
     private final DataStorageLifecycleManager storageLifecycleManager;
     private final DataStorageLifecycleRestoreManager restoreManager;
+    private final StoragePermissionManager storagePermissionManager;
 
     @PreAuthorize(AclExpressions.STORAGE_LIFECYCLE_READER)
     public List<StorageLifecycleRule> listStorageLifecyclePolicyRules(final Long id, final String path) {
@@ -134,13 +136,14 @@ public class DataStorageLifecycleApiService {
                 storage, StorageRestorePath.builder().type(pathType).path(path).build());
     }
 
-    @PreAuthorize(AclExpressions.STORAGE_LIFECYCLE_READER)
+    @PreAuthorize(AclExpressions.STORAGE_ID_READ)
     public List<StorageRestoreAction> loadEffectiveRestoreStorageActionHierarchy(final Long id,
                                                                                  final String path,
                                                                                  final StorageRestorePathType pathType,
                                                                                  final Boolean recursive) {
         final AbstractDataStorage storage = storageManager.load(id);
+        final boolean showArchived = storagePermissionManager.storageArchiveReadPermissions(storage);
         return restoreManager.loadEffectiveRestoreStorageActionHierarchy(
-                storage, StorageRestorePath.builder().type(pathType).path(path).build(), recursive);
+                storage, StorageRestorePath.builder().type(pathType).path(path).build(), recursive, showArchived);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/acl/datastorage/lifecycle/DataStorageLifecycleApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/datastorage/lifecycle/DataStorageLifecycleApiService.java
@@ -45,78 +45,78 @@ public class DataStorageLifecycleApiService {
     private final DataStorageLifecycleManager storageLifecycleManager;
     private final DataStorageLifecycleRestoreManager restoreManager;
 
-    @PreAuthorize(AclExpressions.STORAGE_ID_READ)
+    @PreAuthorize(AclExpressions.STORAGE_LIFECYCLE_READER)
     public List<StorageLifecycleRule> listStorageLifecyclePolicyRules(final Long id, final String path) {
         return storageLifecycleManager.listStorageLifecyclePolicyRules(id, path);
     }
 
-    @PreAuthorize(AclExpressions.STORAGE_ID_READ)
+    @PreAuthorize(AclExpressions.STORAGE_LIFECYCLE_READER)
     public StorageLifecycleRule loadStorageLifecyclePolicyRule(final Long id, final Long ruleId) {
         return storageLifecycleManager.loadStorageLifecyclePolicyRule(id, ruleId);
     }
 
-    @PreAuthorize(AclExpressions.STORAGE_ID_WRITE)
+    @PreAuthorize(AclExpressions.STORAGE_LIFECYCLE_MANAGER)
     public StorageLifecycleRule createStorageLifecyclePolicyRule(final Long id,
                                                                  final StorageLifecycleRule rule) {
         return storageLifecycleManager.createStorageLifecyclePolicyRule(id, rule);
     }
 
-    @PreAuthorize(AclExpressions.STORAGE_ID_WRITE)
+    @PreAuthorize(AclExpressions.STORAGE_LIFECYCLE_MANAGER)
     public StorageLifecycleRule updateStorageLifecyclePolicyRule(final Long id,
                                                                  final StorageLifecycleRule rule) {
         return storageLifecycleManager.updateStorageLifecyclePolicyRule(id, rule);
     }
 
-    @PreAuthorize(AclExpressions.STORAGE_ID_WRITE)
+    @PreAuthorize(AclExpressions.STORAGE_LIFECYCLE_MANAGER)
     public StorageLifecycleRule prolongStorageLifecyclePolicyRule(final Long id,
                                                                   final Long ruleId, final String path,
                                                                   final Long daysToProlong,
                                                                   final Boolean force) {
         return storageLifecycleManager.prolongLifecyclePolicyRule(id, ruleId, path, daysToProlong, force);
     }
-    @PreAuthorize(AclExpressions.STORAGE_ID_WRITE)
+    @PreAuthorize(AclExpressions.STORAGE_LIFECYCLE_MANAGER)
     public StorageLifecycleRule deleteStorageLifecyclePolicyRule(final Long id, final Long ruleId) {
         return storageLifecycleManager.deleteStorageLifecyclePolicyRule(id, ruleId);
     }
 
-    @PreAuthorize(AclExpressions.STORAGE_ID_WRITE)
+    @PreAuthorize(AclExpressions.STORAGE_LIFECYCLE_MANAGER)
     public StorageLifecycleRuleExecution createStorageLifecyclePolicyRuleExecution(
             final Long id, final Long ruleId, final StorageLifecycleRuleExecution execution) {
         return storageLifecycleManager.createStorageLifecycleRuleExecution(ruleId, execution);
     }
 
-    @PreAuthorize(AclExpressions.STORAGE_ID_WRITE)
+    @PreAuthorize(AclExpressions.STORAGE_LIFECYCLE_MANAGER)
     public StorageLifecycleRuleExecution updateStorageLifecycleRuleExecutionStatus(
             final Long id, final Long executionId, final StorageLifecycleRuleExecutionStatus status) {
         return storageLifecycleManager.updateStorageLifecycleRuleExecutionStatus(executionId, status);
     }
 
-    @PreAuthorize(AclExpressions.STORAGE_ID_WRITE)
+    @PreAuthorize(AclExpressions.STORAGE_LIFECYCLE_MANAGER)
     public StorageLifecycleRuleExecution deleteStorageLifecycleRuleExecution(
             final Long id, final Long executionId) {
         return storageLifecycleManager.deleteStorageLifecycleRuleExecution(executionId);
     }
 
-    @PreAuthorize(AclExpressions.STORAGE_ID_READ)
+    @PreAuthorize(AclExpressions.STORAGE_LIFECYCLE_READER)
     public List<StorageLifecycleRuleExecution> listStorageLifecyclePolicyRuleExecutions(
             final Long id, final Long ruleId, final String path, final StorageLifecycleRuleExecutionStatus status) {
         return storageLifecycleManager.listStorageLifecycleRuleExecutionsForRuleAndPath(ruleId, path, status);
     }
 
-    @PreAuthorize(AclExpressions.STORAGE_ID_WRITE)
+    @PreAuthorize(AclExpressions.STORAGE_LIFECYCLE_MANAGER)
     public List<StorageRestoreAction> initiateStorageRestores(final Long id,
                                                               final StorageRestoreActionRequest request) {
         final AbstractDataStorage storage = storageManager.load(id);
         return restoreManager.initiateStorageRestores(storage, request);
     }
 
-    @PreAuthorize(AclExpressions.STORAGE_ID_WRITE)
+    @PreAuthorize(AclExpressions.STORAGE_LIFECYCLE_MANAGER)
     public StorageRestoreAction updateStorageRestoreAction(final Long id,
                                                            final StorageRestoreAction action) {
         return restoreManager.updateStorageRestoreAction(action);
     }
 
-    @PreAuthorize(AclExpressions.STORAGE_ID_READ)
+    @PreAuthorize(AclExpressions.STORAGE_LIFECYCLE_READER)
     public List<StorageRestoreAction> filterRestoreStorageActions(final Long id,
                                                                   final StorageRestoreActionSearchFilter filter) {
         if (filter.getDatastorageId() == null) {
@@ -126,7 +126,7 @@ public class DataStorageLifecycleApiService {
         return restoreManager.filterRestoreStorageActions(storage, filter);
     }
 
-    @PreAuthorize(AclExpressions.STORAGE_ID_READ)
+    @PreAuthorize(AclExpressions.STORAGE_LIFECYCLE_READER)
     public StorageRestoreAction loadEffectiveRestoreStorageAction(final Long id, final String path,
                                                                   final StorageRestorePathType pathType) {
         final AbstractDataStorage storage = storageManager.load(id);
@@ -134,7 +134,7 @@ public class DataStorageLifecycleApiService {
                 storage, StorageRestorePath.builder().type(pathType).path(path).build());
     }
 
-    @PreAuthorize(AclExpressions.STORAGE_ID_READ)
+    @PreAuthorize(AclExpressions.STORAGE_LIFECYCLE_READER)
     public List<StorageRestoreAction> loadEffectiveRestoreStorageActionHierarchy(final Long id,
                                                                                  final String path,
                                                                                  final StorageRestorePathType pathType,

--- a/api/src/main/java/com/epam/pipeline/acl/datastorage/lifecycle/DataStorageLifecycleApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/datastorage/lifecycle/DataStorageLifecycleApiService.java
@@ -28,7 +28,7 @@ import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.manager.datastorage.DataStorageManager;
 import com.epam.pipeline.manager.datastorage.lifecycle.DataStorageLifecycleManager;
 import com.epam.pipeline.manager.datastorage.lifecycle.DataStorageLifecycleRestoreManager;
-import com.epam.pipeline.manager.security.storage.StoragePermissionManager;
+import com.epam.pipeline.manager.security.GrantPermissionManager;
 import com.epam.pipeline.security.acl.AclExpressions;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -45,7 +45,7 @@ public class DataStorageLifecycleApiService {
 
     private final DataStorageLifecycleManager storageLifecycleManager;
     private final DataStorageLifecycleRestoreManager restoreManager;
-    private final StoragePermissionManager storagePermissionManager;
+    private final GrantPermissionManager permissionManager;
 
     @PreAuthorize(AclExpressions.STORAGE_LIFECYCLE_READER)
     public List<StorageLifecycleRule> listStorageLifecyclePolicyRules(final Long id, final String path) {
@@ -142,7 +142,7 @@ public class DataStorageLifecycleApiService {
                                                                                  final StorageRestorePathType pathType,
                                                                                  final Boolean recursive) {
         final AbstractDataStorage storage = storageManager.load(id);
-        final boolean showArchived = storagePermissionManager.storageArchiveReadPermissions(storage);
+        final boolean showArchived = permissionManager.storageArchiveReadPermissions(storage);
         return restoreManager.loadEffectiveRestoreStorageActionHierarchy(
                 storage, StorageRestorePath.builder().type(pathType).path(path).build(), recursive, showArchived);
     }

--- a/api/src/main/java/com/epam/pipeline/acl/datastorage/lifecycle/DataStorageLifecycleApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/datastorage/lifecycle/DataStorageLifecycleApiService.java
@@ -28,7 +28,7 @@ import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.manager.datastorage.DataStorageManager;
 import com.epam.pipeline.manager.datastorage.lifecycle.DataStorageLifecycleManager;
 import com.epam.pipeline.manager.datastorage.lifecycle.DataStorageLifecycleRestoreManager;
-import com.epam.pipeline.manager.security.GrantPermissionManager;
+import com.epam.pipeline.manager.security.storage.StoragePermissionManager;
 import com.epam.pipeline.security.acl.AclExpressions;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -45,7 +45,7 @@ public class DataStorageLifecycleApiService {
 
     private final DataStorageLifecycleManager storageLifecycleManager;
     private final DataStorageLifecycleRestoreManager restoreManager;
-    private final GrantPermissionManager permissionManager;
+    private final StoragePermissionManager permissionManager;
 
     @PreAuthorize(AclExpressions.STORAGE_LIFECYCLE_READER)
     public List<StorageLifecycleRule> listStorageLifecyclePolicyRules(final Long id, final String path) {

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
@@ -867,7 +867,11 @@ public class DataStorageManager implements SecuredEntityManager {
     public StorageUsage getStorageUsage(final String id, final String path) {
         final AbstractDataStorage dataStorage = loadByNameOrId(id);
         final Set<String> storageSizeMasks = resolveSizeMasks(loadSizeCalculationMasksMapping(), dataStorage);
-        return searchManager.getStorageUsage(dataStorage, path, storageSizeMasks);
+        final Set<String> storageClasses = permissionManager.storageArchiveReadPermissions(dataStorage)
+                ? dataStorage.getType().getStorageClasses()
+                : Collections.singleton(DataStorageType.Constants.STANDARD_STORAGE_CLASS);
+        final boolean allowVersions = permissionManager.isOwnerOrAdmin(dataStorage.getOwner());
+        return searchManager.getStorageUsage(dataStorage, path, storageSizeMasks, storageClasses, allowVersions);
     }
 
     public Map<String, Set<String>> loadSizeCalculationMasksMapping() {

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
@@ -93,6 +93,7 @@ import com.epam.pipeline.manager.security.AuthManager;
 import com.epam.pipeline.manager.security.GrantPermissionManager;
 import com.epam.pipeline.manager.security.SecuredEntityManager;
 import com.epam.pipeline.manager.security.acl.AclSync;
+import com.epam.pipeline.manager.security.storage.StoragePermissionManager;
 import com.epam.pipeline.manager.user.RoleManager;
 import com.epam.pipeline.manager.user.UserManager;
 import com.epam.pipeline.utils.DataStorageUtils;
@@ -212,6 +213,9 @@ public class DataStorageManager implements SecuredEntityManager {
 
     @Autowired
     private DataStorageLifecycleRestoreManager storageLifecycleRestoreManager;
+
+    @Autowired
+    private StoragePermissionManager storagePermissionManager;
 
     private AbstractDataStorageFactory dataStorageFactory =
             AbstractDataStorageFactory.getDefaultDataStorageFactory();
@@ -867,7 +871,7 @@ public class DataStorageManager implements SecuredEntityManager {
     public StorageUsage getStorageUsage(final String id, final String path) {
         final AbstractDataStorage dataStorage = loadByNameOrId(id);
         final Set<String> storageSizeMasks = resolveSizeMasks(loadSizeCalculationMasksMapping(), dataStorage);
-        final Set<String> storageClasses = permissionManager.storageArchiveReadPermissions(dataStorage)
+        final Set<String> storageClasses = storagePermissionManager.storageArchiveReadPermissions(dataStorage)
                 ? dataStorage.getType().getStorageClasses()
                 : Collections.singleton(DataStorageType.Constants.STANDARD_STORAGE_CLASS);
         final boolean allowVersions = permissionManager.isOwnerOrAdmin(dataStorage.getOwner());

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSQuotasMonitor.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSQuotasMonitor.java
@@ -308,7 +308,8 @@ public class NFSQuotasMonitor {
     private boolean exceedsLimit(final NFSDataStorage storage, final NFSQuotaNotificationEntry notification,
                                  final Set<String> storageSizeMasks) {
         final Double originalLimit = notification.getValue();
-        final StorageUsage storageUsage = searchManager.getStorageUsage(storage, null, false, storageSizeMasks);
+        final StorageUsage storageUsage = searchManager.getStorageUsage(storage, null, false, storageSizeMasks,
+                storage.getType().getStorageClasses(), false);
         final StorageQuotaType notificationType = notification.getType();
         switch (notificationType) {
             case GIGABYTES:

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchManager.java
@@ -78,15 +78,18 @@ public class SearchManager {
     }
 
     public StorageUsage getStorageUsage(final AbstractDataStorage dataStorage, final String path,
-                                        final Set<String> storageSizeMasks) {
-        return getStorageUsage(dataStorage, path, false, storageSizeMasks);
+                                        final Set<String> storageSizeMasks, final Set<String> storageClasses,
+                                        final boolean allowVersions) {
+        return getStorageUsage(dataStorage, path, false, storageSizeMasks, storageClasses, allowVersions);
     }
 
     public StorageUsage getStorageUsage(final AbstractDataStorage dataStorage, final String path,
-                                        final boolean allowNoIndex, final Set<String> storageSizeMasks) {
+                                        final boolean allowNoIndex, final Set<String> storageSizeMasks,
+                                        final Set<String> storageClasses, final boolean allowVersions) {
         try (RestHighLevelClient client = globalSearchElasticHelper.buildClient()) {
             final MultiSearchRequest searchRequest = requestBuilder.buildStorageSumRequest(
-                    dataStorage.getId(), dataStorage.getType(), path, allowNoIndex, storageSizeMasks);
+                    dataStorage.getId(), dataStorage.getType(), path, allowNoIndex, storageSizeMasks,
+                    storageClasses, allowVersions);
             final MultiSearchResponse searchResponse = client.msearch(searchRequest, RequestOptions.DEFAULT);
             return resultConverter.buildStorageUsageResponse(searchRequest, searchResponse, dataStorage, path);
         } catch (IOException e) {

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchRequestBuilder.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchRequestBuilder.java
@@ -157,7 +157,7 @@ public class SearchRequestBuilder {
                                                      final Set<String> storageSizeMasks,
                                                      final Set<String> storageClasses, final boolean allowVersions) {
         final String searchIndex = String.format(
-                ES_FILE_INDEX_PATTERN, storageType.toString().toLowerCase(), 17410
+                ES_FILE_INDEX_PATTERN, storageType.toString().toLowerCase(), storageId
         );
         final MultiSearchRequest multiSearchRequest = new MultiSearchRequest();
         multiSearchRequest.add(buildSumAggRequest(

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchRequestBuilder.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchRequestBuilder.java
@@ -42,6 +42,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.collections4.SetUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.elasticsearch.action.search.MultiSearchRequest;
@@ -105,6 +106,7 @@ public class SearchRequestBuilder {
     private static final String ES_LONG_TYPE = "long";
     private static final String ES_STORAGE_ID_FIELD = "storage_id";
     private static final String ES_STORAGE_NAME_FIELD = "storage_name";
+    private static final String STORAGE_CLASS_FIELD = "storage_class";
 
     private final PreferenceManager preferenceManager;
     private final AuthManager authManager;
@@ -152,40 +154,50 @@ public class SearchRequestBuilder {
 
     public MultiSearchRequest buildStorageSumRequest(final Long storageId, final DataStorageType storageType,
                                                      final String path, final boolean allowNoIndex,
-                                                     final Set<String> storageSizeMasks) {
+                                                     final Set<String> storageSizeMasks,
+                                                     final Set<String> storageClasses, final boolean allowVersions) {
         final String searchIndex = String.format(
-                ES_FILE_INDEX_PATTERN, storageType.toString().toLowerCase(), storageId
+                ES_FILE_INDEX_PATTERN, storageType.toString().toLowerCase(), 17410
         );
         final MultiSearchRequest multiSearchRequest = new MultiSearchRequest();
         multiSearchRequest.add(buildSumAggRequest(
-                searchIndex, path, storageType.getStorageClasses(), allowNoIndex, null));
+                searchIndex, path, storageClasses, allowNoIndex, null, allowVersions));
         if (CollectionUtils.isNotEmpty(storageSizeMasks)) {
             multiSearchRequest.add(buildSumAggRequest(
-                    searchIndex, path, storageType.getStorageClasses(), allowNoIndex, storageSizeMasks));
+                    searchIndex, path, storageClasses, allowNoIndex, storageSizeMasks, allowVersions));
         }
         return multiSearchRequest;
     }
 
     private SearchRequest buildSumAggRequest(final String searchIndex, final String path,
                                              final Set<String> storageClasses, final boolean allowNoIndex,
-                                             final Set<String> storageSizeMasks) {
+                                             final Set<String> storageSizeMasks, final boolean allowVersions) {
         final BoolQueryBuilder fileFilteringQuery = QueryBuilders.boolQuery();
         CollectionUtils.emptyIfNull(storageSizeMasks)
             .forEach(mask -> fileFilteringQuery.mustNot(QueryBuilders.wildcardQuery(NAME_FIELD, mask)));
         if (StringUtils.isNotBlank(path)) {
             fileFilteringQuery.must(QueryBuilders.prefixQuery(NAME_FIELD, path));
         }
+
+        final BoolQueryBuilder storageClassesQuery = QueryBuilders.boolQuery();
+        SetUtils.emptyIfNull(storageClasses).forEach(storageClass ->
+                storageClassesQuery.should(QueryBuilders.termsQuery(STORAGE_CLASS_FIELD, storageClass)));
+        fileFilteringQuery.must(storageClassesQuery);
+
         final SearchSourceBuilder sizeSumSearch = new SearchSourceBuilder()
                 .query(fileFilteringQuery)
                 .size(0);
 
         final TermsAggregationBuilder sizeSumAgg = AggregationBuilders
-                .terms(STORAGE_SIZE_BY_TIER_AGG_NAME).field("storage_class")
+                .terms(STORAGE_SIZE_BY_TIER_AGG_NAME).field(STORAGE_CLASS_FIELD)
                 .subAggregation(AggregationBuilders.sum(STORAGE_SIZE_AGG_NAME).field("size"));
         sizeSumSearch.aggregation(sizeSumAgg);
-        for (String storageClass : storageClasses) {
-            final String ovSizeFieldName = String.format("ov_%s_size", storageClass.toLowerCase(Locale.ROOT));
-            sizeSumSearch.aggregation(AggregationBuilders.sum(ovSizeFieldName + "_agg").field(ovSizeFieldName));
+        if (allowVersions) {
+            for (String storageClass : storageClasses) {
+                final String ovSizeFieldName = String.format("ov_%s_size", storageClass.toLowerCase(Locale.ROOT));
+                sizeSumSearch.aggregation(AggregationBuilders
+                        .sum(ovSizeFieldName + "_agg").field(ovSizeFieldName));
+            }
         }
         final SearchRequest request = new SearchRequest().indices(searchIndex).source(sizeSumSearch);
         if (allowNoIndex) {

--- a/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionManager.java
@@ -820,21 +820,6 @@ public class GrantPermissionManager {
         return cloudProfileCredentialsManagerProvider.hasAssignedUserOrRole(profileId, currentUser.getId(),
                 currentUser.getRoles());
     }
-
-    public boolean storageArchiveReadPermissions(final AbstractDataStorage storage) {
-        return isOwnerOrAdmin(storage.getOwner())
-                || permissionsHelper.isAllowed(READ, storage) && checkStorageArchiveRoles();
-    }
-
-    private boolean checkStorageArchiveRoles() {
-        final GrantedAuthoritySid archiveManager = new GrantedAuthoritySid(
-                DefaultRoles.ROLE_STORAGE_ARCHIVE_MANAGER.getName());
-        final GrantedAuthoritySid archiveReader = new GrantedAuthoritySid(
-                DefaultRoles.ROLE_STORAGE_ARCHIVE_READER.getName());
-        return permissionsHelper.getSids().stream()
-                .anyMatch(sid -> sid.equals(archiveManager) || sid.equals(archiveReader));
-    }
-
     private List<Sid> convertUserToSids(String user) {
         String principal = user.toUpperCase();
         UserContext eventOwner = userManager.loadUserContext(user.toUpperCase());

--- a/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/GrantPermissionManager.java
@@ -821,6 +821,20 @@ public class GrantPermissionManager {
                 currentUser.getRoles());
     }
 
+    public boolean storageArchiveReadPermissions(final AbstractDataStorage storage) {
+        return isOwnerOrAdmin(storage.getOwner())
+                || permissionsHelper.isAllowed(READ, storage) && checkStorageArchiveRoles();
+    }
+
+    private boolean checkStorageArchiveRoles() {
+        final GrantedAuthoritySid archiveManager = new GrantedAuthoritySid(
+                DefaultRoles.ROLE_STORAGE_ARCHIVE_MANAGER.getName());
+        final GrantedAuthoritySid archiveReader = new GrantedAuthoritySid(
+                DefaultRoles.ROLE_STORAGE_ARCHIVE_READER.getName());
+        return permissionsHelper.getSids().stream()
+                .anyMatch(sid -> sid.equals(archiveManager) || sid.equals(archiveReader));
+    }
+
     private List<Sid> convertUserToSids(String user) {
         String principal = user.toUpperCase();
         UserContext eventOwner = userManager.loadUserContext(user.toUpperCase());

--- a/api/src/main/java/com/epam/pipeline/manager/security/storage/StoragePermissionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/storage/StoragePermissionManager.java
@@ -24,6 +24,7 @@ import com.epam.pipeline.entity.datastorage.DataStorageWithShareMount;
 import com.epam.pipeline.entity.datastorage.NFSStorageMountStatus;
 import com.epam.pipeline.entity.datastorage.nfs.NFSDataStorage;
 import com.epam.pipeline.entity.security.acl.AclClass;
+import com.epam.pipeline.entity.user.DefaultRoles;
 import com.epam.pipeline.manager.EntityManager;
 import com.epam.pipeline.manager.datastorage.DataStoragePathLoader;
 import com.epam.pipeline.manager.quota.QuotaService;
@@ -35,6 +36,7 @@ import com.epam.pipeline.security.acl.AclPermission;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
+import org.springframework.security.acls.domain.GrantedAuthoritySid;
 import org.springframework.security.acls.model.Sid;
 import org.springframework.stereotype.Service;
 
@@ -138,6 +140,11 @@ public class StoragePermissionManager {
         }
     }
 
+    public boolean storageArchiveReadPermissions(final AbstractDataStorage storage) {
+        return grantPermissionManager.isOwnerOrAdmin(storage.getOwner())
+                || permissionHelper.isAllowed(READ, storage) && checkStorageArchiveRoles();
+    }
+
     private boolean checkPermissions(final List<AclPermission> permissions,
                                      final AbstractDataStorage storage,
                                      final boolean allPermissions) {
@@ -149,5 +156,14 @@ public class StoragePermissionManager {
         return permissions.stream()
                 .anyMatch(permission -> permissionsService.isMaskBitSet(storage.getMask(),
                         permission.getSimpleMask()));
+    }
+
+    private boolean checkStorageArchiveRoles() {
+        final GrantedAuthoritySid archiveManager = new GrantedAuthoritySid(
+                DefaultRoles.ROLE_STORAGE_ARCHIVE_MANAGER.getName());
+        final GrantedAuthoritySid archiveReader = new GrantedAuthoritySid(
+                DefaultRoles.ROLE_STORAGE_ARCHIVE_READER.getName());
+        return permissionHelper.getSids().stream()
+                .anyMatch(sid -> sid.equals(archiveManager) || sid.equals(archiveReader));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/security/storage/StoragePermissionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/storage/StoragePermissionManager.java
@@ -24,6 +24,7 @@ import com.epam.pipeline.entity.datastorage.DataStorageWithShareMount;
 import com.epam.pipeline.entity.datastorage.NFSStorageMountStatus;
 import com.epam.pipeline.entity.datastorage.nfs.NFSDataStorage;
 import com.epam.pipeline.entity.security.acl.AclClass;
+import com.epam.pipeline.entity.user.DefaultRoles;
 import com.epam.pipeline.manager.EntityManager;
 import com.epam.pipeline.manager.datastorage.DataStoragePathLoader;
 import com.epam.pipeline.manager.quota.QuotaService;
@@ -35,6 +36,7 @@ import com.epam.pipeline.security.acl.AclPermission;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
+import org.springframework.security.acls.domain.GrantedAuthoritySid;
 import org.springframework.security.acls.model.Sid;
 import org.springframework.stereotype.Service;
 
@@ -136,6 +138,20 @@ public class StoragePermissionManager {
             storages.clear();
             storages.addAll(filtered);
         }
+    }
+
+    public boolean storageArchiveReadPermissions(final AbstractDataStorage storage) {
+        return grantPermissionManager.isOwnerOrAdmin(storage.getOwner())
+                || permissionHelper.isAllowed(READ, storage) && checkStorageArchiveRoles();
+    }
+
+    private boolean checkStorageArchiveRoles() {
+        final GrantedAuthoritySid archiveManager = new GrantedAuthoritySid(
+                DefaultRoles.ROLE_STORAGE_ARCHIVE_MANAGER.getName());
+        final GrantedAuthoritySid archiveReader = new GrantedAuthoritySid(
+                DefaultRoles.ROLE_STORAGE_ARCHIVE_READER.getName());
+        return permissionHelper.getSids().stream()
+                .anyMatch(sid -> sid.equals(archiveManager) || sid.equals(archiveReader));
     }
 
     private boolean checkPermissions(final List<AclPermission> permissions,

--- a/api/src/main/java/com/epam/pipeline/manager/security/storage/StoragePermissionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/storage/StoragePermissionManager.java
@@ -24,7 +24,6 @@ import com.epam.pipeline.entity.datastorage.DataStorageWithShareMount;
 import com.epam.pipeline.entity.datastorage.NFSStorageMountStatus;
 import com.epam.pipeline.entity.datastorage.nfs.NFSDataStorage;
 import com.epam.pipeline.entity.security.acl.AclClass;
-import com.epam.pipeline.entity.user.DefaultRoles;
 import com.epam.pipeline.manager.EntityManager;
 import com.epam.pipeline.manager.datastorage.DataStoragePathLoader;
 import com.epam.pipeline.manager.quota.QuotaService;
@@ -36,7 +35,6 @@ import com.epam.pipeline.security.acl.AclPermission;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
-import org.springframework.security.acls.domain.GrantedAuthoritySid;
 import org.springframework.security.acls.model.Sid;
 import org.springframework.stereotype.Service;
 
@@ -140,11 +138,6 @@ public class StoragePermissionManager {
         }
     }
 
-    public boolean storageArchiveReadPermissions(final AbstractDataStorage storage) {
-        return grantPermissionManager.isOwnerOrAdmin(storage.getOwner())
-                || permissionHelper.isAllowed(READ, storage) && checkStorageArchiveRoles();
-    }
-
     private boolean checkPermissions(final List<AclPermission> permissions,
                                      final AbstractDataStorage storage,
                                      final boolean allPermissions) {
@@ -156,14 +149,5 @@ public class StoragePermissionManager {
         return permissions.stream()
                 .anyMatch(permission -> permissionsService.isMaskBitSet(storage.getMask(),
                         permission.getSimpleMask()));
-    }
-
-    private boolean checkStorageArchiveRoles() {
-        final GrantedAuthoritySid archiveManager = new GrantedAuthoritySid(
-                DefaultRoles.ROLE_STORAGE_ARCHIVE_MANAGER.getName());
-        final GrantedAuthoritySid archiveReader = new GrantedAuthoritySid(
-                DefaultRoles.ROLE_STORAGE_ARCHIVE_READER.getName());
-        return permissionHelper.getSids().stream()
-                .anyMatch(sid -> sid.equals(archiveManager) || sid.equals(archiveReader));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
+++ b/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
@@ -70,9 +70,17 @@ public final class AclExpressions {
             "(hasRole('ADMIN') OR @storagePermissionManager.storagePermissionById(#id, 'OWNER')) "
             + AND + STORAGE_SHARED;
 
-    public static final String STORAGE_SHOW_ARCHIVED_PERMISSIONS = "(#showArchived == false OR "
-            + "hasRole('ADMIN') OR @storagePermissionManager.storagePermissionById(#id, 'OWNER') OR "
-            + "hasRole('ROLE_STORAGE_ARCHIVE_MANAGER') OR hasRole('ROLE_STORAGE_ARCHIVE_READER'))";
+    public static final String ARCHIVED_PERMISSIONS =
+            "hasRole('ROLE_STORAGE_ARCHIVE_MANAGER') OR hasRole('ROLE_STORAGE_ARCHIVE_READER')";
+
+    public static final String STORAGE_SHOW_ARCHIVED_PERMISSIONS = "(#showArchived == false"
+            + OR + STORAGE_ID_OWNER + OR + ARCHIVED_PERMISSIONS + ")";
+
+    public static final String STORAGE_LIFECYCLE_READER = STORAGE_ID_OWNER + OR + STORAGE_ID_READ + AND
+            + ARCHIVED_PERMISSIONS;
+
+    public static final String STORAGE_LIFECYCLE_MANAGER = STORAGE_ID_OWNER + OR + STORAGE_ID_WRITE + AND
+            + "hasRole('ROLE_STORAGE_ARCHIVE_MANAGER')";
 
     public static final String STORAGE_ID_PERMISSIONS =
             "("

--- a/core/src/main/java/com/epam/pipeline/entity/datastorage/DataStorageType.java
+++ b/core/src/main/java/com/epam/pipeline/entity/datastorage/DataStorageType.java
@@ -78,7 +78,7 @@ public enum DataStorageType {
         }
     }
 
-    private static class Constants {
+    public static class Constants {
         public static final String STANDARD_STORAGE_CLASS = "STANDARD";
     }
 }

--- a/pipe-cli/src/model/data_storage_model.py
+++ b/pipe-cli/src/model/data_storage_model.py
@@ -29,6 +29,7 @@ class DataStorageModel(DataStorageItemModel):
         self.region = None
         self.mount_status = None
         self.tools_to_mount = set()
+        self.owner = None
 
     @classmethod
     def load(cls, json):
@@ -52,6 +53,8 @@ class DataStorageModel(DataStorageItemModel):
             cls.parse_policy(instance.policy, json['storagePolicy'])
         if 'toolsToMount' in json:
             cls.parse_tool_to_mount(instance, json)
+        if 'owner' in json:
+            instance.owner = json['owner']
         cls.parse_mount_status(instance, json)
         return instance
 

--- a/pipe-cli/src/utilities/user_operations_manager.py
+++ b/pipe-cli/src/utilities/user_operations_manager.py
@@ -18,6 +18,7 @@ import click
 
 from prettytable import prettytable
 
+from src.api.entity import Entity
 from src.api.pipeline_run import PipelineRun
 from src.api.user import User
 
@@ -69,6 +70,9 @@ class UserOperationsManager:
     def is_admin(self):
         return 'ROLE_ADMIN' in self.get_all_user_roles()
 
+    def is_owner(self, owner):
+        return owner and owner == self.whoami().get('userName')
+
     def get_all_user_roles(self):
         user_groups = self.user.get('groups', [])
         user_roles = [role.get('name') for role in self.user.get('roles', [])]
@@ -76,3 +80,27 @@ class UserOperationsManager:
 
     def whoami(self):
         return self.user
+
+    def has_storage_archive_permissions(self, storage_identifier, owner=None):
+        if self.is_admin():
+            return True
+        if not owner:
+            owner = self.get_owner(storage_identifier, 'DATA_STORAGE')
+        if not owner:
+            return False
+        if self.is_owner(owner):
+            return True
+        user_roles = self.get_all_user_roles()
+        if 'ROLE_STORAGE_ARCHIVE_MANAGER' in user_roles or 'ROLE_STORAGE_ARCHIVE_READER' in user_roles:
+            return True
+        return False
+
+    @staticmethod
+    def get_owner(identifier, acl_class):
+        try:
+            entity = Entity.load_by_id_or_name(identifier, acl_class)
+            return entity.get('owner')
+        except RuntimeError as e:
+            if 'Access is denied' in str(e):
+                return None
+            raise e


### PR DESCRIPTION
The current PR provides implementation for issue #3056 

The following changes were added:
- `pipe storage mount/ls`: if `--show-archive` option specified an error shall be occurred in case if user has not appropriate permissions
- archives for `pipe storage du`: if user has not read archive permissions archive sizes shall not be shown
- versions for `pipe storage du`: if user is not admin or owner `--generation=old` shall not be available, `--generation=all` shall works as `current`.
- archive permissions management added to datastorage lifecycle methods and `GET /datastorage/path/usage` method
