### PR TITLE
Issue #3028 Set region code to elasticsearch doc for nfs files

### DIFF
--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
@@ -28,6 +28,7 @@ import com.epam.pipeline.entity.datastorage.DataStorageDownloadFileUrl;
 import com.epam.pipeline.entity.datastorage.DataStorageFile;
 import com.epam.pipeline.entity.datastorage.DataStorageItemContent;
 import com.epam.pipeline.entity.datastorage.DataStorageTag;
+import com.epam.pipeline.entity.datastorage.DataStorageWithShareMount;
 import com.epam.pipeline.entity.datastorage.FileShareMount;
 import com.epam.pipeline.entity.datastorage.TemporaryCredentials;
 import com.epam.pipeline.entity.docker.DockerRegistryList;
@@ -166,6 +167,9 @@ public interface CloudPipelineAPI {
 
     @GET("datastorage/loadAll")
     Call<Result<List<AbstractDataStorage>>> loadAllDataStorages();
+
+    @GET("datastorage/availableWithMounts")
+    Call<Result<List<DataStorageWithShareMount>>> loadAllDataStoragesWithMounts();
 
     @GET("datastorage/{id}/load")
     Call<Result<AbstractDataStorage>> loadDataStorage(@Path(ID) Long storageId);

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/CloudPipelineAPIClient.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/CloudPipelineAPIClient.java
@@ -24,6 +24,7 @@ import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.DataStorageAction;
 import com.epam.pipeline.entity.datastorage.DataStorageDownloadFileUrl;
 import com.epam.pipeline.entity.datastorage.DataStorageTag;
+import com.epam.pipeline.entity.datastorage.DataStorageWithShareMount;
 import com.epam.pipeline.entity.datastorage.FileShareMount;
 import com.epam.pipeline.entity.datastorage.TemporaryCredentials;
 import com.epam.pipeline.entity.docker.ToolDescription;
@@ -82,6 +83,10 @@ public class CloudPipelineAPIClient {
 
     public List<AbstractDataStorage> loadAllDataStorages() {
         return executor.execute(cloudPipelineAPI.loadAllDataStorages());
+    }
+
+    public List<DataStorageWithShareMount> loadAllDataStoragesWithMounts() {
+        return executor.execute(cloudPipelineAPI.loadAllDataStoragesWithMounts());
     }
 
     public AbstractDataStorage loadDataStorage(final Long id) {

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/NFSObserverEventSynchronizer.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/NFSObserverEventSynchronizer.java
@@ -211,9 +211,7 @@ public class NFSObserverEventSynchronizer extends NFSSynchronizer {
         final Map<Boolean, List<NFSObserverEvent>> groupedEvents = flattenEvents(dataStorage, events).stream()
                 .collect(Collectors.partitioningBy(e -> NFSObserverEventType.REINDEX.equals(e.getEventType())));
         final DataStorageWithShareMount storageWithShareMount = loadStorageWithShareMount(dataStorage);
-        final String regionCode = Optional.ofNullable(storageWithShareMount.getShareMount())
-                .map(mount -> getCloudPipelineAPIClient().loadRegion(mount.getRegionId()).getRegionCode())
-                .orElse(null);
+        final String regionCode = getRegionCode(storageWithShareMount);
         List<NFSObserverEvent> refreshEvents = groupedEvents.get(true);
         if (CollectionUtils.isNotEmpty(refreshEvents)) {
             reindexStorage(storageWithShareMount);


### PR DESCRIPTION
Related to #3028 
This PR fixes problem when we didn't set `storage_region` field for NFS files while indexing it. 

Such logic leads to wrong price calculation in `billing-agent`, because in such cases we use `defaultCost` as a cost for storing such files, and this cost is calculated as max cost from price list.
