### PR TITLE
Use security index alias in System Log API

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/log/LogManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/log/LogManager.java
@@ -233,6 +233,7 @@ public class LogManager {
                     .field(USER, logEntry.getUser())
                     .field(MESSAGE, logEntry.getMessage())
                     .field(SEVERITY, logEntry.getSeverity())
+                    .field(SERVICE_ACCOUNT, authManager.isServiceUser(logEntry.getUser()))
                     .endObject();
         } catch (IOException e) {
             throw new PipelineException(e);

--- a/api/src/main/java/com/epam/pipeline/manager/log/LogManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/log/LogManager.java
@@ -25,6 +25,7 @@ import com.epam.pipeline.entity.log.LogPaginationRequest;
 import com.epam.pipeline.entity.log.PageMarker;
 import com.epam.pipeline.entity.utils.DateUtils;
 import com.epam.pipeline.exception.PipelineException;
+import com.epam.pipeline.manager.security.AuthManager;
 import com.epam.pipeline.manager.utils.GlobalSearchElasticHelper;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -104,6 +105,7 @@ public class LogManager {
     private static final String INDEX_TYPE = "_doc";
 
     private final GlobalSearchElasticHelper elasticHelper;
+    private final AuthManager authManager;
     private final MessageHelper messageHelper;
 
     @Value("${log.security.elastic.index.prefix:security_log}")
@@ -145,7 +147,7 @@ public class LogManager {
 
         final SearchRequest request = new SearchRequest()
                 .source(source)
-                .indices(getLogIndices(logFilter.getMessageTimestampFrom(), logFilter.getMessageTimestampTo()))
+                .indices(getReadIndices(logFilter.getMessageTimestampFrom(), logFilter.getMessageTimestampTo()))
                 .indicesOptions(INDICES_OPTIONS);
         log.debug("Logs request: {} ", request);
 
@@ -175,7 +177,7 @@ public class LogManager {
                 .aggregation(AggregationBuilders.terms(HOSTNAME).field(HOSTNAME + KEYWORD));
         final SearchRequest request = new SearchRequest()
                 .source(source)
-                .indices(getLogIndices())
+                .indices(getAllIndices())
                 .indicesOptions(INDICES_OPTIONS);
         log.debug("Logs request: {} ", request);
 
@@ -203,7 +205,7 @@ public class LogManager {
     }
 
     public void save(final List<LogEntry> logEntries) {
-        final String index = getIndexName();
+        final String index = getWriteIndex();
         final BulkRequest bulkRequest = new BulkRequest();
         final List<IndexRequest> indexRequests = logEntries.stream()
                 .map(e -> getIndexRequest(e, index))
@@ -214,10 +216,6 @@ public class LogManager {
         } catch (IOException e) {
             throw new PipelineException(e);
         }
-    }
-
-    private String getIndexName() {
-        return getIndexName(indexPrefix, LocalDate.now().format(ELASTIC_DATE_FORMATTER));
     }
 
     private IndexRequest getIndexRequest(final LogEntry logEntry, final String index) {
@@ -241,26 +239,30 @@ public class LogManager {
         return new IndexRequest(index, INDEX_TYPE).source(builder);
     }
 
-    private String[] getLogIndices(final LocalDateTime from, final LocalDateTime to) {
+    private String[] getAllIndices() {
+        return new String[]{getIndexName(indexPrefix, ES_WILDCARD)};
+    }
+
+    private String getWriteIndex() {
+        return getIndexName(indexPrefix);
+    }
+
+    /**
+     * Returns system logs day indices taking into consideration filebeat transition period.
+     * <p>
+     * The transition period includes adjacent indices which may contain required documents.
+     */
+    private String[] getReadIndices(final LocalDateTime from, final LocalDateTime to) {
         final LocalDate toDate = Optional.ofNullable(to)
                 .orElseGet(DateUtils::nowUTC)
                 .toLocalDate();
         return Optional.ofNullable(from)
                 .map(LocalDateTime::toLocalDate)
-                .map(fromDate -> getLogDayIndices(fromDate, toDate))
-                .orElseGet(this::getLogIndices);
+                .map(fromDate -> getReadIndices(fromDate, toDate))
+                .orElseGet(this::getAllIndices);
     }
 
-    private String[] getLogIndices() {
-        return new String[]{getIndexName(indexPrefix, ES_WILDCARD)};
-    }
-
-    /**
-     * Returns system logs day indices taking into consideration filebeat transition period.
-     *
-     * The transition period includes adjacent indices which may contain required documents.
-     */
-    private String[] getLogDayIndices(final LocalDate from, final LocalDate to) {
+    private String[] getReadIndices(final LocalDate from, final LocalDate to) {
         final LocalDate actualFrom = from.minus(FILEBEAT_TRANSITION_PERIOD);
         final LocalDate actualTo = to.plus(FILEBEAT_TRANSITION_PERIOD);
         return Stream.iterate(actualFrom, date -> date.plusDays(1))

--- a/api/src/main/java/com/epam/pipeline/manager/security/AuthManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/AuthManager.java
@@ -25,6 +25,7 @@ import com.epam.pipeline.entity.user.Role;
 import com.epam.pipeline.security.UserContext;
 import com.epam.pipeline.security.jwt.JwtAuthenticationToken;
 import com.epam.pipeline.security.jwt.JwtTokenGenerator;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
@@ -193,6 +194,10 @@ public class AuthManager {
         context.setAuthentication(new JwtAuthenticationToken(userContext, authorities));
 
         return context;
+    }
+
+    public boolean isServiceUser(@Nullable String user) {
+        return StringUtils.equalsIgnoreCase(user, defaultAdmin);
     }
 
     private UserContext getAdminContext() {


### PR DESCRIPTION
Relates #3071.

The pull request brings several changes to System Log API changes introduced in #3079:
- Index which is used for logs indexing is changed from *security_log-yyyy.mm.dd* to just *security_log*. The new index is actually an alias which is managed by elasticsearch lifecycle policy. The alias always points to the most recent index. All beats use just the same approach already.
- It adds _service_account_ flag to all log documents. The flag is set to `true` if the log entry's user name is the default user name. Otherwise the flag is set to false.
