### PR TITLE
Issue #3094 Count restored file twice

### DIFF
--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
@@ -30,6 +30,8 @@ import com.epam.pipeline.entity.datastorage.DataStorageItemContent;
 import com.epam.pipeline.entity.datastorage.DataStorageTag;
 import com.epam.pipeline.entity.datastorage.FileShareMount;
 import com.epam.pipeline.entity.datastorage.TemporaryCredentials;
+import com.epam.pipeline.entity.datastorage.lifecycle.restore.StorageRestoreAction;
+import com.epam.pipeline.entity.datastorage.lifecycle.restore.StorageRestorePathType;
 import com.epam.pipeline.entity.docker.DockerRegistryList;
 import com.epam.pipeline.entity.docker.ToolDescription;
 import com.epam.pipeline.entity.dts.submission.DtsRegistry;
@@ -313,4 +315,11 @@ public interface CloudPipelineAPI {
 
     @DELETE("cluster/pool/usage")
     Call<Result<Boolean>> deleteExpiredNodePoolUsage(@Query("date") LocalDate date);
+
+    @GET("datastorage/{id}/lifecycle/restore/effectiveHierarchy")
+    Call<Result<List<StorageRestoreAction>>> loadDataStorageRestoreHierarchy(
+            @Path(ID) long datastorageId, @Query(PATH) String path,
+            @Query("pathType") StorageRestorePathType pathType,
+            @Query("recursive") boolean recursive);
+
 }

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/datastorage/AbstractDataStorageItem.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/datastorage/AbstractDataStorageItem.java
@@ -36,6 +36,9 @@ import lombok.Setter;
         @JsonSubTypes.Type(value = DataStorageFile.class, name = "File"),
         @JsonSubTypes.Type(value = DataStorageFolder.class, name = "Folder")})
 public abstract class AbstractDataStorageItem {
+
+    public static final String DELIMITER = "/";
+
     private String name;
     private String path;
     private Map<String, String> labels;
@@ -54,6 +57,10 @@ public abstract class AbstractDataStorageItem {
             }
             return 0;
         };
+    }
+
+    public String getAbsolutePath() {
+        return this.getPath().startsWith(DELIMITER) ? this.getPath() : DELIMITER + this.getPath();
     }
 
 }

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/datastorage/DataStorageFile.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/datastorage/DataStorageFile.java
@@ -19,9 +19,11 @@ package com.epam.pipeline.entity.datastorage;
 
 import java.io.File;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.commons.collections4.MapUtils;
 
 @Getter
 @Setter
@@ -51,6 +53,24 @@ public class DataStorageFile extends AbstractDataStorageItem {
         file.setVersion(other.getVersion());
         file.setDeleteMarker(other.getDeleteMarker());
         file.setIsHidden(other.getIsHidden());
+        return file;
+    }
+
+    public DataStorageFile copy() {
+        DataStorageFile file = new DataStorageFile();
+        file.setName(this.getName());
+        file.setPath(this.getPath());
+        file.setSize(this.getSize());
+        file.setChanged(this.getChanged());
+        if (MapUtils.isNotEmpty(getVersions())) {
+            file.setVersions(new HashMap<>(this.getVersions()));
+        }
+        if (MapUtils.isNotEmpty(getLabels())) {
+            file.setLabels(new HashMap<>(this.getLabels()));
+        }
+        file.setVersion(this.getVersion());
+        file.setDeleteMarker(this.getDeleteMarker());
+        file.setIsHidden(this.getIsHidden());
         return file;
     }
 

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/datastorage/lifecycle/restore/StorageRestoreAction.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/datastorage/lifecycle/restore/StorageRestoreAction.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.datastorage.lifecycle.restore;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StorageRestoreAction {
+    private Long id;
+    private Long datastorageId;
+    private Long userActorId;
+    private String path;
+    private StorageRestorePathType type;
+    private Boolean restoreVersions;
+    private String restoreMode;
+    private Long days;
+    private LocalDateTime started;
+    private LocalDateTime updated;
+    private LocalDateTime restoredTill;
+    private StorageRestoreStatus status;
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/datastorage/lifecycle/restore/StorageRestoreAction.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/datastorage/lifecycle/restore/StorageRestoreAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/datastorage/lifecycle/restore/StorageRestorePathType.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/datastorage/lifecycle/restore/StorageRestorePathType.java
@@ -1,0 +1,5 @@
+package com.epam.pipeline.entity.datastorage.lifecycle.restore;
+
+public enum StorageRestorePathType {
+    FOLDER, FILE
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/datastorage/lifecycle/restore/StorageRestorePathType.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/datastorage/lifecycle/restore/StorageRestorePathType.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.epam.pipeline.entity.datastorage.lifecycle.restore;
 
 public enum StorageRestorePathType {

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/datastorage/lifecycle/restore/StorageRestoreStatus.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/datastorage/lifecycle/restore/StorageRestoreStatus.java
@@ -1,0 +1,32 @@
+package com.epam.pipeline.entity.datastorage.lifecycle.restore;
+
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public enum StorageRestoreStatus {
+
+    INITIATED(true, false),
+    RUNNING(true, false),
+    SUCCEEDED(true, true),
+    CANCELLED(false, true),
+    FAILED(false, true);
+
+    public static final List<StorageRestoreStatus> ACTIVE_STATUSES = Arrays.stream(StorageRestoreStatus.values())
+            .filter(StorageRestoreStatus::isActive).collect(Collectors.toList());
+
+    public static final List<StorageRestoreStatus> TERMINAL_STATUSES = Arrays.stream(StorageRestoreStatus.values())
+            .filter(StorageRestoreStatus::isTerminal).collect(Collectors.toList());
+
+    private final boolean active;
+    private final boolean terminal;
+
+    StorageRestoreStatus(final boolean active, final boolean terminal) {
+        this.active = active;
+        this.terminal = terminal;
+    }
+
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/datastorage/lifecycle/restore/StorageRestoreStatus.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/datastorage/lifecycle/restore/StorageRestoreStatus.java
@@ -1,4 +1,19 @@
 package com.epam.pipeline.entity.datastorage.lifecycle.restore;
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import lombok.Getter;
 

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/utils/DateUtils.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/utils/DateUtils.java
@@ -49,7 +49,8 @@ public final class DateUtils {
         try {
             return toLocalDateTime(format.parse(dateString));
         } catch (ParseException e) {
-            throw new RuntimeException(String.format("Filed to parse date: %s with format: %s", dateString, format), e);
+            throw new IllegalArgumentException(
+                    String.format("Filed to parse date: %s with format: %s", dateString, format), e);
         }
     }
 }

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/utils/DateUtils.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/utils/DateUtils.java
@@ -16,6 +16,8 @@
 
 package com.epam.pipeline.entity.utils;
 
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -41,5 +43,13 @@ public final class DateUtils {
 
     public static LocalDateTime toLocalDateTime(final Date date) {
         return date.toInstant().atZone(ZoneId.of("Z")).toLocalDateTime();
+    }
+
+    public static LocalDateTime parse(final DateFormat format, final String dateString) {
+        try {
+            return toLocalDateTime(format.parse(dateString));
+        } catch (ParseException e) {
+            throw new RuntimeException(String.format("Filed to parse date: %s with format: %s", dateString, format), e);
+        }
     }
 }

--- a/core/src/main/java/com/epam/pipeline/dto/datastorage/lifecycle/restore/StorageRestorePath.java
+++ b/core/src/main/java/com/epam/pipeline/dto/datastorage/lifecycle/restore/StorageRestorePath.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.epam.pipeline.dto.datastorage.lifecycle.restore;
 
 import lombok.AllArgsConstructor;

--- a/core/src/main/java/com/epam/pipeline/dto/datastorage/lifecycle/restore/StorageRestorePathType.java
+++ b/core/src/main/java/com/epam/pipeline/dto/datastorage/lifecycle/restore/StorageRestorePathType.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.epam.pipeline.dto.datastorage.lifecycle.restore;
 
 public enum StorageRestorePathType {

--- a/core/src/main/java/com/epam/pipeline/dto/datastorage/lifecycle/restore/StorageRestoreStatus.java
+++ b/core/src/main/java/com/epam/pipeline/dto/datastorage/lifecycle/restore/StorageRestoreStatus.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.epam.pipeline.dto.datastorage.lifecycle.restore;
 
 import lombok.Getter;

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/CloudPipelineAPIClient.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/CloudPipelineAPIClient.java
@@ -26,6 +26,8 @@ import com.epam.pipeline.entity.datastorage.DataStorageDownloadFileUrl;
 import com.epam.pipeline.entity.datastorage.DataStorageTag;
 import com.epam.pipeline.entity.datastorage.FileShareMount;
 import com.epam.pipeline.entity.datastorage.TemporaryCredentials;
+import com.epam.pipeline.entity.datastorage.lifecycle.restore.StorageRestoreAction;
+import com.epam.pipeline.entity.datastorage.lifecycle.restore.StorageRestorePathType;
 import com.epam.pipeline.entity.docker.ToolDescription;
 import com.epam.pipeline.entity.git.GitRepositoryEntry;
 import com.epam.pipeline.entity.issue.Issue;
@@ -109,6 +111,14 @@ public class CloudPipelineAPIClient {
         return loadDataStorageTags(id, request).stream()
                 .collect(Collectors.groupingBy(tag -> tag.getObject().getPath(),
                         Collectors.toMap(DataStorageTag::getKey, DataStorageTag::getValue)));
+    }
+
+    public List<StorageRestoreAction> loadDataStorageRestoreHierarchy(
+            final long datastorageId, final String path,
+            final StorageRestorePathType pathType, final boolean recursive) {
+        return ListUtils.emptyIfNull(executor.execute(
+                cloudPipelineAPI.loadDataStorageRestoreHierarchy(datastorageId, path, pathType, recursive)));
+
     }
 
     public PipelineRunWithLog loadPipelineRunWithLogs(final Long pipelineRunId) {

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/ObjectStorageIndexImpl.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/ObjectStorageIndexImpl.java
@@ -165,7 +165,7 @@ public class ObjectStorageIndexImpl implements ObjectStorageIndex {
             // Create second copy of the file with STANDARD_TIER if it's restored,
             // or use original object to hold restored versions
             final DataStorageFile primaryFile;
-            if (fileWasRestored(file, action)) {
+            if (fileIsCoveredByAction(file, action)) {
                 primaryFile = file.copy();
                 primaryFile.getLabels().put(ESConstants.STORAGE_CLASS_LABEL, STANDARD_TIER);
                 primaryFile.setVersions(new HashMap<>());
@@ -179,7 +179,7 @@ public class ObjectStorageIndexImpl implements ObjectStorageIndex {
             if (MapUtils.isNotEmpty(file.getVersions()) && BooleanUtils.isTrue(action.getRestoreVersions())) {
                 final Map<String, DataStorageFile> restoredVersions = file.getVersions().entrySet().stream().map(e -> {
                     final DataStorageFile fileVersion = ((DataStorageFile) e.getValue()).copy();
-                    if (fileWasRestored(fileVersion, action)) {
+                    if (fileIsCoveredByAction(fileVersion, action)) {
                         fileVersion.getLabels().put(ESConstants.STORAGE_CLASS_LABEL, STANDARD_TIER);
                         return ImmutablePair.of(e.getKey() + RESTORED_POSTFIX, fileVersion);
                     } else {
@@ -192,7 +192,7 @@ public class ObjectStorageIndexImpl implements ObjectStorageIndex {
         return filesWithRespectToRestoreStatus;
     }
 
-    private boolean fileWasRestored(final DataStorageFile file, final StorageRestoreAction action) {
+    private boolean fileIsCoveredByAction(final DataStorageFile file, final StorageRestoreAction action) {
         return action.getStarted().isAfter(DateUtils.parse(ESConstants.FILE_DATE_FORMAT, file.getChanged()))
                 && !file.getLabels().getOrDefault(ESConstants.STORAGE_CLASS_LABEL, STANDARD_TIER).equals(STANDARD_TIER);
     }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/ObjectStorageIndexImpl.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/ObjectStorageIndexImpl.java
@@ -21,6 +21,7 @@ import com.epam.pipeline.elasticsearchagent.service.ElasticsearchServiceClient;
 import com.epam.pipeline.elasticsearchagent.service.ObjectStorageFileManager;
 import com.epam.pipeline.elasticsearchagent.service.ObjectStorageIndex;
 import com.epam.pipeline.elasticsearchagent.service.impl.converter.storage.StorageFileMapper;
+import com.epam.pipeline.elasticsearchagent.utils.ESConstants;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorageItem;
 import com.epam.pipeline.entity.datastorage.DataStorageAction;
@@ -28,6 +29,10 @@ import com.epam.pipeline.entity.datastorage.DataStorageDownloadFileUrl;
 import com.epam.pipeline.entity.datastorage.DataStorageFile;
 import com.epam.pipeline.entity.datastorage.DataStorageType;
 import com.epam.pipeline.entity.datastorage.TemporaryCredentials;
+import com.epam.pipeline.entity.datastorage.lifecycle.restore.StorageRestoreAction;
+import com.epam.pipeline.entity.datastorage.lifecycle.restore.StorageRestorePathType;
+import com.epam.pipeline.entity.datastorage.lifecycle.restore.StorageRestoreStatus;
+import com.epam.pipeline.entity.utils.DateUtils;
 import com.epam.pipeline.utils.StreamUtils;
 import com.epam.pipeline.entity.search.SearchDocumentType;
 import com.epam.pipeline.vo.EntityPermissionVO;
@@ -39,13 +44,17 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.elasticsearch.action.index.IndexRequest;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -62,6 +71,9 @@ import static com.epam.pipeline.utils.PasswordGenerator.generateRandomString;
 @RequiredArgsConstructor
 @Slf4j
 public class ObjectStorageIndexImpl implements ObjectStorageIndex {
+
+    private static final String STANDARD_TIER = "STANDARD";
+    private static final String ROOT_PATH = "/";
 
     private final CloudPipelineAPIClient cloudPipelineAPIClient;
     private final ElasticsearchServiceClient elasticsearchServiceClient;
@@ -110,13 +122,19 @@ public class ObjectStorageIndexImpl implements ObjectStorageIndex {
             final TemporaryCredentials credentials = credentialsSupplier.get();
             try (IndexRequestContainer requestContainer = getRequestContainer(indexName, bulkInsertSize)) {
 
+                final List<StorageRestoreAction> restoreActions = ListUtils.emptyIfNull(
+                        cloudPipelineAPIClient.loadDataStorageRestoreHierarchy(
+                                dataStorage.getId(), ROOT_PATH, StorageRestorePathType.FOLDER, true)
+                );
+
                 final Stream<DataStorageFile> files = dataStorage.isVersioningEnabled() && includeVersions
                         ? loadFileWithVersions(dataStorage, credentialsSupplier)
                         : loadFiles(dataStorage, credentialsSupplier);
-                files.map(file -> createIndexRequest(
-                        file, dataStorage, permissionsContainer, indexName, credentials.getRegion(),
-                        findFileContent(dataStorage, file.getPath()))
-                ).forEach(requestContainer::add);
+                files.flatMap(file -> countRestored(restoreActions, file).stream())
+                        .map(file -> createIndexRequest(
+                                file, dataStorage, permissionsContainer, indexName, credentials.getRegion(),
+                                findFileContent(dataStorage, file.getPath()))
+                        ).forEach(requestContainer::add);
             }
 
             elasticsearchServiceClient.createIndexAlias(indexName, alias);
@@ -129,6 +147,45 @@ public class ObjectStorageIndexImpl implements ObjectStorageIndex {
                 elasticsearchServiceClient.deleteIndex(indexName);
             }
         }
+    }
+
+    private List<DataStorageFile> countRestored(final List<StorageRestoreAction> actions, final DataStorageFile file) {
+        final List<DataStorageFile> filesWithRespectToRestoreStatus = new ArrayList<>();
+        filesWithRespectToRestoreStatus.add(file);
+        actions.stream().filter(action -> {
+            final boolean pathsMatches = action.getType() == StorageRestorePathType.FILE
+                    ? action.getPath().equals(file.getAbsolutePath())
+                    : file.getAbsolutePath().startsWith(action.getPath());
+            return pathsMatches && StorageRestoreStatus.SUCCEEDED == action.getStatus();
+        }).findAny().ifPresent(action -> {
+            // Create second copy of the file with STANDARD_TIER
+            if (fileWasRestored(file, action)) {
+                final DataStorageFile restored = file.copy();
+                restored.getLabels().put(ESConstants.STORAGE_CLASS_LABEL, STANDARD_TIER);
+                restored.setVersions(Collections.emptyMap());
+                filesWithRespectToRestoreStatus.add(restored);
+            }
+            // If version were restored too we need to count it twice also, with actual storage class
+            // and STANDARD storage class, to count usage and billing appropriately
+            if (BooleanUtils.isTrue(action.getRestoreVersions())) {
+                Map<String, DataStorageFile> duplicated = file.getVersions().entrySet().stream().map(e -> {
+                    final DataStorageFile fileVersion = ((DataStorageFile) e.getValue()).copy();
+                    if (fileWasRestored(fileVersion, action)) {
+                        fileVersion.getLabels().put(ESConstants.STORAGE_CLASS_LABEL, STANDARD_TIER);
+                        return ImmutablePair.of(e.getKey() + "_restored", fileVersion);
+                    } else {
+                        return null;
+                    }
+                }).filter(Objects::nonNull).collect(Collectors.toMap(Pair::getKey, Pair::getValue));
+                file.getVersions().putAll(duplicated);
+            }
+        });
+        return filesWithRespectToRestoreStatus;
+    }
+
+    private boolean fileWasRestored(final DataStorageFile file, final StorageRestoreAction action) {
+        return action.getStarted().isAfter(DateUtils.parse(ESConstants.FILE_DATE_FORMAT, file.getChanged()))
+                && !file.getLabels().getOrDefault(ESConstants.STORAGE_CLASS_LABEL, STANDARD_TIER).equals(STANDARD_TIER);
     }
 
     private Stream<DataStorageFile> loadFiles(final AbstractDataStorage dataStorage,


### PR DESCRIPTION
Related to #3028 and #3094 
This PR solves problem when we could lose restored files sizes (since such files are stored as primary file in archive storage class and secondary copy is stored in STANDARD class) and as result calculate wrong billing data.
Now we check whether restoring operation was done for this particular file and if yes - count it twice (and its version of applicable) in `elasticsearch` index.