### PR TITLE
Support data access audit in pipe mount

### DIFF
--- a/pipe-cli/mount/pipe-fuse.py
+++ b/pipe-cli/mount/pipe-fuse.py
@@ -48,7 +48,9 @@ if os.path.exists(libfuse_path):
 import fuse
 from fuse import FUSE, fuse_operations, fuse_file_info, c_utimbuf
 
-from pipefuse.api import CloudPipelineClient, CloudType
+from pipefuse.api import CloudPipelineClient, CloudType, CloudPipelineAuditConsumer
+from pipefuse.audit import AuditFileSystemClient, LoggingAuditConsumer, ChunkingAuditConsumer, \
+    NativeSetAuditContainer, AuditDaemon
 from pipefuse.buffread import BufferingReadAheadFileSystemClient
 from pipefuse.buffwrite import BufferingWriteFileSystemClient
 from pipefuse.cache import ListingCache, ThreadSafeListingCache, \
@@ -87,8 +89,9 @@ def start(mountpoint, webdav, bucket,
           xattrs_include_prefixes, xattrs_exclude_prefixes,
           xattrs_cache_ttl, xattrs_cache_size,
           disabled_operations, default_mode,
-          mount_options, threads=False, monitoring_delay=600, recording=False,
-          show_archived=False, storage_class_exclude=None):
+          mount_options, threads, monitoring_delay, recording,
+          show_archived, storage_class_exclude,
+          audit, audit_buffer_ttl):
     try:
         os.makedirs(mountpoint)
     except OSError as e:
@@ -104,6 +107,7 @@ def start(mountpoint, webdav, bucket,
                                                read_ahead_size_multiplier))
     bucket_type = None
     root_path = None
+    daemons = []
     if not bearer:
         raise RuntimeError('Cloud Pipeline API_TOKEN should be specified.')
     if webdav:
@@ -118,18 +122,27 @@ def start(mountpoint, webdav, bucket,
         path_chunks = bucket.rstrip('/').split('/')
         bucket_name = path_chunks[0]
         root_path = '/'.join(path_chunks[1:])
-        bucket_object = pipe.get_storage(bucket)
+        bucket_object = pipe.init_bucket_object(bucket)
         bucket_type = bucket_object.type
         if bucket_type == CloudType.S3:
-            client = S3StorageLowLevelClient(bucket_name, pipe=pipe, chunk_size=chunk_size, storage_path=bucket)
+            client = S3StorageLowLevelClient(bucket_name, bucket_object, pipe=pipe, chunk_size=chunk_size)
             if not show_archived:
                 client = ArchivedFilesFilterFileSystemClient(client, pipe=pipe, bucket=client.bucket_object)
             client = ArchivedAttributesFileSystemClient(client, pipe=pipe, bucket=client.bucket_object)
         elif bucket_type == CloudType.GS:
-            client = GoogleStorageLowLevelFileSystemClient(bucket_name, pipe=pipe, chunk_size=chunk_size,
-                                                           storage_path=bucket)
+            client = GoogleStorageLowLevelFileSystemClient(bucket_name, bucket_object, pipe=pipe, chunk_size=chunk_size)
         else:
             raise RuntimeError('Cloud storage type %s is not supported.' % bucket_object.type)
+        if audit:
+            logging.info('Auditing is enabled.')
+            audit_container = NativeSetAuditContainer()
+            audit_consumer = CloudPipelineAuditConsumer(pipe=pipe, bucket_object=bucket_object)
+            audit_consumer = LoggingAuditConsumer(audit_consumer)
+            audit_consumer = ChunkingAuditConsumer(audit_consumer)
+            daemons.append(AuditDaemon(container=audit_container, consumer=audit_consumer, timeout=audit_buffer_ttl))
+            client = AuditFileSystemClient(client, container=audit_container)
+        else:
+            logging.info('Auditing is disabled.')
         client = StorageHighLevelFileSystemClient(client)
     if storage_class_exclude:
         client = StorageClassFilterFileSystemClient(client, classes=storage_class_exclude)
@@ -201,6 +214,11 @@ def start(mountpoint, webdav, bucket,
         fs = RecordingFS(fs)
 
     logging.info('File system processing chain: \n%s', fs.summary())
+
+    if daemons:
+        logging.info('Initiating file system daemons...')
+        for daemon in daemons:
+            daemon.start()
 
     logging.info('Initializing file system...')
     enable_additional_operations()
@@ -347,12 +365,17 @@ if __name__ == '__main__':
                         help="String with mount options supported by FUSE")
     parser.add_argument("-l", "--logging-level", type=str, required=False, default=_default_logging_level,
                         help="Logging level.")
-    parser.add_argument("-th", "--threads", action='store_true', help="Enables multithreading.")
+    parser.add_argument("-th", "--threads", action='store_true', help="Enables multithreading.",
+                        default=True)
     parser.add_argument("-d", "--monitoring-delay", type=int, required=False, default=600,
                         help="Delay between path lock monitoring cycles.")
     parser.add_argument("--show-archived", action='store_true', help="Show archived files.")
     parser.add_argument("--storage-class-exclude", type=str, required=False, action="append", default=[],
                         help="Storage classes that shall be excluded from listing.")
+    parser.add_argument("--audit", action='store_true', help="Enables data access auditing.",
+                        default=True)
+    parser.add_argument("--audit-buffer-ttl", type=int, required=False, default=60,
+                        help="Data access audit buffer time to live, seconds.")
     args = parser.parse_args()
 
     if args.xattrs_include_prefixes and args.xattrs_exclude_prefixes:
@@ -389,7 +412,8 @@ if __name__ == '__main__':
               disabled_operations=args.disabled_operations,
               default_mode=args.mode, mount_options=parse_mount_options(args.options),
               threads=args.threads, monitoring_delay=args.monitoring_delay, recording=recording,
-              show_archived=args.show_archived, storage_class_exclude=args.storage_class_exclude)
+              show_archived=args.show_archived, storage_class_exclude=args.storage_class_exclude,
+              audit=args.audit, audit_buffer_ttl=args.audit_buffer_ttl)
     except Exception:
         logging.exception('Unhandled error')
         traceback.print_exc()

--- a/pipe-cli/mount/pipefuse/audit.py
+++ b/pipe-cli/mount/pipefuse/audit.py
@@ -17,10 +17,9 @@ from collections import namedtuple
 import logging
 import time
 from abc import abstractmethod, ABCMeta
-from threading import Thread, RLock
+from threading import Thread
 
 from pipefuse.fsclient import FileSystemClientDecorator
-from pipefuse.lock import synchronized
 from pipefuse.storage import StorageLowLevelFileSystemClient
 
 class DataAccessType:
@@ -151,9 +150,9 @@ class AuditFileSystemClient(FileSystemClientDecorator, StorageLowLevelFileSystem
         self._inner.delete(path)
 
     def mv(self, old_path, path):
-        self._container.put_all(DataAccessEntry(old_path, DataAccessType.READ),
-                                DataAccessEntry(old_path, DataAccessType.DELETE),
-                                DataAccessEntry(path, DataAccessType.WRITE))
+        self._container.put_all([DataAccessEntry(old_path, DataAccessType.READ),
+                                 DataAccessEntry(old_path, DataAccessType.DELETE),
+                                 DataAccessEntry(path, DataAccessType.WRITE)])
         self._inner.mv(old_path, path)
 
     def download_range(self, fh, buf, path, offset=0, length=0):

--- a/pipe-cli/mount/pipefuse/audit.py
+++ b/pipe-cli/mount/pipefuse/audit.py
@@ -1,0 +1,157 @@
+#  Copyright 2017-2023 EPAM Systems, Inc. (https://www.epam.com/)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from collections import namedtuple
+
+import logging
+import time
+from abc import abstractmethod, ABCMeta
+from threading import Thread, RLock
+
+from pipefuse.fsclient import FileSystemClientDecorator
+from pipefuse.lock import synchronized
+from pipefuse.storage import StorageLowLevelFileSystemClient
+
+class DataAccessType:
+    READ = 'R'
+    WRITE = 'W'
+    DELETE = 'D'
+
+DataAccessEntry = namedtuple('AuditEntry', 'path,type')
+
+
+def chunks(l, n):
+    for i in range(0, len(l), n):
+        yield l[i:i + n]
+
+
+class AuditContainer:
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def put(self, *entries):
+        pass
+
+    @abstractmethod
+    def pull(self):
+        pass
+
+
+class AuditConsumer:
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def consume(self, entries):
+        pass
+
+
+class NativeSetAuditContainer(AuditContainer):
+
+    def __init__(self):
+        self._entries = set()
+
+    def put(self, *entries):
+        self._entries.update(entries)
+
+    def pull(self):
+        entries = set()
+        while True:
+            try:
+                entries.add(self._entries.pop())
+            except KeyError:
+                break
+        return entries
+
+
+class LoggingAuditConsumer(AuditConsumer):
+
+    def __init__(self, inner=None):
+        self._inner = inner
+
+    def consume(self, entries):
+        for entry in entries:
+            logging.debug('[AUDIT %s] %s', entry.type, entry.path)
+        if self._inner:
+            self._inner.consume(entries)
+
+
+class ChunkingAuditConsumer(AuditConsumer):
+
+    def __init__(self, inner, chunk_size=100):
+        self._inner = inner
+        self._chunk_size = chunk_size
+
+    def consume(self, entries):
+        if not entries:
+            return
+        for chunk_number, chunk_entries in enumerate(chunks(list(entries), self._chunk_size)):
+            logging.info('Processing %s/%s audit entries...', len(chunk_entries) * (chunk_number + 1), len(entries))
+            self._inner.consume(chunk_entries)
+
+
+class AuditDaemon:
+
+    def __init__(self, container, consumer, chunk_size=100, timeout=10):
+        self._container = container
+        self._consumer = consumer
+        self._chunk_size = chunk_size
+        self._timeout = timeout
+        self._thread = Thread(name='Audit', target=self.run)
+        self._thread.daemon = True
+
+    def start(self):
+        self._thread.start()
+
+    def run(self):
+        logging.info('Initiating audit daemon...')
+        while True:
+            time.sleep(self._timeout)
+            try:
+                entries = self._container.pull()
+                self._consumer.consume(entries)
+            except KeyboardInterrupt:
+                logging.warning('Interrupted.')
+                raise
+            except Exception:
+                logging.warning('Audit daemon iteration has failed.', exc_info=True)
+
+
+class AuditFileSystemClient(FileSystemClientDecorator, StorageLowLevelFileSystemClient):
+
+    def __init__(self, inner, container):
+        super(AuditFileSystemClient, self).__init__(inner)
+        self._inner = inner
+        self._container = container
+
+    def upload(self, buf, path):
+        self._container.put(DataAccessEntry(path, DataAccessType.WRITE))
+        self._inner.upload(buf, path)
+
+    def delete(self, path):
+        self._container.put(DataAccessEntry(path, DataAccessType.DELETE))
+        self._inner.delete(path)
+
+    def mv(self, old_path, path):
+        self._container.put(DataAccessEntry(old_path, DataAccessType.READ),
+                            DataAccessEntry(old_path, DataAccessType.DELETE),
+                            DataAccessEntry(path, DataAccessType.WRITE))
+        self._inner.mv(old_path, path)
+
+    def download_range(self, fh, buf, path, offset=0, length=0):
+        self._container.put(DataAccessEntry(path, DataAccessType.READ))
+        self._inner.download_range(fh, buf, path, offset, length)
+
+    def new_mpu(self, path, file_size, download, mv):
+        self._container.put(DataAccessEntry(path, DataAccessType.WRITE))
+        return self._inner.new_mpu(path, file_size, download, mv)

--- a/pipe-cli/mount/pipefuse/fslock.py
+++ b/pipe-cli/mount/pipefuse/fslock.py
@@ -67,6 +67,7 @@ class PathLock(FileSystemLock):
         self._mutex = RLock()
         self._monitor_lock = RLock()
         self._locks = {}
+        # todo: Move to daemons section in pipe-fuse.py
         self._monitor = Thread(target=monitor_locks, args=(self._monitor_lock, self._locks, monitoring_delay,))
         self._monitor.daemon = True
         self._monitor.start()

--- a/pipe-cli/mount/pipefuse/storage.py
+++ b/pipe-cli/mount/pipefuse/storage.py
@@ -182,6 +182,12 @@ class StorageHighLevelFileSystemClient(FileSystemClientDecorator):
         self.upload(modified_bytes, path)
 
     def flush(self, fh, path):
+        try:
+            self._flush_mpu(fh, path)
+        finally:
+            self._inner.flush(fh, path)
+
+    def _flush_mpu(self, fh, path):
         mpu = self._mpus.get(path, None)
         if mpu:
             try:

--- a/pipe-cli/mount/pipefuse/storage.py
+++ b/pipe-cli/mount/pipefuse/storage.py
@@ -39,9 +39,6 @@ class StorageLowLevelFileSystemClient(FileSystemClient):
     def upload_range(self, fh, buf, path, offset):
         pass
 
-    def flush(self, fh, path):
-        pass
-
     @abstractmethod
     def new_mpu(self, path, file_size, download, mv):
         pass


### PR DESCRIPTION
Relates #3075.

The pull request brings support for data access audit to pipe mount. From now on all read/write/delete operations are persisted via Cloud Pipeline System Log API.

In order to provide optimal performance pipe mount uses audit entries buffering. It asynchronously accumulates unique audit entries within a buffer. By default, all buffer entries are flushed to the API every minute.

An additional custom mount option can be used to tweak audit settings.

```bash
# data access audit buffer is flushed every 300 seconds
pipe storage mount -c "audit-buffer-ttl=300" ...

# data access audit is disabled
pipe storage mount -c "audit-buffer-ttl=0" ...
```
