### PR TITLE
Issue #3027 Change the way how indices with storage usage is peeking during billing calculation

### DIFF
--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/app/CommonSyncConfiguration.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/app/CommonSyncConfiguration.java
@@ -74,6 +74,9 @@ public class CommonSyncConfiguration {
     @Value("${sync.storage.file.index.pattern}")
     private String fileIndexPattern;
 
+    @Value("${sync.storage.file.alias.index.pattern}")
+    private String fileAliasIndexPattern;
+
     @Value("${sync.storage.historical.billing.generation:false}")
     private boolean enableStorageHistoricalBillingGeneration;
 
@@ -139,6 +142,7 @@ public class CommonSyncConfiguration {
                 new StorageToBillingRequestConverter(mapper, elasticsearchClient,
                         StorageType.OBJECT_STORAGE,
                         pricingService,
+                        fileAliasIndexPattern,
                         fileIndexPattern,
                         enableStorageHistoricalBillingGeneration),
                 DataStorageType.S3);
@@ -170,6 +174,7 @@ public class CommonSyncConfiguration {
                 new StorageToBillingRequestConverter(mapper, elasticsearchClient,
                         StorageType.FILE_STORAGE,
                         pricingService,
+                        fileAliasIndexPattern,
                         fileIndexPattern,
                         fileShareMountsService,
                         MountType.NFS,
@@ -196,6 +201,7 @@ public class CommonSyncConfiguration {
                 new StorageToBillingRequestConverter(mapper, elasticsearchClient,
                         StorageType.OBJECT_STORAGE,
                         pricingService,
+                        fileAliasIndexPattern,
                         fileIndexPattern,
                         enableStorageHistoricalBillingGeneration),
                 DataStorageType.GS);
@@ -231,6 +237,7 @@ public class CommonSyncConfiguration {
                 new StorageToBillingRequestConverter(mapper, elasticsearchClient,
                         StorageType.OBJECT_STORAGE,
                         pricingService,
+                        fileAliasIndexPattern,
                         fileIndexPattern,
                         enableStorageHistoricalBillingGeneration),
                 DataStorageType.AZ);
@@ -262,6 +269,7 @@ public class CommonSyncConfiguration {
                 new StorageToBillingRequestConverter(mapper, elasticsearchClient,
                         StorageType.FILE_STORAGE,
                         pricingService,
+                        fileAliasIndexPattern,
                         fileIndexPattern,
                         fileShareMountsService,
                         MountType.NFS,
@@ -295,6 +303,7 @@ public class CommonSyncConfiguration {
                                        new StorageToBillingRequestConverter(mapper, elasticsearchClient,
                                                                             StorageType.FILE_STORAGE,
                                                                             pricingService,
+                                                                            fileAliasIndexPattern,
                                                                             fileIndexPattern,
                                                                             fileShareMountsService,
                                                                             MountType.SMB,

--- a/billing-report-agent/src/main/resources/application.properties
+++ b/billing-report-agent/src/main/resources/application.properties
@@ -56,6 +56,7 @@ sync.storage.price.load.mode=json
 sync.storage.index.mapping=classpath:/templates/storage_billing.json
 sync.storage.index.name=storage-
 sync.storage.file.index.pattern=*cp-%s-%s-%d
+sync.storage.file.alias.index.pattern=cp-%s-%s-%d
 sync.aws.json.price.endpoint.template=https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/%s/current/index.json
 sync.storage.billing.exclude.metadata.key=Billing status
 sync.storage.billing.exclude.metadata.value=Exclude

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/StorageToRequestConverterTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/StorageToRequestConverterTest.java
@@ -165,6 +165,7 @@ public class StorageToRequestConverterTest {
     private static final BigDecimal AZ_NFS_STORAGE_1_GB_DAILY_PRICE = BigDecimal.valueOf(2);
     public static final String STORAGE_CLASS = "STANDARD";
     public static final String ARCHIVE_CLASS = "GLACIER";
+    public static final String TEST_INDEX_NAME = "test-index-name";
 
     private final PipelineUser testUser = PipelineUser.builder()
         .userName(USER_NAME)
@@ -221,12 +222,14 @@ public class StorageToRequestConverterTest {
             StorageType.OBJECT_STORAGE,
             testStoragePricing,
             StringUtils.EMPTY,
+            StringUtils.EMPTY,
             false);
         gcpConverter = new StorageToBillingRequestConverter(
             new StorageBillingMapper(SearchDocumentType.GS_STORAGE, BILLING_CENTER_KEY),
             elasticsearchClient,
             StorageType.OBJECT_STORAGE,
             testStoragePricing,
+            StringUtils.EMPTY,
             StringUtils.EMPTY,
             false);
         azureBlobConverter = new StorageToBillingRequestConverter(
@@ -235,12 +238,14 @@ public class StorageToRequestConverterTest {
             StorageType.OBJECT_STORAGE,
             testStoragePricing,
             StringUtils.EMPTY,
+            StringUtils.EMPTY,
             false);
         nfsConverter = new StorageToBillingRequestConverter(
             new StorageBillingMapper(SearchDocumentType.NFS_STORAGE, BILLING_CENTER_KEY),
             elasticsearchClient,
             StorageType.FILE_STORAGE,
             testStoragePricing,
+            StringUtils.EMPTY,
             StringUtils.EMPTY,
             fileShareMountsService,
             MountType.NFS,
@@ -251,6 +256,7 @@ public class StorageToRequestConverterTest {
             StorageType.FILE_STORAGE,
             testAzureNfsStoragePricing,
             StringUtils.EMPTY,
+            StringUtils.EMPTY,
             fileShareMountsService,
             MountType.NFS,
             false);
@@ -259,6 +265,7 @@ public class StorageToRequestConverterTest {
             elasticsearchClient,
             StorageType.FILE_STORAGE,
             testAzureNfsStoragePricing,
+            StringUtils.EMPTY,
             StringUtils.EMPTY,
             fileShareMountsService,
             MountType.SMB,
@@ -520,6 +527,7 @@ public class StorageToRequestConverterTest {
         Mockito.when(response.getAggregations()).thenReturn(aggregations);
         Mockito.when(response.getHits()).thenReturn(hits);
         Mockito.when(elasticsearchClient.isIndexExists(Mockito.anyString())).thenReturn(true);
+        Mockito.when(elasticsearchClient.getIndexNameByAlias(Mockito.anyString())).thenReturn(TEST_INDEX_NAME);
         Mockito.when(elasticsearchClient.search(Mockito.any())).thenReturn(response);
     }
 

--- a/deploy/docker/cp-billing-srv/config/application.properties
+++ b/deploy/docker/cp-billing-srv/config/application.properties
@@ -56,6 +56,7 @@ sync.storage.index.mapping=classpath:/templates/storage_billing.json
 sync.storage.index.name=storage-
 sync.storage.price.load.mode=${CP_BILLING_AWS_PRICE_TYPE:json}
 sync.storage.file.index.pattern=${CP_BILLING_STORAGE_INDEX_PATTERN:*cp-%s-%s-%d}
+sync.storage.file.alias.index.pattern=${CP_BILLING_STORAGE_ALIAS_INDEX_PATTERN:cp-%s-%s-%d}
 sync.aws.json.price.endpoint.template=${CP_BILLING_AWS_PRICES_ENDPOINT:https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/%s/current/index.json}
 sync.storage.billing.exclude.metadata.key=${CP_BILLING_STORAGE_EXCLUDE_METADATA_KEY:Billing status}
 sync.storage.billing.exclude.metadata.value=${CP_BILLING_STORAGE_EXCLUDE_METADATA_VALUE:Exclude}


### PR DESCRIPTION
Related to #3027
Previously billing agent uses index name pattern to match all indices in elasticsearch with particular name, like `*cp-s3-file-1`.
Such approach may lead to incorrect billing data calculation if there are more that 1 index for such pattern.
This PR adds logic to firstly check if we actually have an alias for such index and if we have - use an index attached to this alias.
In case we don't have an alias or there is no indices attached we will use previous approach. 