### PR TITLE
Issue #3027 Extended Billing Reports

### DIFF
--- a/api/src/main/java/com/epam/pipeline/app/BillingConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/BillingConfiguration.java
@@ -87,7 +87,8 @@ public class BillingConfiguration {
         return new CommonBillingExporter<>("Storages Report",
             BillingExportType.STORAGE,
             storageBillingLoader,
-            (request, writer) -> new StorageBillingWriter(writer, request.getFrom(), request.getTo()),
+            (request, writer) -> new StorageBillingWriter(writer, request.getFrom(), request.getTo(),
+                    request.getProperties()),
             elasticHelper);
     }
 

--- a/api/src/main/java/com/epam/pipeline/app/BillingConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/BillingConfiguration.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.epam.pipeline.app;
 
 import com.epam.pipeline.common.MessageHelper;

--- a/api/src/main/java/com/epam/pipeline/controller/vo/billing/BillingCostDetailsRequest.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/billing/BillingCostDetailsRequest.java
@@ -16,6 +16,7 @@
 
 package com.epam.pipeline.controller.vo.billing;
 
+import com.epam.pipeline.entity.billing.BillingDiscount;
 import com.epam.pipeline.entity.billing.BillingGrouping;
 import lombok.Builder;
 import lombok.Value;
@@ -29,6 +30,7 @@ public class BillingCostDetailsRequest {
 
     BillingGrouping grouping;
     Map<String, List<String>> filters;
+    BillingDiscount discount;
     boolean enabled;
 
 }

--- a/api/src/main/java/com/epam/pipeline/controller/vo/billing/BillingExportProperties.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/billing/BillingExportProperties.java
@@ -1,0 +1,13 @@
+package com.epam.pipeline.controller.vo.billing;
+
+import lombok.Value;
+
+import java.util.List;
+
+@Value
+public class BillingExportProperties {
+
+    //Storage specific parameters
+    boolean includeStorageOldVersions;
+    List<String> includeStorageClasses;
+}

--- a/api/src/main/java/com/epam/pipeline/controller/vo/billing/BillingExportProperties.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/billing/BillingExportProperties.java
@@ -1,10 +1,28 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.epam.pipeline.controller.vo.billing;
 
+import lombok.Builder;
 import lombok.Value;
 
 import java.util.List;
 
 @Value
+@Builder
 public class BillingExportProperties {
 
     //Storage specific parameters

--- a/api/src/main/java/com/epam/pipeline/controller/vo/billing/BillingExportRequest.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/billing/BillingExportRequest.java
@@ -14,4 +14,5 @@ public class BillingExportRequest {
     Map<String, List<String>> filters;
     List<BillingExportType> types;
     BillingDiscount discount;
+    BillingExportProperties properties;
 }

--- a/api/src/main/java/com/epam/pipeline/entity/billing/StorageBillingChartCostDetails.java
+++ b/api/src/main/java/com/epam/pipeline/entity/billing/StorageBillingChartCostDetails.java
@@ -44,5 +44,13 @@ public class StorageBillingChartCostDetails implements BillingChartDetails {
         Long oldVersionCost;
         Long oldVersionAvgSize;
         Long oldVersionSize;
+
+        public static StorageBillingDetails empty(String storageClass) {
+            return StorageBillingDetails.builder().storageClass(storageClass)
+                    .cost(0L).oldVersionCost(0L)
+                    .size(0L).oldVersionSize(0L)
+                    .avgSize(0L).oldVersionAvgSize(0L)
+                    .build();
+        }
     }
 }

--- a/api/src/main/java/com/epam/pipeline/entity/billing/StorageBillingMetrics.java
+++ b/api/src/main/java/com/epam/pipeline/entity/billing/StorageBillingMetrics.java
@@ -10,6 +10,7 @@ public class StorageBillingMetrics {
     Long cost;
     Long averageVolume;
     Long currentVolume;
+    BillingChartDetails details;
 
     public static StorageBillingMetrics empty() {
         return StorageBillingMetrics.builder()

--- a/api/src/main/java/com/epam/pipeline/entity/billing/StorageBillingMetrics.java
+++ b/api/src/main/java/com/epam/pipeline/entity/billing/StorageBillingMetrics.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.epam.pipeline.entity.billing;
 
 import lombok.Builder;

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingUtils.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.epam.pipeline.manager.billing;
 
 import com.epam.pipeline.config.Constants;

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingUtils.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingUtils.java
@@ -57,8 +57,14 @@ public final class BillingUtils {
     public static final String STORAGES_COSTS_COLUMN = "Storage costs ($)";
     public static final String DURATION_COLUMN = "Duration (hours)";
     public static final String COST_COLUMN = "Cost ($)";
+    public static final String DETAILED_COST_COLUMN = "Cost, %s ($)";
+    public static final String DETAILED_OV_COST_COLUMN = "Cost, %s Old Versions ($)";
     public static final String AVERAGE_VOLUME_COLUMN = "Average Volume (GB)";
+    public static final String DETAILED_AVERAGE_VOLUME_COLUMN = "Average Volume, %s (GB)";
+    public static final String DETAILED_OV_AVERAGE_VOLUME_COLUMN = "Average Volume, %s Old Versions (GB)";
     public static final String CURRENT_VOLUME_COLUMN = "Current Volume (GB)";
+    public static final String DETAILED_CURRENT_VOLUME_COLUMN = "Current Volume, %s (GB)";
+    public static final String DETAILED_OV_CURRENT_VOLUME_COLUMN = "Current Volume, %s Old Versions (GB)";
 
     public static final String SYNTHETIC_TOTAL_BILLING = "Grand total";
     public static final String MISSING_VALUE = "unknown";

--- a/api/src/main/java/com/epam/pipeline/manager/billing/StorageBillingLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/StorageBillingLoader.java
@@ -1,10 +1,13 @@
 package com.epam.pipeline.manager.billing;
 
+import com.epam.pipeline.controller.vo.billing.BillingCostDetailsRequest;
 import com.epam.pipeline.controller.vo.billing.BillingExportRequest;
 import com.epam.pipeline.entity.billing.BillingDiscount;
+import com.epam.pipeline.entity.billing.BillingGrouping;
 import com.epam.pipeline.entity.billing.StorageBilling;
 import com.epam.pipeline.entity.billing.StorageBillingMetrics;
 import com.epam.pipeline.entity.datastorage.DataStorageType;
+import com.epam.pipeline.manager.billing.billingdetails.StorageBillingCostDetailsLoader;
 import com.epam.pipeline.manager.billing.detail.EntityBillingDetailsLoader;
 import com.epam.pipeline.manager.billing.detail.StorageBillingDetailsLoader;
 import com.epam.pipeline.manager.preference.PreferenceManager;
@@ -21,6 +24,7 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.springframework.stereotype.Service;
 
@@ -91,19 +95,28 @@ public class StorageBillingLoader implements BillingLoader<StorageBilling> {
                                              final BillingDiscount discount,
                                              final int pageOffset,
                                              final int pageSize) {
+        final TermsAggregationBuilder byStorageIdAggregate = billingHelper.aggregateBy(BillingUtils.STORAGE_ID_FIELD)
+                .size(Integer.MAX_VALUE)
+                .subAggregation(billingHelper.aggregateCostSumBucket())
+                .subAggregation(billingHelper.aggregateStorageUsageAverageBucket())
+                .subAggregation(billingHelper.aggregateLastByDateDoc())
+                .subAggregation(billingHelper.aggregateCostSortBucket(pageOffset, pageSize));
+
+        final BillingCostDetailsRequest costDetailsRequest = BillingCostDetailsRequest.builder()
+                .enabled(true).discount(discount).grouping(BillingGrouping.STORAGE).build();
+        StorageBillingCostDetailsLoader.buildQuery(costDetailsRequest, byStorageIdAggregate);
+
+        final DateHistogramAggregationBuilder byMonth = aggregateBillingsByMonth(discount);
+        StorageBillingCostDetailsLoader.buildQuery(costDetailsRequest, byMonth);
+        byStorageIdAggregate.subAggregation(byMonth);
+
         return new SearchRequest()
                 .indicesOptions(IndicesOptions.strictExpandOpen())
                 .indices(billingHelper.storageIndicesByDate(from, to))
                 .source(new SearchSourceBuilder()
                         .size(NumberUtils.INTEGER_ZERO)
                         .query(billingHelper.queryByDateAndFilters(from, to, filters))
-                        .aggregation(billingHelper.aggregateBy(BillingUtils.STORAGE_ID_FIELD)
-                                .size(Integer.MAX_VALUE)
-                                .subAggregation(aggregateBillingsByMonth(discount))
-                                .subAggregation(billingHelper.aggregateCostSumBucket())
-                                .subAggregation(billingHelper.aggregateStorageUsageAverageBucket())
-                                .subAggregation(billingHelper.aggregateLastByDateDoc())
-                                .subAggregation(billingHelper.aggregateCostSortBucket(pageOffset, pageSize))));
+                        .aggregation(byStorageIdAggregate));
     }
 
     private DateHistogramAggregationBuilder aggregateBillingsByMonth(final BillingDiscount discount) {
@@ -121,6 +134,8 @@ public class StorageBillingLoader implements BillingLoader<StorageBilling> {
 
     private StorageBilling getBilling(final String id, final Aggregations aggregations) {
         final Map<String, Object> topHitFields = billingHelper.getLastByDateDocFields(aggregations);
+        final BillingCostDetailsRequest costDetailsRequest = BillingCostDetailsRequest.builder()
+                .enabled(true).grouping(BillingGrouping.STORAGE).build();
         return StorageBilling.builder()
                 .id(NumberUtils.toLong(id))
                 .name(BillingUtils.asString(topHitFields.get(BillingUtils.STORAGE_NAME_FIELD)))
@@ -135,18 +150,22 @@ public class StorageBillingLoader implements BillingLoader<StorageBilling> {
                         .averageVolume(billingHelper.getStorageUsageAvg(aggregations))
                         .currentVolume(Long.valueOf(BillingUtils.asString(
                                 topHitFields.get(BillingUtils.STORAGE_USAGE_FIELD))))
+                        .details(StorageBillingCostDetailsLoader.parseResponse(costDetailsRequest, aggregations))
                         .build())
-                .periodMetrics(getMetrics(aggregations))
+                .periodMetrics(getMetrics(aggregations, costDetailsRequest))
                 .build();
     }
 
-    private Map<Temporal, StorageBillingMetrics> getMetrics(final Aggregations aggregations) {
+    private Map<Temporal, StorageBillingMetrics> getMetrics(final Aggregations aggregations,
+                                                            final BillingCostDetailsRequest costDetailsRequest) {
         return billingHelper.histogramBuckets(aggregations, BillingUtils.HISTOGRAM_AGGREGATION_NAME)
-                .map(bucket -> getMetrics(bucket.getKeyAsString(), bucket.getAggregations()))
+                .map(bucket -> getMetrics(bucket.getKeyAsString(), costDetailsRequest, bucket.getAggregations()))
                 .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
     }
 
-    private Pair<Temporal, StorageBillingMetrics> getMetrics(final String period, final Aggregations aggregations) {
+    private Pair<Temporal, StorageBillingMetrics> getMetrics(final String period,
+                                                             final BillingCostDetailsRequest costDetailsRequest,
+                                                             final Aggregations aggregations) {
         final Map<String, Object> topHitFields = billingHelper.getLastByDateDocFields(aggregations);
         return Pair.of(
                 YearMonth.parse(period, DateTimeFormatter.ofPattern(BillingUtils.HISTOGRAM_AGGREGATION_FORMAT)),
@@ -155,6 +174,7 @@ public class StorageBillingLoader implements BillingLoader<StorageBilling> {
                         .averageVolume(billingHelper.getStorageUsageAvg(aggregations))
                         .currentVolume(Long.valueOf(BillingUtils.asString(
                                 topHitFields.get(BillingUtils.STORAGE_USAGE_FIELD))))
+                        .details(StorageBillingCostDetailsLoader.parseResponse(costDetailsRequest, aggregations))
                         .build());
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/billing/StorageBillingLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/StorageBillingLoader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.epam.pipeline.manager.billing;
 
 import com.epam.pipeline.controller.vo.billing.BillingCostDetailsRequest;

--- a/api/src/main/java/com/epam/pipeline/manager/billing/StorageBillingWriter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/StorageBillingWriter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.epam.pipeline.manager.billing;
 
 import com.epam.pipeline.controller.vo.billing.BillingExportProperties;

--- a/api/src/main/java/com/epam/pipeline/manager/billing/StorageBillingWriter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/StorageBillingWriter.java
@@ -1,12 +1,26 @@
 package com.epam.pipeline.manager.billing;
 
+import com.epam.pipeline.controller.vo.billing.BillingExportProperties;
+import com.epam.pipeline.entity.billing.BillingChartDetails;
 import com.epam.pipeline.entity.billing.StorageBilling;
+import com.epam.pipeline.entity.billing.StorageBillingChartCostDetails;
 import com.epam.pipeline.entity.billing.StorageBillingMetrics;
+import com.epam.pipeline.manager.billing.billingdetails.StorageBillingCostDetailsLoader;
 
 import java.io.IOException;
 import java.io.Writer;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.epam.pipeline.entity.billing.StorageBillingChartCostDetails.StorageBillingDetails;
 
 public class StorageBillingWriter implements BillingWriter<StorageBilling> {
 
@@ -16,7 +30,8 @@ public class StorageBillingWriter implements BillingWriter<StorageBilling> {
 
     public StorageBillingWriter(final Writer writer,
                                 final LocalDate from,
-                                final LocalDate to) {
+                                final LocalDate to,
+                                final BillingExportProperties exportProperties) {
         this.writer = new PeriodBillingWriter<>(writer, from, to, TABLE_NAME,
                 Arrays.asList(
                     BillingUtils.STORAGE_COLUMN,
@@ -25,11 +40,9 @@ public class StorageBillingWriter implements BillingWriter<StorageBilling> {
                     BillingUtils.TYPE_COLUMN,
                     BillingUtils.REGION_COLUMN,
                     BillingUtils.PROVIDER_COLUMN,
-                    BillingUtils.CREATED_COLUMN),
-                Arrays.asList(
-                    BillingUtils.COST_COLUMN,
-                    BillingUtils.AVERAGE_VOLUME_COLUMN,
-                    BillingUtils.CURRENT_VOLUME_COLUMN),
+                    BillingUtils.CREATED_COLUMN
+                ),
+                getPeriodColumns(exportProperties),
                 Arrays.asList(
                     StorageBilling::getName,
                     StorageBilling::getOwner,
@@ -37,11 +50,124 @@ public class StorageBillingWriter implements BillingWriter<StorageBilling> {
                     b -> BillingUtils.asString(b.getType()),
                     StorageBilling::getRegion,
                     StorageBilling::getProvider,
-                    b -> BillingUtils.asString(b.getCreated())),
-                Arrays.asList(
-                    metrics -> BillingUtils.asCostString(metrics.getCost()),
-                    metrics -> BillingUtils.asVolumeString(metrics.getAverageVolume()),
-                    metrics -> BillingUtils.asVolumeString(metrics.getCurrentVolume())));
+                    b -> BillingUtils.asString(b.getCreated())
+                ),
+                getPeriodDataExtractors(exportProperties)
+        );
+    }
+
+    private static List<Function<StorageBillingMetrics, String>> getPeriodDataExtractors(
+            final BillingExportProperties properties) {
+        final List<String> requestedStorageClasses = Optional.ofNullable(properties)
+                .map(BillingExportProperties::getIncludeStorageClasses)
+                .orElse(Collections.emptyList())
+                .stream().filter(StorageBillingCostDetailsLoader.STORAGE_CLASSES::containsKey)
+                .collect(Collectors.toList());
+        final List<Function<StorageBillingMetrics, String>> extractors = new ArrayList<>();
+        extractors.add(metrics -> BillingUtils.asCostString(metrics.getCost()));
+        requestedStorageClasses
+                .stream()
+                .flatMap(sc -> getReportValueExtractors(
+                        sc, properties.isIncludeStorageOldVersions(),
+                        StorageBillingDetails::getCost,
+                        StorageBillingDetails::getOldVersionCost,
+                        BillingUtils::asCostString
+                    )
+                )
+                .forEachOrdered(extractors::add);
+
+        extractors.add(metrics -> BillingUtils.asVolumeString(metrics.getAverageVolume()));
+        requestedStorageClasses
+                .stream()
+                .flatMap(sc -> getReportValueExtractors(
+                                sc, properties.isIncludeStorageOldVersions(),
+                                StorageBillingDetails::getAvgSize,
+                                StorageBillingDetails::getOldVersionAvgSize,
+                                BillingUtils::asVolumeString
+                        )
+                )
+                .forEachOrdered(extractors::add);
+        extractors.add(metrics -> BillingUtils.asVolumeString(metrics.getCurrentVolume()));
+        requestedStorageClasses
+                .stream()
+                .flatMap(sc -> getReportValueExtractors(
+                                sc, properties.isIncludeStorageOldVersions(),
+                                StorageBillingDetails::getSize,
+                                StorageBillingDetails::getOldVersionSize,
+                                BillingUtils::asVolumeString
+                        )
+                )
+                .forEachOrdered(extractors::add);
+        return extractors;
+    }
+
+    private static Function<StorageBillingMetrics, StorageBillingDetails> getStorageClassDetails(final String sc) {
+        return (StorageBillingMetrics metrics) -> {
+            final BillingChartDetails details = metrics.getDetails();
+            if (details instanceof StorageBillingChartCostDetails) {
+                return ((StorageBillingChartCostDetails) details).getTiers()
+                        .stream().filter(d -> d.getStorageClass().equals(sc))
+                        .findFirst().orElse(StorageBillingDetails.empty(sc));
+            }
+            return StorageBillingDetails.empty(sc);
+        };
+    }
+
+    private static Stream<Function<StorageBillingMetrics, String>> getReportValueExtractors(
+            final String sc, final boolean showOV,
+            final Function<StorageBillingDetails, Long> dataFetcher,
+            final Function<StorageBillingDetails, Long> dataOVFetcher,
+            final Function<Long, String> converter) {
+        if (showOV) {
+            return Stream.of(
+                (StorageBillingMetrics metrics) ->
+                        converter.apply(dataFetcher.apply(getStorageClassDetails(sc).apply(metrics))),
+                (StorageBillingMetrics metrics) ->
+                        converter.apply(dataOVFetcher.apply(getStorageClassDetails(sc).apply(metrics)))
+            );
+        } else {
+            return Stream.of(
+                (StorageBillingMetrics metrics) -> {
+                    final StorageBillingDetails details = getStorageClassDetails(sc).apply(metrics);
+                    return converter.apply(dataFetcher.apply(details) + dataOVFetcher.apply(details));
+                }
+            );
+        }
+    }
+
+    private static List<String> getPeriodColumns(BillingExportProperties properties) {
+        final List<String> requestedStorageClasses = Optional.ofNullable(properties)
+                .map(BillingExportProperties::getIncludeStorageClasses)
+                .orElse(Collections.emptyList())
+                .stream().map(StorageBillingCostDetailsLoader.STORAGE_CLASSES::get)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+        
+        final boolean includeStorageOV = Optional.ofNullable(properties)
+                .map(BillingExportProperties::isIncludeStorageOldVersions).orElse(false);
+        final List<String> columns = new ArrayList<>();
+        columns.add(BillingUtils.COST_COLUMN);
+        requestedStorageClasses.forEach(sc -> {
+            columns.add(String.format(BillingUtils.DETAILED_COST_COLUMN, sc));
+            if (includeStorageOV) {
+                columns.add(String.format(BillingUtils.DETAILED_OV_COST_COLUMN, sc));
+            }
+        });
+        columns.add(BillingUtils.AVERAGE_VOLUME_COLUMN);
+        requestedStorageClasses.forEach(sc -> {
+            columns.add(String.format(BillingUtils.DETAILED_AVERAGE_VOLUME_COLUMN, sc));
+            if (includeStorageOV) {
+                columns.add(String.format(BillingUtils.DETAILED_OV_AVERAGE_VOLUME_COLUMN, sc));
+            }
+        });
+        columns.add(BillingUtils.CURRENT_VOLUME_COLUMN);
+        requestedStorageClasses.forEach(sc -> {
+            columns.add(String.format(BillingUtils.DETAILED_CURRENT_VOLUME_COLUMN, sc));
+            if (includeStorageOV) {
+                columns.add(String.format(BillingUtils.DETAILED_OV_CURRENT_VOLUME_COLUMN, sc));
+            }
+        });
+        return columns;
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/manager/billing/billingdetails/StorageBillingCostDetailsLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/billingdetails/StorageBillingCostDetailsLoader.java
@@ -18,12 +18,16 @@ package com.epam.pipeline.manager.billing.billingdetails;
 
 import com.epam.pipeline.controller.vo.billing.BillingCostDetailsRequest;
 import com.epam.pipeline.entity.billing.BillingChartDetails;
+import com.epam.pipeline.entity.billing.BillingDiscount;
 import com.epam.pipeline.entity.billing.BillingGrouping;
 import com.epam.pipeline.entity.billing.StorageBillingChartCostDetails;
 import com.epam.pipeline.entity.billing.StorageBillingChartCostDetails.StorageBillingDetails;
 import com.epam.pipeline.manager.billing.BillingUtils;
 import com.epam.pipeline.manager.utils.ElasticSearchUtils;
 import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.elasticsearch.script.Script;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
@@ -45,6 +49,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public final class StorageBillingCostDetailsLoader {
 
@@ -53,8 +59,13 @@ public final class StorageBillingCostDetailsLoader {
 
     private StorageBillingCostDetailsLoader() {}
 
-    public static final List<String> S3_STORAGE_CLASSES =
-            Arrays.asList("STANDARD", "GLACIER", "GLACIER_IR", "DEEP_ARCHIVE");
+    public static final Map<String, String> STORAGE_CLASSES =
+            Stream.of(
+                    ImmutablePair.of("STANDARD", "Standard Layer"),
+                    ImmutablePair.of("GLACIER", "Glacier"),
+                    ImmutablePair.of("GLACIER_IR", "Glacier IR"),
+                    ImmutablePair.of("DEEP_ARCHIVE", "Deep Archive")
+            ).collect(Collectors.toMap(Pair::getKey, Pair::getValue));
 
     private static final String SC_COST_TEMPLATE = "%s_cost";
     private static final String SC_USAGE_TEMPLATE = "%s_usage_bytes";
@@ -67,13 +78,15 @@ public final class StorageBillingCostDetailsLoader {
     );
 
     public static void buildQuery(BillingCostDetailsRequest request, final AggregationBuilder topAgg) {
+        final long storageDiscount = Optional.ofNullable(request.getDiscount())
+                .map(BillingDiscount::getStorages).orElse(0).longValue();
         if (request.getGrouping() == BillingGrouping.STORAGE) {
             // Since we build topAgg as Term agg for storage (bucket is storage), we can just calculate
             // cost as sum and size as avg + for current size we can grab last value
-            for (String storageClass : S3_STORAGE_CLASSES) {
+            for (String storageClass : STORAGE_CLASSES.keySet()) {
                 final String sc = storageClass.toLowerCase(Locale.ROOT);
-                topAgg.subAggregation(buildSumAggregation(SC_COST_TEMPLATE, sc));
-                topAgg.subAggregation(buildSumAggregation(SC_OV_COST_TEMPLATE, sc));
+                topAgg.subAggregation(buildSumAggregation(SC_COST_TEMPLATE, sc, storageDiscount));
+                topAgg.subAggregation(buildSumAggregation(SC_OV_COST_TEMPLATE, sc, storageDiscount));
                 topAgg.subAggregation(buildAvgAggregation(SC_USAGE_TEMPLATE, sc));
                 topAgg.subAggregation(buildAvgAggregation(SC_OV_USAGE_TEMPLATE, sc));
                 topAgg.subAggregation(buildLastByDateHitAggregation(SC_USAGE_TEMPLATE, sc));
@@ -84,10 +97,10 @@ public final class StorageBillingCostDetailsLoader {
             // So we need to calculate size for storages as avg first and then sum it
             final TermsAggregationBuilder avgUsageOfStorageAgg = AggregationBuilders.terms(STORAGES_SIZE_DETAILS)
                     .field(BillingUtils.STORAGE_ID_FIELD).size(Integer.MAX_VALUE);
-            for (String storageClass : S3_STORAGE_CLASSES) {
+            for (String storageClass : STORAGE_CLASSES.keySet()) {
                 final String sc = storageClass.toLowerCase(Locale.ROOT);
-                topAgg.subAggregation(buildSumAggregation(SC_COST_TEMPLATE, sc));
-                topAgg.subAggregation(buildSumAggregation(SC_OV_COST_TEMPLATE, sc));
+                topAgg.subAggregation(buildSumAggregation(SC_COST_TEMPLATE, sc, storageDiscount));
+                topAgg.subAggregation(buildSumAggregation(SC_OV_COST_TEMPLATE, sc, storageDiscount));
                 avgUsageOfStorageAgg.subAggregation(buildAvgAggregation(SC_USAGE_TEMPLATE, sc));
                 avgUsageOfStorageAgg.subAggregation(buildAvgAggregation(SC_OV_USAGE_TEMPLATE, sc));
                 topAgg.subAggregation(buildPipelineSumAggregation(STORAGES_SIZE_DETAILS, SC_USAGE_TEMPLATE, sc));
@@ -100,7 +113,7 @@ public final class StorageBillingCostDetailsLoader {
     public static BillingChartDetails parseResponse(final BillingCostDetailsRequest request,
                                                     final Aggregations aggregations) {
         final List<StorageBillingDetails> tiers = new ArrayList<>();
-        for (String sc : S3_STORAGE_CLASSES) {
+        for (String sc : STORAGE_CLASSES.keySet()) {
             final StorageBillingDetails.StorageBillingDetailsBuilder detailsBuilder =
                     StorageBillingDetails.builder().storageClass(sc);
             detailsBuilder.cost(fetchSimpleAggregationValue(SC_COST_TEMPLATE, sc, aggregations));
@@ -175,9 +188,19 @@ public final class StorageBillingCostDetailsLoader {
                 .sort(BillingUtils.BILLING_DATE_FIELD, SortOrder.DESC);
     }
 
-    private static SumAggregationBuilder buildSumAggregation(final String template, final String storageClass) {
+    private static SumAggregationBuilder buildSumAggregation(final String template, final String storageClass,
+                                                             final long discount) {
         final String agg = getAggregationField(template, storageClass);
-        return AggregationBuilders.sum(agg).field(agg);
+        SumAggregationBuilder aggregation = AggregationBuilders.sum(agg).field(agg);
+        if (discount != 0) {
+            aggregation.script(new Script(
+                String.format(
+                        BillingUtils.DISCOUNT_SCRIPT_TEMPLATE,
+                        BillingUtils.asPercentToDecimalString(discount))
+                )
+            );
+        }
+        return aggregation;
     }
 
     private static AvgAggregationBuilder buildAvgAggregation(final String template, final String storageClass) {

--- a/api/src/test/java/com/epam/pipeline/manager/billing/StorageBillingWriterTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/billing/StorageBillingWriterTest.java
@@ -16,7 +16,7 @@ public class StorageBillingWriterTest extends AbstractBillingWriterTest<StorageB
 
     @Override
     public BillingWriter<StorageBilling> getWriter(final Writer writer) {
-        return new StorageBillingWriter(writer, START_DATE, FINISH_DATE);
+        return new StorageBillingWriter(writer, START_DATE, FINISH_DATE, null);
     }
 
     @Override

--- a/api/src/test/java/com/epam/pipeline/manager/billing/billingdetails/BillingChartCostDetailsLoaderTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/billing/billingdetails/BillingChartCostDetailsLoaderTest.java
@@ -40,11 +40,11 @@ public class BillingChartCostDetailsLoaderTest {
 
     // For each storage class 2 aggs for cost + 1 Terms agg for avg usage statistics by storage
     public static final int NUMBER_OF_SIMPLE_AGGS_FOR_NON_STORAGE_GROUPING =
-            2 * StorageBillingCostDetailsLoader.S3_STORAGE_CLASSES.size() + 1;
+            2 * StorageBillingCostDetailsLoader.STORAGE_CLASSES.size() + 1;
 
     // For each storage class 2 aggregations to get sum of avg stats by bucket
     public static final int NUMBER_OF_PIPELINE_AGGS_FOR_NON_STORAGE_GROUPING =
-            2 * StorageBillingCostDetailsLoader.S3_STORAGE_CLASSES.size();
+            2 * StorageBillingCostDetailsLoader.STORAGE_CLASSES.size();
 
     @Test
     public void checkThatBuildQueryWillBuildAggsIfCriteriaMatchByGrouping() {


### PR DESCRIPTION
This PR adds possibility to configure Billing Reports to include additional details. 
Currently only Storage Reports are configurable.

By forming export request as:
```
{
"discount": ...,
"types":["STORAGE"],
"properties": {
  "includeStorageOldVersions": true,
  "includeStorageClasses": ["STANDARD", "DEEP_ARCHIVE"]
},
"from": ...,
"to": ...
}
```
It is possible to get as result `csv` report with additional information regarding spending and size in a matter of `Storage Class`