### PR TITLE
Issue #3098: Show compute and disk cost for run separately

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/billing/BillingChartInfo.java
+++ b/api/src/main/java/com/epam/pipeline/entity/billing/BillingChartInfo.java
@@ -32,4 +32,9 @@ public class BillingChartInfo {
     BillingChartDetails costDetails;
     Long cost;
     Long accumulatedCost;
+    Long diskCost;
+    Long accumulatedDiskCost;
+    Long computeCost;
+    Long accumulatedComputeCost;
+
 }

--- a/api/src/main/java/com/epam/pipeline/entity/billing/BillingChartInfo.java
+++ b/api/src/main/java/com/epam/pipeline/entity/billing/BillingChartInfo.java
@@ -32,9 +32,4 @@ public class BillingChartInfo {
     BillingChartDetails costDetails;
     Long cost;
     Long accumulatedCost;
-    Long diskCost;
-    Long accumulatedDiskCost;
-    Long computeCost;
-    Long accumulatedComputeCost;
-
 }

--- a/api/src/main/java/com/epam/pipeline/entity/billing/ComputeBillingChartCostDetails.java
+++ b/api/src/main/java/com/epam/pipeline/entity/billing/ComputeBillingChartCostDetails.java
@@ -16,6 +16,20 @@
 
 package com.epam.pipeline.entity.billing;
 
-public enum BillingChartCostDetailsType {
-    STORAGE_BILLING, COMPUTE_BILLING
+import lombok.Builder;
+import lombok.Value;
+
+@Builder
+@Value
+public class ComputeBillingChartCostDetails implements BillingChartDetails {
+
+    Long diskCost;
+    Long accumulatedDiskCost;
+    Long computeCost;
+    Long accumulatedComputeCost;
+
+    @Override
+    public BillingChartCostDetailsType getType() {
+        return BillingChartCostDetailsType.COMPUTE_BILLING;
+    }
 }

--- a/api/src/main/java/com/epam/pipeline/entity/billing/InstanceBillingMetrics.java
+++ b/api/src/main/java/com/epam/pipeline/entity/billing/InstanceBillingMetrics.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.epam.pipeline.entity.billing;
 
 import lombok.Builder;
@@ -10,12 +26,16 @@ public class InstanceBillingMetrics {
     Long runsNumber;
     Long runsDuration;
     Long runsCost;
+    Long runsDiskCost;
+    Long runsComputeCost;
 
     public static InstanceBillingMetrics empty() {
         return InstanceBillingMetrics.builder()
                 .runsNumber(0L)
                 .runsDuration(0L)
                 .runsCost(0L)
+                .runsDiskCost(0L)
+                .runsDiskCost(0L)
                 .build();
     }
 }

--- a/api/src/main/java/com/epam/pipeline/entity/billing/PipelineBillingMetrics.java
+++ b/api/src/main/java/com/epam/pipeline/entity/billing/PipelineBillingMetrics.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.epam.pipeline.entity.billing;
 
 import lombok.Builder;
@@ -10,12 +26,16 @@ public class PipelineBillingMetrics {
     Long runsNumber;
     Long runsDuration;
     Long runsCost;
+    Long runsDiskCost;
+    Long runsComputeCost;
 
     public static PipelineBillingMetrics empty() {
         return PipelineBillingMetrics.builder()
                 .runsNumber(0L)
                 .runsDuration(0L)
                 .runsCost(0L)
+                .runsDiskCost(0L)
+                .runsComputeCost(0L)
                 .build();
     }
 }

--- a/api/src/main/java/com/epam/pipeline/entity/billing/RunBilling.java
+++ b/api/src/main/java/com/epam/pipeline/entity/billing/RunBilling.java
@@ -19,4 +19,6 @@ public class RunBilling {
     LocalDateTime finished;
     Long duration;
     Long cost;
+    Long diskCost;
+    Long computeCost;
 }

--- a/api/src/main/java/com/epam/pipeline/entity/billing/ToolBillingMetrics.java
+++ b/api/src/main/java/com/epam/pipeline/entity/billing/ToolBillingMetrics.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.epam.pipeline.entity.billing;
 
 import lombok.Builder;
@@ -9,12 +25,16 @@ public class ToolBillingMetrics {
     Long runsNumber;
     Long runsDuration;
     Long runsCost;
+    Long runsDiskCost;
+    Long runsComputeCost;
 
     public static ToolBillingMetrics empty() {
         return ToolBillingMetrics.builder()
                 .runsNumber(0L)
                 .runsDuration(0L)
                 .runsCost(0L)
+                .runsDiskCost(0L)
+                .runsComputeCost(0L)
                 .build();
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingHelper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.epam.pipeline.manager.billing;
 
 import com.epam.pipeline.entity.search.SearchDocumentType;
@@ -207,6 +223,14 @@ public class BillingHelper {
         return BillingUtils.aggregateDiscountCostSum(BillingUtils.COST_FIELD, discount);
     }
 
+    public AggregationBuilder aggregateDiskCostSum(final long discount) {
+        return BillingUtils.aggregateDiscountCostSum(BillingUtils.DISK_COST_FIELD, discount);
+    }
+
+    public AggregationBuilder aggregateComputeCostSum(final long discount) {
+        return BillingUtils.aggregateDiscountCostSum(BillingUtils.COMPUTE_COST_FIELD, discount);
+    }
+
     public SumAggregationBuilder aggregateRunUsageSum() {
         return runUsageAggregation;
     }
@@ -270,6 +294,16 @@ public class BillingHelper {
                 aggsPath(BillingUtils.HISTOGRAM_AGGREGATION_NAME, BillingUtils.COST_FIELD));
     }
 
+    public SumBucketPipelineAggregationBuilder aggregateDiskCostSumBucket() {
+        return PipelineAggregatorBuilders.sumBucket(BillingUtils.DISK_COST_FIELD,
+                aggsPath(BillingUtils.HISTOGRAM_AGGREGATION_NAME, BillingUtils.DISK_COST_FIELD));
+    }
+
+    public SumBucketPipelineAggregationBuilder aggregateComputeCostSumBucket() {
+        return PipelineAggregatorBuilders.sumBucket(BillingUtils.COMPUTE_COST_FIELD,
+                aggsPath(BillingUtils.HISTOGRAM_AGGREGATION_NAME, BillingUtils.COMPUTE_COST_FIELD));
+    }
+
     public AvgBucketPipelineAggregationBuilder aggregateStorageUsageAverageBucket() {
         return PipelineAggregatorBuilders.avgBucket(BillingUtils.STORAGE_USAGE_AGG,
                 aggsPath(BillingUtils.HISTOGRAM_AGGREGATION_NAME, BillingUtils.STORAGE_USAGE_AGG));
@@ -305,6 +339,14 @@ public class BillingHelper {
 
     public Long getCostSum(final Aggregations aggregations) {
         return getLongValue(aggregations, BillingUtils.COST_FIELD);
+    }
+
+    public Long getDiskCostSum(final Aggregations aggregations) {
+        return getLongValue(aggregations, BillingUtils.DISK_COST_FIELD);
+    }
+
+    public Long getComputeCostSum(final Aggregations aggregations) {
+        return getLongValue(aggregations, BillingUtils.COMPUTE_COST_FIELD);
     }
 
     public Long getLongValue(final Aggregations aggregations, final String aggregation) {

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingHelper.java
@@ -204,7 +204,7 @@ public class BillingHelper {
     }
 
     public AggregationBuilder aggregateCostSum(final long discount) {
-        return BillingUtils.aggregateDiscountCostSum(BillingUtils.COST_FIELD, discount, this::aggregateCostSum);
+        return BillingUtils.aggregateDiscountCostSum(BillingUtils.COST_FIELD, discount);
     }
 
     public SumAggregationBuilder aggregateRunUsageSum() {

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
@@ -551,11 +551,11 @@ public class BillingManager {
 
     private BillingChartInfo getChartInfo(final Histogram.Bucket bucket, final DateHistogramInterval interval,
                                           final BillingCostDetailsRequest costDetailsRequest) {
-        final Aggregations aggregations = bucket.getAggregations();
+        final Aggregations intervalAggregations = bucket.getAggregations();
         final BillingChartInfo.BillingChartInfoBuilder builder = BillingChartInfo.builder()
                 .groupingInfo(null)
-                .cost(BillingUtils.parseSum(aggregations, BillingUtils.COST_FIELD))
-                .accumulatedCost(BillingUtils.parseAccumulatedSum(aggregations, BillingUtils.ACCUMULATED_COST));
+                .cost(BillingUtils.parseSum(intervalAggregations, BillingUtils.COST_FIELD))
+                .accumulatedCost(BillingUtils.parseAccumulatedSum(intervalAggregations, BillingUtils.ACCUMULATED_COST));
 
         final DateTime date = (DateTime) bucket.getKey();
         final LocalDate periodStart = LocalDate.of(date.getYear(), date.getMonthOfYear(), date.getDayOfMonth());
@@ -567,7 +567,7 @@ public class BillingManager {
             builder.periodEnd(periodStart.atTime(LocalTime.MAX));
         }
         return builder
-                .costDetails(BillingChartCostDetailsLoader.parseResponse(costDetailsRequest, aggregations))
+                .costDetails(BillingChartCostDetailsLoader.parseResponse(costDetailsRequest, intervalAggregations))
                 .build();
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingUtils.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingUtils.java
@@ -30,7 +30,10 @@ import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -75,6 +78,8 @@ public final class BillingUtils {
     public static final String COST_COLUMN = "Cost ($)";
     public static final String DETAILED_COST_COLUMN = "Cost, %s ($)";
     public static final String DETAILED_OV_COST_COLUMN = "Cost, %s Old Versions ($)";
+    public static final String DISK_COST_COLUMN = "Disk cost ($)";
+    public static final String COMPUTE_COST_COLUMN = "Compute cost ($)";
     public static final String AVERAGE_VOLUME_COLUMN = "Average Volume (GB)";
     public static final String DETAILED_AVERAGE_VOLUME_COLUMN = "Average Volume, %s (GB)";
     public static final String DETAILED_OV_AVERAGE_VOLUME_COLUMN = "Average Volume, %s Old Versions (GB)";
@@ -86,7 +91,11 @@ public final class BillingUtils {
     public static final String MISSING_VALUE = "unknown";
     public static final String DOC_TYPE = "doc_type";
     public static final String COST_FIELD = "cost";
+    public static final String DISK_COST_FIELD = "disk_cost";
+    public static final String COMPUTE_COST_FIELD = "compute_cost";
     public static final String ACCUMULATED_COST = "accumulatedCost";
+    public static final String ACCUMULATED_DISK_COST = "accumulatedDiskCost";
+    public static final String ACCUMULATED_COMPUTE_COST = "accumulatedComputeCost";
     public static final String RUN_USAGE_AGG = "usage_runs";
     public static final String STORAGE_USAGE_AGG = "usage_storages";
     public static final String RUN_USAGE_FIELD = "usage_minutes";
@@ -138,6 +147,8 @@ public final class BillingUtils {
     public static final String PROVIDER_FIELD = "provider";
     public static final String SORT_AGG = "sort";
     public static final String DISCOUNT_SCRIPT_TEMPLATE = "_value + _value * (%s)";
+    public static final String RESOURCE_TYPE = "resource_type";
+    public static final String COMPUTE_GROUP = "COMPUTE";
 
     private BillingUtils() {
     }
@@ -200,6 +211,10 @@ public final class BillingUtils {
                 .flatMap(attributes -> Optional.ofNullable(attributes.get(billingCenterKey)))
                 .flatMap(value -> Optional.ofNullable(value.getValue()))
                 .orElse(StringUtils.EMPTY);
+    }
+
+    public static boolean hasComputeResourceTypeFilter(final Map<String, List<String>> filters) {
+        return filters.getOrDefault(RESOURCE_TYPE, Collections.emptyList()).contains(COMPUTE_GROUP);
     }
 
     private static long tenInPowerOf(final int scale) {

--- a/api/src/main/java/com/epam/pipeline/manager/billing/InstanceBillingLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/InstanceBillingLoader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.epam.pipeline.manager.billing;
 
 import com.epam.pipeline.controller.vo.billing.BillingExportRequest;
@@ -95,6 +111,8 @@ public class InstanceBillingLoader implements BillingLoader<InstanceBilling> {
                                 .subAggregation(billingHelper.aggregateUniqueRunsCount())
                                 .subAggregation(billingHelper.aggregateRunUsageSumBucket())
                                 .subAggregation(billingHelper.aggregateCostSumBucket())
+                                .subAggregation(billingHelper.aggregateDiskCostSumBucket())
+                                .subAggregation(billingHelper.aggregateComputeCostSumBucket())
                                 .subAggregation(billingHelper.aggregateCostSortBucket(pageOffset, pageSize))));
     }
 
@@ -102,7 +120,9 @@ public class InstanceBillingLoader implements BillingLoader<InstanceBilling> {
         return billingHelper.aggregateByMonth()
                 .subAggregation(billingHelper.aggregateUniqueRunsCount())
                 .subAggregation(billingHelper.aggregateRunUsageSum())
-                .subAggregation(billingHelper.aggregateCostSum(discount.getComputes()));
+                .subAggregation(billingHelper.aggregateCostSum(discount.getComputes()))
+                .subAggregation(billingHelper.aggregateDiskCostSum(discount.getComputes()))
+                .subAggregation(billingHelper.aggregateComputeCostSum(discount.getComputes()));
     }
 
     private Stream<InstanceBilling> billings(final SearchResponse response) {
@@ -117,6 +137,8 @@ public class InstanceBillingLoader implements BillingLoader<InstanceBilling> {
                         .runsNumber(billingHelper.getRunCount(aggregations))
                         .runsDuration(billingHelper.getRunUsageSum(aggregations))
                         .runsCost(billingHelper.getCostSum(aggregations))
+                        .runsDiskCost(billingHelper.getDiskCostSum(aggregations))
+                        .runsComputeCost(billingHelper.getComputeCostSum(aggregations))
                         .build())
                 .periodMetrics(getMetrics(aggregations))
                 .build();
@@ -135,6 +157,8 @@ public class InstanceBillingLoader implements BillingLoader<InstanceBilling> {
                         .runsNumber(billingHelper.getRunCount(aggregations))
                         .runsDuration(billingHelper.getRunUsageSum(aggregations))
                         .runsCost(billingHelper.getCostSum(aggregations))
+                        .runsDiskCost(billingHelper.getDiskCostSum(aggregations))
+                        .runsComputeCost(billingHelper.getComputeCostSum(aggregations))
                         .build());
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/billing/InstanceBillingWriter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/InstanceBillingWriter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.epam.pipeline.manager.billing;
 
 import com.epam.pipeline.entity.billing.InstanceBilling;
@@ -23,12 +39,16 @@ public class InstanceBillingWriter implements BillingWriter<InstanceBilling> {
                 Arrays.asList(
                     BillingUtils.RUNS_COUNT_COLUMN,
                     BillingUtils.DURATION_COLUMN,
-                    BillingUtils.COST_COLUMN),
+                    BillingUtils.COST_COLUMN,
+                    BillingUtils.DISK_COST_COLUMN,
+                    BillingUtils.COMPUTE_COST_COLUMN),
                 Collections.singletonList(InstanceBilling::getName),
                 Arrays.asList(
                     metrics -> BillingUtils.asString(metrics.getRunsNumber()),
                     metrics -> BillingUtils.asDurationString(metrics.getRunsDuration()),
-                    metrics -> BillingUtils.asCostString(metrics.getRunsCost())));
+                    metrics -> BillingUtils.asCostString(metrics.getRunsCost()),
+                    metrics -> BillingUtils.asCostString(metrics.getRunsDiskCost()),
+                    metrics -> BillingUtils.asCostString(metrics.getRunsComputeCost())));
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/manager/billing/PipelineBillingLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/PipelineBillingLoader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.epam.pipeline.manager.billing;
 
 import com.epam.pipeline.controller.vo.billing.BillingExportRequest;
@@ -98,6 +114,8 @@ public class PipelineBillingLoader implements BillingLoader<PipelineBilling> {
                                 .subAggregation(billingHelper.aggregateUniqueRunsCount())
                                 .subAggregation(billingHelper.aggregateRunUsageSumBucket())
                                 .subAggregation(billingHelper.aggregateCostSumBucket())
+                                .subAggregation(billingHelper.aggregateDiskCostSumBucket())
+                                .subAggregation(billingHelper.aggregateComputeCostSumBucket())
                                 .subAggregation(billingHelper.aggregateLastByDateDoc())
                                 .subAggregation(billingHelper.aggregateCostSortBucket(pageOffset, pageSize))));
     }
@@ -106,7 +124,9 @@ public class PipelineBillingLoader implements BillingLoader<PipelineBilling> {
         return billingHelper.aggregateByMonth()
                 .subAggregation(billingHelper.aggregateUniqueRunsCount())
                 .subAggregation(billingHelper.aggregateRunUsageSum())
-                .subAggregation(billingHelper.aggregateCostSum(discount.getComputes()));
+                .subAggregation(billingHelper.aggregateCostSum(discount.getComputes()))
+                .subAggregation(billingHelper.aggregateDiskCostSum(discount.getComputes()))
+                .subAggregation(billingHelper.aggregateComputeCostSum(discount.getComputes()));
     }
 
     private Stream<PipelineBilling> billings(final SearchResponse response) {
@@ -125,6 +145,8 @@ public class PipelineBillingLoader implements BillingLoader<PipelineBilling> {
                         .runsNumber(billingHelper.getRunCount(aggregations))
                         .runsDuration(billingHelper.getRunUsageSum(aggregations))
                         .runsCost(billingHelper.getCostSum(aggregations))
+                        .runsDiskCost(billingHelper.getDiskCostSum(aggregations))
+                        .runsComputeCost(billingHelper.getComputeCostSum(aggregations))
                         .build())
                 .periodMetrics(getMetrics(aggregations))
                 .build();
@@ -143,6 +165,8 @@ public class PipelineBillingLoader implements BillingLoader<PipelineBilling> {
                         .runsNumber(billingHelper.getRunCount(aggregations))
                         .runsDuration(billingHelper.getRunUsageSum(aggregations))
                         .runsCost(billingHelper.getCostSum(aggregations))
+                        .runsDiskCost(billingHelper.getDiskCostSum(aggregations))
+                        .runsComputeCost(billingHelper.getComputeCostSum(aggregations))
                         .build());
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/billing/PipelineBillingWriter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/PipelineBillingWriter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.epam.pipeline.manager.billing;
 
 import com.epam.pipeline.entity.billing.PipelineBilling;
@@ -24,14 +40,18 @@ public class PipelineBillingWriter implements BillingWriter<PipelineBilling> {
                 Arrays.asList(
                     BillingUtils.RUNS_COUNT_COLUMN,
                     BillingUtils.DURATION_COLUMN,
-                    BillingUtils.COST_COLUMN),
+                    BillingUtils.COST_COLUMN,
+                    BillingUtils.DISK_COST_COLUMN,
+                    BillingUtils.COMPUTE_COST_COLUMN),
                 Arrays.asList(
                     PipelineBilling::getName,
                     PipelineBilling::getOwner),
                 Arrays.asList(
                     metrics -> BillingUtils.asString(metrics.getRunsNumber()),
                     metrics -> BillingUtils.asDurationString(metrics.getRunsDuration()),
-                    metrics -> BillingUtils.asCostString(metrics.getRunsCost())));
+                    metrics -> BillingUtils.asCostString(metrics.getRunsCost()),
+                    metrics -> BillingUtils.asCostString(metrics.getRunsDiskCost()),
+                    metrics -> BillingUtils.asCostString(metrics.getRunsComputeCost())));
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/manager/billing/RunBillingLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/RunBillingLoader.java
@@ -1,9 +1,24 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.epam.pipeline.manager.billing;
 
 import com.epam.pipeline.controller.vo.billing.BillingExportRequest;
 import com.epam.pipeline.entity.billing.BillingDiscount;
 import com.epam.pipeline.entity.billing.RunBilling;
-import com.epam.pipeline.manager.billing.billingdetails.ComputeBillingCostDetailsLoader;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.utils.StreamUtils;
@@ -86,8 +101,10 @@ public class RunBillingLoader implements BillingLoader<RunBilling> {
                         .aggregation(billingHelper.aggregateBy(BillingUtils.RUN_ID_FIELD)
                                 .size(Integer.MAX_VALUE)
                                 .subAggregation(billingHelper.aggregateCostSum(discount.getComputes()))
-                                .subAggregation(ComputeBillingCostDetailsLoader.aggregateDiskCostSum(discount))
-                                .subAggregation(ComputeBillingCostDetailsLoader.aggregateComputeCostSum(discount))
+                                .subAggregation(BillingUtils.aggregateDiscountCostSum(
+                                        BillingUtils.DISK_COST_FIELD, discount.getComputes()))
+                                .subAggregation(BillingUtils.aggregateDiscountCostSum(
+                                        BillingUtils.COMPUTE_COST_FIELD, discount.getComputes()))
                                 .subAggregation(billingHelper.aggregateRunUsageSum())
                                 .subAggregation(billingHelper.aggregateLastByDateDoc())
                                 .subAggregation(billingHelper.aggregateCostSortBucket(pageOffset, pageSize))));

--- a/api/src/main/java/com/epam/pipeline/manager/billing/RunBillingLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/RunBillingLoader.java
@@ -101,10 +101,8 @@ public class RunBillingLoader implements BillingLoader<RunBilling> {
                         .aggregation(billingHelper.aggregateBy(BillingUtils.RUN_ID_FIELD)
                                 .size(Integer.MAX_VALUE)
                                 .subAggregation(billingHelper.aggregateCostSum(discount.getComputes()))
-                                .subAggregation(BillingUtils.aggregateDiscountCostSum(
-                                        BillingUtils.DISK_COST_FIELD, discount.getComputes()))
-                                .subAggregation(BillingUtils.aggregateDiscountCostSum(
-                                        BillingUtils.COMPUTE_COST_FIELD, discount.getComputes()))
+                                .subAggregation(billingHelper.aggregateDiskCostSum(discount.getComputes()))
+                                .subAggregation(billingHelper.aggregateComputeCostSum(discount.getComputes()))
                                 .subAggregation(billingHelper.aggregateRunUsageSum())
                                 .subAggregation(billingHelper.aggregateLastByDateDoc())
                                 .subAggregation(billingHelper.aggregateCostSortBucket(pageOffset, pageSize))));
@@ -129,8 +127,8 @@ public class RunBillingLoader implements BillingLoader<RunBilling> {
                 .finished(BillingUtils.asDateTime(topHitFields.get(BillingUtils.FINISHED_FIELD)))
                 .duration(billingHelper.getRunUsageSum(aggregations))
                 .cost(billingHelper.getCostSum(aggregations))
-                .diskCost(billingHelper.getLongValue(aggregations, BillingUtils.DISK_COST_FIELD))
-                .computeCost(billingHelper.getLongValue(aggregations, BillingUtils.COMPUTE_COST_FIELD))
+                .diskCost(billingHelper.getDiskCostSum(aggregations))
+                .computeCost(billingHelper.getComputeCostSum(aggregations))
                 .build();
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/billing/RunBillingLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/RunBillingLoader.java
@@ -85,6 +85,8 @@ public class RunBillingLoader implements BillingLoader<RunBilling> {
                         .aggregation(billingHelper.aggregateBy(BillingUtils.RUN_ID_FIELD)
                                 .size(Integer.MAX_VALUE)
                                 .subAggregation(billingHelper.aggregateCostSum(discount.getComputes()))
+                                .subAggregation(billingHelper.aggregateDiskCostSum(discount))
+                                .subAggregation(billingHelper.aggregateComputeCostSum(discount))
                                 .subAggregation(billingHelper.aggregateRunUsageSum())
                                 .subAggregation(billingHelper.aggregateLastByDateDoc())
                                 .subAggregation(billingHelper.aggregateCostSortBucket(pageOffset, pageSize))));
@@ -109,6 +111,8 @@ public class RunBillingLoader implements BillingLoader<RunBilling> {
                 .finished(BillingUtils.asDateTime(topHitFields.get(BillingUtils.FINISHED_FIELD)))
                 .duration(billingHelper.getRunUsageSum(aggregations))
                 .cost(billingHelper.getCostSum(aggregations))
+                .diskCost(billingHelper.getDiskCostSum(aggregations))
+                .computeCost(billingHelper.getComputeCostSum(aggregations))
                 .build();
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/billing/RunBillingLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/RunBillingLoader.java
@@ -3,6 +3,7 @@ package com.epam.pipeline.manager.billing;
 import com.epam.pipeline.controller.vo.billing.BillingExportRequest;
 import com.epam.pipeline.entity.billing.BillingDiscount;
 import com.epam.pipeline.entity.billing.RunBilling;
+import com.epam.pipeline.manager.billing.billingdetails.ComputeBillingCostDetailsLoader;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.utils.StreamUtils;
@@ -85,8 +86,8 @@ public class RunBillingLoader implements BillingLoader<RunBilling> {
                         .aggregation(billingHelper.aggregateBy(BillingUtils.RUN_ID_FIELD)
                                 .size(Integer.MAX_VALUE)
                                 .subAggregation(billingHelper.aggregateCostSum(discount.getComputes()))
-                                .subAggregation(billingHelper.aggregateDiskCostSum(discount))
-                                .subAggregation(billingHelper.aggregateComputeCostSum(discount))
+                                .subAggregation(ComputeBillingCostDetailsLoader.aggregateDiskCostSum(discount))
+                                .subAggregation(ComputeBillingCostDetailsLoader.aggregateComputeCostSum(discount))
                                 .subAggregation(billingHelper.aggregateRunUsageSum())
                                 .subAggregation(billingHelper.aggregateLastByDateDoc())
                                 .subAggregation(billingHelper.aggregateCostSortBucket(pageOffset, pageSize))));
@@ -111,8 +112,8 @@ public class RunBillingLoader implements BillingLoader<RunBilling> {
                 .finished(BillingUtils.asDateTime(topHitFields.get(BillingUtils.FINISHED_FIELD)))
                 .duration(billingHelper.getRunUsageSum(aggregations))
                 .cost(billingHelper.getCostSum(aggregations))
-                .diskCost(billingHelper.getDiskCostSum(aggregations))
-                .computeCost(billingHelper.getComputeCostSum(aggregations))
+                .diskCost(billingHelper.getLongValue(aggregations, BillingUtils.DISK_COST_FIELD))
+                .computeCost(billingHelper.getLongValue(aggregations, BillingUtils.COMPUTE_COST_FIELD))
                 .build();
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/billing/RunBillingWriter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/RunBillingWriter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.epam.pipeline.manager.billing;
 
 import com.epam.pipeline.entity.billing.RunBilling;

--- a/api/src/main/java/com/epam/pipeline/manager/billing/RunBillingWriter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/RunBillingWriter.java
@@ -27,7 +27,9 @@ public class RunBillingWriter implements BillingWriter<RunBilling> {
             BillingUtils.STARTED_COLUMN,
             BillingUtils.FINISHED_COLUMN,
             BillingUtils.DURATION_COLUMN,
-            BillingUtils.COST_COLUMN
+            BillingUtils.COST_COLUMN,
+            BillingUtils.DISK_COST_COLUMN,
+            BillingUtils.COMPUTE_COST_COLUMN
         });
     }
 
@@ -44,7 +46,10 @@ public class RunBillingWriter implements BillingWriter<RunBilling> {
             BillingUtils.asString(billing.getStarted()),
             BillingUtils.asString(billing.getFinished()),
             BillingUtils.asDurationString(billing.getDuration()),
-            BillingUtils.asCostString(billing.getCost())});
+            BillingUtils.asCostString(billing.getCost()),
+            BillingUtils.asCostString(billing.getDiskCost()),
+            BillingUtils.asCostString(billing.getComputeCost())
+        });
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/manager/billing/ToolBillingLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/ToolBillingLoader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.epam.pipeline.manager.billing;
 
 import com.epam.pipeline.controller.vo.billing.BillingExportRequest;
@@ -98,6 +114,8 @@ public class ToolBillingLoader implements BillingLoader<ToolBilling> {
                                 .subAggregation(billingHelper.aggregateUniqueRunsCount())
                                 .subAggregation(billingHelper.aggregateRunUsageSumBucket())
                                 .subAggregation(billingHelper.aggregateCostSumBucket())
+                                .subAggregation(billingHelper.aggregateDiskCostSumBucket())
+                                .subAggregation(billingHelper.aggregateComputeCostSumBucket())
                                 .subAggregation(billingHelper.aggregateLastByDateDoc())
                                 .subAggregation(billingHelper.aggregateCostSortBucket(pageOffset, pageSize))));
     }
@@ -106,7 +124,9 @@ public class ToolBillingLoader implements BillingLoader<ToolBilling> {
         return billingHelper.aggregateByMonth()
                 .subAggregation(billingHelper.aggregateUniqueRunsCount())
                 .subAggregation(billingHelper.aggregateRunUsageSum())
-                .subAggregation(billingHelper.aggregateCostSum(discount.getComputes()));
+                .subAggregation(billingHelper.aggregateCostSum(discount.getComputes()))
+                .subAggregation(billingHelper.aggregateDiskCostSum(discount.getComputes()))
+                .subAggregation(billingHelper.aggregateComputeCostSum(discount.getComputes()));
     }
 
     private Stream<ToolBilling> billings(final SearchResponse response) {
@@ -124,6 +144,8 @@ public class ToolBillingLoader implements BillingLoader<ToolBilling> {
                         .runsNumber(billingHelper.getRunCount(aggregations))
                         .runsDuration(billingHelper.getRunUsageSum(aggregations))
                         .runsCost(billingHelper.getCostSum(aggregations))
+                        .runsDiskCost(billingHelper.getDiskCostSum(aggregations))
+                        .runsComputeCost(billingHelper.getComputeCostSum(aggregations))
                         .build())
                 .periodMetrics(getMetrics(aggregations))
                 .build();
@@ -142,6 +164,8 @@ public class ToolBillingLoader implements BillingLoader<ToolBilling> {
                         .runsNumber(billingHelper.getRunCount(aggregations))
                         .runsDuration(billingHelper.getRunUsageSum(aggregations))
                         .runsCost(billingHelper.getCostSum(aggregations))
+                        .runsDiskCost(billingHelper.getDiskCostSum(aggregations))
+                        .runsComputeCost(billingHelper.getComputeCostSum(aggregations))
                         .build());
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/billing/ToolBillingWriter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/ToolBillingWriter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.epam.pipeline.manager.billing;
 
 import com.epam.pipeline.entity.billing.ToolBilling;
@@ -26,14 +42,18 @@ public class ToolBillingWriter implements BillingWriter<ToolBilling> {
                 Arrays.asList(
                     BillingUtils.RUNS_COUNT_COLUMN,
                     BillingUtils.DURATION_COLUMN,
-                    BillingUtils.COST_COLUMN),
+                    BillingUtils.COST_COLUMN,
+                    BillingUtils.DISK_COST_COLUMN,
+                    BillingUtils.COMPUTE_COST_COLUMN),
                 Arrays.asList(
                     billing -> ToolUtils.getImageWithoutRepository(billing.getName()).orElse(StringUtils.EMPTY),
                     ToolBilling::getOwner),
                 Arrays.asList(
                     metrics -> BillingUtils.asString(metrics.getRunsNumber()),
                     metrics -> BillingUtils.asDurationString(metrics.getRunsDuration()),
-                    metrics -> BillingUtils.asCostString(metrics.getRunsCost())));
+                    metrics -> BillingUtils.asCostString(metrics.getRunsCost()),
+                    metrics -> BillingUtils.asCostString(metrics.getRunsDiskCost()),
+                    metrics -> BillingUtils.asCostString(metrics.getRunsComputeCost())));
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/manager/billing/billingdetails/BillingChartCostDetailsLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/billingdetails/BillingChartCostDetailsLoader.java
@@ -35,13 +35,18 @@ public final class BillingChartCostDetailsLoader {
         if (StorageBillingCostDetailsLoader.isStorageBillingDetailsShouldBeLoaded(request)) {
             StorageBillingCostDetailsLoader.buildQuery(request, topLevelAggregation);
         }
+        if (ComputeBillingCostDetailsLoader.isComputeCostDetailsShallBeLoaded(request)) {
+            ComputeBillingCostDetailsLoader.buildQuery(request, topLevelAggregation);
+        }
     }
-
 
     public static BillingChartDetails parseResponse(final BillingCostDetailsRequest request,
                                                     final Aggregations aggregations) {
         if (StorageBillingCostDetailsLoader.isStorageBillingDetailsShouldBeLoaded(request)) {
             return StorageBillingCostDetailsLoader.parseResponse(request, aggregations);
+        }
+        if (ComputeBillingCostDetailsLoader.isComputeCostDetailsShallBeLoaded(request)) {
+            return ComputeBillingCostDetailsLoader.parseResponse(request, aggregations);
         }
         return null;
     }

--- a/api/src/main/java/com/epam/pipeline/manager/billing/billingdetails/BillingChartCostDetailsLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/billingdetails/BillingChartCostDetailsLoader.java
@@ -22,6 +22,9 @@ import com.epam.pipeline.entity.billing.StorageBillingChartCostDetails;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.Aggregations;
 
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Helper class to encapsulate logic of loading cost details for specific billing entity,
  * currently it loads details for storages {@link StorageBillingChartCostDetails} only but can be easily expanded
@@ -32,23 +35,32 @@ public final class BillingChartCostDetailsLoader {
 
     public static void buildQuery(final BillingCostDetailsRequest request,
                                   final AggregationBuilder topLevelAggregation) {
-        if (StorageBillingCostDetailsLoader.isStorageBillingDetailsShouldBeLoaded(request)) {
+        if (StorageBillingCostDetailsLoader.isBillingDetailsShouldBeLoaded(request)) {
             StorageBillingCostDetailsLoader.buildQuery(request, topLevelAggregation);
-        }
-        if (ComputeBillingCostDetailsLoader.isComputeCostDetailsShallBeLoaded(request)) {
+        } else if (ComputeBillingCostDetailsLoader.isBillingDetailsShouldBeLoaded(request)) {
             ComputeBillingCostDetailsLoader.buildQuery(request, topLevelAggregation);
         }
     }
 
     public static BillingChartDetails parseResponse(final BillingCostDetailsRequest request,
                                                     final Aggregations aggregations) {
-        if (StorageBillingCostDetailsLoader.isStorageBillingDetailsShouldBeLoaded(request)) {
+        if (StorageBillingCostDetailsLoader.isBillingDetailsShouldBeLoaded(request)) {
             return StorageBillingCostDetailsLoader.parseResponse(request, aggregations);
         }
-        if (ComputeBillingCostDetailsLoader.isComputeCostDetailsShallBeLoaded(request)) {
+        if (ComputeBillingCostDetailsLoader.isBillingDetailsShouldBeLoaded(request)) {
             return ComputeBillingCostDetailsLoader.parseResponse(request, aggregations);
         }
         return null;
+    }
+
+    public static List<String> getCostDetailsAggregations(final BillingCostDetailsRequest request) {
+        if (StorageBillingCostDetailsLoader.isBillingDetailsShouldBeLoaded(request)) {
+            return StorageBillingCostDetailsLoader.getCostDetailsAggregations();
+        }
+        if (ComputeBillingCostDetailsLoader.isBillingDetailsShouldBeLoaded(request)) {
+            return ComputeBillingCostDetailsLoader.getCostDetailsAggregations();
+        }
+        return Collections.emptyList();
     }
 
 }

--- a/api/src/main/java/com/epam/pipeline/manager/billing/billingdetails/ComputeBillingCostDetailsLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/billingdetails/ComputeBillingCostDetailsLoader.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.billing.billingdetails;
+
+import com.epam.pipeline.controller.vo.billing.BillingCostDetailsRequest;
+import com.epam.pipeline.entity.billing.BillingChartDetails;
+import com.epam.pipeline.entity.billing.BillingDiscount;
+import com.epam.pipeline.entity.billing.BillingGrouping;
+import com.epam.pipeline.entity.billing.ComputeBillingChartCostDetails;
+import com.epam.pipeline.manager.billing.BillingUtils;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.commons.collections4.MapUtils;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.metrics.sum.ParsedSum;
+import org.elasticsearch.search.aggregations.metrics.sum.SumAggregationBuilder;
+import org.elasticsearch.search.aggregations.pipeline.ParsedSimpleValue;
+import org.elasticsearch.search.aggregations.pipeline.PipelineAggregatorBuilders;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static com.epam.pipeline.manager.billing.BillingUtils.COMPUTE_GROUP;
+import static com.epam.pipeline.manager.billing.BillingUtils.RESOURCE_TYPE;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ComputeBillingCostDetailsLoader {
+
+    public static boolean isComputeCostDetailsShallBeLoaded(final BillingCostDetailsRequest request) {
+        if (request.isHistogram()) {
+            return MapUtils.emptyIfNull(request.getFilters())
+                    .getOrDefault(RESOURCE_TYPE, Collections.emptyList()).contains(COMPUTE_GROUP);
+        }
+        final BillingGrouping grouping = request.getGrouping();
+        if (grouping != null) {
+            return BillingGrouping.TOOL.equals(grouping) || BillingGrouping.PIPELINE.equals(grouping)
+                    || BillingGrouping.RUN_COMPUTE_TYPE.equals(grouping)
+                    || BillingGrouping.RUN_INSTANCE_TYPE.equals(grouping);
+        }
+        return false;
+    }
+
+    public static void buildQuery(final BillingCostDetailsRequest request,
+                                  final AggregationBuilder topLevelAggregation) {
+        topLevelAggregation
+                .subAggregation(aggregateDiskCostSum())
+                .subAggregation(aggregateComputeCostSum());
+        if (request.isHistogram()) {
+            topLevelAggregation
+                    .subAggregation(PipelineAggregatorBuilders.cumulativeSum(BillingUtils.ACCUMULATED_DISK_COST,
+                            BillingUtils.DISK_COST_FIELD))
+                    .subAggregation(PipelineAggregatorBuilders.cumulativeSum(BillingUtils.ACCUMULATED_COMPUTE_COST,
+                            BillingUtils.COMPUTE_COST_FIELD));
+        }
+    }
+
+    public static BillingChartDetails parseResponse(final BillingCostDetailsRequest request,
+                                                    final Aggregations aggregations) {
+        final ComputeBillingChartCostDetails.ComputeBillingChartCostDetailsBuilder builder =
+                ComputeBillingChartCostDetails.builder()
+                        .diskCost(parseSum(aggregations, BillingUtils.DISK_COST_FIELD))
+                        .computeCost(parseSum(aggregations, BillingUtils.COMPUTE_COST_FIELD));
+        if (request.isHistogram()) {
+            return builder
+                    .accumulatedDiskCost(parseAccumulatedSum(aggregations, BillingUtils.ACCUMULATED_DISK_COST))
+                    .accumulatedComputeCost(parseAccumulatedSum(aggregations, BillingUtils.ACCUMULATED_COMPUTE_COST))
+                    .build();
+        }
+        return builder.build();
+    }
+
+    public static List<String> getCostDetailsAggregations() {
+        return Arrays.asList(aggregateDiskCostSum().getName(), aggregateComputeCostSum().getName());
+    }
+
+    public static SumAggregationBuilder aggregateDiskCostSum() {
+        return AggregationBuilders.sum(BillingUtils.DISK_COST_FIELD).field(BillingUtils.DISK_COST_FIELD);
+    }
+
+    public static SumAggregationBuilder aggregateComputeCostSum() {
+        return AggregationBuilders.sum(BillingUtils.COMPUTE_COST_FIELD).field(BillingUtils.COMPUTE_COST_FIELD);
+    }
+
+    public static AggregationBuilder aggregateDiskCostSum(final BillingDiscount discount) {
+        return BillingUtils.aggregateDiscountCostSum(BillingUtils.DISK_COST_FIELD, discount.getComputes(),
+                ComputeBillingCostDetailsLoader::aggregateDiskCostSum);
+    }
+
+    public static AggregationBuilder aggregateComputeCostSum(final BillingDiscount discount) {
+        return BillingUtils.aggregateDiscountCostSum(BillingUtils.COMPUTE_COST_FIELD, discount.getComputes(),
+                ComputeBillingCostDetailsLoader::aggregateComputeCostSum);
+    }
+
+    private static Long parseSum(final Aggregations aggregations, final String field) {
+        final ParsedSum sumAggResult = aggregations.get(field);
+        return Optional.ofNullable(sumAggResult)
+                .map(result -> new Double(result.getValue()).longValue())
+                .orElse(null);
+    }
+
+    private static Long parseAccumulatedSum(final Aggregations aggregations, final String field) {
+        final ParsedSimpleValue accumulatedSumAggResult = aggregations.get(field);
+        return Optional.ofNullable(accumulatedSumAggResult)
+                .map(result -> new Double(result.getValueAsString()).longValue())
+                .orElse(null);
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/manager/billing/InstanceBillingWriterTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/billing/InstanceBillingWriterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.epam.pipeline.manager.billing;
 
 import com.epam.pipeline.entity.billing.InstanceBilling;
@@ -30,17 +46,23 @@ public class InstanceBillingWriterTest extends AbstractBillingWriterTest<Instanc
                                                 .runsNumber(ONE)
                                                 .runsDuration(ONE_HOUR)
                                                 .runsCost(ONE_DOLLAR)
+                                                .runsDiskCost(ONE_DOLLAR)
+                                                .runsComputeCost(ONE_DOLLAR)
                                                 .build()),
                                 Collections.singletonMap(FINISH_YEAR_MONTH,
                                         InstanceBillingMetrics.builder()
                                                 .runsNumber(TEN)
                                                 .runsDuration(TEN_HOURS)
                                                 .runsCost(TEN_DOLLARS)
+                                                .runsDiskCost(TEN_DOLLARS)
+                                                .runsComputeCost(TEN_DOLLARS)
                                                 .build())))
                         .totalMetrics(InstanceBillingMetrics.builder()
                                 .runsNumber(ONE + TEN)
                                 .runsDuration(ONE_HOUR + TEN_HOURS)
                                 .runsCost(ONE_DOLLAR + TEN_DOLLARS)
+                                .runsDiskCost(ONE_DOLLAR + TEN_DOLLARS)
+                                .runsComputeCost(ONE_DOLLAR + TEN_DOLLARS)
                                 .build())
                         .build());
     }

--- a/api/src/test/java/com/epam/pipeline/manager/billing/PipelineBillingWriterTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/billing/PipelineBillingWriterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.epam.pipeline.manager.billing;
 
 import com.epam.pipeline.entity.billing.PipelineBilling;
@@ -31,17 +47,23 @@ public class PipelineBillingWriterTest extends AbstractBillingWriterTest<Pipelin
                                                 .runsNumber(ONE)
                                                 .runsDuration(ONE_HOUR)
                                                 .runsCost(ONE_DOLLAR)
+                                                .runsDiskCost(ONE_DOLLAR)
+                                                .runsComputeCost(ONE_DOLLAR)
                                                 .build()),
                                 Collections.singletonMap(FINISH_YEAR_MONTH,
                                         PipelineBillingMetrics.builder()
                                                 .runsNumber(TEN)
                                                 .runsDuration(TEN_HOURS)
                                                 .runsCost(TEN_DOLLARS)
+                                                .runsDiskCost(TEN_DOLLARS)
+                                                .runsComputeCost(TEN_DOLLARS)
                                                 .build())))
                         .totalMetrics(PipelineBillingMetrics.builder()
                                 .runsNumber(ONE + TEN)
                                 .runsDuration(ONE_HOUR + TEN_HOURS)
                                 .runsCost(ONE_DOLLAR + TEN_DOLLARS)
+                                .runsDiskCost(ONE_DOLLAR + TEN_DOLLARS)
+                                .runsComputeCost(ONE_DOLLAR + TEN_DOLLARS)
                                 .build())
                         .build());
     }

--- a/api/src/test/java/com/epam/pipeline/manager/billing/RunBillingWriterTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/billing/RunBillingWriterTest.java
@@ -29,6 +29,8 @@ public class RunBillingWriterTest extends AbstractBillingWriterTest<RunBilling> 
                         .started(START_DATE_TIME)
                         .duration(ONE_HOUR)
                         .cost(ONE_DOLLAR)
+                        .diskCost(ONE_DOLLAR)
+                        .computeCost(ONE_DOLLAR)
                         .build(),
                 RunBilling.builder()
                         .runId(ID_2)
@@ -42,6 +44,8 @@ public class RunBillingWriterTest extends AbstractBillingWriterTest<RunBilling> 
                         .finished(FINISH_DATE_TIME)
                         .duration(TEN_HOURS)
                         .cost(TEN_DOLLARS)
+                        .diskCost(TEN_DOLLARS)
+                        .computeCost(TEN_DOLLARS)
                         .build());
     }
 }

--- a/api/src/test/java/com/epam/pipeline/manager/billing/ToolBillingWriterTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/billing/ToolBillingWriterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.epam.pipeline.manager.billing;
 
 import com.epam.pipeline.entity.billing.ToolBilling;
@@ -31,17 +47,23 @@ public class ToolBillingWriterTest extends AbstractBillingWriterTest<ToolBilling
                                                 .runsNumber(ONE)
                                                 .runsDuration(ONE_HOUR)
                                                 .runsCost(ONE_DOLLAR)
+                                                .runsDiskCost(ONE_DOLLAR)
+                                                .runsComputeCost(ONE_DOLLAR)
                                                 .build()),
                                 Collections.singletonMap(FINISH_YEAR_MONTH,
                                         ToolBillingMetrics.builder()
                                                 .runsNumber(TEN)
                                                 .runsDuration(TEN_HOURS)
                                                 .runsCost(TEN_DOLLARS)
+                                                .runsDiskCost(TEN_DOLLARS)
+                                                .runsComputeCost(TEN_DOLLARS)
                                                 .build())))
                         .totalMetrics(ToolBillingMetrics.builder()
                                 .runsNumber(ONE + TEN)
                                 .runsDuration(ONE_HOUR + TEN_HOURS)
                                 .runsCost(ONE_DOLLAR + TEN_DOLLARS)
+                                .runsDiskCost(ONE_DOLLAR + TEN_DOLLARS)
+                                .runsComputeCost(ONE_DOLLAR + TEN_DOLLARS)
                                 .build())
                         .build());
     }

--- a/api/src/test/java/com/epam/pipeline/manager/billing/billingdetails/BillingChartCostDetailsLoaderTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/billing/billingdetails/BillingChartCostDetailsLoaderTest.java
@@ -119,7 +119,7 @@ public class BillingChartCostDetailsLoaderTest {
         assertAggregations(
             agg -> BillingChartCostDetailsLoader.buildQuery(
                     BillingCostDetailsRequest.builder().enabled(true)
-                            .grouping(BillingGrouping.TOOL).build(), agg),
+                            .grouping(BillingGrouping.USER).build(), agg),
                 ZERO, ZERO
         );
 

--- a/api/src/test/resources/billings/billing.instance.csv
+++ b/api/src/test/resources/billings/billing.instance.csv
@@ -1,3 +1,3 @@
-"Instances","October 2021","","","November 2021","","","2021-10-11 - 2021-11-11","",""
-"Instance","Runs (count)","Duration (hours)","Cost ($)","Runs (count)","Duration (hours)","Cost ($)","Runs (count)","Duration (hours)","Cost ($)"
-"some_instance_type","1","1.00","1.00","10","10.00","10.00","11","11.00","11.00"
+"Instances","October 2021","","","","","November 2021","","","","","2021-10-11 - 2021-11-11","","","",""
+"Instance","Runs (count)","Duration (hours)","Cost ($)","Disk cost ($)","Compute cost ($)","Runs (count)","Duration (hours)","Cost ($)","Disk cost ($)","Compute cost ($)","Runs (count)","Duration (hours)","Cost ($)","Disk cost ($)","Compute cost ($)"
+"some_instance_type","1","1.00","1.00","1.00","1.00","10","10.00","10.00","10.00","10.00","11","11.00","11.00","11.00","11.00"

--- a/api/src/test/resources/billings/billing.pipeline.csv
+++ b/api/src/test/resources/billings/billing.pipeline.csv
@@ -1,3 +1,3 @@
-"Pipelines","","October 2021","","","November 2021","","","2021-10-11 - 2021-11-11","",""
-"Pipeline","Owner","Runs (count)","Duration (hours)","Cost ($)","Runs (count)","Duration (hours)","Cost ($)","Runs (count)","Duration (hours)","Cost ($)"
-"some_pipeline","some_owner","1","1.00","1.00","10","10.00","10.00","11","11.00","11.00"
+"Pipelines","","October 2021","","","","","November 2021","","","","","2021-10-11 - 2021-11-11","","","",""
+"Pipeline","Owner","Runs (count)","Duration (hours)","Cost ($)","Disk cost ($)","Compute cost ($)","Runs (count)","Duration (hours)","Cost ($)","Disk cost ($)","Compute cost ($)","Runs (count)","Duration (hours)","Cost ($)","Disk cost ($)","Compute cost ($)"
+"some_pipeline","some_owner","1","1.00","1.00","1.00","1.00","10","10.00","10.00","10.00","10.00","11","11.00","11.00","11.00","11.00"

--- a/api/src/test/resources/billings/billing.run.csv
+++ b/api/src/test/resources/billings/billing.run.csv
@@ -1,3 +1,3 @@
-"Run","Owner","Billing center","Pipeline","Tool","Type","Instance","Started","Finished","Duration (hours)","Cost ($)"
-"1","some_owner","some_billing_center",,"some_registry/some_group/some_tool:some_tag","some_compute_type","some_instance_type","2021-10-11 11:11:11",,"1.00","1.00"
-"2","some_owner","some_billing_center","some_pipeline","some_registry/some_group/some_tool:some_tag","some_compute_type","some_instance_type","2021-10-11 11:11:11","2021-11-11 11:11:11","10.00","10.00"
+"Run","Owner","Billing center","Pipeline","Tool","Type","Instance","Started","Finished","Duration (hours)","Cost ($)","Disk cost ($)","Compute cost ($)"
+"1","some_owner","some_billing_center",,"some_registry/some_group/some_tool:some_tag","some_compute_type","some_instance_type","2021-10-11 11:11:11",,"1.00","1.00","1.00","1.00"
+"2","some_owner","some_billing_center","some_pipeline","some_registry/some_group/some_tool:some_tag","some_compute_type","some_instance_type","2021-10-11 11:11:11","2021-11-11 11:11:11","10.00","10.00","10.00","10.00"

--- a/api/src/test/resources/billings/billing.tool.csv
+++ b/api/src/test/resources/billings/billing.tool.csv
@@ -1,3 +1,3 @@
-"Tools","","October 2021","","","November 2021","","","2021-10-11 - 2021-11-11","",""
-"Tool","Owner","Runs (count)","Duration (hours)","Cost ($)","Runs (count)","Duration (hours)","Cost ($)","Runs (count)","Duration (hours)","Cost ($)"
-"some_group/some_tool:some_tag","some_owner","1","1.00","1.00","10","10.00","10.00","11","11.00","11.00"
+"Tools","","October 2021","","","","","November 2021","","","","","2021-10-11 - 2021-11-11","","","",""
+"Tool","Owner","Runs (count)","Duration (hours)","Cost ($)","Disk cost ($)","Compute cost ($)","Runs (count)","Duration (hours)","Cost ($)","Disk cost ($)","Compute cost ($)","Runs (count)","Duration (hours)","Cost ($)","Disk cost ($)","Compute cost ($)"
+"some_group/some_tool:some_tag","some_owner","1","1.00","1.00","1.00","1.00","10","10.00","10.00","10.00","10.00","11","11.00","11.00","11.00","11.00"

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/PipelineRunBillingInfo.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/model/billing/PipelineRunBillingInfo.java
@@ -30,12 +30,17 @@ public class PipelineRunBillingInfo extends AbstractBillingInfo<PipelineRunWithT
 
     private Long usageMinutes;
     private Long pausedMinutes;
+    private Long diskCost;
+    private Long computeCost;
 
     @Builder
     public PipelineRunBillingInfo(final LocalDate date, final PipelineRunWithType run,
-                                  final Long cost, final Long usageMinutes, final Long pausedMinutes) {
+                                  final Long cost, final Long usageMinutes, final Long pausedMinutes,
+                                  final Long diskCost, final Long computeCost) {
         super(date, run, cost, ResourceType.COMPUTE);
         this.usageMinutes = usageMinutes;
         this.pausedMinutes = pausedMinutes;
+        this.diskCost = diskCost;
+        this.computeCost = computeCost;
     }
 }

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverter.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverter.java
@@ -309,9 +309,10 @@ public class RunToBillingRequestConverter implements EntityToBillingRequestConve
             final Duration duration = Duration.between(pointStart, pointEnd);
             final Long disk = getDisksSize(run, pointStart);
             final Long durationMinutes = minutesOf(duration);
-            final Long diskCosts = price.isOldFashioned() ? 0L : getDiskCosts(duration, disk, price);
-            final Long computeCosts = price.isOldFashioned() ? 0L : getComputeCosts(duration, price, active);
-            final Long totalCosts = price.isOldFashioned()
+            final boolean oldFashioned = price.isOldFashioned();
+            final Long diskCosts = oldFashioned ? 0L : getDiskCosts(duration, disk, price);
+            final Long computeCosts = oldFashioned ? 0L : getComputeCosts(duration, price, active);
+            final Long totalCosts = oldFashioned
                     ? getOldFashionedCosts(duration, price, active)
                     : (diskCosts + computeCosts);
             billings.add(PipelineRunBillingInfo.builder()

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapper.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapper.java
@@ -114,6 +114,8 @@ public class RunBillingMapper extends AbstractEntityMapper<PipelineRunBillingInf
                 .field("compute_price", scaled(run.getComputePricePerHour()))
                 .field("disk_price", scaled(run.getDiskPricePerHour()))
                 .field("cost", billingInfo.getCost())
+                .field("disk_cost", billingInfo.getDiskCost())
+                .field("compute_cost", billingInfo.getComputeCost())
 
                 .field("started_date", asString(run.getStartDate()))
                 .field("finished_date", asString(run.getEndDate()));

--- a/billing-report-agent/src/main/resources/templates/pipeline_run_billing.json
+++ b/billing-report-agent/src/main/resources/templates/pipeline_run_billing.json
@@ -38,6 +38,8 @@
         "compute_price": { "type": "long" },
         "disk_price": { "type": "long" },
         "cost": { "type": "long" },
+        "disk_cost": { "type": "long" },
+        "compute_cost": { "type": "long" },
 
         "owner": { "type": "keyword" },
         "owner_id": { "type": "keyword" },


### PR DESCRIPTION
Implements #3098 

The following changes were added:
- fields `disk_cost` and `compute_cost` added to ES run billing index
- fields `diskCost` and `computeCost` adde to `POST billing/charts` API method grouping output. This values shall be shown if grouping by RUN_INSTANCE_TYPE/RUN_COMPUTE_TYPE/PIPELINE/TOOL was requested.
- fields `accumulatedDiskCost` and `accumulatedComputeCost` added to `POST billing/charts` interval output.  This values shal be shown for `COMPUTE` resource type only.
- columns `Disk cost ($)` and `Compute cost ($)` added to export table for runs billing.