### PR TITLE
issue #3027 Add cumulative sum for storage cost details

### DIFF
--- a/api/src/main/java/com/epam/pipeline/controller/vo/billing/BillingCostDetailsRequest.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/billing/BillingCostDetailsRequest.java
@@ -30,6 +30,7 @@ public class BillingCostDetailsRequest {
 
     BillingGrouping grouping;
     Map<String, List<String>> filters;
+    boolean isHistogram;
     BillingDiscount discount;
     boolean enabled;
 

--- a/api/src/main/java/com/epam/pipeline/entity/billing/StorageBillingChartCostDetails.java
+++ b/api/src/main/java/com/epam/pipeline/entity/billing/StorageBillingChartCostDetails.java
@@ -39,9 +39,11 @@ public class StorageBillingChartCostDetails implements BillingChartDetails {
     public static class StorageBillingDetails {
         String storageClass;
         Long cost;
+        Long accumulativeCost;
         Long avgSize;
         Long size;
         Long oldVersionCost;
+        Long accumulativeOldVersionCost;
         Long oldVersionAvgSize;
         Long oldVersionSize;
 

--- a/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/BillingManager.java
@@ -166,7 +166,8 @@ public class BillingManager {
             final DateHistogramInterval interval = request.getInterval();
             final Map<String, List<String>> filters = billingHelper.getFilters(request.getFilters());
             final BillingCostDetailsRequest costDetailsRequest = BillingCostDetailsRequest.builder()
-                    .enabled(request.isLoadCostDetails()).filters(filters).grouping(grouping).build();
+                    .enabled(request.isLoadCostDetails()).filters(filters)
+                    .isHistogram(interval != null).grouping(grouping).build();
             if (interval != null) {
                 return getBillingStats(elasticsearchClient, from, to, filters, interval, costDetailsRequest);
             }


### PR DESCRIPTION
This PR adds `cumulative sum` for `cost` fields, when intervals data is loading.