### PR TITLE
Issue #3027 Fix bug with NPE when client tries to load billing stats with details and details don't exist

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/billing/billingdetails/StorageBillingCostDetailsLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/billing/billingdetails/StorageBillingCostDetailsLoader.java
@@ -23,6 +23,7 @@ import com.epam.pipeline.entity.billing.StorageBillingChartCostDetails;
 import com.epam.pipeline.entity.billing.StorageBillingChartCostDetails.StorageBillingDetails;
 import com.epam.pipeline.manager.billing.BillingUtils;
 import com.epam.pipeline.manager.utils.ElasticSearchUtils;
+import com.epam.pipeline.utils.NumericUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
@@ -138,9 +139,10 @@ public final class StorageBillingCostDetailsLoader {
     }
 
     private static boolean isDetailsEntryEmpty(StorageBillingDetails details) {
-        return details.getCost() == 0 && details.getSize() == 0 && details.getAvgSize() == 0
-                && details.getOldVersionCost() == 0 && details.getOldVersionSize() == 0
-                && details.getOldVersionAvgSize() == 0;
+        return NumericUtils.isZero(details.getCost()) && NumericUtils.isZero(details.getSize())
+                && NumericUtils.isZero(details.getAvgSize()) && NumericUtils.isZero(details.getOldVersionCost())
+                && NumericUtils.isZero(details.getOldVersionSize())
+                && NumericUtils.isZero(details.getOldVersionAvgSize());
     }
 
     private static long fetchSimpleAggregationValue(final String template, final String storageClass,

--- a/api/src/main/java/com/epam/pipeline/utils/NumericUtils.java
+++ b/api/src/main/java/com/epam/pipeline/utils/NumericUtils.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.utils;
+
+public final class NumericUtils {
+
+    private NumericUtils() {}
+
+    public static boolean isZero(final Long value) {
+        return value == null || value == 0;
+    }
+}


### PR DESCRIPTION
This PR fixes problem for loading billing data with cost details for old billing data (data that doesn't have any details yet)