### PR TITLE
Issue 2721 Enhancement for storage lifecycle service

### DIFF
--- a/api/src/main/java/com/epam/pipeline/controller/datastorage/lifecycle/DataStorageLifecycleController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/datastorage/lifecycle/DataStorageLifecycleController.java
@@ -62,8 +62,8 @@ public class DataStorageLifecycleController extends AbstractRestController {
 
     @GetMapping(value = "/datastorage/lifecycle/storages")
     @ApiOperation(
-            value = "Lists all available lifecycle rules with its storages.",
-            notes = "Lists all available lifecycle rules with its storages.",
+            value = "Lists storages with lifecycle configuration(transition rules or restores) only.",
+            notes = "Lists storages with lifecycle configuration(transition rules or restores) only.",
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiResponses(
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)

--- a/api/src/main/java/com/epam/pipeline/controller/datastorage/lifecycle/DataStorageLifecycleController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/datastorage/lifecycle/DataStorageLifecycleController.java
@@ -20,12 +20,14 @@ import com.epam.pipeline.acl.datastorage.lifecycle.DataStorageLifecycleApiServic
 import com.epam.pipeline.controller.AbstractRestController;
 import com.epam.pipeline.controller.Result;
 import com.epam.pipeline.dto.datastorage.lifecycle.StorageLifecycleRule;
+import com.epam.pipeline.dto.datastorage.lifecycle.StorageLifecycleType;
 import com.epam.pipeline.dto.datastorage.lifecycle.execution.StorageLifecycleRuleExecution;
 import com.epam.pipeline.dto.datastorage.lifecycle.execution.StorageLifecycleRuleExecutionStatus;
 import com.epam.pipeline.dto.datastorage.lifecycle.restore.StorageRestoreAction;
 import com.epam.pipeline.dto.datastorage.lifecycle.restore.StorageRestoreActionRequest;
 import com.epam.pipeline.dto.datastorage.lifecycle.restore.StorageRestoreActionSearchFilter;
 import com.epam.pipeline.dto.datastorage.lifecycle.restore.StorageRestorePathType;
+import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
@@ -57,6 +59,20 @@ public class DataStorageLifecycleController extends AbstractRestController {
 
     @Autowired
     private DataStorageLifecycleApiService dataStorageLifecycleApiService;
+
+    @GetMapping(value = "/datastorage/lifecycle/storages")
+    @ApiOperation(
+            value = "Lists all available lifecycle rules with its storages.",
+            notes = "Lists all available lifecycle rules with its storages.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public Result<List<AbstractDataStorage>> listStorageLifecyclePolicyRulesWithStorages(
+            @RequestParam(value = "lifecycleType", required = false) final StorageLifecycleType lifecycleType
+    ) {
+        return Result.success(dataStorageLifecycleApiService.listStoragesWithLifecycle(lifecycleType));
+    }
 
     @GetMapping(value = "/datastorage/{datastorageId}/lifecycle/rule")
     @ApiOperation(

--- a/api/src/main/java/com/epam/pipeline/dao/datastorage/DataStorageDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/datastorage/DataStorageDao.java
@@ -205,7 +205,7 @@ public class DataStorageDao extends NamedParameterJdbcDaoSupport {
                 DataStorageParameters.getToolsToMountForAllStorageRowMapper());
     }
 
-    public List<AbstractDataStorage> loadDataStoragesByIds(final List<Long> ids) {
+    public List<AbstractDataStorage> loadDataStoragesByIds(final Collection<Long> ids) {
         MapSqlParameterSource params = new MapSqlParameterSource();
         params.addValue(DataStorageParameters.DATASTORAGE_IDS.name(), ids);
         return getNamedParameterJdbcTemplate().query(loadDataStoragesByIdsQuery,

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
@@ -268,7 +268,7 @@ public class DataStorageManager implements SecuredEntityManager {
         return dataStorageDao.loadDataStorage(id) != null;
     }
 
-    public List<AbstractDataStorage> getDatastoragesByIds(final List<Long> ids) {
+    public List<AbstractDataStorage> getDatastoragesByIds(final Collection<Long> ids) {
         if(CollectionUtils.isEmpty(ids)) {
             return Collections.emptyList();
         }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/lifecycle/DataStorageLifecycleManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/lifecycle/DataStorageLifecycleManager.java
@@ -90,9 +90,9 @@ public class DataStorageLifecycleManager {
 
     @Transactional(readOnly = true)
     public List<Long> listStorageIdsWithLifecycle() {
-        return dataStorageLifecycleRuleRepository.findAll()
-                .stream().map(StorageLifecycleRuleEntity::getDatastorageId).distinct()
-                .collect(Collectors.toList());
+        return StreamSupport.stream(
+            dataStorageLifecycleRuleRepository.loadDistinctDatastorageIds().spliterator(), false
+        ).collect(Collectors.toList());
     }
 
     public StorageLifecycleRule loadStorageLifecyclePolicyRule(final Long datastorageId, final Long ruleId) {

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/lifecycle/DataStorageLifecycleManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/lifecycle/DataStorageLifecycleManager.java
@@ -88,6 +88,13 @@ public class DataStorageLifecycleManager {
         return listStorageLifecyclePolicyRules(storageId, null);
     }
 
+    @Transactional(readOnly = true)
+    public List<Long> listStorageIdsWithLifecycle() {
+        return dataStorageLifecycleRuleRepository.findAll()
+                .stream().map(StorageLifecycleRuleEntity::getDatastorageId).distinct()
+                .collect(Collectors.toList());
+    }
+
     public StorageLifecycleRule loadStorageLifecyclePolicyRule(final Long datastorageId, final Long ruleId) {
         final StorageLifecycleRuleEntity lifecycleRuleEntity = loadLifecycleRuleEntity(ruleId);
         Assert.isTrue(lifecycleRuleEntity.getDatastorageId().equals(datastorageId),

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/lifecycle/DataStorageLifecycleRestoreManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/lifecycle/DataStorageLifecycleRestoreManager.java
@@ -51,6 +51,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 @Slf4j
 @Service
@@ -69,9 +70,9 @@ public class DataStorageLifecycleRestoreManager {
 
     @Transactional(readOnly = true)
     public List<Long> listStoragesWithLifecycle() {
-        return dataStoragePathRestoreActionRepository.findAll().stream()
-                .map(StorageRestoreActionEntity::getDatastorageId)
-                .distinct().collect(Collectors.toList());
+        return StreamSupport.stream(
+            dataStoragePathRestoreActionRepository.loadDistinctDatastorageIds().spliterator(), false
+        ).collect(Collectors.toList());
     }
 
     @Transactional

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/lifecycle/DataStorageLifecycleRestoreManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/lifecycle/DataStorageLifecycleRestoreManager.java
@@ -67,6 +67,13 @@ public class DataStorageLifecycleRestoreManager {
     private final UserManager userManager;
 
 
+    @Transactional(readOnly = true)
+    public List<Long> listStoragesWithLifecycle() {
+        return dataStoragePathRestoreActionRepository.findAll().stream()
+                .map(StorageRestoreActionEntity::getDatastorageId)
+                .distinct().collect(Collectors.toList());
+    }
+
     @Transactional
     public List<StorageRestoreAction> initiateStorageRestores(final AbstractDataStorage storage,
                                                               final StorageRestoreActionRequest request) {

--- a/api/src/main/java/com/epam/pipeline/repository/datastorage/lifecycle/DataStorageLifecycleRuleRepository.java
+++ b/api/src/main/java/com/epam/pipeline/repository/datastorage/lifecycle/DataStorageLifecycleRuleRepository.java
@@ -18,8 +18,12 @@ package com.epam.pipeline.repository.datastorage.lifecycle;
 
 import com.epam.pipeline.entity.datastorage.lifecycle.StorageLifecycleRuleEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface DataStorageLifecycleRuleRepository extends JpaRepository<StorageLifecycleRuleEntity, Long> {
     Iterable<StorageLifecycleRuleEntity> findByDatastorageId(Long datastorageId);
+
+    @Query("SELECT DISTINCT r.datastorageId FROM StorageLifecycleRuleEntity r")
+    Iterable<Long> loadDistinctDatastorageIds();
 
 }

--- a/api/src/main/java/com/epam/pipeline/repository/datastorage/lifecycle/DataStorageRestoreActionRepository.java
+++ b/api/src/main/java/com/epam/pipeline/repository/datastorage/lifecycle/DataStorageRestoreActionRepository.java
@@ -18,6 +18,7 @@ package com.epam.pipeline.repository.datastorage.lifecycle;
 
 import com.epam.pipeline.entity.datastorage.lifecycle.restore.StorageRestoreActionEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
@@ -27,4 +28,8 @@ public interface DataStorageRestoreActionRepository extends JpaRepository<Storag
     List<StorageRestoreActionEntity> findByDatastorageId(Long datastorageId);
 
     void deleteByDatastorageId(Long datastorageId);
+
+    @Query("SELECT DISTINCT a.datastorageId FROM StorageRestoreActionEntity a")
+    Iterable<Long> loadDistinctDatastorageIds();
+
 }

--- a/core/src/main/java/com/epam/pipeline/dto/datastorage/lifecycle/StorageLifecycleType.java
+++ b/core/src/main/java/com/epam/pipeline/dto/datastorage/lifecycle/StorageLifecycleType.java
@@ -1,0 +1,5 @@
+package com.epam.pipeline.dto.datastorage.lifecycle;
+
+public enum StorageLifecycleType {
+    TRANSITION, RESTORE
+}

--- a/storage-lifecycle-service/sls/app/synchronizer/archiving_synchronizer_impl.py
+++ b/storage-lifecycle-service/sls/app/synchronizer/archiving_synchronizer_impl.py
@@ -44,6 +44,11 @@ ROLE_ADMIN_ID = 1
 
 class StorageLifecycleArchivingSynchronizer(StorageLifecycleSynchronizer):
 
+    STORAGE_LIFECYCLE_TYPE = "TRANSITION"
+
+    def _load_storages(self):
+        return self.pipeline_api_client.load_storages_with_lifecycle(self.STORAGE_LIFECYCLE_TYPE)
+
     def _sync_storage(self, storage):
         if storage.shared:
             self.logger.log("Storage {} marked as shared, skipping".format(storage.path))

--- a/storage-lifecycle-service/sls/app/synchronizer/restoring_synchronizer_impl.py
+++ b/storage-lifecycle-service/sls/app/synchronizer/restoring_synchronizer_impl.py
@@ -17,8 +17,9 @@ from sls.app.storage_permissions_manager import StoragePermissionsManager
 from sls.app.synchronizer.storage_synchronizer_interface import StorageLifecycleSynchronizer
 from sls.pipelineapi.model.restore_action_model import StorageLifecycleRestoreAction
 
-
 class StorageLifecycleRestoringSynchronizer(StorageLifecycleSynchronizer):
+
+    STORAGE_LIFECYCLE_TYPE = "RESTORE"
 
     DATASTORAGE_RESTORE_ACTION_NOTIFICATION_TYPE = "DATASTORAGE_LIFECYCLE_RESTORE_ACTION"
 
@@ -35,6 +36,9 @@ class StorageLifecycleRestoringSynchronizer(StorageLifecycleSynchronizer):
     TERMINAL_STATUSES = [SUCCEEDED_STATUS, CANCELLED_STATUS, FAILED_STATUS]
 
     PATH_TYPE_FOLDER = "FOLDER"
+
+    def _load_storages(self):
+        return self.pipeline_api_client.load_storages_with_lifecycle(self.STORAGE_LIFECYCLE_TYPE)
 
     def _sync_storage(self, storage):
         ongoing_actions = self.pipeline_api_client.filter_restore_actions(

--- a/storage-lifecycle-service/sls/app/synchronizer/storage_synchronizer_interface.py
+++ b/storage-lifecycle-service/sls/app/synchronizer/storage_synchronizer_interface.py
@@ -24,7 +24,7 @@ class StorageLifecycleSynchronizer:
     def sync(self):
         try:
             self.logger.log("Starting object lifecycle synchronization process...")
-            available_storages = [s for s in self.pipeline_api_client.load_available_storages() if s.storage_type != "NFS"]
+            available_storages = self._load_storages()
             self.logger.log("{} storages loaded.".format(len(available_storages)))
             self.cloud_bridge.initialize()
             for storage in available_storages:
@@ -44,6 +44,9 @@ class StorageLifecycleSynchronizer:
             self.logger.log("Done object lifecycle synchronization process...")
         except BaseException:
             self.logger.exception("There was a problem in process of object lifecycle synchronization.")
+
+    def _load_storages(self):
+        return []
 
     def _sync_storage(self, storage):
         pass

--- a/storage-lifecycle-service/sls/pipelineapi/cp_api_interface_impl.py
+++ b/storage-lifecycle-service/sls/pipelineapi/cp_api_interface_impl.py
@@ -47,6 +47,9 @@ class RESTApiCloudPipelineDataSource(CloudPipelineDataSource):
     def load_available_storages(self):
         return self.api.load_available_storages()
 
+    def load_storages_with_lifecycle(self, lifecycle_type):
+        return self.api.load_storages_with_lifecycle(lifecycle_type)
+
     def load_storage(self, datastorage_id):
         return self.api.find_datastorage(datastorage_id)
 

--- a/workflows/pipe-common/pipeline/api/api.py
+++ b/workflows/pipe-common/pipeline/api/api.py
@@ -200,6 +200,7 @@ class PipelineAPI:
     CLONE_PIPELINE_URL = "/pipeline/{}/clone"
     LOAD_WRITABLE_STORAGES = "/datastorage/mount"
     LOAD_AVAILABLE_STORAGES = "/datastorage/available"
+    LOAD_AVAILABLE_STORAGES_WITH_LIFECYCLE = "/datastorage/lifecycle/storages"
     LOAD_LIFECYCLE_RULE_FOR_STORAGE_URL = "/datastorage/{id}/lifecycle/rule/{rule_id}"
     LIFECYCLE_RULES_FOR_STORAGE_URL = "/datastorage/{id}/lifecycle/rule"
     PROLONG_LIFECYCLE_RULES_URL = "/datastorage/{id}/lifecycle/rule/{rule_id}/prolong?path={path}&days={days}&force={force}"
@@ -662,6 +663,19 @@ class PipelineAPI:
             return [DataStorage.from_json(item) for item in result]
         except Exception as e:
             raise RuntimeError("Failed to load storages with READ and WRITE permissions. "
+                               "Error message: {}".format(str(e.message)))
+
+    def load_storages_with_lifecycle(self, lifecycle_type=None):
+        try:
+            url = str(self.api_url) + self.LOAD_AVAILABLE_STORAGES_WITH_LIFECYCLE
+            if lifecycle_type is not None:
+                url += "?lifecycleType={}".format(lifecycle_type)
+            result = self.execute_request(url)
+            if result is None:
+                return []
+            return [DataStorage.from_json(item) for item in result]
+        except Exception as e:
+            raise RuntimeError("Failed to load storages with lifecycle actions. "
                                "Error message: {}".format(str(e.message)))
 
     def load_available_storages_with_share_mount(self, from_region_id=None):


### PR DESCRIPTION
This PR related to #2721.
It changes the way how storages are loaded if `SLS agent`. 

Instead of loading all storages and go over it one by one and making a lot of "empty" loops (with no actual work because there is no any rule or restore for such storage), `sls` will load only storages that have at least one lifecycle configuration (rule or restore).

Such approach should dramatically improve performance, because usually only several buckets will have some lifecycle configuration enabled.