### PR TITLE
Control a number of the layers to squash during a pause operations or completely disable it

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerContainerOperationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerContainerOperationManager.java
@@ -498,6 +498,7 @@ public class DockerContainerOperationManager {
                 .defaultTaskName(run.getTaskName())
                 .preCommitCommand(preferenceManager.getPreference(SystemPreferences.PRE_COMMIT_COMMAND_PATH))
                 .postCommitCommand(preferenceManager.getPreference(SystemPreferences.POST_COMMIT_COMMAND_PATH))
+                .squashLayersCount(preferenceManager.getPreference(SystemPreferences.PAUSE_LAYERS_COUNT_TO_SQUASH))
                 .build()
                 .getCommand();
 

--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerContainerOperationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerContainerOperationManager.java
@@ -498,7 +498,8 @@ public class DockerContainerOperationManager {
                 .defaultTaskName(run.getTaskName())
                 .preCommitCommand(preferenceManager.getPreference(SystemPreferences.PRE_COMMIT_COMMAND_PATH))
                 .postCommitCommand(preferenceManager.getPreference(SystemPreferences.POST_COMMIT_COMMAND_PATH))
-                .squashLayersCount(String.valueOf(preferenceManager.getPreference(SystemPreferences.PAUSE_LAYERS_COUNT_TO_SQUASH)))
+                .squashLayersCount(String.valueOf(
+                    preferenceManager.getPreference(SystemPreferences.PAUSE_LAYERS_COUNT_TO_SQUASH)))
                 .build()
                 .getCommand();
 

--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerContainerOperationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerContainerOperationManager.java
@@ -498,7 +498,7 @@ public class DockerContainerOperationManager {
                 .defaultTaskName(run.getTaskName())
                 .preCommitCommand(preferenceManager.getPreference(SystemPreferences.PRE_COMMIT_COMMAND_PATH))
                 .postCommitCommand(preferenceManager.getPreference(SystemPreferences.POST_COMMIT_COMMAND_PATH))
-                .squashLayersCount(preferenceManager.getPreference(SystemPreferences.PAUSE_LAYERS_COUNT_TO_SQUASH))
+                .squashLayersCount(String.valueOf(preferenceManager.getPreference(SystemPreferences.PAUSE_LAYERS_COUNT_TO_SQUASH)))
                 .build()
                 .getCommand();
 

--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerPauseCommand.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerPauseCommand.java
@@ -38,6 +38,7 @@ public class DockerPauseCommand extends AbstractDockerCommand {
     private final String defaultTaskName;
     private final String preCommitCommand;
     private final String postCommitCommand;
+    private final String squashLayersCount;
 
     private final String runPauseScriptUrl;
 
@@ -61,6 +62,7 @@ public class DockerPauseCommand extends AbstractDockerCommand {
         command.add(preCommitCommand);
         command.add(postCommitCommand);
         command.add(globalDistributionUrl);
+        command.add(squashLayersCount);
         return command;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -146,6 +146,8 @@ public class SystemPreferences {
             "/root/post_commit.sh", COMMIT_GROUP, isNotBlank);
     public static final IntPreference PAUSE_TIMEOUT = new IntPreference("pause.timeout", 24 * 60 * 60,
             COMMIT_GROUP, isGreaterThan(0));
+    public static final IntPreference PAUSE_LAYERS_COUNT_TO_SQUASH = new IntPreference("pause.layers.count.to.squash", 25,
+            COMMIT_GROUP, isGreaterThanOrEquals(-1));
     // List of ',' separated env vars to be cleaned up from docker image before commit
     public static final StringPreference ADDITIONAL_ENVS_TO_CLEAN = new StringPreference(
             "commit.additional.envs.to.clean", "CP_EXEC_TIMEOUT", COMMIT_GROUP, pass);

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -146,8 +146,8 @@ public class SystemPreferences {
             "/root/post_commit.sh", COMMIT_GROUP, isNotBlank);
     public static final IntPreference PAUSE_TIMEOUT = new IntPreference("pause.timeout", 24 * 60 * 60,
             COMMIT_GROUP, isGreaterThan(0));
-    public static final IntPreference PAUSE_LAYERS_COUNT_TO_SQUASH = new IntPreference("pause.layers.count.to.squash", 25,
-            COMMIT_GROUP, isGreaterThanOrEquals(-1));
+    public static final IntPreference PAUSE_LAYERS_COUNT_TO_SQUASH = new IntPreference(
+        "pause.layers.count.to.squash", 25, COMMIT_GROUP, isGreaterThanOrEquals(-1));
     // List of ',' separated env vars to be cleaned up from docker image before commit
     public static final StringPreference ADDITIONAL_ENVS_TO_CLEAN = new StringPreference(
             "commit.additional.envs.to.clean", "CP_EXEC_TIMEOUT", COMMIT_GROUP, pass);

--- a/scripts/commit-run-scripts/pause_run.sh
+++ b/scripts/commit-run-scripts/pause_run.sh
@@ -80,7 +80,7 @@ commit_file_and_stop_docker() {
                             "exit 126"
 
     if [ "$SKIP_DOCKER_SQUASH" != "true" ]; then
-        pipe_exec "$SCRIPTS_DIR/squash_docker_image.sh ${NEW_IMAGE_NAME}" "$TASK_NAME"
+        pipe_exec "$SCRIPTS_DIR/squash_docker_image.sh ${NEW_IMAGE_NAME} ${LAYERS_COUNT_TO_SQUASH}" "$TASK_NAME"
     fi
 
     pipe_exec "docker logs ${CONTAINER_ID}" "${DEFAULT_TASK_NAME}"
@@ -145,6 +145,8 @@ export DEFAULT_TASK_NAME=${9}
 export PRE_COMMIT_COMMAND=${10}
 export POST_COMMIT_COMMAND=${11}
 export GLOBAL_DISTRIBUTION_URL=${12}
+export LAYERS_COUNT_TO_SQUASH=${13}
+
 
 export TASK_NAME="PausePipelineRun"
 export CP_PYTHON2_PATH=python
@@ -171,6 +173,12 @@ download_file "${PAUSE_DISTRIBUTION_URL}squash_docker_image.sh"
 if [ "$?" -ne 0 ];
 then
     pipe_log_warn "[WARN] Docker squash script download failed. Will not attempt to squash" $TASK_NAME
+    export SKIP_DOCKER_SQUASH="true"
+fi
+if  [ -z "$LAYERS_COUNT_TO_SQUASH" ] || \
+    [ -z "${LAYERS_COUNT_TO_SQUASH##*[!0-9]*}" ] || \
+    (( "$LAYERS_COUNT_TO_SQUASH" <= "0" )); then
+    pipe_log_warn "[INFO] Docker squash is disabled (LAYERS_COUNT_TO_SQUASH==${LAYERS_COUNT_TO_SQUASH})." $TASK_NAME
     export SKIP_DOCKER_SQUASH="true"
 fi
 

--- a/scripts/commit-run-scripts/squash_docker_image.sh
+++ b/scripts/commit-run-scripts/squash_docker_image.sh
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-LAYERS_COUNT_TO_SQUASH="25"
-
 function is_null() {
     if [ -z "$1" ] || [ "$1" == "null" ]; then
         return 0
@@ -24,6 +22,7 @@ function is_null() {
 }
 
 image_to_squash="$1"
+layers_count_to_squash="${2:-25}"
 
 if [ -z "$image_to_squash" ]; then
     echo "[ERROR] Image to squash is not specified, exiting"
@@ -44,8 +43,8 @@ if [ -z "$image_to_squash_layers" ]; then
 fi
 echo "[INFO] Image to squash id is $image_to_squash_id with $image_to_squash_layers layers"
 
-if (( "$image_to_squash_layers" < "$LAYERS_COUNT_TO_SQUASH" )); then
-    echo "[INFO] Will not squash an image this time, as it did not reach a layer count threshold yet. Will squash once it has $LAYERS_COUNT_TO_SQUASH layers"
+if (( "$image_to_squash_layers" < "$layers_count_to_squash" )); then
+    echo "[INFO] Will not squash an image this time, as it did not reach a layer count threshold yet. Will squash once it has $layers_count_to_squash layers"
     exit 0
 fi
 


### PR DESCRIPTION
Use `pause.layers.count.to.squash` (default: 25) to control when the docker image will be squashed during a pause operation.
I.e.:
* A user pause an instance
* The docker image, being committed, has 50 layers
* If `pause.layers.count.to.squash` is set to:
  * `25`: squash an image
  * `-1` or `0`: do not squash
  * `60`:  do not squash right now, but squash once the image gets 60+ layers
