### PR TITLE
Introduce non-eager child runs loading

### DIFF
--- a/api/src/main/java/com/epam/pipeline/controller/vo/PipelineRunFilterVO.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/PipelineRunFilterVO.java
@@ -50,6 +50,7 @@ public class PipelineRunFilterVO implements AclSecuredFilter {
     private String prettyUrl;
 
     private boolean userModified = true;
+    private boolean eagerGrouping = true;
     private Map<String, String> tags;
 
     //these filters are used for ACL filtering

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
@@ -112,6 +112,7 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     private String updateRunInstanceQuery;
     private String updatePodIPQuery;
     private String loadRunsGroupingQuery;
+    private String loadRunsCountGroupingQuery;
     private String countRunGroupsQuery;
     private String createPipelineRunSidsQuery;
     private String deleteRunSidsByRunIdQuery;
@@ -340,13 +341,31 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
                 .query(query, params, PipelineRunParameters.getExtendedRowMapper()));
     }
 
-    public List<PipelineRun> searchPipelineGroups(PagingRunFilterVO filter,
-                                                  PipelineRunFilterVO.ProjectFilter projectFilter) {
+    /**
+     * @deprecated because it is extremely inefficient. It collects unlimited amount of child runs.
+     * Use {@link #searchPipelineGroups(PagingRunFilterVO, PipelineRunFilterVO.ProjectFilter)} instead.
+     */
+    @Deprecated
+    public List<PipelineRun> eagerSearchPipelineGroups(PagingRunFilterVO filter,
+                                                       PipelineRunFilterVO.ProjectFilter projectFilter) {
         MapSqlParameterSource params = getPagingParameters(filter);
         String query = wherePattern.matcher(loadRunsGroupingQuery)
                 .replaceFirst(makeFilterCondition(filter, projectFilter, params, false));
         Collection<PipelineRun> runs = getNamedParameterJdbcTemplate()
                 .query(query, params, PipelineRunParameters.getRunGroupExtractor());
+        return addServiceUrls(runs.stream()
+                .filter(run -> run.getParentRunId() == null)
+                .sorted(getPipelineRunComparator())
+                .collect(Collectors.toList()));
+    }
+
+    public List<PipelineRun> searchPipelineGroups(PagingRunFilterVO filter,
+                                                  PipelineRunFilterVO.ProjectFilter projectFilter) {
+        MapSqlParameterSource params = getPagingParameters(filter);
+        String query = wherePattern.matcher(loadRunsCountGroupingQuery)
+                .replaceFirst(makeFilterCondition(filter, projectFilter, params, true));
+        Collection<PipelineRun> runs = getNamedParameterJdbcTemplate()
+                .query(query, params, PipelineRunParameters.getExtendedRowMapper(false, true));
         return addServiceUrls(runs.stream()
                 .filter(run -> run.getParentRunId() == null)
                 .sorted(getPipelineRunComparator())
@@ -758,6 +777,7 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
         END_DATE,
         PARAMETERS,
         PARENT_ID,
+        CHILD_RUNS_COUNT,
         STATUS,
         COMMIT_STATUS,
         LAST_CHANGE_COMMIT_TIME,
@@ -893,11 +913,7 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
                 Map<Long, PipelineRun> runs = new HashMap<>();
                 Map<Long, List<PipelineRun>> childRuns = new HashMap<>();
                 while (rs.next()) {
-                    PipelineRun run = parsePipelineRun(rs);
-                    run.setInitialized(rs.getBoolean(INITIALIZATION_FINISHED.name()));
-                    if (run.getInstance() == null || StringUtils.isBlank(run.getInstance().getNodeName())) {
-                        run.setQueued(rs.getBoolean(QUEUED.name()));
-                    }
+                    PipelineRun run = parseExtendedPipelineRun(rs);
                     runs.put(run.getId(), run);
                     if (run.getParentRunId() != null) {
                         childRuns.putIfAbsent(run.getParentRunId(), new ArrayList<>());
@@ -915,9 +931,13 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
             };
         }
 
-
-        static RowMapper<PipelineRun> getRowMapper() {
-            return (rs, rowNum) -> parsePipelineRun(rs);
+        static PipelineRun parseExtendedPipelineRun(final ResultSet rs) throws SQLException {
+            PipelineRun run = parsePipelineRun(rs);
+            run.setInitialized(rs.getBoolean(INITIALIZATION_FINISHED.name()));
+            if (run.getInstance() == null || StringUtils.isBlank(run.getInstance().getNodeName())) {
+                run.setQueued(rs.getBoolean(QUEUED.name()));
+            }
+            return run;
         }
 
         public static PipelineRun parsePipelineRun(ResultSet rs) throws SQLException {
@@ -1026,19 +1046,27 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
             return run;
         }
 
+        static RowMapper<PipelineRun> getRowMapper() {
+            return (rs, rowNum) -> parsePipelineRun(rs);
+        }
+
         static RowMapper<PipelineRun> getExtendedRowMapper() {
             return getExtendedRowMapper(false);
         }
 
         static RowMapper<PipelineRun> getExtendedRowMapper(final boolean loadEnvVars) {
+            return getExtendedRowMapper(loadEnvVars, false);
+        }
+
+        static RowMapper<PipelineRun> getExtendedRowMapper(final boolean loadEnvVars,
+                                                           final boolean loadChildRunsCount) {
             return (rs, rowNum) -> {
-                PipelineRun run = parsePipelineRun(rs);
-                run.setInitialized(rs.getBoolean(INITIALIZATION_FINISHED.name()));
-                if (run.getInstance() == null || StringUtils.isBlank(run.getInstance().getNodeName())) {
-                    run.setQueued(rs.getBoolean(QUEUED.name()));
-                }
+                PipelineRun run = parseExtendedPipelineRun(rs);
                 if (loadEnvVars) {
                     run.setEnvVars(getEnvVarsRowMapper().mapRow(rs, rowNum));
+                }
+                if (loadChildRunsCount) {
+                    run.setChildRunsCount(rs.getInt(CHILD_RUNS_COUNT.name()));
                 }
                 return run;
             };
@@ -1227,6 +1255,11 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setLoadRunsGroupingQuery(String loadRunsGroupingQuery) {
         this.loadRunsGroupingQuery = loadRunsGroupingQuery;
+    }
+
+    @Required
+    public void setLoadRunsCountGroupingQuery(String loadRunsCountGroupingQuery) {
+        this.loadRunsCountGroupingQuery = loadRunsCountGroupingQuery;
     }
 
     @Required

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -87,6 +87,7 @@ import com.epam.pipeline.manager.security.CheckPermissionHelper;
 import com.epam.pipeline.manager.security.run.RunPermissionManager;
 import com.epam.pipeline.utils.PasswordGenerator;
 import com.fasterxml.jackson.core.type.TypeReference;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.MapUtils;
@@ -128,6 +129,7 @@ import static com.epam.pipeline.manager.pipeline.ToolUtils.getImageWithoutTag;
 import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toSet;
 
+@Slf4j
 @Service
 public class PipelineRunManager {
 
@@ -707,8 +709,14 @@ public class PipelineRunManager {
             return new PagedResult<>(Collections.emptyList(), 0);
         }
         PagedResult<List<PipelineRun>> result;
+        // todo: Get rid of grouping requests altogether.
+        //  Use a single sql request which always counts child runs.
         if (filter.useGrouping()) {
-            result = searchRunsGrouping(filter, projectFilter);
+            if (filter.isEagerGrouping()) {
+                result = eagerSearchRunsGrouping(filter, projectFilter);
+            } else {
+                result = searchRunsGrouping(filter, projectFilter);
+            }
         } else {
             List<PipelineRun> runs = pipelineRunDao.searchPipelineRuns(filter, projectFilter);
             int count = pipelineRunDao.countFilteredPipelineRuns(filter, projectFilter);
@@ -1191,6 +1199,19 @@ public class PipelineRunManager {
         LOGGER.debug("Retrieved image size: {} b, image size on disk: {} Gb, total disk size: {} Gb",
                 imageSizeBytes, requiredDiskSizeGb, requiredDiskSizeGb + requestedDiskSize);
         configuration.setEffectiveDiskSize(Math.toIntExact(requiredDiskSizeGb + requestedDiskSize));
+    }
+
+
+    /**
+     * @deprecated because its underlying method is deprecated.
+     * @see PipelineRunDao#eagerSearchPipelineGroups(PagingRunFilterVO, PipelineRunFilterVO.ProjectFilter)
+     */
+    @Deprecated
+    private PagedResult<List<PipelineRun>> eagerSearchRunsGrouping(PagingRunFilterVO filter,
+                                                                   PipelineRunFilterVO.ProjectFilter projectFilter) {
+        log.debug("Executing deprecated eager filter runs grouping request...");
+        List<PipelineRun> groupedRuns = pipelineRunDao.eagerSearchPipelineGroups(filter, projectFilter);
+        return new PagedResult<>(groupedRuns, pipelineRunDao.countRootRuns(filter, projectFilter));
     }
 
     private PagedResult<List<PipelineRun>> searchRunsGrouping(PagingRunFilterVO filter,

--- a/api/src/main/resources/dao/pipeline-run-dao.xml
+++ b/api/src/main/resources/dao/pipeline-run-dao.xml
@@ -1454,6 +1454,90 @@
                  ]]>
             </value>
         </property>
+        <property name="loadRunsCountGroupingQuery">
+            <value>
+                <![CDATA[
+                    SELECT
+                        r.run_id,
+                        r.pipeline_id,
+                        r.version,
+                        r.start_date,
+                        r.end_date,
+                        r.parameters,
+                        r.status,
+                        r.terminating,
+                        r.pod_id,
+                        r.node_type,
+                        r.node_disk,
+                        r.node_ip,
+                        r.node_id,
+                        r.node_name,
+                        r.node_image,
+                        r.node_cloud_region,
+                        r.node_platform,
+                        r.docker_image,
+                        r.actual_docker_image,
+                        r.platform,
+                        r.timeout,
+                        r.cmd_template,
+                        r.actual_cmd,
+                        r.owner,
+                        r.pod_ip,
+                        r.commit_status,
+                        r.last_change_commit_time,
+                        r.config_name,
+                        r.node_count,
+                        r.parent_id,
+                        r.entities_ids,
+                        r.is_spot,
+                        r.configuration_id,
+                        r.pod_status,
+                        r.prolonged_at_time,
+                        r.last_notification_time,
+                        r.last_idle_notification_time,
+                        r.exec_preferences,
+                        r.pretty_url,
+                        r.price_per_hour,
+                        r.compute_price_per_hour,
+                        r.disk_price_per_hour,
+                        r.state_reason,
+                        r.non_pause,
+                        r.node_real_disk,
+                        r.node_cloud_provider,
+                        r.tags,
+                        r.sensitive,
+                        r.kube_service_enabled,
+                        r.pipeline_name,
+                        r.cluster_price,
+                        r.node_pool_id,
+                        (
+                            SELECT count(*)
+                            FROM pipeline.pipeline_run cr
+                            WHERE cr.parent_id = r.run_id
+                        ) AS child_runs_count,
+                        CASE
+                            WHEN EXISTS (
+                                SELECT 1 FROM pipeline.pipeline_run_log init_tasks
+				                WHERE init_tasks.run_id = r.run_id AND init_tasks.task_name = :TASK_NAME
+				                    AND init_tasks.status = :TASK_STATUS)
+				            THEN TRUE
+				            ELSE FALSE
+				        END AS initialization_finished,
+                        CASE
+                            WHEN EXISTS (
+                                SELECT 1 FROM pipeline.pipeline_run_log nodeup_tasks
+				                WHERE nodeup_tasks.run_id = r.run_id AND nodeup_tasks.task_name = :NODEUP_TASK)
+				            THEN FALSE
+				            ELSE TRUE
+				        END AS queued
+                    FROM
+                        pipeline.pipeline_run r
+                    @WHERE@
+                    ORDER BY r.run_id DESC
+                    LIMIT :LIMIT OFFSET :OFFSET
+                 ]]>
+            </value>
+        </property>
         <property name="countRunGroupsQuery">
             <value>
                 <![CDATA[

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
@@ -419,7 +419,7 @@ public class PipelineRunDaoTest extends AbstractJdbcTest {
     public void searchGroupingRun() {
         Pipeline testPipeline = getPipeline();
         PipelineRun parent = createRun(testPipeline.getId(), null, TaskStatus.SUCCESS, null);
-        PipelineRun child = createRun(testPipeline.getId(), null, TaskStatus.SUCCESS, parent.getId());
+        createRun(testPipeline.getId(), null, TaskStatus.SUCCESS, parent.getId());
         PipelineRun lonely = createRun(testPipeline.getId(), null, TaskStatus.SUCCESS, null);
         parent.setTags(Collections.singletonMap(TAG_KEY_1, TAG_VALUE_1));
         pipelineRunDao.updateRunTags(parent);

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
@@ -432,8 +432,7 @@ public class PipelineRunDaoTest extends AbstractJdbcTest {
         assertEquals(2, runs.size());
         assertEquals(lonely.getId(), runs.get(0).getId());
         assertEquals(parent.getId(), runs.get(1).getId());
-        assertEquals(1, runs.get(1).getChildRuns().size());
-        assertEquals(child.getId(), runs.get(1).getChildRuns().get(0).getId());
+        assertEquals(1, runs.get(1).getChildRunsCount().intValue());
 
         assertThat(runs.get(1).getTags(), is(parent.getTags()));
         assertEquals(2L, pipelineRunDao.countRootRuns(filterVO, null).longValue());

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
@@ -85,6 +85,7 @@ public class PipelineRun extends AbstractSecuredEntity {
     private Integer nodeCount;
     private Long parentRunId;
     private List<PipelineRun> childRuns;
+    private Integer childRunsCount;
     private Boolean initialized;
     private Boolean queued;
     private List<Long> entitiesIds;


### PR DESCRIPTION
The pull request brings support for non-eager child runs loading to `POST run/filter` API method. Additional `eagerGrouping=false` filter flag can be used to disable eager child runs loading. If disabled then the number of child runs can be found in run field called `childRunsCount`.
