### PR TITLE
Exclude only nested shared storage from mount list

### DIFF
--- a/workflows/pipe-common/pipeline/api/datastorage.py
+++ b/workflows/pipe-common/pipeline/api/datastorage.py
@@ -35,7 +35,8 @@ class DataStorage:
     def __init__(self, id, name, description, path, policy, mask, storage_type,
                  owner, region_id, locked, parentId, mount_point, mount_options,
                  region_name=None, sensitive=False, mount_disabled=False,
-                 tools_to_mount=None, mount_status=None, shared=False, cloud_specific_attributes=None):
+                 tools_to_mount=None, mount_status=None, shared=False, source_storage_id=None,
+                 cloud_specific_attributes=None):
         self.id = int(id)
         self.name = str(name)
         self.description = str(description)
@@ -52,6 +53,7 @@ class DataStorage:
         self.region_name = region_name
         self.sensitive = sensitive
         self.shared = shared
+        self.source_storage_id = source_storage_id
         self.mount_disabled = mount_disabled
         self.tools_to_mount = tools_to_mount
         self.mount_status = mount_status
@@ -74,6 +76,7 @@ class DataStorage:
         region_name = JsonParser.get_optional_field(data, 'regionName')
         sensitive = JsonParser.get_optional_field(data, 'sensitive', default=False)
         shared = JsonParser.get_optional_field(data, 'shared', default=False)
+        source_storage_id = JsonParser.get_optional_field(data, 'sourceStorageId', default=None)
         mount_disabled = JsonParser.get_optional_field(data, 'mountDisabled', default=False)
         tools_to_mount = JsonParser.get_optional_field(data, 'toolsToMount')
         policy = StoragePolicy.from_json(data['storagePolicy']) if 'storagePolicy' in data else None
@@ -82,7 +85,7 @@ class DataStorage:
         return DataStorage(id, name, description, path, policy, mask, type, owner, region_id, locked, parentId,
                            mount_point, mount_options, region_name, sensitive=sensitive, mount_disabled=mount_disabled,
                            tools_to_mount=tools_to_mount, mount_status=mount_status, shared=shared,
-                           cloud_specific_attributes=cloud_specific_attributes)
+                           source_storage_id=source_storage_id, cloud_specific_attributes=cloud_specific_attributes)
 
 
 class FileShareMount:

--- a/workflows/pipe-common/scripts/mount_storage.py
+++ b/workflows/pipe-common/scripts/mount_storage.py
@@ -191,8 +191,12 @@ class MountStorageTask:
 
             Logger.info('Fetching list of allowed storages...', task_name=self.task_name)
             available_storages_with_mounts = self.api.load_available_storages_with_share_mount(self.region_id or None)
-            # filtering out shared storages, as they cause "overlapped" mounts and break the "original" storage mountpoint
-            available_storages_with_mounts = [x for x in available_storages_with_mounts if not x.storage.shared]
+            # filtering out shared storage folders, as they cause "overlapped" mounts
+            # and break the "original" storage mountpoint,
+            # storage is shared folder of another storage if it has source_storage_id
+            available_storages_with_mounts = [
+                x for x in available_storages_with_mounts if not x.storage.source_storage_id
+            ]
 
             # filtering out all nfs storages if region id is missing
             if not self.region_id:


### PR DESCRIPTION
This PR changes filtering logic in `mount_storage.py` and now we will filter out shared storage only if it has `sourceStorageId`, that means that this storage is nested (a folder in a real storage)