### PR TITLE
pipe-common: SGE cluster error handling

### DIFF
--- a/workflows/pipe-common/pipeline/cluster/cluster.py
+++ b/workflows/pipe-common/pipeline/cluster/cluster.py
@@ -11,15 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import os
-import subprocess
 from random import getrandbits
 from threading import RLock
+from time import sleep
 from . import utils
+
+MAX_RETRY_COUNT = 5
+WAITING_DELAY = 3
 
 
 class AbstractCluster(object):
-    def submit_job(self, command, job_name, threads, common_logfile, work_directory, get_output=True):
+    def submit_job(self, command, job_name, threads, common_logfile, work_directory, get_output=True,
+                   max_retry_count=MAX_RETRY_COUNT):
         pass
 
     def build_job_command(self, command, job_name, threads, logfile, work_directory):
@@ -27,18 +32,25 @@ class AbstractCluster(object):
 
 
 class SGECluster(AbstractCluster):
+    QSTAT_CMD_TEMPLATE = "qstat -j %s"
+    QACCT_CMD_TEMPLATE = "qacct -j %s"
+    QACCT_RETRY_COUNT = 60
+    QACCT_DELAY = 1
 
     def __init__(self):
         self._lock = RLock()
 
-    def submit_job(self, command, job_name, threads, common_logfile, get_output=True, work_directory=os.getcwd()):
+    def submit_job(self, command, job_name, threads, common_logfile, get_output=True, work_directory=os.getcwd(),
+                   max_retry_count=MAX_RETRY_COUNT):
         if not command:
             raise ValueError("The job command is not set.")
-        if not job_name:
-            print("The job name is not set. The default one will be used.")
+        random_number = getrandbits(64)
+        job_name = "{}-{}".format(job_name, random_number) if job_name else str(random_number)
+        print("The job with name {} will be submitted.".format(job_name))
+
         job_logfile = utils.get_log_filename(work_directory, job_name, lock=self._lock)
         job_command = self.build_job_command(command, job_name, threads, job_logfile, work_directory)
-        job_result = utils.run(job_command, get_output=get_output)
+        job_exit_code = self._execute_job(job_command, job_name, max_retry_count)
         if common_logfile and get_output:
             utils.merge_log(common_logfile, job_logfile, lock=self._lock)
         try:
@@ -46,10 +58,10 @@ class SGECluster(AbstractCluster):
         except OSError as e:
             print("Could not delete {file} file.\n".format(file=job_logfile) + e.__str__())
             pass
-        return job_result
+        return job_exit_code
 
     def build_job_command(self, command, job_name, threads, logfile, work_directory):
-        job_options = "-sync y {job_name} -V -j y -R y -o {standard_output_logfile} -pe local {threads} " \
+        job_options = "{job_name} -V -j y -R y -o {standard_output_logfile} -pe local {threads} " \
             .format(standard_output_logfile=logfile, job_name="-N " + job_name if job_name else "",
                     threads=threads)
         tmp_directory = utils.create_directory(work_directory, "tmp", lock=self._lock)
@@ -60,3 +72,58 @@ class SGECluster(AbstractCluster):
             file.write("#!/usr/bin/env bash\n")
             file.write(command + "\n")
         return "qsub {job_options} {bash_script}".format(job_options=job_options, bash_script=bash_script)
+
+    def _execute_job(self, job_command, job_identifier, max_retry_count):
+        retry_count = 0
+        run_job_result, run_job_error, run_job_exit_code = "", "", ""
+        while retry_count < max_retry_count:
+            retry_count += 1
+            run_job_result, run_job_error, run_job_exit_code = utils.run(job_command)
+            if run_job_exit_code != 0 and not self._is_job_in_queue(job_identifier):
+                sleep(WAITING_DELAY)
+                continue
+            return self._find_job(job_identifier)
+        raise RuntimeError('Exceeded retry count ({}) to launch job.\n'
+                           'Command "{}" failed to start with exit code: {}\nstdout: {}\nstderr: {}'
+                           .format(MAX_RETRY_COUNT, job_command, run_job_exit_code, run_job_result, run_job_error))
+
+    def _is_job_in_queue(self, job_identifier):
+        qacct_command = self.QSTAT_CMD_TEMPLATE % job_identifier
+        _, _, exit_code = utils.run(qacct_command)
+        return exit_code == 0
+
+    def _find_job(self, job_identifier):
+        while True:
+            sleep(WAITING_DELAY)
+            if not self._is_job_in_queue(job_identifier):
+                break
+        job_exit_status = self._find_job_info(job_identifier)
+        if job_exit_status is None:
+            raise RuntimeError("Failed to determine job exit code for job '{}'".format(job_identifier))
+        print("Job {} finished with exit code {}".format(job_identifier, job_exit_status))
+        return job_exit_status
+
+    def _find_job_info(self, job_identifier):
+        retry_count = 0
+        while retry_count < self.QACCT_RETRY_COUNT:
+            retry_count += 1
+            qacct_command = self.QACCT_CMD_TEMPLATE % job_identifier
+            output, _, exit_code = utils.run(qacct_command)
+            if exit_code != 0:
+                sleep(self.QACCT_DELAY)
+                continue
+            return self._parse_job_exit_status(output)
+        raise RuntimeError('Exceeded retry count ({}) to get job info.'.format(self.QACCT_RETRY_COUNT))
+
+    @staticmethod
+    def _parse_job_exit_status(output):
+        if not output:
+            return None
+        for line in output.splitlines():
+            line = line.strip()
+            if line.strip().startswith('exit_status'):
+                parts = line.split()
+                if len(parts) != 2:
+                    return None
+                return int(parts[1])
+        return None

--- a/workflows/pipe-common/pipeline/cluster/cluster.py
+++ b/workflows/pipe-common/pipeline/cluster/cluster.py
@@ -46,8 +46,9 @@ class SGECluster(AbstractCluster):
         if not job_name:
             print("The job name is not set. The default one will be used.")
         random_number = str(getrandbits(64))
-        job_name = "{}-{}".format(job_name, random_number) if job_name else random_number
-        print("The job with name {} will be submitted.".format(job_name))
+        job_prefix = job_name or "job"
+        job_name = "{}-{}".format(job_prefix, random_number)
+        print("Submitted the job with name {}.".format(job_name))
 
         job_logfile = utils.get_log_filename(work_directory, job_name, lock=self._lock)
         job_command = self.build_job_command(command, job_name, threads, job_logfile, work_directory)
@@ -102,7 +103,7 @@ class SGECluster(AbstractCluster):
         job_exit_status = self._parse_job_exit_status(qacct_output)
         if job_exit_status is None:
             raise RuntimeError("Failed to determine job exit code for job '{}'".format(job_identifier))
-        print("Job {} finished with exit code {}".format(job_identifier, job_exit_status))
+        print("Job {} finished with exit code {}.".format(job_identifier, job_exit_status))
         return job_exit_status
 
     @staticmethod

--- a/workflows/pipe-common/pipeline/cluster/cluster.py
+++ b/workflows/pipe-common/pipeline/cluster/cluster.py
@@ -28,15 +28,13 @@ class AbstractCluster(object):
                    max_retry_count=MAX_RETRY_COUNT):
         pass
 
-    def build_job_command(self, command, job_name, threads, logfile, work_directory, job_identifier):
+    def build_job_command(self, command, job_name, threads, logfile, work_directory):
         pass
 
 
 class SGECluster(AbstractCluster):
     QSTAT_CMD_TEMPLATE = "qstat -j %s"
     QACCT_CMD_TEMPLATE = "qacct -j %s"
-    QSTAT_HEADER_LINES = 2
-    IDENTIFIER_ENV_VAR = 'CP_JOB_ID'
 
     def __init__(self):
         self._lock = RLock()
@@ -47,11 +45,13 @@ class SGECluster(AbstractCluster):
             raise ValueError("The job command is not set.")
         if not job_name:
             print("The job name is not set. The default one will be used.")
-        job_identifier = str(getrandbits(64))
+        random_number = str(getrandbits(64))
+        job_name = "{}-{}".format(job_name, random_number) if job_name else random_number
+        print("The job with name {} will be submitted.".format(job_name))
 
-        job_logfile = utils.get_log_filename(work_directory, job_name, lock=self._lock, job_identifier=job_identifier)
-        job_command = self.build_job_command(command, job_name, threads, job_logfile, work_directory, job_identifier)
-        job_exit_code = self._execute_job(job_command, job_identifier, max_retry_count)
+        job_logfile = utils.get_log_filename(work_directory, job_name, lock=self._lock)
+        job_command = self.build_job_command(command, job_name, threads, job_logfile, work_directory)
+        job_exit_code = self._execute_job(job_command, job_name, max_retry_count)
         if common_logfile and get_output:
             utils.merge_log(common_logfile, job_logfile, lock=self._lock)
         try:
@@ -61,14 +61,13 @@ class SGECluster(AbstractCluster):
             pass
         return job_exit_code
 
-    def build_job_command(self, command, job_name, threads, logfile, work_directory, job_identifier):
-        job_options = "{job_name} -V -v {job_identifier} -j y -R y -o {standard_output_logfile} -pe local {threads} " \
-            .format(standard_output_logfile=logfile, job_name="-N " + job_name if job_name else "",
-                    threads=threads, job_identifier=self.IDENTIFIER_ENV_VAR + '=' + job_identifier)
+    def build_job_command(self, command, job_name, threads, logfile, work_directory):
+        job_options = "{job_name} -V -j y -R y -o {standard_output_logfile} -pe local {threads} " \
+            .format(standard_output_logfile=logfile, job_name="-N " + job_name if job_name else "", threads=threads)
         tmp_directory = utils.create_directory(work_directory, "tmp", lock=self._lock)
         bash_script = "{tmp_directory}/{job_name}.sh".format(tmp_directory=tmp_directory,
-                                                             job_name=job_name + job_identifier if job_name
-                                                             else 'JOB-' + job_identifier)
+                                                             job_name=job_name + str(getrandbits(64)) if job_name
+                                                             else str(getrandbits(64)))
         with open(bash_script, "w") as file:
             file.write("#!/usr/bin/env bash\n")
             file.write(command + "\n")
@@ -80,27 +79,18 @@ class SGECluster(AbstractCluster):
         while retry_count < max_retry_count:
             retry_count += 1
             run_job_result, run_job_error, run_job_exit_code = utils.run(job_command)
-            sleep(WAITING_DELAY)
-            job_id = self._find_job_in_queue(job_identifier)
-            if not job_id:
+            if not self._is_job_in_queue(job_identifier):
+                sleep(WAITING_DELAY)
                 continue
-            return self._find_job(job_id)
+            return self._find_job(job_identifier)
         raise RuntimeError('Exceeded retry count ({}) to launch job.\n'
                            'Command "{}" failed to start with exit code: {}\nstdout: {}\nstderr: {}'
                            .format(MAX_RETRY_COUNT, job_command, run_job_exit_code, run_job_result, run_job_error))
 
-    def _find_job_in_queue(self, job_identifier):
-        job_ids = self._find_queued_job_ids()
-        if not job_ids:
-            return None
-        for job_id in job_ids:
-            qstat_command = self.QSTAT_CMD_TEMPLATE % job_id
-            qstat_output, _, exit_code = utils.run(qstat_command)
-            if exit_code == 0:
-                job_id = self._find_job_number_by_identifier(qstat_output, job_identifier)
-                if job_id:
-                    return job_id
-        return None
+    def _is_job_in_queue(self, job_identifier):
+        qacct_command = self.QSTAT_CMD_TEMPLATE % job_identifier
+        _, _, exit_code = utils.run(qacct_command)
+        return exit_code == 0
 
     def _find_job(self, job_identifier):
         while True:
@@ -114,57 +104,6 @@ class SGECluster(AbstractCluster):
             raise RuntimeError("Failed to determine job exit code for job '{}'".format(job_identifier))
         print("Job {} finished with exit code {}".format(job_identifier, job_exit_status))
         return job_exit_status
-
-    def _find_queued_job_ids(self):
-        output, _, exit_code = utils.run('qstat')
-        if exit_code != 0:
-            return None
-        if not output:
-            return None
-        output_lines = output.splitlines()
-        if len(output_lines) < self.QSTAT_HEADER_LINES:
-            return None
-        ids = []
-        for line in output_lines[self.QSTAT_HEADER_LINES:]:
-            line = line.strip()
-            parts = line.split()
-            if len(parts) > 1:
-                ids.append(parts[0])
-        return ids if len(ids) > 0 else None
-
-    def _find_job_number_by_identifier(self, qstat_output, job_identifier):
-        env_list = self._parse_env_vars(qstat_output)
-        if not env_list:
-            return None
-        for env_var in env_list.split(','):
-            env_var = env_var.strip()
-            if env_var == '{}={}'.format(self.IDENTIFIER_ENV_VAR, job_identifier):
-                return self._parse_job_number(qstat_output)
-        return None
-
-    @staticmethod
-    def _parse_env_vars(qstat_output):
-        if not qstat_output:
-            return None
-        for line in qstat_output.splitlines():
-            line = line.strip()
-            if line.startswith('env_list:'):
-                line = line[len('env_list:'):]
-                return line.strip()
-        return None
-
-    @staticmethod
-    def _parse_job_number(qstat_output):
-        if not qstat_output:
-            return None
-        for line in qstat_output.splitlines():
-            line = line.strip()
-            if line.startswith('job_number:'):
-                parts = line.split()
-                if len(parts) != 2:
-                    return None
-                return parts[1]
-        return None
 
     @staticmethod
     def _parse_job_exit_status(output):

--- a/workflows/pipe-common/pipeline/cluster/utils.py
+++ b/workflows/pipe-common/pipeline/cluster/utils.py
@@ -14,14 +14,11 @@
 
 import os
 import subprocess
-from random import getrandbits
 
 
 def get_log_filename(work_directory, job_name, lock):
     logs_directory = create_directory(work_directory, "logs", lock=lock)
-    random_number = getrandbits(64)
-    return os.path.join(logs_directory, "{job_name}_{number}_out.log"
-                        .format(number=random_number, job_name=job_name if job_name else random_number))
+    return os.path.join(logs_directory, "{job_name}_out.log".format(job_name=job_name))
 
 
 def merge_log(common_logfile, job_logfile, lock):
@@ -34,7 +31,6 @@ def merge_log(common_logfile, job_logfile, lock):
                     common_logfile.write("\n".encode())
                     break
                 common_logfile.write(piece)
-
 
 
 def create_directory(path, name, lock):
@@ -52,7 +48,4 @@ def run(job_command, get_output=True, env=None):
         process = subprocess.Popen(job_command, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, env=env)
     stdout, stderr = process.communicate()
     exit_code = process.wait()
-    if exit_code != 0:
-        raise RuntimeError('Command "{}" exited with return code: {}, stdout: {}, stderr: {}'
-                           .format(job_command, exit_code, stdout, stderr))
-    return stdout
+    return stdout, stderr, exit_code

--- a/workflows/pipe-common/pipeline/cluster/utils.py
+++ b/workflows/pipe-common/pipeline/cluster/utils.py
@@ -16,10 +16,9 @@ import os
 import subprocess
 
 
-def get_log_filename(work_directory, job_name, lock, job_identifier):
+def get_log_filename(work_directory, job_name, lock):
     logs_directory = create_directory(work_directory, "logs", lock=lock)
-    return os.path.join(logs_directory, "{job_name}_{number}_out.log"
-                        .format(number=job_identifier, job_name=job_name if job_name else job_identifier))
+    return os.path.join(logs_directory, "{job_name}_out.log".format(job_name=job_name))
 
 
 def merge_log(common_logfile, job_logfile, lock):

--- a/workflows/pipe-common/pipeline/cluster/utils.py
+++ b/workflows/pipe-common/pipeline/cluster/utils.py
@@ -16,9 +16,10 @@ import os
 import subprocess
 
 
-def get_log_filename(work_directory, job_name, lock):
+def get_log_filename(work_directory, job_name, lock, job_identifier):
     logs_directory = create_directory(work_directory, "logs", lock=lock)
-    return os.path.join(logs_directory, "{job_name}_out.log".format(job_name=job_name))
+    return os.path.join(logs_directory, "{job_name}_{number}_out.log"
+                        .format(number=job_identifier, job_name=job_name if job_name else job_identifier))
 
 
 def merge_log(common_logfile, job_logfile, lock):


### PR DESCRIPTION
The following changes were added:
- added new method argument `max_retry_count` to method `submit_job` (Default: 5). This value indicated the number of attempts to restart job if unexpected error occurred during `qsub`.
- a new approach for job submission:
  - removed `-sync y` option from launch command
  - wait job appearance in `qacct -j <job_id>` command output
- a new approach for job error checking:
  -  after the job submission check it appears in queue (despite the exit code)
  -  if not - restart job