### PR TITLE
Issue #3154: Autoscaled clusters monitoring

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
@@ -360,8 +360,8 @@ public class RunApiService {
         return runManager.loadRunsByPoolId(poolId);
     }
 
-    @PreAuthorize(ADMIN_ONLY)
-    public List<RunInfo> loadRunsByParentId(final Long parentId) {
-        return runManager.loadRunsByParentId(parentId);
+    @PreAuthorize(RUN_ID_READ)
+    public List<RunInfo> loadRunsByParentId(final Long runId) {
+        return runManager.loadRunsByParentId(runId);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
@@ -42,6 +42,7 @@ import com.epam.pipeline.entity.pipeline.RunLog;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.epam.pipeline.entity.pipeline.run.PipeRunCmdStartVO;
 import com.epam.pipeline.entity.pipeline.run.PipelineStart;
+import com.epam.pipeline.entity.pipeline.run.RunInfo;
 import com.epam.pipeline.entity.pipeline.run.parameter.RunSid;
 import com.epam.pipeline.entity.utils.DefaultSystemParameter;
 import com.epam.pipeline.manager.cluster.EdgeServiceManager;
@@ -357,5 +358,10 @@ public class RunApiService {
     @PreAuthorize(ADMIN_ONLY)
     public List<PipelineRun> loadRunsByPoolId(final Long poolId) {
         return runManager.loadRunsByPoolId(poolId);
+    }
+
+    @PreAuthorize(ADMIN_ONLY)
+    public List<RunInfo> loadRunsByParentId(final Long parentId) {
+        return runManager.loadRunsByParentId(parentId);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
@@ -42,6 +42,7 @@ import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.RunLog;
 import com.epam.pipeline.entity.pipeline.run.PipeRunCmdStartVO;
 import com.epam.pipeline.entity.pipeline.run.PipelineStart;
+import com.epam.pipeline.entity.pipeline.run.RunInfo;
 import com.epam.pipeline.entity.pipeline.run.parameter.RunSid;
 import com.epam.pipeline.entity.utils.DefaultSystemParameter;
 import com.epam.pipeline.manager.filter.WrongFilterException;
@@ -564,5 +565,15 @@ public class PipelineRunController extends AbstractRestController {
     @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
     public Result<List<PipelineRun>> loadRunsByPoolId(@PathVariable("id") final Long poolId) {
         return Result.success(runApiService.loadRunsByPoolId(poolId));
+    }
+
+    @GetMapping("/run/parents/{runId}")
+    @ApiOperation(
+            value = "Loads a compact representation of child runs of a cluster by parent run ID",
+            notes = "Loads a compact representation of child runs of a cluster by parent run ID",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<List<RunInfo>> loadRunsByParentId(@PathVariable(RUN_ID) final Long parentId) {
+        return Result.success(runApiService.loadRunsByParentId(parentId));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -57,6 +57,7 @@ import com.epam.pipeline.entity.pipeline.run.PipeRunCmdStartVO;
 import com.epam.pipeline.entity.pipeline.run.PipelineStart;
 import com.epam.pipeline.entity.pipeline.run.PipelineStartNotificationRequest;
 import com.epam.pipeline.entity.pipeline.run.RestartRun;
+import com.epam.pipeline.entity.pipeline.run.RunInfo;
 import com.epam.pipeline.entity.pipeline.run.RunStatus;
 import com.epam.pipeline.entity.pipeline.run.parameter.PipelineRunParameter;
 import com.epam.pipeline.entity.pipeline.run.parameter.RunSid;
@@ -1186,6 +1187,17 @@ public class PipelineRunManager {
     public List<PipelineRun> loadRunsByPoolId(final Long poolId) {
         nodePoolManager.load(poolId);
         return runCRUDService.loadRunsByPoolId(poolId);
+    }
+
+    public List<RunInfo> loadRunsByParentId(final Long parentId) {
+        return ListUtils.emptyIfNull(pipelineRunDao.loadRunsByParentRuns(Collections.singletonList(parentId))).stream()
+                .map(run -> RunInfo.builder()
+                        .runId(run.getId())
+                        .status(run.getStatus())
+                        .startDate(run.getStartDate())
+                        .endDate(run.getEndDate())
+                        .build())
+                .collect(Collectors.toList());
     }
 
     private int getTotalSize(final List<InstanceDisk> disks) {

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/run/RunInfo.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/run/RunInfo.java
@@ -15,13 +15,27 @@
 
 package com.epam.pipeline.entity.pipeline.run;
 
-import lombok.Value;
+import com.epam.pipeline.entity.pipeline.TaskStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.Date;
 
 /**
  * Provides minimal run description
  */
-@Value
+@Data
+@AllArgsConstructor
+@Builder
 public class RunInfo {
 
-    Long runId;
+    private Long runId;
+    private TaskStatus status;
+    private Date startDate;
+    private Date endDate;
+
+    public RunInfo(final Long runId) {
+        this.runId = runId;
+    }
 }


### PR DESCRIPTION
The current PR provides API implementation for issue #3154

The following changes were added:
 - a new API method `GET /run/parents/<run ID>` added to pipeline controller. This method returns a compact representation of child runs of a cluster by parent run ID. Output example:
  ```
  GET /run/parents/1
 {
  "payload": [
    {
      "runId": 2,
      "status": "FAILURE",
      "startDate": "2023-03-27 17:23:34.879",
      "endDate": "2023-03-27 17:23:34.879"
    },
    {
      "runId": 3,
      "status": "SUCCESS",
      "startDate": "2023-03-27 17:23:44.550",
      "endDate": "2023-03-27 17:23:44.550"
    }
  ],
  "status": "OK"
}
  ```