### PR TITLE
CommonRepo: fix for python3 - subprocess shall return str

### DIFF
--- a/workflows/pipe-common/pipeline/cluster/cluster.py
+++ b/workflows/pipe-common/pipeline/cluster/cluster.py
@@ -112,7 +112,7 @@ class SGECluster(AbstractCluster):
             return None
         for line in output.splitlines():
             line = line.strip()
-            if line.strip().startswith('exit_status'):
+            if line.startswith('exit_status'):
                 parts = line.split()
                 if len(parts) != 2:
                     return None

--- a/workflows/pipe-common/pipeline/cluster/utils.py
+++ b/workflows/pipe-common/pipeline/cluster/utils.py
@@ -43,9 +43,11 @@ def create_directory(path, name, lock):
 
 def run(job_command, get_output=True, env=None):
     if get_output:
-        process = subprocess.Popen(job_command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
+        process = subprocess.Popen(job_command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env,
+                                   universal_newlines=True)
     else:
-        process = subprocess.Popen(job_command, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, env=env)
+        process = subprocess.Popen(job_command, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, env=env,
+                                   universal_newlines=True)
     stdout, stderr = process.communicate()
     exit_code = process.wait()
     return stdout, stderr, exit_code


### PR DESCRIPTION
This PR provides fix for `pipe-common` -`subprocess.Popen` returns different types for `python2` and `python3` versions (`str` and `bytes`).  The current PR brings fix for such behaviour -   `subprocess.Popen` returns `str` for all python versions. 