### PR TITLE
Issue #2960 "Select Metadata" pop-up tree collapse/expand

### DIFF
--- a/client/src/components/pipelines/launch/dialogs/MetadataBrowser.js
+++ b/client/src/components/pipelines/launch/dialogs/MetadataBrowser.js
@@ -217,6 +217,13 @@ export default class MetadataBrowser extends React.Component {
     } else {
       this.onSelectFolder(item.id);
     }
+    this.onExpand(
+      this.state.expandedKeys,
+      {
+        expanded: !node.node.props.expanded,
+        node: node.node
+      }
+    );
   };
 
   generateTree () {


### PR DESCRIPTION
This PR fixes expand/collapse tree in select metadata pop-up