### PR TITLE
Report SGE worker node status

### DIFF
--- a/workflows/pipe-common/pipeline/api/api.py
+++ b/workflows/pipe-common/pipeline/api/api.py
@@ -253,6 +253,8 @@ class PipelineAPI:
     CATEGORICAL_ATTRIBUTE_URL = "/categoricalAttribute"
     GRANT_PERMISSIONS_URL = "/grant"
     PERMISSION_URL = "/permissions"
+    RUN_TAG = '/run/{id}/tag'
+    RUN_PARENTS = '/run/parents/{runId}'
 
     # Pipeline API default header
 
@@ -1386,3 +1388,14 @@ class PipelineAPI:
             raise RuntimeError("Failed to load permissions for entity '{}' with ID '{}', error: {}".format(
                 entity_class, str(entity_id), str(e)))
 
+    def update_pipeline_run_tags(self, run_id, tags):
+        try:
+            return self._request(endpoint=self.RUN_TAG.format(id=str(run_id)), http_method='post', data=tags)
+        except Exception as e:
+            raise RuntimeError("Failed to update tags for run ID '{}', error: {}".format(str(run_id), str(e)))
+
+    def load_cluster_runs_py_parent_id(self, parent_id):
+        try:
+            return self._request(endpoint=self.RUN_PARENTS.format(runId=str(parent_id)), http_method='get')
+        except Exception as e:
+            raise RuntimeError("Failed to load nested runs for run ID '{}', error: {}".format(str(parent_id), str(e)))

--- a/workflows/pipe-common/pipeline/api/api.py
+++ b/workflows/pipe-common/pipeline/api/api.py
@@ -254,7 +254,6 @@ class PipelineAPI:
     GRANT_PERMISSIONS_URL = "/grant"
     PERMISSION_URL = "/permissions"
     RUN_TAG = '/run/{id}/tag'
-    RUN_PARENTS = '/run/parents/{runId}'
 
     # Pipeline API default header
 
@@ -1393,9 +1392,3 @@ class PipelineAPI:
             return self._request(endpoint=self.RUN_TAG.format(id=str(run_id)), http_method='post', data=tags)
         except Exception as e:
             raise RuntimeError("Failed to update tags for run ID '{}', error: {}".format(str(run_id), str(e)))
-
-    def load_cluster_runs_py_parent_id(self, parent_id):
-        try:
-            return self._request(endpoint=self.RUN_PARENTS.format(runId=str(parent_id)), http_method='get')
-        except Exception as e:
-            raise RuntimeError("Failed to load nested runs for run ID '{}', error: {}".format(str(parent_id), str(e)))

--- a/workflows/pipe-common/scripts/autoscale_sge.py
+++ b/workflows/pipe-common/scripts/autoscale_sge.py
@@ -2207,8 +2207,7 @@ def load_default_hosts(default_hostsfile):
         return []
 
 
-def init_static_hosts(default_hostsfile, static_host_storage, clock, tagging_active_timeout, static_hosts_enabled,
-                      common_utils, parent_run_id):
+def init_static_hosts(default_hostsfile, static_host_storage, clock, tagging_active_timeout, static_hosts_enabled):
     try:
         if static_host_storage.load_hosts():
             Logger.info('Static hosts already initialized.')
@@ -2219,7 +2218,7 @@ def init_static_hosts(default_hostsfile, static_host_storage, clock, tagging_act
             for host in hosts:
                 static_host_storage.add_host(host)
         else:
-            master_host = common_utils.retrieve_pod_name(parent_run_id)
+            master_host = os.getenv('HOSTNAME')
             static_host_storage.add_host(master_host)
             hosts = [master_host]
         # to prevent false positive run tagging let's add outdated date to hosts:
@@ -2380,9 +2379,8 @@ def main():
                                                                           '.static.%s.storage' % queue_name),
                                                 clock=clock)
     init_static_hosts(default_hostsfile=default_hostfile, static_host_storage=static_host_storage, clock=clock,
-                      tagging_active_timeout=tagging_active_timeout, common_utils=common_utils,
-                      static_hosts_enabled=queue_static and static_hosts_number,
-                      parent_run_id=master_run_id)
+                      tagging_active_timeout=tagging_active_timeout,
+                      static_hosts_enabled=queue_static and static_hosts_number)
     if not autoscale_enabled:
         Logger.info('Using non autoscaling mode...')
         autoscaling_hosts_number = 0

--- a/workflows/pipe-common/scripts/autoscale_sge.py
+++ b/workflows/pipe-common/scripts/autoscale_sge.py
@@ -918,7 +918,7 @@ class GridEngineScaleUpHandler:
             Logger.info('Scaling up additional worker (%s)...' % instance.name)
             run_id = self._launch_additional_worker(instance.name, owner)
             run_id_queue.put(run_id)
-            host = self.retrieve_pod_name(run_id)
+            host = self._retrieve_pod_name(run_id)
             self.host_storage.add_host(host)
             pod = self._await_pod_initialization(run_id)
             self._add_worker_to_master_hosts(pod)
@@ -972,7 +972,7 @@ class GridEngineScaleUpHandler:
         """
         return price_type.replace('_', '-')
 
-    def retrieve_pod_name(self, run_id):
+    def _retrieve_pod_name(self, run_id):
         Logger.info('Retrieving pod name of additional worker #%s...' % run_id)
         run = self.api.load_run(run_id)
         if 'podId' in run:

--- a/workflows/pipe-common/scripts/manage_sge_profiles.py
+++ b/workflows/pipe-common/scripts/manage_sge_profiles.py
@@ -252,9 +252,7 @@ def _launch_autoscaler(profile, autoscaling_script_path, logger):
     logger.debug('Launching grid engine queue {} autoscaling...'.format(profile.name))
     subprocess.check_call("""
 source "{autoscaling_profile_path}"
-if check_cp_cap "CP_CAP_AUTOSCALE"; then
-    nohup "$CP_PYTHON2_PATH" "{autoscaling_script_path}" >"$LOG_DIR/.nohup.autoscaler.$CP_CAP_SGE_QUEUE_NAME.log" 2>&1 &
-fi
+nohup "$CP_PYTHON2_PATH" "{autoscaling_script_path}" >"$LOG_DIR/.nohup.autoscaler.$CP_CAP_SGE_QUEUE_NAME.log" 2>&1 &
     """.format(autoscaling_profile_path=profile.path_queue,
                autoscaling_script_path=autoscaling_script_path),
                           shell=True)

--- a/workflows/pipe-common/shell/sge_setup_master
+++ b/workflows/pipe-common/shell/sge_setup_master
@@ -484,8 +484,6 @@ for sge_profile_script in "$CP_CAP_SCRIPTS_DIR"/sge_profile_*_queue.sh; do
     (
         # shellcheck source=/dev/null
         [[ -e "$sge_profile_script" ]] && source "$sge_profile_script"
-        if check_cp_cap "CP_CAP_AUTOSCALE"; then
-            nohup "$CP_PYTHON2_PATH" "$COMMON_REPO_DIR/scripts/autoscale_sge.py" >"$LOG_DIR/.nohup.autoscaler.$CP_CAP_SGE_QUEUE_NAME.log" 2>&1 &
-        fi
+        nohup "$CP_PYTHON2_PATH" "$COMMON_REPO_DIR/scripts/autoscale_sge.py" >"$LOG_DIR/.nohup.autoscaler.$CP_CAP_SGE_QUEUE_NAME.log" 2>&1 &
     )
 done

--- a/workflows/pipe-common/test/test_scale_down.py
+++ b/workflows/pipe-common/test/test_scale_down.py
@@ -70,7 +70,7 @@ def test_scale_down_if_all_jobs_are_running_for_more_than_scale_down_timeout():
     grid_engine.get_jobs = MagicMock(return_value=jobs)
     clock.now = MagicMock(return_value=submit_datetime + timedelta(seconds=scale_down_timeout))
 
-    autoscaler.scale()
+    autoscaler.process_jobs()
 
     autoscaler.scale_down.assert_called_with(ADDITIONAL_HOST)
 
@@ -90,7 +90,7 @@ def test_not_scale_down_if_all_jobs_are_running_for_less_than_scale_down_timeout
     grid_engine.get_jobs = MagicMock(return_value=jobs)
     clock.now = MagicMock(return_value=submit_datetime + timedelta(seconds=scale_down_timeout - 1))
 
-    autoscaler.scale()
+    autoscaler.process_jobs()
 
     autoscaler.scale_down.assert_not_called()
 
@@ -110,7 +110,7 @@ def test_not_scale_down_if_all_jobs_are_running_for_more_than_scale_down_timeout
     grid_engine.get_jobs = MagicMock(return_value=jobs)
     clock.now = MagicMock(return_value=submit_datetime + timedelta(seconds=scale_down_timeout))
 
-    autoscaler.scale()
+    autoscaler.process_jobs()
 
     autoscaler.scale_down.assert_not_called()
 
@@ -135,7 +135,7 @@ def test_that_scale_down_only_stops_inactive_additional_hosts():
 
     for i in range(0, len(inactive_hosts) * 2):
         grid_engine.get_host_to_scale_down = MagicMock(return_value=inactive_hosts[i % 2])
-        autoscaler.scale()
+        autoscaler.process_jobs()
 
     for inactive_host in inactive_hosts:
         autoscaler.scale_down.assert_any_call(inactive_host)
@@ -164,7 +164,7 @@ def test_that_deadlock_can_be_resolved():
         autoscaler.host_storage.add_host(inactive_host)
 
     grid_engine.get_host_to_scale_down = MagicMock(return_value='inactive-host-1')
-    autoscaler.scale()
+    autoscaler.process_jobs()
 
     hosts = autoscaler.host_storage.load_hosts()
     assert len(hosts) == 2
@@ -186,7 +186,7 @@ def test_scale_down_if_there_are_no_pending_and_running_jobs_for_more_than_scale
     grid_engine.get_jobs = MagicMock(return_value=jobs)
     clock.now = MagicMock(return_value=submit_datetime)
 
-    autoscaler.scale()
+    autoscaler.process_jobs()
 
     autoscaler.scale_down.assert_not_called()
     hosts = autoscaler.host_storage.load_hosts()
@@ -196,7 +196,7 @@ def test_scale_down_if_there_are_no_pending_and_running_jobs_for_more_than_scale
     grid_engine.get_jobs = MagicMock(return_value=[])
     clock.now = MagicMock(return_value=submit_datetime + timedelta(seconds=scale_down_timeout))
 
-    autoscaler.scale()
+    autoscaler.process_jobs()
 
     autoscaler.scale_down.assert_called_with(ADDITIONAL_HOST)
     assert len(autoscaler.host_storage.load_hosts()) == 0
@@ -225,7 +225,7 @@ def test_not_scale_down_if_there_are_pending_jobs_and_running_jobs():
     grid_engine.get_jobs = MagicMock(return_value=jobs)
     clock.now = MagicMock(return_value=submit_datetime + timedelta(seconds=scale_down_timeout))
 
-    autoscaler.scale()
+    autoscaler.process_jobs()
 
     autoscaler.scale_down.assert_not_called()
 
@@ -244,7 +244,7 @@ def test_not_scale_down_if_there_are_pending_jobs_and_no_running_jobs_yet():
     grid_engine.get_jobs = MagicMock(return_value=jobs)
     clock.now = MagicMock(return_value=submit_datetime)
 
-    autoscaler.scale()
+    autoscaler.process_jobs()
 
     autoscaler.scale_down.assert_not_called()
 
@@ -265,7 +265,7 @@ def test_host_is_not_removed_from_storage_if_scaling_down_is_aborted():
     clock.now = MagicMock(return_value=submit_datetime + timedelta(seconds=scale_down_timeout))
     autoscaler.scale_down = MagicMock(return_value=False)
 
-    autoscaler.scale()
+    autoscaler.process_jobs()
 
     autoscaler.scale_down.assert_called()
     assert ADDITIONAL_HOST in autoscaler.host_storage.load_hosts()

--- a/workflows/pipe-common/test/test_scale_down_handler.py
+++ b/workflows/pipe-common/test/test_scale_down_handler.py
@@ -30,8 +30,9 @@ cmd_executor = Mock()
 grid_engine = Mock()
 default_hostfile = 'default_hostfile'
 instance_cores = 4
+common_utils = Mock()
 scale_down_handler = GridEngineScaleDownHandler(cmd_executor=cmd_executor, grid_engine=grid_engine,
-                                                default_hostfile=default_hostfile)
+                                                default_hostfile=default_hostfile, common_utils=common_utils)
 
 
 def setup_function():

--- a/workflows/pipe-common/test/test_scale_up.py
+++ b/workflows/pipe-common/test/test_scale_up.py
@@ -81,7 +81,7 @@ def test_scale_up_if_some_of_the_jobs_are_in_queue_for_more_than_scale_up_timeou
     grid_engine.get_resource_demands = MagicMock(return_value=demands)
     clock.now = MagicMock(return_value=submit_datetime + timedelta(seconds=scale_up_timeout))
 
-    autoscaler.scale()
+    autoscaler.process_jobs()
 
     autoscaler.scale_up.assert_called()
 
@@ -111,7 +111,7 @@ def test_not_scale_up_if_none_of_the_jobs_are_in_queue_for_more_than_scale_up_ti
     grid_engine.get_resource_demands = MagicMock(return_value=demands)
     clock.now = MagicMock(return_value=submit_datetime + timedelta(seconds=scale_up_timeout - 1))
 
-    autoscaler.scale()
+    autoscaler.process_jobs()
 
     autoscaler.scale_up.assert_not_called()
 
@@ -142,7 +142,7 @@ def test_that_scale_up_will_not_launch_more_additional_workers_than_limit():
     clock.now = MagicMock(return_value=submit_datetime + timedelta(seconds=scale_up_timeout))
 
     for _ in range(0, max_additional_hosts * 2):
-        autoscaler.scale()
+        autoscaler.process_jobs()
 
     assert autoscaler.scale_up.call_count == max_additional_hosts
     assert len(autoscaler.host_storage.load_hosts()) == max_additional_hosts
@@ -174,7 +174,7 @@ def test_that_scale_up_will_try_to_scale_down_smallest_host_if_additional_worker
     clock.now = MagicMock(return_value=submit_datetime + timedelta(seconds=scale_up_timeout))
 
     for _ in range(0, max_additional_hosts * 2):
-        autoscaler.scale()
+        autoscaler.process_jobs()
 
     assert autoscaler._scale_down.call_count == max_additional_hosts
     assert len(autoscaler.host_storage.load_hosts()) == max_additional_hosts
@@ -245,7 +245,7 @@ def test_scale_up_if_some_of_the_array_jobs_are_in_queue_for_more_than_scale_up_
     grid_engine.get_resource_demands = MagicMock(return_value=demands)
     clock.now = MagicMock(return_value=submit_datetime + timedelta(seconds=scale_up_timeout))
 
-    autoscaler.scale()
+    autoscaler.process_jobs()
 
     autoscaler.scale_up.assert_called()
 
@@ -315,7 +315,7 @@ def test_not_scale_up_if_none_of_the_array_jobs_are_in_queue_for_more_than_scale
     grid_engine.get_resource_demands = MagicMock(return_value=demands)
     clock.now = MagicMock(return_value=submit_datetime + timedelta(seconds=scale_up_timeout - 1))
 
-    autoscaler.scale()
+    autoscaler.process_jobs()
 
     autoscaler.scale_up.assert_not_called()
 
@@ -347,7 +347,7 @@ def test_not_scale_up_if_number_of_additional_workers_is_already_equals_to_the_l
     grid_engine.get_resource_demands = MagicMock(return_value=demands)
     clock.now = MagicMock(return_value=submit_datetime + timedelta(seconds=scale_up_timeout))
 
-    autoscaler.scale()
+    autoscaler.process_jobs()
 
     autoscaler.scale_up.assert_not_called()
 
@@ -419,6 +419,6 @@ def test_not_scale_up_if_number_of_additional_workers_is_already_equals_to_the_l
     grid_engine.get_resource_demands = MagicMock(return_value=demands)
     clock.now = MagicMock(return_value=submit_datetime + timedelta(seconds=scale_up_timeout))
 
-    autoscaler.scale()
+    autoscaler.process_jobs()
 
     autoscaler.scale_up.assert_not_called()

--- a/workflows/pipe-common/test/test_scale_up_handler.py
+++ b/workflows/pipe-common/test/test_scale_up_handler.py
@@ -16,7 +16,7 @@ import logging
 
 from mock import MagicMock, Mock
 
-from scripts.autoscale_sge import GridEngineScaleUpHandler, MemoryHostStorage, Instance, ScaleCommonUtils
+from scripts.autoscale_sge import GridEngineScaleUpHandler, MemoryHostStorage, Instance
 from utils import assert_first_argument_contained
 
 try:
@@ -51,14 +51,13 @@ instance = Instance(name='instance', price_type=price_type, cpu=4, memory=16, gp
 queue_name = 'main.q'
 hostlist = '@allhosts'
 run_id_queue = Queue()
-common_utils = ScaleCommonUtils(api=api)
 scale_up_handler = GridEngineScaleUpHandler(cmd_executor=cmd_executor, api=api, grid_engine=grid_engine,
                                             host_storage=host_storage, parent_run_id=parent_run_id,
                                             default_hostfile=default_hostfile,
                                             instance_disk=instance_disk, instance_image=instance_image,
                                             cmd_template=cmd_template, price_type=price_type,
                                             region_id=region_id, queue=queue_name, hostlist=hostlist,
-                                            owner_param_name=owner_param_name, common_utils=common_utils,
+                                            owner_param_name=owner_param_name,
                                             polling_timeout=polling_timeout, polling_delay=0)
 
 

--- a/workflows/pipe-common/test/test_scale_up_handler.py
+++ b/workflows/pipe-common/test/test_scale_up_handler.py
@@ -16,7 +16,7 @@ import logging
 
 from mock import MagicMock, Mock
 
-from scripts.autoscale_sge import GridEngineScaleUpHandler, MemoryHostStorage, Instance
+from scripts.autoscale_sge import GridEngineScaleUpHandler, MemoryHostStorage, Instance, ScaleCommonUtils
 from utils import assert_first_argument_contained
 
 try:
@@ -51,13 +51,14 @@ instance = Instance(name='instance', price_type=price_type, cpu=4, memory=16, gp
 queue_name = 'main.q'
 hostlist = '@allhosts'
 run_id_queue = Queue()
+common_utils = ScaleCommonUtils(api=api)
 scale_up_handler = GridEngineScaleUpHandler(cmd_executor=cmd_executor, api=api, grid_engine=grid_engine,
                                             host_storage=host_storage, parent_run_id=parent_run_id,
                                             default_hostfile=default_hostfile,
                                             instance_disk=instance_disk, instance_image=instance_image,
                                             cmd_template=cmd_template, price_type=price_type,
                                             region_id=region_id, queue=queue_name, hostlist=hostlist,
-                                            owner_param_name=owner_param_name,
+                                            owner_param_name=owner_param_name, common_utils=common_utils,
                                             polling_timeout=polling_timeout, polling_delay=0)
 
 

--- a/workflows/pipe-common/test/test_worker_validator.py
+++ b/workflows/pipe-common/test/test_worker_validator.py
@@ -33,8 +33,10 @@ host_storage = MemoryHostStorage()
 grid_engine = Mock()
 api = Mock()
 scale_down_handler = Mock()
+common_utils = Mock()
 worker_validator = GridEngineWorkerValidator(cmd_executor=executor, api=api, host_storage=host_storage,
-                                             grid_engine=grid_engine, scale_down_handler=scale_down_handler)
+                                             grid_engine=grid_engine, scale_down_handler=scale_down_handler,
+                                             common_utils=common_utils)
 
 
 def setup_function():
@@ -45,7 +47,7 @@ def setup_function():
     grid_engine.is_valid = MagicMock(side_effect=[True, False, True])
     grid_engine.get_jobs = MagicMock(return_value=[])
     grid_engine.kill_jobs = MagicMock()
-    scale_down_handler._get_run_id_from_host = MagicMock(side_effect=[HOST1_RUN_ID, HOST2_RUN_ID, HOST3_RUN_ID])
+    common_utils.get_run_id_from_host = MagicMock(side_effect=[HOST1_RUN_ID, HOST2_RUN_ID, HOST3_RUN_ID])
 
 
 def test_stopping_hosts_that_are_invalid_in_grid_engine():


### PR DESCRIPTION
The current PR provides implementation for issue #3159 

The following changes were added:
 - a new tag `SGE_IN_USE` is added for all active runs
 - `sge_setup_master` launches `autoscale_sge.py` for all cases (removed `CP_CAP_AUTOSCALE` flag restriction)