### PR TITLE
Possibility to start DCV session with custom init script

### DIFF
--- a/workflows/pipe-common/shell/nice_dcv_setup
+++ b/workflows/pipe-common/shell/nice_dcv_setup
@@ -117,12 +117,14 @@ EOF
 }
 
 function configure_dcv_extras {
+mkdir -p /opt/dcv/extras
 cat <<EOF >>/opt/dcv/extras/xfce4launch
 #!/bin/bash
 mkdir -p ~/.config/xfce4/xfconf/xfce-perchannel-xml
 cp /etc/xdg/xfce4/panel/default.xml ~/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
 startxfce4
 EOF
+chmod +x /opt/dcv/extras/xfce4launch
 }
 
 function run_dcv {
@@ -152,8 +154,10 @@ function run_dcv {
       exit 1
   fi
 
+  CP_DCV_INIT_SCRIPT="${CP_DCV_INIT_SCRIPT:-/opt/dcv/extras/xfce4launch}"
   if [ "$CP_DCV_INIT_SCRIPT" ]; then
-      export CP_DCV_INIT_SCRIPT="--init $CP_DCV_INIT_SCRIPT"
+      CP_DCV_INIT_SCRIPT="--init $CP_DCV_INIT_SCRIPT"
+      pipe_log_info "Using \"$CP_DCV_INIT_SCRIPT\" initialization script for a DCV session" "$DCV_INSTALL_TASK"
   fi
   dcv create-session --owner $OWNER --user $OWNER $CP_DCV_INIT_SCRIPT session
 

--- a/workflows/pipe-common/shell/nice_dcv_setup
+++ b/workflows/pipe-common/shell/nice_dcv_setup
@@ -116,6 +116,15 @@ primary-selection-paste=true
 EOF
 }
 
+function configure_dcv_extras {
+cat <<EOF >>/opt/dcv/extras/xfce4launch
+#!/bin/bash
+mkdir -p ~/.config/xfce4/xfconf/xfce-perchannel-xml
+cp /etc/xdg/xfce4/panel/default.xml ~/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
+startxfce4
+EOF
+}
+
 function run_dcv {
   pipe_log_info "Starting DCV server and waiting for boot up" "$DCV_INSTALL_TASK"
   if [[ "$IS_RPM_BASED" = 0 ]]; then
@@ -143,7 +152,10 @@ function run_dcv {
       exit 1
   fi
 
-  dcv create-session --owner $OWNER --user $OWNER session
+  if [ "$CP_DCV_INIT_SCRIPT" ]; then
+      export CP_DCV_INIT_SCRIPT="--init $CP_DCV_INIT_SCRIPT"
+  fi
+  dcv create-session --owner $OWNER --user $OWNER $CP_DCV_INIT_SCRIPT session
 
   # Serve additional server to provide dcv desktop session file
   if [ -n "${CP_DCV_DESKTOP_PORT}" ]; then
@@ -199,7 +211,8 @@ if [ $IS_DCV_INSTALLED -eq 0 ]; then
 else
    install_prerequisites && \
    install_dcv && \
-   configure_dcv
+   configure_dcv && \
+   configure_dcv_extras
 
    if [ $? -ne 0 ]; then
     pipe_log_fail "[ERROR] DCV installation failed. Exiting" "$DCV_INSTALL_TASK"
@@ -209,4 +222,3 @@ fi
 
 run_dcv
 pipe_log_success "[INFO] DCV server is ready." "$DCV_INSTALL_TASK"
-


### PR DESCRIPTION
Now it is possible to specify custom init script within `CP_DCV_INIT_SCRIPT`
Such feature can be useful f.e. to start another GUI environment instead of default one.
It also includes one `extras` script `/opt/dcv/extras/xfce4launch` to start xfce4 GUI on startup. To do that user will need to specify parameter `CP_DCV_INIT_SCRIPT` as `/opt/dcv/extras/xfce4launch`