### PR TITLE
Issue #3030: Data transition notifications shall be optionally sent to all users with R/W access to the storage

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/lifecycle/DataStorageLifecycleRestoreManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/lifecycle/DataStorageLifecycleRestoreManager.java
@@ -82,7 +82,8 @@ public class DataStorageLifecycleRestoreManager {
         final StorageRestoreActionNotification notification = request.getNotification();
         final boolean notificationFormedCorrectly = notification != null
                 && (BooleanUtils.isFalse(notification.getEnabled())
-                || CollectionUtils.isNotEmpty(notification.getRecipients()));
+                || CollectionUtils.isNotEmpty(notification.getRecipients())
+                || BooleanUtils.isTrue(notification.getNotifyUsers()));
         Assert.state(notificationFormedCorrectly,
                 messageHelper.getMessage(
                         MessageConstants.ERROR_DATASTORAGE_LIFECYCLE_RESTORE_NOTIFICATION_CONFIGURED_INCORRECTLY));

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -313,7 +313,7 @@ debug.datastorage.lifecycle.existing.restore=Restore action that already exists:
 error.datastorage.lifecycle.path.already.restored=Files in storage {0} under the path {1} already in restored status. If you still want to update restore for this folder, please use flag 'force'
 error.datastorage.lifecycle.restore.action.not.found=Cannot find restore action for storage by id: {0}
 error.datastorage.lifecycle.restore.in.final.status=Cannot update action, it is in a terminal status!
-error.datastorage.lifecycle.restore.rule.cant.parse.notification=Restore notification object should be provided and either notification should be disabled or recipients should be specified!
+error.datastorage.lifecycle.restore.rule.cant.parse.notification=Restore notification object should be provided and either notification should be disabled or recipients should be specified or users notifications shall be enabled!
 error.datastirage.lifecycle.rule.notification.recipients.not.provided=Recipients should be provided!
 
 


### PR DESCRIPTION
The current PR provides fix for issue #3030 - do not fail restore if notification enabled without recipients but user notifications requested. 