### PR TITLE
Introduce instance start date in api and billing

### DIFF
--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
@@ -835,7 +835,8 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
         SENSITIVE,
         KUBE_SERVICE_ENABLED,
         CLUSTER_PRICE,
-        NODE_POOL_ID;
+        NODE_POOL_ID,
+        NODE_START_DATE;
 
         public static final RunAccessType DEFAULT_ACCESS_TYPE = RunAccessType.ENDPOINT;
 
@@ -903,6 +904,7 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
                     instance.map(RunInstance::getCloudProvider).map(CloudProvider::name).orElse(null));
             params.addValue(NODE_PLATFORM.name(), instance.map(RunInstance::getNodePlatform).orElse(null));
             params.addValue(NODE_POOL_ID.name(), instance.map(RunInstance::getPoolId).orElse(null));
+            params.addValue(NODE_START_DATE.name(), instance.map(RunInstance::getStartDate).orElse(null));
         }
 
         static ResultSetExtractor<Collection<PipelineRun>> getRunGroupExtractor() {
@@ -985,6 +987,10 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
             instance.setCloudProvider(CloudProvider.valueOf(rs.getString(NODE_CLOUD_PROVIDER.name())));
             instance.setNodePlatform(rs.getString(NODE_PLATFORM.name()));
             instance.setPoolId(rs.getLong(NODE_POOL_ID.name()));
+            Timestamp instanceStart = rs.getTimestamp(NODE_START_DATE.name());
+            if (!rs.wasNull()) {
+                instance.setStartDate(new Date(instanceStart.getTime()));
+            }
 
             boolean spot = rs.getBoolean(IS_SPOT.name());
             if (!rs.wasNull()) {

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/InstanceOfferManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/InstanceOfferManager.java
@@ -39,6 +39,7 @@ import com.epam.pipeline.manager.preference.AbstractSystemPreference;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.manager.region.CloudRegionManager;
+import com.epam.pipeline.utils.RunDurationUtils;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import org.apache.commons.collections4.ListUtils;
@@ -143,7 +144,7 @@ public class InstanceOfferManager {
             long maximumDuration = -1;
             long totalDurations = 0;
             for (PipelineRun run : runs) {
-                long duration = run.getEndDate().getTime() - run.getStartDate().getTime();
+                long duration = RunDurationUtils.getBillableDuration(run).toMillis();
                 if (minimumDuration == -1 || minimumDuration > duration) {
                     minimumDuration = duration;
                 }
@@ -191,8 +192,7 @@ public class InstanceOfferManager {
         price.setPricePerHour(pricePerHour);
 
         if (pipelineRun.getStatus().isFinal()) {
-            long duration = pipelineRun.getEndDate().getTime() - pipelineRun.getStartDate().getTime();
-            price.setTotalPrice(duration / ONE_HOUR * pricePerHour);
+            price.setTotalPrice(RunDurationUtils.getBillableDuration(pipelineRun).toMillis() / ONE_HOUR * pricePerHour);
         } else {
             price.setTotalPrice(0);
         }

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/PodMonitor.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/PodMonitor.java
@@ -41,6 +41,7 @@ import com.epam.pipeline.manager.pipeline.ToolManager;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.manager.scheduling.AbstractSchedulingManager;
+import com.epam.pipeline.utils.RunDurationUtils;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.Node;
 import io.fabric8.kubernetes.api.model.Pod;
@@ -292,7 +293,7 @@ public class PodMonitor extends AbstractSchedulingManager {
         }
 
         private long overallDurationOf(final PipelineRun run) {
-            return Duration.between(run.getStartDate().toInstant(), DateUtils.now().toInstant()).abs().getSeconds();
+            return RunDurationUtils.getOverallDuration(run).getSeconds();
         }
 
         private List<RunStatus> toSortedStatuses(final List<RunStatus> statuses) {

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/AutoscaleManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/AutoscaleManager.java
@@ -491,9 +491,9 @@ public class AutoscaleManager extends AbstractSchedulingManager {
                 pipelineRunManager.updateRunInstance(longId, requiredInstance.getInstance());
                 RunInstance instance = cloudFacade
                         .scaleUpNode(longId, requiredInstance.getInstance(), requiredInstance.getRuntimeParameters());
-                instance.setStartDate(DateUtils.now());
-                //save actual instance
+                //save instance ID and IP
                 pipelineRunManager.updateRunInstance(longId, instance);
+                pipelineRunManager.updateRunInstanceStartDate(longId, DateUtils.nowUTC());
                 autoscalerService.registerDisks(longId, instance);
                 Instant end = Instant.now();
                 removeNodeUpTask(longId);

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/AutoscaleManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/AutoscaleManager.java
@@ -25,6 +25,7 @@ import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.epam.pipeline.entity.pipeline.run.parameter.PipelineRunParameter;
 import com.epam.pipeline.entity.pipeline.run.parameter.RuntimeParameter;
 import com.epam.pipeline.entity.pipeline.run.parameter.RuntimeParameterType;
+import com.epam.pipeline.entity.utils.DateUtils;
 import com.epam.pipeline.exception.CmdExecutionException;
 import com.epam.pipeline.exception.git.GitClientException;
 import com.epam.pipeline.manager.cloud.CloudFacade;
@@ -490,7 +491,8 @@ public class AutoscaleManager extends AbstractSchedulingManager {
                 pipelineRunManager.updateRunInstance(longId, requiredInstance.getInstance());
                 RunInstance instance = cloudFacade
                         .scaleUpNode(longId, requiredInstance.getInstance(), requiredInstance.getRuntimeParameters());
-                //save instance ID and IP
+                instance.setStartDate(DateUtils.now());
+                //save actual instance
                 pipelineRunManager.updateRunInstance(longId, instance);
                 autoscalerService.registerDisks(longId, instance);
                 Instant end = Instant.now();

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/AutoscalerServiceImpl.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/AutoscalerServiceImpl.java
@@ -164,7 +164,7 @@ public class AutoscalerServiceImpl implements AutoscalerService {
     private void registerNodeDisks(long runId, List<InstanceDisk> disks) {
         PipelineRun run = runCRUDService.loadRunById(runId);
         String nodeId = run.getInstance().getNodeId();
-        LocalDateTime creationDate = DateUtils.convertDateToLocalDateTime(run.getStartDate());
+        LocalDateTime creationDate = run.getInstanceStartDateTime();
         List<DiskRegistrationRequest> requests = DiskRegistrationRequest.from(disks);
         nodeDiskManager.register(nodeId, creationDate, requests);
     }

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/AutoscalerServiceImpl.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/AutoscalerServiceImpl.java
@@ -23,7 +23,6 @@ import com.epam.pipeline.entity.cluster.pool.RunningInstance;
 import com.epam.pipeline.entity.configuration.PipelineConfiguration;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.RunInstance;
-import com.epam.pipeline.entity.utils.DateUtils;
 import com.epam.pipeline.manager.cloud.CloudFacade;
 import com.epam.pipeline.manager.cluster.KubernetesConstants;
 import com.epam.pipeline.manager.cluster.NodeDiskManager;

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/ReassignHandler.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/ReassignHandler.java
@@ -24,6 +24,7 @@ import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.PoolInstanceF
 import com.epam.pipeline.entity.cluster.pool.filter.instancefilter.PoolInstanceFilterType;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.RunInstance;
+import com.epam.pipeline.entity.utils.DateUtils;
 import com.epam.pipeline.manager.cloud.CloudFacade;
 import com.epam.pipeline.manager.cluster.KubernetesConstants;
 import com.epam.pipeline.manager.cluster.autoscale.filter.PoolFilterHandler;
@@ -183,6 +184,7 @@ public class ReassignHandler {
         final RunInstance reassignedInstance = StringUtils.isBlank(instance.getNodeId()) ?
                 cloudFacade.describeInstance(runId, instance) : instance;
         reassignedInstance.setPoolId(instance.getPoolId());
+        reassignedInstance.setStartDate(DateUtils.now());
         pipelineRunManager.updateRunInstance(runId, reassignedInstance);
         final List<InstanceDisk> disks = cloudFacade.loadDisks(reassignedInstance.getCloudRegionId(),
                 runId);

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/ReassignHandler.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/ReassignHandler.java
@@ -184,8 +184,8 @@ public class ReassignHandler {
         final RunInstance reassignedInstance = StringUtils.isBlank(instance.getNodeId()) ?
                 cloudFacade.describeInstance(runId, instance) : instance;
         reassignedInstance.setPoolId(instance.getPoolId());
-        reassignedInstance.setStartDate(DateUtils.now());
         pipelineRunManager.updateRunInstance(runId, reassignedInstance);
+        pipelineRunManager.updateRunInstanceStartDate(runId, DateUtils.nowUTC());
         final List<InstanceDisk> disks = cloudFacade.loadDisks(reassignedInstance.getCloudRegionId(),
                 runId);
         autoscalerService.adjustRunPrices(runId, disks);

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/costs/ClusterCostsMonitoringServiceCore.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/costs/ClusterCostsMonitoringServiceCore.java
@@ -17,9 +17,9 @@
 package com.epam.pipeline.manager.cluster.costs;
 
 import com.epam.pipeline.entity.pipeline.PipelineRun;
-import com.epam.pipeline.entity.utils.DateUtils;
 import com.epam.pipeline.manager.pipeline.PipelineRunCRUDService;
 import com.epam.pipeline.manager.pipeline.PipelineRunManager;
+import com.epam.pipeline.utils.RunDurationUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.core.SchedulerLock;
@@ -28,11 +28,9 @@ import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -79,17 +77,7 @@ public class ClusterCostsMonitoringServiceCore {
             return BigDecimal.ZERO;
         }
         return run.getPricePerHour()
-                .multiply(durationInMinutes(run))
+                .multiply(BigDecimal.valueOf(RunDurationUtils.getBillableDuration(run).toMinutes()))
                 .divide(BigDecimal.valueOf(MINUTES_IN_HOUR), DIVIDE_SCALE, RoundingMode.HALF_UP);
-    }
-
-    private BigDecimal durationInMinutes(final PipelineRun run) {
-        if (Objects.isNull(run.getStartDate())) {
-            return BigDecimal.ZERO;
-        }
-
-        final Date pipelineEnd = Objects.isNull(run.getEndDate()) ? DateUtils.now() : run.getEndDate();
-        final long runDurationMs = pipelineEnd.getTime() - run.getStartDate().getTime();
-        return new BigDecimal(TimeUnit.MINUTES.convert(runDurationMs, TimeUnit.MILLISECONDS));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -628,6 +628,11 @@ public class PipelineRunManager {
     }
 
     @Transactional(propagation = Propagation.REQUIRED)
+    public void updateRunInstanceStartDate(Long id, LocalDateTime date) {
+        pipelineRunDao.updateRunInstanceStartDate(id, date);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED)
     public PipelineRun updatePipelineStatusIfNotFinalExternal(Long runId, TaskStatus status) {
         return updatePipelineStatusIfNotFinal(runId, status);
     }

--- a/api/src/main/java/com/epam/pipeline/mapper/PipelineRunMapper.java
+++ b/api/src/main/java/com/epam/pipeline/mapper/PipelineRunMapper.java
@@ -16,12 +16,11 @@
 
 package com.epam.pipeline.mapper;
 
-import java.time.Duration;
 import java.util.Map;
 
 import com.epam.pipeline.config.JsonMapper;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
-import com.epam.pipeline.entity.utils.DateUtils;
+import com.epam.pipeline.utils.RunDurationUtils;
 import org.apache.commons.lang3.StringUtils;
 
 public final class PipelineRunMapper {
@@ -64,6 +63,6 @@ public final class PipelineRunMapper {
     }
 
     private static long overallDurationOf(PipelineRun run) {
-        return Duration.between(run.getStartDate().toInstant(), DateUtils.now().toInstant()).abs().getSeconds();
+        return RunDurationUtils.getOverallDuration(run).getSeconds();
     }
 }

--- a/api/src/main/java/com/epam/pipeline/utils/RunDurationUtils.java
+++ b/api/src/main/java/com/epam/pipeline/utils/RunDurationUtils.java
@@ -1,0 +1,25 @@
+package com.epam.pipeline.utils;
+
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.utils.DateUtils;
+
+import java.time.Duration;
+import java.util.Date;
+import java.util.Optional;
+
+public class RunDurationUtils {
+
+    public static Duration getOverallDuration(final PipelineRun run) {
+        return durationBetween(run.getStartDate(), run.getEndDate());
+    }
+
+    public static Duration getBillableDuration(final PipelineRun run) {
+        return durationBetween(run.getInstanceStartDate(), run.getEndDate());
+    }
+
+    private static Duration durationBetween(final Date from, final Date to) {
+        final Date end = Optional.ofNullable(to).orElseGet(DateUtils::now);
+        final Date start = Optional.ofNullable(from).orElse(end);
+        return Duration.ofMillis(end.getTime() - start.getTime()).abs();
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/utils/RunDurationUtils.java
+++ b/api/src/main/java/com/epam/pipeline/utils/RunDurationUtils.java
@@ -7,7 +7,10 @@ import java.time.Duration;
 import java.util.Date;
 import java.util.Optional;
 
-public class RunDurationUtils {
+public final class RunDurationUtils {
+
+    private RunDurationUtils() {
+    }
 
     public static Duration getOverallDuration(final PipelineRun run) {
         return durationBetween(run.getStartDate(), run.getEndDate());

--- a/api/src/main/resources/dao/filter-dao.xml
+++ b/api/src/main/resources/dao/filter-dao.xml
@@ -74,7 +74,8 @@
                         r.kube_service_enabled,
                         r.pipeline_name,
                         r.cluster_price,
-                        r.node_pool_id
+                        r.node_pool_id,
+                        r.node_start_date
                     FROM
                         pipeline.pipeline_run r
                     WHERE @WHERE@

--- a/api/src/main/resources/dao/pipeline-run-dao.xml
+++ b/api/src/main/resources/dao/pipeline-run-dao.xml
@@ -454,11 +454,20 @@
                         node_id = :NODE_ID,
                         node_disk = :NODE_DISK,
                         node_ip = :NODE_IP,
-                        node_image =:NODE_IMAGE,
-                        node_name =:NODE_NAME,
-                        is_spot =:IS_SPOT,
-                        node_real_disk =:NODE_REAL_DISK,
-                        node_pool_id = :NODE_POOL_ID,
+                        node_image = :NODE_IMAGE,
+                        node_name = :NODE_NAME,
+                        is_spot = :IS_SPOT,
+                        node_real_disk = :NODE_REAL_DISK,
+                        node_pool_id = :NODE_POOL_ID
+                    WHERE
+                        run_id = :RUN_ID
+                ]]>
+            </value>
+        </property>
+        <property name="updateRunInstanceStartDateQuery">
+            <value>
+                <![CDATA[
+                    UPDATE pipeline.pipeline_run SET
                         node_start_date = :NODE_START_DATE
                     WHERE
                         run_id = :RUN_ID

--- a/api/src/main/resources/dao/pipeline-run-dao.xml
+++ b/api/src/main/resources/dao/pipeline-run-dao.xml
@@ -73,7 +73,8 @@
                         node_cloud_provider,
                         tags,
                         sensitive,
-                        pipeline_name)
+                        pipeline_name,
+                        node_start_date)
                     VALUES (
                         :RUN_ID,
                         :PIPELINE_ID,
@@ -124,7 +125,8 @@
                         :NODE_CLOUD_PROVIDER,
                         to_jsonb(:TAGS::jsonb),
                         :SENSITIVE,
-                        :PIPELINE_NAME)
+                        :PIPELINE_NAME,
+                        :NODE_START_DATE)
                 ]]>
             </value>
         </property>
@@ -184,6 +186,7 @@
                         r.cluster_price,
                         r.pipeline_name,
                         r.node_pool_id,
+                        r.node_start_date,
                         CASE
                             WHEN EXISTS (
                                 SELECT 1 FROM pipeline.pipeline_run_log init_tasks
@@ -277,7 +280,8 @@
                         kube_service_enabled,
                         pipeline_name,
                         cluster_price,
-                        node_pool_id
+                        node_pool_id,
+                        node_start_date
                     FROM
                         pipeline.pipeline_run
                     WHERE
@@ -342,7 +346,8 @@
                         kube_service_enabled,
                         pipeline_name,
                         cluster_price,
-                        node_pool_id
+                        node_pool_id,
+                        node_start_date
                     FROM
                         pipeline.pipeline_run
                     WHERE
@@ -407,7 +412,8 @@
                         kube_service_enabled,
                         pipeline_name,
                         cluster_price,
-                        node_pool_id
+                        node_pool_id,
+                        node_start_date
                     FROM
                         pipeline.pipeline_run
                     WHERE
@@ -452,7 +458,8 @@
                         node_name =:NODE_NAME,
                         is_spot =:IS_SPOT,
                         node_real_disk =:NODE_REAL_DISK,
-                        node_pool_id = :NODE_POOL_ID
+                        node_pool_id = :NODE_POOL_ID,
+                        node_start_date = :NODE_START_DATE
                     WHERE
                         run_id = :RUN_ID
                 ]]>
@@ -509,7 +516,8 @@
                         tags = to_jsonb(:TAGS::jsonb),
                         sensitive = :SENSITIVE,
                         kube_service_enabled = :KUBE_SERVICE_ENABLED,
-                        pipeline_name = :PIPELINE_NAME
+                        pipeline_name = :PIPELINE_NAME,
+                        node_start_date = :NODE_START_DATE
                     WHERE
                         run_id = :RUN_ID
                 ]]>
@@ -615,7 +623,8 @@
                       FALSE as queued,
                       r.pipeline_name,
                       r.cluster_price,
-                      r.node_pool_id
+                      r.node_pool_id,
+                      r.node_start_date
                     FROM
                       pipeline.pipeline_run r
                     WHERE
@@ -681,7 +690,8 @@
                       FALSE as queued,
                       r.pipeline_name,
                       r.cluster_price,
-                      r.node_pool_id
+                      r.node_pool_id,
+                      r.node_start_date
                     FROM
                       pipeline.pipeline_run r
                     WHERE
@@ -746,6 +756,7 @@
                       r.pipeline_name,
                       r.cluster_price,
                       r.node_pool_id,
+                      r.node_start_date,
                       CASE
                         WHEN EXISTS (
                             SELECT 1 FROM pipeline.pipeline_run_service_url su
@@ -811,6 +822,7 @@
                       active_run.pipeline_name,
                       active_run.cluster_price,
                       active_run.node_pool_id,
+                      active_run.node_start_date,
                       CASE
                         WHEN EXISTS (
                             SELECT 1 FROM pipeline.pipeline_run_service_url su
@@ -887,6 +899,7 @@
                       r.sensitive,
                       r.pipeline_name,
                       r.node_pool_id,
+                      r.node_start_date,
                       CASE
                         WHEN EXISTS (
                             SELECT 1 FROM pipeline.pipeline_run_service_url su
@@ -949,6 +962,7 @@
                       active_run.sensitive,
                       active_run.pipeline_name,
                       active_run.node_pool_id,
+                      active_run.node_start_date,
                       CASE
                         WHEN EXISTS (
                             SELECT 1 FROM pipeline.pipeline_run_service_url su
@@ -1024,7 +1038,8 @@
                         r.kube_service_enabled,
                         r.pipeline_name,
                         r.cluster_price,
-                        r.node_pool_id
+                        r.node_pool_id,
+                        r.node_start_date
                     FROM
                         pipeline.pipeline_run r
                     WHERE
@@ -1087,7 +1102,8 @@
                         r.kube_service_enabled,
                         r.pipeline_name,
                         r.cluster_price,
-                        r.node_pool_id
+                        r.node_pool_id,
+                        r.node_start_date
                     FROM
                         pipeline.pipeline_run r
                     WHERE
@@ -1151,6 +1167,7 @@
                         r.pipeline_name,
                         r.cluster_price,
                         r.node_pool_id,
+                        r.node_start_date,
                         CASE
                             WHEN EXISTS (
                                 SELECT 1 FROM pipeline.pipeline_run_log init_tasks
@@ -1240,6 +1257,7 @@
                         runs.kube_service_enabled,
                         runs.cluster_price,
                         runs.node_pool_id,
+                        runs.node_start_date,
                         CASE
                             WHEN EXISTS (
                                 SELECT 1 FROM pipeline.pipeline_run_log init_tasks
@@ -1318,7 +1336,8 @@
                             p.kube_service_enabled,
                             p.pipeline_name,
                             p.cluster_price,
-                            p.node_pool_id
+                            p.node_pool_id,
+                            p.node_start_date
                         FROM (SELECT *
                             FROM pipeline.pipeline_run r
                             WHERE parent_id ISNULL @WHERE@
@@ -1377,7 +1396,8 @@
                             c.kube_service_enabled,
                             c.pipeline_name,
                             c.cluster_price,
-                            c.node_pool_id
+                            c.node_pool_id,
+                            c.node_start_date
                         FROM
                             pipeline.pipeline_run c
                         INNER JOIN runs ON runs.run_id = c.parent_id
@@ -1434,6 +1454,7 @@
                         runs.kube_service_enabled,
                         runs.cluster_price,
                         runs.node_pool_id,
+                        runs.node_start_date
                         CASE
                             WHEN EXISTS (
                                 SELECT 1 FROM pipeline.pipeline_run_log init_tasks
@@ -1510,6 +1531,7 @@
                         r.pipeline_name,
                         r.cluster_price,
                         r.node_pool_id,
+                        r.node_start_date,
                         (
                             SELECT count(*)
                             FROM pipeline.pipeline_run cr
@@ -1674,7 +1696,8 @@
                         kube_service_enabled,
                         pipeline_name,
                         cluster_price,
-                        node_pool_id
+                        node_pool_id,
+                        node_start_date
                     FROM
                         pipeline.pipeline_run r
                     INNER JOIN (SELECT DISTINCT ON (run_id) run_id, status
@@ -1753,7 +1776,8 @@
                         kube_service_enabled,
                         pipeline_name,
                         cluster_price,
-                        node_pool_id
+                        node_pool_id,
+                        node_start_date
                     FROM
                         pipeline.pipeline_run
                     WHERE
@@ -1818,7 +1842,8 @@
                         kube_service_enabled,
                         pipeline_name,
                         cluster_price,
-                        node_pool_id
+                        node_pool_id,
+                        node_start_date
                     FROM
                         pipeline.pipeline_run
                     WHERE
@@ -1883,7 +1908,8 @@
                         kube_service_enabled,
                         pipeline_name,
                         cluster_price,
-                        node_pool_id
+                        node_pool_id,
+                        node_start_date
                     FROM
                         pipeline.pipeline_run
                     WHERE
@@ -1948,7 +1974,8 @@
                         kube_service_enabled,
                         pipeline_name,
                         cluster_price,
-                        node_pool_id
+                        node_pool_id,
+                        node_start_date
                     FROM
                         pipeline.pipeline_run
                     WHERE
@@ -2023,7 +2050,8 @@
                         kube_service_enabled,
                         pipeline_name,
                         cluster_price,
-                        node_pool_id
+                        node_pool_id,
+                        node_start_date
                     FROM
                         pipeline.pipeline_run
                     WHERE
@@ -2088,7 +2116,8 @@
                         kube_service_enabled,
                         pipeline_name,
                         cluster_price,
-                        node_pool_id
+                        node_pool_id,
+                        node_start_date
                     FROM
                         pipeline.pipeline_run
                     WHERE

--- a/api/src/main/resources/db/migration/v2023.04.13_14.00__issue_3201_run_instance_start_date.sql
+++ b/api/src/main/resources/db/migration/v2023.04.13_14.00__issue_3201_run_instance_start_date.sql
@@ -1,0 +1,2 @@
+ALTER TABLE pipeline.pipeline_run ADD COLUMN node_start_date TIMESTAMP WITH TIME ZONE;
+UPDATE pipeline.pipeline_run SET node_start_date = start_date;

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
@@ -921,6 +921,56 @@ public class PipelineRunDaoTest extends AbstractJdbcTest {
     }
 
     @Test
+    public void shouldCreatePipelineRunWithStartedDate() {
+        final PipelineRun run = buildPipelineRun(testPipeline.getId());
+        pipelineRunDao.createPipelineRun(run);
+
+        final PipelineRun loadedRun = pipelineRunDao.loadPipelineRun(run.getId());
+        assertNotNull(loadedRun.getStartDate());
+    }
+
+    @Test
+    public void shouldCreatePipelineRunWithEndedDate() {
+        final PipelineRun run = buildPipelineRun(testPipeline.getId());
+        pipelineRunDao.createPipelineRun(run);
+
+        final PipelineRun loadedRun = pipelineRunDao.loadPipelineRun(run.getId());
+        assertNotNull(loadedRun.getEndDate());
+    }
+
+    @Test
+    public void shouldCreatePipelineRunWithInstanceStartedDate() {
+        final PipelineRun run = buildPipelineRun(testPipeline.getId());
+        pipelineRunDao.createPipelineRun(run);
+
+        final PipelineRun loadedRun = pipelineRunDao.loadPipelineRun(run.getId());
+        assertNotNull(loadedRun.getInstance().getStartDate());
+    }
+
+    @Test
+    public void shouldCreatePipelineRunWithoutInstanceStartedDate() {
+        final PipelineRun run = buildPipelineRun(testPipeline.getId());
+        run.getInstance().setStartDate(null);
+        pipelineRunDao.createPipelineRun(run);
+
+        final PipelineRun loadedRun = pipelineRunDao.loadPipelineRun(run.getId());
+        assertNull(loadedRun.getInstance().getStartDate());
+    }
+
+    @Test
+    public void shouldUpdatePipelineRunInstanceWithInstanceStartedDate() {
+        final PipelineRun run = buildPipelineRun(testPipeline.getId());
+        run.getInstance().setStartDate(null);
+        pipelineRunDao.createPipelineRun(run);
+
+        run.getInstance().setStartDate(run.getStartDate());
+        pipelineRunDao.updateRunInstance(run);
+
+        final PipelineRun loadedRun = pipelineRunDao.loadPipelineRun(run.getId());
+        assertNotNull(loadedRun.getInstance().getStartDate());
+    }
+
+    @Test
     public void shouldBatchUpdateRuns() {
         final PipelineRun run1 = buildPipelineRun(testPipeline.getId());
         final PipelineRun run2 = buildPipelineRun(testPipeline.getId());
@@ -1105,6 +1155,7 @@ public class PipelineRunDaoTest extends AbstractJdbcTest {
         runInstance.setCloudProvider(CloudProvider.AWS);
         runInstance.setCloudRegionId(cloudRegion.getId());
         runInstance.setNodePlatform(TEST_PLATFORM);
+        runInstance.setStartDate(run.getStartDate());
         run.setInstance(runInstance);
     }
 
@@ -1183,6 +1234,7 @@ public class PipelineRunDaoTest extends AbstractJdbcTest {
         instance.setSpot(isSpot);
         instance.setNodeId("1");
         instance.setNodePlatform(TEST_PLATFORM);
+        instance.setStartDate(run.getStartDate());
         run.setInstance(instance);
         run.setEntitiesIds(Collections.singletonList(entitiesId));
         run.setConfigurationId(configurationId);

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
@@ -944,30 +944,29 @@ public class PipelineRunDaoTest extends AbstractJdbcTest {
         pipelineRunDao.createPipelineRun(run);
 
         final PipelineRun loadedRun = pipelineRunDao.loadPipelineRun(run.getId());
-        assertNotNull(loadedRun.getInstance().getStartDate());
+        assertNotNull(loadedRun.getInstanceStartDateTime());
     }
 
     @Test
     public void shouldCreatePipelineRunWithoutInstanceStartedDate() {
         final PipelineRun run = buildPipelineRun(testPipeline.getId());
-        run.getInstance().setStartDate(null);
+        run.setInstanceStartDate(null);
         pipelineRunDao.createPipelineRun(run);
 
         final PipelineRun loadedRun = pipelineRunDao.loadPipelineRun(run.getId());
-        assertNull(loadedRun.getInstance().getStartDate());
+        assertNull(loadedRun.getInstanceStartDateTime());
     }
 
     @Test
-    public void shouldUpdatePipelineRunInstanceWithInstanceStartedDate() {
+    public void shouldUpdatePipelineRunInstanceStartDateWithInstanceStartedDate() {
         final PipelineRun run = buildPipelineRun(testPipeline.getId());
-        run.getInstance().setStartDate(null);
+        run.setInstanceStartDate(null);
         pipelineRunDao.createPipelineRun(run);
 
-        run.getInstance().setStartDate(run.getStartDate());
-        pipelineRunDao.updateRunInstance(run);
+        pipelineRunDao.updateRunInstanceStartDate(run.getId(), DateUtils.nowUTC());
 
         final PipelineRun loadedRun = pipelineRunDao.loadPipelineRun(run.getId());
-        assertNotNull(loadedRun.getInstance().getStartDate());
+        assertNotNull(loadedRun.getInstanceStartDateTime());
     }
 
     @Test
@@ -1133,6 +1132,7 @@ public class PipelineRunDaoTest extends AbstractJdbcTest {
         run.setPipelineName(TEST_PIPELINE_NAME);
         run.setVersion("abcdefg");
         run.setStartDate(start);
+        run.setInstanceStartDate(start);
         run.setEndDate(end);
         run.setStatus(TaskStatus.RUNNING);
         run.setCommitStatus(CommitStatus.NOT_COMMITTED);
@@ -1155,7 +1155,6 @@ public class PipelineRunDaoTest extends AbstractJdbcTest {
         runInstance.setCloudProvider(CloudProvider.AWS);
         runInstance.setCloudRegionId(cloudRegion.getId());
         runInstance.setNodePlatform(TEST_PLATFORM);
-        runInstance.setStartDate(run.getStartDate());
         run.setInstance(runInstance);
     }
 
@@ -1217,6 +1216,7 @@ public class PipelineRunDaoTest extends AbstractJdbcTest {
         run.setPipelineId(pipelineId);
         run.setVersion(TEST_REVISION_1);
         run.setStartDate(new Date());
+        run.setInstanceStartDate(run.getStartDate());
         run.setEndDate(new Date());
         run.setStatus(status);
         run.setCommitStatus(CommitStatus.NOT_COMMITTED);
@@ -1234,7 +1234,6 @@ public class PipelineRunDaoTest extends AbstractJdbcTest {
         instance.setSpot(isSpot);
         instance.setNodeId("1");
         instance.setNodePlatform(TEST_PLATFORM);
-        instance.setStartDate(run.getStartDate());
         run.setInstance(instance);
         run.setEntitiesIds(Collections.singletonList(entitiesId));
         run.setConfigurationId(configurationId);

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/costs/ClusterCostsMonitoringServiceCoreTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/costs/ClusterCostsMonitoringServiceCoreTest.java
@@ -16,6 +16,7 @@
 package com.epam.pipeline.manager.cluster.costs;
 
 import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.utils.DateUtils;
 import com.epam.pipeline.manager.pipeline.PipelineRunCRUDService;
 import com.epam.pipeline.manager.pipeline.PipelineRunManager;
@@ -44,13 +45,13 @@ import static org.mockito.Mockito.when;
 
 public class ClusterCostsMonitoringServiceCoreTest {
     private static final Long MASTER_ID_1 = 1L;
-    private static final Long WORKER_ID_11 = 2L;
-    private static final Long WORKER_ID_12 = 3L;
-    private static final Long MASTER_ID_2 = 4L;
-    private static final Long WORKER_ID_21 = 5L;
+    private static final Long WORKER_ID_11 = 11L;
+    private static final Long WORKER_ID_12 = 12L;
+    private static final Long WORKER_ID_13 = 13L;
+    private static final Long MASTER_ID_2 = 2L;
+    private static final Long WORKER_ID_21 = 21L;
     private static final double PRICE_1 = 1.95;
     private static final double PRICE_2 = 20.25;
-    private static final int WORKER_21_DURATION = 2;
     private static final double EXPECTED_PRICE_1 = 0.0975;
     private static final double EXPECTED_PRICE_2 = 0.675;
 
@@ -65,18 +66,21 @@ public class ClusterCostsMonitoringServiceCoreTest {
         final PipelineRun master2 = masterRun(MASTER_ID_2, 1);
         when(pipelineRunManager.loadRunningPipelineRuns()).thenReturn(Arrays.asList(master1, master2));
 
-        final PipelineRun worker11 = workerRun(WORKER_ID_11, MASTER_ID_1, PRICE_1); // not start time
-        final PipelineRun worker12 = workerRun(WORKER_ID_12, MASTER_ID_1, PRICE_1); // 3 min duration
-        worker12.setStartDate(buildDate(5));
-        worker12.setEndDate(buildDate(2));
+        final PipelineRun worker11 = workerRun(WORKER_ID_11, MASTER_ID_1, PRICE_1); // no start times
+        final PipelineRun worker12 = workerRun(WORKER_ID_12, MASTER_ID_1, PRICE_1); // no instance start time
+        final PipelineRun worker13 = workerRun(WORKER_ID_13, MASTER_ID_1, PRICE_1); // 3 min stopped
+        worker12.setStartDate(buildDate(10));
+        worker13.setStartDate(buildDate(10));
+        worker13.getInstance().setStartDate(buildDate(5));
+        worker13.setEndDate(buildDate(2));
 
-        // started 2 min ago and not completed
-        final PipelineRun worker21 = workerRun(WORKER_ID_21, MASTER_ID_2, PRICE_2);
-        worker21.setStartDate(buildDate(WORKER_21_DURATION));
+        final PipelineRun worker21 = workerRun(WORKER_ID_21, MASTER_ID_2, PRICE_2); // 2 min running
+        worker21.setStartDate(buildDate(10));
+        worker21.getInstance().setStartDate(buildDate(2));
 
         when(pipelineRunCRUDService.loadRunsByParentRuns(any())).thenReturn(new HashMap<Long, List<PipelineRun>>() {
             {
-                put(MASTER_ID_1, Arrays.asList(worker11, worker12));
+                put(MASTER_ID_1, Arrays.asList(worker11, worker12, worker13));
                 put(MASTER_ID_2, Collections.singletonList(worker21));
             }
         });
@@ -108,6 +112,7 @@ public class ClusterCostsMonitoringServiceCoreTest {
         pipelineRun.setId(id);
         pipelineRun.setParentRunId(parentRunId);
         pipelineRun.setPricePerHour(BigDecimal.valueOf(price));
+        pipelineRun.setInstance(new RunInstance());
         return pipelineRun;
     }
 

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/costs/ClusterCostsMonitoringServiceCoreTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/costs/ClusterCostsMonitoringServiceCoreTest.java
@@ -71,12 +71,12 @@ public class ClusterCostsMonitoringServiceCoreTest {
         final PipelineRun worker13 = workerRun(WORKER_ID_13, MASTER_ID_1, PRICE_1); // 3 min stopped
         worker12.setStartDate(buildDate(10));
         worker13.setStartDate(buildDate(10));
-        worker13.getInstance().setStartDate(buildDate(5));
+        worker13.setInstanceStartDate(buildDate(5));
         worker13.setEndDate(buildDate(2));
 
         final PipelineRun worker21 = workerRun(WORKER_ID_21, MASTER_ID_2, PRICE_2); // 2 min running
         worker21.setStartDate(buildDate(10));
-        worker21.getInstance().setStartDate(buildDate(2));
+        worker21.setInstanceStartDate(buildDate(2));
 
         when(pipelineRunCRUDService.loadRunsByParentRuns(any())).thenReturn(new HashMap<Long, List<PipelineRun>>() {
             {

--- a/api/src/test/java/com/epam/pipeline/util/TestUtils.java
+++ b/api/src/test/java/com/epam/pipeline/util/TestUtils.java
@@ -158,6 +158,7 @@ public final class TestUtils {
         instance.setSpot(isSpot);
         instance.setNodeId("1");
         instance.setNodePlatform(TEST_PLATFORM);
+        instance.setStartDate(new Date());
         run.setInstance(instance);
         run.setEntitiesIds(Collections.singletonList(entitiesId));
         run.setConfigurationId(configurationId);

--- a/api/src/test/java/com/epam/pipeline/util/TestUtils.java
+++ b/api/src/test/java/com/epam/pipeline/util/TestUtils.java
@@ -141,6 +141,7 @@ public final class TestUtils {
         PipelineRun run = new PipelineRun();
         run.setPipelineId(pipelineId);
         run.setStartDate(new Date());
+        run.setInstanceStartDate(new Date());
         run.setEndDate(new Date());
         run.setStatus(status);
         run.setCommitStatus(CommitStatus.NOT_COMMITTED);
@@ -158,7 +159,6 @@ public final class TestUtils {
         instance.setSpot(isSpot);
         instance.setNodeId("1");
         instance.setNodePlatform(TEST_PLATFORM);
-        instance.setStartDate(new Date());
         run.setInstance(instance);
         run.setEntitiesIds(Collections.singletonList(entitiesId));
         run.setConfigurationId(configurationId);

--- a/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverter.java
+++ b/billing-report-agent/src/main/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverter.java
@@ -93,16 +93,14 @@ public class RunToBillingRequestConverter implements EntityToBillingRequestConve
         final LocalDateTime syncStart) {
         final PipelineRun pipelineRun = runContainer.getEntity().getPipelineRun();
         if (previousSync != null && pipelineRun.getStatus().isFinal() &&
-                pipelineRun.getEndDate() != null &&
-                getEnd(pipelineRun).isBefore(previousSync)) {
+                getEnd(pipelineRun).orElse(LocalDateTime.MAX).isBefore(previousSync)) {
             log.debug("Run {} [{} - {}] was not active in period {} - {}.",
                     pipelineRun.getId(), pipelineRun.getStartDate(),
                     pipelineRun.getEndDate(), previousSync, syncStart);
             return Collections.emptyList();
         }
         final RunPrice price = getPrice(runContainer);
-        final List<RunStatus> statuses = adjustStatuses(pipelineRun,
-                previousSync, syncStart);
+        final List<RunStatus> statuses = adjustStatuses(pipelineRun, previousSync, syncStart);
 
         return createBillingsForPeriod(runContainer.getEntity(), price, statuses).stream()
             .filter(this::isNotEmpty)
@@ -117,32 +115,48 @@ public class RunToBillingRequestConverter implements EntityToBillingRequestConve
     }
 
     protected List<RunStatus> adjustStatuses(final PipelineRun run,
-                                             final LocalDateTime previousSync,
-                                             final LocalDateTime syncStart) {
+                                             final LocalDateTime prevSync,
+                                             final LocalDateTime currSync) {
+        final LocalDateTime syncStart = toStartOfDay(prevSync).orElse(LocalDateTime.MIN);
+        final LocalDateTime syncEnd = toStartOfDay(currSync).orElseThrow(this::throwMissingSyncEnd);
+        final LocalDateTime runStart = getStart(run).orElse(LocalDateTime.MAX);
+        final LocalDateTime runEnd = getEnd(run).orElse(LocalDateTime.MAX);
+        if (runEnd.isBefore(syncStart) || runEnd.isBefore(runStart)
+                || syncEnd.isBefore(syncStart) || syncEnd.isBefore(runStart)) {
+            return getInactiveStatuses(run, syncStart);
+        }
+        final LocalDateTime start = max(syncStart, runStart);
+        final LocalDateTime end = min(syncEnd, runEnd);
         final List<RunStatus> statuses = run.getRunStatuses();
-        final LocalDateTime start = getBillingPeriodStart(previousSync);
-        final LocalDateTime end = getBillingPeriodEnd(syncStart);
-        return CollectionUtils.isNotEmpty(statuses) 
-                ? getAdjustedStatuses(run, statuses, start, end) 
-                : getDefaultStatuses(run, start, end);
+        if (CollectionUtils.isEmpty(statuses)) {
+            return getActiveStatuses(run, start, end);
+        }
+        return getAdjustedStatuses(run, statuses, start, end);
     }
 
-    private LocalDateTime getBillingPeriodStart(final LocalDateTime periodStart) {
-        return toStartOfDay(periodStart).orElse(LocalDateTime.MIN);
+    private List<RunStatus> getInactiveStatuses(final PipelineRun run, final LocalDateTime start) {
+        return Collections.singletonList(
+                new RunStatus(run.getId(), TaskStatus.STOPPED, start));
     }
 
-    private LocalDateTime getBillingPeriodEnd(final LocalDateTime periodEnd) {
-        return toStartOfDay(periodEnd)
-                .orElseThrow(() -> new IllegalArgumentException("Billing period end date should be provided."));
+    private List<RunStatus> getActiveStatuses(final PipelineRun run,
+                                              final LocalDateTime start,
+                                              final LocalDateTime end) {
+        return Arrays.asList(
+                new RunStatus(run.getId(), TaskStatus.RUNNING, start),
+                new RunStatus(run.getId(), TaskStatus.STOPPED, end));
+    }
+    private IllegalArgumentException throwMissingSyncEnd() {
+        return new IllegalArgumentException("Billing period end date should be provided.");
     }
 
-    private Optional<LocalDateTime> toStartOfDay(final LocalDateTime previousSync) {
-        return Optional.ofNullable(previousSync)
+    private Optional<LocalDateTime> toStartOfDay(final LocalDateTime date) {
+        return Optional.ofNullable(date)
                 .map(LocalDateTime::toLocalDate)
                 .map(LocalDate::atStartOfDay);
     }
 
-    private List<RunStatus> getAdjustedStatuses(final PipelineRun run, final List<RunStatus> statuses, 
+    private List<RunStatus> getAdjustedStatuses(final PipelineRun run, final List<RunStatus> statuses,
                                                 final LocalDateTime start, final LocalDateTime end) {
         final List<RunStatus> sortedStatuses = statuses.stream()
                 .sorted(Comparator.comparing(RunStatus::getTimestamp))
@@ -185,28 +199,28 @@ public class RunToBillingRequestConverter implements EntityToBillingRequestConve
                 .orElse(sortedStatuses.size() - 1);
     }
 
-    private RunStatus getSyntheticFirstRunningStatus(final PipelineRun run, final LocalDateTime start) {
-        return new RunStatus(run.getId(), TaskStatus.RUNNING, max(start, getStart(run)));
+    private RunStatus getSyntheticFirstRunningStatus(final PipelineRun run, final LocalDateTime date) {
+        return new RunStatus(run.getId(), TaskStatus.RUNNING, date);
     }
 
-    private RunStatus getSyntheticLastStoppedStatus(final PipelineRun run, final LocalDateTime end) {
-        return new RunStatus(run.getId(), TaskStatus.STOPPED, min(end, getEnd(run)));
+    private RunStatus getSyntheticLastStoppedStatus(final PipelineRun run, final LocalDateTime date) {
+        return new RunStatus(run.getId(), TaskStatus.STOPPED, date);
     }
 
     private RunStatus getAdjustedStatus(final RunStatus status, final LocalDateTime date) {
         return new RunStatus(status.getRunId(), status.getStatus(), date);
     }
 
-    private LocalDateTime getStart(final PipelineRun run) {
-        return getDate(run, PipelineRun::getStartDate).orElse(LocalDateTime.MIN);
+    private Optional<LocalDateTime> getStart(final PipelineRun run) {
+        return getDate(run, PipelineRun::getInstanceStartDate);
     }
 
-    private LocalDateTime getEnd(final PipelineRun run) {
-        return getDate(run, PipelineRun::getEndDate).orElse(LocalDateTime.MAX);
+    private Optional<LocalDateTime> getEnd(final PipelineRun run) {
+        return getDate(run, PipelineRun::getEndDate);
     }
 
     private Optional<LocalDateTime> getDate(final PipelineRun run, final Function<PipelineRun, Date> function) {
-        return Optional.ofNullable(run).map(function).map(DateUtils::toLocalDateTime);
+        return Optional.ofNullable(run).map(function).map(DateUtils::convertDateToLocalDateTime);
     }
 
     private LocalDateTime min(final LocalDateTime first, final LocalDateTime second) {
@@ -215,17 +229,6 @@ public class RunToBillingRequestConverter implements EntityToBillingRequestConve
 
     private LocalDateTime max(final LocalDateTime first, final LocalDateTime second) {
         return second.isAfter(first) ? second : first;
-    }
-
-    private List<RunStatus> getDefaultStatuses(final PipelineRun run, final LocalDateTime start, 
-                                               final LocalDateTime end) {
-        final LocalDateTime runStart = getStart(run);
-        final LocalDateTime runEnd = getEnd(run);
-        return runEnd.isBefore(start) || runStart.isAfter(end)
-                ? Collections.singletonList(new RunStatus(run.getId(), TaskStatus.STOPPED, start))
-                : Arrays.asList(
-                new RunStatus(run.getId(), TaskStatus.RUNNING, max(start, runStart)),
-                new RunStatus(run.getId(), TaskStatus.STOPPED, min(end, runEnd)));
     }
 
     private RunPrice getPrice(final EntityContainer<PipelineRunWithType> runContainer) {

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/TestUtils.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/TestUtils.java
@@ -22,7 +22,6 @@ import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.epam.pipeline.entity.region.AbstractCloudRegion;
 import com.epam.pipeline.entity.region.AwsRegion;
-import com.epam.pipeline.entity.utils.DateUtils;
 import com.fasterxml.jackson.core.JsonFactory;
 import org.apache.commons.collections.CollectionUtils;
 import org.elasticsearch.common.Strings;
@@ -37,7 +36,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
-import java.util.Optional;
 
 public final class TestUtils {
 
@@ -70,7 +68,8 @@ public final class TestUtils {
     }
 
     public static PipelineRun createTestPipelineRun(final Long runId, final Long pipelineId, final String tool,
-                                                    final BigDecimal price, final RunInstance instance) {
+                                                    final BigDecimal price, final LocalDateTime date,
+                                                    final RunInstance instance) {
         final PipelineRun run = new PipelineRun();
         run.setId(runId);
         run.setPipelineId(pipelineId);
@@ -78,20 +77,15 @@ public final class TestUtils {
         run.setPricePerHour(price);
         run.setInstance(instance);
         run.setStatus(TaskStatus.RUNNING);
+        run.setInstanceStartDateTime(date);
         return run;
     }
 
-    public static RunInstance createTestInstance(final Long regionId, final String nodeType,
-                                                 final LocalDateTime date) {
+    public static RunInstance createTestInstance(final Long regionId, final String nodeType) {
         final RunInstance instance = new RunInstance();
         instance.setCloudRegionId(regionId);
         instance.setNodeType(nodeType);
-        instance.setStartDate(Optional.ofNullable(date).map(DateUtils::convertLocalDateTimeToDate).orElse(null));
         return instance;
-    }
-
-    public static RunInstance createTestInstance(final Long regionId, final String nodeType) {
-        return createTestInstance(regionId, nodeType, null);
     }
 
     public static AbstractCloudRegion createTestRegion(final Long regionId) {

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/TestUtils.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/TestUtils.java
@@ -22,6 +22,7 @@ import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.epam.pipeline.entity.region.AbstractCloudRegion;
 import com.epam.pipeline.entity.region.AwsRegion;
+import com.epam.pipeline.entity.utils.DateUtils;
 import com.fasterxml.jackson.core.JsonFactory;
 import org.apache.commons.collections.CollectionUtils;
 import org.elasticsearch.common.Strings;
@@ -36,6 +37,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 
 public final class TestUtils {
 
@@ -79,11 +81,17 @@ public final class TestUtils {
         return run;
     }
 
-    public static RunInstance createTestInstance(final Long regionId, final String nodeType) {
+    public static RunInstance createTestInstance(final Long regionId, final String nodeType,
+                                                 final LocalDateTime date) {
         final RunInstance instance = new RunInstance();
         instance.setCloudRegionId(regionId);
         instance.setNodeType(nodeType);
+        instance.setStartDate(Optional.ofNullable(date).map(DateUtils::convertLocalDateTimeToDate).orElse(null));
         return instance;
+    }
+
+    public static RunInstance createTestInstance(final Long regionId, final String nodeType) {
+        return createTestInstance(regionId, nodeType, null);
     }
 
     public static AbstractCloudRegion createTestRegion(final Long regionId) {

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverterImplTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverterImplTest.java
@@ -27,7 +27,6 @@ import com.epam.pipeline.billingreportagent.service.impl.TestUtils;
 import com.epam.pipeline.billingreportagent.service.impl.mapper.RunBillingMapper;
 import com.epam.pipeline.entity.cluster.NodeDisk;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
-import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.epam.pipeline.entity.pipeline.run.RunStatus;
 import com.epam.pipeline.entity.user.PipelineUser;
@@ -91,9 +90,8 @@ public class RunToBillingRequestConverterImplTest {
         final LocalDateTime prevSync = LocalDate.of(2019, 12, 4).atStartOfDay();
         final LocalDateTime syncStart = LocalDate.of(2019, 12, 5).atStartOfDay();
 
-        final PipelineRun run = TestUtils.createTestPipelineRun(RUN_ID, PIPELINE_ID, TOOL_IMAGE, PRICE,
-                TestUtils.createTestInstance(REGION_ID, NODE_TYPE,
-                        prevSync));
+        final PipelineRun run = TestUtils.createTestPipelineRun(RUN_ID, PIPELINE_ID, TOOL_IMAGE, PRICE, prevSync,
+                TestUtils.createTestInstance(REGION_ID, NODE_TYPE));
 
         final EntityContainer<PipelineRunWithType> runContainer =
                 EntityContainer.<PipelineRunWithType>builder()
@@ -770,15 +768,9 @@ public class RunToBillingRequestConverterImplTest {
         run.setId(RUN_ID);
         run.setStatus(end == null ? TaskStatus.RUNNING : TaskStatus.STOPPED);
         run.setRunStatuses(Arrays.asList(statuses));
+        run.setInstanceStartDate(toDate(start));
         run.setEndDate(toDate(end));
-        run.setInstance(instance(start));
         return run;
-    }
-
-    private RunInstance instance(final LocalDateTime start) {
-        final RunInstance instance = new RunInstance();
-        instance.setStartDate(toDate(start));
-        return instance;
     }
 
     private Date toDate(final LocalDateTime date) {

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverterImplTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/converter/RunToBillingRequestConverterImplTest.java
@@ -37,7 +37,6 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
-import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapperTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapperTest.java
@@ -85,7 +85,7 @@ public class RunBillingMapperTest {
     private static final List<String> TEST_GROUPS = Arrays.asList(TEST_GROUP_1, TEST_GROUP_2);
 
     private static final Date TEST_JAVA_DATE = DateUtils.now();
-    private static final LocalDate TEST_DATE = DateUtils.toLocalDateTime(TEST_JAVA_DATE).toLocalDate();
+    private static final LocalDate TEST_DATE = DateUtils.convertDateToLocalDateTime(TEST_JAVA_DATE).toLocalDate();
     private static final Date TEST_STARTED_DATE = toDate(TEST_DATE.atStartOfDay());
     private static final String TEST_STARTED_DATE_STR = toString(TEST_STARTED_DATE);
     private static final Date TEST_FINISHED_DATE = toDate(TEST_DATE.plusDays(1L).atStartOfDay());

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapperTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/RunBillingMapperTest.java
@@ -115,7 +115,7 @@ public class RunBillingMapperTest {
     public void testRunMapperMap() throws IOException {
         final PipelineRun run =
             TestUtils.createTestPipelineRun(TEST_RUN_ID, TEST_PIPELINE_ID, TEST_TOOL_IMAGE, TEST_PRICE,
-                                            TestUtils.createTestInstance(TEST_REGION_ID, TEST_NODE_TYPE));
+                    DateUtils.nowUTC(), TestUtils.createTestInstance(TEST_REGION_ID, TEST_NODE_TYPE));
         run.setPipelineId(TEST_PIPELINE_ID);
         run.setPipelineName(TEST_PIPELINE_NAME);
         run.setVersion(TEST_PIPELINE_VERSION);

--- a/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapperTest.java
+++ b/billing-report-agent/src/test/java/com/epam/pipeline/billingreportagent/service/impl/mapper/StorageBillingMapperTest.java
@@ -61,7 +61,7 @@ public class StorageBillingMapperTest {
     private static final long TEST_USAGE_BYTES = 600;
     private static final List<String> TEST_GROUPS = Arrays.asList(TEST_GROUP_1, TEST_GROUP_2);
     private static final Date TEST_JAVA_DATE = DateUtils.now();
-    private static final LocalDate TEST_DATE = DateUtils.toLocalDateTime(TEST_JAVA_DATE).toLocalDate();
+    private static final LocalDate TEST_DATE = DateUtils.convertDateToLocalDateTime(TEST_JAVA_DATE).toLocalDate();
     private static final String TEST_STORAGE_NAME = "storage_name";
     private static final String TEST_STORAGE_PATH = "storage_path";
 

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
@@ -24,6 +24,7 @@ import com.epam.pipeline.entity.pipeline.run.RunStatus;
 import com.epam.pipeline.entity.pipeline.run.parameter.PipelineRunParameter;
 import com.epam.pipeline.entity.pipeline.run.parameter.RunSid;
 import com.epam.pipeline.entity.security.acl.AclClass;
+import com.epam.pipeline.entity.utils.DateUtils;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -33,6 +34,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
@@ -186,5 +188,15 @@ public class PipelineRun extends AbstractSecuredEntity {
 
     public String getTaskName() {
         return StringUtils.isEmpty(pipelineName) ? podId : pipelineName;
+    }
+
+    @JsonIgnore
+    public Date getInstanceStartDate() {
+        return Optional.ofNullable(instance).map(RunInstance::getStartDate).orElse(null);
+    }
+
+    @JsonIgnore
+    public LocalDateTime getInstanceStartDateTime() {
+        return Optional.ofNullable(getInstanceStartDate()).map(DateUtils::convertDateToLocalDateTime).orElse(null);
     }
 }

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
@@ -55,6 +55,7 @@ public class PipelineRun extends AbstractSecuredEntity {
 
     private Long pipelineId;
     private Date startDate;
+    private Date instanceStartDate;
     private String version;
     private Date endDate;
     private TaskStatus status;
@@ -191,12 +192,12 @@ public class PipelineRun extends AbstractSecuredEntity {
     }
 
     @JsonIgnore
-    public Date getInstanceStartDate() {
-        return Optional.ofNullable(instance).map(RunInstance::getStartDate).orElse(null);
+    public LocalDateTime getInstanceStartDateTime() {
+        return Optional.ofNullable(getInstanceStartDate()).map(DateUtils::convertDateToLocalDateTime).orElse(null);
     }
 
     @JsonIgnore
-    public LocalDateTime getInstanceStartDateTime() {
-        return Optional.ofNullable(getInstanceStartDate()).map(DateUtils::convertDateToLocalDateTime).orElse(null);
+    public void setInstanceStartDateTime(final LocalDateTime date) {
+        instanceStartDate = Optional.ofNullable(date).map(DateUtils::convertLocalDateTimeToDate).orElse(null);
     }
 }

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/pipeline/RunInstance.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/pipeline/RunInstance.java
@@ -18,6 +18,8 @@ package com.epam.pipeline.entity.pipeline;
 
 import com.epam.pipeline.entity.region.CloudProvider;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.util.Date;
 import java.util.Objects;
 import java.util.Set;
 
@@ -58,6 +60,7 @@ public class RunInstance {
      */
     private Set<String> prePulledDockerImages;
     private Long poolId;
+    private Date startDate;
 
     @JsonIgnore
     public boolean isEmpty() {

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/pipeline/RunInstance.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/pipeline/RunInstance.java
@@ -19,7 +19,6 @@ package com.epam.pipeline.entity.pipeline;
 import com.epam.pipeline.entity.region.CloudProvider;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
-import java.util.Date;
 import java.util.Objects;
 import java.util.Set;
 
@@ -60,7 +59,6 @@ public class RunInstance {
      */
     private Set<String> prePulledDockerImages;
     private Long poolId;
-    private Date startDate;
 
     @JsonIgnore
     public boolean isEmpty() {

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/utils/DateUtils.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/utils/DateUtils.java
@@ -41,13 +41,17 @@ public final class DateUtils {
         return LocalDateTime.now(Clock.systemUTC());
     }
 
-    public static LocalDateTime toLocalDateTime(final Date date) {
-        return date.toInstant().atZone(ZoneId.of("Z")).toLocalDateTime();
+    public static LocalDateTime convertDateToLocalDateTime(final Date date) {
+        return date.toInstant().atZone(ZoneOffset.UTC).toLocalDateTime();
+    }
+
+    public static Date convertLocalDateTimeToDate(final LocalDateTime dateTime) {
+        return new Date(dateTime.toInstant(ZoneOffset.UTC).toEpochMilli());
     }
 
     public static LocalDateTime parse(final DateFormat format, final String dateString) {
         try {
-            return toLocalDateTime(format.parse(dateString));
+            return convertDateToLocalDateTime(format.parse(dateString));
         } catch (ParseException e) {
             throw new IllegalArgumentException(
                     String.format("Filed to parse date: %s with format: %s", dateString, format), e);

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/utils/DateUtils.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/utils/DateUtils.java
@@ -20,7 +20,6 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.time.Clock;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Date;
 

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
@@ -57,6 +57,7 @@ public class PipelineRun extends AbstractSecuredEntity {
 
     private Long pipelineId;
     private Date startDate;
+    private Date instanceStartDate;
     private String version;
     private Date endDate;
     private TaskStatus status;
@@ -256,12 +257,12 @@ public class PipelineRun extends AbstractSecuredEntity {
     }
 
     @JsonIgnore
-    public Date getInstanceStartDate() {
-        return Optional.ofNullable(instance).map(RunInstance::getStartDate).orElse(null);
+    public LocalDateTime getInstanceStartDateTime() {
+        return Optional.ofNullable(instanceStartDate).map(DateUtils::convertDateToLocalDateTime).orElse(null);
     }
 
     @JsonIgnore
-    public LocalDateTime getInstanceStartDateTime() {
-        return Optional.ofNullable(getInstanceStartDate()).map(DateUtils::convertDateToLocalDateTime).orElse(null);
+    public void setInstanceStartDateTime(final LocalDateTime date) {
+        instanceStartDate = Optional.ofNullable(date).map(DateUtils::convertLocalDateTimeToDate).orElse(null);
     }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/PipelineRun.java
@@ -24,6 +24,7 @@ import com.epam.pipeline.entity.pipeline.run.RunStatus;
 import com.epam.pipeline.entity.pipeline.run.parameter.PipelineRunParameter;
 import com.epam.pipeline.entity.pipeline.run.parameter.RunSid;
 import com.epam.pipeline.entity.security.acl.AclClass;
+import com.epam.pipeline.entity.utils.DateUtils;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
 import lombok.Setter;
@@ -252,5 +253,15 @@ public class PipelineRun extends AbstractSecuredEntity {
      */
     public void removeTag(final String key) {
         tags.remove(key);
+    }
+
+    @JsonIgnore
+    public Date getInstanceStartDate() {
+        return Optional.ofNullable(instance).map(RunInstance::getStartDate).orElse(null);
+    }
+
+    @JsonIgnore
+    public LocalDateTime getInstanceStartDateTime() {
+        return Optional.ofNullable(getInstanceStartDate()).map(DateUtils::convertDateToLocalDateTime).orElse(null);
     }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/RunInstance.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/RunInstance.java
@@ -25,7 +25,6 @@ import lombok.Setter;
 import lombok.ToString;
 import org.springframework.util.StringUtils;
 
-import java.util.Date;
 import java.util.Objects;
 import java.util.Set;
 
@@ -61,7 +60,6 @@ public class RunInstance {
      */
     private Set<String> prePulledDockerImages;
     private Long poolId;
-    private Date startDate;
 
     public RunInstance(final String nodeType,
                        final Integer nodeDisk,

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/RunInstance.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/RunInstance.java
@@ -25,6 +25,7 @@ import lombok.Setter;
 import lombok.ToString;
 import org.springframework.util.StringUtils;
 
+import java.util.Date;
 import java.util.Objects;
 import java.util.Set;
 
@@ -60,6 +61,7 @@ public class RunInstance {
      */
     private Set<String> prePulledDockerImages;
     private Long poolId;
+    private Date startDate;
 
     public RunInstance(final String nodeType,
                        final Integer nodeDisk,

--- a/core/src/main/java/com/epam/pipeline/entity/utils/DateUtils.java
+++ b/core/src/main/java/com/epam/pipeline/entity/utils/DateUtils.java
@@ -55,6 +55,10 @@ public final class DateUtils {
         return date.toInstant().atZone(ZoneOffset.UTC).toLocalDateTime();
     }
 
+    public static Date convertLocalDateTimeToDate(final LocalDateTime dateTime) {
+        return new Date(dateTime.toInstant(ZoneOffset.UTC).toEpochMilli());
+    }
+
     public static LocalDateTime convertEpochMillisToLocalDateTime(final long epochMillis) {
         return Instant.ofEpochMilli(epochMillis).atZone(ZoneOffset.UTC).toLocalDateTime();
     }


### PR DESCRIPTION
Relates #3201.

The pull request introduces `instanceStartDate` field to Cloud Pipeline runs. For new runs it represents node attach/reassign date and for already existing runs it has the same value as run start date.
