### PR TITLE
Validate GPU and RAM job requirements in grid engine autoscaler

### DIFF
--- a/workflows/pipe-common/README.md
+++ b/workflows/pipe-common/README.md
@@ -21,6 +21,6 @@ To run python tests you should add `workflows/pipe-common` to your `PYTHOPATH`.
 ```bash
 cd /path/to/cloud-pipeline/workflows/pipe-common
 export PYTHONPATH=$PYTHONPATH:$PWD
-python -m pip install mock
+python -m pip install mock pytest
 python -m pytest
 ```

--- a/workflows/pipe-common/scripts/autoscale_sge.py
+++ b/workflows/pipe-common/scripts/autoscale_sge.py
@@ -15,7 +15,9 @@
 import functools
 import json
 import logging
+import math
 import multiprocessing
+import operator
 import os
 import re
 import subprocess
@@ -40,6 +42,18 @@ except ImportError:
 
 GridEngineParameter = namedtuple('GridEngineParameter', 'name,help')
 KubernetesPod = namedtuple('KubernetesPod', 'ip,name')
+
+
+def _not(func):
+    def _func(*args, **kwargs):
+        return not func(*args, **kwargs)
+    return _func
+
+
+def _or(left_func, right_func):
+    def _func(*args, **kwargs):
+        return left_func(*args, **kwargs) or right_func(*args, **kwargs)
+    return _func
 
 
 class GridEngineParametersGroup:
@@ -274,7 +288,7 @@ class Logger:
 
     @staticmethod
     def warn(message, crucial=False, *args, **kwargs):
-        logging.warn(message, *args, **kwargs)
+        logging.warning(message, *args, **kwargs)
         if not Logger.cmd and (crucial or Logger.verbose):
             CloudPipelineLogger.warn(message, task_name=Logger.task, omit_console=True)
 
@@ -319,6 +333,7 @@ class GridEngineJobState:
     SUSPENDED = 'suspended'
     ERROR = 'errored'
     DELETED = 'deleted'
+    UNKNOWN = 'unknown'
 
     _letter_codes_to_states = {
         RUNNING: ['r', 't', 'Rr', 'Rt'],
@@ -333,12 +348,12 @@ class GridEngineJobState:
         for key in GridEngineJobState._letter_codes_to_states:
             if code in GridEngineJobState._letter_codes_to_states[key]:
                 return key
-        raise ParsingError('Unknown sge job state: %s.' % code)
+        raise GridEngineJobState.UNKNOWN
 
 
 class GridEngineJob:
 
-    def __init__(self, id, root_id, name, user, state, datetime, hosts=None, slots=0, pe='local'):
+    def __init__(self, id, root_id, name, user, state, datetime, hosts=None, slots=0, gpus=0, mem=0, pe='local'):
         self.id = id
         self.root_id = root_id
         self.name = name
@@ -346,8 +361,15 @@ class GridEngineJob:
         self.state = state
         self.datetime = datetime
         self.hosts = hosts if hosts else []
+        # todo: Rename to cpu
         self.slots = slots
+        # todo: Rename to gpu
+        self.gpus = gpus
+        self.mem = mem
         self.pe = pe
+
+    def __repr__(self):
+        return str(self.__dict__)
 
 
 class GridEngine:
@@ -367,14 +389,15 @@ class GridEngine:
     _FORCE_KILL_JOBS = 'qdel -f %s'
     _BAD_HOST_STATES = ['u', 'E', 'd']
 
-    def __init__(self, cmd_executor, max_instance_cores, max_cluster_cores, queue, hostlist, queue_default):
+    def __init__(self, cmd_executor, queue, hostlist, queue_default):
         self.cmd_executor = cmd_executor
-        self.max_instance_cores = max_instance_cores
-        self.max_cluster_cores = max_cluster_cores
         self.queue = queue
         self.hostlist = hostlist
         self.queue_default = queue_default
         self.tmp_queue_name_attribute = 'tmp_queue_name'
+        # todo: Move to script init function
+        self.gpu_resource_name = os.getenv('CP_CAP_GE_CONSUMABLE_RESOURCE_NAME_GPU', 'gpus')
+        self.mem_resource_name = os.getenv('CP_CAP_GE_CONSUMABLE_RESOURCE_NAME_RAM', 'ram')
 
     def get_jobs(self):
         try:
@@ -418,6 +441,29 @@ class GridEngine:
             requested_pe = job_list.find('requested_pe')
             job_slots = int(requested_pe.text if requested_pe is not None else '1')
             job_pe = requested_pe.get('name') if requested_pe is not None else 'local'
+            hard_requests = job_list.findall('hard_request')
+            job_gpus = 0
+            job_mem = 0
+            for hard_request in hard_requests:
+                hard_request_name = hard_request.get('name')
+                if hard_request_name == self.gpu_resource_name:
+                    job_gpu_request = hard_request.text or '0'
+                    try:
+                        job_gpus = int(job_gpu_request)
+                    except ValueError:
+                        Logger.warn('Job #{job_id} by {job_user} has invalid gpu requirement '
+                                    'which cannot be parsed: {request}'
+                                    .format(job_id=root_job_id, job_user=job_user, request=job_gpu_request))
+                        Logger.warn(traceback.format_exc())
+                if hard_request_name == self.mem_resource_name:
+                    job_mem_request = hard_request.text or '0G'
+                    try:
+                        job_mem = self._parse_mem(job_mem_request)
+                    except Exception:
+                        Logger.warn('Job #{job_id} by {job_user} has invalid mem requirement '
+                                    'which cannot be parsed: {request}'
+                                    .format(job_id=root_job_id, job_user=job_user, request=job_mem_request))
+                        Logger.warn(traceback.format_exc())
             for job_id in job_ids:
                 if job_id in jobs:
                     job = jobs[job_id]
@@ -433,6 +479,8 @@ class GridEngine:
                         datetime=job_datetime,
                         hosts=job_hosts,
                         slots=job_slots,
+                        gpus=job_gpus,
+                        mem=job_mem,
                         pe=job_pe
                     )
         return jobs.values()
@@ -456,29 +504,23 @@ class GridEngine:
                 result += [int(interval)]
         return result
 
-    def is_job_valid(self, job):
-        result = True
-        allocation_rule = self.get_pe_allocation_rule(job.pe) if job.pe else AllocationRule.pe_slots()
-        if job.slots:
-            if allocation_rule == AllocationRule.pe_slots():
-                result = job.slots <= self.max_instance_cores
-                if not result:
-                    Logger.warn('Invalid job {job_id} found with allocation_rule={alloc_rule} and slots={slots}. '
-                                'Number of job slots should be less or equal '
-                                'to the number of instance cores of the largest allowed instance. '
-                                'It is {max_instance_cores} for the current launch.'
-                                .format(job_id=job.id, alloc_rule=allocation_rule.value, slots=job.slots,
-                                        max_instance_cores=self.max_instance_cores))
-            elif allocation_rule in [AllocationRule.fill_up(), AllocationRule.round_robin()]:
-                result = job.slots <= self.max_cluster_cores
-                if not result:
-                    Logger.warn('Invalid job {job_id} found with allocation_rule={alloc_rule} and slots={slots}. '
-                                'Number of job slots should be less or equal '
-                                'to the maximum possible number of cluster cores. '
-                                'It is {max_cluster_cores} for the current launch.'
-                                .format(job_id=job.id, alloc_rule=allocation_rule.value, slots=job.slots,
-                                        max_cluster_cores=self.max_cluster_cores))
-        return result
+    def _parse_mem(self, mem_request):
+        """
+        See https://linux.die.net/man/1/sge_types
+        """
+        modifiers = {
+            'k': 1000,
+            'm': 1000 ** 2,
+            'g': 1000 ** 3,
+            'K': 1024,
+            'M': 1024 ** 2,
+            'G': 1024 ** 3
+        }
+        number = int(mem_request[:-1] or '0')
+        letter = mem_request[-1:] or 'G'
+        size_in_bytes = number * modifiers.get(letter, 0)
+        size_in_gibibytes = int(math.ceil(size_in_bytes / modifiers['G']))
+        return size_in_gibibytes
 
     def disable_host(self, host):
         """
@@ -528,15 +570,18 @@ class GridEngine:
     def get_resource_demands(self, expired_jobs):
         demands = []
         available_slots = self._get_available_slots()
+        allocation_rules = {}
         for job in sorted(expired_jobs, key=lambda job: job.root_id):
-            if self.get_pe_allocation_rule(job.pe) in [AllocationRule.round_robin(), AllocationRule.fill_up()]:
+            allocation_rule = allocation_rules[job.pe] = allocation_rules.get(job.pe) \
+                                                         or self.get_pe_allocation_rule(job.pe)
+            if allocation_rule in AllocationRule.fractional_rules():
                 if available_slots >= job.slots:
                     available_slots -= job.slots
                 else:
-                    demands.append(FractionalDemand(job.slots - available_slots, owner=job.user))
+                    demands.append(FractionalDemand(cpu=job.slots - available_slots, owner=job.user))
                     available_slots = 0
             else:
-                demands.append(IntegralDemand(job.slots, owner=job.user))
+                demands.append(IntegralDemand(cpu=job.slots, owner=job.user))
         return demands
 
     def get_host_to_scale_down(self, hosts):
@@ -651,6 +696,52 @@ class GridEngine:
         self.cmd_executor.execute((GridEngine._FORCE_KILL_JOBS if force else GridEngine._KILL_JOBS) % ' '.join(job_ids))
 
 
+class GridEngineJobValidator:
+
+    def __init__(self, grid_engine, instance_max_supply, cluster_max_supply):
+        self.grid_engine = grid_engine
+        self.instance_max_supply = instance_max_supply
+        self.cluster_max_supply = cluster_max_supply
+
+    def validate(self, jobs):
+        valid_jobs, invalid_jobs = [], []
+        allocation_rules = {}
+        for job in jobs:
+            allocation_rule = allocation_rules[job.pe] = allocation_rules.get(job.pe) \
+                                                         or self.grid_engine.get_pe_allocation_rule(job.pe)
+            job_demand = IntegralDemand(cpu=job.slots, gpu=job.gpus, memory=job.mem)
+            if allocation_rule in AllocationRule.fractional_rules():
+                if job_demand > self.cluster_max_supply:
+                    Logger.warn('Invalid job #{job_id} {job_name} by {job_user} requires resources '
+                                'which cannot be satisfied by the cluster: '
+                                '{job_cpus}/{available_cpus} cpus, '
+                                '{job_gpus}/{available_gpus} gpus, '
+                                '{job_mem}/{available_mem} mem.'
+                                .format(job_id=job.id, job_name=job.name, job_user=job.user,
+                                        job_cpus=job.slots, available_cpus=self.cluster_max_supply.cpu,
+                                        job_gpus=job.gpus, available_gpus=self.cluster_max_supply.gpu,
+                                        job_mem=job.mem, available_mem=self.cluster_max_supply.memory),
+                                crucial=True)
+                    invalid_jobs.append(job)
+                    continue
+            else:
+                if job_demand > self.instance_max_supply:
+                    Logger.warn('Invalid job #{job_id} {job_name} by {job_user} requires resources '
+                                'which cannot be satisfied by the biggest instance in cluster: '
+                                '{job_cpus}/{available_cpus} cpus, '
+                                '{job_gpus}/{available_gpus} gpus, '
+                                '{job_mem}/{available_mem} mem.'
+                                .format(job_id=job.id, job_name=job.name, job_user=job.user,
+                                        job_cpus=job.slots, available_cpus=self.instance_max_supply.cpu,
+                                        job_gpus=job.gpus, available_gpus=self.instance_max_supply.gpu,
+                                        job_mem=job.mem, available_mem=self.instance_max_supply.memory),
+                                crucial=True)
+                    invalid_jobs.append(job)
+                    continue
+            valid_jobs.append(job)
+        return valid_jobs, invalid_jobs
+
+
 class ComputeResource:
 
     def __init__(self, cpu=0, gpu=0, memory=0, disk=0, owner=None):
@@ -659,7 +750,9 @@ class ComputeResource:
         """
         self.cpu = cpu
         self.gpu = gpu
+        # todo: Rename to mem
         self.memory = memory
+        # todo: Remove
         self.disk = disk
         self.owner = owner
 
@@ -682,10 +775,43 @@ class ComputeResource:
                                 disk=max(0, other.disk - self.disk),
                                 owner=self.owner or other.owner))
 
-    def __bool__(self):
+    def sub(self, other):
+        return self.subtract(other)[0]
+
+    def mul(self, other):
+        if isinstance(other, int):
+            return self.__class__(cpu=self.cpu * other,
+                                  gpu=self.gpu * other,
+                                  memory=self.memory * other,
+                                  disk=self.disk * other,
+                                  owner=self.owner)
+        else:
+            raise ArithmeticError('Compute resource can be multiplied to integer values only')
+
+    def gt(self, other):
+        return self.cpu > other.cpu or self.gpu > other.gpu or self.memory > other.memory or self.disk > other.disk
+
+    def eq(self, other):
+        return self.__dict__ == other.__dict__
+
+    def bool(self):
         return self.cpu + self.gpu + self.memory + self.disk > 0
 
-    __nonzero__ = __bool__
+    def __repr__(self):
+        return str(self.__dict__)
+
+    __add__ = add
+    __sub__ = sub
+    __mul__ = mul
+    __cmp__ = gt
+    __eq__ = eq
+    __ne__ = _not(__eq__)
+    __lt__ = _not(gt)
+    __gt__ = gt
+    __le__ = _or(__lt__, __eq__)
+    __ge__ = _or(__gt__, __eq__)
+    __bool__ = bool
+    __nonzero__ = bool
 
 
 class FractionalDemand(ComputeResource):
@@ -701,7 +827,7 @@ class IntegralDemand(ComputeResource):
     """
     Integral resource demand which can be fulfilled using only a single resource supply.
 
-    Example of a integral demand is non mpi grid engine job requirements.
+    Example of an integral demand is non mpi grid engine job requirements.
     """
     pass
 
@@ -711,6 +837,10 @@ class ResourceSupply(ComputeResource):
     Resource supply which can be used to fulfill resource demands.
     """
     pass
+
+    @classmethod
+    def of(cls, instance):
+        return ResourceSupply(cpu=instance.cpu, gpu=instance.gpu, memory=instance.memory)
 
 
 class InstanceDemand:
@@ -731,15 +861,15 @@ class InstanceDemand:
 
 class Instance:
 
-    def __init__(self, name, price_type, memory, gpu, cpu):
+    def __init__(self, name, price_type, cpu, gpu, memory):
         """
         Execution instance.
         """
         self.name = name
         self.price_type = price_type
-        self.memory = memory
-        self.gpu = gpu
         self.cpu = cpu
+        self.gpu = gpu
+        self.memory = memory
 
     @staticmethod
     def from_cp_response(instance):
@@ -1348,7 +1478,7 @@ class GridEngineWorkerTagsHandler:
 
     def process_tags(self):
         try:
-            Logger.info('Start tags processing step at %s.' % self.clock.now())
+            Logger.info('Init: Tags processing.')
             current_hosts = self.host_storage.load_hosts()
             hosts_activity = self.host_storage.get_hosts_activity(current_hosts)
             hosts_activity.update(self.static_host_storage.get_hosts_activity(self.static_hosts))
@@ -1356,9 +1486,9 @@ class GridEngineWorkerTagsHandler:
             current_hosts += self.static_hosts
             self._process_current_hosts(current_hosts, hosts_activity)
             self._process_outdated_hosts(monitored_hosts, current_hosts)
-            Logger.info('Finish tags processing step at %s.' % self.clock.now())
+            Logger.info('Done: Tags processing.')
         except Exception as e:
-            Logger.warn('Tags processing has failed: %s' % str(e))
+            Logger.warn('Fail: Tags processing due to %s' % str(e))
             Logger.warn(traceback.format_exc())
 
     def _run_is_active(self, timestamp):
@@ -1422,7 +1552,8 @@ class GridEngineWorkerTagsHandler:
 
 class GridEngineAutoscaler:
 
-    def __init__(self, grid_engine, cmd_executor, scale_up_orchestrator, scale_down_handler, host_storage,
+    def __init__(self, grid_engine, job_validator,
+                 cmd_executor, scale_up_orchestrator, scale_down_handler, host_storage,
                  static_host_storage, scale_up_timeout, scale_down_timeout, max_additional_hosts, idle_timeout=30,
                  clock=Clock()):
         """
@@ -1435,6 +1566,7 @@ class GridEngineAutoscaler:
         and there were no new jobs for the given time interval.
 
         :param grid_engine: Grid engine.
+        :param job_validator: Job validator.
         :param cmd_executor: Cmd executor.
         :param scale_up_orchestrator: Scaling up orchestrator.
         :param scale_down_handler: Scaling down handler.
@@ -1449,6 +1581,7 @@ class GridEngineAutoscaler:
         :param idle_timeout: Maximum number of seconds a host could wait for a new job before getting scaled-down.
         """
         self.grid_engine = grid_engine
+        self.job_validator = job_validator
         self.executor = cmd_executor
         self.scale_up_orchestrator = scale_up_orchestrator
         self.scale_down_handler = scale_down_handler
@@ -1464,28 +1597,32 @@ class GridEngineAutoscaler:
 
     def scale(self):
         now = self.clock.now()
-        Logger.info('Start scaling step at %s.' % now)
+        Logger.info('Init: Scaling.')
         additional_hosts = self.host_storage.load_hosts()
         Logger.info('There are %s/%s additional workers.' % (len(additional_hosts), self.max_additional_hosts))
         updated_jobs = self.grid_engine.get_jobs()
         running_jobs = [job for job in updated_jobs if job.state == GridEngineJobState.RUNNING]
-        pending_jobs = self._filter_pending_job(updated_jobs)
         if running_jobs:
             self.host_storage.update_running_jobs_host_activity(running_jobs, now)
             self.static_host_storage.update_running_jobs_host_activity(running_jobs, now)
             self.latest_running_job = sorted(running_jobs, key=lambda job: job.datetime, reverse=True)[0]
-        if pending_jobs:
-            Logger.info('There are %s waiting jobs.' % len(pending_jobs))
-            expiration_datetimes = [job.datetime + self.scale_up_timeout for job in pending_jobs]
-            expired_jobs = [job for index, job in enumerate(pending_jobs) if now >= expiration_datetimes[index]]
+        if not self.max_additional_hosts:
+            Logger.info('Done: Scaling.')
+            return
+        pending_jobs = [job for job in updated_jobs if job.state == GridEngineJobState.PENDING]
+        waiting_jobs = self._get_valid_jobs(pending_jobs)
+        Logger.info('There are %s waiting jobs.' % len(waiting_jobs))
+        if waiting_jobs:
+            expiration_datetimes = [job.datetime + self.scale_up_timeout for job in waiting_jobs]
+            expired_jobs = [job for index, job in enumerate(waiting_jobs) if now >= expiration_datetimes[index]]
             if expired_jobs:
                 Logger.info('There are %s waiting jobs that are in queue for more than %s seconds. '
                             'Scaling up is required.' % (len(expired_jobs), self.scale_up_timeout.seconds))
                 if len(additional_hosts) < self.max_additional_hosts:
                     Logger.info('There are %s/%s additional workers. Scaling up will be performed.' %
                                 (len(additional_hosts), self.max_additional_hosts))
-                    resource_demands = self.grid_engine.get_resource_demands(pending_jobs)
-                    resource_demand = functools.reduce(ComputeResource.add, resource_demands)
+                    resource_demands = self.grid_engine.get_resource_demands(waiting_jobs)
+                    resource_demand = functools.reduce(operator.add, resource_demands)
                     Logger.info('Waiting jobs require: '
                                 '{cpu} cpus, {gpu} gpus, {mem} mem, {disk} disk.'
                                 .format(cpu=resource_demand.cpu, gpu=resource_demand.gpu,
@@ -1498,10 +1635,9 @@ class GridEngineAutoscaler:
                     Logger.info('Probable deadlock situation observed. Scaling down will be attempted.')
                     self._scale_down(running_jobs, additional_hosts)
             else:
-                Logger.info('There are no waiting jobs that are in queue for more than %s seconds. '
+                Logger.info('There are 0 waiting jobs that are in queue for more than %s seconds. '
                             'Scaling up is not required.' % self.scale_up_timeout.seconds)
         else:
-            Logger.info('There are no waiting jobs.')
             if self.latest_running_job:
                 Logger.info('Latest started job with id %s has started at %s.' %
                             (self.latest_running_job.id, self.latest_running_job.datetime))
@@ -1513,35 +1649,23 @@ class GridEngineAutoscaler:
                     Logger.info('Latest job started less than %s seconds. '
                                 'Scaling down is not required.' % self.scale_down_timeout.seconds)
             else:
-                Logger.info('There are no previously running jobs. Scaling down is required.')
+                Logger.info('There are 0 previously running jobs. Scaling down is required.')
                 self._scale_down(running_jobs, additional_hosts, now)
-        Logger.info('Finish scaling step at %s.' % self.clock.now())
         post_scale_additional_hosts = self.host_storage.load_hosts()
         Logger.info('There are %s/%s additional workers.'
                     % (len(post_scale_additional_hosts), self.max_additional_hosts))
+        Logger.info('Done: Scaling.')
 
-    def _filter_pending_job(self, updated_jobs):
-        # kill jobs that are pending and can't be satisfied with requested resource
-        # f.i. we have only 3 instance max and the biggest possible type has 10 cores but job requests 40 coresf
-        pending_jobs = [job for job in updated_jobs if job.state == GridEngineJobState.PENDING]
-        if not pending_jobs:
-            return []
-        valid_pending_jobs = []
-        invalid_pending_jobs = []
-        Logger.info('Validate %s pending jobs.' % len(pending_jobs))
-        for pending_job in pending_jobs:
-            if not self.grid_engine.is_job_valid(pending_job):
-                invalid_pending_jobs.append(pending_job)
-            else:
-                valid_pending_jobs.append(pending_job)
-        if invalid_pending_jobs:
+    def _get_valid_jobs(self, jobs):
+        Logger.info('Validating %s jobs...' % len(jobs))
+        valid_jobs, invalid_jobs = self.job_validator.validate(jobs)
+        if invalid_jobs:
             Logger.warn('The following jobs cannot be satisfied with the requested resources '
-                        'and therefore they will be rejected: %s'
-                        % ', '.join('%s (%s cpu)' % (job.id, job.slots) for job in invalid_pending_jobs),
+                        'and therefore will be killed: #{}'
+                        .format(', #'.join(job.id for job in invalid_jobs)),
                         crucial=True)
-            self.grid_engine.kill_jobs(invalid_pending_jobs)
-        Logger.info('Pending jobs validation has finished.')
-        return valid_pending_jobs
+            self.grid_engine.kill_jobs(invalid_jobs)
+        return valid_jobs
 
     def scale_up(self, resource_demands, remaining_additional_hosts):
         """
@@ -1568,7 +1692,7 @@ class GridEngineAutoscaler:
             if succeed:
                 self.host_storage.remove_host(inactive_additional_host)
         else:
-            Logger.info('There are no additional workers to scale down.')
+            Logger.info('There are 0 additional workers to scale down. Scaling down is aborted.')
 
     def _filter_valid_idle_hosts(self, inactive_host_candidates, scaling_period_start):
         inactive_hosts = []
@@ -1616,17 +1740,21 @@ class GridEngineWorkerValidator:
         self.scale_down_handler = scale_down_handler
         self.common_utils = common_utils
 
-    def validate_hosts(self):
+    def validate(self):
         """
         Finds and removes any additional hosts which aren't valid execution hosts in GE or active runs.
         """
         hosts = self.host_storage.load_hosts()
-        Logger.info('Validate %s additional workers.' % len(hosts))
-        invalid_hosts = []
+        if not hosts:
+            Logger.info('Skip: Workers validation.')
+            return
+        Logger.info('Init: Workers validation.')
+        valid_hosts, invalid_hosts = [], []
         for host in hosts:
             run_id = self.common_utils.get_run_id_from_host(host)
             if (not self.grid_engine.is_valid(host)) or (not self._is_running(run_id)):
                 invalid_hosts.append((host, run_id))
+                continue
         for host, run_id in invalid_hosts:
             Logger.warn('Invalid additional host %s was found. It will be downscaled.' % host, crucial=True)
             self._try_stop_worker(run_id)
@@ -1635,7 +1763,7 @@ class GridEngineWorkerValidator:
             self.grid_engine.delete_host(host, skip_on_failure=True)
             self._remove_worker_from_hosts(host)
             self.host_storage.remove_host(host)
-        Logger.info('Additional hosts validation has finished.')
+        Logger.info('Done: Workers validation.')
 
     def _is_running(self, run_id):
         try:
@@ -1761,8 +1889,7 @@ class CpuCapacityInstanceSelector(GridEngineInstanceSelector):
             for instance in instances:
                 supply = ResourceSupply(cpu=instance.cpu - self.free_cores, gpu=instance.gpu, memory=instance.memory)
                 current_remaining_demands, current_fulfilled_demands = self._apply(remaining_demands, supply)
-                current_fulfilled_demand = functools.reduce(ComputeResource.add, current_fulfilled_demands,
-                                                            IntegralDemand())
+                current_fulfilled_demand = functools.reduce(operator.add, current_fulfilled_demands, IntegralDemand())
                 current_capacity = current_fulfilled_demand.cpu
                 if current_capacity > best_capacity:
                     best_capacity = current_capacity
@@ -1796,7 +1923,7 @@ class CpuCapacityInstanceSelector(GridEngineInstanceSelector):
                 current_remaining_supply, remaining_demand = remaining_supply.subtract(demand)
                 if remaining_demand:
                     remaining_demands.append(remaining_demand)
-                fulfilled_demand, _ = demand.subtract(remaining_demand)
+                fulfilled_demand = demand - remaining_demand
                 fulfilled_demands.append(fulfilled_demand)
                 remaining_supply = current_remaining_supply
             else:
@@ -2053,6 +2180,14 @@ class AllocationRule:
     def round_robin():
         return AllocationRule('$round_robin')
 
+    @staticmethod
+    def fractional_rules():
+        return [AllocationRule.round_robin(), AllocationRule.fill_up()]
+
+    @staticmethod
+    def integral_rules():
+        return [AllocationRule.pe_slots()]
+
     def __eq__(self, other):
         if not isinstance(other, AllocationRule):
             # don't attempt to compare against unrelated types
@@ -2081,14 +2216,14 @@ class GridEngineAutoscalingDaemon:
         while True:
             try:
                 time.sleep(self.timeout)
-                self.worker_validator.validate_hosts()
+                self.worker_validator.validate()
                 self.autoscaler.scale()
                 self.worker_tags_handler.process_tags()
             except KeyboardInterrupt:
                 Logger.warn('Manual stop of the autoscaler daemon.', crucial=True)
                 break
             except Exception as e:
-                Logger.warn('Scaling step has failed due to %s.' % str(e), crucial=True)
+                Logger.warn('Scaling has failed due to %s' % str(e), crucial=True)
                 Logger.warn(traceback.format_exc())
 
 
@@ -2233,10 +2368,12 @@ def main():
     params = GridEngineParameters()
     pipeline_api = os.environ['API']
     master_run_id = os.environ['RUN_ID']
+    master_host = os.getenv('HOSTNAME', 'pipeline-' + str(master_run_id))
     default_hostfile = os.environ['DEFAULT_HOSTFILE']
 
-    static_hosts_cores = int(os.getenv('CLOUD_PIPELINE_NODE_CORES', multiprocessing.cpu_count()))
+    static_hosts_cpus = int(os.getenv('CLOUD_PIPELINE_NODE_CORES', multiprocessing.cpu_count()))
     static_hosts_number = int(os.getenv('node_count', 0))
+    static_hosts_instance_type = os.environ['instance_size']
     autoscaling_hosts_number = int(os.getenv(params.autoscaling.autoscaling_hosts_number.name, 3))
     autoscale_enabled = os.getenv(params.autoscaling.autoscale.name, 'false').strip().lower() == 'true'
 
@@ -2267,9 +2404,9 @@ def main():
     queue_static = os.getenv(params.queue.queue_static.name, 'false').strip().lower() == 'true'
     queue_default = os.getenv(params.queue.queue_default.name, 'false').strip().lower() == 'true'
     hostlist_name = os.getenv(params.queue.hostlist_name.name, '@allhosts')
-    hosts_free_cores = int(os.getenv(params.queue.hosts_free_cores.name, 0))
-    master_cores = int(os.getenv(params.queue.master_cores.name, static_hosts_cores))
-    master_cores = master_cores - hosts_free_cores if master_cores - hosts_free_cores > 0 else master_cores
+    reserved_cpus = int(os.getenv(params.queue.hosts_free_cores.name, 0))
+    master_cpus = int(os.getenv(params.queue.master_cores.name, static_hosts_cpus))
+    effective_master_cpus = master_cpus - reserved_cpus if master_cpus - reserved_cpus > 0 else master_cpus
 
     work_dir = os.getenv(params.autoscaling_advanced.work_dir.name, os.getenv('TMP_DIR', '/tmp'))
     log_dir = os.getenv(params.autoscaling.log_dir.name, os.getenv('LOG_DIR', '/var/log'))
@@ -2280,6 +2417,10 @@ def main():
                 task=log_task, verbose=log_verbose)
 
     Logger.info('Initiating grid engine autoscaling...')
+
+    if not autoscale_enabled:
+        Logger.info('Using non autoscaling mode...')
+        autoscaling_hosts_number = 0
 
     # TODO: Replace all the usages of PipelineAPI raw client with an actual CloudPipelineAPI client
     pipe = PipelineAPI(api_url=pipeline_api, log_dir=os.path.join(log_dir, '.autoscaler.%s.pipe.log' % queue_name))
@@ -2294,6 +2435,7 @@ def main():
     cloud_instance_provider = CloudPipelineInstanceProvider(pipe=pipe, region_id=instance_region_id,
                                                             price_type=instance_price_type)
     default_instance_provider = DefaultInstanceProvider(inner=cloud_instance_provider, instance_type=instance_type)
+    static_instance_provider = DefaultInstanceProvider(inner=cloud_instance_provider, instance_type=instance_type)
 
     descending_instance = default_instance_provider.provide().pop()
     descending_instance_cores = descending_instance.cpu if descending_instance else 0
@@ -2335,33 +2477,38 @@ def main():
         Logger.info('Using default autoscaling of {} instances...'.format(instance_type))
         instance_provider = default_instance_provider
 
-    Logger.info('Using the following instance types:\n{}'
-                .format('\n'.join('- {} ({} cpus, {} gpus)'.format(instance.name, instance.cpu, instance.gpu)
-                                  for instance in instance_provider.provide())))
-
     if scale_up_strategy == 'cpu-capacity':
         Logger.info('Selecting instances using cpu capacity strategy...')
         instance_selector = CpuCapacityInstanceSelector(instance_provider=instance_provider,
-                                                        free_cores=hosts_free_cores)
+                                                        free_cores=reserved_cpus)
     elif scale_up_strategy == 'naive-cpu-capacity':
         Logger.info('Selecting instances using fractional cpu capacity strategy...')
         instance_selector = NaiveCpuCapacityInstanceSelector(instance_provider=instance_provider,
-                                                             free_cores=hosts_free_cores)
+                                                             free_cores=reserved_cpus)
     else:
         Logger.info('Selecting instances using default strategy...')
         instance_selector = BackwardCompatibleInstanceSelector(instance_provider=instance_provider,
-                                                               free_cores=hosts_free_cores,
+                                                               free_cores=reserved_cpus,
                                                                batch_size=scale_up_batch_size)
 
-    max_instance = sorted(instance_provider.provide(), key=lambda instance: instance.cpu).pop()
-    max_instance_cores = max_instance.cpu - hosts_free_cores
-    max_cluster_cores = max_instance_cores * autoscaling_hosts_number
-    if queue_static:
-        max_cluster_cores += master_cores + (static_hosts_cores - hosts_free_cores) * static_hosts_number
+    biggest_instance = sorted(instance_provider.provide(), key=lambda instance: instance.cpu).pop()
+    static_instance = static_instance_provider.provide().pop()
 
-    grid_engine = GridEngine(cmd_executor=cmd_executor, max_instance_cores=max_instance_cores,
-                             max_cluster_cores=max_cluster_cores, queue=queue_name, hostlist=hostlist_name,
+    reserved_supply = ResourceSupply(cpu=reserved_cpus)
+    biggest_instance_supply = ResourceSupply.of(biggest_instance) - reserved_supply
+    static_instance_supply = ResourceSupply.of(static_instance) - reserved_supply
+    master_instance_supply = ResourceSupply(cpu=effective_master_cpus,
+                                            gpu=static_instance_supply.gpu,
+                                            memory=static_instance_supply.memory)
+    cluster_supply = biggest_instance_supply * autoscaling_hosts_number
+    if queue_static:
+        cluster_supply += master_instance_supply + static_instance_supply * static_hosts_number
+
+    grid_engine = GridEngine(cmd_executor=cmd_executor, queue=queue_name, hostlist=hostlist_name,
                              queue_default=queue_default)
+    job_validator = GridEngineJobValidator(grid_engine=grid_engine,
+                                           instance_max_supply=biggest_instance_supply,
+                                           cluster_max_supply=cluster_supply)
     host_storage = FileSystemHostStorage(cmd_executor=cmd_executor,
                                          storage_file=os.path.join(work_dir, '.autoscaler.%s.storage' % queue_name),
                                          clock=clock)
@@ -2379,9 +2526,26 @@ def main():
     init_static_hosts(default_hostsfile=default_hostfile, static_host_storage=static_host_storage, clock=clock,
                       tagging_active_timeout=tagging_active_timeout,
                       static_hosts_enabled=queue_static and static_hosts_number)
-    if not autoscale_enabled:
-        Logger.info('Using non autoscaling mode...')
-        autoscaling_hosts_number = 0
+
+    Logger.info('Using static workers:\n{}\n{}'
+                .format('- {} {} ({} cpus, {} gpus, {} mem)'
+                        .format(master_host, static_instance.name,
+                                master_instance_supply.cpu,
+                                master_instance_supply.gpu,
+                                master_instance_supply.memory),
+                        '\n'.join('- {} {} ({} cpus, {} gpus, {} mem)'
+                                  .format(host, static_instance.name,
+                                          static_instance_supply.cpu,
+                                          static_instance_supply.gpu,
+                                          static_instance_supply.memory)
+                                  for host in static_host_storage.load_hosts()
+                                  if host != master_host))
+                .strip())
+    Logger.info('Using autoscaling instance types:\n{}'
+                .format('\n'.join('- {} ({} cpus, {} gpus, {} mem)'
+                                  .format(instance.name, instance.cpu, instance.gpu, instance.memory)
+                                  for instance in instance_provider.provide())))
+
     scale_up_handler = GridEngineScaleUpHandler(cmd_executor=cmd_executor, api=api, grid_engine=grid_engine,
                                                 host_storage=host_storage,
                                                 parent_run_id=master_run_id, default_hostfile=default_hostfile,
@@ -2412,7 +2576,8 @@ def main():
     worker_validator = GridEngineWorkerValidator(cmd_executor=cmd_executor, api=api, host_storage=host_storage,
                                                  grid_engine=grid_engine, scale_down_handler=scale_down_handler,
                                                  common_utils=common_utils)
-    autoscaler = GridEngineAutoscaler(grid_engine=grid_engine, cmd_executor=cmd_executor,
+    autoscaler = GridEngineAutoscaler(grid_engine=grid_engine, job_validator=job_validator,
+                                      cmd_executor=cmd_executor,
                                       scale_up_orchestrator=scale_up_orchestrator,
                                       scale_down_handler=scale_down_handler,
                                       host_storage=host_storage, static_host_storage=static_host_storage,

--- a/workflows/pipe-common/test/test_available_instance_provider.py
+++ b/workflows/pipe-common/test/test_available_instance_provider.py
@@ -35,9 +35,9 @@ clock = Mock()
 instance_provider = AvailableInstanceProvider(inner=inner_instance_provider, worker_recorder=worker_recorder,
                                               unavailability_delay=unavailability_delay, clock=clock)
 
-instance_2cpu = Instance(name='m5.large', price_type=price_type, cpu=2, memory=8, gpu=0)
-instance_4cpu = Instance(name='m5.xlarge', price_type=price_type, cpu=4, memory=16, gpu=0)
-instance_8cpu = Instance(name='m5.2xlarge', price_type=price_type, cpu=8, memory=32, gpu=0)
+instance_2cpu = Instance(name='m5.large', price_type=price_type, cpu=2, mem=8, gpu=0)
+instance_4cpu = Instance(name='m5.xlarge', price_type=price_type, cpu=4, mem=16, gpu=0)
+instance_8cpu = Instance(name='m5.2xlarge', price_type=price_type, cpu=8, mem=32, gpu=0)
 
 
 def setup_function():

--- a/workflows/pipe-common/test/test_compute_resource.py
+++ b/workflows/pipe-common/test/test_compute_resource.py
@@ -17,51 +17,59 @@ from scripts.autoscale_sge import ComputeResource
 
 
 def test_add():
-    assert ComputeResource(cpu=2, gpu=3, memory=4, disk=5) \
-           + ComputeResource(cpu=20, gpu=30, memory=40, disk=50) \
-           == ComputeResource(cpu=22, gpu=33, memory=44, disk=55)
+    assert ComputeResource(cpu=2, gpu=3, mem=4) \
+           + ComputeResource(cpu=20, gpu=30, mem=40) \
+           == ComputeResource(cpu=22, gpu=33, mem=44)
 
 
 def test_sub():
-    assert ComputeResource(cpu=22, gpu=33, memory=44, disk=55) \
-           - ComputeResource(cpu=2, gpu=3, memory=4, disk=5) \
-           == ComputeResource(cpu=20, gpu=30, memory=40, disk=50)
-    assert ComputeResource(cpu=2, gpu=3, memory=4, disk=5) \
-           - ComputeResource(cpu=22, gpu=33, memory=44, disk=55) \
-           == ComputeResource(cpu=0, gpu=0, memory=0, disk=0)
+    assert ComputeResource(cpu=22, gpu=33, mem=44) \
+           - ComputeResource(cpu=2, gpu=3, mem=4) \
+           == ComputeResource(cpu=20, gpu=30, mem=40)
+    assert ComputeResource(cpu=2, gpu=3, mem=4) \
+           - ComputeResource(cpu=22, gpu=33, mem=44) \
+           == ComputeResource(cpu=0, gpu=0, mem=0)
 
 
 def test_subtract():
-    assert ComputeResource(cpu=22, gpu=33, memory=44, disk=55) \
-               .subtract(ComputeResource(cpu=2, gpu=3, memory=4, disk=5)) \
-           == (ComputeResource(cpu=20, gpu=30, memory=40, disk=50),
-               ComputeResource(cpu=0, gpu=0, memory=0, disk=0))
-    assert ComputeResource(cpu=2, gpu=3, memory=4, disk=5) \
-               .subtract(ComputeResource(cpu=22, gpu=33, memory=44, disk=55)) \
-           == (ComputeResource(cpu=0, gpu=0, memory=0, disk=0),
-               ComputeResource(cpu=20, gpu=30, memory=40, disk=50))
+    assert ComputeResource(cpu=22, gpu=33, mem=44) \
+               .subtract(ComputeResource(cpu=2, gpu=3, mem=4)) \
+           == (ComputeResource(cpu=20, gpu=30, mem=40),
+               ComputeResource(cpu=0, gpu=0, mem=0))
+    assert ComputeResource(cpu=2, gpu=3, mem=4) \
+               .subtract(ComputeResource(cpu=22, gpu=33, mem=44)) \
+           == (ComputeResource(cpu=0, gpu=0, mem=0),
+               ComputeResource(cpu=20, gpu=30, mem=40))
 
 
 def test_mul():
-    assert ComputeResource(cpu=2, gpu=3, memory=4, disk=5) \
+    assert ComputeResource(cpu=2, gpu=3, mem=4) \
            * 10 \
-           == ComputeResource(cpu=20, gpu=30, memory=40, disk=50)
+           == ComputeResource(cpu=20, gpu=30, mem=40)
 
 
-def test_compare():
-    assert ComputeResource(cpu=2, gpu=3, memory=4, disk=5) \
-           < ComputeResource(cpu=20, gpu=30, memory=40, disk=50)
-    assert ComputeResource(cpu=20, gpu=30, memory=40, disk=50) \
-           > ComputeResource(cpu=2, gpu=3, memory=4, disk=5)
+def test_cmp():
+    assert ComputeResource(cpu=2, gpu=3, mem=4) \
+           < ComputeResource(cpu=20, gpu=30, mem=40)
+    assert not ComputeResource(cpu=2, gpu=3, mem=4) \
+           < ComputeResource(cpu=2, gpu=3, mem=4)
+    assert ComputeResource(cpu=2, gpu=3, mem=4) \
+           <= ComputeResource(cpu=2, gpu=3, mem=4)
+    assert ComputeResource(cpu=20, gpu=30, mem=40) \
+           > ComputeResource(cpu=2, gpu=3, mem=4)
+    assert not ComputeResource(cpu=20, gpu=30, mem=40) \
+           > ComputeResource(cpu=20, gpu=30, mem=40)
+    assert ComputeResource(cpu=20, gpu=30, mem=40) \
+           >= ComputeResource(cpu=20, gpu=30, mem=40)
 
 
-def test_equals():
-    assert ComputeResource(cpu=2, gpu=3, memory=4, disk=5) \
-           == ComputeResource(cpu=2, gpu=3, memory=4, disk=5)
-    assert ComputeResource(cpu=2, gpu=3, memory=4, disk=5) \
-           != ComputeResource(cpu=20, gpu=30, memory=40, disk=50)
+def test_eq():
+    assert ComputeResource(cpu=2, gpu=3, mem=4) \
+           == ComputeResource(cpu=2, gpu=3, mem=4)
+    assert ComputeResource(cpu=2, gpu=3, mem=4) \
+           != ComputeResource(cpu=20, gpu=30, mem=40)
 
 
 def test_bool():
-    assert ComputeResource(cpu=2, gpu=3, memory=4, disk=5)
-    assert not ComputeResource(cpu=0, gpu=0, memory=0, disk=0)
+    assert ComputeResource(cpu=2, gpu=3, mem=4)
+    assert not ComputeResource(cpu=0, gpu=0, mem=0)

--- a/workflows/pipe-common/test/test_compute_resource.py
+++ b/workflows/pipe-common/test/test_compute_resource.py
@@ -1,0 +1,67 @@
+#  Copyright 2017-2023 EPAM Systems, Inc. (https://www.epam.com/)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+from scripts.autoscale_sge import ComputeResource
+
+
+def test_add():
+    assert ComputeResource(cpu=2, gpu=3, memory=4, disk=5) \
+           + ComputeResource(cpu=20, gpu=30, memory=40, disk=50) \
+           == ComputeResource(cpu=22, gpu=33, memory=44, disk=55)
+
+
+def test_sub():
+    assert ComputeResource(cpu=22, gpu=33, memory=44, disk=55) \
+           - ComputeResource(cpu=2, gpu=3, memory=4, disk=5) \
+           == ComputeResource(cpu=20, gpu=30, memory=40, disk=50)
+    assert ComputeResource(cpu=2, gpu=3, memory=4, disk=5) \
+           - ComputeResource(cpu=22, gpu=33, memory=44, disk=55) \
+           == ComputeResource(cpu=0, gpu=0, memory=0, disk=0)
+
+
+def test_subtract():
+    assert ComputeResource(cpu=22, gpu=33, memory=44, disk=55) \
+               .subtract(ComputeResource(cpu=2, gpu=3, memory=4, disk=5)) \
+           == (ComputeResource(cpu=20, gpu=30, memory=40, disk=50),
+               ComputeResource(cpu=0, gpu=0, memory=0, disk=0))
+    assert ComputeResource(cpu=2, gpu=3, memory=4, disk=5) \
+               .subtract(ComputeResource(cpu=22, gpu=33, memory=44, disk=55)) \
+           == (ComputeResource(cpu=0, gpu=0, memory=0, disk=0),
+               ComputeResource(cpu=20, gpu=30, memory=40, disk=50))
+
+
+def test_mul():
+    assert ComputeResource(cpu=2, gpu=3, memory=4, disk=5) \
+           * 10 \
+           == ComputeResource(cpu=20, gpu=30, memory=40, disk=50)
+
+
+def test_compare():
+    assert ComputeResource(cpu=2, gpu=3, memory=4, disk=5) \
+           < ComputeResource(cpu=20, gpu=30, memory=40, disk=50)
+    assert ComputeResource(cpu=20, gpu=30, memory=40, disk=50) \
+           > ComputeResource(cpu=2, gpu=3, memory=4, disk=5)
+
+
+def test_equals():
+    assert ComputeResource(cpu=2, gpu=3, memory=4, disk=5) \
+           == ComputeResource(cpu=2, gpu=3, memory=4, disk=5)
+    assert ComputeResource(cpu=2, gpu=3, memory=4, disk=5) \
+           != ComputeResource(cpu=20, gpu=30, memory=40, disk=50)
+
+
+def test_bool():
+    assert ComputeResource(cpu=2, gpu=3, memory=4, disk=5)
+    assert not ComputeResource(cpu=0, gpu=0, memory=0, disk=0)

--- a/workflows/pipe-common/test/test_cpu_capacity_instance_selector.py
+++ b/workflows/pipe-common/test/test_cpu_capacity_instance_selector.py
@@ -18,24 +18,24 @@ import pytest
 from mock import MagicMock, Mock
 
 from scripts.autoscale_sge import CpuCapacityInstanceSelector, IntegralDemand, InstanceDemand, Instance, \
-    FractionalDemand
+    FractionalDemand, ResourceSupply
 
 logging.basicConfig(level=logging.DEBUG, format='%(asctime)s [%(threadName)s] [%(levelname)s] %(message)s')
 
 instance_provider = Mock()
-free_cores = 0
+reserved_supply = ResourceSupply()
 price_type = 'price_type'
 owner = 'owner'
 another_owner = 'another_owner'
 
-instance_2cpu = Instance(name='m5.large', price_type=price_type, cpu=2, memory=8, gpu=0)
-instance_4cpu = Instance(name='m5.xlarge', price_type=price_type, cpu=4, memory=16, gpu=0)
-instance_8cpu = Instance(name='m5.2xlarge', price_type=price_type, cpu=8, memory=32, gpu=0)
-instance_16cpu = Instance(name='m5.4xlarge', price_type=price_type, cpu=16, memory=64, gpu=0)
-instance_32cpu = Instance(name='m5.8xlarge', price_type=price_type, cpu=32, memory=128, gpu=0)
-instance_48cpu = Instance(name='m5.12xlarge', price_type=price_type, cpu=48, memory=192, gpu=0)
-instance_64cpu = Instance(name='m5.16xlarge', price_type=price_type, cpu=64, memory=256, gpu=0)
-instance_96cpu = Instance(name='m5.24xlarge', price_type=price_type, cpu=96, memory=384, gpu=0)
+instance_2cpu = Instance(name='m5.large', price_type=price_type, cpu=2, mem=8, gpu=0)
+instance_4cpu = Instance(name='m5.xlarge', price_type=price_type, cpu=4, mem=16, gpu=0)
+instance_8cpu = Instance(name='m5.2xlarge', price_type=price_type, cpu=8, mem=32, gpu=0)
+instance_16cpu = Instance(name='m5.4xlarge', price_type=price_type, cpu=16, mem=64, gpu=0)
+instance_32cpu = Instance(name='m5.8xlarge', price_type=price_type, cpu=32, mem=128, gpu=0)
+instance_48cpu = Instance(name='m5.12xlarge', price_type=price_type, cpu=48, mem=192, gpu=0)
+instance_64cpu = Instance(name='m5.16xlarge', price_type=price_type, cpu=64, mem=256, gpu=0)
+instance_96cpu = Instance(name='m5.24xlarge', price_type=price_type, cpu=96, mem=384, gpu=0)
 all_instances = [instance_2cpu, instance_4cpu,
                  instance_8cpu, instance_16cpu,
                  instance_32cpu, instance_48cpu,
@@ -193,6 +193,6 @@ test_cases = [
                          ids=[test_case[0] for test_case in test_cases])
 def test_select(instances, resource_demands, required_instance_demands):
     instance_provider.provide = MagicMock(return_value=instances)
-    instance_selector = CpuCapacityInstanceSelector(instance_provider, free_cores)
+    instance_selector = CpuCapacityInstanceSelector(instance_provider, reserved_supply)
     actual_instance_demands = list(instance_selector.select(resource_demands))
     assert required_instance_demands == actual_instance_demands

--- a/workflows/pipe-common/test/test_grid_engine.py
+++ b/workflows/pipe-common/test/test_grid_engine.py
@@ -22,15 +22,12 @@ from utils import assert_first_argument_contained, assert_first_argument_not_con
 
 logging.basicConfig(level=logging.DEBUG, format='%(asctime)s [%(threadName)s] [%(levelname)s] %(message)s')
 
-MAX_CLUSTER_CORES = 6
-MAX_INSTANCE_CORES = 2
 QUEUE = 'main.q'
 HOSTLIST = '@allhosts'
 QUEUE_DEFAULT = True
 
 executor = Mock()
 grid_engine = GridEngine(cmd_executor=executor,
-                         max_instance_cores=MAX_INSTANCE_CORES, max_cluster_cores=MAX_CLUSTER_CORES,
                          queue=QUEUE, hostlist=HOSTLIST, queue_default=QUEUE_DEFAULT)
 
 
@@ -47,7 +44,7 @@ def test_qstat_parsing():
       <qtype>BIP</qtype>
       <slots_used>2</slots_used>
       <slots_resv>0</slots_resv>
-      <slots_total>2</slots_total>
+      <slots_total>4</slots_total>
       <load_avg>1.00000</load_avg>
       <arch>lx-amd64</arch>
       <job_list state="running">
@@ -74,9 +71,11 @@ def test_qstat_parsing():
       <JB_owner>someUser</JB_owner>
       <state>qw</state>
       <JB_submission_time>2018-12-21T12:39:38</JB_submission_time>
-      <slots>2</slots>
+      <slots>3</slots>
       <full_job_name>sleep</full_job_name>
-      <requested_pe name="local">2</requested_pe>
+      <requested_pe name="local">3</requested_pe>
+      <hard_request name="gpus" resource_contribution="0.000000">4</hard_request>
+      <hard_request name="ram" resource_contribution="0.000000">5G</hard_request>
       <hard_req_queue>main.q</hard_req_queue>
       <binding>NONE</binding>
     </job_list>
@@ -94,6 +93,9 @@ def test_qstat_parsing():
     assert job_1.name == 'name1'
     assert job_1.user == 'root'
     assert job_1.state == GridEngineJobState.RUNNING
+    assert job_1.slots == 2
+    assert job_1.gpus == 0
+    assert job_1.mem == 0
     assert job_1.datetime == datetime(2018, 12, 21,
                                       11, 48, 00)
     assert 'pipeline-38415' in job_1.hosts
@@ -101,6 +103,9 @@ def test_qstat_parsing():
     assert job_2.name == 'name2'
     assert job_2.user == 'someUser'
     assert job_2.state == GridEngineJobState.PENDING
+    assert job_2.slots == 3
+    assert job_2.gpus == 4
+    assert job_2.mem == 5
     assert job_2.datetime == datetime(2018, 12, 21,
                                       12, 39, 38)
     assert len(job_2.hosts) == 0

--- a/workflows/pipe-common/test/test_grid_engine.py
+++ b/workflows/pipe-common/test/test_grid_engine.py
@@ -93,8 +93,8 @@ def test_qstat_parsing():
     assert job_1.name == 'name1'
     assert job_1.user == 'root'
     assert job_1.state == GridEngineJobState.RUNNING
-    assert job_1.slots == 2
-    assert job_1.gpus == 0
+    assert job_1.cpu == 2
+    assert job_1.gpu == 0
     assert job_1.mem == 0
     assert job_1.datetime == datetime(2018, 12, 21,
                                       11, 48, 00)
@@ -103,8 +103,8 @@ def test_qstat_parsing():
     assert job_2.name == 'name2'
     assert job_2.user == 'someUser'
     assert job_2.state == GridEngineJobState.PENDING
-    assert job_2.slots == 3
-    assert job_2.gpus == 4
+    assert job_2.cpu == 3
+    assert job_2.gpu == 4
     assert job_2.mem == 5
     assert job_2.datetime == datetime(2018, 12, 21,
                                       12, 39, 38)

--- a/workflows/pipe-common/test/test_job_validator.py
+++ b/workflows/pipe-common/test/test_job_validator.py
@@ -30,8 +30,8 @@ QUEUE = 'main.q'
 HOSTLIST = '@allhosts'
 QUEUE_DEFAULT = True
 
-instance_max_supply = ResourceSupply(cpu=2, gpu=3, memory=4)
-cluster_max_supply = ResourceSupply(cpu=20, gpu=30, memory=40)
+instance_max_supply = ResourceSupply(cpu=2, gpu=3, mem=4)
+cluster_max_supply = ResourceSupply(cpu=20, gpu=30, mem=40)
 
 
 grid_engine = Mock()
@@ -58,9 +58,9 @@ def test_validate_empty_jobs():
 def test_validate_valid_jobs():
     jobs = [
         GridEngineJob(id='1', root_id=1, name='', user='', state='', datetime='',
-                      slots=2, gpus=3, mem=4, pe=LOCAL_PE),
+                      cpu=2, gpu=3, mem=4, pe=LOCAL_PE),
         GridEngineJob(id='2', root_id=2, name='', user='', state='', datetime='',
-                      slots=20, gpus=30, mem=40, pe=MPI_PE),
+                      cpu=20, gpu=30, mem=40, pe=MPI_PE),
     ]
 
     valid_jobs, invalid_jobs = job_validator.validate(jobs)
@@ -72,9 +72,9 @@ def test_validate_valid_jobs():
 def test_validate_invalid_jobs():
     jobs = [
         GridEngineJob(id='1', root_id=1, name='', user='', state='', datetime='',
-                      slots=3, gpus=4, mem=5, pe=LOCAL_PE),
+                      cpu=3, gpu=4, mem=5, pe=LOCAL_PE),
         GridEngineJob(id='2', root_id=2, name='', user='', state='', datetime='',
-                      slots=30, gpus=40, mem=50, pe=MPI_PE),
+                      cpu=30, gpu=40, mem=50, pe=MPI_PE),
     ]
 
     valid_jobs, invalid_jobs = job_validator.validate(jobs)
@@ -86,13 +86,13 @@ def test_validate_invalid_jobs():
 def test_validate_both_valid_invalid_jobs():
     jobs = [
         GridEngineJob(id='1', root_id=1, name='', user='', state='', datetime='',
-                      slots=2, gpus=3, mem=4, pe=LOCAL_PE),
+                      cpu=2, gpu=3, mem=4, pe=LOCAL_PE),
         GridEngineJob(id='2', root_id=2, name='', user='', state='', datetime='',
-                      slots=3, gpus=4, mem=5, pe=LOCAL_PE),
+                      cpu=3, gpu=4, mem=5, pe=LOCAL_PE),
         GridEngineJob(id='3', root_id=3, name='', user='', state='', datetime='',
-                      slots=20, gpus=30, mem=40, pe=MPI_PE),
+                      cpu=20, gpu=30, mem=40, pe=MPI_PE),
         GridEngineJob(id='4', root_id=4, name='', user='', state='', datetime='',
-                      slots=30, gpus=40, mem=50, pe=MPI_PE),
+                      cpu=30, gpu=40, mem=50, pe=MPI_PE),
     ]
 
     valid_jobs, invalid_jobs = job_validator.validate(jobs)

--- a/workflows/pipe-common/test/test_job_validator.py
+++ b/workflows/pipe-common/test/test_job_validator.py
@@ -99,3 +99,45 @@ def test_validate_both_valid_invalid_jobs():
 
     assert valid_jobs == [jobs[0], jobs[2]]
     assert invalid_jobs == [jobs[1], jobs[3]]
+
+
+def test_validate_invalid_cpu_job():
+    jobs = [
+        GridEngineJob(id='1', root_id=1, name='', user='', state='', datetime='',
+                      cpu=100, gpu=3, mem=4, pe=LOCAL_PE),
+        GridEngineJob(id='3', root_id=3, name='', user='', state='', datetime='',
+                      cpu=100, gpu=30, mem=40, pe=MPI_PE),
+    ]
+
+    valid_jobs, invalid_jobs = job_validator.validate(jobs)
+
+    assert not valid_jobs
+    assert invalid_jobs == jobs
+
+
+def test_validate_invalid_gpu_job():
+    jobs = [
+        GridEngineJob(id='1', root_id=1, name='', user='', state='', datetime='',
+                      cpu=2, gpu=100, mem=4, pe=LOCAL_PE),
+        GridEngineJob(id='3', root_id=3, name='', user='', state='', datetime='',
+                      cpu=20, gpu=100, mem=40, pe=MPI_PE),
+    ]
+
+    valid_jobs, invalid_jobs = job_validator.validate(jobs)
+
+    assert not valid_jobs
+    assert invalid_jobs == jobs
+
+
+def test_validate_invalid_mem_job():
+    jobs = [
+        GridEngineJob(id='1', root_id=1, name='', user='', state='', datetime='',
+                      cpu=2, gpu=3, mem=100, pe=LOCAL_PE),
+        GridEngineJob(id='3', root_id=3, name='', user='', state='', datetime='',
+                      cpu=20, gpu=30, mem=100, pe=MPI_PE),
+    ]
+
+    valid_jobs, invalid_jobs = job_validator.validate(jobs)
+
+    assert not valid_jobs
+    assert invalid_jobs == jobs

--- a/workflows/pipe-common/test/test_job_validator.py
+++ b/workflows/pipe-common/test/test_job_validator.py
@@ -1,0 +1,101 @@
+# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from mock import MagicMock, Mock
+
+from scripts.autoscale_sge import GridEngineJob, GridEngineJobValidator, ResourceSupply, AllocationRule
+
+
+LOCAL_PE = 'local'
+MPI_PE = 'mpi'
+
+logging.basicConfig(level=logging.DEBUG, format='%(asctime)s [%(threadName)s] [%(levelname)s] %(message)s')
+
+MAX_CLUSTER_CORES = 6
+MAX_INSTANCE_CORES = 2
+QUEUE = 'main.q'
+HOSTLIST = '@allhosts'
+QUEUE_DEFAULT = True
+
+instance_max_supply = ResourceSupply(cpu=2, gpu=3, memory=4)
+cluster_max_supply = ResourceSupply(cpu=20, gpu=30, memory=40)
+
+
+grid_engine = Mock()
+job_validator = GridEngineJobValidator(grid_engine=grid_engine,
+                                       instance_max_supply=instance_max_supply,
+                                       cluster_max_supply=cluster_max_supply)
+
+
+def setup_function():
+    grid_engine.get_pe_allocation_rule = MagicMock(
+        side_effect=lambda pe: AllocationRule.round_robin() if pe == MPI_PE else AllocationRule.pe_slots())
+
+
+def test_validate_empty_jobs():
+    jobs = [
+    ]
+
+    valid_jobs, invalid_jobs = job_validator.validate(jobs)
+
+    assert not valid_jobs
+    assert not invalid_jobs
+
+
+def test_validate_valid_jobs():
+    jobs = [
+        GridEngineJob(id='1', root_id=1, name='', user='', state='', datetime='',
+                      slots=2, gpus=3, mem=4, pe=LOCAL_PE),
+        GridEngineJob(id='2', root_id=2, name='', user='', state='', datetime='',
+                      slots=20, gpus=30, mem=40, pe=MPI_PE),
+    ]
+
+    valid_jobs, invalid_jobs = job_validator.validate(jobs)
+
+    assert valid_jobs == jobs
+    assert not invalid_jobs
+
+
+def test_validate_invalid_jobs():
+    jobs = [
+        GridEngineJob(id='1', root_id=1, name='', user='', state='', datetime='',
+                      slots=3, gpus=4, mem=5, pe=LOCAL_PE),
+        GridEngineJob(id='2', root_id=2, name='', user='', state='', datetime='',
+                      slots=30, gpus=40, mem=50, pe=MPI_PE),
+    ]
+
+    valid_jobs, invalid_jobs = job_validator.validate(jobs)
+
+    assert not valid_jobs
+    assert invalid_jobs == jobs
+
+
+def test_validate_both_valid_invalid_jobs():
+    jobs = [
+        GridEngineJob(id='1', root_id=1, name='', user='', state='', datetime='',
+                      slots=2, gpus=3, mem=4, pe=LOCAL_PE),
+        GridEngineJob(id='2', root_id=2, name='', user='', state='', datetime='',
+                      slots=3, gpus=4, mem=5, pe=LOCAL_PE),
+        GridEngineJob(id='3', root_id=3, name='', user='', state='', datetime='',
+                      slots=20, gpus=30, mem=40, pe=MPI_PE),
+        GridEngineJob(id='4', root_id=4, name='', user='', state='', datetime='',
+                      slots=30, gpus=40, mem=50, pe=MPI_PE),
+    ]
+
+    valid_jobs, invalid_jobs = job_validator.validate(jobs)
+
+    assert valid_jobs == [jobs[0], jobs[2]]
+    assert invalid_jobs == [jobs[1], jobs[3]]

--- a/workflows/pipe-common/test/test_scale_down.py
+++ b/workflows/pipe-common/test/test_scale_down.py
@@ -26,6 +26,7 @@ ADDITIONAL_HOST = 'pipeline-1001'
 
 cmd_executor = Mock()
 grid_engine = Mock()
+grid_engine_validator = Mock()
 host_storage = MemoryHostStorage()
 static_storage = MemoryHostStorage()
 submit_datetime = datetime(2018, 12, 21, 11, 00, 00)
@@ -35,6 +36,7 @@ idle_timeout = 30
 max_additional_hosts = 2
 clock = Clock()
 autoscaler = GridEngineAutoscaler(grid_engine=grid_engine,
+                                  job_validator=grid_engine_validator,
                                   cmd_executor=cmd_executor,
                                   scale_up_orchestrator=None,
                                   scale_down_handler=None,
@@ -52,6 +54,7 @@ def setup_function():
     autoscaler.host_storage.clear()
     autoscaler.host_storage.add_host(ADDITIONAL_HOST)
     grid_engine.get_host_to_scale_down = MagicMock(return_value=ADDITIONAL_HOST)
+    grid_engine_validator.validate = MagicMock(side_effect=lambda jobs: (jobs, []))
     host_storage.get_hosts_activity = MagicMock(return_value={
         ADDITIONAL_HOST: submit_datetime + timedelta(seconds=scale_down_timeout) - timedelta(seconds=idle_timeout)
     })

--- a/workflows/pipe-common/test/test_scale_up.py
+++ b/workflows/pipe-common/test/test_scale_up.py
@@ -26,6 +26,7 @@ MASTER_HOST = 'pipeline-1000'
 
 cmd_executor = Mock()
 grid_engine = Mock()
+grid_engine_validator = Mock()
 host_storage = MemoryHostStorage()
 static_storage = MemoryHostStorage()
 submit_datetime = datetime(2018, 12, 21, 11, 00, 00)
@@ -34,6 +35,7 @@ scale_down_timeout = 30
 max_additional_hosts = 2
 clock = Clock()
 autoscaler = GridEngineAutoscaler(grid_engine=grid_engine,
+                                  job_validator=grid_engine_validator,
                                   cmd_executor=cmd_executor,
                                   scale_up_orchestrator=None,
                                   scale_down_handler=None,
@@ -56,6 +58,7 @@ def setup_function():
     autoscaler.scale_up = MagicMock(side_effect=add_host)
     autoscaler._scale_down = MagicMock()
     autoscaler.host_storage.clear()
+    grid_engine_validator.validate = MagicMock(side_effect=lambda jobs: (jobs, []))
 
 
 def test_scale_up_if_some_of_the_jobs_are_in_queue_for_more_than_scale_up_timeout():

--- a/workflows/pipe-common/test/test_scale_up_handler.py
+++ b/workflows/pipe-common/test/test_scale_up_handler.py
@@ -47,7 +47,7 @@ owner_param_name = 'owner_param_name'
 region_id = 1
 instance_cores = 4
 polling_timeout = 600
-instance = Instance(name='instance', price_type=price_type, cpu=4, memory=16, gpu=0)
+instance = Instance(name='instance', price_type=price_type, cpu=4, mem=16, gpu=0)
 queue_name = 'main.q'
 hostlist = '@allhosts'
 run_id_queue = Queue()

--- a/workflows/pipe-common/test/test_worker_validator.py
+++ b/workflows/pipe-common/test/test_worker_validator.py
@@ -51,13 +51,13 @@ def setup_function():
 
 
 def test_stopping_hosts_that_are_invalid_in_grid_engine():
-    worker_validator.validate_hosts()
+    worker_validator.validate()
 
     assert sorted([HOST1, HOST3]) == sorted(host_storage.load_hosts())
 
 
 def test_stopping_invalid_worker_pipeline():
-    worker_validator.validate_hosts()
+    worker_validator.validate()
 
     assert_first_argument_contained(executor.execute, 'pipe stop --yes ' + HOST2_RUN_ID)
     assert_first_argument_not_contained(executor.execute, 'pipe stop --yes ' + HOST1_RUN_ID)
@@ -68,7 +68,7 @@ def test_force_killing_invalid_host_jobs():
     jobs = [GridEngineJob(id='1', root_id=1, name='', user='', state='', datetime='', hosts=[HOST2])]
     grid_engine.get_jobs = MagicMock(return_value=jobs)
 
-    worker_validator.validate_hosts()
+    worker_validator.validate()
 
     grid_engine.kill_jobs.assert_called_with(jobs, force=True)
 
@@ -76,6 +76,6 @@ def test_force_killing_invalid_host_jobs():
 def test_stopping_dead_worker_hosts():
     api.load_run = MagicMock(side_effect=[{'status': 'STOPPED'}, {'status': 'RUNNING'}, {'status': 'FAILURE'}])
     grid_engine.is_valid = MagicMock(return_value=True)
-    worker_validator.validate_hosts()
+    worker_validator.validate()
 
     assert [HOST2] == host_storage.load_hosts()


### PR DESCRIPTION
Relates #1028.

The pull request brings support for GPU and RAM job requirements validation to grid engine autoscaler. From now on, if a job demands more CPU, GPU or RAM resources than a cluster can supply, then the job will be killed with the corresponding warning message in logs.
