### PR TITLE
Introduce run recovery support

### DIFF
--- a/deploy/contents/install/preferences/launch.system.parameters.json
+++ b/deploy/contents/install/preferences/launch.system.parameters.json
@@ -556,5 +556,12 @@
         "description": "Specifies if run pod should be run with host network capability",
         "defaultValue": "false",
         "passToWorkers": true
+    },
+    {
+        "name": "CP_CAP_RECOVERY",
+        "type": "boolean",
+        "description": "Enables recovery support for a current run",
+        "defaultValue": "true",
+        "passToWorkers": false
     }
 ]

--- a/scripts/pipeline-launch/launch.sh
+++ b/scripts/pipeline-launch/launch.sh
@@ -108,7 +108,7 @@ function install_pip_package {
      if [ "$_DOWNLOAD_RESULT" -ne 0 ];
         then
             echo "[ERROR] ${_DIST_NAME} download failed. Exiting"
-            fail_init "$_DOWNLOAD_RESULT"
+            exit_init "$_DOWNLOAD_RESULT"
         fi
     $CP_PYTHON2_PATH -m pip install $CP_PIP_EXTRA_ARGS ${_DIST_NAME}.tar.gz -q -I
     _INSTALL_RESULT=$?
@@ -116,7 +116,7 @@ function install_pip_package {
     if [ "$_INSTALL_RESULT" -ne 0 ];
     then
         echo "[ERROR] Failed to install ${_DIST_NAME}. Exiting"
-        fail_init "$_INSTALL_RESULT"
+        exit_init "$_INSTALL_RESULT"
     fi
 
 
@@ -133,7 +133,7 @@ function mount_nfs_if_required {
             if [ "$_SETUP_RESULT" -ne 0 ];
             then
                 echo "[ERROR] Mounting NFS failed. Exiting"
-                fail_init "$_SETUP_RESULT"
+                exit_init "$_SETUP_RESULT"
             fi
      fi
 
@@ -154,7 +154,7 @@ function setup_nfs_if_required {
           if [ "$_SETUP_RESULT" -ne 0 ];
           then
                 echo "[ERROR] NFS mount failed. Exiting"
-                fail_init "$_SETUP_RESULT"
+                exit_init "$_SETUP_RESULT"
           fi
           echo "------"
     fi
@@ -298,7 +298,7 @@ function cp_cap_init {
             if [ $_CAP_INIT_SCRIPT_RESULT -ne 0 ];
             then
                   echo "[ERROR] $_CAP_INIT_SCRIPT failed with $_CAP_INIT_SCRIPT_RESULT. Exiting"
-                  fail_init "$_CAP_INIT_SCRIPT_RESULT"
+                  exit_init "$_CAP_INIT_SCRIPT_RESULT"
             else
                   # Reload env vars, in case they were updated within cap init scripts
                   source "$CP_ENV_FILE_TO_SOURCE"
@@ -905,55 +905,38 @@ function self_terminate_on_cleanup_timeout() {
       fi
 }
 
-function recover_run() {
+function exit_stage() {
     local _EXIT_CODE="$1"
     local _RECOVERY_MODE="$2"
 
-    echo "Tagging run as recovering..."
-    tag_run "RECOVERING" "true"
-
-    if [ "$_RECOVERY_MODE" == "skip" ]; then
-        echo "Recovering from exit code $_EXIT_CODE by continuing the execution..."
+    if [ "$_RECOVERY_MODE" == "continue" ]; then
+        tag_run "$CP_CAP_RECOVERY_TAG" "true"
+        echo "Recovering from $_EXIT_CODE using continue recovery mode..."
         return "$_EXIT_CODE"
     fi
-    if [ "$_RECOVERY_MODE" == "stop" ]; then
-        echo "Recovering from exit code $_EXIT_CODE by stopping the execution..."
+    if [ "$_RECOVERY_MODE" == "sleep" ]; then
+        tag_run "$CP_CAP_RECOVERY_TAG" "true"
+        echo "Recovering from $_EXIT_CODE using sleep recovery mode..."
         sleep 10000d
     fi
-    if [ "$_RECOVERY_MODE" == "fail" ]; then
-        echo "Recovering from exit code $_EXIT_CODE by failing the execution..."
-        exit "$_EXIT_CODE"
-    fi
+
+    echo "Exiting with $_EXIT_CODE..."
+    exit "$_EXIT_CODE"
 }
 
-function recover_init {
+function exit_init {
     local _EXIT_CODE="$1"
-    recover_run "$_EXIT_CODE" "$CP_CAP_RECOVERY_MODE_INIT"
+    exit_stage "$_EXIT_CODE" "$CP_CAP_RECOVERY_MODE_INIT"
 }
 
-function recover_exec {
+function exit_exec {
     local _EXIT_CODE="$1"
-    recover_run "$_EXIT_CODE" "$CP_CAP_RECOVERY_MODE_EXEC"
+    exit_stage "$_EXIT_CODE" "$CP_CAP_RECOVERY_MODE_EXEC"
 }
 
-function fail_init {
+function exit_term {
     local _EXIT_CODE="$1"
-
-    if check_cp_cap CP_CAP_RECOVERY; then
-        recover_init "$_EXIT_CODE"
-    else
-        exit "$_EXIT_CODE"
-    fi
-}
-
-function finish_exec {
-    local _EXIT_CODE="$1"
-
-    if check_cp_cap CP_CAP_RECOVERY && [ "$_EXIT_CODE" != "0" ]; then
-        recover_exec "$_EXIT_CODE"
-    else
-        return "$_EXIT_CODE"
-    fi
+    exit_stage "$_EXIT_CODE" "$CP_CAP_RECOVERY_MODE_TERM"
 }
 
 function call_api() {
@@ -1016,13 +999,14 @@ else
     SINGLE_RUN=false;
 fi
 
-if check_cp_cap RESUMED_RUN; then
-    export CP_CAP_RECOVERY="true"
+if check_cp_cap CP_CAP_RECOVERY || check_cp_cap RESUMED_RUN ; then
+    export CP_CAP_RECOVERY_MODE_INIT="${CP_CAP_RECOVERY_MODE_INIT:-continue}"
+    export CP_CAP_RECOVERY_MODE_EXEC="${CP_CAP_RECOVERY_MODE_EXEC:-sleep}"
+else
+    export CP_CAP_RECOVERY_MODE_INIT="${CP_CAP_RECOVERY_MODE_INIT:-exit}"
+    export CP_CAP_RECOVERY_MODE_EXEC="${CP_CAP_RECOVERY_MODE_EXEC:-continue}"
 fi
-
-export CP_CAP_RECOVERY="${CP_CAP_RECOVERY:-false}"
-export CP_CAP_RECOVERY_MODE_INIT="${CP_CAP_RECOVERY_MODE_INIT:-skip}"
-export CP_CAP_RECOVERY_MODE_EXEC="${CP_CAP_RECOVERY_MODE_EXEC:-stop}"
+export CP_CAP_RECOVERY_MODE_TERM="${CP_CAP_RECOVERY_MODE_TERM:-exit}"
 export CP_CAP_RECOVERY_TAG="${CP_CAP_RECOVERY_TAG:-RECOVERED}"
 
 ######################################################
@@ -1107,7 +1091,7 @@ then
       if [ "$_CP_UPGRADE_RESULT" -ne 0 ]
       then
             echo "[WARN] Packages upgrade done with exit code $_CP_UPGRADE_RESULT, review any issues above"
-            fail_init "$_DOWNLOAD_RESULT"
+            exit_init "$_DOWNLOAD_RESULT"
       else
             echo "Packages upgrade done"
       fi
@@ -1149,7 +1133,7 @@ if [ ! -f "$CP_PYTHON2_PATH" ]; then
             if [ -z "$CP_PYTHON2_PATH" ]
             then
                   echo "[ERROR] python2 environment not found, exiting."
-                  fail_init 1
+                  exit_init 1
             fi
       fi
 fi
@@ -1484,7 +1468,7 @@ CP_PIPE_COMMON_ENABLED=${CP_PIPE_COMMON_ENABLED:-"true"}
 if [ "$CP_PIPE_COMMON_ENABLED" == "true" ]; then
       if [ -z "$DISTRIBUTION_URL" ]; then
             echo "[ERROR] Distribution URL is not defined. Exiting"
-            fail_init 1
+            exit_init 1
       else
             cd $COMMON_REPO_DIR
             # Fixed setuptools version to be compatible with the pipe-common package
@@ -1494,7 +1478,7 @@ if [ "$CP_PIPE_COMMON_ENABLED" == "true" ]; then
             if [ "$_DOWNLOAD_RESULT" -ne 0 ];
             then
                   echo "[ERROR] Main repository download failed. Exiting"
-                  fail_init "$_DOWNLOAD_RESULT"
+                  exit_init "$_DOWNLOAD_RESULT"
             fi
             _INSTALL_RESULT=0
             tar xf pipe-common.tar.gz
@@ -1503,7 +1487,7 @@ if [ "$CP_PIPE_COMMON_ENABLED" == "true" ]; then
             if [ "$_INSTALL_RESULT" -ne 0 ];
             then
                   echo "[ERROR] Main repository install failed. Exiting"
-                  fail_init "$_INSTALL_RESULT"
+                  exit_init "$_INSTALL_RESULT"
             fi
             cd -
       fi
@@ -1544,7 +1528,7 @@ if [ "$CP_PIPE_CLI_ENABLED" == "true" ]; then
 
             if [ $? -ne 0 ]; then
                   echo "[ERROR] 'pipe' CLI download failed. Exiting"
-                  fail_init 1
+                  exit_init 1
             fi
 
             # Clean any known locations, where previous version of the pipe might reside (E.g. committed by the user)
@@ -1584,7 +1568,7 @@ elif [ "$CP_FSBROWSER_ENABLED" == "true" ]; then
       download_file "${DISTRIBUTION_URL}${CP_FSBROWSER_NAME}"
       if [ $? -ne 0 ]; then
             echo "[ERROR] Unable to install FSBrowser"
-            fail_init 1
+            exit_init 1
       fi
 
       rm -f /bin/fsbrowser
@@ -1620,7 +1604,7 @@ if [ "$CP_GPUSTAT_ENABLED" != "false" ] && check_installed "nvidia-smi"; then
       download_file "${DISTRIBUTION_URL}${CP_GPUSTAT_NAME}"
       if [ $? -ne 0 ]; then
             echo "[ERROR] Unable to download gpustat"
-            fail_init 1
+            exit_init 1
       fi
 
       CP_GPUSTAT_INSTALL_DIR=${CP_GPUSTAT_INSTALL_DIR:-${CP_USR_BIN}/gpustat-dist}
@@ -1682,7 +1666,7 @@ else
       if [ "$_CLONE_RESULT" -ne 0 ];
       then
             echo "[ERROR] Pipeline repository clone failed. Exiting"
-            fail_init "$_CLONE_RESULT"
+            exit_init "$_CLONE_RESULT"
       fi
       cd -
 fi
@@ -1782,7 +1766,7 @@ fi
 if [ "$_SETUP_RESULT" -ne 0 ];
 then
     echo "[ERROR] Cluster setup failed. Exiting"
-    fail_init "$_SETUP_RESULT"
+    exit_init "$_SETUP_RESULT"
 fi
 
 if [ "${OWNER}" ] && [ -d /root/.ssh ]; then
@@ -1858,7 +1842,7 @@ if [ "$CP_DATA_LOCALIZATION_ENABLED" == "true" ]; then
 
             if [ $? -ne 0 ]; then
                   echo "Failed to upload input data"
-                  fail_init 1
+                  exit_init 1
             fi
             echo
 
@@ -1874,7 +1858,7 @@ if [ "$CP_DATA_LOCALIZATION_ENABLED" == "true" ]; then
                   if [ "$CP_LOCALIZE_FROM_FILES_KEEP_JOB_ON_FAILURE" == "true" ]; then
                         echo "--> It is requested to continue running on config files based localization failure"
                   else
-                        fail_init 1
+                        exit_init 1
                   fi
             fi
             echo
@@ -2405,7 +2389,9 @@ else
   CP_EXEC_RESULT=$?
 fi
 
-finish_exec "$CP_EXEC_RESULT"
+if [ "$CP_EXEC_RESULT" != "0" ]; then
+    exit_exec "$CP_EXEC_RESULT"
+fi
 
 echo "------"
 echo
@@ -2469,6 +2455,10 @@ else
     rm -Rf $RUN_DIR
 fi
 
-echo "Exiting with $CP_EXEC_RESULT"
-exit "$CP_EXEC_RESULT"
+if [ "$CP_EXEC_RESULT" != "0" ]; then
+    exit_term "$CP_EXEC_RESULT"
+else
+    echo "Exiting with $CP_EXEC_RESULT..."
+    exit "$CP_EXEC_RESULT"
+fi
 ######################################################

--- a/scripts/pipeline-launch/launch.sh
+++ b/scripts/pipeline-launch/launch.sh
@@ -1023,7 +1023,7 @@ fi
 export CP_CAP_RECOVERY="${CP_CAP_RECOVERY:-false}"
 export CP_CAP_RECOVERY_MODE_INIT="${CP_CAP_RECOVERY_MODE_INIT:-skip}"
 export CP_CAP_RECOVERY_MODE_EXEC="${CP_CAP_RECOVERY_MODE_EXEC:-stop}"
-export CP_CAP_RECOVERY_TAG="${CP_CAP_RECOVERY_TAG:-RECOVERING}"
+export CP_CAP_RECOVERY_TAG="${CP_CAP_RECOVERY_TAG:-RECOVERED}"
 
 ######################################################
 # Configure Hyperthreading


### PR DESCRIPTION
Resolves #3215.

The pull request brings support for run recovery to Cloud Pipeline. 

If enabled, it skips all run initialisation and execution errors and also keeps run alive until it is manually stopped if cmd template exits with an error. Moreover, all runs which were recovered are also tagged. Please notice that run recovery is enabled by default for all resumed runs.

The pull request introduces the following system parameters:
- `CP_CAP_RECOVERY` enables run recovery default modes. Defaults to _false_.

## Advanced settings

There are the several _stages_ in _launch.sh_:
- _init_ stage includes everything before _cmd_template_ execution
- _exec_ stage includes _cmd_template_ execution
- _term_ stage includes everything after _cmd_template_ execution

Also, there are several _recovery modes_:
- _continue_ mode ignores errors
- _sleep_ mode halts execution on error
- _exit_ mode kills current run on error

The following run parameters allows advanced run recovery configuration:

- `CP_CAP_RECOVERY_TAG` specifies tag to mark recovered runs. Defaults to _RECOVERED_.
- `CP_CAP_RECOVERY_MODE_INIT` specifies _recovery mode_ for errors during _init_ stage. Defaults to _exit_ but if run recovery is enabled then defaults to _continue_.
- `CP_CAP_RECOVERY_MODE_EXEC` specifies _recovery mode_ for errors during _exec_ stage.  Defaults to _continue_ but if run recovery is enabled then defaults to _sleep_.
- `CP_CAP_RECOVERY_MODE_TERM` specifies _recovery mode_ for errors during _term_ stage. Defaults to _exit_.
