### PR TITLE
Issue #3219: Invalid gitlab listing

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/git/GitLabApi.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/GitLabApi.java
@@ -68,6 +68,8 @@ public interface GitLabApi {
     String PRIVATE_TOKEN = "PRIVATE-TOKEN";
     String API_VERSION = "api_version";
     String ISSUE_ID = "issue_id";
+    String PER_PAGE = "per_page";
+    String PAGE = "page";
 
     /**
      * @param userName The name of the GitLab user
@@ -136,12 +138,16 @@ public interface GitLabApi {
      * @param path      (optional) - The path inside repository. Used to get contend of subdirectories
      * @param reference (optional) - The name of a repository branch or tag or if not given the default branch
      * @param recursive (optional) - Boolean value used to get a recursive tree (false by default)
+     * @param perPage   (optional) - Number of results to show per page. If not specified, defaults to 20.
+     * @param page      (optional) - Page number (default: 1). Deprecated in GitLab 14.3.
      */
     @GET("api/v4/projects/{project}/repository/tree")
     Call<List<GitRepositoryEntry>> getRepositoryTree(@Path(PROJECT) String idOrName,
                                                      @Query(PATH) String path,
                                                      @Query(REF) String reference,
-                                                     @Query(RECURSIVE) Boolean recursive);
+                                                     @Query(RECURSIVE) Boolean recursive,
+                                                     @Query(PER_PAGE) Integer perPage,
+                                                     @Query(PAGE) Integer page);
 
     /**
      * Allows you to receive information about file in repository like name, size, content.
@@ -380,8 +386,8 @@ public interface GitLabApi {
                                       @Path(PROJECT) String idOrName,
                                       @Query("labels") String labels,
                                       @Query("not[labels]") String notLabels,
-                                      @Query("page") Integer page,
-                                      @Query("per_page") Integer pageSize,
+                                      @Query(PAGE) Integer page,
+                                      @Query(PER_PAGE) Integer pageSize,
                                       @Query("search") String search);
 
     @GET("api/{api_version}/projects/{project}/issues/{issue_id}")

--- a/api/src/main/java/com/epam/pipeline/manager/git/RestApiUtils.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/RestApiUtils.java
@@ -25,6 +25,8 @@ import retrofit2.Response;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
+import java.util.Objects;
 
 public final class RestApiUtils {
 
@@ -47,6 +49,15 @@ public final class RestApiUtils {
         } catch (IOException e) {
             throw new GitClientException(e.getMessage(), e);
         }
+    }
+
+    public static <T> Response<List<T>> fetchPage(final Call<List<T>> call,
+                                                  final List<T>  results) throws GitClientException {
+        final Response<List<T>> response = getResponse(call);
+        if (Objects.nonNull(response.body())) {
+            results.addAll(response.body());
+        }
+        return response;
     }
 
     public static byte[] getFileContent(final Call<ResponseBody> filesRawContent, final int byteLimit) {

--- a/api/src/main/java/com/epam/pipeline/manager/git/RestApiUtils.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/RestApiUtils.java
@@ -52,7 +52,7 @@ public final class RestApiUtils {
     }
 
     public static <T> Response<List<T>> fetchPage(final Call<List<T>> call,
-                                                  final List<T>  results) throws GitClientException {
+                                                  final List<T> results) throws GitClientException {
         final Response<List<T>> response = getResponse(call);
         if (Objects.nonNull(response.body())) {
             results.addAll(response.body());

--- a/api/src/test/java/com/epam/pipeline/manager/git/GitManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/git/GitManagerTest.java
@@ -38,6 +38,7 @@ import com.epam.pipeline.manager.pipeline.PipelineManager;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import lombok.SneakyThrows;
@@ -319,7 +320,7 @@ public class GitManagerTest extends AbstractManagerTest {
                 .withQueryParam(REF, equalTo(TEST_REVISION))
                 .withQueryParam(PATH, equalTo(DOCS + "/"))
                 .withQueryParam(RECURSIVE, equalTo(String.valueOf(false)))
-                .willReturn(okJson(with(tree)))
+                .willReturn(treeResponse(tree))
         );
         final GitTagEntry tag = new GitTagEntry();
         givenThat(
@@ -404,7 +405,7 @@ public class GitManagerTest extends AbstractManagerTest {
                 .withQueryParam(REF, equalTo(GIT_MASTER_REPOSITORY))
                 .withQueryParam(PATH, equalTo(DOCS))
                 .withQueryParam(RECURSIVE, equalTo(String.valueOf(true)))
-                .willReturn(okJson(with(tree)))
+                .willReturn(treeResponse(tree))
         );
         final GitCommitEntry expectedCommit = mockGitCommitRequest();
         final Pipeline pipeline = testingPipeline();
@@ -494,7 +495,7 @@ public class GitManagerTest extends AbstractManagerTest {
         givenThat(
             get(urlPathEqualTo(apiV4(REPOSITORY_TREE)))
                 .withQueryParam(PATH, equalTo(DOCS))
-                .willReturn(okJson(with(tree)))
+                .willReturn(treeResponse(tree))
         );
         givenThat(
                 get(urlPathEqualTo(api(REPOSITORY_FILES + "/" + encodeUrlPath(DOCS))))
@@ -518,7 +519,7 @@ public class GitManagerTest extends AbstractManagerTest {
         givenThat(
                 get(urlPathEqualTo(apiV4(REPOSITORY_TREE)))
                         .withQueryParam(PATH, equalTo(DOCS))
-                        .willReturn(okJson(with(tree)))
+                        .willReturn(treeResponse(tree))
         );
         mockFileContentRequest(DOCS, GIT_MASTER_REPOSITORY, FILE_CONTENT);
         gitManager.createOrRenameFolder(pipeline.getId(), folder);
@@ -769,5 +770,9 @@ public class GitManagerTest extends AbstractManagerTest {
                         .willReturn(okJson(with(expectedCommit)))
         );
         return expectedCommit;
+    }
+
+    private ResponseDefinitionBuilder treeResponse(final List<GitRepositoryEntry> tree) {
+        return okJson(with(tree)).withHeader("X-Total", String.valueOf(tree.size()));
     }
 }


### PR DESCRIPTION
The current PR provides implementation for issue #3219 

This PR brings changes for API method `GET /pipeline/{id}/sources`: all requested data shall be loaded