### PR TITLE
Issue #3220: Gitlab token duration

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/git/GitManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/GitManager.java
@@ -103,7 +103,6 @@ public class GitManager {
     private static final String BASE64_ENCODING = "base64";
     public static final String EXCLUDE_MARK = ":!";
 
-    private static final long DEFAULT_TOKEN_DURATION = 1L;
     private static final String EMPTY = "";
     private static final String COMMA = ",";
     private static final String ANY_SUB_PATH = "*";
@@ -182,16 +181,19 @@ public class GitManager {
 
     public GitCredentials getGitCredentials(Long id, boolean useEnvVars, boolean issueToken) {
         Pipeline pipeline = pipelineManager.load(id);
+        final Long defaultTokenDuration = preferenceManager.getPreference(
+                SystemPreferences.GIT_DEFAULT_TOKEN_DURATION_DAYS);
         try {
             return pipelineRepositoryService
-                    .getPipelineCloneCredentials(pipeline, useEnvVars, issueToken, DEFAULT_TOKEN_DURATION);
+                    .getPipelineCloneCredentials(pipeline, useEnvVars, issueToken, defaultTokenDuration);
         } catch (GitClientException e) {
             throw new IllegalArgumentException(e.getMessage());
         }
     }
 
     public GitCredentials getGitlabCredentials(Long duration) {
-        Long expiration = Optional.ofNullable(duration).orElse(DEFAULT_TOKEN_DURATION);
+        Long expiration = Optional.ofNullable(duration)
+                .orElse(preferenceManager.getPreference(SystemPreferences.GIT_DEFAULT_TOKEN_DURATION_DAYS));
         try {
             return getDefaultGitlabClient()
                     .withFullUrl(preferenceManager.getPreference(SystemPreferences.GIT_EXTERNAL_URL))

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -337,6 +337,8 @@ public class SystemPreferences {
     public static final ObjectPreference<GitlabIssueLabelsFilter> GITLAB_ISSUE_DEFAULT_FILTER = new ObjectPreference<>(
             "git.gitlab.issue.default.filter", null, new TypeReference<GitlabIssueLabelsFilter>() {},
             GIT_GROUP, isNullOrValidJson(new TypeReference<GitlabIssueLabelsFilter>() {}), true);
+    public static final LongPreference GIT_DEFAULT_TOKEN_DURATION_DAYS = new LongPreference(
+            "git.default.token.duration.days", 1L, GIT_GROUP, isGreaterThan(0L));
 
     // DOCKER_SECURITY_GROUP
     /**


### PR DESCRIPTION
The current PR provides implementation for issue #3220 

This PR brings a new system preference `git.default.token.duration.days` (default 1 day) instead of hardcoded constant.