### PR TITLE
pipe storage mount: timeout support 

### DIFF
--- a/deploy/contents/install/preferences/launch.system.parameters.json
+++ b/deploy/contents/install/preferences/launch.system.parameters.json
@@ -355,10 +355,10 @@
         "passToWorkers": true
     },
     {
-        "name": "CP_PIPE_FUSE_TIMEOUT",
+        "name": "CP_PIPE_FUSE_MOUNT_DELAY",
         "type": "int",
         "description": "Allows to specify the pipe fuse timeout",
-        "defaultValue": "500",
+        "defaultValue": "10000",
         "passToWorkers": false
     },
     {

--- a/deploy/contents/install/preferences/launch.system.parameters.json
+++ b/deploy/contents/install/preferences/launch.system.parameters.json
@@ -355,7 +355,7 @@
         "passToWorkers": true
     },
     {
-        "name": "CP_PIPE_FUSE_MOUNT_DELAY",
+        "name": "CP_PIPE_FUSE_MOUNT_TIMEOUT",
         "type": "int",
         "description": "Allows to specify the pipe fuse timeout",
         "defaultValue": "10000",

--- a/pipe-cli/mount/pipe-fuse.py
+++ b/pipe-cli/mount/pipe-fuse.py
@@ -227,7 +227,7 @@ def start(mountpoint, webdav, bucket,
     enable_additional_operations()
     ro = client.is_read_only() or mount_options.get('ro', False)
     mount_options.pop('ro', None)
-    FUSE(fs, mountpoint, nothreads=not threads, foreground=True, ro=ro, **mount_options)
+    FUSE(fs, mountpoint, nothreads=not threads, foreground=True, ro=ro, fsname='PIPE_FUSE', **mount_options)
 
 
 def get_audit_client(client, pipe, storage, audit_buffer_ttl, audit_buffer_size):

--- a/pipe-cli/mount/pipe-fuse.py
+++ b/pipe-cli/mount/pipe-fuse.py
@@ -82,6 +82,7 @@ _debug_logging_level = 'DEBUG'
 _info_logging_level = 'INFO'
 _xattrs_operations = ['setxattr', 'getxattr', 'listxattr', 'removexattr']
 _xattrs_include_prefix = 'user'
+_fs_name = 'PIPE_FUSE'
 
 
 def start(mountpoint, webdav, bucket,
@@ -227,7 +228,7 @@ def start(mountpoint, webdav, bucket,
     enable_additional_operations()
     ro = client.is_read_only() or mount_options.get('ro', False)
     mount_options.pop('ro', None)
-    FUSE(fs, mountpoint, nothreads=not threads, foreground=True, ro=ro, fsname='PIPE_FUSE', **mount_options)
+    FUSE(fs, mountpoint, nothreads=not threads, foreground=True, ro=ro, fsname=_fs_name, **mount_options)
 
 
 def get_audit_client(client, pipe, storage, audit_buffer_ttl, audit_buffer_size):

--- a/pipe-cli/mount/pipe-fuse.py
+++ b/pipe-cli/mount/pipe-fuse.py
@@ -82,7 +82,6 @@ _debug_logging_level = 'DEBUG'
 _info_logging_level = 'INFO'
 _xattrs_operations = ['setxattr', 'getxattr', 'listxattr', 'removexattr']
 _xattrs_include_prefix = 'user'
-_fs_name = 'PIPE_FUSE'
 
 
 def start(mountpoint, webdav, bucket,
@@ -110,6 +109,7 @@ def start(mountpoint, webdav, bucket,
                                                read_ahead_size_multiplier))
     audit_buffer_ttl = int(os.getenv('CP_PIPE_FUSE_AUDIT_BUFFER_TTL', audit_buffer_ttl))
     audit_buffer_size = int(os.getenv('CP_PIPE_FUSE_AUDIT_BUFFER_SIZE', audit_buffer_size))
+    fs_name = os.getenv('CP_PIPE_FUSE_FS_NAME', 'PIPE_FUSE')
     bucket_type = None
     bucket_path = None
     daemons = []
@@ -228,7 +228,7 @@ def start(mountpoint, webdav, bucket,
     enable_additional_operations()
     ro = client.is_read_only() or mount_options.get('ro', False)
     mount_options.pop('ro', None)
-    FUSE(fs, mountpoint, nothreads=not threads, foreground=True, ro=ro, fsname=_fs_name, **mount_options)
+    FUSE(fs, mountpoint, nothreads=not threads, foreground=True, ro=ro, fsname=fs_name, **mount_options)
 
 
 def get_audit_client(client, pipe, storage, audit_buffer_ttl, audit_buffer_size):

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1366,7 +1366,7 @@ def storage_delete_object_tags(path, tags, version):
 @click.option('-t', '--threads', help='Enables multithreading', is_flag=True)
 @click.option('-m', '--mode', required=False, help='Default file permissions',  default=700, type=int)
 @click.option('-w', '--timeout', required=False, help='Waiting time in ms to check whether mount was successful',
-              default=60000, type=int)
+              default=10000, type=int)
 @click.option('-g', '--show-archive', is_flag=True, help='Show archived files.')
 @common_options
 def mount_storage(mountpoint, file, bucket, options, custom_options, log_file, log_level, quiet, threads, mode,

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1366,7 +1366,7 @@ def storage_delete_object_tags(path, tags, version):
 @click.option('-t', '--threads', help='Enables multithreading', is_flag=True)
 @click.option('-m', '--mode', required=False, help='Default file permissions',  default=700, type=int)
 @click.option('-w', '--timeout', required=False, help='Waiting time in ms to check whether mount was successful',
-              default=1000, type=int)
+              default=60000, type=int)
 @click.option('-g', '--show-archive', is_flag=True, help='Show archived files.')
 @common_options
 def mount_storage(mountpoint, file, bucket, options, custom_options, log_file, log_level, quiet, threads, mode,

--- a/pipe-cli/src/utilities/datastorage_operations.py
+++ b/pipe-cli/src/utilities/datastorage_operations.py
@@ -543,7 +543,7 @@ class DataStorageOperations(object):
 
     @classmethod
     def mount_storage(cls, mountpoint, file=False, bucket=None, log_file=None, log_level=None, options=None,
-                      custom_options=None, quiet=False, threading=False, mode=700, timeout=1000, show_archive=False):
+                      custom_options=None, quiet=False, threading=False, mode=700, timeout=10000, show_archive=False):
         if not file and not bucket:
             click.echo('Either file system mode should be enabled (-f/--file) '
                        'or bucket name should be specified (-b/--bucket BUCKET).', err=True)

--- a/pipe-cli/src/utilities/storage/mount.py
+++ b/pipe-cli/src/utilities/storage/mount.py
@@ -190,6 +190,7 @@ class Mount(object):
             mount_environment = os.environ.copy()
             mount_environment['API'] = config.api
             mount_environment['API_TOKEN'] = config.get_token()
+            mount_environment['CP_PIPE_FUSE_FS_NAME'] = self.PIPE_FUSE_FS_NAME
             if python_path:
                 mount_environment['PYTHONPATH'] = python_path
             if config.proxy:

--- a/pipe-cli/src/utilities/storage/mount.py
+++ b/pipe-cli/src/utilities/storage/mount.py
@@ -150,7 +150,8 @@ class Mount(object):
     PIPE_FUSE_FS_NAME = 'PIPE_FUSE'
 
     def mount_storages(self, mountpoint, file=False, bucket=None, options=None, custom_options=None, quiet=False,
-                       log_file=None, log_level=None, threading=False, mode=700, timeout=60000, show_archive=False):
+                       log_file=None, log_level=None, threading=False, mode=700, timeout=10*MS_IN_SEC,
+                       show_archive=False):
         config = Config.instance()
         username = self.normalize_username(config.get_current_user())
         mount = FrozenMount() if is_frozen() else SourceMount()
@@ -171,20 +172,20 @@ class Mount(object):
         return username.split('@')[0]
 
     def mount_dav(self, mount, config, mountpoint, options, custom_options, web_dav_url, mode,
-                  log_file=None, log_level=None, threading=False, timeout=60000, show_archive=False):
+                  log_file=None, log_level=None, threading=False, timeout=10*MS_IN_SEC, show_archive=False):
         mount_cmd = mount.get_mount_webdav_cmd(config, mountpoint, options, custom_options, web_dav_url, mode,
                                                log_level=log_level, threading=threading, show_archive=show_archive)
         python_path = mount.get_python_path()
         self.run(config, mount_cmd, mountpoint, python_path=python_path, log_file=log_file, mount_timeout=timeout)
 
     def mount_storage(self, mount, config, mountpoint, options, custom_options, bucket, mode,
-                      log_file=None, log_level=None, threading=False, timeout=60000, show_archive=False):
+                      log_file=None, log_level=None, threading=False, timeout=10*MS_IN_SEC, show_archive=False):
         mount_cmd = mount.get_mount_storage_cmd(config, mountpoint, options, custom_options, bucket, mode,
                                                 log_level=log_level, threading=threading, show_archive=show_archive)
         python_path = mount.get_python_path()
         self.run(config, mount_cmd, mountpoint, python_path=python_path, log_file=log_file, mount_timeout=timeout)
 
-    def run(self, config, mount_cmd, mountpoint, mount_timeout=60*MS_IN_SEC, python_path=None, log_file=None):
+    def run(self, config, mount_cmd, mountpoint, mount_timeout=10*MS_IN_SEC, python_path=None, log_file=None):
         output_file = log_file if log_file else os.devnull
         with open(output_file, 'w') as output:
             mount_environment = os.environ.copy()
@@ -204,9 +205,11 @@ class Mount(object):
             self._wait_mount_point(mount_timeout, mount_aps_proc, mountpoint)
 
     def _wait_mount_point(self, mount_timeout, mount_aps_proc, mountpoint):
-        max_init_try = int(mount_timeout / MS_IN_SEC)
-        for iteration in range(1, max_init_try):
-            time.sleep(1)
+        pooling_delay = os.environ.get('CP_PIPE_FUSE_MOUNT_DELAY', 500)
+        max_init_try = int(mount_timeout / pooling_delay) or 1
+        pooling_delay = float(pooling_delay) / MS_IN_SEC
+        for iteration in range(0, max_init_try):
+            time.sleep(pooling_delay)
             self._check_mount_proc_is_alive(mount_aps_proc)
             if os.path.ismount(mountpoint):
                 self._validate_fs_name(mountpoint)

--- a/pipe-cli/src/utilities/storage/mount.py
+++ b/pipe-cli/src/utilities/storage/mount.py
@@ -205,7 +205,7 @@ class Mount(object):
             self._wait_mount_point(mount_timeout, mount_aps_proc, mountpoint)
 
     def _wait_mount_point(self, mount_timeout, mount_aps_proc, mountpoint):
-        pooling_delay = os.environ.get('CP_PIPE_FUSE_MOUNT_DELAY', 500)
+        pooling_delay = int(os.environ.get('CP_PIPE_FUSE_MOUNT_DELAY', 500))
         max_init_try = int(mount_timeout / pooling_delay) or 1
         pooling_delay = float(pooling_delay) / MS_IN_SEC
         for iteration in range(0, max_init_try):

--- a/scripts/nfs-roles-management/syncmounts.sh
+++ b/scripts/nfs-roles-management/syncmounts.sh
@@ -260,7 +260,7 @@ while IFS='|' read -r id name path type region_id; do
          blobfuse ${mount_root_srv_dir} --container-name=${path} --tmp-path=$CP_TMP_DIR_PATH
          mount_result=$?
      elif [[ "${type}" == "S3" ]] || [[ "${type}" == "GCP" ]]; then
-         pipe storage mount ${mount_root_srv_dir} -b ${path} -t --mode 775 -w ${CP_PIPE_FUSE_TIMEOUT:-500} -o allow_other -c audit-buffer-ttl=0 -l /var/log/fuse_${id}.log
+         pipe storage mount ${mount_root_srv_dir} -b ${path} -t --mode 775 -w ${CP_PIPE_FUSE_MOUNT_TIMEOUT:-10000} -o allow_other -c audit-buffer-ttl=0 -l /var/log/fuse_${id}.log
          mount_result=$?
          # Even in the "pipe storage mount" is OK, it may take a second or two to fully initialized
          # During this period the directory is considered as an empty "overlayfs"

--- a/workflows/pipe-common/scripts/mount_storage.py
+++ b/workflows/pipe-common/scripts/mount_storage.py
@@ -522,7 +522,7 @@ class S3Mounter(StorageMounter):
         permissions = 'rw'
         stat_cache = os.getenv('CP_S3_FUSE_STAT_CACHE', '1m0s')
         type_cache = os.getenv('CP_S3_FUSE_TYPE_CACHE', '1m0s')
-        mount_timeout = os.getenv('CP_PIPE_FUSE_TIMEOUT', 500)
+        mount_timeout = os.getenv('CP_PIPE_FUSE_MOUNT_TIMEOUT', 10000)
         aws_key_id, aws_secret, region_name, session_token = self._get_credentials(self.storage)
         path_chunks = self.storage.path.split('/')
         bucket = path_chunks[0]
@@ -631,7 +631,7 @@ class GCPMounter(StorageMounter):
         super(GCPMounter, self).mount(mount_root, task_name)
 
     def build_mount_params(self, mount_point):
-        mount_timeout = os.getenv('CP_PIPE_FUSE_TIMEOUT', 500)
+        mount_timeout = os.getenv('CP_PIPE_FUSE_MOUNT_TIMEOUT', 10000)
         gcp_creds_content, _ = self._get_credentials(self.storage)
         if gcp_creds_content:
             creds_named_pipe_path = "<(echo \'{gcp_creds_content}\')".format(gcp_creds_content=gcp_creds_content)


### PR DESCRIPTION
## Background
It would be useful to wait for `pipe-fuse` initialisation more accurate.

## Approach
- `pipe-fuse` script sets specific name to the file system
- `pipe storage mount` command waits for `pipe-fuse` script with the following manner:
  - checks if `pipe-fuse` process still alive; if not exists immediately
  - checks mount point readiness; wait if not ready
  - if mount point ready checks file system name  
- If timeout expired terminate existing process
- A new envvar `CP_PIPE_FUSE_MOUNT_DELAY` to manipulate pooling delay (Default 0.5 sec)
- Increase default value for `--timeout` option up to 10 sec
- rename `CP_PIPE_FUSE_MOUNT_TIMEOUT` instead of `CP_PIPE_FUSE_TIMEOUT` to specify `pipe-fuse` waiting timeout