### PR TITLE
Issue #3233: Automatic restart of stopped runs

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/AutoscaleManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/AutoscaleManager.java
@@ -520,7 +520,8 @@ public class AutoscaleManager extends AbstractSchedulingManager {
                     final int nodeUpRetryCount = preferenceManager.getPreference(
                             SystemPreferences.CLUSTER_NODEUP_RETRY_COUNT);
 
-                    if (retryCount >= nodeUpRetryCount) {
+                    if (retryCount >= nodeUpRetryCount &&
+                            !pipelineRunManager.loadPipelineRun(longId).getStatus().isFinal()) {
                         pipelineRunManager.updateStateReasonMessageById(longId, preferenceManager
                                 .getPreference(SystemPreferences.LAUNCH_INSUFFICIENT_CAPACITY_MESSAGE));
                         runRegionShiftHandler.restartRunInAnotherRegion(longId);


### PR DESCRIPTION
The current PR provides fix for issue #3233

This issue occurs during the last retry to launch run. This way `AutoscaleManager` shall check if the run already stopped before restarting run in the another region. 