### PR TITLE
Issue #3235: Return additional information for docker tree

### DIFF
--- a/api/src/main/java/com/epam/pipeline/dao/tool/ToolVersionDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/tool/ToolVersionDao.java
@@ -123,7 +123,8 @@ public class ToolVersionDao extends NamedParameterJdbcDaoSupport {
     }
 
     public List<ToolVersion> loadAllLatestToolVersions() {
-        return getJdbcTemplate().query(loadAllLatestToolVersionsQuery, ToolVersionParameters.getRowMapperWithSettings());
+        return getJdbcTemplate().query(loadAllLatestToolVersionsQuery,
+                ToolVersionParameters.getRowMapperWithSettings());
     }
 
     enum ToolVersionParameters {

--- a/api/src/main/java/com/epam/pipeline/dao/tool/ToolVersionDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/tool/ToolVersionDao.java
@@ -52,6 +52,7 @@ public class ToolVersionDao extends NamedParameterJdbcDaoSupport {
     private String loadToolVersionListSettingsQuery;
     private String createToolVersionWithSettingsQuery;
     private String updateToolVersionWithSettingsQuery;
+    private String loadAllLatestToolVersionsQuery;
 
     @Autowired
     private DaoHelper daoHelper;
@@ -119,6 +120,10 @@ public class ToolVersionDao extends NamedParameterJdbcDaoSupport {
                 .query(loadToolVersionListSettingsQuery, params, ToolVersionParameters.getRowMapper())
                 .stream()
                 .collect(Collectors.toMap(ToolVersion::getVersion, Function.identity()));
+    }
+
+    public List<ToolVersion> loadAllLatestToolVersions() {
+        return getJdbcTemplate().query(loadAllLatestToolVersionsQuery, ToolVersionParameters.getRowMapperWithSettings());
     }
 
     enum ToolVersionParameters {
@@ -244,5 +249,10 @@ public class ToolVersionDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setLoadToolVersionListSettingsQuery(final String loadToolVersionListSettingsQuery) {
         this.loadToolVersionListSettingsQuery = loadToolVersionListSettingsQuery;
+    }
+
+    @Required
+    public void setLoadAllLatestToolVersionsQuery(final String loadAllLatestToolVersionsQuery) {
+        this.loadAllLatestToolVersionsQuery = loadAllLatestToolVersionsQuery;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerRegistryManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerRegistryManager.java
@@ -57,7 +57,6 @@ import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.mockito.internal.util.collections.ListUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerRegistryManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerRegistryManager.java
@@ -672,7 +672,7 @@ public class DockerRegistryManager implements SecuredEntityManager {
 
     private Set<Long> getGpuToolIds() {
         final Set<String> gpuTypes = getGpuInstanceTypes();
-        return ListUtils.emptyIfNull(toolVersionManager.loadAllToolVersionSettings()).stream()
+        return ListUtils.emptyIfNull(toolVersionManager.loadAllLatestToolVersionSettings()).stream()
                 .filter(toolVersion -> ListUtils.emptyIfNull(toolVersion.getSettings()).stream()
                         .map(configuration -> Optional.ofNullable(configuration.getConfiguration())
                                 .map(PipelineConfiguration::getInstanceType)

--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerRegistryManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerRegistryManager.java
@@ -23,11 +23,14 @@ import com.epam.pipeline.controller.vo.EntityVO;
 import com.epam.pipeline.controller.vo.docker.DockerRegistryVO;
 import com.epam.pipeline.dao.docker.DockerRegistryDao;
 import com.epam.pipeline.entity.AbstractSecuredEntity;
+import com.epam.pipeline.entity.cluster.InstanceType;
+import com.epam.pipeline.entity.configuration.PipelineConfiguration;
 import com.epam.pipeline.entity.docker.DockerRegistryList;
 import com.epam.pipeline.entity.docker.DockerRegistrySecret;
 import com.epam.pipeline.entity.docker.ImageDescription;
 import com.epam.pipeline.entity.docker.ImageHistoryLayer;
 import com.epam.pipeline.entity.docker.ManifestV2;
+import com.epam.pipeline.entity.docker.ToolVersion;
 import com.epam.pipeline.entity.pipeline.DockerRegistry;
 import com.epam.pipeline.entity.pipeline.DockerRegistryEvent;
 import com.epam.pipeline.entity.pipeline.DockerRegistryEventEnvelope;
@@ -38,6 +41,7 @@ import com.epam.pipeline.entity.security.JwtRawToken;
 import com.epam.pipeline.entity.security.acl.AclClass;
 import com.epam.pipeline.entity.utils.DateUtils;
 import com.epam.pipeline.exception.docker.DockerAuthorizationException;
+import com.epam.pipeline.manager.cloud.CloudFacade;
 import com.epam.pipeline.manager.cluster.KubernetesManager;
 import com.epam.pipeline.manager.metadata.MetadataManager;
 import com.epam.pipeline.manager.pipeline.ToolGroupManager;
@@ -53,6 +57,7 @@ import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.mockito.internal.util.collections.ListUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -123,6 +128,9 @@ public class DockerRegistryManager implements SecuredEntityManager {
 
     @Autowired
     private ToolVersionManager toolVersionManager;
+
+    @Autowired
+    private CloudFacade cloudFacade;
 
     @Transactional(propagation = Propagation.REQUIRED)
     public DockerRegistry create(DockerRegistryVO dockerRegistryVO) {
@@ -411,10 +419,15 @@ public class DockerRegistryManager implements SecuredEntityManager {
      * pseudo root {@link DockerRegistryList} object
      */
     public DockerRegistryList loadAllRegistriesContent() {
-        List<DockerRegistry> registries = dockerRegistryDao.loadAllRegistriesContent();
+        final List<DockerRegistry> registries = dockerRegistryDao.loadAllRegistriesContent();
+        final Set<Long> gpuToolsIds = getGpuToolIds();
+
         registries.stream()
                 .flatMap(registry -> registry.getGroups().stream())
-                .forEach(group -> group.setPrivateGroup(toolGroupManager.isGroupPrivate(group)));
+                .peek(group -> group.setPrivateGroup(toolGroupManager.isGroupPrivate(group)))
+                .flatMap(group -> ListUtils.emptyIfNull(group.getTools()).stream())
+                .filter(tool -> gpuToolsIds.contains(tool.getId()))
+                .forEach(tool -> tool.setGpuEnabled(true));
         return new DockerRegistryList(registries);
     }
 
@@ -648,5 +661,26 @@ public class DockerRegistryManager implements SecuredEntityManager {
     public DockerClient getDockerClient(DockerRegistry registry, String image) {
         String token = getImageToken(registry, image);
         return dockerClientFactory.getDockerClient(registry, token);
+    }
+
+    private Set<String> getGpuInstanceTypes() {
+        final List<InstanceType> allInstanceTypes = cloudFacade.getAllInstanceTypes(null, false);
+        return ListUtils.emptyIfNull(allInstanceTypes).stream()
+                .filter(instanceType -> instanceType.getGpu() > 0)
+                .map(InstanceType::getName)
+                .collect(Collectors.toSet());
+    }
+
+    private Set<Long> getGpuToolIds() {
+        final Set<String> gpuTypes = getGpuInstanceTypes();
+        return ListUtils.emptyIfNull(toolVersionManager.loadAllToolVersionSettings()).stream()
+                .filter(toolVersion -> ListUtils.emptyIfNull(toolVersion.getSettings()).stream()
+                        .map(configuration -> Optional.ofNullable(configuration.getConfiguration())
+                                .map(PipelineConfiguration::getInstanceType)
+                                .orElse(StringUtils.EMPTY))
+                        .filter(StringUtils::isNotBlank)
+                        .anyMatch(gpuTypes::contains))
+                .map(ToolVersion::getToolId)
+                .collect(Collectors.toSet());
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/docker/ToolVersionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/ToolVersionManager.java
@@ -158,7 +158,7 @@ public class ToolVersionManager {
         return toolVersionDao.loadToolWithSettings(toolId);
     }
 
-    public List<ToolVersion> loadAllToolVersionSettings() {
+    public List<ToolVersion> loadAllLatestToolVersionSettings() {
         return toolVersionDao.loadAllLatestToolVersions();
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/docker/ToolVersionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/ToolVersionManager.java
@@ -158,6 +158,10 @@ public class ToolVersionManager {
         return toolVersionDao.loadToolWithSettings(toolId);
     }
 
+    public List<ToolVersion> loadAllToolVersionSettings() {
+        return toolVersionDao.loadAllLatestToolVersions();
+    }
+
     private void validateToolExistsAndCanBeModified(final Long toolId) {
         final Tool tool = toolManager.load(toolId);
         validateToolNotNull(tool, toolId);

--- a/api/src/main/resources/dao/dockerregistry-dao.xml
+++ b/api/src/main/resources/dao/dockerregistry-dao.xml
@@ -157,7 +157,7 @@
                   LEFT JOIN pipeline.tool tl ON t.link = tl.id
                   LEFT JOIN pipeline.tool_version tv ON (t.id = tv.tool_id AND tv.version = 'latest')
                   LEFT JOIN pipeline.tool_version tlv ON (tl.id = tlv.tool_id AND tlv.version = 'latest')
-                  LEFT JOIN pipeline.tool_version_scan tvs ON (tl.id = tvs.tool_id AND tvs.version = 'latest')
+                  LEFT JOIN pipeline.tool_version_scan tvs ON (t.id = tvs.tool_id AND tvs.version = 'latest')
                   ORDER BY
                       dr.id
                 ]]>

--- a/api/src/main/resources/dao/dockerregistry-dao.xml
+++ b/api/src/main/resources/dao/dockerregistry-dao.xml
@@ -147,7 +147,9 @@
                       t.owner as tool_owner,
                       COALESCE(tl.allow_sensitive, t.allow_sensitive) as tool_allow_sensitive,
                       COALESCE(tl.allow_commit, t.allow_commit) as tool_allow_commit,
-                      COALESCE(tl.icon_id, t.icon_id) AS tool_icon_id
+                      COALESCE(tl.icon_id, t.icon_id) AS tool_icon_id,
+                      tvs.os_name as tool_os_name,
+                      tvs.os_version as tool_os_version
                   FROM
                       pipeline.docker_registry dr
                   LEFT JOIN pipeline.tool_group g ON g.registry_id = dr.id
@@ -155,6 +157,7 @@
                   LEFT JOIN pipeline.tool tl ON t.link = tl.id
                   LEFT JOIN pipeline.tool_version tv ON (t.id = tv.tool_id AND tv.version = 'latest')
                   LEFT JOIN pipeline.tool_version tlv ON (tl.id = tlv.tool_id AND tlv.version = 'latest')
+                  LEFT JOIN pipeline.tool_version_scan tvs ON (tl.id = tvs.tool_id AND tvs.version = 'latest')
                   ORDER BY
                       dr.id
                 ]]>

--- a/api/src/main/resources/dao/tool-version.xml
+++ b/api/src/main/resources/dao/tool-version.xml
@@ -187,5 +187,34 @@
                 ]]>
             </value>
         </property>
+        <property name="loadAllLatestToolVersionsQuery">
+            <value>
+                <![CDATA[
+                    SELECT
+                        tv.id,
+                        tv.tool_id,
+                        tv.version,
+                        tv.settings,
+                        tv.size,
+                        tv.platform,
+                        tv.allow_commit
+                    FROM pipeline.tool_version AS tv
+                    WHERE tv.version = 'latest'
+                    UNION ALL
+                    SELECT
+                        tv.id,
+                        t.id as tool_id,
+                        tv.version,
+                        tv.settings,
+                        tv.size,
+                        tv.platform,
+                        tv.allow_commit
+                    FROM pipeline.tool_version AS tv
+                    LEFT JOIN pipeline.tool tl ON (tl.id = tv.tool_id)
+                    LEFT JOIN pipeline.tool t ON (t.link = tl.id)
+                    WHERE tv.version = 'latest'
+                ]]>
+            </value>
+        </property>
     </bean>
 </beans>

--- a/api/src/test/java/com/epam/pipeline/assertions/tool/ToolAssertions.java
+++ b/api/src/test/java/com/epam/pipeline/assertions/tool/ToolAssertions.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.assertions.tool;
+
+import com.epam.pipeline.entity.pipeline.DockerRegistry;
+import com.epam.pipeline.entity.pipeline.Tool;
+import com.epam.pipeline.entity.pipeline.ToolGroup;
+
+import java.util.Comparator;
+import java.util.List;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+public final class ToolAssertions {
+
+    private ToolAssertions() {
+        // no-op
+    }
+
+    public static void assertRegistryTools(final List<DockerRegistry> actualRegistries,
+                                           final List<DockerRegistry> expectedRegistries) {
+        actualRegistries.sort(Comparator.comparing(DockerRegistry::getId));
+        expectedRegistries.sort(Comparator.comparing(DockerRegistry::getId));
+        assertThat(actualRegistries.size(), is(expectedRegistries.size()));
+        assertThat(actualRegistries.size(), greaterThan(0));
+        for (int i = 0; i < actualRegistries.size(); i++) {
+            final DockerRegistry dockerRegistry = actualRegistries.get(i);
+            final DockerRegistry expectedRegistry = expectedRegistries.get(i);
+            final List<Tool> actualTools = dockerRegistry.getTools();
+            final List<Tool> expectedTools = expectedRegistry.getTools();
+            assertTools(actualTools, expectedTools);
+        }
+    }
+
+    public static void assertRegistryGroups(final List<DockerRegistry> actualRegistries,
+                                            final List<DockerRegistry> expectedRegistries) {
+        actualRegistries.sort(Comparator.comparing(DockerRegistry::getId));
+        expectedRegistries.sort(Comparator.comparing(DockerRegistry::getId));
+        assertThat(actualRegistries.size(), is(expectedRegistries.size()));
+        assertThat(actualRegistries.size(), greaterThan(0));
+        for (int i = 0; i < actualRegistries.size(); i++) {
+            final DockerRegistry actualRegistry = actualRegistries.get(i);
+            final DockerRegistry expectedRegistry = expectedRegistries.get(i);
+            final List<ToolGroup> actualGroups = actualRegistry.getGroups();
+            final List<ToolGroup> expectedGroups = expectedRegistry.getGroups();
+            assertGroups(actualGroups, expectedGroups);
+        }
+    }
+
+    public static void assertGroups(final List<ToolGroup> actualGroups, final List<ToolGroup> expectedGroups) {
+        actualGroups.sort(Comparator.comparing(ToolGroup::getId));
+        expectedGroups.sort(Comparator.comparing(ToolGroup::getId));
+        assertThat(actualGroups.size(), is(expectedGroups.size()));
+        assertThat(actualGroups.size(), greaterThan(0));
+        for (int i = 0; i < actualGroups.size(); i++) {
+            final ToolGroup actualGroup = actualGroups.get(i);
+            final ToolGroup expectedGroup = expectedGroups.get(i);
+            final List<Tool> actualTools = actualGroup.getTools();
+            final List<Tool> expectedTools = expectedGroup.getTools();
+            assertTools(actualTools, expectedTools);
+        }
+    }
+
+    public static void assertTools(final List<Tool> actualTools, final List<Tool> expectedTools) {
+        actualTools.sort(Comparator.comparing(Tool::getId));
+        expectedTools.sort(Comparator.comparing(Tool::getId));
+        assertThat(actualTools.size(), is(expectedTools.size()));
+        assertThat(actualTools.size(), greaterThan(0));
+        for (int i = 0; i < actualTools.size(); i++) {
+            final Tool actualTool = actualTools.get(i);
+            final Tool expectedTool = expectedTools.get(i);
+            assertTools(actualTool, expectedTool);
+        }
+    }
+
+    public static void assertTools(final Tool actualTool, final Tool expectedTool) {
+        assertThat(actualTool.getId(), is(expectedTool.getId()));
+        assertThat(actualTool.getImage(), is(expectedTool.getImage()));
+        assertThat(actualTool.getLink(), is(expectedTool.getLink()));
+        assertThat(actualTool.getCpu(), is(expectedTool.getCpu()));
+        assertThat(actualTool.getRam(), is(expectedTool.getRam()));
+        assertThat(actualTool.getDefaultCommand(), is(expectedTool.getDefaultCommand()));
+        assertThat(actualTool.getLabels(), is(expectedTool.getLabels()));
+        assertThat(actualTool.getEndpoints(), is(expectedTool.getEndpoints()));
+        assertThat(actualTool.getShortDescription(), is(expectedTool.getShortDescription()));
+        assertThat(actualTool.getIconId(), is(expectedTool.getIconId()));
+        assertThat(actualTool.isGpuEnabled(), is(expectedTool.isGpuEnabled()));
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/dao/tool/DockerRegistryDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/tool/DockerRegistryDaoTest.java
@@ -34,15 +34,15 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.epam.pipeline.assertions.tool.ToolAssertions.assertRegistryGroups;
+import static com.epam.pipeline.assertions.tool.ToolAssertions.assertRegistryTools;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertThat;
 
 public class DockerRegistryDaoTest extends AbstractJdbcTest {
@@ -393,36 +393,6 @@ public class DockerRegistryDaoTest extends AbstractJdbcTest {
         return tool;
     }
 
-    private void assertRegistryTools(final List<DockerRegistry> actualRegistries,
-                                     final List<DockerRegistry> expectedRegistries) {
-        actualRegistries.sort(Comparator.comparing(DockerRegistry::getId));
-        expectedRegistries.sort(Comparator.comparing(DockerRegistry::getId));
-        assertThat(actualRegistries.size(), is(expectedRegistries.size()));
-        assertThat(actualRegistries.size(), greaterThan(0));
-        for (int i = 0; i < actualRegistries.size(); i++) {
-            final DockerRegistry dockerRegistry = actualRegistries.get(i);
-            final DockerRegistry expectedRegistry = expectedRegistries.get(i);
-            final List<Tool> actualTools = dockerRegistry.getTools();
-            final List<Tool> expectedTools = expectedRegistry.getTools();
-            assertTools(actualTools, expectedTools);
-        }
-    }
-
-    private void assertRegistryGroups(final List<DockerRegistry> actualRegistries,
-                                      final List<DockerRegistry> expectedRegistries) {
-        actualRegistries.sort(Comparator.comparing(DockerRegistry::getId));
-        expectedRegistries.sort(Comparator.comparing(DockerRegistry::getId));
-        assertThat(actualRegistries.size(), is(expectedRegistries.size()));
-        assertThat(actualRegistries.size(), greaterThan(0));
-        for (int i = 0; i < actualRegistries.size(); i++) {
-            final DockerRegistry actualRegistry = actualRegistries.get(i);
-            final DockerRegistry expectedRegistry = expectedRegistries.get(i);
-            final List<ToolGroup> actualGroups = actualRegistry.getGroups();
-            final List<ToolGroup> expectedGroups = expectedRegistry.getGroups();
-            assertGroups(actualGroups, expectedGroups);
-        }
-    }
-
     private void assertToolOsVersions(final List<DockerRegistry> actualRegistries,
                                       final ToolOSVersion expectedOsVersion) {
         actualRegistries.stream()
@@ -433,44 +403,5 @@ public class DockerRegistryDaoTest extends AbstractJdbcTest {
                     assertThat(actualOsVersion.getVersion(), is(expectedOsVersion.getVersion()));
                     assertThat(actualOsVersion.getDistribution(), is(actualOsVersion.getDistribution()));
                 });
-    }
-
-    private void assertGroups(final List<ToolGroup> actualGroups, final List<ToolGroup> expectedGroups) {
-        actualGroups.sort(Comparator.comparing(ToolGroup::getId));
-        expectedGroups.sort(Comparator.comparing(ToolGroup::getId));
-        assertThat(actualGroups.size(), is(expectedGroups.size()));
-        assertThat(actualGroups.size(), greaterThan(0));
-        for (int i = 0; i < actualGroups.size(); i++) {
-            final ToolGroup actualGroup = actualGroups.get(i);
-            final ToolGroup expectedGroup = expectedGroups.get(i);
-            final List<Tool> actualTools = actualGroup.getTools();
-            final List<Tool> expectedTools = expectedGroup.getTools();
-            assertTools(actualTools, expectedTools);
-        }
-    }
-
-    private void assertTools(final List<Tool> actualTools, final List<Tool> expectedTools) {
-        actualTools.sort(Comparator.comparing(Tool::getId));
-        expectedTools.sort(Comparator.comparing(Tool::getId));
-        assertThat(actualTools.size(), is(expectedTools.size()));
-        assertThat(actualTools.size(), greaterThan(0));
-        for (int i = 0; i < actualTools.size(); i++) {
-            final Tool actualTool = actualTools.get(i);
-            final Tool expectedTool = expectedTools.get(i);
-            assertTools(actualTool, expectedTool);
-        }
-    }
-
-    private void assertTools(final Tool actualTool, final Tool expectedTool) {
-        assertThat(actualTool.getId(), is(expectedTool.getId()));
-        assertThat(actualTool.getImage(), is(expectedTool.getImage()));
-        assertThat(actualTool.getLink(), is(expectedTool.getLink()));
-        assertThat(actualTool.getCpu(), is(expectedTool.getCpu()));
-        assertThat(actualTool.getRam(), is(expectedTool.getRam()));
-        assertThat(actualTool.getDefaultCommand(), is(expectedTool.getDefaultCommand()));
-        assertThat(actualTool.getLabels(), is(expectedTool.getLabels()));
-        assertThat(actualTool.getEndpoints(), is(expectedTool.getEndpoints()));
-        assertThat(actualTool.getShortDescription(), is(expectedTool.getShortDescription()));
-        assertThat(actualTool.getIconId(), is(expectedTool.getIconId()));
     }
 }

--- a/api/src/test/java/com/epam/pipeline/dao/tool/ToolVersionDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/tool/ToolVersionDaoTest.java
@@ -79,6 +79,7 @@ public class ToolVersionDaoTest extends AbstractJdbcTest {
     private Tool symlink;
     private ToolVersion toolVersion1;
     private ToolVersion toolVersion2;
+    private ConfigurationEntry configurationEntry;
 
     @Before
     public void setUp() {
@@ -123,7 +124,7 @@ public class ToolVersionDaoTest extends AbstractJdbcTest {
         symlink.setLink(tool.getId());
         toolDao.createTool(symlink);
 
-        ConfigurationEntry configurationEntry = new ConfigurationEntry();
+        configurationEntry = new ConfigurationEntry();
         configurationEntry.setName(ConfigurationEntry.DEFAULT);
         toolVersion1 = ToolVersion
                 .builder()
@@ -310,6 +311,30 @@ public class ToolVersionDaoTest extends AbstractJdbcTest {
         final List<ToolVersion> actualVersions = toolVersionDao.loadToolWithSettings(symlink.getId());
 
         assertVersionsWithSettings(actualVersions, expectedVersions);
+    }
+
+    @Test
+    @Transactional
+    public void testLoadAllToolWithSettings() {
+        final List<ToolVersion> versions = Arrays.asList(toolVersion1, toolVersion2);
+        versions.forEach(toolVersionDao::createToolVersionWithSettings);
+
+        final List<ToolVersion> actualVersions = toolVersionDao.loadAllLatestToolVersions();
+
+        final ToolVersion symlinkVersion = ToolVersion
+                .builder()
+                .id(toolVersion1.getId())
+                .digest(TEST_DIGEST)
+                .size(TEST_SIZE)
+                .version(TEST_VERSION)
+                .modificationDate(TEST_LAST_MODIFIED_DATE)
+                .platform(TEST_PLATFORM)
+                .toolId(symlink.getId())
+                .settings(Collections.singletonList(configurationEntry))
+                .build();
+        final List<ToolVersion> expected = Arrays.asList(toolVersion1, symlinkVersion);
+
+        assertVersionsWithSettings(actualVersions, expected);
     }
 
     private void assertVersions(final List<ToolVersion> actualVersions, final List<ToolVersion> expectedVersions) {

--- a/api/src/test/java/com/epam/pipeline/manager/docker/DockerRegistryManagerUnitTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/docker/DockerRegistryManagerUnitTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.docker;
+
+import com.epam.pipeline.dao.docker.DockerRegistryDao;
+import com.epam.pipeline.entity.cluster.InstanceType;
+import com.epam.pipeline.entity.configuration.ConfigurationEntry;
+import com.epam.pipeline.entity.configuration.PipelineConfiguration;
+import com.epam.pipeline.entity.docker.DockerRegistryList;
+import com.epam.pipeline.entity.docker.ToolVersion;
+import com.epam.pipeline.entity.pipeline.DockerRegistry;
+import com.epam.pipeline.entity.pipeline.Tool;
+import com.epam.pipeline.entity.pipeline.ToolGroup;
+import com.epam.pipeline.manager.cloud.CloudFacade;
+import com.epam.pipeline.manager.pipeline.ToolGroupManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static com.epam.pipeline.assertions.tool.ToolAssertions.assertRegistryGroups;
+import static com.epam.pipeline.test.creator.CommonCreatorConstants.*;
+import static com.epam.pipeline.test.creator.docker.DockerCreatorUtils.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+
+public class DockerRegistryManagerUnitTest {
+    private static final String GPU_INSTANCE = "gpu.support";
+    private static final String NO_GPU_INSTANCE = "no.gpu.support";
+    private static final int GPU_CNT = 2;
+    private static final Long ID_4 = 4L;
+    private static final Long ID_5 = 5L;
+
+    @Mock
+    private DockerRegistryDao dockerRegistryDaoMock;
+
+    @Mock
+    private ToolVersionManager toolVersionManagerMock;
+
+    @Mock
+    private CloudFacade cloudFacadeMock;
+
+    @Mock
+    private ToolGroupManager toolGroupManagerMock;
+
+    @InjectMocks
+    private DockerRegistryManager dockerRegistryManager;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void shallLoadAllRegistriesContents() {
+        final Tool gpuTool1 = getGpuTool(ID);
+        final Tool noGpuTool1 = getNoGpuTool(ID_4);
+        final DockerRegistry expectedRegistries1 = getRegistry(ID, gpuTool1, noGpuTool1);
+
+        final Tool gpuTool2 = getGpuTool(ID_2);
+        final Tool noGpuTool2 = getNoGpuTool(ID_5);
+        final Tool tool3 = getNoGpuTool(ID_3);
+        final DockerRegistry expectedRegistries2 = getRegistry(ID_2, gpuTool2, noGpuTool2, tool3);
+
+        final List<DockerRegistry> expectedRegistries = Arrays.asList(expectedRegistries1, expectedRegistries2);
+        doReturn(expectedRegistries).when(dockerRegistryDaoMock).loadAllRegistriesContent();
+
+        final InstanceType gpuType = InstanceType.builder().name(GPU_INSTANCE).gpu(GPU_CNT).build();
+        final InstanceType noGpuType = InstanceType.builder().name(NO_GPU_INSTANCE).gpu(0).build();
+        doReturn(Arrays.asList(gpuType, noGpuType)).when(cloudFacadeMock).getAllInstanceTypes(null, false);
+
+        final ToolVersion gpuVersion1 = getToolVersion(gpuTool1.getId(), GPU_INSTANCE);
+        final ToolVersion noGpuVersion1 = getToolVersion(noGpuTool1.getId(), NO_GPU_INSTANCE);
+        final ToolVersion gpuVersion2 = getToolVersion(gpuTool2.getId(), GPU_INSTANCE);
+        final ToolVersion noGpuVersion2 = getToolVersion(noGpuTool2.getId(), NO_GPU_INSTANCE);
+        final ToolVersion emptyConfig = ToolVersion.builder()
+                .settings(Collections.singletonList(new ConfigurationEntry()))
+                .toolId(tool3.getId())
+                .build();
+        doReturn(Arrays.asList(gpuVersion1, noGpuVersion1, gpuVersion2, noGpuVersion2, emptyConfig))
+                .when(toolVersionManagerMock).loadAllLatestToolVersionSettings();
+
+        doReturn(false).when(toolGroupManagerMock).isGroupPrivate(any());
+
+        final DockerRegistryList loadedList = dockerRegistryManager.loadAllRegistriesContent();
+        assertRegistryGroups(loadedList.getRegistries(), expectedRegistries);
+    }
+
+    private Tool getGpuTool(final Long id) {
+        return initTool(id, true);
+    }
+
+    private Tool getNoGpuTool(final Long id) {
+        return initTool(id, false);
+    }
+
+    private Tool initTool(final Long id, final boolean gpuEnabled) {
+        final Tool tool = getTool(id, TEST_STRING);
+        tool.setGpuEnabled(gpuEnabled);
+        return tool;
+    }
+
+    private DockerRegistry getRegistry(final Long id, final Tool... tools) {
+        final DockerRegistry registry = getDockerRegistry(id, TEST_STRING);
+        final ToolGroup group = getToolGroup(id, TEST_STRING, registry.getId(), TEST_STRING);
+        group.setTools(Arrays.asList(tools));
+        registry.setGroups(Collections.singletonList(group));
+        return registry;
+    }
+
+    private ToolVersion getToolVersion(final Long toolId, final String instanceType) {
+        final PipelineConfiguration pipelineConfiguration = new PipelineConfiguration();
+        pipelineConfiguration.setInstanceType(instanceType);
+        final ConfigurationEntry configurationEntry = new ConfigurationEntry();
+        configurationEntry.setConfiguration(pipelineConfiguration);
+        return ToolVersion.builder()
+                .settings(Collections.singletonList(configurationEntry))
+                .toolId(toolId)
+                .build();
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/test/aspect/AspectTestBeans.java
+++ b/api/src/test/java/com/epam/pipeline/test/aspect/AspectTestBeans.java
@@ -70,6 +70,7 @@ import com.epam.pipeline.dao.user.RoleDao;
 import com.epam.pipeline.dao.user.UserDao;
 import com.epam.pipeline.manager.billing.BillingManager;
 import com.epam.pipeline.manager.billing.detail.EntityBillingDetailsLoader;
+import com.epam.pipeline.manager.cloud.CloudFacade;
 import com.epam.pipeline.manager.cluster.InstanceOfferScheduler;
 import com.epam.pipeline.manager.cluster.PodMonitor;
 import com.epam.pipeline.manager.contextual.handler.ContextualPreferenceHandler;
@@ -485,4 +486,7 @@ public class AspectTestBeans {
 
     @MockBean
     protected StorageEventCollector events;
+
+    @MockBean
+    protected CloudFacade cloudFacade;
 }

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/Tool.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/Tool.java
@@ -55,6 +55,8 @@ public class Tool extends AbstractSecuredEntity {
     private Long iconId;
     private boolean allowSensitive = false;
     private boolean allowCommit = true;
+    private ToolOSVersion toolOSVersion;
+    private boolean gpuEnabled = false;
 
     public void setIconId(Long iconId) {
         this.iconId = iconId;

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/ToolOSVersion.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/ToolOSVersion.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.pipeline;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class ToolOSVersion {
+    String distribution;
+    String version;
+}


### PR DESCRIPTION
The current PR provides implementation for issue #3235 - a new fields `toolOSVersion` and `gpuEnabled` were added to tool object for `GET /dockerRegistry/loadTree` query response.