### PR TITLE
Exclude failing instance types in grid engine autoscaler

### DIFF
--- a/workflows/pipe-common/test/test_available_instance_provider.py
+++ b/workflows/pipe-common/test/test_available_instance_provider.py
@@ -14,11 +14,10 @@
 
 import logging
 
-from datetime import datetime, timedelta
+from datetime import datetime
 from mock import MagicMock, Mock
 
-from scripts.autoscale_sge import Instance, \
-    AvailableInstanceProvider, GridEngineWorkerRecord
+from scripts.autoscale_sge import Instance, AvailableInstanceProvider
 
 logging.basicConfig(level=logging.DEBUG, format='%(asctime)s [%(threadName)s] [%(levelname)s] %(message)s')
 
@@ -30,10 +29,8 @@ worker_name = 'pipeline-12345'
 price_type = 'spot'
 
 inner_instance_provider = Mock()
-worker_recorder = Mock()
-clock = Mock()
-instance_provider = AvailableInstanceProvider(inner=inner_instance_provider, worker_recorder=worker_recorder,
-                                              unavailability_delay=unavailability_delay, clock=clock)
+availability_manager = Mock()
+instance_provider = AvailableInstanceProvider(inner=inner_instance_provider, availability_manager=availability_manager)
 
 instance_2cpu = Instance(name='m5.large', price_type=price_type, cpu=2, mem=8, gpu=0)
 instance_4cpu = Instance(name='m5.xlarge', price_type=price_type, cpu=4, mem=16, gpu=0)
@@ -42,30 +39,13 @@ instance_8cpu = Instance(name='m5.2xlarge', price_type=price_type, cpu=8, mem=32
 
 def setup_function():
     inner_instance_provider.provide = MagicMock(return_value=[
-        instance_2cpu, instance_4cpu, instance_8cpu])
+        instance_2cpu,
+        instance_4cpu,
+        instance_8cpu])
 
 
-def test_all_available_without_worker_records():
-    worker_recorder.get = MagicMock(return_value=[])
-    clock.now = MagicMock(return_value=stopped + timedelta(seconds=unavailability_delay - 1))
-
-    instances = instance_provider.provide()
-
-    assert len(instances) == 3
-
-
-def test_all_available_with_worker_records():
-    worker_recorder.get = MagicMock(return_value=[
-        GridEngineWorkerRecord(id=run_id, name=worker_name, instance_type=instance_8cpu.name,
-                               started=started, stopped=stopped,
-                               has_insufficient_instance_capacity=False),
-        GridEngineWorkerRecord(id=run_id, name=worker_name, instance_type=instance_4cpu.name,
-                               started=started, stopped=stopped,
-                               has_insufficient_instance_capacity=False),
-        GridEngineWorkerRecord(id=run_id, name=worker_name, instance_type=instance_2cpu.name,
-                               started=started, stopped=stopped,
-                               has_insufficient_instance_capacity=False)])
-    clock.now = MagicMock(return_value=stopped + timedelta(seconds=unavailability_delay - 1))
+def test_provide_if_all_available():
+    availability_manager.get_unavailable = MagicMock(return_value=[])
 
     instances = instance_provider.provide()
 
@@ -75,18 +55,9 @@ def test_all_available_with_worker_records():
     assert instance_8cpu in instances
 
 
-def test_one_unavailable_with_worker_records():
-    worker_recorder.get = MagicMock(return_value=[
-        GridEngineWorkerRecord(id=run_id, name=worker_name, instance_type=instance_8cpu.name,
-                               started=started, stopped=stopped,
-                               has_insufficient_instance_capacity=True),
-        GridEngineWorkerRecord(id=run_id, name=worker_name, instance_type=instance_4cpu.name,
-                               started=started, stopped=stopped,
-                               has_insufficient_instance_capacity=False),
-        GridEngineWorkerRecord(id=run_id, name=worker_name, instance_type=instance_2cpu.name,
-                               started=started, stopped=stopped,
-                               has_insufficient_instance_capacity=False)])
-    clock.now = MagicMock(return_value=stopped + timedelta(seconds=unavailability_delay - 1))
+def test_provide_if_one_unavailable():
+    availability_manager.get_unavailable = MagicMock(return_value=[
+        instance_8cpu.name])
 
     instances = instance_provider.provide()
 
@@ -96,18 +67,10 @@ def test_one_unavailable_with_worker_records():
     assert instance_8cpu not in instances
 
 
-def test_two_unavailable_with_worker_records():
-    worker_recorder.get = MagicMock(return_value=[
-        GridEngineWorkerRecord(id=run_id, name=worker_name, instance_type=instance_8cpu.name,
-                               started=started, stopped=stopped,
-                               has_insufficient_instance_capacity=True),
-        GridEngineWorkerRecord(id=run_id, name=worker_name, instance_type=instance_4cpu.name,
-                               started=started, stopped=stopped,
-                               has_insufficient_instance_capacity=False),
-        GridEngineWorkerRecord(id=run_id, name=worker_name, instance_type=instance_2cpu.name,
-                               started=started, stopped=stopped,
-                               has_insufficient_instance_capacity=True)])
-    clock.now = MagicMock(return_value=stopped + timedelta(seconds=unavailability_delay - 1))
+def test_provide_if_two_unavailable():
+    availability_manager.get_unavailable = MagicMock(return_value=[
+        instance_8cpu.name,
+        instance_2cpu.name])
 
     instances = instance_provider.provide()
 
@@ -117,43 +80,12 @@ def test_two_unavailable_with_worker_records():
     assert instance_8cpu not in instances
 
 
-def test_all_unavailable_with_worker_records():
-    worker_recorder.get = MagicMock(return_value=[
-        GridEngineWorkerRecord(id=run_id, name=worker_name, instance_type=instance_8cpu.name,
-                               started=started, stopped=stopped,
-                               has_insufficient_instance_capacity=True),
-        GridEngineWorkerRecord(id=run_id, name=worker_name, instance_type=instance_4cpu.name,
-                               started=started, stopped=stopped,
-                               has_insufficient_instance_capacity=True),
-        GridEngineWorkerRecord(id=run_id, name=worker_name, instance_type=instance_2cpu.name,
-                               started=started, stopped=stopped,
-                               has_insufficient_instance_capacity=True)])
-    clock.now = MagicMock(return_value=stopped + timedelta(seconds=unavailability_delay - 1))
+def test_provide_if_all_unavailable():
+    availability_manager.get_unavailable = MagicMock(return_value=[
+        instance_8cpu.name,
+        instance_4cpu.name,
+        instance_2cpu.name])
 
     instances = instance_provider.provide()
 
-    assert len(instances) == 3
-    assert instance_2cpu in instances
-    assert instance_4cpu in instances
-    assert instance_8cpu in instances
-
-
-def test_one_unavailable_with_outdated_worker_records():
-    worker_recorder.get = MagicMock(return_value=[
-        GridEngineWorkerRecord(id=run_id, name=worker_name, instance_type=instance_8cpu.name,
-                               started=started, stopped=stopped,
-                               has_insufficient_instance_capacity=True),
-        GridEngineWorkerRecord(id=run_id, name=worker_name, instance_type=instance_4cpu.name,
-                               started=started, stopped=stopped,
-                               has_insufficient_instance_capacity=True),
-        GridEngineWorkerRecord(id=run_id, name=worker_name, instance_type=instance_2cpu.name,
-                               started=started, stopped=stopped,
-                               has_insufficient_instance_capacity=True)])
-    clock.now = MagicMock(return_value=stopped + timedelta(seconds=unavailability_delay + 1))
-
-    instances = instance_provider.provide()
-
-    assert len(instances) == 3
-    assert instance_2cpu in instances
-    assert instance_4cpu in instances
-    assert instance_8cpu in instances
+    assert not instances

--- a/workflows/pipe-common/test/test_cpu_capacity_instance_selector.py
+++ b/workflows/pipe-common/test/test_cpu_capacity_instance_selector.py
@@ -42,6 +42,11 @@ all_instances = [instance_2cpu, instance_4cpu,
                  instance_64cpu, instance_96cpu]
 
 test_cases = [
+    ['2cpu job using no instances',
+     [],
+     [IntegralDemand(cpu=2, owner=owner)],
+     []],
+
     ['2cpu job using 2cpu instances',
      [instance_2cpu],
      [IntegralDemand(cpu=2, owner=owner)],

--- a/workflows/pipe-common/test/test_event_manager.py
+++ b/workflows/pipe-common/test/test_event_manager.py
@@ -1,0 +1,46 @@
+#  Copyright 2017-2023 EPAM Systems, Inc. (https://www.epam.com/)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from datetime import datetime, timedelta
+
+from mock import Mock, MagicMock
+
+from scripts.autoscale_sge import GridEngineEventManager, AvailableInstanceEvent, InsufficientInstanceEvent, \
+    FailingInstanceEvent
+
+ttl = timedelta(minutes=30)
+instance_type = 'm5.large'
+date = datetime(2018, 12, 21, 11, 00, 00)
+
+clock = Mock()
+event_manager = GridEngineEventManager(ttl=ttl.total_seconds(), clock=clock)
+
+
+def setup_function():
+    clock.now = MagicMock(return_value=date)
+
+
+def test_get_returns_only_recent_events():
+    outdated_events = [FailingInstanceEvent(instance_type=instance_type, date=date - 3 * ttl),
+                       AvailableInstanceEvent(instance_type=instance_type, date=date - 2 * ttl)]
+    recent_events = [InsufficientInstanceEvent(instance_type=instance_type, date=date - ttl / 2),
+                     AvailableInstanceEvent(instance_type=instance_type, date=date)]
+    for event in recent_events + outdated_events:
+        event_manager.register(event)
+
+    events = event_manager.get()
+
+    assert len(events) == 2
+    for event in recent_events:
+        assert event in events

--- a/workflows/pipe-common/test/test_instance_availability_manager.py
+++ b/workflows/pipe-common/test/test_instance_availability_manager.py
@@ -1,0 +1,190 @@
+#  Copyright 2017-2023 EPAM Systems, Inc. (https://www.epam.com/)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import logging
+
+from datetime import datetime, timedelta
+from mock import MagicMock, Mock
+
+from scripts.autoscale_sge import Instance, InstanceAvailabilityManager, \
+    AvailableInstanceEvent, InsufficientInstanceEvent, FailingInstanceEvent
+
+logging.basicConfig(level=logging.DEBUG, format='%(asctime)s [%(threadName)s] [%(levelname)s] %(message)s')
+
+unavailability_delay = 3600
+unavailability_count_insufficient = 1
+unavailability_count_failure = 10
+started = datetime(2018, 12, 21, 11, 00, 00)
+stopped = datetime(2018, 12, 21, 11, 5, 00)
+run_id = 12345
+worker_name = 'pipeline-12345'
+price_type = 'spot'
+
+inner_instance_provider = Mock()
+clock = Mock()
+event_manager = Mock()
+availability_manager = InstanceAvailabilityManager(event_manager=event_manager, clock=clock,
+                                                   unavail_delay=unavailability_delay,
+                                                   unavail_count_insufficient=unavailability_count_insufficient,
+                                                   unavail_count_failure=unavailability_count_failure)
+
+instance_2cpu = Instance(name='m5.large', price_type=price_type, cpu=2, mem=8, gpu=0)
+instance_4cpu = Instance(name='m5.xlarge', price_type=price_type, cpu=4, mem=16, gpu=0)
+instance_8cpu = Instance(name='m5.2xlarge', price_type=price_type, cpu=8, mem=32, gpu=0)
+
+
+def setup_function():
+    inner_instance_provider.provide = MagicMock(return_value=[
+        instance_2cpu,
+        instance_4cpu,
+        instance_8cpu])
+    clock.now = MagicMock(return_value=stopped + timedelta(seconds=unavailability_delay - 1))
+
+
+def test_get_unavailable_if_no_events():
+    event_manager.get = MagicMock(return_value=[])
+
+    unavailable_instances = list(availability_manager.get_unavailable())
+
+    assert not unavailable_instances
+
+
+def test_get_unavailable_if_available_event():
+    event_manager.get = MagicMock(return_value=[
+        AvailableInstanceEvent(instance_type=instance_8cpu.name, date=stopped)])
+
+    unavailable_instances = list(availability_manager.get_unavailable())
+
+    assert not unavailable_instances
+
+
+def test_get_unavailable_if_insufficient_event():
+    event_manager.get = MagicMock(return_value=[
+        InsufficientInstanceEvent(instance_type=instance_8cpu.name, date=stopped)])
+
+    unavailable_instances = list(availability_manager.get_unavailable())
+
+    assert len(unavailable_instances) == 1
+    assert instance_8cpu.name in unavailable_instances
+
+
+def test_get_unavailable_if_insufficient_outdated_event():
+    clock.now = MagicMock(return_value=stopped + timedelta(seconds=unavailability_delay + 1))
+    event_manager.get = MagicMock(return_value=[
+        InsufficientInstanceEvent(instance_type=instance_8cpu.name, date=stopped)])
+
+    unavailable_instances = list(availability_manager.get_unavailable())
+
+    assert not unavailable_instances
+
+
+def test_get_unavailable_if_available_and_insufficient_events():
+    event_manager.get = MagicMock(return_value=[
+        AvailableInstanceEvent(instance_type=instance_8cpu.name, date=stopped),
+        InsufficientInstanceEvent(instance_type=instance_8cpu.name, date=stopped)])
+
+    unavailable_instances = list(availability_manager.get_unavailable())
+
+    assert len(unavailable_instances) == 1
+    assert instance_8cpu.name in unavailable_instances
+
+
+def test_get_unavailable_if_insufficient_and_available_events():
+    event_manager.get = MagicMock(return_value=[
+        InsufficientInstanceEvent(instance_type=instance_8cpu.name, date=stopped),
+        AvailableInstanceEvent(instance_type=instance_8cpu.name, date=stopped)])
+
+    unavailable_instances = list(availability_manager.get_unavailable())
+
+    assert not unavailable_instances
+
+
+def test_get_unavailable_if_failing_event():
+    event_manager.get = MagicMock(return_value=[
+        FailingInstanceEvent(instance_type=instance_8cpu.name, date=stopped)])
+
+    unavailable_instances = list(availability_manager.get_unavailable())
+
+    assert not unavailable_instances
+
+
+def test_get_unavailable_if_multiple_failing_events():
+    event_manager.get = MagicMock(
+        return_value=unavailability_count_failure *
+                     [FailingInstanceEvent(instance_type=instance_8cpu.name, date=stopped)])
+
+    unavailable_instances = list(availability_manager.get_unavailable())
+
+    assert len(unavailable_instances) == 1
+    assert instance_8cpu.name in unavailable_instances
+
+
+def test_get_unavailable_if_multiple_failing_outdated_events():
+    clock.now = MagicMock(return_value=stopped + timedelta(seconds=unavailability_delay + 1))
+    event_manager.get = MagicMock(
+        return_value=unavailability_count_failure *
+                     [FailingInstanceEvent(instance_type=instance_8cpu.name, date=stopped)])
+
+    unavailable_instances = list(availability_manager.get_unavailable())
+
+    assert not unavailable_instances
+
+
+def test_get_unavailable_if_available_and_multiple_failing_events():
+    event_manager.get = MagicMock(
+        return_value=[AvailableInstanceEvent(instance_type=instance_8cpu.name, date=stopped)]
+                     + unavailability_count_failure *
+                     [FailingInstanceEvent(instance_type=instance_8cpu.name, date=stopped)])
+
+    unavailable_instances = list(availability_manager.get_unavailable())
+
+    assert len(unavailable_instances) == 1
+    assert instance_8cpu.name in unavailable_instances
+
+
+def test_get_unavailable_if_multiple_failing_and_available_events():
+    event_manager.get = MagicMock(
+        return_value=unavailability_count_failure *
+                     [FailingInstanceEvent(instance_type=instance_8cpu.name, date=stopped)]
+                     + [AvailableInstanceEvent(instance_type=instance_8cpu.name, date=stopped)])
+
+    unavailable_instances = list(availability_manager.get_unavailable())
+
+    assert not unavailable_instances
+
+
+def test_get_unavailable_if_couple_failing_and_available_and_couple_failing_events():
+    event_manager.get = MagicMock(
+        return_value=(unavailability_count_failure - 1) *
+                     [FailingInstanceEvent(instance_type=instance_8cpu.name, date=stopped)]
+                     + [AvailableInstanceEvent(instance_type=instance_8cpu.name, date=stopped)]
+                     + (unavailability_count_failure - 1) *
+                     [FailingInstanceEvent(instance_type=instance_8cpu.name, date=stopped)])
+
+    unavailable_instances = list(availability_manager.get_unavailable())
+
+    assert not unavailable_instances
+
+
+def test_get_unavailable_if_first_instance_insufficient_and_second_instance_multiple_failing_events():
+    event_manager.get = MagicMock(
+        return_value=([InsufficientInstanceEvent(instance_8cpu.name, date=stopped)]
+                      + unavailability_count_failure *
+                      [FailingInstanceEvent(instance_type=instance_4cpu.name, date=stopped)]))
+
+    unavailable_instances = list(availability_manager.get_unavailable())
+
+    assert len(unavailable_instances) == 2
+    assert instance_8cpu.name in unavailable_instances
+    assert instance_4cpu.name in unavailable_instances

--- a/workflows/pipe-common/test/test_scale_down_handler.py
+++ b/workflows/pipe-common/test/test_scale_down_handler.py
@@ -28,11 +28,10 @@ RUN_ID = '12345'
 
 cmd_executor = Mock()
 grid_engine = Mock()
-default_hostfile = 'default_hostfile'
 instance_cores = 4
 common_utils = Mock()
 scale_down_handler = GridEngineScaleDownHandler(cmd_executor=cmd_executor, grid_engine=grid_engine,
-                                                default_hostfile=default_hostfile, common_utils=common_utils)
+                                                common_utils=common_utils)
 
 
 def setup_function():

--- a/workflows/pipe-common/test/test_scale_up_handler.py
+++ b/workflows/pipe-common/test/test_scale_up_handler.py
@@ -36,7 +36,6 @@ api = Mock()
 host_storage = MemoryHostStorage()
 instance_helper = Mock()
 parent_run_id = 'parent_run_id'
-default_hostfile = 'default_hostfile'
 instance_disk = 'instance_disk'
 instance_type = 'instance_type'
 instance_image = 'instance_image'
@@ -53,7 +52,6 @@ hostlist = '@allhosts'
 run_id_queue = Queue()
 scale_up_handler = GridEngineScaleUpHandler(cmd_executor=cmd_executor, api=api, grid_engine=grid_engine,
                                             host_storage=host_storage, parent_run_id=parent_run_id,
-                                            default_hostfile=default_hostfile,
                                             instance_disk=instance_disk, instance_image=instance_image,
                                             cmd_template=cmd_template, price_type=price_type,
                                             region_id=region_id, queue=queue_name, hostlist=hostlist,

--- a/workflows/pipe-common/test/test_worker_recorder.py
+++ b/workflows/pipe-common/test/test_worker_recorder.py
@@ -17,7 +17,8 @@ from datetime import datetime
 
 from mock import MagicMock, Mock
 
-from scripts.autoscale_sge import CloudPipelineWorkerRecorder
+from scripts.autoscale_sge import CloudPipelineWorkerRecorder, AvailableInstanceEvent, \
+    InsufficientInstanceEvent, FailingInstanceEvent
 
 logging.basicConfig(level=logging.DEBUG, format='%(asctime)s [%(threadName)s] [%(levelname)s] %(message)s')
 
@@ -25,32 +26,20 @@ run_id = 12345
 run_name = 'pipeline-12345'
 started = datetime(2018, 12, 21, 11, 00, 00)
 stopped = datetime(2018, 12, 21, 11, 5, 00)
+now = datetime(2018, 12, 21, 11, 10, 00)
 started_str = '2018-12-21 11:00:00.000'
 stopped_str = '2018-12-21 11:05:00.000'
 instance_type = 'm5.xlarge'
 capacity = 5
 
 api = Mock()
-worker_recorder = CloudPipelineWorkerRecorder(api=api, capacity=capacity)
+event_manager = Mock()
+clock = Mock()
+worker_recorder = CloudPipelineWorkerRecorder(api=api, event_manager=event_manager, clock=clock)
 
 
 def setup_function():
-    worker_recorder.clear()
-
-
-def test_record():
-    api.load_run = MagicMock(return_value=_sufficient_capacity_run())
-
-    worker_recorder.record(run_id)
-
-    records = worker_recorder.get()
-    assert len(records) == 1
-    record = records[0]
-    assert record.id == run_id
-    assert record.name == run_name
-    assert record.instance_type == instance_type
-    assert record.started == started
-    assert record.stopped == stopped
+    clock.now = MagicMock(return_value=now)
 
 
 def test_record_sufficient_instance_type():
@@ -58,10 +47,8 @@ def test_record_sufficient_instance_type():
 
     worker_recorder.record(run_id)
 
-    records = worker_recorder.get()
-    assert len(records) == 1
-    record = records[0]
-    assert not record.has_insufficient_instance_capacity
+    event_manager.register.assert_called_with(
+        AvailableInstanceEvent(instance_type=instance_type, date=now))
 
 
 def test_record_insufficient_instance_type():
@@ -69,26 +56,28 @@ def test_record_insufficient_instance_type():
 
     worker_recorder.record(run_id)
 
-    records = worker_recorder.get()
-    assert len(records) == 1
-    record = records[0]
-    assert record.has_insufficient_instance_capacity
+    event_manager.register.assert_called_with(
+        InsufficientInstanceEvent(instance_type=instance_type, date=stopped))
 
 
-def test_record_multiple_workers():
-    api.load_run = MagicMock(return_value=_insufficient_capacity_run())
+def test_record_failing_instance_type():
+    api.load_run = MagicMock(return_value=_failing_run())
 
-    for _ in range(0, capacity * 2):
-        worker_recorder.record(run_id)
+    worker_recorder.record(run_id)
 
-    records = worker_recorder.get()
-    assert len(records) == capacity
+    event_manager.register.assert_called_with(
+        FailingInstanceEvent(instance_type=instance_type, date=stopped))
 
 
 def _insufficient_capacity_run():
+    run = _failing_run()
+    run['stateReasonMessage'] = 'Insufficient instance capacity.'
+    return run
+
+
+def _failing_run():
     run = _sufficient_capacity_run()
     run['status'] = 'FAILURE'
-    run['stateReasonMessage'] = 'Insufficient instance capacity.'
     return run
 
 

--- a/workflows/pipe-common/test/test_worker_validator.py
+++ b/workflows/pipe-common/test/test_worker_validator.py
@@ -36,7 +36,7 @@ scale_down_handler = Mock()
 common_utils = Mock()
 worker_validator = GridEngineWorkerValidator(cmd_executor=executor, api=api, host_storage=host_storage,
                                              grid_engine=grid_engine, scale_down_handler=scale_down_handler,
-                                             common_utils=common_utils)
+                                             common_utils=common_utils, dry_run=False)
 
 
 def setup_function():


### PR DESCRIPTION
Relates #2958 and depends on #3247.

The pull request improves unavailable instance types management in grid engine autoscaler so that both insufficient and failing instance types are temporary excluded from autoscaling.
