### PR TITLE
Pipeline run: NPE fix for empty instance type

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineConfigurationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineConfigurationManager.java
@@ -133,7 +133,7 @@ public class PipelineConfigurationManager {
             mergeParametersFromTool(configuration, tool);
         }
 
-        getParametersFromNetworkConfig(runVO.getInstanceType(), runVO.getCloudRegionId())
+        getParametersFromNetworkConfig(configuration.getInstanceType(), runVO.getCloudRegionId())
                 .forEach((key, parameter) -> {
                     if(!configuration.getParameters().containsKey(key)) {
                         configuration.getParameters().put(key, parameter);

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineConfigurationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineConfigurationManager.java
@@ -411,7 +411,7 @@ public class PipelineConfigurationManager {
         final CloudRegionsConfiguration cloudRegionsConfiguration = preferenceManager.getPreference(
                 SystemPreferences.CLUSTER_NETWORKS_CONFIG);
 
-        if (cloudRegionsConfiguration == null) {
+        if (cloudRegionsConfiguration == null || !StringUtils.hasText(instanceType)) {
             return Collections.emptyMap();
         }
 


### PR DESCRIPTION
### Background

In case of launching pipeline through the CLI without `--instance-type` it throws a server error, but it works normally when `-it` option specified. 

For example:
```
# pipe run -n pipeline-name@draft-12345 -c config-name
Error: Failed to get data from the server. The server responded with a message: Your operation has been aborted because we encountered a server problem.
```

This error occurs due to NPE server error.