### PR TITLE
Add support for role-based runs filtering

### DIFF
--- a/api/src/main/java/com/epam/pipeline/controller/vo/PipelineRunFilterVO.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/PipelineRunFilterVO.java
@@ -42,6 +42,7 @@ public class PipelineRunFilterVO implements AclSecuredFilter {
     private String partialParameters;
     private Long parentId;
     private List<String> owners;
+    private List<String> roles;
     private String ownershipFilter;
     private List<Long> entitiesIds;
     private List<Long> configurationIds;
@@ -80,7 +81,7 @@ public class PipelineRunFilterVO implements AclSecuredFilter {
     private boolean areSimpleArgumentsEmpty() {
         return CollectionUtils.isEmpty(pipelineIds) && CollectionUtils.isEmpty(versions)
                 && startDateFrom == null && endDateTo == null && partialParameters == null
-                && parentId == null && CollectionUtils.isEmpty(owners)
+                && parentId == null && CollectionUtils.isEmpty(owners) && CollectionUtils.isEmpty(roles)
                 && CollectionUtils.isEmpty(configurationIds) && CollectionUtils.isEmpty(entitiesIds)
                 && CollectionUtils.isEmpty(projectIds)
                 && MapUtils.isEmpty(tags)


### PR DESCRIPTION
Resolves issue #3260.

The pull request brings support for role-based runs filtering.

In order to filter runs by roles the following API call can be used.

`POST /run/filter`
```json
{
    "roles": ["ROLE_ADMIN", "ROLE_USER"]
}
```
