### PR TITLE
Introduce storage tags restricted access mode

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/datastorage/DataStorageApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/datastorage/DataStorageApiService.java
@@ -277,7 +277,7 @@ public class DataStorageApiService {
                 messageHelper.getMessage(MessageConstants.ERROR_INVALID_CREDENTIALS_REQUEST)));
     }
 
-    @PreAuthorize(AclExpressions.STORAGE_ID_WRITE)
+    @PreAuthorize(AclExpressions.STORAGE_ID_TAGS_WRITE)
     public Map<String, String> updateDataStorageObjectTags(Long id, String path, Map<String, String> tags,
                                                            String version, Boolean rewrite) {
         return dataStorageManager.updateDataStorageObjectTags(id, path, tags, version, rewrite);
@@ -293,7 +293,7 @@ public class DataStorageApiService {
         return dataStorageManager.loadDataStorageObjectTags(id, path, version);
     }
 
-    @PreAuthorize(AclExpressions.STORAGE_ID_WRITE)
+    @PreAuthorize(AclExpressions.STORAGE_ID_TAGS_WRITE)
     public Map<String, String> deleteDataStorageObjectTags(Long id, String path, String version, Set<String> tags) {
         return dataStorageManager.deleteDataStorageObjectTags(id, path, version, tags);
     }

--- a/api/src/main/java/com/epam/pipeline/acl/datastorage/tag/DataStorageTagBatchApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/datastorage/tag/DataStorageTagBatchApiService.java
@@ -37,39 +37,34 @@ public class DataStorageTagBatchApiService {
 
     private final DataStorageTagBatchManager dataStorageTagBatchManager;
 
-    @PreAuthorize(AclExpressions.STORAGE_ID_WRITE)
-    public List<DataStorageTag> insert(final Long id,
-                                       final DataStorageTagInsertBatchRequest request) {
+    @PreAuthorize(AclExpressions.STORAGE_ID_TAGS_REQUEST_WRITE)
+    public List<DataStorageTag> insert(final Long id, final DataStorageTagInsertBatchRequest request) {
         return dataStorageTagBatchManager.insert(id, request);
     }
 
-    @PreAuthorize(AclExpressions.STORAGE_ID_WRITE)
+    @PreAuthorize(AclExpressions.STORAGE_ID_TAGS_REQUEST_WRITE)
     public List<DataStorageTag> upsert(final Long id, final DataStorageTagUpsertBatchRequest request) {
         return dataStorageTagBatchManager.upsert(id, request);
 
     }
 
     @PreAuthorize(AclExpressions.STORAGE_ID_WRITE)
-    public List<DataStorageTag> copy(final Long id,
-                                     final DataStorageTagCopyBatchRequest request) {
+    public List<DataStorageTag> copy(final Long id, final DataStorageTagCopyBatchRequest request) {
         return dataStorageTagBatchManager.copy(id, request);
     }
 
     @PreAuthorize(AclExpressions.STORAGE_ID_READ)
-    public List<DataStorageTag> load(final Long id,
-                                     final DataStorageTagLoadBatchRequest request) {
+    public List<DataStorageTag> load(final Long id, final DataStorageTagLoadBatchRequest request) {
         return dataStorageTagBatchManager.load(id, request);
     }
 
     @PreAuthorize(AclExpressions.STORAGE_ID_WRITE)
-    public void delete(final Long id,
-                       final DataStorageTagDeleteBatchRequest request) {
+    public void delete(final Long id, final DataStorageTagDeleteBatchRequest request) {
         dataStorageTagBatchManager.delete(id, request);
     }
 
     @PreAuthorize(AclExpressions.STORAGE_ID_WRITE)
-    public void deleteAll(final Long id,
-                          final DataStorageTagDeleteAllBatchRequest request) {
+    public void deleteAll(final Long id, final DataStorageTagDeleteAllBatchRequest request) {
         dataStorageTagBatchManager.deleteAll(id, request);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/entity/user/DefaultRoles.java
+++ b/api/src/main/java/com/epam/pipeline/entity/user/DefaultRoles.java
@@ -35,7 +35,9 @@ public enum DefaultRoles {
     ROLE_SERVICE_ACCOUNT(new Role(null, "ROLE_SERVICE_ACCOUNT", true, false, null, null, null, null)),
     ROLE_ALLOW_ALL_POLICY(new Role(null, "ROLE_ALLOW_ALL_POLICY", true, false, null, null, null, null)),
     ROLE_STORAGE_ARCHIVE_MANAGER(new Role(null, "ROLE_STORAGE_ARCHIVE_MANAGER", true, false, null, null, null, null)),
-    ROLE_STORAGE_ARCHIVE_READER(new Role(null, "ROLE_STORAGE_ARCHIVE_READER", true, false, null, null, null, null));
+    ROLE_STORAGE_ARCHIVE_READER(new Role(null, "ROLE_STORAGE_ARCHIVE_READER", true, false, null, null, null, null)),
+    ROLE_STORAGE_MANAGER(new Role(null, "ROLE_STORAGE_MANAGER", true, false, null, null, null, null)),
+    ROLE_STORAGE_TAG_MANAGER(new Role(null, "ROLE_STORAGE_TAG_MANAGER", true, false, null, null, null, null));
 
     private Role role;
 

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -67,6 +67,7 @@ import com.epam.pipeline.manager.preference.AbstractSystemPreference.ObjectPrefe
 import com.epam.pipeline.manager.preference.AbstractSystemPreference.StringPreference;
 import com.epam.pipeline.security.ExternalServiceEndpoint;
 import com.fasterxml.jackson.core.type.TypeReference;
+import org.apache.commons.collections4.ListUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
@@ -161,6 +162,14 @@ public class SystemPreferences {
             COMMIT_GROUP, isGreaterThan(0));
 
     // DATA_STORAGE_GROUP
+    public static final BooleanPreference DATA_STORAGE_TAG_RESTRICTED_ACCESS_ENABLED = new BooleanPreference(
+        "storage.tag.restricted.access", false, DATA_STORAGE_GROUP, pass);
+    public static final ObjectPreference<List<String>> DATA_STORAGE_TAG_RESTRICTED_ACCESS_EXCLUDE_KEYS =
+        new ObjectPreference<>("storage.tag.restricted.access.exclude.keys",
+        ListUtils.unmodifiableList(Arrays.asList("CP_SOURCE", "CP_OWNER", "CP_RUN_ID", "CP_JOB_ID",
+                "CP_JOB_NAME", "CP_JOB_VERSION", "CP_JOB_CONFIGURATION", "CP_DOCKER_IMAGE", "CP_CALC_CONFIG")),
+        new TypeReference<List<String>>() {}, DATA_STORAGE_GROUP,
+        isNullOrValidJson(new TypeReference<List<String>>() {}));
     public static final IntPreference DATA_STORAGE_MAX_DOWNLOAD_SIZE = new IntPreference(
         "storage.max.download.size", 10000, DATA_STORAGE_GROUP, isGreaterThan(0));
     public static final IntPreference DATA_STORAGE_TEMP_CREDENTIALS_DURATION = new IntPreference(

--- a/api/src/main/java/com/epam/pipeline/manager/security/storage/StoragePermissionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/storage/StoragePermissionManager.java
@@ -23,27 +23,41 @@ import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.DataStorageWithShareMount;
 import com.epam.pipeline.entity.datastorage.NFSStorageMountStatus;
 import com.epam.pipeline.entity.datastorage.nfs.NFSDataStorage;
+import com.epam.pipeline.entity.datastorage.tag.DataStorageTagInsertBatchRequest;
+import com.epam.pipeline.entity.datastorage.tag.DataStorageTagInsertRequest;
+import com.epam.pipeline.entity.datastorage.tag.DataStorageTagUpsertBatchRequest;
+import com.epam.pipeline.entity.datastorage.tag.DataStorageTagUpsertRequest;
 import com.epam.pipeline.entity.security.acl.AclClass;
 import com.epam.pipeline.entity.user.DefaultRoles;
 import com.epam.pipeline.manager.EntityManager;
 import com.epam.pipeline.manager.datastorage.DataStoragePathLoader;
+import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.manager.quota.QuotaService;
 import com.epam.pipeline.manager.security.AuthManager;
 import com.epam.pipeline.manager.security.CheckPermissionHelper;
 import com.epam.pipeline.manager.security.GrantPermissionManager;
 import com.epam.pipeline.manager.security.PermissionsService;
 import com.epam.pipeline.security.acl.AclPermission;
+import com.epam.pipeline.utils.CommonUtils;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.collections4.SetUtils;
 import org.springframework.security.acls.domain.GrantedAuthoritySid;
 import org.springframework.security.acls.model.Sid;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -58,6 +72,7 @@ public class StoragePermissionManager {
     private final QuotaService quotaService;
     private final AuthManager authManager;
     private final DataStoragePathLoader storagePathLoader;
+    private final PreferenceManager preferenceManager;
 
     public boolean storagePermission(final AbstractDataStorage storage,
                                      final String permissionName) {
@@ -108,6 +123,88 @@ public class StoragePermissionManager {
         } catch (IllegalArgumentException e) {
             return false;
         }
+    }
+
+    public boolean storageTagsPermission(final Long id, final DataStorageTagInsertBatchRequest request,
+                                         final String permission) {
+        return storageTagsPermission(id, toTags(request), permission);
+    }
+
+    public boolean storageTagsPermission(final Long id, final DataStorageTagUpsertBatchRequest request,
+                                         final String permission) {
+        return storageTagsPermission(id, toTags(request), permission);
+    }
+
+    private List<String> toTags(final DataStorageTagInsertBatchRequest request) {
+        return Optional.ofNullable(request)
+                .map(DataStorageTagInsertBatchRequest::getRequests)
+                .map(List::stream)
+                .orElseGet(Stream::empty)
+                .map(DataStorageTagInsertRequest::getKey)
+                .collect(Collectors.toList());
+    }
+
+    private List<String> toTags(final DataStorageTagUpsertBatchRequest request) {
+        return Optional.ofNullable(request)
+                .map(DataStorageTagUpsertBatchRequest::getRequests)
+                .map(List::stream)
+                .orElseGet(Stream::empty)
+                .map(DataStorageTagUpsertRequest::getKey)
+                .collect(Collectors.toList());
+    }
+
+    public boolean storageTagsPermission(final Long id, final Map<String, String> tags, final String permission) {
+        return storageTagsPermission(id, MapUtils.emptyIfNull(tags).keySet(), permission);
+    }
+
+    public boolean storageTagsPermission(final Long id, final Set<String> tags, final String permission) {
+        return storageTagsPermission(id, new ArrayList<>(SetUtils.emptyIfNull(tags)), permission);
+    }
+
+    public boolean storageTagsPermission(final Long id, final List<String> tags, final String permission) {
+        final AbstractSecuredEntity storage = entityManager.load(AclClass.DATA_STORAGE, id);
+        return storageTagsPermission(storage, tags, permission);
+    }
+
+    private boolean storageTagsPermission(final AbstractSecuredEntity storage, final List<String> tags,
+                                          final String permission) {
+        return grantPermissionManager.storagePermission(storage, permission)
+                && (grantPermissionManager.isOwnerOrAdmin(storage.getOwner())
+                || !isRestrictedTagsAccessEnabled()
+                || !hasRestrictedTags(tags)
+                || hasAnyRole(DefaultRoles.ROLE_STORAGE_MANAGER, DefaultRoles.ROLE_STORAGE_TAG_MANAGER));
+    }
+
+    private boolean isRestrictedTagsAccessEnabled() {
+        return Optional.of(SystemPreferences.DATA_STORAGE_TAG_RESTRICTED_ACCESS_ENABLED)
+                .map(preferenceManager::getPreference)
+                .orElse(false);
+    }
+
+    private boolean hasRestrictedTags(final List<String> tags) {
+        return CollectionUtils.isNotEmpty(CommonUtils.subtract(ListUtils.emptyIfNull(tags),
+                getRestrictedTagsExcludeKeys()));
+    }
+
+    private List<String> getRestrictedTagsExcludeKeys() {
+        return Optional.of(SystemPreferences.DATA_STORAGE_TAG_RESTRICTED_ACCESS_EXCLUDE_KEYS)
+                .map(preferenceManager::getPreference)
+                .orElseGet(Collections::emptyList);
+    }
+
+    private boolean hasAnyRole(final DefaultRoles... roles) {
+        return hasAnyRole(Arrays.asList(roles));
+    }
+
+    private boolean hasAnyRole(final List<DefaultRoles> roles) {
+        return hasAnySid(roles.stream()
+                .map(DefaultRoles::getName)
+                .map(GrantedAuthoritySid::new)
+                .collect(Collectors.toList()));
+    }
+
+    private boolean hasAnySid(final List<Sid> sids) {
+        return permissionHelper.getSids().stream().anyMatch(sids::contains);
     }
 
     public void filterStorage(final List<AbstractDataStorage> storages,

--- a/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
+++ b/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
@@ -59,15 +59,23 @@ public final class AclExpressions {
     public static final String STORAGE_SHARED = "@grantPermissionManager.checkStorageShared(#id)";
 
     public static final String STORAGE_ID_READ =
-            "(hasRole('ADMIN') OR @storagePermissionManager.storagePermissionById(#id, 'READ')) "
+            "(" + ADMIN_ONLY + OR + "@storagePermissionManager.storagePermissionById(#id, 'READ')" + ")"
             + AND + STORAGE_SHARED;
 
     public static final String STORAGE_ID_WRITE =
-            "(hasRole('ADMIN') OR @storagePermissionManager.storagePermissionById(#id, 'WRITE')) "
+            "(" + ADMIN_ONLY + OR + "@storagePermissionManager.storagePermissionById(#id, 'WRITE')" + ")"
             + AND + STORAGE_SHARED;
 
     public static final String STORAGE_ID_OWNER =
-            "(hasRole('ADMIN') OR @storagePermissionManager.storagePermissionById(#id, 'OWNER')) "
+            "(" + ADMIN_ONLY + OR + "@storagePermissionManager.storagePermissionById(#id, 'OWNER')" + ")"
+            + AND + STORAGE_SHARED;
+
+    public static final String STORAGE_ID_TAGS_WRITE =
+            "(" + ADMIN_ONLY + OR + "@storagePermissionManager.storageTagsPermission(#id, #tags, 'WRITE')" + ")"
+            + AND + STORAGE_SHARED;
+
+    public static final String STORAGE_ID_TAGS_REQUEST_WRITE =
+            "(" + ADMIN_ONLY + OR + "@storagePermissionManager.storageTagsPermission(#id, #request, 'WRITE')" + ")"
             + AND + STORAGE_SHARED;
 
     public static final String ARCHIVED_PERMISSIONS =

--- a/api/src/main/resources/db/migration/v2023.06.02_16.00__issue-3261_storage_tag_manager_role.sql
+++ b/api/src/main/resources/db/migration/v2023.06.02_16.00__issue-3261_storage_tag_manager_role.sql
@@ -1,0 +1,2 @@
+INSERT INTO pipeline.role (id, name, predefined, user_default)
+VALUES (nextval('pipeline.s_role'), 'ROLE_STORAGE_TAG_MANAGER', TRUE, FALSE);

--- a/api/src/test/java/com/epam/pipeline/acl/datastorage/AbstractDataStorageAclTest.java
+++ b/api/src/test/java/com/epam/pipeline/acl/datastorage/AbstractDataStorageAclTest.java
@@ -23,6 +23,7 @@ import com.epam.pipeline.manager.EntityManager;
 import com.epam.pipeline.manager.datastorage.DataStorageManager;
 import com.epam.pipeline.manager.datastorage.convert.DataStorageConvertManager;
 import com.epam.pipeline.manager.datastorage.tag.DataStorageTagBatchManager;
+import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.security.AuthManager;
 import com.epam.pipeline.security.UserContext;
 import com.epam.pipeline.test.acl.AbstractAclTest;
@@ -63,6 +64,9 @@ abstract class AbstractDataStorageAclTest extends AbstractAclTest {
 
     @Autowired
     protected EntityManager mockEntityManager;
+
+    @Autowired
+    protected PreferenceManager preferenceManager;
 
     protected void initUserAndEntityMocks(final String user,
                                           final AbstractDataStorage entity,

--- a/api/src/test/java/com/epam/pipeline/dao/user/RoleDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/user/RoleDaoTest.java
@@ -45,7 +45,7 @@ import static org.junit.Assert.assertTrue;
 @Transactional
 public class RoleDaoTest extends AbstractJdbcTest {
 
-    private static final int EXPECTED_DEFAULT_ROLES_NUMBER = 18;
+    private static final int EXPECTED_DEFAULT_ROLES_NUMBER = 19;
     private static final String TEST_USER1 = "test_user1";
     private static final String TEST_ROLE = "ROLE_TEST";
     private static final String TEST_ROLE_UPDATED = "NEW_ROLE";

--- a/api/src/test/java/com/epam/pipeline/dao/user/UserDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/user/UserDaoTest.java
@@ -57,7 +57,7 @@ public class UserDaoTest extends AbstractJdbcTest {
     private static final String ATTRIBUTES_KEY = "email";
     private static final String ATTRIBUTES_VALUE = "test_email";
     private static final String ATTRIBUTES_VALUE2 = "Mail@epam.com";
-    private static final int EXPECTED_DEFAULT_ROLES_NUMBER = 18;
+    private static final int EXPECTED_DEFAULT_ROLES_NUMBER = 19;
     private static final String TEST_ROLE = "ROLE_TEST";
 
     @Autowired


### PR DESCRIPTION
Resolves issue #3261.

The pull request brings support for storage tags restricted access mode.

By default, when storage tags restricted access mode is disabled, all users with write access to a data storage are allowed to add, modify or delete data storage object tags.

In case restricted access mode is enabled, users with storage write access are allowed to add, modify or delete only a limited set of data storage object tags. Only if a user is either an admin or a storage owner or they have either `ROLE_STORAGE_MANAGER` or `ROLE_STORAGE_TAG_MANAGER` role, then they are allowed to add, modify or delete all data storage object tags.

The following new system preferences are added:
- `storage.tag.restricted.access` enables restricted access mode. Defaults to _false_ or default access mode.
- `storage.tag.restricted.access.exclude.keys` specifies a list of storage tags that are allowed to be managed by any user with a storage write access when restricted mode is enabled. Defaults to _["CP_SOURCE", "CP_OWNER", "CP_RUN_ID", "CP_JOB_ID", "CP_JOB_NAME", "CP_JOB_VERSION", "CP_JOB_CONFIGURATION", "CP_DOCKER_IMAGE", "CP_CALC_CONFIG"]_
