### PR TITLE
Add CUDA availability check when GPU instance is launched

### DIFF
--- a/api/src/main/java/com/epam/pipeline/dao/tool/ToolVulnerabilityDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/tool/ToolVulnerabilityDao.java
@@ -157,9 +157,9 @@ public class ToolVulnerabilityDao extends NamedParameterJdbcDaoSupport {
     public void insertToolVersionScan(long toolId, String version, ToolOSVersion toolOSVersion, String layerRef,
                                       String digest, ToolScanStatus newStatus, Date scanDate,
                                       Map<VulnerabilitySeverity, Integer> vulnerabilitiesCount, String defaultCmd,
-                                      Integer layersCount) {
+                                      Integer layersCount, boolean cudaAvailable) {
         MapSqlParameterSource params = ToolVulnerabilityColumns.getParams(toolId, version, toolOSVersion, layerRef,
-                digest, newStatus, scanDate, false, vulnerabilitiesCount, defaultCmd, layersCount);
+                digest, newStatus, scanDate, false, vulnerabilitiesCount, defaultCmd, layersCount, cudaAvailable);
         getNamedParameterJdbcTemplate().update(insertToolVersionScanQuery, params);
     }
 
@@ -167,9 +167,9 @@ public class ToolVulnerabilityDao extends NamedParameterJdbcDaoSupport {
     public void updateToolVersionScan(long toolId, String version, ToolOSVersion toolOSVersion, String layerRef,
                                       String digest, ToolScanStatus newStatus, Date scanDate, boolean whiteList,
                                       Map<VulnerabilitySeverity, Integer> vulnerabilitiesCount, String defaultCmd,
-                                      Integer layersCount) {
+                                      Integer layersCount, boolean cudaAvailable) {
         MapSqlParameterSource params = ToolVulnerabilityColumns.getParams(toolId, version, toolOSVersion, layerRef,
-                digest, newStatus, scanDate, whiteList, vulnerabilitiesCount, defaultCmd, layersCount);
+                digest, newStatus, scanDate, whiteList, vulnerabilitiesCount, defaultCmd, layersCount, cudaAvailable);
         if (newStatus == ToolScanStatus.COMPLETED) {
             getNamedParameterJdbcTemplate().update(updateToolVersionScanWithSuccessQuery, params);
         } else {
@@ -421,7 +421,8 @@ public class ToolVulnerabilityDao extends NamedParameterJdbcDaoSupport {
                                                        final String digest, final ToolScanStatus newStatus,
                                                        final Date scanDate, final boolean whiteList,
                                                        final Map<VulnerabilitySeverity, Integer> vulnerabilitiesCount,
-                                                       final String defaultCmd, final Integer layersCount) {
+                                                       final String defaultCmd, final Integer layersCount,
+                                                       final boolean cudaAvailable) {
             MapSqlParameterSource params = new MapSqlParameterSource();
             params.addValue(ToolVersionColumns.TOOL_ID.name(), toolId);
             params.addValue(ToolVersionColumns.VERSION.name(), version);
@@ -442,6 +443,7 @@ public class ToolVulnerabilityDao extends NamedParameterJdbcDaoSupport {
                             .orElse(null));
             params.addValue(ToolVersionColumns.DEFAULT_CMD.name(), defaultCmd);
             params.addValue(ToolVersionColumns.LAYERS_COUNT.name(), layersCount);
+            params.addValue(ToolVersionColumns.CUDA_AVAILABLE.name(), cudaAvailable);
             return params;
         }
 
@@ -491,7 +493,8 @@ public class ToolVulnerabilityDao extends NamedParameterJdbcDaoSupport {
         OS_VERSION,
         VULNERABILITIES_COUNT,
         DEFAULT_CMD,
-        LAYERS_COUNT;
+        LAYERS_COUNT,
+        CUDA_AVAILABLE;
 
         private static RowMapper<ToolVersionScanResult> getRowMapper() {
             return (rs, rowNum) -> {
@@ -530,6 +533,7 @@ public class ToolVulnerabilityDao extends NamedParameterJdbcDaoSupport {
                 }
                 versionScan.setDefaultCmd(rs.getString(ToolVersionColumns.DEFAULT_CMD.name()));
                 versionScan.setLayersCount(rs.getInt(ToolVersionColumns.LAYERS_COUNT.name()));
+                versionScan.setCudaAvailable(rs.getBoolean(ToolVersionColumns.CUDA_AVAILABLE.name()));
                 return versionScan;
             };
         }

--- a/api/src/main/java/com/epam/pipeline/entity/docker/ContainerConfig.java
+++ b/api/src/main/java/com/epam/pipeline/entity/docker/ContainerConfig.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 @JsonIgnoreProperties(ignoreUnknown=true)
@@ -28,4 +29,7 @@ public class ContainerConfig {
 
     @JsonProperty("Cmd")
     private List<String> commands;
+
+    @JsonProperty("Labels")
+    private Map<String, String> labels;
 }

--- a/api/src/main/java/com/epam/pipeline/entity/scan/ToolDependency.java
+++ b/api/src/main/java/com/epam/pipeline/entity/scan/ToolDependency.java
@@ -55,6 +55,7 @@ public class ToolDependency {
         SWIFT("Swift.PM"),
         CMAKE("CMAKE"),
         RUBY("Ruby.Bundle"),
+        NVIDIA("Nvidia"),
         OTHER("OTHER");
 
         private static Map<String, Ecosystem> map;

--- a/api/src/main/java/com/epam/pipeline/entity/scan/ToolVersionScanResult.java
+++ b/api/src/main/java/com/epam/pipeline/entity/scan/ToolVersionScanResult.java
@@ -39,6 +39,7 @@ public class ToolVersionScanResult {
     private Long toolId;
     private String version;
     private ToolOSVersion toolOSVersion;
+    private boolean cudaAvailable;
     private ToolScanStatus status;
     private Date scanDate;
     private Date successScanDate;

--- a/api/src/main/java/com/epam/pipeline/entity/scan/ToolVersionScanResultView.java
+++ b/api/src/main/java/com/epam/pipeline/entity/scan/ToolVersionScanResultView.java
@@ -34,6 +34,7 @@ public class ToolVersionScanResultView {
     private Long toolId;
     private String version;
     private ToolOSVersionView toolOSVersion;
+    private boolean cudaAvailable;
     private ToolScanStatus status;
     private Date scanDate;
     private Date successScanDate;
@@ -63,6 +64,7 @@ public class ToolVersionScanResultView {
                     .vulnerabilitiesCount(scan.getVulnerabilitiesCount())
                     .defaultCmd(scan.getDefaultCmd())
                     .layersCount(scan.getLayersCount())
+                    .cudaAvailable(scan.isCudaAvailable())
                     .build()
         ).orElse(null);
     }

--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerClient.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerClient.java
@@ -207,6 +207,11 @@ public class DockerClient {
             }).collect(Collectors.toList());
     }
 
+    public Map<String, String> getImageLabels(final DockerRegistry registry, final String imageName, final String tag) {
+        final RawImageDescription rawImage = getRawImageDescription(registry, imageName, tag, getAuthHeaders());
+        return DockerParsingUtils.getLabels(rawImage);
+    }
+
     private Map<String, Long> getLayersSize(final DockerRegistry registry, final String imageName, final String tag) {
         return getManifest(registry, imageName, tag)
             .map(ManifestV2::getLayers)

--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerParsingUtils.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerParsingUtils.java
@@ -22,6 +22,7 @@ import com.epam.pipeline.entity.docker.HistoryEntryV1;
 import com.epam.pipeline.entity.docker.RawImageDescription;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
@@ -34,6 +35,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -80,6 +82,15 @@ public final class DockerParsingUtils {
             .collect(Collectors.toList());
         Collections.reverse(commandsHistory);
         return commandsHistory;
+    }
+
+    public static Map<String, String> getLabels(final RawImageDescription rawImage) {
+        return getHistoryEntryStream(rawImage)
+                .map(HistoryEntryV1::getContainerConfig)
+                .map(ContainerConfig::getLabels)
+                .filter(MapUtils::isNotEmpty)
+                .flatMap(labels -> labels.entrySet().stream())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     private static Stream<HistoryEntryV1> getHistoryEntryStream(final RawImageDescription rawImage) {

--- a/api/src/main/java/com/epam/pipeline/manager/docker/scan/AggregatingToolScanManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/scan/AggregatingToolScanManager.java
@@ -56,6 +56,7 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.OkHttpClient;
 import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -316,12 +317,14 @@ public class AggregatingToolScanManager implements ToolScanManager {
             final DockerClient client = getDockerClient(tool.getImage(), registry);
             final String digest = client.getVersionAttributes(registry, tool.getImage(), tag).getDigest();
             final List<ImageHistoryLayer> imageHistory = client.getImageHistory(registry, tool.getImage(), tag);
+            final boolean hasCudnnVersion = hasCudnnVersion(client, registry, tool.getImage(), tag);
             final String defaultCmd = toolManager.loadToolDefaultCommand(imageHistory);
 
             final ClairScanResult clairResult = getScanResult(tool, clairService.getScanResult(clairRef));
             final DockerComponentScanResult dockerScanResult = dockerComponentService == null ? null :
                     getScanResult(tool, dockerComponentService.getScanResult(clairRef));
-            return convertResults(clairResult, dockerScanResult, tool, tag, digest, defaultCmd, imageHistory.size());
+            return convertResults(clairResult, dockerScanResult, tool,
+                    tag, digest, defaultCmd, imageHistory.size(), hasCudnnVersion);
         } catch (IOException e) {
             throw new ToolScanExternalServiceException(tool, e);
         }
@@ -436,7 +439,8 @@ public class AggregatingToolScanManager implements ToolScanManager {
                                                  final String tag,
                                                  final String digest,
                                                  final String defaultCmd,
-                                                 final int layersCount) {
+                                                 final int layersCount,
+                                                 final boolean hasCudnnVersion) {
         final Map<VulnerabilitySeverity, Integer> vulnerabilitiesCount = new HashMap<>();
         final List<Vulnerability> vulnerabilities = Optional.ofNullable(clairScanResult)
                 .map(result -> ListUtils.emptyIfNull(result.getFeatures()).stream())
@@ -481,9 +485,12 @@ public class AggregatingToolScanManager implements ToolScanManager {
                 .findFirst().map(td -> new ToolOSVersion(td.getName(), td.getVersion()))
                 .orElseGet(() -> createEmptyToolOsVersion(tool, tag));
 
+        final boolean cudaAvailable = hasCudnnVersion && hasNvidiaInstalled(dependencies, tool, tag);
+
         final ToolVersionScanResult result = new ToolVersionScanResult(tag, osVersion, vulnerabilities,
                 dependencies, ToolScanStatus.COMPLETED, clairScanResult.getName(), digest, defaultCmd, layersCount);
         result.setVulnerabilitiesCount(vulnerabilitiesCount);
+        result.setCudaAvailable(cudaAvailable);
         return result;
     }
 
@@ -494,5 +501,26 @@ public class AggregatingToolScanManager implements ToolScanManager {
             .filter(WINDOWS_PLATFORM::equalsIgnoreCase)
             .map(platform -> new ToolOSVersion(WINDOWS_PLATFORM, StringUtils.EMPTY))
             .orElse(new ToolOSVersion(NOT_DETERMINED, NOT_DETERMINED));
+    }
+
+    private boolean hasCudnnVersion(final DockerClient client, final DockerRegistry registry,
+                                   final String image, final String tag) {
+        final String cudnnVersionLabel = preferenceManager.getPreference(
+                SystemPreferences.DOCKER_SECURITY_CUDNN_VERSION_LABEL);
+        final boolean hasCudnnVersion = MapUtils.emptyIfNull(client.getImageLabels(registry, image, tag))
+                .containsKey(cudnnVersionLabel);
+        if (hasCudnnVersion) {
+            LOGGER.debug("Found cudnn version label for tool '{}:{}'", image, tag);
+        }
+        return hasCudnnVersion;
+    }
+
+    private boolean hasNvidiaInstalled(final List<ToolDependency> dependencies, final Tool tool, final String tag) {
+        final boolean nvidiaInstalled = dependencies.stream()
+                .anyMatch(toolDependency -> ToolDependency.Ecosystem.NVIDIA.equals(toolDependency.getEcosystem()));
+        if (nvidiaInstalled) {
+            LOGGER.debug("Found nvidia version file for tool '{}:{}'", tool.getImage(), tag);
+        }
+        return nvidiaInstalled;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/docker/scan/ToolScanSchedulerCore.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/scan/ToolScanSchedulerCore.java
@@ -112,7 +112,7 @@ class ToolScanSchedulerCore {
                     toolManager.updateToolVersionScanStatus(tool.getId(), ToolScanStatus.COMPLETED, new Date(),
                             version, result.getToolOSVersion(),
                             result.getLastLayerRef(), result.getDigest(), result.getVulnerabilitiesCount(),
-                            result.getDefaultCmd(), result.getLayersCount());
+                            result.getDefaultCmd(), result.getLayersCount(), result.isCudaAvailable());
                     updateToolVersion(tool, version, registry, dockerClient);
                 } catch (ToolScanExternalServiceException e) {
                     log.error(messageHelper.getMessage(MessageConstants.ERROR_TOOL_SCAN_FAILED,
@@ -173,7 +173,7 @@ class ToolScanSchedulerCore {
                     toolManager.updateToolVersionScanStatus(tool.getId(), ToolScanStatus.COMPLETED,
                             scanResult.getScanDate(), version, scanResult.getToolOSVersion(),
                             scanResult.getLastLayerRef(), scanResult.getDigest(), scanResult.getVulnerabilitiesCount(),
-                            scanResult.getDefaultCmd(), scanResult.getLayersCount());
+                            scanResult.getDefaultCmd(), scanResult.getLayersCount(), scanResult.isCudaAvailable());
                     return scanResult;
                 } catch (Exception e) {
                     toolManager.updateToolVersionScanStatus(tool.getId(), ToolScanStatus.FAILED, new Date(),

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/ToolManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/ToolManager.java
@@ -609,12 +609,12 @@ public class ToolManager implements SecuredEntityManager {
                                             String version, ToolOSVersion toolOSVersion,
                                             String layerRef, String digest,
                                             Map<VulnerabilitySeverity, Integer> vulnerabilityCount,
-                                            String defaultCmd, Integer layersCount) {
+                                            String defaultCmd, Integer layersCount, boolean cudaAvailable) {
         final Tool tool = load(toolId);
         validateToolNotNull(tool, toolId);
         validateToolCanBeModified(tool);
         Optional<ToolVersionScanResult> prev = loadToolVersionScan(tool, version);
-        if(prev.isPresent()) {
+        if (prev.isPresent()) {
             ToolVersionScanResult scanResult = prev.get();
             boolean whiteList = scanResult.isFromWhiteList();
             if (scanResult.getDigest() == null || !scanResult.getDigest().equals(digest)) {
@@ -622,10 +622,10 @@ public class ToolManager implements SecuredEntityManager {
                 whiteList = false;
             }
             toolVulnerabilityDao.updateToolVersionScan(toolId, version, toolOSVersion, layerRef, digest, newStatus,
-                    scanDate, whiteList, vulnerabilityCount, defaultCmd, layersCount);
+                    scanDate, whiteList, vulnerabilityCount, defaultCmd, layersCount, cudaAvailable);
         } else {
             toolVulnerabilityDao.insertToolVersionScan(toolId, version, toolOSVersion, layerRef,
-                    digest, newStatus, scanDate, vulnerabilityCount, defaultCmd, layersCount);
+                    digest, newStatus, scanDate, vulnerabilityCount, defaultCmd, layersCount, cudaAvailable);
         }
     }
 
@@ -635,7 +635,7 @@ public class ToolManager implements SecuredEntityManager {
                                             Map<VulnerabilitySeverity, Integer> vulnerabilityCount,
                                             String defaultCmd, Integer layersCount) {
         updateToolVersionScanStatus(toolId, newStatus, scanDate, version, null, layerRef, digest,
-                vulnerabilityCount, defaultCmd, layersCount);
+                vulnerabilityCount, defaultCmd, layersCount, false);
     }
 
     @Transactional(propagation = Propagation.REQUIRED)
@@ -647,7 +647,7 @@ public class ToolManager implements SecuredEntityManager {
         Optional<ToolVersionScanResult> toolVersionScanResult = loadToolVersionScan(tool, version);
         if (!toolVersionScanResult.isPresent()) {
             toolVulnerabilityDao.insertToolVersionScan(toolId, version, null, null, null, ToolScanStatus.NOT_SCANNED,
-                    DateUtils.now(), new HashMap<>(), null, null);
+                    DateUtils.now(), new HashMap<>(), null, null, false);
         }
         toolVulnerabilityDao.updateWhiteListWithToolVersion(toolId, version, fromWhiteList);
         return loadToolVersionScan(tool, version).orElse(null);

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -415,6 +415,9 @@ public class SystemPreferences {
      */
     public static final IntPreference DOCKER_SECURITY_TOOL_POLICY_MAX_HIGH_VULNERABILITIES = new IntPreference(
         "security.tools.policy.max.high.vulnerabilities", 20, DOCKER_SECURITY_GROUP, isGreaterThanOrEquals(0));
+    public static final StringPreference DOCKER_SECURITY_CUDNN_VERSION_LABEL = new StringPreference(
+            "security.tools.nvidia.cudnn.version.label", "com.nvidia.cudnn.version", DOCKER_SECURITY_GROUP,
+            PreferenceValidators.isValidUrlOrBlank);
 
     // CLUSTER_GROUP
     /**

--- a/api/src/main/resources/dao/tool-vulnerability-dao.xml
+++ b/api/src/main/resources/dao/tool-vulnerability-dao.xml
@@ -194,7 +194,8 @@
                         os_version,
                         vulnerabilities_count,
                         default_cmd,
-                        layers_count
+                        layers_count,
+                        cuda_available
                     ) VALUES (
                         :TOOL_ID,
                         :VERSION,
@@ -207,7 +208,8 @@
                         :OS_VERSION,
                         :VULNERABILITIES_COUNT,
                         :DEFAULT_CMD,
-                        :LAYERS_COUNT
+                        :LAYERS_COUNT,
+                        :CUDA_AVAILABLE
                     )
                 ]]>
             </value>
@@ -226,7 +228,8 @@
                         os_version=:OS_VERSION,
                         vulnerabilities_count=:VULNERABILITIES_COUNT,
                         default_cmd=:DEFAULT_CMD,
-                        layers_count=:LAYERS_COUNT
+                        layers_count=:LAYERS_COUNT,
+                        cuda_available = :CUDA_AVAILABLE
                     WHERE
                         tool_id=:TOOL_ID
                         AND version=:VERSION
@@ -260,7 +263,8 @@
                         os_version=:OS_VERSION,
                         vulnerabilities_count=:VULNERABILITIES_COUNT,
                         default_cmd=:DEFAULT_CMD,
-                        layers_count=:LAYERS_COUNT
+                        layers_count=:LAYERS_COUNT,
+                        cuda_available=:CUDA_AVAILABLE
                     WHERE
                         tool_id=:TOOL_ID
                         AND version=:VERSION
@@ -283,7 +287,8 @@
                         os_version,
                         vulnerabilities_count,
                         default_cmd,
-                        layers_count
+                        layers_count,
+                        cuda_available
                     FROM
                         pipeline.tool_version_scan
                     WHERE
@@ -308,7 +313,8 @@
                         os_version,
                         vulnerabilities_count,
                         default_cmd,
-                        layers_count
+                        layers_count,
+                        cuda_available
                     FROM
                         pipeline.tool_version_scan
                     WHERE
@@ -332,7 +338,8 @@
                         os_version,
                         vulnerabilities_count,
                         default_cmd,
-                        layers_count
+                        layers_count,
+                        cuda_available
                     FROM
                         pipeline.tool_version_scan
                     WHERE

--- a/api/src/main/resources/db/migration/v2023.06.06_14.00__tool_version_scan_nvidia_version.sql
+++ b/api/src/main/resources/db/migration/v2023.06.06_14.00__tool_version_scan_nvidia_version.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pipeline.tool_version_scan ADD COLUMN cuda_available BOOL DEFAULT FALSE;

--- a/api/src/test/java/com/epam/pipeline/dao/tool/DockerRegistryDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/tool/DockerRegistryDaoTest.java
@@ -220,7 +220,7 @@ public class DockerRegistryDaoTest extends AbstractJdbcTest {
                 .flatMap(group -> group.getTools().stream())
                 .forEach(tool -> toolVulnerabilityDao.insertToolVersionScan(tool.getId(), LATEST_VERSION,
                         expectedOsVersion, TEST_USER, TEST_USER, ToolScanStatus.COMPLETED, new Date(),
-                        Collections.emptyMap(), TEST_USER, 1));
+                        Collections.emptyMap(), TEST_USER, 1, false));
 
         final List<DockerRegistry> loadedRegistries = registryDao.loadAllRegistriesContent();
 

--- a/api/src/test/java/com/epam/pipeline/dao/tool/ToolVulnerabilityDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/tool/ToolVulnerabilityDaoTest.java
@@ -49,6 +49,7 @@ public class ToolVulnerabilityDaoTest extends AbstractJdbcTest {
     private static final String LATEST_VERSION = "latest";
     private static final String PREV = "prev";
     private static final ToolOSVersion TOOL_OS_VERSION = new ToolOSVersion("centos", "7");
+    private static final String DIGEST = "digest";
 
     @Autowired
     private ToolVulnerabilityDao toolVulnerabilityDao;
@@ -124,7 +125,7 @@ public class ToolVulnerabilityDaoTest extends AbstractJdbcTest {
         vulnerabilitiesCount.put(VulnerabilitySeverity.Critical, 1);
         vulnerabilitiesCount.put(VulnerabilitySeverity.Medium, 2);
         toolVulnerabilityDao.insertToolVersionScan(tool.getId(), LATEST_VERSION,
-                TOOL_OS_VERSION, "", "digest",
+                TOOL_OS_VERSION, "", DIGEST,
                 ToolScanStatus.COMPLETED, new Date(), vulnerabilitiesCount, null, null, false);
         final Optional<ToolVersionScanResult> result = toolVulnerabilityDao
                 .loadToolVersionScan(tool.getId(), LATEST_VERSION);
@@ -136,7 +137,7 @@ public class ToolVulnerabilityDaoTest extends AbstractJdbcTest {
     public void shouldSaveAndLoadVersionWithLayersCount() {
         final Integer layersCount = 10;
         toolVulnerabilityDao.insertToolVersionScan(tool.getId(), LATEST_VERSION,
-                TOOL_OS_VERSION, "", "digest",
+                TOOL_OS_VERSION, "", DIGEST,
                 ToolScanStatus.COMPLETED, new Date(), new HashMap<>(), null, layersCount, false);
         final Optional<ToolVersionScanResult> result = toolVulnerabilityDao
                 .loadToolVersionScan(tool.getId(), LATEST_VERSION);
@@ -148,7 +149,7 @@ public class ToolVulnerabilityDaoTest extends AbstractJdbcTest {
     public void shouldSaveAndLoadVersionWithDefaultCmd() {
         final String defaultCmd = "defaultCmd";
         toolVulnerabilityDao.insertToolVersionScan(tool.getId(), LATEST_VERSION,
-                TOOL_OS_VERSION, "", "digest",
+                TOOL_OS_VERSION, "", DIGEST,
                 ToolScanStatus.COMPLETED, new Date(), new HashMap<>(), defaultCmd, null, false);
         final Optional<ToolVersionScanResult> result = toolVulnerabilityDao
                 .loadToolVersionScan(tool.getId(), LATEST_VERSION);
@@ -159,7 +160,7 @@ public class ToolVulnerabilityDaoTest extends AbstractJdbcTest {
     @Test
     public void shouldSaveAndLoadVersionWithCudaAvailable() {
         toolVulnerabilityDao.insertToolVersionScan(tool.getId(), LATEST_VERSION,
-                TOOL_OS_VERSION, "", "digest",
+                TOOL_OS_VERSION, "", DIGEST,
                 ToolScanStatus.COMPLETED, new Date(), new HashMap<>(), null, null, true);
         final Optional<ToolVersionScanResult> result = toolVulnerabilityDao
                 .loadToolVersionScan(tool.getId(), LATEST_VERSION);

--- a/api/src/test/java/com/epam/pipeline/dao/tool/ToolVulnerabilityDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/tool/ToolVulnerabilityDaoTest.java
@@ -48,6 +48,7 @@ public class ToolVulnerabilityDaoTest extends AbstractJdbcTest {
 
     private static final String LATEST_VERSION = "latest";
     private static final String PREV = "prev";
+    private static final ToolOSVersion TOOL_OS_VERSION = new ToolOSVersion("centos", "7");
 
     @Autowired
     private ToolVulnerabilityDao toolVulnerabilityDao;
@@ -123,8 +124,8 @@ public class ToolVulnerabilityDaoTest extends AbstractJdbcTest {
         vulnerabilitiesCount.put(VulnerabilitySeverity.Critical, 1);
         vulnerabilitiesCount.put(VulnerabilitySeverity.Medium, 2);
         toolVulnerabilityDao.insertToolVersionScan(tool.getId(), LATEST_VERSION,
-                new ToolOSVersion("centos", "7"), "", "digest",
-                ToolScanStatus.COMPLETED, new Date(), vulnerabilitiesCount, null, null);
+                TOOL_OS_VERSION, "", "digest",
+                ToolScanStatus.COMPLETED, new Date(), vulnerabilitiesCount, null, null, false);
         final Optional<ToolVersionScanResult> result = toolVulnerabilityDao
                 .loadToolVersionScan(tool.getId(), LATEST_VERSION);
         Assert.assertTrue(result.isPresent());
@@ -135,8 +136,8 @@ public class ToolVulnerabilityDaoTest extends AbstractJdbcTest {
     public void shouldSaveAndLoadVersionWithLayersCount() {
         final Integer layersCount = 10;
         toolVulnerabilityDao.insertToolVersionScan(tool.getId(), LATEST_VERSION,
-                new ToolOSVersion("centos", "7"), "", "digest",
-                ToolScanStatus.COMPLETED, new Date(), new HashMap<>(), null, layersCount);
+                TOOL_OS_VERSION, "", "digest",
+                ToolScanStatus.COMPLETED, new Date(), new HashMap<>(), null, layersCount, false);
         final Optional<ToolVersionScanResult> result = toolVulnerabilityDao
                 .loadToolVersionScan(tool.getId(), LATEST_VERSION);
         Assert.assertTrue(result.isPresent());
@@ -147,12 +148,23 @@ public class ToolVulnerabilityDaoTest extends AbstractJdbcTest {
     public void shouldSaveAndLoadVersionWithDefaultCmd() {
         final String defaultCmd = "defaultCmd";
         toolVulnerabilityDao.insertToolVersionScan(tool.getId(), LATEST_VERSION,
-                new ToolOSVersion("centos", "7"), "", "digest",
-                ToolScanStatus.COMPLETED, new Date(), new HashMap<>(), defaultCmd, null);
+                TOOL_OS_VERSION, "", "digest",
+                ToolScanStatus.COMPLETED, new Date(), new HashMap<>(), defaultCmd, null, false);
         final Optional<ToolVersionScanResult> result = toolVulnerabilityDao
                 .loadToolVersionScan(tool.getId(), LATEST_VERSION);
         Assert.assertTrue(result.isPresent());
         Assert.assertEquals(defaultCmd, result.get().getDefaultCmd());
+    }
+
+    @Test
+    public void shouldSaveAndLoadVersionWithCudaAvailable() {
+        toolVulnerabilityDao.insertToolVersionScan(tool.getId(), LATEST_VERSION,
+                TOOL_OS_VERSION, "", "digest",
+                ToolScanStatus.COMPLETED, new Date(), new HashMap<>(), null, null, true);
+        final Optional<ToolVersionScanResult> result = toolVulnerabilityDao
+                .loadToolVersionScan(tool.getId(), LATEST_VERSION);
+        Assert.assertTrue(result.isPresent());
+        Assert.assertTrue(result.get().isCudaAvailable());
     }
 
     @Test

--- a/api/src/test/java/com/epam/pipeline/manager/docker/scan/AggregatingToolScanManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/docker/scan/AggregatingToolScanManagerTest.java
@@ -84,6 +84,8 @@ public class AggregatingToolScanManagerTest {
     public static final String DIGEST_1 = "digest1";
     public static final String DIGEST_2 = "digest2";
     public static final String DIGEST_3 = "digest3";
+    private static final String TEST_LABEL_NAME = "label-name";
+    private static final String TEST_LABEL_VALUE = "label-value";
 
     @InjectMocks
     private AggregatingToolScanManager aggregatingToolScanManager = new AggregatingToolScanManager();
@@ -139,6 +141,8 @@ public class AggregatingToolScanManagerTest {
     private ClairScanResult.ClairVulnerability clairVulnerability;
     private ClairScanResult.ClairFeature feature;
     private ToolDependency testDependency;
+    private final ToolDependency nvidiaDependency = new ToolDependency(
+            1, "latest", "NvidiaVersion", null, ToolDependency.Ecosystem.NVIDIA, null);
 
     @Before
     public void setUp() throws Exception {
@@ -157,6 +161,8 @@ public class AggregatingToolScanManagerTest {
                 .thenReturn(MAX_MEDIUM_VULNERABILITIES);
         when(preferenceManager.getPreference(SystemPreferences.DOCKER_SECURITY_TOOL_GRACE_HOURS))
                 .thenReturn(0);
+        when(preferenceManager.getPreference(SystemPreferences.DOCKER_SECURITY_CUDNN_VERSION_LABEL))
+                .thenReturn(TEST_LABEL_NAME);
 
         Assert.assertNotNull(pipelineConfigurationManager); // Dummy line, to shut up PMD
 
@@ -206,7 +212,7 @@ public class AggregatingToolScanManagerTest {
         DockerComponentLayerScanResult layerScanResult = new DockerComponentLayerScanResult();
         testDependency = new ToolDependency(
                 1, "latest", "test", "1.0", ToolDependency.Ecosystem.R_PKG, "R Package");
-        layerScanResult.setDependencies(Collections.singletonList(testDependency));
+        layerScanResult.setDependencies(Arrays.asList(testDependency, nvidiaDependency));
         dockerComponentScanResult.setLayers(Collections.singletonList(layerScanResult));
 
         when(dataStorageApiService.getDataStorages()).thenReturn(Collections.emptyList());
@@ -222,6 +228,8 @@ public class AggregatingToolScanManagerTest {
                 .thenReturn(attributes);
         when(mockDockerClient.getVersionAttributes(any(), eq(TEST_IMAGE), eq(ACTUAL_SCANNED_VERSION)))
                 .thenReturn(actualAttr);
+        when(mockDockerClient.getImageLabels(any(), any(), any()))
+                .thenReturn(Collections.singletonMap(TEST_LABEL_NAME, TEST_LABEL_VALUE));
 
         when(clairService.scanLayer(any(ClairScanRequest.class)))
             .then((Answer<MockCall<ClairScanRequest>>) invocation ->
@@ -279,6 +287,7 @@ public class AggregatingToolScanManagerTest {
         when(toolManager.loadToolVersionAttributes(Mockito.anyLong(), Mockito.anyString()))
             .thenReturn(new ToolVersionAttributes());
         ToolVersionScanResult result = aggregatingToolScanManager.scanTool(testTool, LATEST_VERSION, false);
+        Assert.assertTrue(result.isCudaAvailable());
 
         Assert.assertFalse(result.getVulnerabilities().isEmpty());
 
@@ -290,7 +299,7 @@ public class AggregatingToolScanManagerTest {
         Assert.assertEquals(feature.getVersion(), loadedVulnerability.getFeatureVersion());
 
         List<ToolDependency> dependencies = result.getDependencies();
-        Assert.assertEquals(2, dependencies.size());
+        Assert.assertEquals(3, dependencies.size());
 
         ToolDependency loadedDependency = dependencies.get(0);
         Assert.assertEquals(testDependency.getName(), loadedDependency.getName());
@@ -299,6 +308,10 @@ public class AggregatingToolScanManagerTest {
         Assert.assertEquals(testDependency.getDescription(), loadedDependency.getDescription());
 
         loadedDependency = dependencies.get(1);
+        Assert.assertEquals(nvidiaDependency.getName(), "NvidiaVersion");
+        Assert.assertEquals(nvidiaDependency.getEcosystem(), loadedDependency.getEcosystem());
+
+        loadedDependency = dependencies.get(2);
         Assert.assertEquals(feature.getName(), loadedDependency.getName());
         Assert.assertEquals(ToolDependency.Ecosystem.SYSTEM, loadedDependency.getEcosystem());
         Assert.assertEquals(feature.getVersion(), loadedDependency.getVersion());

--- a/api/src/test/java/com/epam/pipeline/manager/docker/scan/ToolScanSchedulerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/docker/scan/ToolScanSchedulerTest.java
@@ -283,7 +283,7 @@ public class ToolScanSchedulerTest extends AbstractSpringTest {
         public void updateToolVersionScanStatus(long toolId, ToolScanStatus newStatus, Date scanDate, String version,
                                                 ToolOSVersion toolOSVersion, String layerRef, String digest,
                                                 Map<VulnerabilitySeverity, Integer> vulnerabilityCount,
-                                                String defaultCmd, Integer layersCount) {
+                                                String defaultCmd, Integer layersCount, boolean cudaAvailable) {
             Assert.assertNotNull(version);
 
             ToolVersionScanResult versionScan = new ToolVersionScanResult();
@@ -310,7 +310,7 @@ public class ToolScanSchedulerTest extends AbstractSpringTest {
                                                 Map<VulnerabilitySeverity, Integer> vulnerabilityCount,
                                                 String defaultCmd, Integer layersCount) {
             updateToolVersionScanStatus(toolId, newStatus, scanDate, version, null, layerRef,
-                    digest, vulnerabilityCount, defaultCmd, layersCount);
+                    digest, vulnerabilityCount, defaultCmd, layersCount, false);
         }
 
         @Override

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/ToolManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/ToolManagerTest.java
@@ -457,7 +457,7 @@ public class ToolManagerTest extends AbstractManagerTest {
 
         toolManager.updateToolVersionScanStatus(
                 tool.getId(), ToolScanStatus.COMPLETED, new Date(), LATEST_TAG,
-                new ToolOSVersion(TEST, TEST), LAYER_REF, DIGEST, new HashMap<>(), null, null);
+                new ToolOSVersion(TEST, TEST), LAYER_REF, DIGEST, new HashMap<>(), null, null, false);
         toolManager.updateToolVulnerabilities(Collections.emptyList(), tool.getId(), LATEST_TAG);
         toolManager.updateToolDependencies(Collections.emptyList(), tool.getId(), LATEST_TAG);
         Assert.assertNotNull(toolManager.load(tool.getId()));
@@ -504,7 +504,7 @@ public class ToolManagerTest extends AbstractManagerTest {
         ToolScanStatus status = ToolScanStatus.COMPLETED;
 
         toolManager.updateToolVersionScanStatus(tool.getId(), status, now, LATEST_TAG, new ToolOSVersion(TEST, TEST),
-                layerRef, digest, new HashMap<>(), null, null);
+                layerRef, digest, new HashMap<>(), null, null, false);
         toolManager.updateWhiteListWithToolVersionStatus(tool.getId(), LATEST_TAG, true);
         ToolVersionScanResult versionScan = toolManager.loadToolVersionScan(
                 tool.getId(), LATEST_TAG).get();
@@ -518,7 +518,7 @@ public class ToolManagerTest extends AbstractManagerTest {
         now = new Date();
 
         toolManager.updateToolVersionScanStatus(tool.getId(), status, now, LATEST_TAG, new ToolOSVersion(TEST, TEST),
-                layerRef, digest, new HashMap<>(), null, null);
+                layerRef, digest, new HashMap<>(), null, null, false);
         Assert.assertEquals(1, toolManager.loadToolScanResult(tool).getToolVersionScanResults().values().size());
         versionScan = toolManager.loadToolVersionScan(tool.getId(), LATEST_TAG).get();
         Assert.assertEquals(now, versionScan.getScanDate());
@@ -546,7 +546,7 @@ public class ToolManagerTest extends AbstractManagerTest {
 
         toolManager.updateToolVersionScanStatus(tool.getId(), ToolScanStatus.COMPLETED, scanDate,
                 latestVersion, new ToolOSVersion(CENTOS, CENTOS_VERSION), testRef, testRef, new HashMap<>(),
-                null, null);
+                null, null, false);
 
         ToolScanResult loaded = toolManager.loadToolScanResult(tool);
         ToolOSVersion toolOSVersion = loaded.getToolVersionScanResults().get(LATEST_TAG).getToolOSVersion();
@@ -578,7 +578,7 @@ public class ToolManagerTest extends AbstractManagerTest {
         toolManager.create(tool, true);
 
         toolManager.updateToolVersionScanStatus(tool.getId(), ToolScanStatus.COMPLETED, scanDate,
-                latestVersion, new ToolOSVersion(TEST, TEST), testRef, testRef, new HashMap<>(), null, null);
+                latestVersion, new ToolOSVersion(TEST, TEST), testRef, testRef, new HashMap<>(), null, null, false);
 
         ToolScanResult loaded = toolManager.loadToolScanResult(tool);
         Assert.assertEquals(
@@ -679,7 +679,7 @@ public class ToolManagerTest extends AbstractManagerTest {
 
         toolManager.updateToolVersionScanStatus(
                 tool.getId(), status, scanDate, LATEST_TAG, new ToolOSVersion(TEST, TEST), layerRef, digest,
-                new HashMap<>(), null, null);
+                new HashMap<>(), null, null, false);
         ToolVersionScanResult versionScan =
                 toolManager.loadToolVersionScan(tool.getId(), LATEST_TAG).get();
         Assert.assertEquals(status, versionScan.getStatus());
@@ -775,7 +775,7 @@ public class ToolManagerTest extends AbstractManagerTest {
         assertThrows(IllegalArgumentException.class, 
             () -> toolManager.updateToolVersionScanStatus(symlink.getId(), ToolScanStatus.COMPLETED, 
                     DateUtils.now(), LATEST_TAG, new ToolOSVersion(CENTOS, CENTOS_VERSION), LAYER_REF, DIGEST,
-                    new HashMap<>(), null, null));
+                    new HashMap<>(), null, null, false));
         assertThrows(IllegalArgumentException.class, 
             () -> toolManager.updateToolVersionScanStatus(symlink.getId(), ToolScanStatus.COMPLETED, 
                     DateUtils.now(), LATEST_TAG, LAYER_REF, DIGEST, new HashMap<>(), null, null));

--- a/deploy/docker/cp-docker-comp/config/application.properties
+++ b/deploy/docker/cp-docker-comp/config/application.properties
@@ -4,5 +4,5 @@ worker.threads.count=4
 number.cached.scans=500
 expire.cached.scan.time=36
 base.working.dir=${CP_DOCKER_COMP_WORKING_DIR}
-enable.analyzers=ANALYZER_PYTHON_DISTRIBUTION,ANALYZER_R_PACKAGE,ANALYZER_OS_PACKAGE
+enable.analyzers=ANALYZER_PYTHON_DISTRIBUTION,ANALYZER_R_PACKAGE,ANALYZER_OS_PACKAGE,ANALYZER_NVIDIA_PACKAGE
 ssl.insecure.enable=true

--- a/docker-comp-scan/src/main/java/com/epam/dockercompscan/owasp/analyzer/AnalyzeEnabler.java
+++ b/docker-comp-scan/src/main/java/com/epam/dockercompscan/owasp/analyzer/AnalyzeEnabler.java
@@ -56,7 +56,8 @@ public enum AnalyzeEnabler {
     ANALYZER_CENTRAL("analyzer.central.enabled", AnalyzerConstants.SYSTEM),
     ANALYZER_NEXUS("analyzer.nexus.enabled", AnalyzerConstants.SYSTEM),
     ANALYZER_R_PACKAGE("analyzer.r.package.enabled", "R.Pkg"),
-    ANALYZER_OS_PACKAGE("analyzer.os.enabled", "OS");
+    ANALYZER_OS_PACKAGE("analyzer.os.enabled", "OS"),
+    ANALYZER_NVIDIA_VERSION("analyzer.nvidia.version.enabled", "Nvidia");
 
 
     private final String value;

--- a/docker-comp-scan/src/main/java/com/epam/dockercompscan/owasp/analyzer/AnalyzeEnabler.java
+++ b/docker-comp-scan/src/main/java/com/epam/dockercompscan/owasp/analyzer/AnalyzeEnabler.java
@@ -57,7 +57,7 @@ public enum AnalyzeEnabler {
     ANALYZER_NEXUS("analyzer.nexus.enabled", AnalyzerConstants.SYSTEM),
     ANALYZER_R_PACKAGE("analyzer.r.package.enabled", "R.Pkg"),
     ANALYZER_OS_PACKAGE("analyzer.os.enabled", "OS"),
-    ANALYZER_NVIDIA_VERSION("analyzer.nvidia.version.enabled", "Nvidia");
+    ANALYZER_NVIDIA_PACKAGE("analyzer.nvidia.version.enabled", "Nvidia");
 
 
     private final String value;

--- a/docker-comp-scan/src/main/java/com/epam/dockercompscan/owasp/analyzer/NvidiaVersionAnalyzer.java
+++ b/docker-comp-scan/src/main/java/com/epam/dockercompscan/owasp/analyzer/NvidiaVersionAnalyzer.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.dockercompscan.owasp.analyzer;
+
+import com.epam.dockercompscan.owasp.analyzer.filter.FilePathGlobFilter;
+import org.owasp.dependencycheck.Engine;
+import org.owasp.dependencycheck.analyzer.AbstractFileTypeAnalyzer;
+import org.owasp.dependencycheck.analyzer.AnalysisPhase;
+import org.owasp.dependencycheck.analyzer.Experimental;
+import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
+import org.owasp.dependencycheck.dependency.Confidence;
+import org.owasp.dependencycheck.dependency.Dependency;
+import org.owasp.dependencycheck.dependency.EvidenceType;
+import org.owasp.dependencycheck.exception.InitializationException;
+import org.owasp.dependencycheck.utils.FileFilterBuilder;
+
+import java.io.FileFilter;
+
+@Experimental
+public class NvidiaVersionAnalyzer extends AbstractFileTypeAnalyzer {
+    public static final String DEPENDENCY_ECOSYSTEM = "Nvidia";
+    public static final String NVIDIA_VERSION_ANALYZER_ENABLED = AnalyzeEnabler.ANALYZER_NVIDIA_VERSION.getValue();
+    static final String DEPENDENCY_NAME = "NvidiaVersion";
+    private static final String NVIDIA_VERSION_ANALYZER_NAME = "Nvidia Version Analyzer";
+    private static final String NVIDIA_VERSION_PATH = "/**/proc/driver/nvidia/version";
+    private static final String EVIDENCE_SOURCE = "version";
+    private static final String EVIDENCE_VALUE = "found";
+
+    @Override
+    protected FileFilter getFileFilter() {
+        return FileFilterBuilder.newInstance().addFileFilters(new FilePathGlobFilter(NVIDIA_VERSION_PATH)).build();
+    }
+
+    @Override
+    protected void prepareFileTypeAnalyzer(final Engine engine) throws InitializationException {
+        // no-op
+    }
+
+    @Override
+    protected void analyzeDependency(final Dependency dependency, final Engine engine) throws AnalysisException {
+        dependency.setEcosystem(DEPENDENCY_ECOSYSTEM);
+        dependency.setName(DEPENDENCY_NAME);
+        dependency.addEvidence(EvidenceType.VERSION, EVIDENCE_SOURCE, DEPENDENCY_NAME, EVIDENCE_VALUE, Confidence.HIGH);
+    }
+
+    @Override
+    protected String getAnalyzerEnabledSettingKey() {
+        return NVIDIA_VERSION_ANALYZER_ENABLED;
+    }
+
+    @Override
+    public String getName() {
+        return NVIDIA_VERSION_ANALYZER_NAME;
+    }
+
+    @Override
+    public AnalysisPhase getAnalysisPhase() {
+        return AnalysisPhase.INFORMATION_COLLECTION;
+    }
+}

--- a/docker-comp-scan/src/main/java/com/epam/dockercompscan/owasp/analyzer/NvidiaVersionAnalyzer.java
+++ b/docker-comp-scan/src/main/java/com/epam/dockercompscan/owasp/analyzer/NvidiaVersionAnalyzer.java
@@ -33,16 +33,18 @@ import java.io.FileFilter;
 @Experimental
 public class NvidiaVersionAnalyzer extends AbstractFileTypeAnalyzer {
     public static final String DEPENDENCY_ECOSYSTEM = "Nvidia";
-    public static final String NVIDIA_VERSION_ANALYZER_ENABLED = AnalyzeEnabler.ANALYZER_NVIDIA_VERSION.getValue();
+    public static final String NVIDIA_VERSION_ANALYZER_ENABLED = AnalyzeEnabler.ANALYZER_NVIDIA_PACKAGE.getValue();
     static final String DEPENDENCY_NAME = "NvidiaVersion";
     private static final String NVIDIA_VERSION_ANALYZER_NAME = "Nvidia Version Analyzer";
     private static final String NVIDIA_VERSION_PATH = "/**/proc/driver/nvidia/version";
     private static final String EVIDENCE_SOURCE = "version";
     private static final String EVIDENCE_VALUE = "found";
+    private static final FilePathGlobFilter NAME_FILE_FILTER = new FilePathGlobFilter(NVIDIA_VERSION_PATH);
+    private static final FileFilter FILTER = FileFilterBuilder.newInstance().addFileFilters(NAME_FILE_FILTER).build();
 
     @Override
     protected FileFilter getFileFilter() {
-        return FileFilterBuilder.newInstance().addFileFilters(new FilePathGlobFilter(NVIDIA_VERSION_PATH)).build();
+        return FILTER;
     }
 
     @Override
@@ -54,7 +56,7 @@ public class NvidiaVersionAnalyzer extends AbstractFileTypeAnalyzer {
     protected void analyzeDependency(final Dependency dependency, final Engine engine) throws AnalysisException {
         dependency.setEcosystem(DEPENDENCY_ECOSYSTEM);
         dependency.setName(DEPENDENCY_NAME);
-        dependency.addEvidence(EvidenceType.VERSION, EVIDENCE_SOURCE, DEPENDENCY_NAME, EVIDENCE_VALUE, Confidence.HIGH);
+        dependency.addEvidence(EvidenceType.PRODUCT, EVIDENCE_SOURCE, DEPENDENCY_NAME, EVIDENCE_VALUE, Confidence.HIGH);
     }
 
     @Override

--- a/docker-comp-scan/src/main/resources/META-INF/services/org.owasp.dependencycheck.analyzer.Analyzer
+++ b/docker-comp-scan/src/main/resources/META-INF/services/org.owasp.dependencycheck.analyzer.Analyzer
@@ -32,3 +32,4 @@ org.owasp.dependencycheck.analyzer.SwiftPackageManagerAnalyzer
 org.owasp.dependencycheck.analyzer.VersionFilterAnalyzer
 com.epam.dockercompscan.owasp.analyzer.RPackageAnalyzer
 com.epam.dockercompscan.owasp.analyzer.OSVersionAnalyzer
+com.epam.dockercompscan.owasp.analyzer.NvidiaVersionAnalyzer

--- a/docker-comp-scan/src/main/resources/application.properties
+++ b/docker-comp-scan/src/main/resources/application.properties
@@ -4,6 +4,6 @@ worker.threads.count=4
 number.cached.scans=500
 expire.cached.scan.time=36
 base.working.dir=/dev/shm/
-enable.analyzers=ANALYZER_PYTHON_DISTRIBUTION,ANALYZER_R_PACKAGE,ANALYZER_OS_PACKAGE
+enable.analyzers=ANALYZER_PYTHON_DISTRIBUTION,ANALYZER_R_PACKAGE,ANALYZER_OS_PACKAGE,ANALYZER_NVIDIA_VERSION
 ssl.insecure.enable=true
 

--- a/docker-comp-scan/src/main/resources/application.properties
+++ b/docker-comp-scan/src/main/resources/application.properties
@@ -4,6 +4,6 @@ worker.threads.count=4
 number.cached.scans=500
 expire.cached.scan.time=36
 base.working.dir=/dev/shm/
-enable.analyzers=ANALYZER_PYTHON_DISTRIBUTION,ANALYZER_R_PACKAGE,ANALYZER_OS_PACKAGE,ANALYZER_NVIDIA_VERSION
+enable.analyzers=ANALYZER_PYTHON_DISTRIBUTION,ANALYZER_R_PACKAGE,ANALYZER_OS_PACKAGE,ANALYZER_NVIDIA_PACKAGE
 ssl.insecure.enable=true
 

--- a/docker-comp-scan/src/test/java/com/epam/dockercompscan/owasp/analyzer/NvidiaVersionAnalyzerTest.java
+++ b/docker-comp-scan/src/test/java/com/epam/dockercompscan/owasp/analyzer/NvidiaVersionAnalyzerTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.dockercompscan.owasp.analyzer;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
+import org.owasp.dependencycheck.dependency.Dependency;
+
+public class NvidiaVersionAnalyzerTest {
+    private final NvidiaVersionAnalyzer nvidiaVersionAnalyzer = new NvidiaVersionAnalyzer();
+
+    @Test
+    public void shouldAnalyzeNvidiaVersion() throws AnalysisException {
+        final Dependency dependency = new Dependency();
+        nvidiaVersionAnalyzer.analyzeDependency(dependency, null);
+
+        Assert.assertEquals(NvidiaVersionAnalyzer.DEPENDENCY_ECOSYSTEM, dependency.getEcosystem());
+        Assert.assertEquals(NvidiaVersionAnalyzer.DEPENDENCY_NAME, dependency.getName());
+    }
+}

--- a/pipe-cli/src/api/tool.py
+++ b/pipe-cli/src/api/tool.py
@@ -47,8 +47,15 @@ class Tool(API):
 
     def load_vulnerabilities(self, registry, group, tool):
         tool_path = group + '/' + tool
-        response_data = self.call('/tool/scan?registry=%s&tool=%s'
-                                  % (urllib.quote(registry), urllib.quote(tool_path)), None)
+        url = '/tool/scan?registry=%s&tool=%s' % (urllib.quote(registry), urllib.quote(tool_path))
+        return self._load_tool_scan(url)
+
+    def load_tool_scan(self, tool_path):
+        url = '/tool/scan?tool=%s' % urllib.quote(tool_path)
+        return self._load_tool_scan(url)
+
+    def _load_tool_scan(self, url):
+        response_data = self.call(url, None)
         if 'payload' in response_data:
             return ToolScanResultsModel.load(response_data['payload'])
         if 'message' in response_data:

--- a/pipe-cli/src/model/cluster_instance_type_model.py
+++ b/pipe-cli/src/model/cluster_instance_type_model.py
@@ -17,6 +17,7 @@ class ClusterInstanceTypeModel(object):
         self.name = None
         self.vcpu = None
         self.memory = None
+        self.gpu = None
 
     @classmethod
     def load(cls, json):
@@ -28,3 +29,4 @@ class ClusterInstanceTypeModel(object):
         self.name = json['name']
         self.vcpu = json['vcpu']
         self.memory = json['memory']
+        self.gpu = json.get('gpu', 0)

--- a/pipe-cli/src/model/docker_registry_model.py
+++ b/pipe-cli/src/model/docker_registry_model.py
@@ -123,14 +123,16 @@ class ToolScanResultModel:
     def __init__(self):
         self.vulnerabilities = []
         self.dependencies = []
+        self.cuda_available = False
 
     @classmethod
     def load(cls, json):
-        instance = ToolScanResultsModel()
+        instance = ToolScanResultModel()
         instance.vulnerabilities = [ToolVulnerabilityModel.load(vulnerability_json)
                                     for vulnerability_json in json.get('vulnerabilities', [])]
         instance.dependencies = [ToolDependencyModel.load(dependency_json)
                                  for dependency_json in json.get('dependencies', [])]
+        instance.cuda_available = json.get('cudaAvailable', False) or False
         return instance
 
 

--- a/pipe-cli/src/model/pipeline_run_parameters_model.py
+++ b/pipe-cli/src/model/pipeline_run_parameters_model.py
@@ -23,6 +23,7 @@ class PipelineRunParametersModel(object):
         self.instance_size = None
         self.parameters = []
         self.version = None
+        self.docker_image = None
 
     @classmethod
     def load(cls, json, version):
@@ -30,6 +31,7 @@ class PipelineRunParametersModel(object):
         instance.version = version
         instance.instance_disk = json['instance_disk']
         instance.instance_size = json['instance_size']
+        instance.docker_image = json.get('docker_image', None)
         if 'main_file' in json:
             instance.main_file = json['main_file']
 

--- a/pipe-cli/src/utilities/cluster_manager.py
+++ b/pipe-cli/src/utilities/cluster_manager.py
@@ -34,6 +34,19 @@ class ClusterManager(object):
         return ClusterManager.get_instance_type(core_type, instance_types_list, ncores)
 
     @classmethod
+    def is_gpu_instance(cls, instance_type):
+        if not instance_type:
+            return False
+        instance_types_list = Cluster.list_instance_types()
+        if len(instance_types_list) == 0:
+            return False
+        for available_type in instance_types_list:
+            if available_type.name == instance_type:
+                return int(available_type.gpu) > 0
+        return False
+
+
+    @classmethod
     def get_core_type(cls, core_type=None):
         if core_type:
             return ClusterManager.parse_core_type(core_type)


### PR DESCRIPTION
The current PR provides implementation for issue #3270

The following changes were added:
 - a new field `cudaAvailable` added to tool version object (with corresponding new column `cuda_availble` for `tool_version_scan` table)
 - this value calculates based on two indicators:
   - `com.nvidia.cudnn.version` docker label obtained from docker manifest (the label name can be configured via `security.tools.nvidia.cudnn.version.label` preference)
   - `docker-component-scan` service shall return a new dependency with ecosystem `Nvidia` (this dependency appears only if `/proc/driver/nvidia/version` file found in image layers)
 - CLI: for `pipe run` command a warning appears if gpu instance requested with tool that not supports cuda 