### PR TITLE
Introduce RSMAP-like GPU devices mgmt in SGE

### DIFF
--- a/deploy/contents/install/preferences/launch.system.parameters.json
+++ b/deploy/contents/install/preferences/launch.system.parameters.json
@@ -570,5 +570,12 @@
         "description": "Enables GPU exclusive mode",
         "defaultValue": "true",
         "passToWorkers": true
+    },
+    {
+        "name": "CP_CAP_SGE_GPU_RSMAP_DEVICES",
+        "type": "boolean",
+        "description": "Enables RSMAP-like GPU devices assignment",
+        "defaultValue": "true",
+        "passToWorkers": true
     }
 ]

--- a/workflows/pipe-common/shell/sge_epilog
+++ b/workflows/pipe-common/shell/sge_epilog
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Copyright (c) 2015 Kota Yamaguchi
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. The name of the author may not be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+echo "Executing Cloud Pipeline epilog script as $(whoami)..."
+
+JOB_ENV_FILE="$SGE_JOB_SPOOL_DIR/environment"
+
+if [ ! -f "$JOB_ENV_FILE" ]; then
+    echo "ERROR: Job environment file is not accessible at $JOB_ENV_FILE. Exiting..."
+    exit 100
+fi
+
+CP_CAP_GE_CONSUMABLE_RESOURCE_NAME_GPU="${CP_CAP_GE_CONSUMABLE_RESOURCE_NAME_GPU:-gpus}"
+CP_CAP_GE_CONSUMABLE_RESOURCE_LOCKS_GPU="${CP_CAP_GE_CONSUMABLE_RESOURCE_LOCKS_GPU:-/tmp/sge-gpus-locks}"
+
+JOB_GPUS_NUMBER="$(qstat -j "$JOB_ID" | grep -oP "$CP_CAP_GE_CONSUMABLE_RESOURCE_NAME_GPU=\K\d+")"
+JOB_GPUS_NUMBER="${JOB_GPUS_NUMBER:-0}"
+
+if [ "$JOB_GPUS_NUMBER" -le 0 ]; then
+    exit 0
+fi
+
+JOB_GPU_DEVICES=$(grep -oP "CUDA_VISIBLE_DEVICES=\K.*" "$JOB_ENV_FILE" | sed -e "s/,/ /g")
+for GPU_DEVICE in $JOB_GPU_DEVICES; do
+    echo -n "Releasing GPU device $GPU_DEVICE... "
+    if ! rmdir "$CP_CAP_GE_CONSUMABLE_RESOURCE_LOCKS_GPU/inuse/$GPU_DEVICE" 2>/dev/null; then
+        echo "NOT OK"
+        continue
+    fi
+    echo "OK"
+done
+
+exit 0

--- a/workflows/pipe-common/shell/sge_prolog
+++ b/workflows/pipe-common/shell/sge_prolog
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# Copyright (c) 2015 Kota Yamaguchi
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. The name of the author may not be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+echo "Executing Cloud Pipeline prolog script as $(whoami)..."
+
+JOB_ENV_FILE="$SGE_JOB_SPOOL_DIR/environment"
+
+if [ ! -f "$JOB_ENV_FILE" ]; then
+    echo "ERROR: Job environment file is not accessible at $JOB_ENV_FILE. Exiting..."
+    exit 100
+fi
+
+CP_CAP_GE_CONSUMABLE_RESOURCE_NAME_GPU="${CP_CAP_GE_CONSUMABLE_RESOURCE_NAME_GPU:-gpus}"
+CP_CAP_GE_CONSUMABLE_RESOURCE_LOCKS_GPU="${CP_CAP_GE_CONSUMABLE_RESOURCE_LOCKS_GPU:-/tmp/sge-gpus-locks}"
+
+JOB_GPUS_NUMBER="$(qstat -j "$JOB_ID" | grep -oP "$CP_CAP_GE_CONSUMABLE_RESOURCE_NAME_GPU=\K\d+")"
+JOB_GPUS_NUMBER="${JOB_GPUS_NUMBER:-0}"
+
+if [ "$JOB_GPUS_NUMBER" -le 0 ]; then
+    exit 0
+fi
+
+JOB_GPU_DEVICES=""
+JOB_GPU_DEVICES_NUMBER=0
+for GPU_DEVICE in "$CP_CAP_GE_CONSUMABLE_RESOURCE_LOCKS_GPU/total/"*; do
+    GPU_DEVICE="$(basename "$GPU_DEVICE")"
+    echo -n "Acquiring GPU device $GPU_DEVICE... "
+    if ! mkdir "$CP_CAP_GE_CONSUMABLE_RESOURCE_LOCKS_GPU/inuse/$GPU_DEVICE" 2>/dev/null; then
+        echo "NOT OK"
+        continue
+    fi
+    echo "OK"
+    JOB_GPU_DEVICES="$JOB_GPU_DEVICES $GPU_DEVICE"
+    JOB_GPU_DEVICES_NUMBER="$(( JOB_GPU_DEVICES_NUMBER + 1 ))"
+    if [ "$JOB_GPU_DEVICES_NUMBER" -ge "$JOB_GPUS_NUMBER" ]; then
+        break
+    fi
+done
+
+if [ "$JOB_GPU_DEVICES_NUMBER" -lt "$JOB_GPUS_NUMBER" ]; then
+    echo "ERROR: Insufficient amount of available GPU devices at $CP_CAP_GE_CONSUMABLE_RESOURCE_LOCKS_GPU ($JOB_GPU_DEVICES_NUMBER/$JOB_GPUS_NUMBER)"
+    for GPU_DEVICE in $JOB_GPU_DEVICES; do
+        echo -n "Releasing GPU device $GPU_DEVICE... "
+        if ! rmdir "$CP_CAP_GE_CONSUMABLE_RESOURCE_LOCKS_GPU/inuse/$GPU_DEVICE" 2>/dev/null; then
+            echo "NOT OK"
+            continue
+        fi
+        echo "OK"
+    done
+    echo "Exiting..."
+    exit 100
+fi
+
+CUDA_VISIBLE_DEVICES="$(echo "$JOB_GPU_DEVICES" | sed -e 's/^ //' | sed -e 's/ /,/g')"
+
+if ! echo "CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES" >> "$JOB_ENV_FILE"; then
+    echo "ERROR: Job environment file is not writable at $JOB_ENV_FILE. Exiting..."
+    exit 100
+fi
+
+exit 0

--- a/workflows/pipe-common/shell/sge_setup_master
+++ b/workflows/pipe-common/shell/sge_setup_master
@@ -60,6 +60,11 @@ configure_global() {
     sed -i "/reporting_params/c\reporting_params $_SGE_REPORTING_PARAMS" ./global
     sed -i '/gid_range/c\gid_range 20000-30000' ./global
 
+    if check_cp_cap CP_CAP_SGE_GPU_RSMAP_DEVICES; then
+        sed -i "/prolog/c\prolog sgeadmin@$COMMON_REPO_DIR/shell/sge_prolog" ./global
+        sed -i "/epilog/c\epilog sgeadmin@$COMMON_REPO_DIR/shell/sge_epilog" ./global
+    fi
+
     qconf -Mconf ./global
     rm -f ./global
 }

--- a/workflows/pipe-common/shell/sge_setup_resources
+++ b/workflows/pipe-common/shell/sge_setup_resources
@@ -83,6 +83,18 @@ if (( _NODE_GPUS_COUNT > 0 )) && check_cp_cap "CP_CAP_SGE_GPU_EXCLUSIVE_MODE"; t
     pipe_log_info "GPUs are set to exclusive mode via CP_CAP_SGE_GPU_EXCLUSIVE_MODE" "$_SGE_RESOURCES_SETUP_TASK"
 fi
 
+if (( _NODE_GPUS_COUNT > 0 )) && check_cp_cap "CP_CAP_SGE_GPU_RSMAP_DEVICES"; then
+    CP_CAP_GE_CONSUMABLE_RESOURCE_LOCKS_GPU="${CP_CAP_GE_CONSUMABLE_RESOURCE_LOCKS_GPU:-/tmp/sge-gpus-locks}"
+    mkdir -p "$CP_CAP_GE_CONSUMABLE_RESOURCE_LOCKS_GPU/total"
+    for DEVICE_ID in $(seq 0 "$(( _NODE_GPUS_COUNT - 1 ))"); do
+        mkdir "$CP_CAP_GE_CONSUMABLE_RESOURCE_LOCKS_GPU/total/$DEVICE_ID"
+    done
+    mkdir -p "$CP_CAP_GE_CONSUMABLE_RESOURCE_LOCKS_GPU/inuse"
+    chmod g+rw,o+rw "$CP_CAP_GE_CONSUMABLE_RESOURCE_LOCKS_GPU/inuse" -R
+    setfacl -d -m user::rwx -m group::rwx -m other::rwx "$CP_CAP_GE_CONSUMABLE_RESOURCE_LOCKS_GPU/inuse"
+    pipe_log_info "GPUs are managed as RSMAP devices via CP_CAP_SGE_GPU_RSMAP_DEVICES" "$_SGE_RESOURCES_SETUP_TASK"
+fi
+
 _NODE_RAM_COUNT=$(grep MemTotal /proc/meminfo | awk '{print int($2 / (1024 * 1024)) "G"}')
 CP_CAP_GE_CONSUMABLE_RESOURCE_NAME_RAM=${CP_CAP_GE_CONSUMABLE_RESOURCE_NAME_RAM:-ram}
 pipe_log_info "$_NODE_RAM_COUNT RAM found" "$_SGE_RESOURCES_SETUP_TASK"


### PR DESCRIPTION
Resolves #3274.

The pull request brings support for RSMAP-like GPU devices assignment in SGE. If enabled, then all jobs which require GPUs via `-l gpus=2` will have `CUDA_VISIBLE_DEVICES` environment variable set to unoccupied GPU device ids like `0`, `2,3` and etc. 

The following run parameters are introduced:
- `CP_CAP_SGE_GPU_RSMAP_DEVICES` enables RSMAP-like GPU devices assignment for all existing and newly created SGE queues.
