### PR TITLE
Security logs shall be deleted only if the snapshots were created

### DIFF
--- a/deploy/contents/k8s/cp-search/cp-search-elk-dpl.yaml
+++ b/deploy/contents/k8s/cp-search/cp-search-elk-dpl.yaml
@@ -33,6 +33,8 @@ spec:
           volumeMounts:
             - mountPath: /usr/share/elasticsearch/data
               name: search-elk-data
+            - mountPath: /var/log/curator
+              name: search-elk-curator-log
             - name: cp-cloud-credentials
               mountPath: "/root/.cloud"
               readOnly: true
@@ -47,6 +49,9 @@ spec:
         - name: search-elk-data
           hostPath:
             path: /opt/search-elk/data
+        - name: search-elk-curator-log
+          hostPath:
+            path: /opt/search-elk/log/curator
         - name: cp-cloud-credentials
           secret:
             secretName: cp-cloud-credentials

--- a/deploy/docker/cp-search-elk/curator-actions-template.yml
+++ b/deploy/docker/cp-search-elk/curator-actions-template.yml
@@ -14,6 +14,7 @@ actions:
       wait_for_completion: True
       skip_repo_fs_check: False
       disable_action: False
+      continue_if_exception: False
     filters:
       - filtertype: pattern
         kind: prefix
@@ -31,6 +32,8 @@ actions:
     options:
       repository: log_backup_repo
       disable_action: False
+      continue_if_exception: True
+      ignore_empty_list: True
     filters:
       - filtertype: pattern
         kind: prefix
@@ -41,3 +44,19 @@ actions:
         direction: older
         unit: days
         unit_count: ${CP_SECURITY_LOGS_ELASTIC_BACKUP_DAYS}
+  3:
+    action: delete_indices
+    description: "Delete indices that are older then CP_SECURITY_LOGS_ROLLOVER_DAYS"
+    options:
+      timeout_override: 300
+      continue_if_exception: True
+      ignore_empty_list: True
+    filters:
+      - filtertype: pattern
+        kind: prefix
+        value: ${CP_SECURITY_LOGS_ELASTIC_PREFIX}
+      - filtertype: age
+        source: creation_date
+        direction: older
+        unit: days
+        unit_count: ${CP_SECURITY_LOGS_ROLLOVER_DAYS}

--- a/deploy/docker/cp-search-elk/curator.yml
+++ b/deploy/docker/cp-search-elk/curator.yml
@@ -13,7 +13,7 @@ client:
   master_only: False
 
 logging:
-  loglevel: DEBUG
+  loglevel: INFO
   logfile:
   logformat: default
   blacklist: ['elasticsearch', 'urllib3']

--- a/deploy/docker/cp-search-elk/init.sh
+++ b/deploy/docker/cp-search-elk/init.sh
@@ -127,9 +127,12 @@ fi
 
 curl -H 'Content-Type: application/json' -XPUT localhost:9200/_snapshot/log_backup_repo -d "$LOG_BACKUP_REPO"
 
+if [ ! -d /var/log/curator ]; then
+  mkdir -p /var/log/curator
+fi
 envsubst < /root/.curator/curator-actions-template.yml > /root/.curator/curator-actions.yml
 cat > /etc/cron.d/curator-cron <<EOL
-0 0 * * * curator --config /root/.curator/curator.yml /root/.curator/curator-actions.yml
+0 0 * * * curator --config /root/.curator/curator.yml /root/.curator/curator-actions.yml >> /var/log/curator/curator.log 2>&1
 EOL
 
 chmod 0644 /etc/cron.d/curator-cron

--- a/deploy/docker/cp-search-elk/policies/security_log_policy.json
+++ b/deploy/docker/cp-search-elk/policies/security_log_policy.json
@@ -7,12 +7,6 @@
             "max_age": "1d"
           }
         }
-      },
-      "delete": {
-        "min_age": "${CP_SECURITY_LOGS_ROLLOVER_DAYS}d",
-        "actions": {
-          "delete": {}
-        }
       }
     }
   }


### PR DESCRIPTION
* Removed the rollover from the ILM
* Added the `delete_indices` to the curator config (so it will not be executed if the `snapshot` has failed