### PR TITLE
Respect GPU and RAM job requirements in grid engine autoscaler

### DIFF
--- a/workflows/pipe-common/pipeline/hpc/gridengine.py
+++ b/workflows/pipe-common/pipeline/hpc/gridengine.py
@@ -425,12 +425,18 @@ class GridEngineDemandSelector:
             allocation_rule = allocation_rules[job.pe] = allocation_rules.get(job.pe) \
                                                          or self.grid_engine.get_pe_allocation_rule(job.pe)
             if allocation_rule in AllocationRule.fractional_rules():
-                remaining_demand = FractionalDemand(cpu=job.cpu, owner=job.user)
+                remaining_demand = FractionalDemand(cpu=job.cpu, gpu=job.gpu, mem=job.mem, owner=job.user)
                 remaining_demand, remaining_supply = remaining_demand.subtract(remaining_supply)
-                if not remaining_demand:
-                    remaining_demand += FractionalDemand(cpu=1)
             else:
-                remaining_demand = IntegralDemand(cpu=job.cpu, owner=job.user)
+                remaining_demand = IntegralDemand(cpu=job.cpu, gpu=job.gpu, mem=job.mem, owner=job.user)
+            if not remaining_demand:
+                Logger.warn('Problematic job #{job_id} {job_name} by {job_user} is pending for an unknown reason. '
+                            'The job requires resources which are already satisfied by the cluster: '
+                            '{job_cpu} cpu, {job_gpu} gpu, {job_mem} mem.'
+                            .format(job_id=job.id, job_name=job.name, job_user=job.user,
+                                    job_cpu=job.cpu, job_gpu=job.gpu, job_mem=job.mem),
+                            crucial=True)
+                continue
             yield remaining_demand
 
 

--- a/workflows/pipe-common/pipeline/hpc/param.py
+++ b/workflows/pipe-common/pipeline/hpc/param.py
@@ -145,7 +145,7 @@ class GridEngineAutoscalingParametersGroup(GridEngineParametersGroup):
             help='Specifies a maximum number of CPUs available on hybrid autoscaling workers.\n'
                  'If specified, only instance types which have less or equal number of CPUs will be used.')
         self.descending_autoscale = GridEngineParameter(
-            name='CP_CAP_AUTOSCALE_DESCENDING', type=PARAM_BOOL, default=True,
+            name='CP_CAP_AUTOSCALE_DESCENDING', type=PARAM_BOOL, default=False,
             help='Enables descending autoscaling.\n'
                  'As long as default instance type is available then autoscaling works as non hybrid.\n'
                  'If target instance type is temporary unavailable then autoscaling works as hybrid\n'

--- a/workflows/pipe-common/pipeline/hpc/param.py
+++ b/workflows/pipe-common/pipeline/hpc/param.py
@@ -174,6 +174,14 @@ class GridEngineAutoscalingParametersGroup(GridEngineParametersGroup):
             help='Specifies a delay in seconds to temporary avoid unavailable instance types usage.\n'
                  'An instance type is considered unavailable if cloud region lacks such instances at the moment '
                  'or instance type has failed to initialize several times.')
+        self.scale_up_unavail_count_insufficient = GridEngineParameter(
+            name='CP_CAP_AUTOSCALE_INSTANCE_UNAVAILABILITY_COUNT_INSUFFICIENT', type=PARAM_INT, default=5,
+            help='Specifies a number of runs which may fail because of insufficient instance type capacity '
+                 'before instance type will be considered unavailable.')
+        self.scale_up_unavail_count_failure = GridEngineParameter(
+            name='CP_CAP_AUTOSCALE_INSTANCE_UNAVAILABILITY_COUNT_FAILURE', type=PARAM_INT, default=5,
+            help='Specifies a number of runs which may fail during initialization '
+                 'before instance type will be considered unavailable.')
         self.scale_down_batch_size = GridEngineParameter(
             name='CP_CAP_AUTOSCALE_SCALE_DOWN_BATCH_SIZE', type=PARAM_INT, default=1,
             help='Specifies a maximum number of simultaneously scaling down workers.')
@@ -238,14 +246,6 @@ class GridEngineAdvancedAutoscalingParametersGroup(GridEngineParametersGroup):
             help='Enables dry run mode. '
                  'Grid engine autoscaling will be performed '
                  'but no instances will be scaled up or scaled down.')
-        self.scale_up_unavail_count_insufficient = GridEngineParameter(
-            name='CP_CAP_AUTOSCALE_INSTANCE_UNAVAILABILITY_COUNT_INSUFFICIENT', type=PARAM_INT, default=1,
-            help='Specifies a number of runs which may fail because of insufficient instance type capacity '
-                 'before instance type will be considered unavailable.')
-        self.scale_up_unavail_count_failure = GridEngineParameter(
-            name='CP_CAP_AUTOSCALE_INSTANCE_UNAVAILABILITY_COUNT_FAILURE', type=PARAM_INT, default=5,
-            help='Specifies a number of runs which may fail during initialization '
-                 'before instance type will be considered unavailable.')
         self.event_ttl = GridEngineParameter(
             name='CP_CAP_AUTOSCALE_EVENT_TTL', type=PARAM_INT, default=3 * 60 * 60,
             help='Specifies event ttl in seconds after which an event is removed.')

--- a/workflows/pipe-common/scripts/autoscale_sge.py
+++ b/workflows/pipe-common/scripts/autoscale_sge.py
@@ -199,8 +199,8 @@ def get_daemon():
     scale_up_batch_size = params.autoscaling.scale_up_batch_size.get()
     scale_up_polling_delay = params.autoscaling.scale_up_polling_delay.get()
     scale_up_unavail_delay = params.autoscaling.scale_up_unavail_delay.get()
-    scale_up_unavail_count_insufficient = params.autoscaling_advanced.scale_up_unavail_count_insufficient.get()
-    scale_up_unavail_count_failure = params.autoscaling_advanced.scale_up_unavail_count_failure.get()
+    scale_up_unavail_count_insufficient = params.autoscaling.scale_up_unavail_count_insufficient.get()
+    scale_up_unavail_count_failure = params.autoscaling.scale_up_unavail_count_failure.get()
     scale_up_timeout = int(api.retrieve_preference('ge.autoscaling.scale.up.timeout', default=30))
     scale_up_polling_timeout = int(api.retrieve_preference('ge.autoscaling.scale.up.polling.timeout', default=900))
 

--- a/workflows/pipe-common/test/test_cpu_capacity_instance_selector.py
+++ b/workflows/pipe-common/test/test_cpu_capacity_instance_selector.py
@@ -37,6 +37,9 @@ instance_32cpu = Instance(name='m5.8xlarge', price_type=price_type, cpu=32, mem=
 instance_48cpu = Instance(name='m5.12xlarge', price_type=price_type, cpu=48, mem=192, gpu=0)
 instance_64cpu = Instance(name='m5.16xlarge', price_type=price_type, cpu=64, mem=256, gpu=0)
 instance_96cpu = Instance(name='m5.24xlarge', price_type=price_type, cpu=96, mem=384, gpu=0)
+instance_8cpu1gpu = Instance(name='p3.2xlarge', price_type=price_type, cpu=8, mem=61, gpu=1)
+instance_32cpu4gpu = Instance(name='p3.8xlarge', price_type=price_type, cpu=32, mem=244, gpu=4)
+instance_64cpu8gpu = Instance(name='p3.16xlarge', price_type=price_type, cpu=64, mem=488, gpu=8)
 all_instances = [instance_2cpu, instance_4cpu,
                  instance_8cpu, instance_16cpu,
                  instance_32cpu, instance_48cpu,
@@ -46,6 +49,11 @@ test_cases = [
     ['2cpu job using no instances',
      [],
      [IntegralDemand(cpu=2, owner=owner)],
+     []],
+
+    ['4cpu job using 2cpu instances',
+     [instance_2cpu],
+     [IntegralDemand(cpu=4, owner=owner)],
      []],
 
     ['2cpu job using 2cpu instances',
@@ -197,7 +205,114 @@ test_cases = [
       instance_2cpu],
      3 * [IntegralDemand(cpu=2, owner=owner)],
      [InstanceDemand(instance=instance_4cpu, owner=owner),
-      InstanceDemand(instance=instance_4cpu, owner=owner)]]
+      InstanceDemand(instance=instance_4cpu, owner=owner)]],
+
+    ['2cpu,1gpu job using 2cpu instances',
+     [instance_2cpu],
+     [IntegralDemand(cpu=2, gpu=1, owner=owner)],
+     []],
+
+    ['2cpu,1gpu job using 8cpu,1gpu instances',
+     [instance_8cpu1gpu],
+     [IntegralDemand(cpu=2, gpu=1, owner=owner)],
+     [InstanceDemand(instance=instance_8cpu1gpu, owner=owner)]],
+
+    ['2x2cpu,1gpu job using 8cpu,1gpu instances',
+     [instance_8cpu1gpu],
+     2 * [IntegralDemand(cpu=2, gpu=1, owner=owner)],
+     [InstanceDemand(instance=instance_8cpu1gpu, owner=owner),
+      InstanceDemand(instance=instance_8cpu1gpu, owner=owner)]],
+
+    ['2cpu,2gpu job using 8cpu,1gpu instances',
+     [instance_8cpu1gpu],
+     [IntegralDemand(cpu=2, gpu=2, owner=owner)],
+     []],
+
+    ['2cpu,2gpu job using 32cpu,4gpu instances',
+     [instance_32cpu4gpu],
+     [IntegralDemand(cpu=2, gpu=2, owner=owner)],
+     [InstanceDemand(instance=instance_32cpu4gpu, owner=owner)]],
+
+    ['2x2cpu,2gpu job using 32cpu,4gpu instances',
+     [instance_32cpu4gpu],
+     2 * [IntegralDemand(cpu=2, gpu=2, owner=owner)],
+     [InstanceDemand(instance=instance_32cpu4gpu, owner=owner)]],
+
+    ['3x2cpu,2gpu job using 32cpu,4gpu instances',
+     [instance_32cpu4gpu],
+     3 * [IntegralDemand(cpu=2, gpu=2, owner=owner)],
+     [InstanceDemand(instance=instance_32cpu4gpu, owner=owner),
+      InstanceDemand(instance=instance_32cpu4gpu, owner=owner)]],
+
+    ['3x2cpu,2gpu job using 32cpu,4gpu instances',
+     [instance_32cpu4gpu],
+     4 * [IntegralDemand(cpu=2, gpu=2, owner=owner)],
+     [InstanceDemand(instance=instance_32cpu4gpu, owner=owner),
+      InstanceDemand(instance=instance_32cpu4gpu, owner=owner)]],
+
+    ['4cpu,4gpu job using 32cpu,4gpu instances',
+     [instance_32cpu4gpu],
+     [IntegralDemand(cpu=4, gpu=4, owner=owner)],
+     [InstanceDemand(instance=instance_32cpu4gpu, owner=owner)]],
+
+    ['2x4cpu,4gpu job using 32cpu,4gpu instances',
+     [instance_32cpu4gpu],
+     2 * [IntegralDemand(cpu=4, gpu=4, owner=owner)],
+     [InstanceDemand(instance=instance_32cpu4gpu, owner=owner),
+      InstanceDemand(instance=instance_32cpu4gpu, owner=owner)]],
+
+    ['4cpu,4gpu job using 8cpu,1gpu instances',
+     [instance_8cpu1gpu],
+     [IntegralDemand(cpu=4, gpu=4, owner=owner)],
+     []],
+
+    ['1cpu,1gpu job using 8cpu,1gpu and 32cpu,4gpu instances',
+     [instance_8cpu1gpu,
+      instance_32cpu4gpu],
+     [IntegralDemand(cpu=1, gpu=1, owner=owner)],
+     [InstanceDemand(instance=instance_8cpu1gpu, owner=owner)]],
+
+    ['2x1cpu,1gpu job using 8cpu,1gpu and 32cpu,4gpu instances',
+     [instance_8cpu1gpu,
+      instance_32cpu4gpu],
+     2 * [IntegralDemand(cpu=1, gpu=1, owner=owner)],
+     [InstanceDemand(instance=instance_32cpu4gpu, owner=owner)]],
+
+    ['4cpu,4gpu job using 8cpu,1gpu and 32cpu,4gpu instances',
+     [instance_8cpu1gpu,
+      instance_32cpu4gpu],
+     [IntegralDemand(cpu=4, gpu=4, owner=owner)],
+     [InstanceDemand(instance=instance_32cpu4gpu, owner=owner)]],
+
+    ['4cpu,4gpu job using 8cpu,1gpu and 32cpu,4gpu and 64cpu,8gpu instances',
+     [instance_8cpu1gpu,
+      instance_32cpu4gpu,
+      instance_64cpu8gpu],
+     [IntegralDemand(cpu=4, gpu=4, owner=owner)],
+     [InstanceDemand(instance=instance_32cpu4gpu, owner=owner)]],
+
+    ['1cpu,1gpu job using 8cpu,1gpu and 32cpu,4gpu and 64cpu,8gpu instances',
+     [instance_8cpu1gpu,
+      instance_32cpu4gpu,
+      instance_64cpu8gpu],
+     [IntegralDemand(cpu=1, gpu=1, owner=owner)],
+     [InstanceDemand(instance=instance_8cpu1gpu, owner=owner)]],
+
+    ['9x1cpu,1gpu job using 8cpu,1gpu and 32cpu,4gpu and 64cpu,8gpu instances',
+     [instance_8cpu1gpu,
+      instance_32cpu4gpu,
+      instance_64cpu8gpu],
+     9 * [IntegralDemand(cpu=1, gpu=1, owner=owner)],
+     [InstanceDemand(instance=instance_64cpu8gpu, owner=owner),
+      InstanceDemand(instance=instance_8cpu1gpu, owner=owner)]],
+
+    ['10x1cpu,1gpu job using 8cpu,1gpu and 32cpu,4gpu and 64cpu,8gpu instances',
+     [instance_8cpu1gpu,
+      instance_32cpu4gpu,
+      instance_64cpu8gpu],
+     10 * [IntegralDemand(cpu=1, gpu=1, owner=owner)],
+     [InstanceDemand(instance=instance_64cpu8gpu, owner=owner),
+      InstanceDemand(instance=instance_32cpu4gpu, owner=owner)]],
 ]
 
 

--- a/workflows/pipe-common/test/test_demand_selector.py
+++ b/workflows/pipe-common/test/test_demand_selector.py
@@ -20,23 +20,29 @@ from mock import MagicMock, Mock
 from pipeline.hpc.gridengine import GridEngineDemandSelector, GridEngineJob, AllocationRule
 from pipeline.hpc.resource import IntegralDemand, FractionalDemand, ResourceSupply
 
+PE_LOCAL = 'local'
+PE_MPI = 'mpi'
+
 logging.basicConfig(level=logging.DEBUG, format='%(asctime)s [%(threadName)s] [%(levelname)s] %(message)s')
 
 grid_engine = Mock()
 owner = 'owner'
 
-job_2cpu_local = GridEngineJob(id='1', root_id=1, name='', user=owner, state='', datetime='',
-                               pe='local', cpu=2)
-job_4cpu_local = GridEngineJob(id='1', root_id=1, name='', user=owner, state='', datetime='',
-                               pe='local', cpu=4)
-job_8cpu_local = GridEngineJob(id='1', root_id=1, name='', user=owner, state='', datetime='',
-                               pe='local', cpu=8)
-job_2cpu_mpi = GridEngineJob(id='1', root_id=1, name='', user=owner, state='', datetime='',
-                             pe='mpi', cpu=2)
-job_4cpu_mpi = GridEngineJob(id='1', root_id=1, name='', user=owner, state='', datetime='',
-                             pe='mpi', cpu=4)
-job_8cpu_mpi = GridEngineJob(id='1', root_id=1, name='', user=owner, state='', datetime='',
-                             pe='mpi', cpu=8)
+job_args = {'id': '1', 'root_id': 1, 'name': '', 'user': owner, 'state': '', 'datetime': ''}
+
+job_2cpu_local = GridEngineJob(cpu=2, gpu=0, pe=PE_LOCAL, **job_args)
+job_4cpu_local = GridEngineJob(cpu=4, gpu=0, pe=PE_LOCAL, **job_args)
+job_8cpu_local = GridEngineJob(cpu=8, gpu=0, pe=PE_LOCAL, **job_args)
+
+job_2cpu_mpi = GridEngineJob(cpu=2, gpu=0, pe=PE_MPI, **job_args)
+job_4cpu_mpi = GridEngineJob(cpu=4, gpu=0, pe=PE_MPI, **job_args)
+job_8cpu_mpi = GridEngineJob(cpu=8, gpu=0, pe=PE_MPI, **job_args)
+
+job_8cpu1gpu_local = GridEngineJob(cpu=8, gpu=1, pe=PE_LOCAL, **job_args)
+job_32cpu4gpu_local = GridEngineJob(cpu=32, gpu=4, pe=PE_LOCAL, **job_args)
+
+job_8cpu1gpu_mpi = GridEngineJob(cpu=8, gpu=1, pe=PE_MPI, **job_args)
+job_32cpu4gpu_mpi = GridEngineJob(cpu=32, gpu=4, pe=PE_MPI, **job_args)
 
 test_cases = [
     ['2cpu and 4cpu and 8cpu local jobs using 0cpu supply',
@@ -47,6 +53,7 @@ test_cases = [
      [IntegralDemand(cpu=2, owner=owner),
       IntegralDemand(cpu=4, owner=owner),
       IntegralDemand(cpu=8, owner=owner)]],
+
     ['2cpu and 4cpu and 8cpu local jobs using 2cpu supply',
      [job_2cpu_local,
       job_4cpu_local,
@@ -55,6 +62,7 @@ test_cases = [
      [IntegralDemand(cpu=2, owner=owner),
       IntegralDemand(cpu=4, owner=owner),
       IntegralDemand(cpu=8, owner=owner)]],
+
     ['2cpu and 4cpu and 8cpu local jobs using 16cpu supply',
      [job_2cpu_local,
       job_4cpu_local,
@@ -63,40 +71,84 @@ test_cases = [
      [IntegralDemand(cpu=2, owner=owner),
       IntegralDemand(cpu=4, owner=owner),
       IntegralDemand(cpu=8, owner=owner)]],
+
     ['2cpu mpi job using 0cpu supply',
      [job_2cpu_mpi],
      [ResourceSupply(cpu=0)],
      [FractionalDemand(cpu=2, owner=owner)]],
+
     ['2cpu mpi job using 2cpu supply',
      [job_2cpu_mpi],
      [ResourceSupply(cpu=2)],
-     [FractionalDemand(cpu=1, owner=owner)]],
+     []],
+
     ['2cpu mpi job using 4cpu supply',
      [job_2cpu_mpi],
      [ResourceSupply(cpu=4)],
-     [FractionalDemand(cpu=1, owner=owner)]],
+     []],
+
     ['4cpu mpi job using 2cpu supply',
      [job_4cpu_mpi],
      [ResourceSupply(cpu=2)],
      [FractionalDemand(cpu=2, owner=owner)]],
+
     ['2cpu and 8cpu mpi jobs using 3cpu supply',
      [job_2cpu_mpi,
       job_8cpu_mpi],
      [ResourceSupply(cpu=3)],
-     [FractionalDemand(cpu=1, owner=owner),
-      FractionalDemand(cpu=7, owner=owner)]],
+     [FractionalDemand(cpu=7, owner=owner)]],
+
     ['2cpu and 8cpu mpi jobs using 2x3cpu supply',
      [job_2cpu_mpi,
       job_8cpu_mpi],
      [ResourceSupply(cpu=3),
       ResourceSupply(cpu=3)],
-     [FractionalDemand(cpu=1, owner=owner),
-      FractionalDemand(cpu=4, owner=owner)]],
+     [FractionalDemand(cpu=4, owner=owner)]],
+
     ['2x8cpu mpi jobs using 2x32cpu supply',
      2 * [job_8cpu_mpi],
      [ResourceSupply(cpu=32),
       ResourceSupply(cpu=32)],
-     2 * [FractionalDemand(cpu=1, owner=owner)]],
+     []],
+
+    ['8cpu/1gpu local job using 0cpu supply',
+     [job_8cpu1gpu_local],
+     [ResourceSupply(cpu=0)],
+     [IntegralDemand(cpu=8, gpu=1, owner=owner)]],
+
+    ['8cpu/1gpu and 32cpu/4gpu local job using 0cpu supply',
+     [job_8cpu1gpu_local,
+      job_32cpu4gpu_local],
+     [ResourceSupply(cpu=0)],
+     [IntegralDemand(cpu=8, gpu=1, owner=owner),
+      IntegralDemand(cpu=32, gpu=4, owner=owner)]],
+
+    ['8cpu/1gpu local job using 32cpu/4gpu supply',
+     [job_8cpu1gpu_local],
+     [ResourceSupply(cpu=32, gpu=4)],
+     [IntegralDemand(cpu=8, gpu=1, owner=owner)]],
+
+    ['8cpu/1gpu mpi job using 0cpu supply',
+     [job_8cpu1gpu_mpi],
+     [ResourceSupply(cpu=0)],
+     [FractionalDemand(cpu=8, gpu=1, owner=owner)]],
+
+    ['8cpu/1gpu mpi job using 2cpu supply',
+     [job_8cpu1gpu_mpi],
+     [ResourceSupply(cpu=2)],
+     [FractionalDemand(cpu=6, gpu=1, owner=owner)]],
+
+    ['8cpu/1gpu mpi job using 32cpu/4gpu supply',
+     [job_8cpu1gpu_mpi],
+     [ResourceSupply(cpu=32, gpu=4)],
+     []],
+
+    ['8cpu/1gpu and 32cpu/4gpu mpi job using 0cpu supply',
+     [job_8cpu1gpu_mpi,
+      job_32cpu4gpu_mpi],
+     [ResourceSupply(cpu=0)],
+     [FractionalDemand(cpu=8, gpu=1, owner=owner),
+      FractionalDemand(cpu=32, gpu=4, owner=owner)]]
 ]
 
 
@@ -105,7 +157,7 @@ test_cases = [
                          ids=[test_case[0] for test_case in test_cases])
 def test_select(jobs, resource_supplies, required_resource_demands):
     grid_engine.get_pe_allocation_rule = MagicMock(
-        side_effect=lambda pe: AllocationRule.pe_slots() if pe == 'local' else AllocationRule.fill_up())
+        side_effect=lambda pe: AllocationRule.pe_slots() if pe == PE_LOCAL else AllocationRule.fill_up())
     grid_engine.get_host_supplies = MagicMock(return_value=iter(resource_supplies))
     demand_selector = GridEngineDemandSelector(grid_engine=grid_engine)
     actual_resource_demands = list(demand_selector.select(jobs))


### PR DESCRIPTION
Relates #1028.

The pull request brings support for RAM and GPU based autoscaling. From now on, grid engine autoscaler respects CPU, RAM and GPU job requirements while considering how many and which instances to scale.

Additionally, the pull request disables descending autoscaling by default and makes unavailable instance counts general autoscaling parameters.
