### PR TITLE
Introduce export support in sge utility

### DIFF
--- a/workflows/pipe-common/scripts/manage_sge_profiles.py
+++ b/workflows/pipe-common/scripts/manage_sge_profiles.py
@@ -399,6 +399,7 @@ def cli():
     VI. Export certain existing grid engine profiles
 
         sge export queue1.q sge.export.tar.gz
+
         sge export queue1.q queue2.q sge.export.tar.gz
 
     """
@@ -491,7 +492,9 @@ def export(names, output):
     Examples:
 
         sge export sge.export.tar.gz
+
         sge export queue1.q sge.export.tar.gz
+
         sge export queue1.q queue2.q sge.export.tar.gz
 
     """

--- a/workflows/pipe-common/scripts/manage_sge_profiles.py
+++ b/workflows/pipe-common/scripts/manage_sge_profiles.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
 import logging
 import os
 import re
@@ -40,18 +41,245 @@ class GridEngineProfileError(RuntimeError):
     pass
 
 
-class ManagementTask:
-    CREATE = 'CREATE'
-    CONFIGURE = 'CONFIGURE'
-    RESTART = 'RESTART'
-    LIST = 'LIST'
+def errorhandling(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return_value = func(*args, **kwargs)
+            return return_value
+        except GridEngineProfileError:
+            exit(1)
+    return wrapper
 
 
-def manage(task, profile_name=None):
+class GridEngineProfileManager:
+
+    def __init__(self, executor, logger, cap_scripts_dir, queue_profile_regexp, autoscaling_script_path):
+        self._executor = executor
+        self._logger = logger
+        self._cap_scripts_dir = cap_scripts_dir
+        self._queue_profile_regexp = queue_profile_regexp
+        self._autoscaling_script_path = autoscaling_script_path
+
+    @errorhandling
+    def create(self, profile_name):
+        self._logger.info('Initiating grid engine profiles creation...')
+        editor = self._find_editor()
+        profile_name = self._preprocess_profile_name(profile_name)
+        profile = self._find_profile(self._cap_scripts_dir, self._queue_profile_regexp, profile_name)
+        if profile:
+            self._logger.warning('Grid engine {} profile already exists.'.format(profile_name))
+            raise GridEngineProfileError()
+        self._generate_profile(profile_name)
+        profile = self._find_profile(self._cap_scripts_dir, self._queue_profile_regexp, profile_name)
+        if not profile:
+            self._logger.warning('Grid engine {} profile does not exist.'.format(profile_name))
+            raise GridEngineProfileError()
+        self._create_queue(profile)
+        modified_profile = self._configure_profile(profile, editor)
+        verified = True
+        if modified_profile:
+            verified = self._verify_profile(modified_profile, self._autoscaling_script_path)
+            if verified:
+                self._persist_profile(modified_profile, profile)
+        self._launch_autoscaler(profile, self._autoscaling_script_path)
+        if not verified:
+            raise GridEngineProfileError()
+
+    @errorhandling
+    def configure(self, profile_name):
+        self._logger.info('Initiating grid engine profile configuration...')
+        editor = self._find_editor()
+        profile = self._find_profile(self._cap_scripts_dir, self._queue_profile_regexp, profile_name)
+        if not profile:
+            self._logger.warning('Grid engine {} profile does not exist.'.format(profile_name))
+            raise GridEngineProfileError()
+        modified_profile = self._configure_profile(profile, editor)
+        verified = True
+        if modified_profile:
+            self._stop_autoscaler(profile, self._autoscaling_script_path)
+            verified = self._verify_profile(modified_profile, self._autoscaling_script_path)
+            if verified:
+                self._persist_profile(modified_profile, profile)
+            self._launch_autoscaler(profile, self._autoscaling_script_path)
+        if not verified:
+            raise GridEngineProfileError()
+
+    @errorhandling
+    def restart(self, profile_name):
+        self._logger.info('Initiating grid engine profile restart...')
+        profile = self._find_profile(self._cap_scripts_dir, self._queue_profile_regexp, profile_name)
+        if not profile:
+            self._logger.warning('Grid engine {} profile does not exist.'.format(profile_name))
+            raise GridEngineProfileError()
+        self._stop_autoscaler(profile, self._autoscaling_script_path)
+        self._launch_autoscaler(profile, self._autoscaling_script_path)
+
+    @errorhandling
+    def list(self):
+        self._logger.info('Initiating grid engine profiles listing...')
+        profiles = self._collect_profiles(self._cap_scripts_dir, self._queue_profile_regexp)
+        for profile in profiles:
+            self._logger.info('Grid engine profile has been found: {}'.format(profile.name))
+
+    def _find_editor(self):
+        self._logger.debug('Searching for editor...')
+        default_editor = os.getenv('VISUAL', os.getenv('EDITOR'))
+        fallback_editors = ['nano', 'vi', 'vim']
+        editors = [default_editor] + fallback_editors if default_editor else fallback_editors
+        editor = None
+        for potential_editor in editors:
+            try:
+                subprocess.check_output('command -v ' + potential_editor, shell=True, stderr=subprocess.STDOUT)
+                editor = potential_editor
+                self._logger.debug('Editor {} has been found.'.format(editor))
+                break
+            except subprocess.CalledProcessError as e:
+                self._logger.debug('Editor {} has not been found because {}.'
+                                   .format(potential_editor, e.output or 'the tool is not installed'))
+        if not editor:
+            self._logger.warning('Grid engine profiles configuration requires a text editor to be installed locally.\n'
+                                 'Please set VISUAL/EDITOR environment variable or install vi/vim/nano using one of the commands below.\n\n'
+                                 'yum install -y nano\n'
+                                 'apt-get install -y nano\n\n')
+            raise GridEngineProfileError()
+        return editor
+
+    def _preprocess_profile_name(self, profile_name):
+        self._logger.debug('Preprocessing profile name...')
+        profile_name = re.sub(PROFILE_NAME_REMOVAL_PATTERN, '', profile_name.lower())
+        if not profile_name:
+            self._logger.warning('Grid engine profile name should consist only of alphanumeric characters and dots.')
+            raise GridEngineProfileError()
+        if not profile_name.endswith('.q'):
+            profile_name = profile_name + '.q'
+        return profile_name
+
+    def _find_profile(self, cap_scripts_dir, queue_profile_regexp, profile_name):
+        profiles = self._collect_profiles(cap_scripts_dir, queue_profile_regexp)
+        for profile in profiles:
+            if profile.name == profile_name:
+                return profile
+
+    def _collect_profiles(self, cap_scripts_dir, profile_regexp):
+        self._logger.debug('Collecting existing profiles...')
+        for profile_name in os.listdir(cap_scripts_dir):
+            profile_match = profile_regexp.match(profile_name)
+            if not profile_match:
+                continue
+            queue_name = profile_match.group(1)
+            self._logger.debug('Profile {} has been collected.'.format(queue_name))
+            yield Profile(name=queue_name,
+                          path_queue=os.path.join(cap_scripts_dir, PROFILE_QUEUE_FORMAT.format(queue_name)),
+                          path_autoscaling=os.path.join(cap_scripts_dir, PROFILE_AUTOSCALING_FORMAT.format(queue_name)))
+
+    def _generate_profile(self, profile_name):
+        profile_index = str(int(time.time()))
+        self._logger.debug('Creating grid engine {} profile...'.format(profile_name))
+        os.environ['CP_CAP_SGE_QUEUE_NAME_{}'.format(profile_index)] = profile_name
+        generate_sge_profiles()
+        self._logger.info('Grid engine {} profile has been created.'.format(profile_name))
+
+    def _configure_profile(self, profile, editor):
+        tmp_profile = Profile(name=profile.name,
+                              path_queue=tempfile.mktemp(),
+                              path_autoscaling=tempfile.mktemp())
+        self._logger.debug('Copying grid engine {} profile to {}...'.format(profile.name, tmp_profile.path_autoscaling))
+        shutil.copy2(profile.path_autoscaling, tmp_profile.path_autoscaling)
+        shutil.copy2(profile.path_queue, tmp_profile.path_queue)
+        self._replace_in_file(tmp_profile.path_queue, profile.path_autoscaling, tmp_profile.path_autoscaling)
+        self._logger.debug('Modifying temporary grid engine {} profile...'.format(profile.name))
+        subprocess.check_call([editor, tmp_profile.path_autoscaling])
+        self._logger.debug('Extracting changes from grid engine {} profile...'.format(profile.name))
+        profile_changes = self._compare_file(profile.path_autoscaling, tmp_profile.path_autoscaling)
+        if not profile_changes:
+            self._logger.info('Grid engine {} profile has not been changed.'.format(profile.name))
+            return None
+        self._logger.info('Grid engine {} profile has been changed:\n{}'.format(profile.name, profile_changes))
+        return tmp_profile
+
+    def _replace_in_file(self, file_path, before, after):
+        with open(file_path, 'r') as file:
+            content = file.read()
+        updated_content = re.sub(re.escape(before), re.escape(after), content)
+        with open(file_path, 'w') as file:
+            file.write(updated_content)
+
+    def _compare_file(self, before_path, after_path):
+        try:
+            return subprocess.check_output(['diff', before_path, after_path], stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            return e.output
+
+    def _persist_profile(self, modified_profile, profile):
+        self._logger.debug('Persisting grid engine {} profile changes...'.format(profile.name))
+        shutil.move(modified_profile.path_autoscaling, profile.path_autoscaling)
+
+    def _create_queue(self, profile):
+        self._logger.debug('Creating grid engine {} queue...'.format(profile.name))
+        subprocess.check_call("""
+source "{autoscaling_profile_path}"
+sge_setup_queue
+        """.format(autoscaling_profile_path=profile.path_queue),
+                              shell=True)
+        self._logger.info('Grid engine {} queue has been created.'.format(profile.name))
+
+    def _stop_autoscaler(self, profile, autoscaling_script_path):
+        self._logger.debug('Searching for {} autoscaler processes...'.format(profile.name))
+        for proc in self._get_processes(autoscaling_script_path, CP_CAP_SGE_QUEUE_NAME=profile.name):
+            self._logger.debug('Stopping process #{}...'.format(proc.pid))
+            proc.terminate()
+
+    def _get_processes(self, *args, **kwargs):
+        for proc in psutil.process_iter():
+            try:
+                proc_cmdline = proc.cmdline()
+                proc_environ = proc.environ()
+            except KeyboardInterrupt:
+                raise
+            except Exception:
+                self._logger.error('Please use root account to configure grid engine profiles.')
+                raise GridEngineProfileError()
+            if all(arg in proc_cmdline for arg in args) \
+                    and all(proc_environ.get(k) == v for k, v in kwargs.items()):
+                yield proc
+
+    def _verify_profile(self, profile, autoscaling_script_path):
+        self._logger.debug('Verifying grid engine queue {} autoscaling...'.format(profile.name))
+        try:
+            self._executor.execute("""
+export CP_CAP_AUTOSCALE_LOGGING_LEVEL_RUN="ERROR"
+export CP_CAP_AUTOSCALE_LOGGING_LEVEL_FILE="ERROR"
+export CP_CAP_AUTOSCALE_LOGGING_LEVEL_CONSOLE="INFO"
+export CP_CAP_AUTOSCALE_LOGGING_FORMAT="%(message)s"
+export CP_CAP_AUTOSCALE_DRY_INIT="true"
+source "{autoscaling_profile_path}"
+"$CP_PYTHON2_PATH" "{autoscaling_script_path}"
+            """.format(autoscaling_profile_path=profile.path_queue,
+                       autoscaling_script_path=autoscaling_script_path))
+            self._logger.debug('Grid engine {} autoscaling has been verified.'.format(profile.name))
+            return True
+        except ExecutorError:
+            self._logger.warning('Grid engine profile verification has failed. Reverting the changes...')
+            return False
+
+    def _launch_autoscaler(self, profile, autoscaling_script_path):
+        self._logger.debug('Launching grid engine queue {} autoscaling...'.format(profile.name))
+        self._executor.execute("""
+source "{autoscaling_profile_path}"
+nohup "$CP_PYTHON2_PATH" "{autoscaling_script_path}" >"$LOG_DIR/.nohup.autoscaler.$CP_CAP_SGE_QUEUE_NAME.log" 2>&1 &
+        """.format(autoscaling_profile_path=profile.path_queue,
+                   autoscaling_script_path=autoscaling_script_path))
+        self._logger.info('Grid engine {} autoscaling has been launched.'.format(profile.name))
+
+
+@errorhandling
+def _get_manager():
     logging_level_run = os.getenv('CP_CAP_SGE_PROFILE_CONFIGURATION_LOGGING_LEVEL_RUN', default='INFO')
     logging_level_file = os.getenv('CP_CAP_SGE_PROFILE_CONFIGURATION_LOGGING_LEVEL_FILE', default='DEBUG')
     logging_level_console = os.getenv('CP_CAP_SGE_PROFILE_CONFIGURATION_LOGGING_LEVEL_CONSOLE', default='INFO')
-    logging_format = os.getenv('CP_CAP_SGE_PROFILE_CONFIGURATION_LOGGING_FORMAT', default='%(asctime)s [%(levelname)s] %(message)s')
+    logging_format_file = os.getenv('CP_CAP_SGE_PROFILE_CONFIGURATION_LOGGING_FORMAT_FILE', default='%(asctime)s [%(levelname)s] %(message)s')
+    logging_format_console = os.getenv('CP_CAP_SGE_PROFILE_CONFIGURATION_LOGGING_FORMAT_CONSOLE', default='%(message)s')
     logging_task = os.getenv('CP_CAP_SGE_PROFILE_CONFIGURATION_LOGGING_TASK', default='ConfigureSGEProfiles')
     logging_dir = os.getenv('CP_CAP_SGE_PROFILE_CONFIGURATION_LOG_DIR', default=os.getenv('LOG_DIR', '/var/log'))
     logging_file = os.getenv('CP_CAP_SGE_PROFILE_CONFIGURATION_LOGGING_FILE', default='configure_sge_profiles_interactively.log')
@@ -66,8 +294,6 @@ def manage(task, profile_name=None):
     autoscaling_script_path = os.path.join(common_repo_dir, 'scripts', 'autoscale_sge.py')
     queue_profile_regexp = re.compile(PROFILE_QUEUE_PATTERN)
 
-    logging_formatter = logging.Formatter(logging_format)
-
     logging_logger_root = logging.getLogger()
     logging_logger_root.setLevel(logging.WARNING)
 
@@ -75,17 +301,20 @@ def manage(task, profile_name=None):
     logging_logger.setLevel(logging.DEBUG)
 
     if not logging_logger.handlers:
+        console_formatter = logging.Formatter(logging_format_console)
         console_handler = logging.StreamHandler(sys.stdout)
         console_handler.setLevel(logging_level_console)
-        console_handler.setFormatter(logging_formatter)
+        console_handler.setFormatter(console_formatter)
         logging_logger.addHandler(console_handler)
 
+        file_formatter = logging.Formatter(logging_format_file)
         file_handler = logging.FileHandler(os.path.join(logging_dir, logging_file))
         file_handler.setLevel(logging_level_file)
-        file_handler.setFormatter(logging_formatter)
+        file_handler.setFormatter(file_formatter)
         logging_logger.addHandler(file_handler)
 
     api = PipelineAPI(api_url=api_url, log_dir=logging_dir)
+
     logger = RunLogger(api=api, run_id=run_id)
     logger = TaskLogger(task=logging_task, inner=logger)
     logger = LevelLogger(level=logging_level_run, inner=logger)
@@ -95,228 +324,10 @@ def manage(task, profile_name=None):
     executor = LocalExecutor()
     executor = LoggingExecutor(logger=executor_logger, inner=executor)
 
-    try:
-        if task == ManagementTask.CREATE:
-            logger.info('Initiating grid engine profiles creation...')
-            editor = _find_editor(logger)
-            profile_name = _preprocess_profile_name(profile_name, logger)
-            profile = _find_profile(cap_scripts_dir, queue_profile_regexp, profile_name, logger)
-            if profile:
-                logger.warning('Grid engine {} profile already exists.'.format(profile_name))
-                raise GridEngineProfileError()
-            _generate_profile(profile_name, logger)
-            profile = _find_profile(cap_scripts_dir, queue_profile_regexp, profile_name, logger)
-            if not profile:
-                logger.warning('Grid engine {} profile does not exist.'.format(profile_name))
-                raise GridEngineProfileError()
-            _create_queue(profile, logger)
-            modified_profile = _configure_profile(profile, editor, logger)
-            verified = True
-            if modified_profile:
-                verified = _verify_profile(modified_profile, autoscaling_script_path, logger, executor)
-                if verified:
-                    _persist_profile(modified_profile, profile, logger)
-            _launch_autoscaler(profile, autoscaling_script_path, logger, executor)
-            if not verified:
-                raise GridEngineProfileError()
-        elif task == ManagementTask.CONFIGURE:
-            logger.info('Initiating grid engine profile configuration...')
-            editor = _find_editor(logger)
-            profile = _find_profile(cap_scripts_dir, queue_profile_regexp, profile_name, logger)
-            if not profile:
-                logger.warning('Grid engine {} profile does not exist.'.format(profile_name))
-                raise GridEngineProfileError()
-            modified_profile = _configure_profile(profile, editor, logger)
-            verified = True
-            if modified_profile:
-                _stop_autoscaler(profile, autoscaling_script_path, logger)
-                verified = _verify_profile(modified_profile, autoscaling_script_path, logger, executor)
-                if verified:
-                    _persist_profile(modified_profile, profile, logger)
-                _launch_autoscaler(profile, autoscaling_script_path, logger, executor)
-            if not verified:
-                raise GridEngineProfileError()
-        elif task == ManagementTask.RESTART:
-            logger.info('Initiating grid engine profile restart...')
-            profile = _find_profile(cap_scripts_dir, queue_profile_regexp, profile_name, logger)
-            if not profile:
-                logger.warning('Grid engine {} profile does not exist.'.format(profile_name))
-                raise GridEngineProfileError()
-            _stop_autoscaler(profile, autoscaling_script_path, logger)
-            _launch_autoscaler(profile, autoscaling_script_path, logger, executor)
-        elif task == ManagementTask.LIST:
-            logger.info('Initiating grid engine profiles listing...')
-            profiles = _collect_profiles(cap_scripts_dir, queue_profile_regexp, logger)
-            for profile in profiles:
-                logger.info('Grid engine profile has been found: {}'.format(profile.name))
-    except KeyboardInterrupt:
-        logger.warning('Interrupted.')
-    except GridEngineProfileError:
-        exit(1)
-
-
-def _find_editor(logger):
-    logger.debug('Searching for editor...')
-    default_editor = os.getenv('VISUAL', os.getenv('EDITOR'))
-    fallback_editors = ['nano', 'vi', 'vim']
-    editors = [default_editor] + fallback_editors if default_editor else fallback_editors
-    editor = None
-    for potential_editor in editors:
-        try:
-            subprocess.check_output('command -v ' + potential_editor, shell=True, stderr=subprocess.STDOUT)
-            editor = potential_editor
-            logger.debug('Editor {} has been found.'.format(editor))
-            break
-        except subprocess.CalledProcessError as e:
-            logger.debug('Editor {} has not been found because {}.'
-                         .format(potential_editor, e.output or 'the tool is not installed'))
-    if not editor:
-        logger.warning('Grid engine profiles configuration requires a text editor to be installed locally.\n'
-                       'Please set VISUAL/EDITOR environment variable or install vi/vim/nano using one of the commands below.\n\n'
-                       'yum install -y nano\n'
-                       'apt-get install -y nano\n\n')
-        raise GridEngineProfileError()
-    return editor
-
-
-def _preprocess_profile_name(profile_name, logger):
-    logger.debug('Preprocessing profile name...')
-    profile_name = re.sub(PROFILE_NAME_REMOVAL_PATTERN, '', profile_name.lower())
-    if not profile_name:
-        logger.warning('Grid engine profile name should consist only of alphanumeric characters and dots.')
-        raise GridEngineProfileError()
-    if not profile_name.endswith('.q'):
-        profile_name = profile_name + '.q'
-    return profile_name
-
-
-def _find_profile(cap_scripts_dir, queue_profile_regexp, profile_name, logger):
-    profiles = _collect_profiles(cap_scripts_dir, queue_profile_regexp, logger)
-    for profile in profiles:
-        if profile.name == profile_name:
-            return profile
-
-
-def _collect_profiles(cap_scripts_dir, profile_regexp, logger):
-    logger.debug('Collecting existing profiles...')
-    for profile_name in os.listdir(cap_scripts_dir):
-        profile_match = profile_regexp.match(profile_name)
-        if not profile_match:
-            continue
-        queue_name = profile_match.group(1)
-        logger.debug('Profile {} has been collected.'.format(queue_name))
-        yield Profile(name=queue_name,
-                      path_queue=os.path.join(cap_scripts_dir, PROFILE_QUEUE_FORMAT.format(queue_name)),
-                      path_autoscaling=os.path.join(cap_scripts_dir, PROFILE_AUTOSCALING_FORMAT.format(queue_name)))
-
-
-def _generate_profile(profile_name, logger):
-    profile_index = str(int(time.time()))
-    logger.debug('Creating grid engine {} profile...'.format(profile_name))
-    os.environ['CP_CAP_SGE_QUEUE_NAME_{}'.format(profile_index)] = profile_name
-    generate_sge_profiles()
-    logger.info('Grid engine {} profile has been created.'.format(profile_name))
-
-
-def _configure_profile(profile, editor, logger):
-    tmp_profile = Profile(name=profile.name,
-                          path_queue=tempfile.mktemp(),
-                          path_autoscaling=tempfile.mktemp())
-    logger.debug('Copying grid engine {} profile to {}...'.format(profile.name, tmp_profile.path_autoscaling))
-    shutil.copy2(profile.path_autoscaling, tmp_profile.path_autoscaling)
-    shutil.copy2(profile.path_queue, tmp_profile.path_queue)
-    _replace_in_file(tmp_profile.path_queue, profile.path_autoscaling, tmp_profile.path_autoscaling)
-    logger.debug('Modifying temporary grid engine {} profile...'.format(profile.name))
-    subprocess.check_call([editor, tmp_profile.path_autoscaling])
-    logger.debug('Extracting changes from grid engine {} profile...'.format(profile.name))
-    profile_changes = _compare_file(profile.path_autoscaling, tmp_profile.path_autoscaling)
-    if not profile_changes:
-        logger.info('Grid engine {} profile has not been changed.'.format(profile.name))
-        return None
-    logger.info('Grid engine {} profile has been changed:\n{}'.format(profile.name, profile_changes))
-    return tmp_profile
-
-
-def _replace_in_file(file_path, before, after):
-    with open(file_path, 'r') as file:
-        content = file.read()
-    updated_content = re.sub(re.escape(before), re.escape(after), content)
-    with open(file_path, 'w') as file:
-        file.write(updated_content)
-
-
-def _compare_file(before_path, after_path):
-    try:
-        return subprocess.check_output(['diff', before_path, after_path], stderr=subprocess.STDOUT)
-    except subprocess.CalledProcessError as e:
-        return e.output
-
-
-def _persist_profile(modified_profile, profile, logger):
-    logger.debug('Persisting grid engine {} profile changes...'.format(profile.name))
-    shutil.move(modified_profile.path_autoscaling, profile.path_autoscaling)
-
-
-def _create_queue(profile, logger):
-    logger.debug('Creating grid engine {} queue...'.format(profile.name))
-    subprocess.check_call("""
-source "{autoscaling_profile_path}"
-sge_setup_queue
-    """.format(autoscaling_profile_path=profile.path_queue),
-                          shell=True)
-    logger.info('Grid engine {} queue has been created.'.format(profile.name))
-
-
-def _stop_autoscaler(profile, autoscaling_script_path, logger):
-    logger.debug('Searching for {} autoscaler processes...'.format(profile.name))
-    for proc in _get_processes(logger, autoscaling_script_path, CP_CAP_SGE_QUEUE_NAME=profile.name):
-        logger.debug('Stopping process #{}...'.format(proc.pid))
-        proc.terminate()
-
-
-def _get_processes(logger, *args, **kwargs):
-    for proc in psutil.process_iter():
-        try:
-            proc_cmdline = proc.cmdline()
-            proc_environ = proc.environ()
-        except KeyboardInterrupt:
-            raise
-        except Exception:
-            logger.error('Please use root account to configure grid engine profiles.')
-            raise GridEngineProfileError()
-        if all(arg in proc_cmdline for arg in args) \
-                and all(proc_environ.get(k) == v for k, v in kwargs.items()):
-            yield proc
-
-
-def _verify_profile(profile, autoscaling_script_path, logger, executor):
-    logger.debug('Verifying grid engine queue {} autoscaling...'.format(profile.name))
-    try:
-        executor.execute("""
-export CP_CAP_AUTOSCALE_LOGGING_LEVEL_RUN="ERROR"
-export CP_CAP_AUTOSCALE_LOGGING_LEVEL_FILE="ERROR"
-export CP_CAP_AUTOSCALE_LOGGING_LEVEL_CONSOLE="INFO"
-export CP_CAP_AUTOSCALE_LOGGING_FORMAT="%(message)s"
-export CP_CAP_AUTOSCALE_DRY_INIT="true"
-source "{autoscaling_profile_path}"
-"$CP_PYTHON2_PATH" "{autoscaling_script_path}"
-        """.format(autoscaling_profile_path=profile.path_queue,
-                   autoscaling_script_path=autoscaling_script_path))
-        logger.debug('Grid engine {} autoscaling has been verified.'.format(profile.name))
-        return True
-    except ExecutorError:
-        logger.warning('Grid engine profile verification has failed. Reverting the changes...')
-        return False
-
-
-def _launch_autoscaler(profile, autoscaling_script_path, logger, executor):
-    logger.debug('Launching grid engine queue {} autoscaling...'.format(profile.name))
-    executor.execute("""
-source "{autoscaling_profile_path}"
-nohup "$CP_PYTHON2_PATH" "{autoscaling_script_path}" >"$LOG_DIR/.nohup.autoscaler.$CP_CAP_SGE_QUEUE_NAME.log" 2>&1 &
-    """.format(autoscaling_profile_path=profile.path_queue,
-               autoscaling_script_path=autoscaling_script_path))
-    logger.info('Grid engine {} autoscaling has been launched.'.format(profile.name))
+    return GridEngineProfileManager(executor=executor, logger=logger,
+                                    cap_scripts_dir=cap_scripts_dir,
+                                    queue_profile_regexp=queue_profile_regexp,
+                                    autoscaling_script_path=autoscaling_script_path)
 
 
 @click.group()
@@ -364,7 +375,8 @@ def create(name):
         sge create queue.q
 
     """
-    manage(task=ManagementTask.CREATE, profile_name=name)
+    manager = _get_manager()
+    manager.create(profile_name=name)
 
 
 @cli.command()
@@ -383,7 +395,8 @@ def configure(name):
         sge configure queue.q
 
     """
-    manage(task=ManagementTask.CONFIGURE, profile_name=name)
+    manager = _get_manager()
+    manager.configure(profile_name=name)
 
 
 @cli.command()
@@ -400,11 +413,12 @@ def restart(name):
         sge restart queue.q
 
     """
-    manage(task=ManagementTask.RESTART, profile_name=name)
+    manager = _get_manager()
+    manager.restart(profile_name=name)
 
 
-@cli.command(name='list')
-def ls():
+@cli.command()
+def list():
     """
     Lists profiles.
 
@@ -415,7 +429,8 @@ def ls():
         sge list
 
     """
-    manage(task=ManagementTask.LIST)
+    manager = _get_manager()
+    manager.list()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Relates #3280.

The pull request brings support for configuration export to sge utility. Either all or certain grid engine queues (profiles) can be exported. 

Check the following output to find out the details.

```
Usage: manage_sge_profiles.py [OPTIONS] COMMAND [ARGS]...

  Grid engine profiles management utility.

  It allows to interactively manage grid engine profiles (queues).

  Examples:

  I. Create new grid engine profile

      sge create queue.q

  II. Configure an existing grid engine profile

      sge configure queue.q

  III. Restart an existing grid engine profile

      sge restart queue.q

  IV. List all existing grid engine profiles

      sge list

  V. Export all existing grid engine profiles

      sge export sge.export.tar.gz

  VI. Export certain existing grid engine profiles

      sge export queue1.q sge.export.tar.gz

      sge export queue1.q queue2.q sge.export.tar.gz

Options:
  --help  Show this message and exit.

Commands:
  configure  Configures profiles.
  create     Creates profiles.
  export     Export profiles.
  list       Lists profiles.
  restart    Restarts profiles.
```