### PR TITLE
Issue 3285 change approach to scan tool

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/docker/scan/AggregatingToolScanManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/scan/AggregatingToolScanManager.java
@@ -41,7 +41,6 @@ import com.epam.pipeline.manager.docker.ToolVersionManager;
 import com.epam.pipeline.manager.docker.scan.clair.ClairScanRequest;
 import com.epam.pipeline.manager.docker.scan.clair.ClairScanResult;
 import com.epam.pipeline.manager.docker.scan.clair.ClairService;
-import com.epam.pipeline.manager.docker.scan.dockercompscan.DockerComponentLayerScanResult;
 import com.epam.pipeline.manager.docker.scan.dockercompscan.DockerComponentScanRequest;
 import com.epam.pipeline.manager.docker.scan.dockercompscan.DockerComponentScanResult;
 import com.epam.pipeline.manager.docker.scan.dockercompscan.DockerComponentScanService;
@@ -55,9 +54,11 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.OkHttpClient;
+import okhttp3.ResponseBody;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -79,6 +80,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -147,7 +149,7 @@ public class AggregatingToolScanManager implements ToolScanManager {
 
     }
 
-    private <T> T initClient(StringPreference clientUrl, Class<T> serviceType) {
+    private <T> T initClient(final StringPreference clientUrl, final Class<T> serviceType) {
         String baseUrl = preferenceManager.getPreference(clientUrl);
 
         T service = null;
@@ -185,20 +187,20 @@ public class AggregatingToolScanManager implements ToolScanManager {
         return service;
     }
 
-    public ToolVersionScanResult scanTool(Tool tool, String tag, Boolean rescan)
+    public ToolVersionScanResult scanTool(final Tool tool, final String tag, final Boolean rescan)
             throws ToolScanExternalServiceException {
         DockerRegistry registry = dockerRegistryManager.load(tool.getRegistryId());
         Optional<ToolVersionScanResult> actualScan = rescan ? Optional.empty() : getActualScan(tool, tag, registry);
         return actualScan.isPresent() ? actualScan.get() : doScan(tool, tag, registry);
     }
 
-    public ToolVersionScanResult scanTool(Long toolId, String tag, Boolean rescan)
+    public ToolVersionScanResult scanTool(final Long toolId, final String tag, final Boolean rescan)
             throws ToolScanExternalServiceException {
         Tool tool = toolManager.load(toolId);
         return scanTool(tool, tag, rescan);
     }
 
-    public ToolExecutionCheckStatus checkTool(Tool tool, String tag) {
+    public ToolExecutionCheckStatus checkTool(final Tool tool, final String tag) {
         final Optional<ToolVersionScanResult> versionScanOp =
                 toolScanInfoManager.loadToolVersionScanInfo(tool.getId(), tag);
         return checkStatus(tool, tag, versionScanOp);
@@ -302,48 +304,39 @@ public class AggregatingToolScanManager implements ToolScanManager {
 
     private ToolVersionScanResult doScan(final Tool tool, final String tag, final DockerRegistry registry)
             throws ToolScanExternalServiceException {
-
-        if (clairService == null) {
-            LOGGER.error("Clair service is not configured!");
-            ToolVersionScanResult result = new ToolVersionScanResult();
-            result.setToolId(tool.getId());
-            result.setVersion(tag);
-            result.setStatus(ToolScanStatus.NOT_SCANNED);
-            return result;
-        }
-
         try {
-            final String clairRef = scanLayers(tool, tag, registry);
+            final String lastLayerRef = scanLayers(tool, tag, registry);
             final DockerClient client = getDockerClient(tool.getImage(), registry);
             final String digest = client.getVersionAttributes(registry, tool.getImage(), tag).getDigest();
             final List<ImageHistoryLayer> imageHistory = client.getImageHistory(registry, tool.getImage(), tag);
             final boolean hasCudnnVersion = hasCudnnVersion(client, registry, tool.getImage(), tag);
             final String defaultCmd = toolManager.loadToolDefaultCommand(imageHistory);
-
-            final ClairScanResult clairResult = getScanResult(tool, clairService.getScanResult(clairRef));
-            final DockerComponentScanResult dockerScanResult = dockerComponentService == null ? null :
-                    getScanResult(tool, dockerComponentService.getScanResult(clairRef));
-            return convertResults(clairResult, dockerScanResult, tool,
-                    tag, digest, defaultCmd, imageHistory.size(), hasCudnnVersion);
+            return gatherResults(tool, tag, lastLayerRef, digest, defaultCmd, imageHistory.size(), hasCudnnVersion);
         } catch (IOException e) {
             throw new ToolScanExternalServiceException(tool, e);
         }
     }
 
-    private <T> T getScanResult(final Tool tool,
-                                final Call<T> call) throws IOException, ToolScanExternalServiceException {
-        Response<T> response = call.execute();
-        if (!response.isSuccessful()) {
-            String error = response.errorBody() != null
-                    ? "Clair error: " + response.errorBody().string() : "";
-            throw new ToolScanExternalServiceException(tool, error);
+    private <T> Pair<Boolean, T> getScanResult(final boolean initialized,
+                                               final Supplier<Call<T>> call) throws IOException {
+        if (!initialized) {
+            return Pair.of(false, null);
         }
-        return response.body();
+
+        final Response<T> response = call.get().execute();
+        if (!response.isSuccessful()) {
+            try (ResponseBody erroredBody = response.errorBody()) {
+                LOGGER.error(erroredBody != null ? "Error while getting scan result: " + erroredBody.string() : "");
+                return Pair.of(false, null);
+            }
+        }
+        return Pair.of(true, response.body());
     }
 
     private Optional<ToolVersionScanResult> getActualScan(Tool tool, String tag, DockerRegistry registry) {
         Optional<ToolVersionScanResult> versionScanResult = toolManager.loadToolVersionScan(tool.getId(), tag);
-        if (versionScanResult.isPresent() && versionScanResult.get().getLastLayerRef() != null) {
+        if (versionScanResult.isPresent() && versionScanResult.get().getLastLayerRef() != null
+                && versionScanResult.get().getStatus() != ToolScanStatus.FAILED) {
             ToolVersionScanResult vs = versionScanResult.get();
             LOGGER.info(messageHelper.getMessage(MessageConstants.INFO_TOOL_SCAN_ALREADY_SCANNED, tool.getImage()));
             DockerClient dockerClient = getDockerClient(tool.getImage(), registry);
@@ -361,58 +354,76 @@ public class AggregatingToolScanManager implements ToolScanManager {
         return Optional.empty();
     }
 
-    private String scanLayers(Tool tool, String tag, DockerRegistry registry)
+    private String scanLayers(final Tool tool, final String tag, final DockerRegistry registry)
         throws IOException, ToolScanExternalServiceException {
-        List<String> layers = fetchLayers(tool, tag, registry);
+        final List<String> layers = fetchLayers(tool, tag, registry);
 
         String lastLayer = null;
         for (int i = 0; i < layers.size(); i++) {
+            LOGGER.debug("Scanning {}:{}, started for {} of {} layers", tool.getImage(), tag, i + 1, layers.size());
             String layerDigest = layers.get(i);
             // Debug: use "172.31.38.143:5000" as registry path
-            Response<ClairScanRequest> clairResp;
-            Response<DockerComponentLayerScanResult> dockerCompResp;
             String layerRef = getLayerName(tool.getImage(), tag);
 
-            ClairScanRequest clairRequest;
-            DockerComponentScanRequest dockerComponentScanRequest;
+            executeClairLayerScan(tool, tag, registry, lastLayer, layerDigest, layerRef);
+            executeDockerCompLayerScan(tool, tag, registry, lastLayer, layerDigest, layerRef);
 
-            if (registry.isPipelineAuth()) {
-                clairRequest = new ClairScanRequest(layerRef, layerDigest, registry.getPath(),
-                        tool.getImage(), lastLayer, dockerRegistryManager.getImageToken(registry, tool.getImage()));
-                dockerComponentScanRequest = new DockerComponentScanRequest(layerRef, layerDigest, registry.getPath(),
-                        tool.getImage(), lastLayer, dockerRegistryManager.getImageToken(registry, tool.getImage()));
-            } else {
-                clairRequest = new ClairScanRequest(layerRef, layerDigest, registry.getPath(),
-                        tool.getImage(), lastLayer, registry.getUserName(), registry.getPassword());
-                dockerComponentScanRequest = new DockerComponentScanRequest(layerRef, layerDigest, registry.getPath(),
-                        tool.getImage(), lastLayer, registry.getUserName(), registry.getPassword());
-            }
-
-            clairResp = clairService.scanLayer(clairRequest).execute();
-            dockerCompResp = dockerComponentService == null ? null :
-                    dockerComponentService.scanLayer(dockerComponentScanRequest).execute();
-
-            if (!clairResp.isSuccessful()) {
-                String errorBody = clairResp.errorBody() != null ? clairResp.errorBody().string() : null;
-                throw new ToolScanExternalServiceException(tool,
-                        String.format("Service: %s : Failed on %d of %d layers: %s:%s response code: %d",
-                        ClairService.class, i + 1, layers.size(), clairResp.message(), errorBody, clairResp.code()));
-            }
-            if (dockerCompResp != null && !dockerCompResp.isSuccessful()) {
-                String errorBody = dockerCompResp.errorBody() != null ? dockerCompResp.errorBody().string() : null;
-                throw new ToolScanExternalServiceException(tool,
-                        String.format("Service: %s : Failed on %d of %d layers: %s:%s response code: %d",
-                        DockerComponentScanService.class, i + 1, layers.size(), dockerCompResp.message(),
-                                errorBody, dockerCompResp.code()));
-            }
-
-            ClairScanRequest clairFulfilled = clairResp.body();
-
-            lastLayer = clairFulfilled.getLayer().getName();
-            LOGGER.debug("Scanning {}:{}, done {} of {} layers", tool.getImage(), tag, i + 1, layers.size());
+            lastLayer = layerRef;
         }
-
+        LOGGER.debug("Scanning {}:{} done.", tool.getImage(), tag);
         return lastLayer;
+    }
+
+    private void executeDockerCompLayerScan(final Tool tool, final String tag, final DockerRegistry registry,
+                                            final String lastLayer, final String layerDigest, final String layerRef)
+            throws IOException {
+        if (dockerComponentService == null) {
+            return;
+        }
+        final DockerComponentScanRequest dockerComponentScanRequest;
+        if (registry.isPipelineAuth()) {
+            dockerComponentScanRequest = new DockerComponentScanRequest(layerRef, layerDigest, registry.getPath(),
+                    tool.getImage(), lastLayer, dockerRegistryManager.getImageToken(registry, tool.getImage()));
+        } else {
+            dockerComponentScanRequest = new DockerComponentScanRequest(layerRef, layerDigest, registry.getPath(),
+                    tool.getImage(), lastLayer, registry.getUserName(), registry.getPassword());
+        }
+        checkExecutionStatus(
+                dockerComponentService.scanLayer(dockerComponentScanRequest).execute(), tool.getImage(), tag, layerRef);
+
+    }
+
+    private void executeClairLayerScan(final Tool tool, final String tag, final DockerRegistry registry,
+                                       final String prevLayer, final String layerDigest, final String layerRef)
+            throws IOException {
+        if (clairService == null) {
+            return;
+        }
+        final ClairScanRequest clairRequest;
+        if (registry.isPipelineAuth()) {
+            clairRequest = new ClairScanRequest(layerRef, layerDigest, registry.getPath(),
+                    tool.getImage(), prevLayer, dockerRegistryManager.getImageToken(registry, tool.getImage()));
+        } else {
+            clairRequest = new ClairScanRequest(layerRef, layerDigest, registry.getPath(),
+                    tool.getImage(), prevLayer, registry.getUserName(), registry.getPassword());
+        }
+        checkExecutionStatus(clairService.scanLayer(clairRequest).execute(), tool.getImage(), tag, layerRef);
+    }
+
+    private <T> void checkExecutionStatus(final Response<T> response, final String image,
+                                          final String tag, final String layerRef) throws IOException {
+        if (!response.isSuccessful()) {
+            try (ResponseBody error = response.errorBody()) {
+                final String errorBody = error != null ? error.string() : null;
+                LOGGER.error(
+                        String.format(
+                                "Service: %s : Failed for %s:%s on %s layer: %s:%s response code: %d",
+                                ClairService.class, image, tag, layerRef, response.message(),
+                                errorBody, response.code()
+                        )
+                );
+            }
+        }
     }
 
     private List<String> fetchLayers(Tool tool, String tag, DockerRegistry registry)
@@ -424,7 +435,7 @@ public class AggregatingToolScanManager implements ToolScanManager {
 
         return manifest.getLayers()
             .stream()
-            .map(c -> c.getDigest())
+            .map(ManifestV2.Config::getDigest)
             .collect(Collectors.toList());
     }
 
@@ -433,49 +444,62 @@ public class AggregatingToolScanManager implements ToolScanManager {
         return dockerClientFactory.getDockerClient(registry, token);
     }
 
-    private ToolVersionScanResult convertResults(final ClairScanResult clairScanResult,
-                                                 final DockerComponentScanResult compScanResult,
-                                                 final Tool tool,
-                                                 final String tag,
-                                                 final String digest,
-                                                 final String defaultCmd,
-                                                 final int layersCount,
-                                                 final boolean hasCudnnVersion) {
+    private ToolVersionScanResult gatherResults(final Tool tool, final String tag,
+                                                final String lastLayerRef, final String digest,
+                                                final String defaultCmd, final int layersCount,
+                                                final boolean hasCudnnVersion) throws IOException {
+
+        ToolScanStatus toolScanStatus = ToolScanStatus.COMPLETED;
+
+        final Pair<Boolean, ClairScanResult> clairScanResult =
+                getScanResult(clairService != null, () -> clairService.getScanResult(lastLayerRef));
+
+        if (!clairScanResult.getKey()) {
+            toolScanStatus = ToolScanStatus.FAILED;
+        }
+
         final Map<VulnerabilitySeverity, Integer> vulnerabilitiesCount = new HashMap<>();
-        final List<Vulnerability> vulnerabilities = Optional.ofNullable(clairScanResult)
+        final List<Vulnerability> vulnerabilities = Optional.ofNullable(clairScanResult.getValue())
                 .map(result -> ListUtils.emptyIfNull(result.getFeatures()).stream())
                 .orElse(Stream.empty())
-            .flatMap(f -> f.getVulnerabilities() != null ? f.getVulnerabilities().stream().map(v -> {
-                Vulnerability vulnerability = new Vulnerability();
-                vulnerability.setName(v.getName());
-                vulnerability.setDescription(v.getDescription());
-                vulnerability.setFixedBy(v.getFixedBy());
-                vulnerability.setLink(v.getLink());
-                vulnerability.setSeverity(v.getSeverity());
-                vulnerability.setFeature(f.getName());
-                vulnerability.setFeatureVersion(f.getVersion());
-                vulnerabilitiesCount.merge(v.getSeverity(), 1,  (oldVal, newVal) -> oldVal + 1);
-                return vulnerability;
-            }) : Stream.empty())
-            .collect(Collectors.toList());
+                .flatMap(f -> f.getVulnerabilities() != null ? f.getVulnerabilities().stream().map(v -> {
+                    Vulnerability vulnerability = new Vulnerability();
+                    vulnerability.setName(v.getName());
+                    vulnerability.setDescription(v.getDescription());
+                    vulnerability.setFixedBy(v.getFixedBy());
+                    vulnerability.setLink(v.getLink());
+                    vulnerability.setSeverity(v.getSeverity());
+                    vulnerability.setFeature(f.getName());
+                    vulnerability.setFeatureVersion(f.getVersion());
+                    vulnerabilitiesCount.merge(v.getSeverity(), 1,  (oldVal, newVal) -> oldVal + 1);
+                    return vulnerability;
+                }) : Stream.empty())
+                .collect(Collectors.toList());
 
         LOGGER.debug("Found: " + vulnerabilities.size() + " vulnerabilities for " + tool.getImage() + ":" + tag);
 
+        final Pair<Boolean, DockerComponentScanResult> compScanResult = getScanResult(
+                dockerComponentService != null, () -> dockerComponentService.getScanResult(lastLayerRef));
+
+        if (!compScanResult.getKey()) {
+            toolScanStatus = ToolScanStatus.FAILED;
+        }
+
         //Concat dependencies from Clair and DockerCompScan
         final List<ToolDependency> dependencies = Stream.concat(
-                Optional.ofNullable(compScanResult).map(result ->
-                                ListUtils.emptyIfNull(result.getLayers()).stream())
-                        .orElse(Stream.empty())
-                        .flatMap(l -> l.getDependencies().stream().peek(dependency -> {
-                            dependency.setToolVersion(tag);
-                            dependency.setToolId(tool.getId());
-                        })),
+            Optional.ofNullable(compScanResult.getValue()).map(result ->
+                            ListUtils.emptyIfNull(result.getLayers()).stream())
+                    .orElse(Stream.empty())
+                    .flatMap(l -> l.getDependencies().stream().peek(dependency -> {
+                        dependency.setToolVersion(tag);
+                        dependency.setToolId(tool.getId());
+                    })),
 
-                Optional.ofNullable(clairScanResult).map(result -> ListUtils.emptyIfNull(result.getFeatures())
-                        .stream())
-                        .orElse(Stream.empty())
-                        .map(f -> new ToolDependency(tool.getId(), tag, f.getName(),
-                                f.getVersion(), ToolDependency.Ecosystem.SYSTEM, null))
+            Optional.ofNullable(clairScanResult.getValue()).map(result -> ListUtils.emptyIfNull(result.getFeatures())
+                    .stream())
+                    .orElse(Stream.empty())
+                    .map(f -> new ToolDependency(tool.getId(), tag, f.getName(),
+                            f.getVersion(), ToolDependency.Ecosystem.SYSTEM, null))
         ).distinct().collect(Collectors.toList());
 
         LOGGER.debug("Found: " + dependencies.size() + " dependencies for " + tool.getImage() + ":" + tag);
@@ -488,7 +512,7 @@ public class AggregatingToolScanManager implements ToolScanManager {
         final boolean cudaAvailable = hasCudnnVersion && hasNvidiaInstalled(dependencies, tool, tag);
 
         final ToolVersionScanResult result = new ToolVersionScanResult(tag, osVersion, vulnerabilities,
-                dependencies, ToolScanStatus.COMPLETED, clairScanResult.getName(), digest, defaultCmd, layersCount);
+                dependencies, toolScanStatus, lastLayerRef, digest, defaultCmd, layersCount);
         result.setVulnerabilitiesCount(vulnerabilitiesCount);
         result.setCudaAvailable(cudaAvailable);
         return result;

--- a/api/src/main/java/com/epam/pipeline/manager/docker/scan/ToolScanSchedulerCore.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/scan/ToolScanSchedulerCore.java
@@ -170,7 +170,9 @@ class ToolScanSchedulerCore {
                     toolManager.updateToolVulnerabilities(scanResult.getVulnerabilities(), tool.getId(),
                             version);
                     toolManager.updateToolDependencies(scanResult.getDependencies(), tool.getId(), version);
-                    toolManager.updateToolVersionScanStatus(tool.getId(), ToolScanStatus.COMPLETED,
+                    final ToolScanStatus effectiveScanStatus = scanResult.getStatus() != null
+                            ? scanResult.getStatus() : ToolScanStatus.COMPLETED;
+                    toolManager.updateToolVersionScanStatus(tool.getId(), effectiveScanStatus,
                             scanResult.getScanDate(), version, scanResult.getToolOSVersion(),
                             scanResult.getLastLayerRef(), scanResult.getDigest(), scanResult.getVulnerabilitiesCount(),
                             scanResult.getDefaultCmd(), scanResult.getLayersCount(), scanResult.isCudaAvailable());

--- a/api/src/test/java/com/epam/pipeline/manager/docker/scan/AggregatingToolScanManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/docker/scan/AggregatingToolScanManagerTest.java
@@ -23,6 +23,7 @@ import com.epam.pipeline.entity.docker.ToolVersion;
 import com.epam.pipeline.entity.docker.ToolVersionAttributes;
 import com.epam.pipeline.entity.pipeline.DockerRegistry;
 import com.epam.pipeline.entity.pipeline.Tool;
+import com.epam.pipeline.entity.pipeline.ToolScanStatus;
 import com.epam.pipeline.entity.preference.Preference;
 import com.epam.pipeline.entity.scan.*;
 import com.epam.pipeline.entity.user.PipelineUser;
@@ -49,6 +50,8 @@ import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.manager.security.AuthManager;
 import com.epam.pipeline.util.TestUtils;
 import okhttp3.Request;
+import okhttp3.internal.http.RealResponseBody;
+import okio.Buffer;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -63,7 +66,10 @@ import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -86,6 +92,7 @@ public class AggregatingToolScanManagerTest {
     public static final String DIGEST_3 = "digest3";
     private static final String TEST_LABEL_NAME = "label-name";
     private static final String TEST_LABEL_VALUE = "label-value";
+    private static final int ERROR_CODE = 500;
 
     @InjectMocks
     private AggregatingToolScanManager aggregatingToolScanManager = new AggregatingToolScanManager();
@@ -287,6 +294,8 @@ public class AggregatingToolScanManagerTest {
         when(toolManager.loadToolVersionAttributes(Mockito.anyLong(), Mockito.anyString()))
             .thenReturn(new ToolVersionAttributes());
         ToolVersionScanResult result = aggregatingToolScanManager.scanTool(testTool, LATEST_VERSION, false);
+        Assert.assertEquals(ToolScanStatus.COMPLETED, result.getStatus());
+
         Assert.assertTrue(result.isCudaAvailable());
 
         Assert.assertFalse(result.getVulnerabilities().isEmpty());
@@ -357,6 +366,47 @@ public class AggregatingToolScanManagerTest {
         when(toolScanInfoManager.loadToolVersionScanInfo(testTool.getId(), LATEST_VERSION))
                 .thenReturn(Optional.of(scanResult));
         Assert.assertTrue(aggregatingToolScanManager.checkTool(testTool, LATEST_VERSION).isAllowed());
+    }
+
+    @Test
+    public void testThatScanIsPerformedEvenIfClairFails() throws ToolScanExternalServiceException {
+        when(clairService.getScanResult(Mockito.anyString())).thenReturn(new MockCall<>(true));
+        when(toolManager.loadToolVersionAttributes(Mockito.anyLong(), Mockito.anyString()))
+                .thenReturn(new ToolVersionAttributes());
+
+        ToolVersionScanResult result = aggregatingToolScanManager.scanTool(testTool, LATEST_VERSION, false);
+
+        Assert.assertEquals(ToolScanStatus.FAILED, result.getStatus());
+        List<ToolDependency> dependencies = result.getDependencies();
+        Assert.assertEquals(2, dependencies.size());
+    }
+
+    @Test
+    public void testThatScanIsPerformedEvenIfClairFailsToScan() throws ToolScanExternalServiceException {
+        when(clairService.scanLayer(Mockito.any())).thenReturn(new MockCall<>(true));
+        when(clairService.getScanResult(Mockito.anyString())).thenReturn(new MockCall<>(true));
+        when(toolManager.loadToolVersionAttributes(Mockito.anyLong(), Mockito.anyString()))
+                .thenReturn(new ToolVersionAttributes());
+
+        ToolVersionScanResult result = aggregatingToolScanManager.scanTool(testTool, LATEST_VERSION, false);
+
+        Assert.assertEquals(ToolScanStatus.FAILED, result.getStatus());
+        List<ToolDependency> dependencies = result.getDependencies();
+        Assert.assertEquals(2, dependencies.size());
+    }
+
+    @Test
+    public void testThatScanIsPerformedEvenIfDockerCompFails() throws ToolScanExternalServiceException {
+        when(compScanService.getScanResult(Mockito.anyString())).thenReturn(new MockCall<>(true));
+        when(toolManager.loadToolVersionAttributes(Mockito.anyLong(), Mockito.anyString()))
+                .thenReturn(new ToolVersionAttributes());
+
+        ToolVersionScanResult result = aggregatingToolScanManager.scanTool(testTool, LATEST_VERSION, false);
+
+        // Check that even that status is FAILED we still get vulnerabilities from clair
+        Assert.assertEquals(ToolScanStatus.FAILED, result.getStatus());
+        Assert.assertEquals(1, result.getVulnerabilities().size());
+        Assert.assertEquals(1, result.getVulnerabilities().stream().map(Vulnerability::getFeature).count());
     }
 
     @Test
@@ -463,15 +513,26 @@ public class AggregatingToolScanManagerTest {
     }
 
     private final class MockCall<T> implements Call<T> {
+        private final boolean errored;
         private T payload;
 
         private MockCall(T payload) {
             this.payload = payload;
+            this.errored = false;
+        }
+
+        private MockCall(boolean errored) {
+            this.errored = errored;
         }
 
         @Override
         public Response<T> execute() {
-            return Response.success(payload);
+            if (!errored) {
+                return Response.success(payload);
+            } else {
+                return Response.error(ERROR_CODE,
+                        new RealResponseBody(null, 0, new Buffer()));
+            }
         }
 
         @Override


### PR DESCRIPTION
Now we scan tool independently in Docker Comp and Clair services.
If any of these services will fail, results of another one will be persisted any way.