### PR TITLE
Issue #3270: Add CUDA availability check when GPU instance is launched - Fix

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/scan/ToolDependency.java
+++ b/api/src/main/java/com/epam/pipeline/entity/scan/ToolDependency.java
@@ -66,6 +66,7 @@ public class ToolDependency {
             map.put(R_PKG.value, R_PKG);
             map.put(OS.value, OS);
             map.put(SYSTEM.value, SYSTEM);
+            map.put(NVIDIA.value, NVIDIA);
         }
 
         private String value;

--- a/docker-comp-scan/src/main/java/com/epam/dockercompscan/owasp/analyzer/NvidiaCudaAnalyzer.java
+++ b/docker-comp-scan/src/main/java/com/epam/dockercompscan/owasp/analyzer/NvidiaCudaAnalyzer.java
@@ -31,16 +31,17 @@ import org.owasp.dependencycheck.utils.FileFilterBuilder;
 import java.io.FileFilter;
 
 @Experimental
-public class NvidiaVersionAnalyzer extends AbstractFileTypeAnalyzer {
+public class NvidiaCudaAnalyzer extends AbstractFileTypeAnalyzer {
     public static final String DEPENDENCY_ECOSYSTEM = "Nvidia";
     public static final String NVIDIA_VERSION_ANALYZER_ENABLED = AnalyzeEnabler.ANALYZER_NVIDIA_PACKAGE.getValue();
-    static final String DEPENDENCY_NAME = "NvidiaVersion";
-    private static final String NVIDIA_VERSION_ANALYZER_NAME = "Nvidia Version Analyzer";
-    private static final String NVIDIA_VERSION_PATH = "/**/proc/driver/nvidia/version";
-    private static final String EVIDENCE_SOURCE = "version";
+    static final String DEPENDENCY_NAME = "NvidiaCuda";
+    private static final String NVIDIA_VERSION_ANALYZER_NAME = "Nvidia Cuda Analyzer";
+    private static final String NVIDIA_VERSION_PATH = "/**/usr/local/cuda-*/targets/x86_64-linux/lib/libcuda*.so.*";
+    private static final String EVIDENCE_SOURCE = "cuda";
     private static final String EVIDENCE_VALUE = "found";
     private static final FilePathGlobFilter NAME_FILE_FILTER = new FilePathGlobFilter(NVIDIA_VERSION_PATH);
     private static final FileFilter FILTER = FileFilterBuilder.newInstance().addFileFilters(NAME_FILE_FILTER).build();
+    private static final AnalysisPhase ANALYSIS_PHASE = AnalysisPhase.INFORMATION_COLLECTION;
 
     @Override
     protected FileFilter getFileFilter() {
@@ -71,6 +72,6 @@ public class NvidiaVersionAnalyzer extends AbstractFileTypeAnalyzer {
 
     @Override
     public AnalysisPhase getAnalysisPhase() {
-        return AnalysisPhase.INFORMATION_COLLECTION;
+        return ANALYSIS_PHASE;
     }
 }

--- a/docker-comp-scan/src/main/resources/META-INF/services/org.owasp.dependencycheck.analyzer.Analyzer
+++ b/docker-comp-scan/src/main/resources/META-INF/services/org.owasp.dependencycheck.analyzer.Analyzer
@@ -32,4 +32,4 @@ org.owasp.dependencycheck.analyzer.SwiftPackageManagerAnalyzer
 org.owasp.dependencycheck.analyzer.VersionFilterAnalyzer
 com.epam.dockercompscan.owasp.analyzer.RPackageAnalyzer
 com.epam.dockercompscan.owasp.analyzer.OSVersionAnalyzer
-com.epam.dockercompscan.owasp.analyzer.NvidiaVersionAnalyzer
+com.epam.dockercompscan.owasp.analyzer.NvidiaCudaAnalyzer

--- a/docker-comp-scan/src/test/java/com/epam/dockercompscan/owasp/analyzer/NvidiaCudaAnalyzerTest.java
+++ b/docker-comp-scan/src/test/java/com/epam/dockercompscan/owasp/analyzer/NvidiaCudaAnalyzerTest.java
@@ -21,15 +21,15 @@ import org.junit.Test;
 import org.owasp.dependencycheck.analyzer.exception.AnalysisException;
 import org.owasp.dependencycheck.dependency.Dependency;
 
-public class NvidiaVersionAnalyzerTest {
-    private final NvidiaVersionAnalyzer nvidiaVersionAnalyzer = new NvidiaVersionAnalyzer();
+public class NvidiaCudaAnalyzerTest {
+    private final NvidiaCudaAnalyzer nvidiaCudaAnalyzer = new NvidiaCudaAnalyzer();
 
     @Test
     public void shouldAnalyzeNvidiaVersion() throws AnalysisException {
         final Dependency dependency = new Dependency();
-        nvidiaVersionAnalyzer.analyzeDependency(dependency, null);
+        nvidiaCudaAnalyzer.analyzeDependency(dependency, null);
 
-        Assert.assertEquals(NvidiaVersionAnalyzer.DEPENDENCY_ECOSYSTEM, dependency.getEcosystem());
-        Assert.assertEquals(NvidiaVersionAnalyzer.DEPENDENCY_NAME, dependency.getName());
+        Assert.assertEquals(NvidiaCudaAnalyzer.DEPENDENCY_ECOSYSTEM, dependency.getEcosystem());
+        Assert.assertEquals(NvidiaCudaAnalyzer.DEPENDENCY_NAME, dependency.getName());
     }
 }


### PR DESCRIPTION
The current PR relates with issue #3270 and provides fix for `docker-comp-scan` service.