### PR TITLE
Add support for storage level contextual preferences

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/datastorage/DataStorageApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/datastorage/DataStorageApiService.java
@@ -226,19 +226,18 @@ public class DataStorageApiService {
         return dataStorageManager.create(dataStorageVO, proceedOnCloud, true, true, skipPolicy);
     }
 
-    @PreAuthorize("hasRole('ADMIN') OR @storagePermissionManager.storagePermissionById(#dataStorageVO.id, 'OWNER')")
+    @PreAuthorize(AclExpressions.STORAGE_MGMT_UPDATE)
     @AclMask
-    public AbstractDataStorage update(DataStorageVO dataStorageVO) {
-        return dataStorageManager.update(dataStorageVO);
+    public AbstractDataStorage update(DataStorageVO storage) {
+        return dataStorageManager.update(storage);
     }
 
-    @PreAuthorize("hasRole('ADMIN') OR @storagePermissionManager.storagePermissionById(#dataStorageVO.id, 'OWNER')")
-    public AbstractDataStorage updatePolicy(DataStorageVO dataStorageVO) {
-        return dataStorageManager.updatePolicy(dataStorageVO);
+    @PreAuthorize(AclExpressions.STORAGE_MGMT_UPDATE)
+    public AbstractDataStorage updatePolicy(DataStorageVO storage) {
+        return dataStorageManager.updatePolicy(storage);
     }
 
-    @PreAuthorize("hasRole('ADMIN') OR (hasRole('STORAGE_MANAGER') AND "
-            + "@storagePermissionManager.storagePermissionById(#id, 'OWNER'))")
+    @PreAuthorize(AclExpressions.STORAGE_ID_MGMT_DELETE)
     public AbstractDataStorage delete(Long id, boolean proceedOnCloud) {
         return dataStorageManager.delete(id, proceedOnCloud);
     }

--- a/api/src/main/java/com/epam/pipeline/entity/contextual/ContextualPreferenceLevel.java
+++ b/api/src/main/java/com/epam/pipeline/entity/contextual/ContextualPreferenceLevel.java
@@ -54,7 +54,14 @@ public enum ContextualPreferenceLevel {
      *
      * It is translated to a system preference.
      */
-    SYSTEM(3);
+    SYSTEM(3),
+
+    /**
+     * Storage contextual preference level.
+     *
+     * It is associated with a single storage.
+     */
+    STORAGE(4);
 
     private final long id;
 

--- a/api/src/main/java/com/epam/pipeline/manager/contextual/ContextualPreferenceManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/contextual/ContextualPreferenceManager.java
@@ -101,7 +101,7 @@ public class ContextualPreferenceManager {
      *
      * Returns a first found preference from the list of preferences.
      *
-     * Methods takes into account the context preference was searched in. It includes
+     * Method takes into account the context preference was searched in. It includes
      * user, its role, requested resource, etc.
      *
      * @param preferences List of preference names.
@@ -115,8 +115,6 @@ public class ContextualPreferenceManager {
         }
         validateNames(preferences);
         validateResource(resource);
-        Assert.isTrue(resource.getLevel() == ContextualPreferenceLevel.TOOL, messageHelper.getMessage(
-                MessageConstants.ERROR_SEARCH_CONTEXTUAL_PREFERENCE_EXTERNAL_RESOURCE_LEVEL_INVALID));
         return contextualPreferenceHandler.search(preferences, resources(resource))
                 .orElseThrow(() -> new IllegalArgumentException(messageHelper.getMessage(
                         MessageConstants.ERROR_CONTEXTUAL_PREFERENCE_NOT_FOUND, preferences, resource)));
@@ -127,7 +125,7 @@ public class ContextualPreferenceManager {
      *
      * Returns a first found preference from the list of preferences.
      *
-     * Methods takes into account the context preference was searched in. It includes
+     * Method takes into account the context preference was searched in. It includes
      * user, its role, etc.
      *
      * @param preferences List of preference names.

--- a/api/src/main/java/com/epam/pipeline/manager/contextual/handler/BooleanContextualPreferenceReducer.java
+++ b/api/src/main/java/com/epam/pipeline/manager/contextual/handler/BooleanContextualPreferenceReducer.java
@@ -1,0 +1,28 @@
+package com.epam.pipeline.manager.contextual.handler;
+
+import com.epam.pipeline.entity.contextual.ContextualPreference;
+import org.apache.commons.lang3.BooleanUtils;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BinaryOperator;
+
+public class BooleanContextualPreferenceReducer implements ContextualPreferenceReducer {
+
+    private final BinaryOperator<Boolean> reducer = (left, right) -> left || right;
+
+    @Override
+    public Optional<ContextualPreference> reduce(final List<ContextualPreference> preferences) {
+        if (preferences.isEmpty()) {
+            return Optional.empty();
+        }
+        final boolean value = preferences.stream()
+                .map(ContextualPreference::getValue)
+                .map(BooleanUtils::toBoolean)
+                .reduce(false, reducer);
+        return Optional.of(preferences.get(0)
+                .withValue(BooleanUtils.toString(value, "true", "false"))
+                .withCreatedDate(null)
+                .withResource(null));
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/contextual/handler/StorageContextualPreferenceHandler.java
+++ b/api/src/main/java/com/epam/pipeline/manager/contextual/handler/StorageContextualPreferenceHandler.java
@@ -1,0 +1,35 @@
+package com.epam.pipeline.manager.contextual.handler;
+
+import com.epam.pipeline.dao.contextual.ContextualPreferenceDao;
+import com.epam.pipeline.dao.datastorage.DataStorageDao;
+import com.epam.pipeline.entity.contextual.ContextualPreference;
+import com.epam.pipeline.entity.contextual.ContextualPreferenceLevel;
+import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
+
+/**
+ * Storage contextual preference handler.
+ *
+ * It handles preferences with {@link ContextualPreferenceLevel#STORAGE} level.
+ * Handler associates preference with a single {@link AbstractDataStorage} entity.
+ */
+public class StorageContextualPreferenceHandler extends AbstractDaoContextualPreferenceHandler {
+
+    private final DataStorageDao storageDao;
+
+    public StorageContextualPreferenceHandler(final DataStorageDao storageDao,
+                                              final ContextualPreferenceDao contextualPreferenceDao,
+                                              final ContextualPreferenceHandler nextHandler) {
+        super(ContextualPreferenceLevel.STORAGE, nextHandler, contextualPreferenceDao);
+        this.storageDao = storageDao;
+    }
+
+    public StorageContextualPreferenceHandler(final DataStorageDao storageDao,
+                                              final ContextualPreferenceDao contextualPreferenceDao) {
+        this(storageDao, contextualPreferenceDao, null);
+    }
+
+    @Override
+    boolean externalEntityExists(final ContextualPreference preference) {
+        return storageDao.loadDataStorage(Long.valueOf(preference.getResource().getResourceId())) != null;
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -170,6 +170,8 @@ public class SystemPreferences {
                 "CP_JOB_NAME", "CP_JOB_VERSION", "CP_JOB_CONFIGURATION", "CP_DOCKER_IMAGE", "CP_CALC_CONFIG")),
         new TypeReference<List<String>>() {}, DATA_STORAGE_GROUP,
         isNullOrValidJson(new TypeReference<List<String>>() {}));
+    public static final BooleanPreference DATA_STORAGE_MGMT_RESTRICTED_ACCESS_ENABLED = new BooleanPreference(
+        "storage.mgmt.restricted.access", false, DATA_STORAGE_GROUP, pass);
     public static final IntPreference DATA_STORAGE_MAX_DOWNLOAD_SIZE = new IntPreference(
         "storage.max.download.size", 10000, DATA_STORAGE_GROUP, isGreaterThan(0));
     public static final IntPreference DATA_STORAGE_TEMP_CREDENTIALS_DURATION = new IntPreference(

--- a/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
+++ b/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
@@ -78,6 +78,13 @@ public final class AclExpressions {
             "(" + ADMIN_ONLY + OR + "@storagePermissionManager.storagePermissionById(#id, 'OWNER')" + ")"
             + AND + STORAGE_SHARED;
 
+    public static final String STORAGE_MGMT_UPDATE =
+            ADMIN_ONLY + OR + "@storagePermissionManager.storageMgmtPermission(#storage.id, 'OWNER')";
+
+    public static final String STORAGE_ID_MGMT_DELETE =
+            ADMIN_ONLY + OR + "(" + "hasRole('STORAGE_MANAGER')"
+                + AND + "@storagePermissionManager.storageMgmtPermission(#id, 'OWNER')" + ")";
+
     public static final String STORAGE_ID_TAGS_WRITE =
             "(" + ADMIN_ONLY + OR + "@storagePermissionManager.storageTagsPermission(#id, #tags, 'WRITE')" + ")"
             + AND + STORAGE_SHARED;

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -543,7 +543,6 @@ error.contextual.preference.type.invalid=Contextual preference type ''{0}'' diff
 error.contextual.preference.external.resource.missing=Contextual preference external resource is missing.
 error.contextual.preference.external.resource.level.missing=Contextual preference external resource level is missing.
 error.save.contextual.preference.external.resource.level.invalid=Contextual preference external resource level should not be SYSTEM.
-error.search.contextual.preference.external.resource.level.invalid=Contextual preference external resource level should be TOOL.
 error.contextual.preference.external.resource.id.missing=Contextual preference external resource id is missing.
 error.contextual.preference.external.resource.not.found=Contextual preference external resource ''{0}'' was not found.
 warn.contextual.preference.reducing.failed=Contextual preferences reducing failed because some of the preferences have \

--- a/api/src/test/java/com/epam/pipeline/manager/contextual/ContextualPreferenceManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/contextual/ContextualPreferenceManagerTest.java
@@ -248,15 +248,6 @@ public class ContextualPreferenceManagerTest {
     }
 
     @Test
-    public void searchShouldFailIfPreferenceLevelIsNotTool() {
-        Arrays.stream(ContextualPreferenceLevel.values())
-                .filter(level -> level != ContextualPreferenceLevel.TOOL)
-                .forEach(level ->
-                        assertThrows(IllegalArgumentException.class,
-                            () -> manager.search(NAMES, new ContextualPreferenceExternalResource(level, TOOL_ID))));
-    }
-
-    @Test
     public void searchShouldSearchPreferenceWithResourceConstructedFromTheRequestedResourceIfItIsSpecified() {
         final ContextualPreference preference = new ContextualPreference(NAME, VALUE, toolResource);
         when(contextualPreferenceHandler.search(eq(NAMES), any())).thenReturn(Optional.of(preference));

--- a/api/src/test/java/com/epam/pipeline/manager/contextual/handler/BooleanContextualPreferenceReducerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/contextual/handler/BooleanContextualPreferenceReducerTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.contextual.handler;
+
+import com.epam.pipeline.entity.contextual.ContextualPreference;
+import com.epam.pipeline.entity.contextual.ContextualPreferenceExternalResource;
+import com.epam.pipeline.entity.contextual.ContextualPreferenceLevel;
+import com.nimbusds.jose.util.Pair;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class BooleanContextualPreferenceReducerTest {
+
+    private static final String NAME = "somePreference";
+    private static final ContextualPreferenceLevel LEVEL = ContextualPreferenceLevel.USER;
+    private static final String RESOURCE_ID = "resourceId";
+    private static final String TRUE = "true";
+    private static final String FALSE = "false";
+
+    private final ContextualPreferenceReducer reducer = new BooleanContextualPreferenceReducer();
+
+    @Test
+    public void reduceShouldReturnPreferenceWithTrueValueIfTheGivenListOfPreferencesHasAtLeastOneTrueValue() {
+        final ContextualPreferenceExternalResource resource = new ContextualPreferenceExternalResource(LEVEL,
+                RESOURCE_ID);
+        final ContextualPreference truePreference = new ContextualPreference(NAME, TRUE, resource);
+        final ContextualPreference falsePreference = new ContextualPreference(NAME, FALSE, resource);
+        final List<Pair<List<ContextualPreference>, String>> preferences = Arrays.asList(
+                Pair.of(Arrays.asList(truePreference, truePreference), TRUE),
+                Pair.of(Arrays.asList(truePreference, falsePreference), TRUE),
+                Pair.of(Arrays.asList(falsePreference, truePreference), TRUE),
+                Pair.of(Arrays.asList(falsePreference, falsePreference), FALSE));
+        preferences.stream().collect(Collectors.toMap(Pair::getLeft, Pair::getRight))
+                .forEach((inputs, expectedMergedValue) -> {
+                    final Optional<ContextualPreference> reducedPreference = reducer.reduce(inputs);
+                    assertTrue(reducedPreference.isPresent());
+                    assertThat(reducedPreference.get().getValue(), is(expectedMergedValue));
+                });
+    }
+
+    @Test
+    public void reduceShouldReturnEmptyOptionalIfTheGivenListOfPreferencesIsEmpty() {
+        final Optional<ContextualPreference> reducedPreference = reducer.reduce(Collections.emptyList());
+
+        assertFalse(reducedPreference.isPresent());
+    }
+
+    @Test
+    public void reduceShouldReturnPreferenceWithoutCreatedDateAndResource() {
+        final ContextualPreferenceExternalResource resource = new ContextualPreferenceExternalResource(LEVEL,
+                RESOURCE_ID);
+        final ContextualPreference preference1 = new ContextualPreference(NAME, TRUE, resource);
+        final ContextualPreference preference2 = new ContextualPreference(NAME, FALSE, resource);
+        final List<ContextualPreference> preferences = Arrays.asList(preference1, preference2);
+
+        final Optional<ContextualPreference> reducedPreference = reducer.reduce(preferences);
+
+        assertTrue(reducedPreference.isPresent());
+        assertThat(reducedPreference.get().getCreatedDate(), is(nullValue()));
+        assertThat(reducedPreference.get().getResource(), is(nullValue()));
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/manager/contextual/handler/StorageContextualPreferenceHandlerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/contextual/handler/StorageContextualPreferenceHandlerTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.contextual.handler;
+
+import com.epam.pipeline.dao.datastorage.DataStorageDao;
+import com.epam.pipeline.entity.contextual.ContextualPreference;
+import com.epam.pipeline.entity.contextual.ContextualPreferenceLevel;
+import com.epam.pipeline.entity.datastorage.aws.S3bucketDataStorage;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class StorageContextualPreferenceHandlerTest extends AbstractDaoContextualPreferenceHandlerTest {
+
+    private final DataStorageDao storageDao = mock(DataStorageDao.class);
+
+    @Override
+    public ContextualPreferenceHandler handler() {
+        return new StorageContextualPreferenceHandler(storageDao, contextualPreferenceDao, nextHandler);
+    }
+
+    @Override
+    public ContextualPreferenceHandler lastHandler() {
+        return new StorageContextualPreferenceHandler(storageDao, contextualPreferenceDao);
+    }
+
+    @Override
+    public ContextualPreferenceLevel level() {
+        return ContextualPreferenceLevel.STORAGE;
+    }
+
+    @Test
+    public void isValidShouldReturnFalseIfStorageDoesNotExist() {
+        final ContextualPreference preference = new ContextualPreference(NAME, VALUE, resource);
+        when(storageDao.loadDataStorage(eq(Long.valueOf(RESOURCE_ID)))).thenReturn(null);
+
+        assertFalse(handler().isValid(preference));
+    }
+
+    @Test
+    public void isValidShouldReturnTrueIfStorageExists() {
+        final ContextualPreference preference = new ContextualPreference(NAME, VALUE, resource);
+        when(storageDao.loadDataStorage(eq(Long.valueOf(RESOURCE_ID)))).thenReturn(new S3bucketDataStorage());
+
+        assertTrue(handler().isValid(preference));
+    }
+}


### PR DESCRIPTION
Relates #3289.

The pull request brings several updates to contextual preferences management:
- storage level contextual preferences are added
- contextual preferences can be searched for any type of resource such as tool, storage and etc.
- boolean contextual preferences reducing support is added
