### PR TITLE
Introduce storage management restricted access mode

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/datastorage/DataStorageApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/datastorage/DataStorageApiService.java
@@ -226,19 +226,18 @@ public class DataStorageApiService {
         return dataStorageManager.create(dataStorageVO, proceedOnCloud, true, true, skipPolicy);
     }
 
-    @PreAuthorize("hasRole('ADMIN') OR @storagePermissionManager.storagePermissionById(#dataStorageVO.id, 'OWNER')")
+    @PreAuthorize(AclExpressions.STORAGE_MGMT_UPDATE)
     @AclMask
-    public AbstractDataStorage update(DataStorageVO dataStorageVO) {
-        return dataStorageManager.update(dataStorageVO);
+    public AbstractDataStorage update(DataStorageVO storage) {
+        return dataStorageManager.update(storage);
     }
 
-    @PreAuthorize("hasRole('ADMIN') OR @storagePermissionManager.storagePermissionById(#dataStorageVO.id, 'OWNER')")
-    public AbstractDataStorage updatePolicy(DataStorageVO dataStorageVO) {
-        return dataStorageManager.updatePolicy(dataStorageVO);
+    @PreAuthorize(AclExpressions.STORAGE_MGMT_UPDATE)
+    public AbstractDataStorage updatePolicy(DataStorageVO storage) {
+        return dataStorageManager.updatePolicy(storage);
     }
 
-    @PreAuthorize("hasRole('ADMIN') OR (hasRole('STORAGE_MANAGER') AND "
-            + "@storagePermissionManager.storagePermissionById(#id, 'OWNER'))")
+    @PreAuthorize(AclExpressions.STORAGE_ID_MGMT_DELETE)
     public AbstractDataStorage delete(Long id, boolean proceedOnCloud) {
         return dataStorageManager.delete(id, proceedOnCloud);
     }

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -170,6 +170,8 @@ public class SystemPreferences {
                 "CP_JOB_NAME", "CP_JOB_VERSION", "CP_JOB_CONFIGURATION", "CP_DOCKER_IMAGE", "CP_CALC_CONFIG")),
         new TypeReference<List<String>>() {}, DATA_STORAGE_GROUP,
         isNullOrValidJson(new TypeReference<List<String>>() {}));
+    public static final BooleanPreference DATA_STORAGE_MGMT_RESTRICTED_ACCESS_ENABLED = new BooleanPreference(
+        "storage.mgmt.restricted.access", false, DATA_STORAGE_GROUP, pass);
     public static final IntPreference DATA_STORAGE_MAX_DOWNLOAD_SIZE = new IntPreference(
         "storage.max.download.size", 10000, DATA_STORAGE_GROUP, isGreaterThan(0));
     public static final IntPreference DATA_STORAGE_TEMP_CREDENTIALS_DURATION = new IntPreference(

--- a/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
+++ b/api/src/main/java/com/epam/pipeline/security/acl/AclExpressions.java
@@ -78,6 +78,13 @@ public final class AclExpressions {
             "(" + ADMIN_ONLY + OR + "@storagePermissionManager.storagePermissionById(#id, 'OWNER')" + ")"
             + AND + STORAGE_SHARED;
 
+    public static final String STORAGE_MGMT_UPDATE =
+            ADMIN_ONLY + OR + "@storagePermissionManager.storageMgmtPermission(#storage.id, 'OWNER')";
+
+    public static final String STORAGE_ID_MGMT_DELETE =
+            ADMIN_ONLY + OR + "(" + "hasRole('STORAGE_MANAGER')"
+                + AND + "@storagePermissionManager.storageMgmtPermission(#id, 'OWNER')" + ")";
+
     public static final String STORAGE_ID_TAGS_WRITE =
             "(" + ADMIN_ONLY + OR + "@storagePermissionManager.storageTagsPermission(#id, #tags, 'WRITE')" + ")"
             + AND + STORAGE_SHARED;


### PR DESCRIPTION
Relates #3289 and depends on #3292.

The pull request brings support for storage management restricted access mode.

By default, when storage management restricted access mode is disabled, all users with owner access to a storage are allowed to update or delete it. _Please notice that storage deletion also requires STORAGE_MANAGER role._

In case restricted access mode is enabled, users with storage owner access are not allowed to update or delete a storage.

The following system preference is added:

- `storage.mgmt.restricted.access` enables restricted access mode globally. Defaults to false or default access mode.

Additionally, restricted storage management access mode can be enabled/disabled on a user, group or storage level using `storage.mgmt.restricted.access` contextual preference.
