### PR TITLE
Introduce restricted access in sge utility

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -1124,6 +1124,9 @@ public class SystemPreferences {
             new ObjectPreference<>("ge.autoscaling.scale.multi.queues.template", null,
                     new TypeReference<Map<String, Object>>() {}, GRID_ENGINE_AUTOSCALING_GROUP,
                     isNullOrValidJson(new TypeReference<Map<String, Object>>() {}));
+    public static final StringPreference GE_UTILITY_ALLOWED_GROUPS =
+            new StringPreference("ge.utility.allowed.groups", "ROLE_ADMIN,ROLE_ADVANCED_USER",
+                    GRID_ENGINE_AUTOSCALING_GROUP, pass, true);
 
     //GCP
     public static final ObjectPreference<List<String>> GCP_REGION_LIST = new ObjectPreference<>(

--- a/workflows/pipe-common/pipeline/api/api.py
+++ b/workflows/pipe-common/pipeline/api/api.py
@@ -334,6 +334,9 @@ class PipelineAPI:
         preference = self.get_preference_efficiently(name) or {}
         return preference.get('value')
 
+    def load_current_user_efficiently(self):
+        return self._request('GET', 'whoami')
+
     def _request(self, http_method, endpoint, data=None):
         url = '{}/{}'.format(self.api_url, endpoint)
         count = 0


### PR DESCRIPTION
Resolves #3295.

The pull request brings restricted access to sge utility. From now on only admins and advanced users will have access to sge utility.

The following system preference is introduced:
- `ge.utility.allowed.groups` specifies a comma-separated list of roles which give access to sge utility. Defaults to _ROLE_ADMIN,ROLE_ADVANCED_USER_.
