### PR TITLE
Issue 3298 Reschedule run only if configured

### DIFF
--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -138,6 +138,7 @@ public final class MessageConstants {
     public static final String ERROR_RUN_PARAMETERS_CLOUD_DEPENDENT = "error.run.parameters.cloud.dependent";
     public static final String ERROR_RESTART_CLUSTER_FORBIDDEN = "error.restart.cluster.forbidden";
     public static final String ERROR_RESTART_WORKER_FORBIDDEN = "error.restart.worker.forbidden";
+    public static final String ERROR_RUN_IS_NOT_CONFIGURED_FOR_RESTART = "error.restart.is.not.configured";
     public static final String ERROR_RESTART_RUN_FAILURE = "error.restart.run.failure";
     public static final String INFO_RESTART_RUN_SUCCESS = "info.restart.run.success";
     public static final String ERROR_RUN_START_FAILURE = "error.run.start.failure";

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/AutoscaleManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/AutoscaleManager.java
@@ -520,8 +520,11 @@ public class AutoscaleManager extends AbstractSchedulingManager {
                     final int nodeUpRetryCount = preferenceManager.getPreference(
                             SystemPreferences.CLUSTER_NODEUP_RETRY_COUNT);
 
-                    if (retryCount >= nodeUpRetryCount &&
-                            !pipelineRunManager.findRun(longId).get().getStatus().isFinal()) {
+                    final PipelineRun runToReschedule = pipelineRunManager.findRun(longId)
+                            .orElseThrow(() -> new IllegalArgumentException(
+                                    String.format("Cannot find run by id: %d", longId)));
+
+                    if (retryCount >= nodeUpRetryCount && !runToReschedule.getStatus().isFinal()) {
                         pipelineRunManager.updateStateReasonMessageById(longId, preferenceManager
                                 .getPreference(SystemPreferences.LAUNCH_INSUFFICIENT_CAPACITY_MESSAGE));
                         runRegionShiftHandler.restartRunInAnotherRegion(longId);

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -619,6 +619,10 @@ public class SystemPreferences {
     public static final ObjectPreference<List<DockerMount>> DOCKER_IN_DOCKER_MOUNTS = new ObjectPreference<>(
             "launch.dind.mounts", null, new TypeReference<List<DockerMount>>() {},
             LAUNCH_GROUP, isNullOrValidJson(new TypeReference<List<DockerMount>>() {}));
+
+    public static final BooleanPreference LAUNCH_RUN_RESCHEDULE_ENABLED = new BooleanPreference(
+            "launch.run.reschedule.enabled", true, LAUNCH_GROUP, pass);
+
     /**
      * Specifies a comma-separated list of environment variables that should be inherited by DIND containers
      * from run container.

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -116,6 +116,7 @@ error.run.next.region.not.found=Cannot restart run ''{0}'': no next region avail
 error.run.parameters.cloud.dependent=Cannot restart run ''{0}'': run parameters connected with storage.
 error.restart.cluster.forbidden=Cannot restart run ''{0}'': restart cluster run is not allowed.
 error.restart.worker.forbidden=Cannot restart run ''{0}'': restart worker run is not allowed.
+error.restart.is.not.configured=Cannot restart run ''{0}'': run is not configured for restart.
 error.restart.run.failure=Failed to restart run ''{0}''.
 info.restart.run.success=A new run ''{0}'' started in a region ''{1}''.
 error.run.start.failure=Run ''{0}'' failed to start.

--- a/deploy/contents/install/preferences/launch.system.parameters.json
+++ b/deploy/contents/install/preferences/launch.system.parameters.json
@@ -581,7 +581,7 @@
     {
         "name": "CP_CAP_RESCHEDULE_RUN",
         "type": "boolean",
-        "description": "Enables rescheduling run to another regions",
+        "description": "Enables rescheduling run to other regions",
         "passToWorkers": false
     }
 ]

--- a/deploy/contents/install/preferences/launch.system.parameters.json
+++ b/deploy/contents/install/preferences/launch.system.parameters.json
@@ -577,5 +577,11 @@
         "description": "Enables RSMAP-like GPU devices assignment",
         "defaultValue": "true",
         "passToWorkers": true
+    },
+    {
+        "name": "CP_CAP_RESCHEDULE_RUN",
+        "type": "boolean",
+        "description": "Enables rescheduling run to another regions",
+        "passToWorkers": false
     }
 ]


### PR DESCRIPTION
This PR changes logic for rescheduling run to another region.
Run will be rescheduled only configured with `CP_CAP_RESCHEDULE_RUN` run parameter or with `launch.run.reschedule.enabled` (if run parameter is not present)