### PR TITLE
Introduce grace period for unavailable nodes

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesConstants.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesConstants.java
@@ -62,6 +62,8 @@ public final class KubernetesConstants {
     public static final String KUBERNETES_APP_LABEL = "k8s-app";
     public static final String KUBE_DNS_APP = "kube-dns";
     public static final String HYPHEN = "-";
+    public static final String KUBE_UNREACHABLE_NODE_LABEL = "node.kubernetes.io/unreachable";
+    public static final String KUBE_NOT_READY_NODE_LABEL = "node.kubernetes.io/not-ready";
 
     protected static final String SYSTEM_NAMESPACE = "kube-system";
     protected static final String POD_NODE_SELECTOR = "spec.nodeName";

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesConstants.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesConstants.java
@@ -40,6 +40,7 @@ public final class KubernetesConstants {
     public static final String CLOUD_PROVIDER_LABEL = "cloud_provider";
     public static final String POD_WORKER_NODE_LABEL = "cluster_id";
     public static final String PAUSED_NODE_LABEL = "Paused";
+    public static final String UNAVAILABLE_NODE_LABEL = "Unavailable";
 
     public static final String CP_CAP_DIND_NATIVE = "CP_CAP_DIND_NATIVE";
     public static final String CP_CAP_SYSTEMD_CONTAINER = "CP_CAP_SYSTEMD_CONTAINER";

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesManager.java
@@ -16,8 +16,6 @@
 
 package com.epam.pipeline.manager.cluster;
 
-import static com.epam.pipeline.manager.cluster.KubernetesConstants.HYPHEN;
-
 import com.epam.pipeline.common.MessageConstants;
 import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.config.JsonMapper;
@@ -41,6 +39,8 @@ import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.Node;
 import io.fabric8.kubernetes.api.model.NodeCondition;
 import io.fabric8.kubernetes.api.model.NodeList;
+import io.fabric8.kubernetes.api.model.NodeStatus;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodCondition;
 import io.fabric8.kubernetes.api.model.PodList;
@@ -71,6 +71,7 @@ import retrofit2.Retrofit;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -81,6 +82,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+
+import static com.epam.pipeline.manager.cluster.KubernetesConstants.HYPHEN;
 
 @Slf4j
 @Component
@@ -628,6 +631,48 @@ public class KubernetesManager {
         modifyNodeLabel(nodeName, labelName, labels -> labels.remove(labelName));
     }
 
+    private void modifyNodeLabel(String nodeName, String labelName, Consumer<Map<String, String>> actionOnLabel) {
+        if (StringUtils.isBlank(nodeName) || StringUtils.isBlank(labelName)) {
+            return;
+        }
+        try (KubernetesClient client = getKubernetesClient()) {
+            Node node = getNode(client, nodeName);
+
+            Map<String, String> labels = node.getMetadata().getLabels();
+
+            actionOnLabel.accept(labels);
+
+            node.getMetadata().setLabels(labels);
+            client.nodes().createOrReplace(node);
+        } catch (KubernetesClientException e) {
+            LOGGER.error(e.getMessage(), e);
+        }
+    }
+
+    public Map<String, String> getNodeLabels(final KubernetesClient client, final String nodeName) {
+        if (StringUtils.isBlank(nodeName)) {
+            return Collections.emptyMap();
+        }
+        try {
+            return findNode(client, nodeName)
+                    .map(Node::getMetadata)
+                    .map(ObjectMeta::getLabels)
+                    .orElseGet(Collections::emptyMap);
+        } catch (KubernetesClientException e) {
+            LOGGER.error(e.getMessage(), e);
+            return Collections.emptyMap();
+        }
+    }
+
+    private Node getNode(final KubernetesClient client, final String nodeName) {
+        return findNode(client, nodeName).orElseThrow(() -> new IllegalArgumentException(messageHelper.getMessage(
+                MessageConstants.ERROR_NODE_NOT_FOUND, nodeName)));
+    }
+
+    private Optional<Node> findNode(final KubernetesClient client, final String nodeName) {
+        return Optional.ofNullable(client.nodes().withName(nodeName).get());
+    }
+
     /**
      * Waits until node will be removed from Kubernetes cluster.
      *
@@ -653,26 +698,6 @@ public class KubernetesManager {
         } catch (InterruptedException e) {
             LOGGER.error(e.getMessage(), e);
             Thread.currentThread().interrupt();
-        }
-    }
-
-    private void modifyNodeLabel(String nodeName, String labelName, Consumer<Map<String, String>> actionOnLabel) {
-        if (StringUtils.isBlank(nodeName) || StringUtils.isBlank(labelName)) {
-            return;
-        }
-        try (KubernetesClient client = getKubernetesClient()) {
-            Node node = client.nodes().withName(nodeName).get();
-            Assert.notNull(node, messageHelper.getMessage(MessageConstants.ERROR_NODE_NOT_FOUND,
-                    node.getMetadata().getName()));
-
-            Map<String, String> labels = node.getMetadata().getLabels();
-
-            actionOnLabel.accept(labels);
-
-            node.getMetadata().setLabels(labels);
-            client.nodes().createOrReplace(node);
-        } catch (KubernetesClientException e) {
-            LOGGER.error(e.getMessage(), e);
         }
     }
 
@@ -929,25 +954,41 @@ public class KubernetesManager {
     }
 
     public boolean isNodeAvailable(final Node node) {
-        if (node == null) {
-            return false;
-        }
-        List<NodeCondition> conditions = node.getStatus().getConditions();
-        if (CollectionUtils.isEmpty(conditions)) {
-            return true;
-        }
-        String lastReason = conditions.get(0).getReason();
-        for (String reason : KubernetesConstants.NODE_OUT_OF_ORDER_REASONS) {
-            if (lastReason.contains(reason)) {
-                log.debug("Node is out of order: {}", conditions);
-                return false;
-            }
-        }
-        return true;
+        return !isLastConditionUnavailable(node);
     }
 
     public boolean isNodeUnavailable(final Node node) {
-        return !isNodeAvailable(node);
+        return isLastConditionUnavailable(node);
+    }
+
+    private boolean isLastConditionUnavailable(final Node node) {
+        return getLastCondition(node)
+                .map(NodeCondition::getReason)
+                .map(lastReason -> {
+                    for (String reason : KubernetesConstants.NODE_OUT_OF_ORDER_REASONS) {
+                        if (lastReason.contains(reason)) {
+                            log.debug("Node is out of order: {}", node.getStatus().getConditions());
+                            return true;
+                        }
+                    }
+                    return false;
+                })
+                .orElse(true);
+    }
+
+    public Optional<LocalDateTime> getLastConditionDateTime(final Node node) {
+        return getLastCondition(node)
+                .map(NodeCondition::getLastHeartbeatTime)
+                .map(dateTime -> LocalDateTime.parse(dateTime, KubernetesConstants.KUBE_DATE_FORMATTER));
+    }
+
+    private Optional<NodeCondition> getLastCondition(final Node node) {
+        return Optional.ofNullable(node)
+                .map(Node::getStatus)
+                .map(NodeStatus::getConditions)
+                .orElseGet(Collections::emptyList)
+                .stream()
+                .findFirst();
     }
 
     public void createNodeService(final RunInstance instance) {

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/ScaleDownHandler.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/ScaleDownHandler.java
@@ -75,6 +75,7 @@ public class ScaleDownHandler {
     private final PipelineRunCRUDService runCRUDService;
     private final PreferenceManager preferenceManager;
 
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public void checkFreeNodes(final Set<String> scheduledRuns,
                                final KubernetesClient client,
                                final Set<String> pods) {

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -95,6 +95,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
@@ -104,7 +105,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -388,7 +388,7 @@ public class PipelineRunManager {
         validateCloudRegion(toolConfiguration, region);
         validateInstanceAndPriceTypes(configuration, pipeline, region, instanceType);
         final String instanceDisk = configuration.getInstanceDisk();
-        if (StringUtils.hasText(instanceDisk)) {
+        if (StringUtils.isNotBlank(instanceDisk)) {
             Assert.isTrue(NumberUtils.isNumber(instanceDisk) &&
                 Integer.parseInt(instanceDisk) > 0,
                     messageHelper.getMessage(MessageConstants.ERROR_INSTANCE_DISK_IS_INVALID, instanceDisk));
@@ -408,17 +408,10 @@ public class PipelineRunManager {
         final PipelineRun run = createPipelineRun(version, configuration, pipeline, tool, toolVersion.orElse(null),
                 region, parentRun.orElse(null), entityIds, configurationId, sensitive);
 
-        // If there is no podAssignPolicy we need to schedule run to be launched on dedicated node
+        // If there is no podAssignPolicy, then run is scheduled to a dedicated node
         if (configuration.getPodAssignPolicy() == null || !configuration.getPodAssignPolicy().isValid()) {
-            log.debug(String.format("Setup run assign policy as run id for run: %d", run.getId()));
-            configuration.setPodAssignPolicy(
-                RunAssignPolicy.builder()
-                    .selector(
-                        RunAssignPolicy.PodAssignSelector.builder()
-                                .label(KubernetesConstants.RUN_ID_LABEL)
-                                .value(run.getId().toString()).build())
-                    .build()
-            );
+            log.debug(String.format("Configuring default pod assign policy for run #%d", run.getId()));
+            configuration.setPodAssignPolicy(getDefaultPodAssignPolicy(run));
         }
 
         configuration.getPodAssignPolicy()
@@ -448,7 +441,7 @@ public class PipelineRunManager {
 
     private void checkGPUInstance(final PipelineConfiguration configuration, final Long regionId) {
         final String instanceType = configuration.getInstanceType();
-        if (StringUtils.hasText(instanceType)) {
+        if (StringUtils.isNotBlank(instanceType)) {
             final Optional<InstanceOffer> instance = instanceOfferManager.findOffer(instanceType, regionId);
             if (instance.isPresent()) {
                 final InstanceOffer offer = instance.get();
@@ -462,6 +455,24 @@ public class PipelineRunManager {
             }
         }
         MapUtils.emptyIfNull(configuration.getParameters()).remove(CP_GPU_COUNT);
+    }
+
+    private RunAssignPolicy getDefaultPodAssignPolicy(final PipelineRun run) {
+        return RunAssignPolicy.builder()
+                .selector(
+                        RunAssignPolicy.PodAssignSelector.builder()
+                                .label(KubernetesConstants.RUN_ID_LABEL)
+                                .value(run.getId().toString()).build())
+                .tolerances(Arrays.asList(
+                        RunAssignPolicy.PodAssignTolerance.builder()
+                                .label(KubernetesConstants.KUBE_UNREACHABLE_NODE_LABEL)
+                                .value(StringUtils.EMPTY)
+                                .build(),
+                        RunAssignPolicy.PodAssignTolerance.builder()
+                                .label(KubernetesConstants.KUBE_NOT_READY_NODE_LABEL)
+                                .value(StringUtils.EMPTY)
+                                .build()))
+                .build();
     }
 
     private AbstractCloudRegion resolveCloudRegion(final PipelineRun parentRun,
@@ -515,7 +526,7 @@ public class PipelineRunManager {
                                                        final PriceType priceType,
                                                        final Long regionId,
                                                        final boolean isMasterNode) {
-        Assert.isTrue(!StringUtils.hasText(instanceType)
+        Assert.isTrue(StringUtils.isBlank(instanceType)
                         || instanceOfferManager.isInstanceAllowed(instanceType, regionId, priceType == PriceType.SPOT),
                 messageHelper.getMessage(MessageConstants.ERROR_INSTANCE_TYPE_IS_NOT_ALLOWED, instanceType));
         Assert.isTrue(instanceOfferManager.isPriceTypeAllowed(priceType.getLiteral(), null, isMasterNode),
@@ -530,7 +541,7 @@ public class PipelineRunManager {
         final Tool tool = toolManager.loadByNameOrId(dockerImage);
         final ContextualPreferenceExternalResource toolResource =
                 new ContextualPreferenceExternalResource(ContextualPreferenceLevel.TOOL, tool.getId().toString());
-        Assert.isTrue(!StringUtils.hasText(instanceType)
+        Assert.isTrue(StringUtils.isBlank(instanceType)
                         || instanceOfferManager.isToolInstanceAllowed(instanceType, toolResource,
                                                     regionId, priceType == PriceType.SPOT),
                 messageHelper.getMessage(MessageConstants.ERROR_INSTANCE_TYPE_IS_NOT_ALLOWED, instanceType));
@@ -928,7 +939,7 @@ public class PipelineRunManager {
         run.setConfigurationId(configurationId);
         run.setExecutionPreferences(Optional.ofNullable(configuration.getExecutionPreferences())
                 .orElse(ExecutionPreferences.getDefault()));
-        if (StringUtils.hasText(configuration.getPrettyUrl())) {
+        if (StringUtils.isNotBlank(configuration.getPrettyUrl())) {
             validatePrettyUrlFree(configuration.getPrettyUrl());
             run.setPrettyUrl(configuration.getPrettyUrl());
         }
@@ -947,7 +958,7 @@ public class PipelineRunManager {
                             if (LIMIT_MOUNTS_NONE.equalsIgnoreCase(limitMounts)) {
                                 return Stream.empty();
                             }
-                            return Arrays.stream(StringUtils.commaDelimitedListToStringArray(limitMounts))
+                            return Arrays.stream(commaDelimitedListToStringArray(limitMounts))
                                          .map(Long::valueOf);
                         }
                 )
@@ -957,6 +968,10 @@ public class PipelineRunManager {
         }
         return dataStorageManager.getDatastoragesByIds(datastorageIds)
                 .stream().anyMatch(AbstractDataStorage::isSensitive);
+    }
+
+    private String[] commaDelimitedListToStringArray(final String limitMounts) {
+        return org.springframework.util.StringUtils.commaDelimitedListToStringArray(limitMounts);
     }
 
     @Transactional(propagation = Propagation.REQUIRED)
@@ -1457,7 +1472,7 @@ public class PipelineRunManager {
         }
         params.forEach(p -> p.setResolvedValue(p.getValue()));
         final List<PipelineRunParameter> paramsWithPossibleEnvVars = params.stream()
-                .filter(p -> org.apache.commons.lang3.StringUtils.isNotBlank(p.getValue()) &&
+                .filter(p -> StringUtils.isNotBlank(p.getValue()) &&
                         p.getValue().contains("$"))
                 .collect(Collectors.toList());
         if (CollectionUtils.isEmpty(paramsWithPossibleEnvVars)) {
@@ -1478,8 +1493,8 @@ public class PipelineRunManager {
                                             final String envVarName,
                                             final String envVarValue,
                                             final String parameter) {
-        if (!StringUtils.hasText(parameter) || !StringUtils.hasText(envVarName)
-                || !StringUtils.hasText(envVarValue)) {
+        if (StringUtils.isBlank(parameter) || StringUtils.isBlank(envVarName)
+                || StringUtils.isBlank(envVarValue)) {
             return parameter;
         }
         try {
@@ -1676,7 +1691,7 @@ public class PipelineRunManager {
             return;
         }
         final String dataKey = runStatusParameter.get().getValue();
-        if (!StringUtils.hasText(dataKey)) {
+        if (StringUtils.isBlank(dataKey)) {
             LOGGER.error("Parameter {} was specified for pipeline run {} but empty", CP_REPORT_RUN_STATUS, run.getId());
             return;
         }

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -444,6 +444,8 @@ public class SystemPreferences {
         "cluster.kill.not.matching.nodes", true, CLUSTER_GROUP, pass);
     public static final BooleanPreference CLUSTER_ENABLE_AUTOSCALING = new BooleanPreference(
         "cluster.enable.autoscaling", true, CLUSTER_GROUP, pass);
+    public static final IntPreference CLUSTER_NODE_UNAVAILABLE_GRACE_PERIOD_MINUTES = new IntPreference(
+        "cluster.node.unavailable.grace.period.minutes", 30, CLUSTER_GROUP, isGreaterThanOrEquals(0));
     public static final IntPreference CLUSTER_AUTOSCALE_RATE = new IntPreference("cluster.autoscale.rate",
                                                     40000, CLUSTER_GROUP, isGreaterThan(1000));
     public static final IntPreference CLUSTER_MAX_SIZE = new IntPreference("cluster.max.size", 50,


### PR DESCRIPTION
Resolves issue #3297.

The pull request brings support for grace period to unavailable nodes. From now on, all nodes which become unavailable or not ready have a grace period before they are terminated.

In order to prevent Kubernetes from evicting pods from unavailable nodes, a default set of pod tolerations are added to all run pods:
```jaml
tolerations:
- key: "node.kubernetes.io/unreachable"
  operator: "Exists"
  effect: "NoExecute"
- key: "node.kubernetes.io/not-ready"
  operator: "Exists"
  effect: "NoExecute"
```

The following system preference is introduced:
- `cluster.node.unavailable.grace.period.minutes` configures a grace period in minutes after which unavailable nodes are terminated. Defaults to **30 minutes**.
