### PR TITLE
Issue #3270: Add CUDA availability check when GPU instance is launchd (nvidia label fix)

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/docker/scan/AggregatingToolScanManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/scan/AggregatingToolScanManager.java
@@ -542,7 +542,8 @@ public class AggregatingToolScanManager implements ToolScanManager {
         }
         final boolean hasNvidia = Stream.concat(SetUtils.emptyIfNull(imageLabels.keySet()).stream(),
                         CollectionUtils.emptyIfNull(imageLabels.values()).stream())
-                .anyMatch(imageLabel -> nvidiaLabels.stream().anyMatch(imageLabel::contains));
+                .anyMatch(imageLabel -> nvidiaLabels.stream()
+                        .anyMatch(nvidiaLabel -> StringUtils.containsIgnoreCase(imageLabel, nvidiaLabel)));
         if (hasNvidia) {
             LOGGER.debug("Found nvidia label for tool '{}:{}'", image, tag);
         }

--- a/api/src/main/java/com/epam/pipeline/manager/docker/scan/AggregatingToolScanManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/scan/AggregatingToolScanManager.java
@@ -55,8 +55,10 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.OkHttpClient;
 import okhttp3.ResponseBody;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.collections4.SetUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -77,6 +79,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -308,9 +311,9 @@ public class AggregatingToolScanManager implements ToolScanManager {
             final DockerClient client = getDockerClient(tool.getImage(), registry);
             final String digest = client.getVersionAttributes(registry, tool.getImage(), tag).getDigest();
             final List<ImageHistoryLayer> imageHistory = client.getImageHistory(registry, tool.getImage(), tag);
-            final boolean hasCudnnVersion = hasCudnnVersion(client, registry, tool.getImage(), tag);
+            final boolean hasNvidiaMark = hasNvidiaMark(client, registry, tool.getImage(), tag);
             final String defaultCmd = toolManager.loadToolDefaultCommand(imageHistory);
-            return gatherResults(tool, tag, lastLayerRef, digest, defaultCmd, imageHistory.size(), hasCudnnVersion);
+            return gatherResults(tool, tag, lastLayerRef, digest, defaultCmd, imageHistory.size(), hasNvidiaMark);
         } catch (IOException e) {
             throw new ToolScanExternalServiceException(tool, e);
         }
@@ -446,7 +449,7 @@ public class AggregatingToolScanManager implements ToolScanManager {
     private ToolVersionScanResult gatherResults(final Tool tool, final String tag,
                                                 final String lastLayerRef, final String digest,
                                                 final String defaultCmd, final int layersCount,
-                                                final boolean hasCudnnVersion) throws IOException {
+                                                final boolean hasNvidiaMark) throws IOException {
 
         ToolScanStatus toolScanStatus = ToolScanStatus.COMPLETED;
 
@@ -508,7 +511,7 @@ public class AggregatingToolScanManager implements ToolScanManager {
                 .findFirst().map(td -> new ToolOSVersion(td.getName(), td.getVersion()))
                 .orElseGet(() -> createEmptyToolOsVersion(tool, tag));
 
-        final boolean cudaAvailable = hasCudnnVersion && hasNvidiaInstalled(dependencies, tool, tag);
+        final boolean cudaAvailable = hasNvidiaMark && hasNvidiaInstalled(dependencies, tool, tag);
 
         final ToolVersionScanResult result = new ToolVersionScanResult(tag, osVersion, vulnerabilities,
                 dependencies, toolScanStatus, lastLayerRef, digest, defaultCmd, layersCount);
@@ -526,16 +529,24 @@ public class AggregatingToolScanManager implements ToolScanManager {
             .orElse(new ToolOSVersion(NOT_DETERMINED, NOT_DETERMINED));
     }
 
-    private boolean hasCudnnVersion(final DockerClient client, final DockerRegistry registry,
-                                   final String image, final String tag) {
-        final String cudnnVersionLabel = preferenceManager.getPreference(
+    private boolean hasNvidiaMark(final DockerClient client, final DockerRegistry registry, final String image,
+                                  final String tag) {
+        final Set<String> nvidiaLabels = preferenceManager.getPreference(
                 SystemPreferences.DOCKER_SECURITY_CUDNN_VERSION_LABEL);
-        final boolean hasCudnnVersion = MapUtils.emptyIfNull(client.getImageLabels(registry, image, tag))
-                .containsKey(cudnnVersionLabel);
-        if (hasCudnnVersion) {
-            LOGGER.debug("Found cudnn version label for tool '{}:{}'", image, tag);
+        if (CollectionUtils.isEmpty(nvidiaLabels)) {
+            return true;
         }
-        return hasCudnnVersion;
+        final Map<String, String> imageLabels = MapUtils.emptyIfNull(client.getImageLabels(registry, image, tag));
+        if (MapUtils.isEmpty(imageLabels)) {
+            return false;
+        }
+        final boolean hasNvidia = Stream.concat(SetUtils.emptyIfNull(imageLabels.keySet()).stream(),
+                        CollectionUtils.emptyIfNull(imageLabels.values()).stream())
+                .anyMatch(imageLabel -> nvidiaLabels.stream().anyMatch(imageLabel::contains));
+        if (hasNvidia) {
+            LOGGER.debug("Found nvidia label for tool '{}:{}'", image, tag);
+        }
+        return hasNvidia;
     }
 
     private boolean hasNvidiaInstalled(final List<ToolDependency> dependencies, final Tool tool, final String tag) {

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -417,9 +417,9 @@ public class SystemPreferences {
      */
     public static final IntPreference DOCKER_SECURITY_TOOL_POLICY_MAX_HIGH_VULNERABILITIES = new IntPreference(
         "security.tools.policy.max.high.vulnerabilities", 20, DOCKER_SECURITY_GROUP, isGreaterThanOrEquals(0));
-    public static final StringPreference DOCKER_SECURITY_CUDNN_VERSION_LABEL = new StringPreference(
-            "security.tools.nvidia.cudnn.version.label", "com.nvidia.cudnn.version", DOCKER_SECURITY_GROUP,
-            PreferenceValidators.isValidUrlOrBlank);
+    public static final ObjectPreference<Set<String>> DOCKER_SECURITY_CUDNN_VERSION_LABEL =
+            new ObjectPreference<>("security.tools.nvidia.cudnn.version.label", null,
+                    new TypeReference<Set<String>>() {}, DOCKER_SECURITY_GROUP, pass, true);
 
     // CLUSTER_GROUP
     /**

--- a/api/src/test/java/com/epam/pipeline/manager/docker/scan/AggregatingToolScanManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/docker/scan/AggregatingToolScanManagerTest.java
@@ -70,6 +70,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -90,8 +91,9 @@ public class AggregatingToolScanManagerTest {
     public static final String DIGEST_1 = "digest1";
     public static final String DIGEST_2 = "digest2";
     public static final String DIGEST_3 = "digest3";
-    private static final String TEST_LABEL_NAME = "label-name";
+    private static final String TEST_LABEL_NAME = "test-label-name";
     private static final String TEST_LABEL_VALUE = "label-value";
+    private static final Set<String> TEST_LABEL_MARK = Collections.singleton("label-name");
     private static final int ERROR_CODE = 500;
 
     @InjectMocks
@@ -169,7 +171,7 @@ public class AggregatingToolScanManagerTest {
         when(preferenceManager.getPreference(SystemPreferences.DOCKER_SECURITY_TOOL_GRACE_HOURS))
                 .thenReturn(0);
         when(preferenceManager.getPreference(SystemPreferences.DOCKER_SECURITY_CUDNN_VERSION_LABEL))
-                .thenReturn(TEST_LABEL_NAME);
+                .thenReturn(TEST_LABEL_MARK);
 
         Assert.assertNotNull(pipelineConfigurationManager); // Dummy line, to shut up PMD
 

--- a/api/src/test/java/com/epam/pipeline/manager/docker/scan/AggregatingToolScanManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/docker/scan/AggregatingToolScanManagerTest.java
@@ -93,7 +93,7 @@ public class AggregatingToolScanManagerTest {
     public static final String DIGEST_3 = "digest3";
     private static final String TEST_LABEL_NAME = "test-label-name";
     private static final String TEST_LABEL_VALUE = "label-value";
-    private static final Set<String> TEST_LABEL_MARK = Collections.singleton("label-name");
+    private static final Set<String> TEST_LABEL_MARK = Collections.singleton("LABEL-name");
     private static final int ERROR_CODE = 500;
 
     @InjectMocks


### PR DESCRIPTION
The current PR relates to issue #3270 and provides fix for `security.tools.nvidia.cudnn.version.label` system preference. From now this preference accepts several values. If this preference is empty cuda availability shall be determined based on `docker-comp-scan` result only. The nvidia cuda considers available if one of the tool image labels contains substring from `security.tools.nvidia.cudnn.version.label` preferences list.