### PR TITLE
Issue #3326. Fix SGE installation: link pipe_mail to /usr/bin/mail

### DIFF
--- a/deploy/contents/install/preferences/launch.system.parameters.json
+++ b/deploy/contents/install/preferences/launch.system.parameters.json
@@ -587,8 +587,15 @@
     {
         "name": "CP_CAP_GRID_ENGINE_NOTIFICATIONS",
         "type": "boolean",
-        "defaultValue": "false",
+        "defaultValue": "true",
         "description": "Enables notifications for Slurm and SGE engines.",
+        "passToWorkers": true
+    },
+    {
+        "name": "CP_CAP_MAIL",
+        "type": "boolean",
+        "defaultValue": "true",
+        "description": "Changes default mail client if favor to pipe_mail script.",
         "passToWorkers": true
     }
 ]

--- a/scripts/pipeline-launch/launch.sh
+++ b/scripts/pipeline-launch/launch.sh
@@ -221,6 +221,19 @@ function cp_cap_publish {
             
             sed -i "/$_SGE_WORKER_INIT/d" $_WORKER_CAP_INIT_PATH
             echo "$_SGE_WORKER_INIT" >> $_WORKER_CAP_INIT_PATH
+
+            # Due to strange behavior of sge_execd with updating global config values,
+            # we need to change default mail client if favor to our custom
+            if check_cp_cap "CP_CAP_GRID_ENGINE_NOTIFICATIONS"
+            then
+                _PIPE_MAIL_ENABLER_SCRIPT="pipe_mail_enabler"
+
+                sed -i "/$_PIPE_MAIL_ENABLER_SCRIPT/d" $_MASTER_CAP_INIT_PATH
+                echo "$_PIPE_MAIL_ENABLER_SCRIPT" >> $_MASTER_CAP_INIT_PATH
+
+                sed -i "/$_PIPE_MAIL_ENABLER_SCRIPT/d" $_WORKER_CAP_INIT_PATH
+                echo "$_PIPE_MAIL_ENABLER_SCRIPT" >> $_WORKER_CAP_INIT_PATH
+            fi
       fi
 
       if check_cp_cap "CP_CAP_SLURM"
@@ -1806,6 +1819,16 @@ echo "------"
 echo
 ######################################################
 
+
+######################################################
+echo "Configure custom mail client if requested"
+echo "-"
+######################################################
+
+if check_cp_cap CP_CAP_MAIL; then
+    pipe_mail_enabler
+fi
+######################################################
 
 
 ######################################################

--- a/workflows/pipe-common/shell/pipe_mail
+++ b/workflows/pipe-common/shell/pipe_mail
@@ -37,8 +37,8 @@ function get_cp_user_id {
         fi
     done
 
-    if [[ "$_effective_user_id" == "root" ]]; then
-        echo "Job owner is $_effective_user_id, changing receiver to $OWNER_CP_ACCOUNT"
+    if [[ "$_effective_user_id" == "root" ]] || [[ "$_effective_user_id" == "$OWNER" ]]; then
+        echo "Job owner is $_effective_user_id, will send notification to $OWNER_CP_ACCOUNT"
         _effective_user_id="$OWNER_CP_ACCOUNT"
     fi
 

--- a/workflows/pipe-common/shell/pipe_mail_enabler
+++ b/workflows/pipe-common/shell/pipe_mail_enabler
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "Linking $COMMON_REPO_DIR_MUTUAL_LOC/shell/pipe_mail as default linux mail client"
+rm -rf "/usr/bin/mail" && ln -s "$COMMON_REPO_DIR_MUTUAL_LOC/shell/pipe_mail" "/usr/bin/mail" \
+    && rm -rf "/bin/mail" && ln -s "$COMMON_REPO_DIR_MUTUAL_LOC/shell/pipe_mail" "/bin/mail"
+if [ "$?" -eq "0" ]; then
+    echo "Successfully linked $COMMON_REPO_DIR_MUTUAL_LOC/shell/pipe_mail as default linux mail client"
+else
+    echo "Fail to link $COMMON_REPO_DIR_MUTUAL_LOC/shell/pipe_mail"
+fi

--- a/workflows/pipe-common/shell/sge_setup_master
+++ b/workflows/pipe-common/shell/sge_setup_master
@@ -471,12 +471,6 @@ fi
 # Setup any additional SGE consumable resources if available
 sge_setup_resources "$HOSTNAME" "$SGE_MASTER_SETUP_TASK" "$_MASTER_WORKER_CORES"
 
-# Override default mail program
-if check_cp_cap CP_CAP_GRID_ENGINE_NOTIFICATIONS; then
-    rm -rf "/usr/bin/mail" && ln -s "$COMMON_REPO_DIR_MUTUAL_LOC/shell/pipe_mail" "/usr/bin/mail"
-    check_last_exit_code $? "$COMMON_REPO_DIR_MUTUAL_LOC/shell/pipe_mail was linked as as /usr/bin/mail" "Fail to link $COMMON_REPO_DIR_MUTUAL_LOC/shell/pipe_mail"
-fi
-
 pipe_log_success "SGE master node was successfully configured" "$SGE_MASTER_SETUP_TASK"
 
 # Wait for worker nodes to initiate and connect to the master

--- a/workflows/pipe-common/shell/sge_setup_master
+++ b/workflows/pipe-common/shell/sge_setup_master
@@ -67,11 +67,6 @@ configure_global() {
     sed -i "/reporting_params/c\reporting_params $_SGE_REPORTING_PARAMS" ./global
     sed -i '/gid_range/c\gid_range 20000-30000' ./global
 
-    # Override default mail program for SGE
-    if check_cp_cap CP_CAP_GRID_ENGINE_NOTIFICATIONS; then
-        sed -i "/mailer/c\mailer $COMMON_REPO_DIR_MUTUAL_LOC/shell/pipe_mail" ./global
-    fi
-
     if check_cp_cap CP_CAP_SGE_GPU_RSMAP_DEVICES; then
         sed -i "/prolog/c\prolog sgeadmin@$COMMON_REPO_DIR_MUTUAL_LOC/shell/sge_prolog" ./global
         sed -i "/epilog/c\epilog sgeadmin@$COMMON_REPO_DIR_MUTUAL_LOC/shell/sge_epilog" ./global
@@ -475,6 +470,12 @@ fi
 
 # Setup any additional SGE consumable resources if available
 sge_setup_resources "$HOSTNAME" "$SGE_MASTER_SETUP_TASK" "$_MASTER_WORKER_CORES"
+
+# Override default mail program
+if check_cp_cap CP_CAP_GRID_ENGINE_NOTIFICATIONS; then
+    rm -rf "/usr/bin/mail" && ln -s "$COMMON_REPO_DIR_MUTUAL_LOC/shell/pipe_mail" "/usr/bin/mail"
+    check_last_exit_code $? "$COMMON_REPO_DIR_MUTUAL_LOC/shell/pipe_mail was linked as as /usr/bin/mail" "Fail to link $COMMON_REPO_DIR_MUTUAL_LOC/shell/pipe_mail"
+fi
 
 pipe_log_success "SGE master node was successfully configured" "$SGE_MASTER_SETUP_TASK"
 

--- a/workflows/pipe-common/shell/sge_setup_worker
+++ b/workflows/pipe-common/shell/sge_setup_worker
@@ -315,4 +315,10 @@ echo "export SGE_CLUSTER_NAME=$SGE_CLUSTER_NAME" >> /etc/cp_env.sh
 # Setup any additional SGE consumable resources if available
 sge_setup_resources "$HOSTNAME" "$SGE_WORKER_SETUP_TASK" "$_WORKER_CORES"
 
+# Override default mail program
+if check_cp_cap CP_CAP_GRID_ENGINE_NOTIFICATIONS; then
+    rm -rf "/usr/bin/mail" && ln -s "$COMMON_REPO_DIR_MUTUAL_LOC/shell/pipe_mail" "/usr/bin/mail"
+    check_last_exit_code $? "$COMMON_REPO_DIR_MUTUAL_LOC/shell/pipe_mail was linked as as /usr/bin/mail" "Fail to link $COMMON_REPO_DIR_MUTUAL_LOC/shell/pipe_mail"
+fi
+
 pipe_log_success "SGE worker node was successfully configured" "$SGE_WORKER_SETUP_TASK"

--- a/workflows/pipe-common/shell/sge_setup_worker
+++ b/workflows/pipe-common/shell/sge_setup_worker
@@ -315,10 +315,4 @@ echo "export SGE_CLUSTER_NAME=$SGE_CLUSTER_NAME" >> /etc/cp_env.sh
 # Setup any additional SGE consumable resources if available
 sge_setup_resources "$HOSTNAME" "$SGE_WORKER_SETUP_TASK" "$_WORKER_CORES"
 
-# Override default mail program
-if check_cp_cap CP_CAP_GRID_ENGINE_NOTIFICATIONS; then
-    rm -rf "/usr/bin/mail" && ln -s "$COMMON_REPO_DIR_MUTUAL_LOC/shell/pipe_mail" "/usr/bin/mail"
-    check_last_exit_code $? "$COMMON_REPO_DIR_MUTUAL_LOC/shell/pipe_mail was linked as as /usr/bin/mail" "Fail to link $COMMON_REPO_DIR_MUTUAL_LOC/shell/pipe_mail"
-fi
-
 pipe_log_success "SGE worker node was successfully configured" "$SGE_WORKER_SETUP_TASK"


### PR DESCRIPTION
This PR fixes problem with SGE notification integration.
Due to strange behavior of sge_execd with updating global config values we changed logic as follow:
 - instead of changing `mailer` value if sge_conf we just link `pipe_mail` to `/usr/bin/mail` 
 - introducing new `CP_CAP_MAIL` system launch param, through this parameter custom `pipe_mail` client can be enabled