### PR TITLE
Issue #3336. Remove node from cluster immediately if it isn't present on a cloud

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacade.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacade.java
@@ -24,6 +24,7 @@ import com.epam.pipeline.entity.cluster.InstanceDisk;
 import com.epam.pipeline.entity.cluster.InstanceImage;
 import com.epam.pipeline.entity.cluster.InstanceOffer;
 import com.epam.pipeline.entity.cluster.InstanceType;
+import com.epam.pipeline.entity.cluster.NodeRegionLabels;
 import com.epam.pipeline.entity.cluster.pool.NodePool;
 import com.epam.pipeline.entity.pipeline.DiskAttachRequest;
 import com.epam.pipeline.entity.pipeline.RunInstance;
@@ -72,6 +73,8 @@ public interface CloudFacade {
 
     boolean instanceExists(Long regionId, String instanceId);
 
+    boolean instanceExists(NodeRegionLabels nodeRegion, String instanceId);
+
     Map<String, String> buildContainerCloudEnvVars(Long regionId);
 
     List<InstanceOffer> refreshPriceListForRegion(Long regionId);
@@ -82,6 +85,8 @@ public interface CloudFacade {
     double getSpotPrice(Long regionId, String instanceType);
 
     Optional<InstanceTerminationState> getInstanceTerminationState(Long regionId, String instanceId);
+
+    Optional<InstanceTerminationState> getInstanceTerminationState(NodeRegionLabels nodeRegion, String instanceId);
 
     List<InstanceType> getAllInstanceTypes(Long regionId, boolean spot);
 

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacade.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacade.java
@@ -73,8 +73,6 @@ public interface CloudFacade {
 
     boolean instanceExists(Long regionId, String instanceId);
 
-    boolean instanceExists(NodeRegionLabels nodeRegion, String instanceId);
-
     Map<String, String> buildContainerCloudEnvVars(Long regionId);
 
     List<InstanceOffer> refreshPriceListForRegion(Long regionId);
@@ -85,8 +83,6 @@ public interface CloudFacade {
     double getSpotPrice(Long regionId, String instanceType);
 
     Optional<InstanceTerminationState> getInstanceTerminationState(Long regionId, String instanceId);
-
-    Optional<InstanceTerminationState> getInstanceTerminationState(NodeRegionLabels nodeRegion, String instanceId);
 
     List<InstanceType> getAllInstanceTypes(Long regionId, boolean spot);
 
@@ -101,6 +97,8 @@ public interface CloudFacade {
     List<InstanceDisk> loadDisks(Long regionId, Long runId);
 
     CloudInstanceState getInstanceState(Long runId);
+
+    CloudInstanceState getInstanceState(NodeRegionLabels nodeRegion, String instanceLabel);
 
     InstanceDNSRecord createDNSRecord(Long regionId, InstanceDNSRecord record);
 

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacadeImpl.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacadeImpl.java
@@ -199,6 +199,13 @@ public class CloudFacadeImpl implements CloudFacade {
     }
 
     @Override
+    public boolean instanceExists(final NodeRegionLabels nodeRegion, final String instanceId) {
+        final AbstractCloudRegion region = regionManager.load(
+                nodeRegion.getCloudProvider(), nodeRegion.getRegionCode());
+        return getInstanceService(region).instanceExists(region, instanceId);
+    }
+
+    @Override
     public Map<String, String> buildContainerCloudEnvVars(final Long regionId) {
         return regionManager.loadAll().stream()
                 .map(r -> {
@@ -232,6 +239,14 @@ public class CloudFacadeImpl implements CloudFacade {
     public Optional<InstanceTerminationState> getInstanceTerminationState(
             final Long regionId, final String instanceId) {
         final AbstractCloudRegion region = regionManager.loadOrDefault(regionId);
+        return getInstanceService(region).getInstanceTerminationState(region, instanceId);
+    }
+
+    @Override
+    public Optional<InstanceTerminationState> getInstanceTerminationState(final NodeRegionLabels nodeRegion,
+                                                                          final String instanceId) {
+        final AbstractCloudRegion region = regionManager.load(
+                nodeRegion.getCloudProvider(), nodeRegion.getRegionCode());
         return getInstanceService(region).getInstanceTerminationState(region, instanceId);
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacadeImpl.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacadeImpl.java
@@ -199,13 +199,6 @@ public class CloudFacadeImpl implements CloudFacade {
     }
 
     @Override
-    public boolean instanceExists(final NodeRegionLabels nodeRegion, final String instanceId) {
-        final AbstractCloudRegion region = regionManager.load(
-                nodeRegion.getCloudProvider(), nodeRegion.getRegionCode());
-        return getInstanceService(region).instanceExists(region, instanceId);
-    }
-
-    @Override
     public Map<String, String> buildContainerCloudEnvVars(final Long regionId) {
         return regionManager.loadAll().stream()
                 .map(r -> {
@@ -239,14 +232,6 @@ public class CloudFacadeImpl implements CloudFacade {
     public Optional<InstanceTerminationState> getInstanceTerminationState(
             final Long regionId, final String instanceId) {
         final AbstractCloudRegion region = regionManager.loadOrDefault(regionId);
-        return getInstanceService(region).getInstanceTerminationState(region, instanceId);
-    }
-
-    @Override
-    public Optional<InstanceTerminationState> getInstanceTerminationState(final NodeRegionLabels nodeRegion,
-                                                                          final String instanceId) {
-        final AbstractCloudRegion region = regionManager.load(
-                nodeRegion.getCloudProvider(), nodeRegion.getRegionCode());
         return getInstanceService(region).getInstanceTerminationState(region, instanceId);
     }
 
@@ -295,6 +280,14 @@ public class CloudFacadeImpl implements CloudFacade {
     public CloudInstanceState getInstanceState(final Long runId) {
         final AbstractCloudRegion region = getRegionByRunId(runId);
         return getInstanceService(region).getInstanceState(region, String.valueOf(runId));
+    }
+
+    @Override
+    public CloudInstanceState getInstanceState(final NodeRegionLabels nodeRegion,
+                                               final String instanceLabel) {
+        final AbstractCloudRegion region = regionManager.load(
+                nodeRegion.getCloudProvider(), nodeRegion.getRegionCode());
+        return getInstanceService(region).getInstanceState(region, instanceLabel);
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSInstanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSInstanceService.java
@@ -267,20 +267,24 @@ public class AWSInstanceService implements CloudInstanceService<AwsRegion> {
 
     @Override
     public CloudInstanceState getInstanceState(final AwsRegion region, final String nodeLabel) {
-        final Instance aliveInstance = ec2Helper.getAliveInstance(nodeLabel, region);
-        if (Objects.isNull(aliveInstance)) {
-            return CloudInstanceState.TERMINATED;
-        }
-        final String instanceStateName = aliveInstance.getState().getName();
-        if (InstanceStateName.Pending.toString().equals(instanceStateName)
-                || InstanceStateName.Running.toString().equals(instanceStateName)) {
-            return CloudInstanceState.RUNNING;
-        }
-        if (InstanceStateName.Stopping.toString().equals(instanceStateName)) {
-            return CloudInstanceState.STOPPING;
-        }
-        if (InstanceStateName.Stopped.toString().equals(instanceStateName)) {
-            return CloudInstanceState.STOPPED;
+        try {
+            final Instance aliveInstance = ec2Helper.getAliveInstance(nodeLabel, region);
+            if (Objects.isNull(aliveInstance)) {
+                return CloudInstanceState.TERMINATED;
+            }
+            final String instanceStateName = aliveInstance.getState().getName();
+            if (InstanceStateName.Pending.toString().equals(instanceStateName)
+                    || InstanceStateName.Running.toString().equals(instanceStateName)) {
+                return CloudInstanceState.RUNNING;
+            }
+            if (InstanceStateName.Stopping.toString().equals(instanceStateName)) {
+                return CloudInstanceState.STOPPING;
+            }
+            if (InstanceStateName.Stopped.toString().equals(instanceStateName)) {
+                return CloudInstanceState.STOPPED;
+            }
+        } catch (AwsEc2Exception e) {
+            log.error("Fail to get instance state by instance label {} for regionId {}", nodeLabel, region.getId());
         }
         return null;
     }

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSInstanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSInstanceService.java
@@ -286,7 +286,7 @@ public class AWSInstanceService implements CloudInstanceService<AwsRegion> {
         } catch (AwsEc2Exception e) {
             log.error("Fail to get instance state by instance label {} for regionId {}", nodeLabel, region.getId());
         }
-        return null;
+        return CloudInstanceState.TERMINATED;
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPInstanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPInstanceService.java
@@ -272,7 +272,7 @@ public class GCPInstanceService implements CloudInstanceService<GCPRegion> {
                 return CloudInstanceState.STOPPING;
             }
             return CloudInstanceState.TERMINATED;
-        } catch (IOException e) {
+        } catch (IOException | GCPException e) {
             log.error(e.getMessage(), e);
             return CloudInstanceState.TERMINATED;
         }

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesConstants.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesConstants.java
@@ -32,6 +32,7 @@ import java.util.stream.Stream;
 public final class KubernetesConstants {
 
     public static final String RUN_ID_LABEL = "runid";
+    public static final String CLOUD_INSTANCE_ID = "cloud_ins_id";
     public static final String TYPE_LABEL = "type";
     public static final String PIPELINE_TYPE = "pipeline";
     public static final String NODE_POOL_ID_LABEL = "pool_id";

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/ScaleDownHandler.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/ScaleDownHandler.java
@@ -223,7 +223,7 @@ public class ScaleDownHandler {
             state = cloudFacade.getInstanceState(runId);
         }
         log.debug("Check if unavailable node {} is alive. Termination state: {}", instanceId, state);
-        return state != null && state != CloudInstanceState.TERMINATED;
+        return state == CloudInstanceState.RUNNING;
     }
 
     private void scaleDownUnavailableNode(final KubernetesClient client, final Node node) {


### PR DESCRIPTION
Related to issue #3336  
Check if node isn't present on a cloud while tagging it as unavailable and if so - remove in immediately.