### PR TITLE
Issue #3345. Synchronize umask for cp_dav service and permissions that we are granting during file and folder creation on API

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageMounter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageMounter.java
@@ -10,6 +10,7 @@ import com.epam.pipeline.entity.datastorage.nfs.NFSDataStorage;
 import com.epam.pipeline.entity.region.AbstractCloudRegion;
 import com.epam.pipeline.entity.region.AbstractCloudRegionCredentials;
 import com.epam.pipeline.entity.region.CloudProvider;
+import com.epam.pipeline.entity.user.PipelineUser;
 import com.epam.pipeline.exception.CmdExecutionException;
 import com.epam.pipeline.manager.CmdExecutor;
 import com.epam.pipeline.manager.datastorage.FileShareMountManager;
@@ -36,6 +37,7 @@ public class NFSStorageMounter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NFSStorageMounter.class);
     private static final String NFS_MOUNT_CMD_PATTERN = "sudo mount -t %s %s %s %s";
+    private static final String CHOWN_CMD_PATTERN = "sudo chown %d:%d %s";
     /**
      * -l is for "lazy" unmounting: Detach the filesystem from the filesystem hierarchy now, and cleanup all references
      * to the filesystem as soon as it is not busy anymore
@@ -120,6 +122,18 @@ public class NFSStorageMounter {
             } catch (IOException e) {
                 throw new DataStorageException(e);
             }
+        }
+    }
+
+    public void chown(final File file, final PipelineUser user, final Integer seed) {
+        final Long userUID = user.getId() + seed;
+        final String path = file.getAbsoluteFile().getPath();
+        final String cmd = String.format(CHOWN_CMD_PATTERN, userUID, userUID, path);
+        try {
+            cmdExecutor.executeCommand(cmd);
+        } catch (CmdExecutionException e) {
+            LOGGER.error("Failed to change owner for path {}:", path);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 

--- a/api/src/main/java/com/epam/pipeline/utils/PosixPermissionUtils.java
+++ b/api/src/main/java/com/epam/pipeline/utils/PosixPermissionUtils.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.utils;
+
+import org.springframework.data.util.Pair;
+
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+public final class PosixPermissionUtils {
+
+    public static final List<Pair<Integer, PosixFilePermission>> OWNER_PERMISSIONS = Arrays.asList(
+            Pair.of(0b1, PosixFilePermission.OWNER_READ),
+            Pair.of(0b10, PosixFilePermission.OWNER_WRITE),
+            Pair.of(0b100, PosixFilePermission.OWNER_EXECUTE)
+    );
+    public static final List<Pair<Integer, PosixFilePermission>> GROUP_PERMISSIONS = Arrays.asList(
+            Pair.of(0b1, PosixFilePermission.GROUP_READ),
+            Pair.of(0b10, PosixFilePermission.GROUP_WRITE),
+            Pair.of(0b100, PosixFilePermission.GROUP_EXECUTE)
+    );
+    public static final List<Pair<Integer, PosixFilePermission>> OTHER_PERMISSIONS = Arrays.asList(
+            Pair.of(0b1, PosixFilePermission.OTHERS_READ),
+            Pair.of(0b10, PosixFilePermission.OTHERS_WRITE),
+            Pair.of(0b100, PosixFilePermission.OTHERS_EXECUTE)
+    );
+    private static final List<List<Pair<Integer, PosixFilePermission>>> ALL_PERMISSIONS = Arrays.asList(
+            OWNER_PERMISSIONS,
+            GROUP_PERMISSIONS,
+            OTHER_PERMISSIONS
+    );
+
+    private PosixPermissionUtils() {
+    }
+
+    public static Set<PosixFilePermission> getAllowedPermissionsFromUMask(final String fileShareUMask) {
+        final Set<PosixFilePermission> allowedPermissions = new LinkedHashSet<>();
+        final String umask = getValidatedUMask(fileShareUMask);
+        for (int i = 0; i < umask.length(); i++) {
+            int mask = Integer.parseInt(umask.substring(i, i + 1));
+            for (Pair<Integer, PosixFilePermission> permission : ALL_PERMISSIONS.get(i)) {
+                // if umask matches with permissions -> permission is prohibited
+                // e.g. for mask 0002 write permission for OTHERS should be prohibited
+                if ((mask & permission.getFirst()) == 0) {
+                    allowedPermissions.add(permission.getSecond());
+                }
+            }
+        }
+        return allowedPermissions;
+    }
+
+    private static String getValidatedUMask(final String fileShareUMask) {
+        if (!fileShareUMask.matches("\\d?\\d\\d\\d")) {
+            throw new IllegalArgumentException(
+                    String.format("Wrong umask pattern: %s, should be: \\d\\d\\d\\d or \\d\\d\\d", fileShareUMask));
+        }
+        if (fileShareUMask.length() == 4) {
+            return fileShareUMask.substring(1);
+        }
+        return fileShareUMask;
+    }
+
+}

--- a/api/src/main/java/com/epam/pipeline/utils/PosixPermissionUtils.java
+++ b/api/src/main/java/com/epam/pipeline/utils/PosixPermissionUtils.java
@@ -26,6 +26,9 @@ import java.util.Set;
 
 public final class PosixPermissionUtils {
 
+    public static final List<PosixFilePermission> EXECUTE_PERMISSIONS = Arrays.asList(
+            PosixFilePermission.OWNER_EXECUTE, PosixFilePermission.GROUP_EXECUTE, PosixFilePermission.OTHERS_EXECUTE);
+
     public static final List<Pair<Integer, PosixFilePermission>> OWNER_PERMISSIONS = Arrays.asList(
             Pair.of(0b1, PosixFilePermission.OWNER_READ),
             Pair.of(0b10, PosixFilePermission.OWNER_WRITE),

--- a/api/src/test/java/com/epam/pipeline/utils/PosixPermissionUtilsTest.java
+++ b/api/src/test/java/com/epam/pipeline/utils/PosixPermissionUtilsTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.*;
+
+@RunWith(Parameterized.class)
+public class PosixPermissionUtilsTest {
+
+    private final String inputMask;
+    private final List<PosixFilePermission> expectedPermissions;
+    private final boolean shouldThrow;
+
+    public PosixPermissionUtilsTest(String inputMask, List<PosixFilePermission> expectedPermissions,
+                                    boolean shouldThrow) {
+        this.inputMask = inputMask;
+        this.expectedPermissions = expectedPermissions;
+        this.shouldThrow = shouldThrow;
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {
+                "0002",
+                Arrays.asList(
+                        PosixFilePermission.OWNER_EXECUTE, PosixFilePermission.OWNER_WRITE,
+                        PosixFilePermission.OWNER_READ, PosixFilePermission.GROUP_EXECUTE,
+                        PosixFilePermission.GROUP_WRITE, PosixFilePermission.GROUP_READ,
+                        PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE
+                ),
+                false
+            },
+            {
+                    "1002",
+                    Arrays.asList(
+                            PosixFilePermission.OWNER_EXECUTE, PosixFilePermission.OWNER_WRITE,
+                            PosixFilePermission.OWNER_READ, PosixFilePermission.GROUP_EXECUTE,
+                            PosixFilePermission.GROUP_WRITE, PosixFilePermission.GROUP_READ,
+                            PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE
+                    ),
+                    false
+            },
+            {
+                    "002",
+                    Arrays.asList(
+                            PosixFilePermission.OWNER_EXECUTE, PosixFilePermission.OWNER_WRITE,
+                            PosixFilePermission.OWNER_READ, PosixFilePermission.GROUP_EXECUTE,
+                            PosixFilePermission.GROUP_WRITE, PosixFilePermission.GROUP_READ,
+                            PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE
+                    ),
+                    false
+            },
+            {
+                    "0022",
+                    Arrays.asList(
+                            PosixFilePermission.OWNER_EXECUTE, PosixFilePermission.OWNER_WRITE,
+                            PosixFilePermission.OWNER_READ,
+                            PosixFilePermission.GROUP_EXECUTE, PosixFilePermission.GROUP_READ,
+                            PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE
+                    ),
+                    false
+            },
+            {
+                    "0722",
+                    Arrays.asList(
+                            PosixFilePermission.GROUP_EXECUTE, PosixFilePermission.GROUP_READ,
+                            PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE
+                    ),
+                    false
+            },
+            {
+                    "badMask", Collections.emptyList(), true
+            }
+        });
+    }
+
+    @Test
+    public void getAllowedPermissionsFromUMask() {
+        if (shouldThrow) {
+            try {
+                PosixPermissionUtils.getAllowedPermissionsFromUMask(inputMask);
+            } catch (IllegalArgumentException e) {
+                Assert.assertTrue(true);
+            }
+        } else {
+            final Set<PosixFilePermission> result = PosixPermissionUtils.getAllowedPermissionsFromUMask(inputMask);
+            Assert.assertTrue(result.containsAll(expectedPermissions));
+        }
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/utils/PosixPermissionUtilsTest.java
+++ b/api/src/test/java/com/epam/pipeline/utils/PosixPermissionUtilsTest.java
@@ -52,45 +52,45 @@ public class PosixPermissionUtilsTest {
                 false
             },
             {
-                    "1002",
-                    Arrays.asList(
-                            PosixFilePermission.OWNER_EXECUTE, PosixFilePermission.OWNER_WRITE,
-                            PosixFilePermission.OWNER_READ, PosixFilePermission.GROUP_EXECUTE,
-                            PosixFilePermission.GROUP_WRITE, PosixFilePermission.GROUP_READ,
-                            PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE
-                    ),
-                    false
+                "1002",
+                Arrays.asList(
+                        PosixFilePermission.OWNER_EXECUTE, PosixFilePermission.OWNER_WRITE,
+                        PosixFilePermission.OWNER_READ, PosixFilePermission.GROUP_EXECUTE,
+                        PosixFilePermission.GROUP_WRITE, PosixFilePermission.GROUP_READ,
+                        PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE
+                ),
+                false
             },
             {
-                    "002",
-                    Arrays.asList(
-                            PosixFilePermission.OWNER_EXECUTE, PosixFilePermission.OWNER_WRITE,
-                            PosixFilePermission.OWNER_READ, PosixFilePermission.GROUP_EXECUTE,
-                            PosixFilePermission.GROUP_WRITE, PosixFilePermission.GROUP_READ,
-                            PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE
-                    ),
-                    false
+                "002",
+                Arrays.asList(
+                        PosixFilePermission.OWNER_EXECUTE, PosixFilePermission.OWNER_WRITE,
+                        PosixFilePermission.OWNER_READ, PosixFilePermission.GROUP_EXECUTE,
+                        PosixFilePermission.GROUP_WRITE, PosixFilePermission.GROUP_READ,
+                        PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE
+                ),
+                false
             },
             {
-                    "0022",
-                    Arrays.asList(
-                            PosixFilePermission.OWNER_EXECUTE, PosixFilePermission.OWNER_WRITE,
-                            PosixFilePermission.OWNER_READ,
-                            PosixFilePermission.GROUP_EXECUTE, PosixFilePermission.GROUP_READ,
-                            PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE
-                    ),
-                    false
+                "0022",
+                Arrays.asList(
+                        PosixFilePermission.OWNER_EXECUTE, PosixFilePermission.OWNER_WRITE,
+                        PosixFilePermission.OWNER_READ,
+                        PosixFilePermission.GROUP_EXECUTE, PosixFilePermission.GROUP_READ,
+                        PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE
+                ),
+                false
             },
             {
-                    "0722",
-                    Arrays.asList(
-                            PosixFilePermission.GROUP_EXECUTE, PosixFilePermission.GROUP_READ,
-                            PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE
-                    ),
-                    false
+                "0722",
+                Arrays.asList(
+                        PosixFilePermission.GROUP_EXECUTE, PosixFilePermission.GROUP_READ,
+                        PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE
+                ),
+                false
             },
             {
-                    "badMask", Collections.emptyList(), true
+                "badMask", Collections.emptyList(), true
             }
         });
     }

--- a/deploy/docker/cp-api-srv/config/application.properties
+++ b/deploy/docker/cp-api-srv/config/application.properties
@@ -177,6 +177,7 @@ luigi.graph.script=/usr/lib/python2.7/site-packages/scripts/deps_graph.py
 
 # File storages
 data.storage.nfs.root.mount.point=/opt/api/file-systems
+data.storage.nfs.default.umask=${CP_FILE_SHARE_STORAGE_DEFAULT_UMASK:0002}
 
 #Billing API
 billing.index.common.prefix=cp-billing

--- a/deploy/docker/cp-dav/init
+++ b/deploy/docker/cp-dav/init
@@ -95,7 +95,7 @@ envsubst < /tmp/webdav.conf > ${APACHE_HOME}/conf/extra/webdav.conf
 rm -rf /tmp/*.conf
 
 # Apache shall use 0002 mask to allow owner and group rw access
-umask ${CP_DAV_UMASK:-0002}
+umask ${CP_FILE_SHARE_STORAGE_DEFAULT_UMASK:-0002}
 
 # Start Apache in the foreground
 ${APACHE_HOME}/bin/apachectl -DFOREGROUND


### PR DESCRIPTION
Related to #3345 

 - Introducing `CP_FILE_SHARE_STORAGE_DEFAULT_UMASK` env to use it in `cp-dav` and `cp-api-srv`
 
Taking in consideration that in Linux  the default maks for files is `666` and folders `777`, logic in the `cp-api-srv` as follow:
 - get `umask` from `CP_FILE_SHARE_STORAGE_DEFAULT_UMASK`
 - calculate allowed permissions from that umask
 - filter these permission with regards to default linux masks for files and folders