### PR TITLE
Add region price list refresh API method

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/cluster/InstanceOfferApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/cluster/InstanceOfferApiService.java
@@ -1,0 +1,20 @@
+package com.epam.pipeline.acl.cluster;
+
+import com.epam.pipeline.manager.cluster.InstanceOfferScheduler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+
+import static com.epam.pipeline.security.acl.AclExpressions.ADMIN_ONLY;
+
+@Service
+@RequiredArgsConstructor
+public class InstanceOfferApiService {
+
+    private final InstanceOfferScheduler instanceOfferScheduler;
+
+    @PreAuthorize(ADMIN_ONLY)
+    public void updatePriceList(final Long id) {
+        instanceOfferScheduler.updatePriceList(id);
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/aspect/cluster/InstancePriceListAspect.java
+++ b/api/src/main/java/com/epam/pipeline/aspect/cluster/InstancePriceListAspect.java
@@ -26,7 +26,6 @@ import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Aspect
@@ -38,27 +37,17 @@ public class InstancePriceListAspect {
 
     private final InstanceOfferScheduler instanceOfferScheduler;
 
-    @Async("pauseRunExecutor")
     @AfterReturning(pointcut = "execution(* com.epam.pipeline.manager.region.CloudRegionManager.create(..))",
             returning = "region")
     public void updatePriceListForNewRegion(JoinPoint joinPoint, AbstractCloudRegion region) {
-        log.debug("Scheduling price list update for new region {} {} #{}",
-                region.getProvider(), region.getRegionCode(), region.getId());
         instanceOfferScheduler.updatePriceList(region);
-        log.debug("Finished price list update for new region {} {} #{}",
-                region.getProvider(), region.getRegionCode(), region.getId());
     }
 
-    @Async("pauseRunExecutor")
     @AfterReturning(pointcut = "execution(* com.epam.pipeline.manager.region.CloudRegionManager.update(..))",
             returning = "region")
     public void updatePriceListForUpdatedRegion(JoinPoint joinPoint, AbstractCloudRegion region) {
         if (region.getProvider().equals(CloudProvider.GCP)) {
-            log.debug("Scheduling price list update for updated region {} {} #{}",
-                    region.getProvider(), region.getRegionCode(), region.getId());
             instanceOfferScheduler.updatePriceList(region);
-            log.debug("Finished price list update for updated region {} {} #{}",
-                    region.getProvider(), region.getRegionCode(), region.getId());
         }
     }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/region/CloudRegionController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/region/CloudRegionController.java
@@ -16,6 +16,7 @@
 
 package com.epam.pipeline.controller.region;
 
+import com.epam.pipeline.acl.cluster.InstanceOfferApiService;
 import com.epam.pipeline.controller.AbstractRestController;
 import com.epam.pipeline.controller.Result;
 import com.epam.pipeline.controller.vo.region.AbstractCloudRegionDTO;
@@ -51,6 +52,7 @@ public class CloudRegionController extends AbstractRestController {
     private static final String REGION_ID = "regionId";
 
     private final CloudRegionApiService cloudRegionApiService;
+    private final InstanceOfferApiService instanceOfferApiService;
 
     @GetMapping("/provider")
     @ApiOperation(
@@ -134,7 +136,7 @@ public class CloudRegionController extends AbstractRestController {
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
             })
     public Result<AbstractCloudRegion> update(@PathVariable(REGION_ID) final Long id,
-                                    @RequestBody final AbstractCloudRegionDTO region) {
+                                              @RequestBody final AbstractCloudRegionDTO region) {
         return Result.success(cloudRegionApiService.update(id, region));
     }
 
@@ -150,4 +152,14 @@ public class CloudRegionController extends AbstractRestController {
         return Result.success(cloudRegionApiService.delete(id));
     }
 
+    @PostMapping(REGION_ID_URL + "/price")
+    @ApiOperation(
+            value = "Refreshes price list asynchronously",
+            notes = "Refreshes price list asynchronously",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<Object> updatePriceList(@PathVariable(REGION_ID) final Long id) {
+        instanceOfferApiService.updatePriceList(id);
+        return Result.success();
+    }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/InstanceOfferManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/InstanceOfferManager.java
@@ -340,22 +340,36 @@ public class InstanceOfferManager {
     @Transactional(propagation = Propagation.REQUIRED)
     public void refreshPriceList() {
         LOGGER.debug(messageHelper.getMessage(MessageConstants.DEBUG_INSTANCE_OFFERS_UPDATE_STARTED));
-        List<InstanceOffer> instanceOffers = cloudRegionManager.loadAll()
+        List<InstanceOffer> offers = cloudRegionManager.loadAll()
                 .stream()
-                .map(this::updatePriceListForRegion)
+                .map(this::updatePriceList)
                 .flatMap(List::stream)
                 .collect(toList());
 
         LOGGER.debug(messageHelper.getMessage(MessageConstants.DEBUG_INSTANCE_OFFERS_UPDATE_FINISHED));
-        LOGGER.info(messageHelper.getMessage(MessageConstants.INFO_INSTANCE_OFFERS_UPDATED, instanceOffers.size()));
+        LOGGER.info(messageHelper.getMessage(MessageConstants.INFO_INSTANCE_OFFERS_UPDATED, offers.size()));
     }
 
     @Transactional(propagation = Propagation.REQUIRED)
-    public List<InstanceOffer> updatePriceListForRegion(AbstractCloudRegion cloudRegion) {
-        List<InstanceOffer> instanceOffers = cloudFacade.refreshPriceListForRegion(cloudRegion.getId());
-        instanceOfferDao.removeInstanceOffersForRegion(cloudRegion.getId());
-        instanceOfferDao.insertInstanceOffers(instanceOffers);
-        return instanceOffers;
+    public void refreshPriceList(Long id) {
+        AbstractCloudRegion region = cloudRegionManager.load(id);
+        updatePriceList(region);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void refreshPriceList(AbstractCloudRegion region) {
+        updatePriceList(region);
+    }
+
+    private List<InstanceOffer> updatePriceList(AbstractCloudRegion region) {
+        LOGGER.debug("Updating instance offers for {} {} region #{}...",
+                region.getProvider(), region.getRegionCode(), region.getId());
+        List<InstanceOffer> offers = cloudFacade.refreshPriceListForRegion(region.getId());
+        instanceOfferDao.removeInstanceOffersForRegion(region.getId());
+        instanceOfferDao.insertInstanceOffers(offers);
+        LOGGER.debug("Inserted {} instance offers to {} {} region #{}.",
+                offers.size(), region.getProvider(), region.getRegionCode(), region.getId());
+        return offers;
     }
 
     private boolean isSpotRequest(Boolean spot) {

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/InstanceOfferScheduler.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/InstanceOfferScheduler.java
@@ -20,6 +20,7 @@ import com.epam.pipeline.entity.region.AbstractCloudRegion;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.manager.scheduling.AbstractSchedulingManager;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
@@ -40,15 +41,15 @@ public class InstanceOfferScheduler extends AbstractSchedulingManager {
                 "Instance Offers Expiration Status Check");
     }
 
-    public void checkAndUpdatePriceListIfNecessary() {
-        core.checkAndUpdatePriceListIfNecessary();
-    }
-
-    public void updatePriceList() {
-        core.updatePriceList();
-    }
-
+    // todo: Use price list executor
+    @Async("pauseRunExecutor")
     public void updatePriceList(final AbstractCloudRegion region) {
         core.updatePriceList(region);
+    }
+
+    // todo: Use price list executor
+    @Async("pauseRunExecutor")
+    public void updatePriceList(final Long id) {
+        core.updatePriceList(id);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -544,6 +544,8 @@ public class SystemPreferences {
         "cluster.allowed.instance.types.docker", "m5.*,c5.*,r4.*,t2.*", CLUSTER_GROUP, pass);
     public static final IntPreference CLUSTER_INSTANCE_OFFER_UPDATE_RATE = new IntPreference(
         "instance.offer.update.rate", 3600000, CLUSTER_GROUP, isGreaterThan(10000));
+    public static final IntPreference CLUSTER_INSTANCE_OFFER_EXPIRATION_RATE_HOURS = new IntPreference(
+        "instance.offer.expiration.rate.hours", 72, CLUSTER_GROUP, isGreaterThan(0));
     public static final IntPreference CLUSTER_BATCH_RETRY_COUNT = new IntPreference("cluster.batch.retry.count",
             0, CLUSTER_GROUP, isGreaterThanOrEquals(0));
     public static final ObjectPreference<List<String>> INSTANCE_RESTART_STATE_REASONS = new ObjectPreference<>(

--- a/api/src/test/java/com/epam/pipeline/acl/cluster/InstanceOfferApiServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/acl/cluster/InstanceOfferApiServiceTest.java
@@ -1,0 +1,34 @@
+package com.epam.pipeline.acl.cluster;
+
+import com.epam.pipeline.manager.cluster.InstanceOfferScheduler;
+import com.epam.pipeline.test.acl.AbstractAclTest;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import static com.epam.pipeline.test.creator.CommonCreatorConstants.ID;
+import static org.mockito.Mockito.verify;
+
+public class InstanceOfferApiServiceTest extends AbstractAclTest {
+
+    @Autowired
+    private InstanceOfferApiService instanceOfferApiService;
+
+    @Autowired
+    private InstanceOfferScheduler mockInstanceOfferScheduler;
+
+    @Test
+    @WithMockUser(roles = ADMIN_ROLE)
+    public void shouldUpdatePriceListForAdmin() {
+        instanceOfferApiService.updatePriceList(ID);
+
+        verify(mockInstanceOfferScheduler).updatePriceList(ID);
+    }
+
+    @Test(expected = AccessDeniedException.class)
+    @WithMockUser(username = SIMPLE_USER)
+    public void shouldFailUpdatingPriceListWithoutPermission() {
+        instanceOfferApiService.updatePriceList(ID);
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/app/TestApplication.java
+++ b/api/src/test/java/com/epam/pipeline/app/TestApplication.java
@@ -184,6 +184,9 @@ public class TestApplication {
     @MockBean
     public StorageEventCollector events;
 
+    @MockBean
+    public InstanceOfferScheduler instanceOfferScheduler;
+
     @Bean
     public EmbeddedServletContainerCustomizer containerCustomizer() throws FileNotFoundException {
 

--- a/api/src/test/java/com/epam/pipeline/controller/region/CloudRegionControllerTest.java
+++ b/api/src/test/java/com/epam/pipeline/controller/region/CloudRegionControllerTest.java
@@ -16,6 +16,7 @@
 
 package com.epam.pipeline.controller.region;
 
+import com.epam.pipeline.acl.cluster.InstanceOfferApiService;
 import com.epam.pipeline.acl.region.CloudRegionApiService;
 import com.epam.pipeline.controller.vo.region.AzureRegionDTO;
 import com.epam.pipeline.controller.vo.region.GCPRegionDTO;
@@ -52,6 +53,8 @@ public class CloudRegionControllerTest extends AbstractControllerTest {
     private static final String LOAD_REGIONS_INFO_URL = REGION_URL + "/info";
     private static final String LOAD_AVAILABLE_REGIONS_URL = REGION_URL + "/available";
     private static final String REGION_ID_URL = REGION_URL + "/%d";
+    private static final String REGION_ID_PRICE_URL = REGION_ID_URL + "/price";
+
     private final AwsRegion awsRegion = RegionCreatorUtils.getDefaultAwsRegion();
     private final AWSRegionDTO awsRegionDTO = RegionCreatorUtils.getDefaultAwsRegionDTO();
     private final AzureRegion azureRegion = RegionCreatorUtils.getDefaultAzureRegion();
@@ -61,6 +64,9 @@ public class CloudRegionControllerTest extends AbstractControllerTest {
 
     @Autowired
     private CloudRegionApiService mockCloudRegionApiService;
+
+    @Autowired
+    private InstanceOfferApiService mockInstanceOfferApiService;
 
     @Test
     public void shouldFailLoadProvidersForUnauthorizedUser() throws Exception {
@@ -315,5 +321,15 @@ public class CloudRegionControllerTest extends AbstractControllerTest {
         Mockito.verify(mockCloudRegionApiService).delete(ID);
 
         assertResponse(mvcResult, gcpRegion, RegionCreatorUtils.GCP_REGION_TYPE);
+    }
+
+    @Test
+    @WithMockUser
+    public void shouldUpdatePriceList() throws Exception {
+        final MvcResult mvcResult = performRequest(post(String.format(REGION_ID_PRICE_URL, ID)));
+
+        Mockito.verify(mockInstanceOfferApiService).updatePriceList(ID);
+
+        assertResponse(mvcResult);
     }
 }

--- a/api/src/test/java/com/epam/pipeline/test/acl/AclTestBeans.java
+++ b/api/src/test/java/com/epam/pipeline/test/acl/AclTestBeans.java
@@ -40,6 +40,7 @@ import com.epam.pipeline.manager.cloud.credentials.CloudProfileCredentialsManage
 import com.epam.pipeline.manager.cluster.EdgeServiceManager;
 import com.epam.pipeline.manager.cluster.InfrastructureManager;
 import com.epam.pipeline.manager.cluster.InstanceOfferManager;
+import com.epam.pipeline.manager.cluster.InstanceOfferScheduler;
 import com.epam.pipeline.manager.cluster.NatGatewayManager;
 import com.epam.pipeline.manager.cluster.NodeDiskManager;
 import com.epam.pipeline.manager.cluster.NodesManager;
@@ -589,6 +590,9 @@ public class AclTestBeans {
 
     @MockBean
     protected StorageRequestManager storageRequestManager;
+
+    @MockBean
+    protected InstanceOfferScheduler instanceOfferScheduler;
 
     @Bean
     public GrantPermissionManager grantPermissionManager() {

--- a/api/src/test/java/com/epam/pipeline/test/web/AbstractControllerTest.java
+++ b/api/src/test/java/com/epam/pipeline/test/web/AbstractControllerTest.java
@@ -121,6 +121,10 @@ public abstract class AbstractControllerTest {
         assertEquals(expectedResult.getPayload(), actualResult.getPayload());
     }
 
+    public void assertResponse(final MvcResult mvcResult) {
+        assertResponse(mvcResult, null, new TypeReference<Result<Object>>() {});
+    }
+
     public void assertFileResponse(final MvcResult mvcResult, final String fileName, final byte[] fileContent) {
         assertResponseHeader(mvcResult, fileName);
         assertContent(mvcResult, fileContent);

--- a/api/src/test/java/com/epam/pipeline/test/web/ControllerTestBeans.java
+++ b/api/src/test/java/com/epam/pipeline/test/web/ControllerTestBeans.java
@@ -18,6 +18,7 @@ package com.epam.pipeline.test.web;
 
 import com.epam.pipeline.acl.billing.BillingApiService;
 import com.epam.pipeline.acl.cloud.credentials.CloudProfileCredentialsApiService;
+import com.epam.pipeline.acl.cluster.InstanceOfferApiService;
 import com.epam.pipeline.acl.cluster.NatGatewayApiService;
 import com.epam.pipeline.acl.datastorage.lifecycle.DataStorageLifecycleApiService;
 import com.epam.pipeline.acl.datastorage.lustre.LustreFSApiService;
@@ -282,4 +283,7 @@ public class ControllerTestBeans {
 
     @MockBean
     protected StorageRequestApiService storageRequestApiService;
+
+    @MockBean
+    protected InstanceOfferApiService instanceOfferApiService;
 }


### PR DESCRIPTION
Resolves issue #1019.

The pull request brings support for `POST /cloud/region/{id}/price` API method which can be used to asynchronously update region's price list.

Additionally, the pull request brings the following system preference:
- `instance.offer.expiration.rate.hours` specifies price list expiration rate in hours. Defaults to 72 hours or 3 days. After 3 days a price list is considered expired and gets refreshed on the next price list check iteration (see _instance.offer.update.rate_).

Please notice that there are already a similar yet different system preference:
- `instance.offer.update.rate` specifies price list check rate in ms. Defaults to 3600000 ms or 1 hour. Each hour price lists are checked and updated if expired.
