### PR TITLE
Manage price list refresh transactions more efficiently

### DIFF
--- a/api/src/main/java/com/epam/pipeline/dao/cluster/InstanceOfferDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/cluster/InstanceOfferDao.java
@@ -74,6 +74,12 @@ public class InstanceOfferDao extends NamedParameterJdbcDaoSupport {
         getJdbcTemplate().update(removeInstanceOffersForRegionQuery, regionId);
     }
 
+    @Transactional
+    public void replaceInstanceOffersForRegion(Long id, List<InstanceOffer> offers) {
+        removeInstanceOffersForRegion(id);
+        insertInstanceOffers(offers);
+    }
+
     public List<InstanceOffer> loadInstanceOffers(InstanceOfferRequestVO instanceOfferRequestVO) {
         MapSqlParameterSource params = new MapSqlParameterSource();
         String query = wherePattern.matcher(loadInstanceOfferQuery)

--- a/api/src/main/java/com/epam/pipeline/dao/cluster/InstanceOfferDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/cluster/InstanceOfferDao.java
@@ -75,7 +75,7 @@ public class InstanceOfferDao extends NamedParameterJdbcDaoSupport {
     }
 
     @Transactional
-    public void replaceInstanceOffersForRegion(Long id, List<InstanceOffer> offers) {
+    public void replaceInstanceOffersForRegion(final Long id, final List<InstanceOffer> offers) {
         removeInstanceOffersForRegion(id);
         insertInstanceOffers(offers);
     }

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSPriceListReader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSPriceListReader.java
@@ -63,15 +63,22 @@ public class AWSPriceListReader implements InstanceOfferReader {
                 .withFirstRecordAsHeader()
                 .withIgnoreHeaderCase()
                 .withTrim())) {
-
-            return StreamSupport.stream(csvParser.spliterator(), false)
-                    .map(this::parseRecord)
-                    .collect(Collectors.toList());
-
+            return read(csvParser);
         } catch (IOException e) {
             log.error(e.getMessage(), e);
             return Collections.emptyList();
         }
+    }
+
+    private List<InstanceOffer> read(final CSVParser csvParser) {
+        log.debug("Reading price list for region {} {} #{}...",
+                region.getProvider(), region.getRegionCode(), region.getId());
+        final List<InstanceOffer> offers = StreamSupport.stream(csvParser.spliterator(), false)
+                .map(this::parseRecord)
+                .collect(Collectors.toList());
+        log.debug("Read {} price list entries for region {} {} #{}.",
+                offers.size(), region.getProvider(), region.getRegionCode(), region.getId());
+        return offers;
     }
 
     private InstanceOffer parseRecord(CSVRecord record) {

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/InstanceOfferManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/InstanceOfferManager.java
@@ -372,7 +372,7 @@ public class InstanceOfferManager {
         LOGGER.debug("Retrieving instance offers for region {} {} #{}...",
                 region.getProvider(), region.getRegionCode(), region.getId());
         final List<InstanceOffer> offers = cloudFacade.refreshPriceListForRegion(region.getId());
-        LOGGER.debug("Retrieved {} instance offers for regin {} {} #{}.",
+        LOGGER.debug("Retrieved {} instance offers for region {} {} #{}.",
                 offers.size(), region.getProvider(), region.getRegionCode(), region.getId());
         return offers;
     }

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/InstanceOfferManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/InstanceOfferManager.java
@@ -48,8 +48,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.Assert;
 
@@ -337,7 +335,6 @@ public class InstanceOfferManager {
         return isPriceTypeAllowed(priceType, toolResource, false);
     }
 
-    @Transactional(propagation = Propagation.REQUIRED)
     public void refreshPriceList() {
         LOGGER.debug(messageHelper.getMessage(MessageConstants.DEBUG_INSTANCE_OFFERS_UPDATE_STARTED));
         List<InstanceOffer> offers = cloudRegionManager.loadAll()
@@ -350,24 +347,41 @@ public class InstanceOfferManager {
         LOGGER.info(messageHelper.getMessage(MessageConstants.INFO_INSTANCE_OFFERS_UPDATED, offers.size()));
     }
 
-    @Transactional(propagation = Propagation.REQUIRED)
     public void refreshPriceList(Long id) {
         AbstractCloudRegion region = cloudRegionManager.load(id);
         updatePriceList(region);
     }
 
-    @Transactional(propagation = Propagation.REQUIRED)
     public void refreshPriceList(AbstractCloudRegion region) {
         updatePriceList(region);
     }
 
-    private List<InstanceOffer> updatePriceList(AbstractCloudRegion region) {
-        LOGGER.debug("Updating instance offers for {} {} region #{}...",
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    private List<InstanceOffer> updatePriceList(final AbstractCloudRegion region) {
+        try {
+            final List<InstanceOffer> offers = retrievePriceList(region);
+            return replacePriceList(region, offers);
+        } catch (RuntimeException e) {
+            LOGGER.error("Failed to update instance offers for region {} {} #{}.",
+                    region.getProvider(), region.getRegionCode(), region.getId(), e);
+            return Collections.emptyList();
+        }
+    }
+
+    private List<InstanceOffer> retrievePriceList(final AbstractCloudRegion region) {
+        LOGGER.debug("Retrieving instance offers for region {} {} #{}...",
                 region.getProvider(), region.getRegionCode(), region.getId());
-        List<InstanceOffer> offers = cloudFacade.refreshPriceListForRegion(region.getId());
-        instanceOfferDao.removeInstanceOffersForRegion(region.getId());
-        instanceOfferDao.insertInstanceOffers(offers);
-        LOGGER.debug("Inserted {} instance offers to {} {} region #{}.",
+        final List<InstanceOffer> offers = cloudFacade.refreshPriceListForRegion(region.getId());
+        LOGGER.debug("Retrieved {} instance offers for regin {} {} #{}.",
+                offers.size(), region.getProvider(), region.getRegionCode(), region.getId());
+        return offers;
+    }
+
+    private List<InstanceOffer> replacePriceList(final AbstractCloudRegion region, final List<InstanceOffer> offers) {
+        LOGGER.debug("Inserting {} instance offers to region {} {} #{}.",
+                offers.size(), region.getProvider(), region.getRegionCode(), region.getId());
+        instanceOfferDao.replaceInstanceOffersForRegion(region.getId(), offers);
+        LOGGER.debug("Inserted {} instance offers to region {} {} #{}.",
                 offers.size(), region.getProvider(), region.getRegionCode(), region.getId());
         return offers;
     }

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -544,6 +544,10 @@ public class SystemPreferences {
         "cluster.allowed.instance.types.docker", "m5.*,c5.*,r4.*,t2.*", CLUSTER_GROUP, pass);
     public static final IntPreference CLUSTER_INSTANCE_OFFER_UPDATE_RATE = new IntPreference(
         "instance.offer.update.rate", 3600000, CLUSTER_GROUP, isGreaterThan(10000));
+    public static final StringPreference CLUSTER_AWS_EC2_PRICING_URL_TEMPLATE = new StringPreference(
+        "cluster.aws.ec2.pricing.url.template",
+        "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/%s/index.csv",
+        CLUSTER_GROUP, isNotBlank);
     public static final IntPreference CLUSTER_INSTANCE_OFFER_EXPIRATION_RATE_HOURS = new IntPreference(
         "instance.offer.expiration.rate.hours", 72, CLUSTER_GROUP, isGreaterThan(0));
     public static final IntPreference CLUSTER_BATCH_RETRY_COUNT = new IntPreference("cluster.batch.retry.count",


### PR DESCRIPTION
Relates #1019.

The pull request adds more efficient transaction management to region price list refresh operations.

Additionally, the pull request brings the following system preference:

- `cluster.aws.ec2.pricing.url.template` specifies aws ec2 pricing url template. Defaults to *https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/%s/index.csv*.
