### PR TITLE
GCP: Implement upload URLs generation

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -133,7 +133,7 @@ dependencies {
     compile "com.google.apis:google-api-services-compute:v1-rev20220720-1.32.1"
     compile "com.google.apis:google-api-services-cloudbilling:v1-rev30-1.25.0"
     compile "com.google.apis:google-api-services-iamcredentials:v1-rev32-1.25.0"
-    compile "com.google.cloud:google-cloud-storage:1.64.0"
+    compile "com.google.cloud:google-cloud-storage:1.70.0"
 
     testCompile group: "org.springframework.security", name: "spring-security-test", version: "4.2.2.RELEASE"
     testCompile group: "com.github.tomakehurst", name: "wiremock", version: "2.14.0"

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageHelper.java
@@ -56,6 +56,7 @@ import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.CopyWriter;
 import com.google.cloud.storage.Cors;
+import com.google.cloud.storage.HttpMethod;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageClass;
 import lombok.RequiredArgsConstructor;
@@ -387,6 +388,19 @@ public class GSBucketStorageHelper {
         final URL signedUrl = client.signUrl(BlobInfo.newBuilder(blob.getBlobId()).build(), 1, TimeUnit.DAYS);
         final DataStorageDownloadFileUrl dataStorageDownloadFileUrl = new DataStorageDownloadFileUrl();
         dataStorageDownloadFileUrl.setUrl(signedUrl.toString());
+        dataStorageDownloadFileUrl.setExpires(new Date((new Date()).getTime() + URL_EXPIRATION));
+        return dataStorageDownloadFileUrl;
+    }
+
+    public DataStorageDownloadFileUrl generateUploadUrl(final GSBucketStorage storage, final String path) {
+        final Storage client = gcpClient.buildStorageClient(region);
+
+        final URL url = client.signUrl(BlobInfo.newBuilder(storage.getPath(), path).build(), 1, TimeUnit.DAYS,
+                Storage.SignUrlOption.withV4Signature(),
+                Storage.SignUrlOption.httpMethod(HttpMethod.PUT));
+
+        final DataStorageDownloadFileUrl dataStorageDownloadFileUrl = new DataStorageDownloadFileUrl();
+        dataStorageDownloadFileUrl.setUrl(url.toString());
         dataStorageDownloadFileUrl.setExpires(new Date((new Date()).getTime() + URL_EXPIRATION));
         return dataStorageDownloadFileUrl;
     }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageProvider.java
@@ -135,7 +135,7 @@ public class GSBucketStorageProvider implements StorageProvider<GSBucketStorage>
     @Override
     public DataStorageDownloadFileUrl generateDataStorageItemUploadUrl(final GSBucketStorage dataStorage,
                                                                        final String path) {
-        return null;
+        return getHelper(dataStorage).generateUploadUrl(dataStorage, path);
     }
 
     @Override


### PR DESCRIPTION
This PR provides implementation `GET  datastorage/{id}/generateUploadUrl` API method for GCP provider.