### PR TITLE
GCP: custom instance types improvements

### DIFF
--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -662,6 +662,11 @@ public final class MessageConstants {
 
     public static final String ERROR_GCP_INSTANCE_NOT_RUNNING = "error.gcp.instance.not.running";
     public static final String ERROR_GCP_INSTANCE_NOT_FOUND = "error.gcp.instance.not.found";
+    public static final String ERROR_GCP_CUSTOM_INSTANCE_CPU_LOWER_LIMIT = "error.gcp.custom.instance.cpu.lower.limit";
+    public static final String ERROR_GCP_CUSTOM_INSTANCE_FAMILY_NOT_SUPPORTED =
+            "error.gcp.custom.instance.family.not.supported";
+    public static final String ERROR_GCP_CUSTOM_INSTANCE_FAMILY_NOT_ALLOWED_WITH_GPU =
+            "error.gcp.custom.instance.family.not.allowed.with.gpu";
 
     //AWS
     public static final String ERROR_AWS_PROFILE_UNIQUENESS = "error.aws.profile.uniqueness";

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/extractor/GCPPredefinedMachineExtractor.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/extractor/GCPPredefinedMachineExtractor.java
@@ -97,7 +97,8 @@ public class GCPPredefinedMachineExtractor implements GCPObjectExtractor {
                 .filter(items -> items.length > 1)
                 .map(items -> GpuDevice.from(items[items.length - 1], items[0]));
 
-        return Optional.of(new GCPMachine(name, family, cpu, ram, extendedRam, gpu, gpuDevice.orElse(null)));
+        return Optional.of(new GCPMachine(name, family, cpu, ram, extendedRam, gpu, gpuDevice.orElse(null),
+                null));
     }
 
     private double getMemory(final MachineType machineType) {

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/resource/GCPMachine.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/resource/GCPMachine.java
@@ -140,7 +140,7 @@ public class GCPMachine extends AbstractGCPObject {
 
     @Override
     public String billingKey(final GCPBilling billing, final GCPResourceType type) {
-        return String.format(BILLING_KEY_PATTERN, type.alias(), billing.alias(), calculateBillingKeyFamily(type));
+        return String.format(BILLING_KEY_PATTERN, type.alias(), billing.alias(), getBillingKeyFamily(type));
     }
 
     @Override
@@ -148,7 +148,7 @@ public class GCPMachine extends AbstractGCPObject {
         return "Compute";
     }
 
-    private String calculateBillingKeyFamily(final GCPResourceType type) {
+    private String getBillingKeyFamily(final GCPResourceType type) {
         if (type == GCPResourceType.GPU) {
             return Optional.ofNullable(gpuDevice)
                             .map(GpuDevice::getName)

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -575,6 +575,10 @@ error.gcp.impersonate.account=Impersonated account for temporary credentials mus
 error.gcp.instance.not.running=GCP instance ''{0}'' is not in active state. Current state: ''{1}''
 error.gcp.instance.not.found=Instance with label ''{0}'' not found!
 
+error.gcp.custom.instance.cpu.lower.limit=The number of CPU shall be greater than 1.
+error.gcp.custom.instance.family.not.supported=Specified instance family ''{0}'' is not supported for GCP custom instances. Allowed values: [{1}].
+error.gcp.custom.instance.family.not.allowed.with.gpu=Only N1 family allowed for gpu instances.
+
 #AWS
 error.aws.profile.uniqueness=Exactly one account profile is supported for AWS provider
 error.aws.s3.role.uniqueness=Exactly one role is supported to assume for AWS provider

--- a/api/src/test/java/com/epam/pipeline/manager/cloud/gcp/GCPCustomMachineExtractorTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cloud/gcp/GCPCustomMachineExtractorTest.java
@@ -51,7 +51,7 @@ public class GCPCustomMachineExtractorTest {
     public void testCustomCpuMachineExtraction() {
         final GCPRegion region = new GCPRegion();
         region.setCustomInstanceTypes(Collections.singletonList(GCPCustomInstanceType.withCpu(CPU, RAM)));
-        final GCPMachine expectedMachine = GCPMachine.withCpu("custom-1-2048", CUSTOM_FAMILY, CPU, RAM, 0);
+        final GCPMachine expectedMachine = GCPMachine.withCpu("custom-1-2048", CUSTOM_FAMILY, CPU, RAM, 0, null);
 
         final List<AbstractGCPObject> actualMachines = extractor.extract(region);
 
@@ -66,7 +66,7 @@ public class GCPCustomMachineExtractorTest {
         final GCPRegion region = new GCPRegion();
         region.setCustomInstanceTypes(Collections.singletonList(GCPCustomInstanceType.withGpu(CPU, RAM, GPU, K_80)));
         final GCPMachine expectedMachine = GCPMachine.withGpu("gpu-custom-1-2048-k80-3", CUSTOM_FAMILY, CPU, RAM, 0,
-                GPU, GpuDevice.from(K_80, NVIDIA));
+                GPU, GpuDevice.from(K_80, NVIDIA), null);
 
         final List<AbstractGCPObject> actualMachines = extractor.extract(region);
 
@@ -82,7 +82,7 @@ public class GCPCustomMachineExtractorTest {
         region.setCustomInstanceTypes(Collections.singletonList(GCPCustomInstanceType.withCpu(2 * CPU,
                 EXTENDED_RAM_FACTOR * 2 + EXTENDED_RAM)));
         final GCPMachine expectedMachine = GCPMachine.withCpu("gpu-custom-1-2048-k80-3", CUSTOM_FAMILY, 2 * CPU,
-                EXTENDED_RAM_FACTOR * 2, EXTENDED_RAM);
+                EXTENDED_RAM_FACTOR * 2, EXTENDED_RAM, null);
 
         final List<AbstractGCPObject> actualMachines = extractor.extract(region);
 

--- a/api/src/test/java/com/epam/pipeline/manager/cloud/gcp/GCPCustomMachineExtractorTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cloud/gcp/GCPCustomMachineExtractorTest.java
@@ -18,6 +18,7 @@ package com.epam.pipeline.manager.cloud.gcp;
 
 import com.epam.pipeline.entity.cluster.GpuDevice;
 import com.epam.pipeline.entity.region.GCPCustomInstanceType;
+import com.epam.pipeline.entity.region.GCPCustomVMType;
 import com.epam.pipeline.entity.region.GCPRegion;
 import com.epam.pipeline.manager.cloud.gcp.extractor.GCPCustomMachineExtractor;
 import com.epam.pipeline.manager.cloud.gcp.extractor.GCPObjectExtractor;
@@ -40,6 +41,7 @@ public class GCPCustomMachineExtractorTest {
     private static final double RAM = 2.0;
     private static final double EXTENDED_RAM = 2.0;
     private static final double EXTENDED_RAM_FACTOR = 6.5;
+    private static final double N2_EXTENDED_RAM_FACTOR = 8.0;
     private static final int GPU = 3;
     private static final String K_80 = "K80";
     public static final String CUSTOM_FAMILY = "custom";
@@ -51,14 +53,12 @@ public class GCPCustomMachineExtractorTest {
     public void testCustomCpuMachineExtraction() {
         final GCPRegion region = new GCPRegion();
         region.setCustomInstanceTypes(Collections.singletonList(GCPCustomInstanceType.withCpu(CPU, RAM)));
-        final GCPMachine expectedMachine = GCPMachine.withCpu("custom-1-2048", CUSTOM_FAMILY, CPU, RAM, 0, null);
+        final GCPMachine expectedMachine = GCPMachine.withCpu("custom-1-2048",
+                CUSTOM_FAMILY, CPU, RAM, 0, GCPCustomVMType.n1);
 
         final List<AbstractGCPObject> actualMachines = extractor.extract(region);
 
-        assertThat(actualMachines.size(), is(1));
-        final AbstractGCPObject actualObject = actualMachines.get(0);
-        assertThat(actualObject, instanceOf(GCPMachine.class));
-        assertMachineEquals(expectedMachine, (GCPMachine) actualObject);
+        assertGCPMachine(expectedMachine, actualMachines);
     }
 
     @Test
@@ -66,14 +66,11 @@ public class GCPCustomMachineExtractorTest {
         final GCPRegion region = new GCPRegion();
         region.setCustomInstanceTypes(Collections.singletonList(GCPCustomInstanceType.withGpu(CPU, RAM, GPU, K_80)));
         final GCPMachine expectedMachine = GCPMachine.withGpu("gpu-custom-1-2048-k80-3", CUSTOM_FAMILY, CPU, RAM, 0,
-                GPU, GpuDevice.from(K_80, NVIDIA), null);
+                GPU, GpuDevice.from(K_80, NVIDIA), GCPCustomVMType.n1);
 
         final List<AbstractGCPObject> actualMachines = extractor.extract(region);
 
-        assertThat(actualMachines.size(), is(1));
-        final AbstractGCPObject actualObject = actualMachines.get(0);
-        assertThat(actualObject, instanceOf(GCPMachine.class));
-        assertMachineEquals(expectedMachine, (GCPMachine) actualObject);
+        assertGCPMachine(expectedMachine, actualMachines);
     }
 
     @Test
@@ -81,11 +78,42 @@ public class GCPCustomMachineExtractorTest {
         final GCPRegion region = new GCPRegion();
         region.setCustomInstanceTypes(Collections.singletonList(GCPCustomInstanceType.withCpu(2 * CPU,
                 EXTENDED_RAM_FACTOR * 2 + EXTENDED_RAM)));
-        final GCPMachine expectedMachine = GCPMachine.withCpu("gpu-custom-1-2048-k80-3", CUSTOM_FAMILY, 2 * CPU,
-                EXTENDED_RAM_FACTOR * 2, EXTENDED_RAM, null);
+        final GCPMachine expectedMachine = GCPMachine.withCpu("custom-2-15360-ext", CUSTOM_FAMILY, 2 * CPU,
+                EXTENDED_RAM_FACTOR * 2, EXTENDED_RAM, GCPCustomVMType.n1);
 
         final List<AbstractGCPObject> actualMachines = extractor.extract(region);
 
+        assertGCPMachine(expectedMachine, actualMachines);
+    }
+
+    @Test
+    public void testExtendedCustomGpuMachineExtraction() {
+        final GCPRegion region = new GCPRegion();
+        region.setCustomInstanceTypes(Collections.singletonList(GCPCustomInstanceType
+                .withGpu(2 * CPU, EXTENDED_RAM_FACTOR * 2 + EXTENDED_RAM, GPU, K_80)));
+        final GCPMachine expectedMachine = GCPMachine.withGpu("gpu-custom-2-15360-k80-3-ext",
+                CUSTOM_FAMILY, 2 * CPU, EXTENDED_RAM_FACTOR * 2, EXTENDED_RAM,
+                GPU, GpuDevice.from(K_80, NVIDIA), GCPCustomVMType.n1);
+
+        final List<AbstractGCPObject> actualMachines = extractor.extract(region);
+
+        assertGCPMachine(expectedMachine, actualMachines);
+    }
+
+    @Test
+    public void testExtendedCustomMachineWithFamilyExtraction() {
+        final GCPRegion region = new GCPRegion();
+        region.setCustomInstanceTypes(Collections.singletonList(GCPCustomInstanceType.withCpu(2 * CPU,
+                N2_EXTENDED_RAM_FACTOR * 2 + EXTENDED_RAM, "n2")));
+        final GCPMachine expectedMachine = GCPMachine.withCpu("n2-custom-2-18432-ext", CUSTOM_FAMILY, 2 * CPU,
+                N2_EXTENDED_RAM_FACTOR * 2, EXTENDED_RAM, GCPCustomVMType.n2);
+
+        final List<AbstractGCPObject> actualMachines = extractor.extract(region);
+
+        assertGCPMachine(expectedMachine, actualMachines);
+    }
+
+    private void assertGCPMachine(final GCPMachine expectedMachine, final List<AbstractGCPObject> actualMachines) {
         assertThat(actualMachines.size(), is(1));
         final AbstractGCPObject actualObject = actualMachines.get(0);
         assertThat(actualObject, instanceOf(GCPMachine.class));
@@ -97,5 +125,7 @@ public class GCPCustomMachineExtractorTest {
         assertEquals(actualMachine.getRam(), expectedMachine.getRam(), DELTA);
         assertEquals(actualMachine.getExtendedRam(), expectedMachine.getExtendedRam(), DELTA);
         assertEquals(actualMachine.getGpu(), expectedMachine.getGpu());
+        assertEquals(actualMachine.getName(), expectedMachine.getName());
+        assertEquals(actualMachine.getFamily(), expectedMachine.getFamily());
     }
 }

--- a/api/src/test/java/com/epam/pipeline/manager/cloud/gcp/GCPInstancePriceServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cloud/gcp/GCPInstancePriceServiceTest.java
@@ -357,7 +357,7 @@ public class GCPInstancePriceServiceTest {
         assertTrue(optionalOffer.isPresent());
         final InstanceOffer offer = optionalOffer.get();
         assertThat(offer.getVCPU(), is(customCpuMachine.getCpu()));
-        assertThat(offer.getMemory(), is(customCpuMachine.getRam()));
+        assertThat(offer.getMemory(), is(customCpuMachine.getRam() + customCpuMachine.getExtendedRam()));
         assertThat(offer.getGpu(), is(customCpuMachine.getGpu()));
         assertTrue(offer.getProductFamily().toLowerCase().contains(INSTANCE_PRODUCT_FAMILY));
         final double expectedNanos = CUSTOM_CPU_COST * customCpuMachine.getCpu()

--- a/api/src/test/java/com/epam/pipeline/manager/cloud/gcp/GCPInstancePriceServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cloud/gcp/GCPInstancePriceServiceTest.java
@@ -84,14 +84,14 @@ public class GCPInstancePriceServiceTest {
     private static final GCPResourceMapping MAPPING = new GCPResourceMapping("prefix", "group");
 
     private final GCPRegion region = defaultRegion();
-    private final GCPMachine cpuMachine = GCPMachine.withCpu("n1-standard-1", STANDARD_FAMILY, 1, 4, 0);
+    private final GCPMachine cpuMachine = GCPMachine.withCpu("n1-standard-1", STANDARD_FAMILY, 1, 4, 0, null);
     private final GCPMachine gpuMachine = GCPMachine.withGpu("a2-highgpu-2g", HIGHGPU_FAMILY, 24, 170, 0, 2,
-            NVIDIA_A100);
-    private final GCPMachine customCpuMachine = GCPMachine.withCpu("custom-2-15360", CUSTOM_FAMILY, 2, 13, 2);
+            NVIDIA_A100, null);
+    private final GCPMachine customCpuMachine = GCPMachine.withCpu("custom-2-15360", CUSTOM_FAMILY, 2, 13, 2, null);
     private final GCPMachine customGpuMachine = GCPMachine.withGpu("gpu-custom-2-8192-k80-1", CUSTOM_FAMILY, 2, 8, 0, 3,
-            NVIDIA_K80);
+            NVIDIA_K80, null);
     private final GCPMachine cpuMachineWithNoPrices = GCPMachine.withCpu("n1-familywithoutprices-1",
-            "familywithoutprices", 10, 20, 0);
+            "familywithoutprices", 10, 20, 0, null);
     private final GCPDisk disk = new GCPDisk("SSD", "SSD");
     private final List<AbstractGCPObject> predefinedMachines = Arrays.asList(cpuMachine, gpuMachine,
             cpuMachineWithNoPrices);
@@ -131,7 +131,7 @@ public class GCPInstancePriceServiceTest {
     @Test
     public void refreshShouldGenerateRequestsForExtractedObject() {
         final GCPObjectExtractor extractor = mock(GCPObjectExtractor.class);
-        final GCPMachine machine = GCPMachine.withCpu("name", STANDARD_FAMILY, 2, 8.0, 0);
+        final GCPMachine machine = GCPMachine.withCpu("name", STANDARD_FAMILY, 2, 8.0, 0, null);
         when(extractor.extract(any())).thenReturn(Collections.singletonList(machine));
         final GCPInstancePriceService service = getService(extractor);
         final List<GCPResourceRequest> expectedRequests = Arrays.asList(
@@ -155,8 +155,8 @@ public class GCPInstancePriceServiceTest {
     @Test
     public void refreshShouldGenerateRequestsForAllExtractedObjects() {
         final GCPObjectExtractor extractor = mock(GCPObjectExtractor.class);
-        final GCPMachine machine1 = GCPMachine.withCpu("name", STANDARD_FAMILY, 2, 8.0, 0);
-        final GCPMachine machine2 = GCPMachine.withCpu("another-name", STANDARD_FAMILY, 3, 10.0, 0);
+        final GCPMachine machine1 = GCPMachine.withCpu("name", STANDARD_FAMILY, 2, 8.0, 0, null);
+        final GCPMachine machine2 = GCPMachine.withCpu("another-name", STANDARD_FAMILY, 3, 10.0, 0, null);
         when(extractor.extract(any())).thenReturn(Arrays.asList(machine1, machine2));
         final GCPInstancePriceService service = getService(extractor);
         final List<GCPResourceRequest> expectedRequests = Arrays.asList(

--- a/api/src/test/java/com/epam/pipeline/manager/region/GCPCloudRegionManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/region/GCPCloudRegionManagerTest.java
@@ -42,8 +42,8 @@ public class GCPCloudRegionManagerTest extends AbstractCloudRegionManagerTest {
     private static final String SSH_PUB_PATH = "/ssh.pub";
     private static final String IMPERSONATED_ACCOUNT = "acc";
     private static final List<GCPCustomInstanceType> CUSTOM_INSTANCE_TYPES = Arrays.asList(
-            GCPCustomInstanceType.withCpu(1, 3.75),
-            GCPCustomInstanceType.withGpu(1, 3.75, 1, "K80")
+            GCPCustomInstanceType.withCpu(2, 3.75),
+            GCPCustomInstanceType.withGpu(2, 3.75, 1, "K80")
     );
 
     @Before

--- a/core/src/main/java/com/epam/pipeline/entity/region/GCPCustomInstanceType.java
+++ b/core/src/main/java/com/epam/pipeline/entity/region/GCPCustomInstanceType.java
@@ -37,6 +37,12 @@ public class GCPCustomInstanceType {
         return new GCPCustomInstanceType(cpu, ram, 0, null, null);
     }
 
+    public static GCPCustomInstanceType withCpu(final int cpu,
+                                                final double ram,
+                                                final String family) {
+        return new GCPCustomInstanceType(cpu, ram, 0, null, family);
+    }
+
     public static GCPCustomInstanceType withGpu(final int cpu,
                                                 final double ram,
                                                 final int gpu,

--- a/core/src/main/java/com/epam/pipeline/entity/region/GCPCustomInstanceType.java
+++ b/core/src/main/java/com/epam/pipeline/entity/region/GCPCustomInstanceType.java
@@ -30,16 +30,17 @@ public class GCPCustomInstanceType {
     private double ram;
     private int gpu;
     private String gpuType;
+    private GCPCustomVMType family;
 
     public static GCPCustomInstanceType withCpu(final int cpu,
                                                 final double ram) {
-        return new GCPCustomInstanceType(cpu, ram, 0, null);
+        return new GCPCustomInstanceType(cpu, ram, 0, null, null);
     }
 
     public static GCPCustomInstanceType withGpu(final int cpu,
                                                 final double ram,
                                                 final int gpu,
                                                 final String gpuType) {
-        return new GCPCustomInstanceType(cpu, ram, gpu, gpuType);
+        return new GCPCustomInstanceType(cpu, ram, gpu, gpuType, null);
     }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/region/GCPCustomInstanceType.java
+++ b/core/src/main/java/com/epam/pipeline/entity/region/GCPCustomInstanceType.java
@@ -30,7 +30,7 @@ public class GCPCustomInstanceType {
     private double ram;
     private int gpu;
     private String gpuType;
-    private GCPCustomVMType family;
+    private String family;
 
     public static GCPCustomInstanceType withCpu(final int cpu,
                                                 final double ram) {

--- a/core/src/main/java/com/epam/pipeline/entity/region/GCPCustomVMType.java
+++ b/core/src/main/java/com/epam/pipeline/entity/region/GCPCustomVMType.java
@@ -18,6 +18,9 @@ package com.epam.pipeline.entity.region;
 
 import lombok.Getter;
 
+/**
+ * Represents allowed instance families for GCP custom instance types.
+ */
 @Getter
 public enum GCPCustomVMType {
 

--- a/core/src/main/java/com/epam/pipeline/entity/region/GCPCustomVMType.java
+++ b/core/src/main/java/com/epam/pipeline/entity/region/GCPCustomVMType.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.region;
+
+import lombok.Getter;
+
+@Getter
+public enum GCPCustomVMType {
+
+    n1(true, 6.5, ""),
+    n2(true, 8.0, "n2-"),
+    n2d(true, 8.0, "n2d-"),
+    e2(false, null, "e2-");
+
+    private final boolean supportExternal;
+    private final Double extendedFactor;
+    private final String prefix;
+
+    GCPCustomVMType(final boolean supportExternal, final Double extendedFactor, final String prefix) {
+        this.supportExternal = supportExternal;
+        this.extendedFactor = extendedFactor;
+        this.prefix = prefix;
+    }
+}

--- a/workflows/pipe-common/pipeline/autoscaling/gcpprovider.py
+++ b/workflows/pipe-common/pipeline/autoscaling/gcpprovider.py
@@ -39,6 +39,7 @@ GPU_CUSTOM_INSTANCE_TYPE_INDEX = 3
 GPU_CUSTOM_INSTANCE_COUNT_INDEX = 4
 GPU_NVIDIA_PREFIX = 'nvidia-tesla-'
 GPU_TYPE_PREFIX = 'gpu-'
+CUSTOM_INSTANCE_EXTENDED_MEMORY_SUFFIX = '-ext'
 
 
 class GCPInstanceProvider(AbstractInstanceProvider):
@@ -140,15 +141,34 @@ class GCPInstanceProvider(AbstractInstanceProvider):
     def parse_instance_type(self, ins_type):
         # Custom type with GPU: gpu-custom-4-16000-k80-1
         # Custom type with CPU only: custom-4-16000
+        # Custom type with CPU and extended RAM: custom-1-65536-ext
         # Predefined type: n1-standard-1
         if not ins_type.startswith(GPU_TYPE_PREFIX):
             return ins_type, None, 0
-        parts = ins_type[len(GPU_TYPE_PREFIX):].split('-')
-        if len(parts) != GPU_CUSTOM_INSTANCE_PARTS:
-            raise RuntimeError('Custom instance type with GPU "%s" does not match expected pattern.' % ins_type)
-        gpu_type = parts[GPU_CUSTOM_INSTANCE_TYPE_INDEX]
-        gpu_count = parts[GPU_CUSTOM_INSTANCE_COUNT_INDEX]
-        return '-'.join(parts[0:GPU_CUSTOM_INSTANCE_TYPE_INDEX]), GPU_NVIDIA_PREFIX + gpu_type, gpu_count
+
+        # Custom GPU type with extended RAM: gpu-custom-4-16000-k80-1-ext
+        extended_ram = str(ins_type).endswith(CUSTOM_INSTANCE_EXTENDED_MEMORY_SUFFIX)
+        if extended_ram:
+            parts = ins_type[len(GPU_TYPE_PREFIX):-len(CUSTOM_INSTANCE_EXTENDED_MEMORY_SUFFIX)].split('-')
+        else:
+            parts = ins_type[len(GPU_TYPE_PREFIX):].split('-')
+
+        if len(parts) == GPU_CUSTOM_INSTANCE_PARTS:
+            return self.parse_gpu_instance_type(
+                parts, GPU_CUSTOM_INSTANCE_TYPE_INDEX, GPU_CUSTOM_INSTANCE_COUNT_INDEX, extended_ram)
+        # Custom GPU type with family: gpu-n2-custom-4-16000-k80-1
+        if len(parts) == GPU_CUSTOM_INSTANCE_PARTS + 1:
+            return self.parse_gpu_instance_type(
+                parts, GPU_CUSTOM_INSTANCE_TYPE_INDEX + 1, GPU_CUSTOM_INSTANCE_COUNT_INDEX + 1, extended_ram)
+        raise RuntimeError('Custom instance type with GPU "%s" does not match expected pattern.' % ins_type)
+
+    def parse_gpu_instance_type(self, parts, gpu_type_index, gpu_count_index, extended_ram):
+        gpu_type = parts[gpu_type_index]
+        gpu_count = parts[gpu_count_index]
+        machine_type = '-'.join(parts[0:gpu_type_index])
+        if extended_ram:
+            machine_type = machine_type + CUSTOM_INSTANCE_EXTENDED_MEMORY_SUFFIX
+        return machine_type, GPU_NVIDIA_PREFIX + gpu_type, gpu_count
 
     def find_and_tag_instance(self, old_id, new_id):
         instance = self.__find_instance(old_id)


### PR DESCRIPTION
The following PR brings the following changes for GCP provider:

- Support custom extended instance types
  - `-ext` suffix shall be added to the instance type ending (`custom-2-65536-ext`)
- Support VM families for custom instance types
  - a new field `family` added to `region#customInstanceTypes` entity. Example:
```
...
 {
    "cpu": 2,
    "ram": 64,
    "family": "n2"
 },
...
```
  - allowed families: `n1`, `n2`, `n2d`, `e2`
   - Not available for GPU
   - `gcp.sku.mapping` preference family pattern: `<family>-custom` (`n2-custom`). Example:
```
...
"ram_ondemand_n2-custom": {
      "prefix": "N2 Custom Instance Ram",
      "group": "RAM"
},
...
```
   - `<family>-` prefix shall be added to the instance type beginning. Example: `n2-custom-2-1536`  or `gpu-n2-custom-2-1536-k80-1`