### PR TITLE
Generate user SSH keys automatically in API

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -121,6 +121,7 @@ dependencies {
     compile group: "net.sf.ehcache", name: "ehcache", version: "2.10.4"
     compile group: "org.springframework", name: "spring-context", version: "4.3.7.RELEASE"
     compile group: "org.springframework", name: "spring-context-support", version: "4.3.7.RELEASE"
+    compile "com.jcraft:jsch:0.1.55"
 
     //Cache
     compile("org.springframework.boot:spring-boot-starter-cache")

--- a/api/src/main/java/com/epam/pipeline/manager/keypair/JSchSshKeyPairManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/keypair/JSchSshKeyPairManager.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2023 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.epam.pipeline.manager.keypair;
+
+import com.epam.pipeline.exception.PipelineException;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.KeyPair;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.output.WriterOutputStream;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.StringWriter;
+
+@Slf4j
+@Component
+public class JSchSshKeyPairManager implements SshKeyPairManager {
+
+    @Override
+    public SshKeyPair generate() {
+        final StringWriter privateKeyWriter = new StringWriter();
+        final StringWriter publicKeyWriter = new StringWriter();
+        try(OutputStream privateKeyOutputStream = new WriterOutputStream(privateKeyWriter);
+            OutputStream publicKeyOutputStream = new WriterOutputStream(publicKeyWriter)) {
+            final KeyPair keyPair = KeyPair.genKeyPair(new JSch(), KeyPair.RSA, 4096);
+            keyPair.writePrivateKey(privateKeyOutputStream);
+            keyPair.writePublicKey(publicKeyOutputStream, null);
+            keyPair.dispose();
+        } catch (JSchException | IOException e) {
+            log.error("SSH keys generation has failed.", e);
+            throw new PipelineException(e);
+        }
+        final String privateKey = StringUtils.strip(privateKeyWriter.toString());
+        final String publicKey = StringUtils.strip(publicKeyWriter.toString());
+        return new SshKeyPair(privateKey, publicKey);
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/keypair/SshKeyPair.java
+++ b/api/src/main/java/com/epam/pipeline/manager/keypair/SshKeyPair.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2023 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.epam.pipeline.manager.keypair;
+
+import lombok.Value;
+
+@Value
+public class SshKeyPair {
+    String privateKey;
+    String publicKey;
+}

--- a/api/src/main/java/com/epam/pipeline/manager/keypair/SshKeyPairManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/keypair/SshKeyPairManager.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017-2023 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.epam.pipeline.manager.keypair;
+
+public interface SshKeyPairManager {
+
+    SshKeyPair generate();
+}

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -1014,6 +1014,12 @@ public class SystemPreferences {
      */
     public static final IntPreference SYSTEM_USER_JWT_LAST_LOGIN_THRESHOLD = new IntPreference(
             "system.user.jwt.last.login.threshold.hours", 1, SYSTEM_GROUP, pass);
+    public static final BooleanPreference SYSTEM_USER_SSH_KEYS_AUTO_CREATE = new BooleanPreference(
+            "system.user.ssh.keys.auto.create", true, SYSTEM_GROUP, pass);
+    public static final StringPreference SYSTEM_USER_SSH_KEYS_PRV_METADATA_KEY = new StringPreference(
+            "system.user.ssh.keys.prv.metadata.key", "ssh_prv", SYSTEM_GROUP, isNotBlank);
+    public static final StringPreference SYSTEM_USER_SSH_KEYS_PUB_METADATA_KEY = new StringPreference(
+            "system.user.ssh.keys.pub.metadata.key", "ssh_pub", SYSTEM_GROUP, isNotBlank);
 
     public static final ObjectPreference<Map<String, NotificationFilter>>
             SYSTEM_NOTIFICATIONS_EXCLUDE_PARAMS = new ObjectPreference("system.notifications.exclude.params",

--- a/api/src/test/java/com/epam/pipeline/manager/keypair/SshKeyPairManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/keypair/SshKeyPairManagerTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2023 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.epam.pipeline.manager.keypair;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+@RequiredArgsConstructor
+public class SshKeyPairManagerTest {
+
+    private final SshKeyPairManager manager;
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {new JSchSshKeyPairManager()},
+        });
+    }
+
+    @Test
+    public void testKeysAreNotBlank() {
+        final SshKeyPair pair = manager.generate();
+
+        assertTrue(StringUtils.isNotBlank(pair.getPrivateKey()));
+        assertTrue(StringUtils.isNotBlank(pair.getPublicKey()));
+    }
+
+    @Test
+    public void testKeysAreUnique() {
+        assertThat(manager.generate(), is(not(manager.generate())));
+    }
+}


### PR DESCRIPTION
Resolves #3365.

The pull request brings support for user SSH keys generation to API. From now on each new user will have assigned SSH keys.
