### PR TITLE
Update slurm version for ubuntu

### DIFF
--- a/workflows/pipe-common/shell/slurm_setup_master
+++ b/workflows/pipe-common/shell/slurm_setup_master
@@ -20,6 +20,7 @@ SLURM_MASTER_SETUP_TASK_WORKERS="SLURMMasterSetupWorkers"
 CURRENT_PID=$$
 
 configure_slurm() {
+    local _distro="$1"
 
     mkdir -p ${SLURM_COMMON_CONFIG_DIR}
 
@@ -38,6 +39,15 @@ ConstrainCores=no
 ConstrainRAMSpace=no
 EOL
 
+if [ "$_distro" == "redhat" ]; then
+    _scheduling_config="SchedulerType=sched/backfill
+SelectType=select/cons_tres
+SelectTypeParameters=CR_CPU"
+else
+    _scheduling_config="SchedulerType=sched/backfill
+SelectType=select/linear"
+fi
+
     cat > ${SLURM_COMMON_CONFIG_DIR}/slurm.conf <<EOL
 ControlMachine=$HOSTNAME
 #
@@ -54,9 +64,7 @@ SwitchType=switch/none
 TaskPlugin=task/none
 
 # SCHEDULING
-SchedulerType=sched/backfill
-SelectType=select/cons_tres
-SelectTypeParameters=CR_CPU
+$_scheduling_config
 
 # LOGGING AND ACCOUNTING
 ClusterName=cloudpipeline
@@ -201,7 +209,7 @@ elif [ "$LINUX_DISTRIBUTION" = "redhat" ]; then
 fi
 
 _SLURM_CONFIG_LOCATION=$( slurm_config_location )
-configure_slurm
+configure_slurm "$LINUX_DISTRIBUTION"
 
 dd if=/dev/urandom bs=1 count=1024 > ${SLURM_COMMON_CONFIG_DIR}/munge.key
 cp ${SLURM_COMMON_CONFIG_DIR}/munge.key /etc/munge/

--- a/workflows/pipe-common/shell/slurm_setup_master
+++ b/workflows/pipe-common/shell/slurm_setup_master
@@ -20,17 +20,23 @@ SLURM_MASTER_SETUP_TASK_WORKERS="SLURMMasterSetupWorkers"
 CURRENT_PID=$$
 
 configure_slurm() {
-    local _distro="$1"
+    _SLURM_CONFIG_LOCATION=$( slurm_config_location )
 
     mkdir -p ${SLURM_COMMON_CONFIG_DIR}
 
-    mkdir /var/spool/slurmctld
-    chown slurm: /var/spool/slurmctld
-    chmod 755 /var/spool/slurmctld
-    touch /var/log/slurmctld.log
-    chown slurm: /var/log/slurmctld.log
-    touch /var/log/slurm_jobacct.log /var/log/slurm_jobcomp.log
-    chown slurm: /var/log/slurm_jobacct.log /var/log/slurm_jobcomp.log
+    mkdir -p /var/spool/slurmctld \
+             /var/spool/slurmd
+    chown slurm: /var/spool/slurmctld \
+                 /var/spool/slurmd
+    chmod 755 /var/spool/slurmctld \
+              /var/spool/slurmd
+
+    touch /var/log/slurmctld.log \
+          /var/log/slurm_jobacct.log \
+          /var/log/slurm_jobcomp.log
+    chown slurm: /var/log/slurmctld.log \
+                 /var/log/slurm_jobacct.log \
+                 /var/log/slurm_jobcomp.log
 
     cat > ${SLURM_COMMON_CONFIG_DIR}/cgroup.conf <<EOL
 CgroupAutomount=yes
@@ -38,15 +44,6 @@ CgroupMountpoint=/cgroup
 ConstrainCores=no
 ConstrainRAMSpace=no
 EOL
-
-if [ "$_distro" == "redhat" ]; then
-    _scheduling_config="SchedulerType=sched/backfill
-SelectType=select/cons_tres
-SelectTypeParameters=CR_CPU"
-else
-    _scheduling_config="SchedulerType=sched/backfill
-SelectType=select/linear"
-fi
 
     cat > ${SLURM_COMMON_CONFIG_DIR}/slurm.conf <<EOL
 ControlMachine=$HOSTNAME
@@ -64,7 +61,9 @@ SwitchType=switch/none
 TaskPlugin=task/none
 
 # SCHEDULING
-$_scheduling_config
+SchedulerType=sched/backfill
+SelectType=select/cons_tres
+SelectTypeParameters=CR_CPU
 
 # LOGGING AND ACCOUNTING
 ClusterName=cloudpipeline
@@ -123,21 +122,15 @@ EOL
         echo -e "\n# Mail notification configuration" >> ${SLURM_COMMON_CONFIG_DIR}/slurm.conf
         echo "MailProg=$COMMON_REPO_DIR_MUTUAL_LOC/shell/pipe_mail" >> ${SLURM_COMMON_CONFIG_DIR}/slurm.conf
     fi
-}
 
-get_linux_dist() {
-    result=
-    command -v apt-get > /dev/null
-    if [ $? -eq 0 ]; then
-        result="debian"
-    fi
+    dd if=/dev/urandom bs=1 count=1024 > ${SLURM_COMMON_CONFIG_DIR}/munge.key
+    cp ${SLURM_COMMON_CONFIG_DIR}/munge.key /etc/munge/
+    chown munge: /etc/munge/munge.key
+    chmod 400 /etc/munge/munge.key
+    su -c /usr/sbin/munged -s /bin/bash munge
 
-    command -v yum > /dev/null
-    if [ $? -eq 0 ]; then
-        result="redhat"
-    fi
-
-    echo "$result"
+    ln -s ${SLURM_COMMON_CONFIG_DIR}/slurm.conf "$_SLURM_CONFIG_LOCATION"
+    ln -s  ${SLURM_COMMON_CONFIG_DIR}/cgroup.conf "$_SLURM_CONFIG_LOCATION"
 }
 
 check_last_exit_code() {
@@ -164,28 +157,58 @@ slurm_config_location() {
    fi
 }
 
-pipe_log_info "Installing SLURM master" "$SLURM_MASTER_SETUP_TASK"
+install_slurm() {
+    create_slurm_user
 
-LINUX_DISTRIBUTION=$( get_linux_dist )
-
-if [ "$LINUX_DISTRIBUTION" = "debian" ]; then
-    apt-get update && apt-get install -y munge slurm-wlm
-    mkdir -p /var/run/munge
-    chown munge: /var/run/munge
-    mkdir -p /run/munge
-    chown munge: /run/munge
-    chmod +t /run/munge
-elif [ "$LINUX_DISTRIBUTION" = "redhat" ]; then
-
-    if [ -z $CP_SLURM_PACKAGE_URL ]; then
-        CP_SLURM_PACKAGE_URL="${GLOBAL_DISTRIBUTION_URL}tools/slurm/rpm/slurm-22.05.5-1.el7.x86_64.tar"
-        CP_SLURM_SOURCE_URL="https://download.schedmd.com/slurm/slurm-22.05.5.tar.bz2"
+    if [ "$CP_OS_FAMILY" == "debian" ]; then
+        if [ "$CP_OS" == "ubuntu" ] && [ "$CP_VER" == "16.04" ]; then
+            pipe_log_fail "SLURM support for Ubuntu 16.04 has been dropped. Please use Ubuntu 18.04 instead." "$SLURM_MASTER_SETUP_TASK"
+            return 1
+        fi
+        install_slurm_debian
+    elif [ "$CP_OS_FAMILY" == "rhel" ]; then
+        install_slurm_rhel
+    else
+        return 1
     fi
+}
 
+create_slurm_user() {
     export SLURMUSER=992
     groupadd -g $SLURMUSER slurm
     useradd  -m -c "SLURM workload manager" -d /var/lib/slurm -u $SLURMUSER -g slurm  -s /bin/bash slurm
+}
 
+install_slurm_debian() {
+    apt-get update -y
+    apt-get install -y munge
+
+    mkdir -p /var/run/munge \
+             /run/munge
+    chown munge: /var/run/munge \
+                 /run/munge
+    chmod +t /run/munge
+
+    wget -q "$CP_SLURM_PACKAGE_DEB_URL" -O /tmp/slurm.deb
+    if ! apt-get install -y -f /tmp/slurm.deb; then
+        return 1
+    fi
+    rm -f /tmp/slurm.deb
+
+    mkdir -p /etc/slurm \
+             /etc/slurm/prolog.d \
+             /etc/slurm/epilog.d
+    chown slurm: /etc/slurm \
+                 /etc/slurm/prolog.d \
+                 /etc/slurm/epilog.d
+
+    ln -s /usr/local/slurm/bin/* /usr/bin/
+    ln -s /usr/local/slurm/sbin/* /usr/sbin/
+
+    return 0
+}
+
+install_slurm_rhel() {
     yum install epel-release -y
     yum install gcc gcc-c++ mariadb-server mariadb-devel  munge munge-libs munge-devel openssl openssl-devel \
                 pam-devel numactl hwloc hwloc-devel lua lua-devel readline-devel rrdtool-devel ncurses-devel  \
@@ -193,10 +216,10 @@ elif [ "$LINUX_DISTRIBUTION" = "redhat" ]; then
 
     _TMP_PACKAGE_DIR=/tmp/localinstall && mkdir -p $_TMP_PACKAGE_DIR
     mkdir -p /common/slurm-pkgs
-    wget $CP_SLURM_PACKAGE_URL --directory-prefix=$_TMP_PACKAGE_DIR
+    wget -q "$CP_SLURM_PACKAGE_RPM_URL" --directory-prefix=$_TMP_PACKAGE_DIR
     if [[ $? -ne 0 ]]; then
         rm -rf /root/rpmbuild/RPMS/x86_64/*
-        wget $CP_SLURM_SOURCE_URL --directory-prefix=$_TMP_PACKAGE_DIR
+        wget -q $CP_SLURM_SOURCE_URL --directory-prefix=$_TMP_PACKAGE_DIR
         rpmbuild -ta $_TMP_PACKAGE_DIR/slurm*.tar.bz2
         cp /root/rpmbuild/RPMS/x86_64/* /common/slurm-pkgs/
     else
@@ -205,41 +228,36 @@ elif [ "$LINUX_DISTRIBUTION" = "redhat" ]; then
     fi
 
     yum --nogpgcheck localinstall /common/slurm-pkgs/* -y
-    check_last_exit_code $? "Successfully install SLURM packages" "Can't install SLURM packages from /common/slurm-pkgs/"
+}
+
+pipe_log_info "Installing SLURM master" "$SLURM_MASTER_SETUP_TASK"
+
+export CP_SLURM_SOURCE_URL="${CP_SLURM_SOURCE_URL:-"${GLOBAL_DISTRIBUTION_URL}tools/slurm/slurm-22.05.5.tar.bz2"}"
+export CP_SLURM_PACKAGE_DEB_URL="${CP_SLURM_PACKAGE_DEB_URL:-"${GLOBAL_DISTRIBUTION_URL}tools/slurm/deb/slurm_22.05.5_amd64.deb"}"
+export CP_SLURM_PACKAGE_RPM_URL="${CP_SLURM_PACKAGE_RPM_URL:-"${GLOBAL_DISTRIBUTION_URL}tools/slurm/rpm/slurm-22.05.5-1.el7.x86_64.tar"}"
+
+if check_cp_cap CP_CAP_SLURM_PREINSTALLED; then
+    pipe_log_info "Skipping SLURM packages installation because packages are preinstalled" "$SLURM_MASTER_SETUP_TASK"
+elif check_cp_cap RESUMED_RUN; then
+    pipe_log_info "Skipping SLURM packages installation because run is resumed" "$SLURM_MASTER_SETUP_TASK"
+else
+    pipe_log_info "Installing SLURM packages" "$SLURM_MASTER_SETUP_TASK"
+    install_slurm
+    check_last_exit_code $? "SLURM packages have been installed" "Can't install SLURM packages"
 fi
 
-_SLURM_CONFIG_LOCATION=$( slurm_config_location )
-configure_slurm "$LINUX_DISTRIBUTION"
-
-dd if=/dev/urandom bs=1 count=1024 > ${SLURM_COMMON_CONFIG_DIR}/munge.key
-cp ${SLURM_COMMON_CONFIG_DIR}/munge.key /etc/munge/
-chown munge: /etc/munge/munge.key
-chmod 400 /etc/munge/munge.key
-su -c /usr/sbin/munged -s /bin/bash munge
-
-ln -s ${SLURM_COMMON_CONFIG_DIR}/slurm.conf "$_SLURM_CONFIG_LOCATION"
-ln -s  ${SLURM_COMMON_CONFIG_DIR}/cgroup.conf "$_SLURM_CONFIG_LOCATION"
+if check_cp_cap RESUMED_RUN; then
+    pipe_log_info "Skipping SLURM cluster configuration because run is resumed" "$SLURM_MASTER_SETUP_TASK"
+else
+    pipe_log_info "Configuring SLURM cluster" "$SLURM_MASTER_SETUP_TASK"
+    configure_slurm
+    pipe_log_info "SLURM cluster has been configured" "$SLURM_MASTER_SETUP_TASK"
+fi
 
 slurmctld && slurmd
+check_last_exit_code $? "SLURM daemons have started" "Fail to start SLURM daemons."
 
-check_last_exit_code $? "SLURM demons have started" "Fail to start SLURM demons."
-
-pipe_log_success "Master ENV is ready" "$SLURM_MASTER_SETUP_TASK"
-
-
-# Verify whether it is a resumed run - if so, do not reinstall SLURM, instead - just rerun master and worker daemon
-if [ "$RESUMED_RUN" = true ]; then
-    pipe_log_info "Run is resumed - SLURM master node won't be reconfigured. Starting master and worker daemons" "$SLURM_MASTER_SETUP_TASK"
-    slurmctld -f /etc/slurm/slurm.conf && slurmd -f /etc/slurm/slurm.conf
-    _SLURM_RESUME_RESULT=$?
-
-    if [ $_SLURM_RESUME_RESULT -eq 0 ]; then
-        pipe_log_success "SLURM daemons started" "$SLURM_MASTER_SETUP_TASK"
-    else
-        pipe_log_fail "SLURM daemons start failed. See any errors in the ConsoleOutput" "$SLURM_MASTER_SETUP_TASK"
-    fi
-    exit 0
-fi
+pipe_log_success "SLURM master node has been successfully configured" "$SLURM_MASTER_SETUP_TASK"
 
 # Wait for worker nodes to initiate and connect to the master
 if [ -z "$node_count" ] || (( "$node_count" == 0 )); then
@@ -255,11 +273,14 @@ else
         _MASTER_EXEC_WAIT_ATTEMPTS=$(( _MASTER_EXEC_WAIT_ATTEMPTS-1 ))
 
         if (( $_MASTER_EXEC_WAIT_ATTEMPTS <= 0 )); then
-            pipe_log_success "NOT all execution hosts are connected. But we are giving up waiting as threshold has been reached" "$SLURM_MASTER_SETUP_TASK_WORKERS"
-            exit 0
+            break
         fi
     done
-    pipe_log_success "All SLURM hosts are connected" "$SLURM_MASTER_SETUP_TASK_WORKERS"
+    if [ "$node_count" -gt "$_CURRENT_EXEC_HOSTS_COUNT" ]; then
+        pipe_log_success "NOT all execution hosts are connected. But we are giving up waiting as threshold has been reached" "$SLURM_MASTER_SETUP_TASK_WORKERS"
+    else
+        pipe_log_success "All SLURM hosts are connected" "$SLURM_MASTER_SETUP_TASK_WORKERS"
+    fi
 fi
 
 (

--- a/workflows/pipe-common/shell/slurm_setup_worker
+++ b/workflows/pipe-common/shell/slurm_setup_worker
@@ -19,6 +19,7 @@ SLURM_WORKER_SETUP_TASK="SLURMWorkerSetup"
 CURRENT_PID=$$
 
 add_worker() {
+    _SLURM_CONFIG_LOCATION=$( slurm_config_location )
 
     cp ${SLURM_COMMON_CONFIG_DIR}/munge.key /etc/munge/
     chown munge: /etc/munge/munge.key
@@ -54,21 +55,6 @@ add_worker() {
     fi
 }
 
-get_linux_dist() {
-    result=
-    command -v apt-get > /dev/null
-    if [ $? -eq 0 ]; then
-        result="debian"
-    fi
-
-    command -v yum > /dev/null
-    if [ $? -eq 0 ]; then
-        result="redhat"
-    fi
-
-    echo "$result"
-}
-
 check_last_exit_code() {
    exit_code=$1
    msg_if_success=$2
@@ -87,15 +73,78 @@ slurm_config_location() {
    if [ "$_SLURM_CONFIG_DIR" != "" ]; then
       echo "/etc/$_SLURM_CONFIG_DIR"
    else
-      pipe_log_fail "Failed to find SLURM config dir" "${SLURM_MASTER_SETUP_TASK}"
+      pipe_log_fail "Failed to find SLURM config dir" "${SLURM_WORKER_SETUP_TASK}"
       kill -s "$CURRENT_PID"
       exit 1
    fi
 }
 
-LINUX_DISTRIBUTION=$( get_linux_dist )
+install_slurm() {
+    create_slurm_user
+
+    if [ "$CP_OS_FAMILY" == "debian" ]; then
+        if [ "$CP_OS" == "ubuntu" ] && [ "$CP_VER" == "16.04" ]; then
+            pipe_log_fail "SLURM support for Ubuntu 16.04 has been dropped. Please use Ubuntu 18.04 instead." "$SLURM_WORKER_SETUP_TASK"
+            return 1
+        fi
+        install_slurm_debian
+    elif [ "$CP_OS_FAMILY" == "rhel" ]; then
+        install_slurm_rhel
+    else
+        return 1
+    fi
+}
+
+create_slurm_user() {
+    export SLURMUSER=992
+    groupadd -g $SLURMUSER slurm
+    useradd -m -c "SLURM workload manager" -d /var/lib/slurm -u $SLURMUSER -g slurm  -s /bin/bash slurm
+}
+
+install_slurm_debian() {
+    apt-get update -y
+    apt-get install -y munge
+#    todo: Check if there is need to install libmunge2 / libmunge-dev is needed
+
+    mkdir -p /var/run/munge \
+             /run/munge
+    chown munge: /var/run/munge \
+                 /run/munge
+    chmod +t /run/munge
+
+    wget -q "$CP_SLURM_PACKAGE_DEB_URL" -O /tmp/slurm.deb
+    if ! apt-get install -y -f /tmp/slurm.deb; then
+        return 1
+    fi
+    rm -f /tmp/slurm.deb
+
+    mkdir -p /etc/slurm \
+             /etc/slurm/prolog.d \
+             /etc/slurm/epilog.d
+    chown slurm: /etc/slurm \
+                 /etc/slurm/prolog.d \
+                 /etc/slurm/epilog.d
+
+    ln -s /usr/local/slurm/bin/* /usr/bin/
+    ln -s /usr/local/slurm/sbin/* /usr/sbin/
+
+    return 0
+}
+
+install_slurm_rhel() {
+    yum install epel-release -y
+    yum install munge munge-libs munge-devel openssl openssl-devel \
+                pam-devel numactl hwloc hwloc-devel lua lua-devel readline-devel  \
+                rrdtool-devel ncurses-devel man2html libibmad libibumad rpm-build perl-devel perl-CPAN -y
+
+    yum --nogpgcheck localinstall /common/slurm-pkgs/* -y
+}
 
 pipe_log_info "Installing SLURM worker" "$SLURM_WORKER_SETUP_TASK"
+
+export CP_SLURM_SOURCE_URL="${CP_SLURM_SOURCE_URL:-"${GLOBAL_DISTRIBUTION_URL}tools/slurm/slurm-22.05.5.tar.bz2"}"
+export CP_SLURM_PACKAGE_DEB_URL="${CP_SLURM_PACKAGE_DEB_URL:-"${GLOBAL_DISTRIBUTION_URL}tools/slurm/deb/slurm_22.05.5_amd64.deb"}"
+export CP_SLURM_PACKAGE_RPM_URL="${CP_SLURM_PACKAGE_RPM_URL:-"${GLOBAL_DISTRIBUTION_URL}tools/slurm/rpm/slurm-22.05.5-1.el7.x86_64.tar"}"
 
 MASTER_INFO_RESULT=$(eval "${CP_PYTHON2_PATH} ${COMMON_REPO_DIR}/scripts/cluster_wait_for_master.py --master-id ${parent_id} --task-name SLURMMasterSetup")
 _MASTER_AWAIT_RESULT=$?
@@ -104,30 +153,16 @@ MASTER_IP=${MASTER_INFO[-1]}
 MASTER_NAME=${MASTER_INFO[-2]}
 check_last_exit_code $_MASTER_AWAIT_RESULT "Master info received: $MASTER_NAME : $MASTER_IP" "Fail to install SLURM worker. Unable to get master information"
 
-if [ "$LINUX_DISTRIBUTION" = "debian" ]; then
-    apt install -y munge slurm-wlm
-    mkdir -p /var/run/munge
-    chown munge: /var/run/munge
-    mkdir -p /run/munge
-    chown munge: /run/munge
-    chmod +t /run/munge
-elif [ "$LINUX_DISTRIBUTION" = "redhat" ]; then
-    export SLURMUSER=992
-    groupadd -g $SLURMUSER slurm
-    useradd  -m -c "SLURM workload manager" -d /var/lib/slurm -u $SLURMUSER -g slurm  -s /bin/bash slurm
-
-    yum install epel-release -y
-    yum install munge munge-libs munge-devel openssl openssl-devel \
-                pam-devel numactl hwloc hwloc-devel lua lua-devel readline-devel  \
-                rrdtool-devel ncurses-devel man2html libibmad libibumad rpm-build perl-devel perl-CPAN -y
-
-    yum --nogpgcheck localinstall /common/slurm-pkgs/* -y
-    check_last_exit_code $? "Successfully install SLURM packages" "Can't install SLURM packages from /common/slurm-pkgs/"
+if check_cp_cap CP_CAP_SLURM_PREINSTALLED; then
+    pipe_log_info "Skipping SLURM packages installation because packages are preinstalled" "$SLURM_WORKER_SETUP_TASK"
+else
+    pipe_log_info "Installing SLURM packages" "$SLURM_WORKER_SETUP_TASK"
+    install_slurm
+    check_last_exit_code $? "SLURM packages have been installed" "Can't install SLURM packages"
 fi
 
 pipe_log_info "Adding worker node to SLURM cluster" "$SLURM_WORKER_SETUP_TASK"
-_SLURM_CONFIG_LOCATION=$( slurm_config_location )
 add_worker
-check_last_exit_code $? "Host was added as a worker to the SLURM cluster" "Fail to add SLURM worker host"
+check_last_exit_code $? "SLURM daemons have started" "Fail to start SLURM daemons."
 
-pipe_log_success "SLURM worker node was successfully configured" "$SLURM_WORKER_SETUP_TASK"
+pipe_log_success "SLURM worker node has been successfully configured" "$SLURM_WORKER_SETUP_TASK"


### PR DESCRIPTION
Relates #3330.

The pull request brings support for slurm 22.05.5 on ubuntu.

Additionally, the pull request:
- deprecates slurm support for ubuntu 16.04
- fixes slurm installation for resumed runs

The following run parameters are introduced:
- `CP_SLURM_SOURCE_URL` specifies slurm source url. Defaults *https://cloud-pipeline-oss-builds.s3.us-east-1.amazonaws.com/tools/slurm/slurm-22.05.5.tar.bz2*
- `CP_SLURM_PACKAGE_DEB_URL` specifies slurm deb package url. Defaults to *https://cloud-pipeline-oss-builds.s3.us-east-1.amazonaws.com/tools/slurm/deb/slurm_22.05.5_amd64.deb*.
- `CP_SLURM_PACKAGE_RPM_URL` specifies slurm rpm package url. Defaults to *https://cloud-pipeline-oss-builds.s3.us-east-1.amazonaws.com/tools/slurm/rpm/slurm-22.05.5-1.el7.x86_64.tar*.
- `CP_CAP_SLURM_PREINSTALLED` disables slurm installation. Defaults to *false*.

<details>
  <summary>Click here to see Dockerfile which was used to build slurm 22.05.5 on ubuntu</summary>

  ```Dockerfile
FROM ubuntu:18.04

RUN DEBIAN_FRONTEND=noninteractive apt-get update -y \
    && DEBIAN_FRONTEND=noninteractive apt-get install -y wget \
                                                         vim \
                                                         xterm \
                                                         pulseaudio \
                                                         cups \
                                                         curl \
                                                         libgconf2-4 \
                                                         libnss3-dev \
                                                         libxss1 \
                                                         xdg-utils \
                                                         libpango1.0-0 \
                                                         fonts-liberation \
                                                         g++ \
                                                         git \
                                                         python \
                                                         mesa-utils \
                                                         build-essential \
                                                         cmake \
                                                         csh \
                                                         evince \
                                                         ghostscript-x \
                                                         libfftw3-dev \
                                                         libtiff5-dev \
                                                         unzip \
                                                         xorg-dev \
                                                         xorg \
                                                         libgtk2.0-0 \
                                                         libfltk1.3-dev \
                                                         libx11-dev \
                                                         gfortran \
    && rm -rf /var/lib/apt/lists/*

RUN DEBIAN_FRONTEND=noninteractive apt-get update -y \
    && DEBIAN_FRONTEND=noninteractive apt-get install -y munge \
                                                         libmunge-dev \
    && rm -rf /var/lib/apt/lists/*

RUN DEBIAN_FRONTEND=noninteractive apt-get update -y \
    && DEBIAN_FRONTEND=noninteractive apt-get install -y rubygems \
    && rm -rf /var/lib/apt/lists/* \
    && gem install fpm

RUN mkdir /workdir \
    && cd /workdir \
    && wget "https://cloud-pipeline-oss-builds.s3.us-east-1.amazonaws.com/tools/slurm/slurm-22.05.5.tar.bz2" \
    && tar --bzip -x -f slurm-22.05.5.tar.bz2 \
    && cd slurm-22.05.5 \
    && ./configure --prefix=/usr/local/slurm \
                   --sysconfdir=/etc/slurm \
                   --without-shared-libslurm \
    && make \
    && make install \
    && cd .. \
    && fpm -s dir -t deb \
           -n slurm -v 22.05.5 \
           --prefix=/usr/local/slurm \
           --chdir /usr/local/slurm \
           -p slurm_22.05.5_amd64.deb
  ```

</details>


