### PR TITLE
Fix for Storage Lifecycle Service: Archive in GLACIER_IR files with size bigger than 128 kb

### DIFF
--- a/storage-lifecycle-service/integrational_tests/model/testcase.py
+++ b/storage-lifecycle-service/integrational_tests/model/testcase.py
@@ -57,11 +57,12 @@ class TestCaseStorageCloudState:
 
 class TestCaseFile:
 
-    def __init__(self, path, storage_date_shift, storage_class, tags):
+    def __init__(self, path, storage_date_shift, storage_class, tags, size=128*1024):
         self.path = path
         self.storage_date_shift = storage_date_shift
         self.storage_class = storage_class
         self.tags = tags
+        self.size = size
 
 
 class TestCasePlatformStorageState:

--- a/storage-lifecycle-service/integrational_tests/processor/environment_preparation.py
+++ b/storage-lifecycle-service/integrational_tests/processor/environment_preparation.py
@@ -66,7 +66,7 @@ class AWSStorageTestCasePreparator(StorageTestCasePreparator):
             CreateBucketConfiguration={'LocationConstraint': self.aws_region})
         for file in storage.files:
             self.aws_s3_client.put_object(
-                Body=file_utils.generate_object_content(128*1024),
+                Body=file_utils.generate_object_content(file.size),
                 Bucket=storage.storage,
                 Key=file.path
             )

--- a/storage-lifecycle-service/integrational_tests/processor/result_gathering.py
+++ b/storage-lifecycle-service/integrational_tests/processor/result_gathering.py
@@ -72,7 +72,8 @@ class AWSCloudTestCaseStorageResultGatherer:
                     result.with_file(
                         TestCaseFile(
                             obj["Key"], None, None,
-                            {tag["Key"]: tag["Value"] for tag in get_tags_response["TagSet"]}
+                            {tag["Key"]: tag["Value"] for tag in get_tags_response["TagSet"]},
+                            obj["Size"]
                         )
                     )
         return result

--- a/storage-lifecycle-service/integrational_tests/processor/test_case_preprocessing.py
+++ b/storage-lifecycle-service/integrational_tests/processor/test_case_preprocessing.py
@@ -73,7 +73,8 @@ def _parse_storage_cloud_state(storage_json):
             _file_json["key"],
             _file_json["creationDateShift"] if "creationDateShift" in _file_json else None,
             _file_json["storageClass"] if "storageClass" in _file_json else None,
-            _file_json["tags"] if "tags" in _file_json else {}
+            _file_json["tags"] if "tags" in _file_json else {},
+            _file_json["size"] if "size" in _file_json else 128 * 1024
         )
 
     if "storage" not in storage_json:

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_38_nothing_eligable_to_do_because_files_are_small_for_glacier_ir.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_38_nothing_eligable_to_do_because_files_are_small_for_glacier_ir.json
@@ -5,9 +5,9 @@
         "storageProvider": "S3",
         "storage": "cp-lifecycle-storage-policy-test-storage",
         "files": [
-          {"key": "data/file1.txt", "creationDateShift": 10, "storageClass": "STANDARD"},
-          {"key": "data/file2.txt", "creationDateShift": 9, "storageClass": "STANDARD"},
-          {"key": "data/file3.txt", "creationDateShift": 8, "storageClass": "STANDARD"}
+          {"key": "data/file1.txt", "creationDateShift": 10, "storageClass": "STANDARD", "size": 127},
+          {"key": "data/file2.txt", "creationDateShift": 9, "storageClass": "STANDARD", "size": 127},
+          {"key": "data/file3.txt", "creationDateShift": 8, "storageClass": "STANDARD", "size": 127}
         ]
       }
     ]
@@ -30,18 +30,10 @@
             },
             "transitions": [
               {
-                "transitionAfterDays": 30,
-                "storageClass": "GLACIER"
+                "transitionAfterDays": 5,
+                "storageClass": "GLACIER_IR"
               }
-            ],
-            "notification": {
-              "notifyBeforeDays": 10,
-              "prolongDays": 10,
-              "recipients": [{"name": "ROLE_ADMIN", "principal": false}],
-              "enabled": true,
-              "subject": "Lifecycle rule is about to be applied!",
-              "body": "Lifecycle rule is about to be applied!"
-            }
+            ]
           }
         ],
         "executions": []

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_39_action_should_succeed_because_other_files_are_small_for_glacier_ir.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_39_action_should_succeed_because_other_files_are_small_for_glacier_ir.json
@@ -1,0 +1,71 @@
+{
+  "cloud": {
+    "storages": [
+      {
+        "storageProvider": "S3",
+        "storage": "cp-lifecycle-storage-policy-test-storage",
+        "files": [
+          {"key": "data/file1.txt", "creationDateShift": 10, "storageClass": "GLACIER_IR", "size": 264192},
+          {"key": "data/file2.txt", "creationDateShift": 9, "storageClass": "STANDARD", "size": 127},
+          {"key": "data/file3.txt", "creationDateShift": 8, "storageClass": "STANDARD", "size": 127}
+        ]
+      }
+    ]
+  },
+  "platform": {
+    "storages": [
+      {
+        "id": 1,
+        "storageProvider": "S3",
+        "storage": "cp-lifecycle-storage-policy-test-storage",
+        "rules": [
+          {
+            "id": 1,
+            "datastorageId": 1,
+            "pathGlob": "/data/",
+            "objectGlob": "*.txt",
+            "transitionMethod": "EARLIEST_FILE",
+            "transitionCriterion": {
+              "type": "DEFAULT"
+            },
+            "transitions": [
+              {
+                "transitionAfterDays": 5,
+                "storageClass": "GLACIER_IR"
+              }
+            ]
+          }
+        ],
+        "executions": [
+          {
+            "ruleId": 1,
+            "path": "/data",
+            "status": "RUNNING",
+            "storageClass": "GLACIER_IR"
+          }
+        ]
+      }
+    ]
+  },
+  "result": {
+    "platform": {
+      "storages": [
+        {
+          "id": 1,
+          "storage": "cp-lifecycle-storage-policy-test-storage",
+          "executions": [
+            {
+              "ruleId": 1,
+              "path": "/data",
+              "status": "SUCCESS",
+              "storageClass": "GLACIER_IR"
+            }
+          ]
+        }
+      ]
+    },
+    "cloud": {
+      "storages": []
+    }
+  }
+}

--- a/storage-lifecycle-service/integrational_tests/resources/testcases/case_40_action_to_glacer_ir_should_start_only_for_one_file_because_other_files_are_small.json
+++ b/storage-lifecycle-service/integrational_tests/resources/testcases/case_40_action_to_glacer_ir_should_start_only_for_one_file_because_other_files_are_small.json
@@ -1,0 +1,74 @@
+{
+  "cloud": {
+    "storages": [
+      {
+        "storageProvider": "S3",
+        "storage": "cp-lifecycle-storage-policy-test-storage",
+        "files": [
+          {"key": "data/file1.txt", "creationDateShift": 10, "storageClass": "STANDARD", "size": 264192},
+          {"key": "data/file2.txt", "creationDateShift": 9, "storageClass": "STANDARD", "size": 127},
+          {"key": "data/file3.txt", "creationDateShift": 8, "storageClass": "STANDARD", "size": 127}
+        ]
+      }
+    ]
+  },
+  "platform": {
+    "storages": [
+      {
+        "id": 1,
+        "storageProvider": "S3",
+        "storage": "cp-lifecycle-storage-policy-test-storage",
+        "rules": [
+          {
+            "id": 1,
+            "datastorageId": 1,
+            "pathGlob": "/data/",
+            "objectGlob": "*.txt",
+            "transitionMethod": "EARLIEST_FILE",
+            "transitionCriterion": {
+              "type": "DEFAULT"
+            },
+            "transitions": [
+              {
+                "transitionAfterDays": 5,
+                "storageClass": "GLACIER_IR"
+              }
+            ]
+          }
+        ],
+        "executions": []
+      }
+    ]
+  },
+  "result": {
+    "platform": {
+      "storages": [
+        {
+          "id": 1,
+          "storage": "cp-lifecycle-storage-policy-test-storage",
+          "executions": [
+            {
+              "ruleId": 1,
+              "path": "/data",
+              "status": "RUNNING",
+              "storageClass": "GLACIER_IR"
+            }
+          ]
+        }
+      ]
+    },
+    "cloud": {
+     "storages": [
+        {
+          "storage": "cp-lifecycle-storage-policy-test-storage",
+          "storageProvider": "S3",
+          "files": [
+            {"key": "data/file1.txt", "tags": {"DESTINATION_STORAGE_CLASS":  "GLACIER_IR"}},
+            {"key": "data/file2.txt"},
+            {"key": "data/file3.txt"}
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/storage-lifecycle-service/sls/cloud/cloud_utils.py
+++ b/storage-lifecycle-service/sls/cloud/cloud_utils.py
@@ -1,0 +1,14 @@
+# Way to provide specific logic about transitioning files to specific STORAGE_CLASS.
+# f.e. Transitioning to GLACIER_IR will be applied only for file that is bigger that 128kb, according to AWS docs,
+#      so, we need to filter such files out
+#
+# This filter applying in both situation, when actual archiving action is performed
+# and when we check the result of the existing actions
+def get_storage_class_specific_file_filter(target_storage_class):
+    if target_storage_class == "GLACIER_IR":
+        # Docs: https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-transition-general-considerations.html
+        # Files with size smaller that 128kb will not be moved from the S3 Standard or
+        # S3 Standard-IA storage classes to S3 Intelligent-Tiering or S3 Glacier Instant Retrieval
+        return lambda f: f.size > 128 * 1024
+    else:
+        return lambda f: True

--- a/storage-lifecycle-service/sls/cloud/model/cloud_object_model.py
+++ b/storage-lifecycle-service/sls/cloud/model/cloud_object_model.py
@@ -14,9 +14,10 @@
 
 class CloudObject:
 
-    def __init__(self, path, creation_date, storage_class, version_id=None):
+    def __init__(self, path, creation_date, storage_class, size=0, version_id=None):
         self.path = path
         self.version_id = version_id
         self.creation_date = creation_date
         self.storage_class = storage_class
+        self.size = size
 

--- a/storage-lifecycle-service/sls/cloud/s3_cloud.py
+++ b/storage-lifecycle-service/sls/cloud/s3_cloud.py
@@ -411,6 +411,7 @@ class S3StorageOperations(StorageOperations):
             S3StorageOperations._path_from_s3_format(s3_object["Key"]) if convert_path else s3_object["Key"],
             s3_object["LastModified"],
             s3_object["StorageClass"],
+            s3_object["Size"],
             s3_object["VersionId"] if 'VersionId' in s3_object else None
         )
 


### PR DESCRIPTION
This PR changes approach on archiving files in `GLACIER_IR` storage type: now only files with size bigger than 128 kb will be tagged to transition (according to AWS docs: https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-transition-general-considerations.html)