### PR TITLE
Introduce price list filtering based on minimum requirements

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/cloud/offer/InstanceOfferMinimumRequirementsFilter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/offer/InstanceOfferMinimumRequirementsFilter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2023 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cloud.offer;
+
+import com.epam.pipeline.entity.cluster.InstanceOffer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RequiredArgsConstructor
+public class InstanceOfferMinimumRequirementsFilter implements InstanceOfferFilter {
+
+    private final int cpu;
+    private final int mem;
+
+    @Override
+    public List<InstanceOffer> filter(final List<InstanceOffer> offers) {
+        log.debug("Filtering instance offers with at least {} cpu and {} mem...", cpu, mem);
+        final List<InstanceOffer> filteredOffers = offers.stream()
+                .filter(offer -> offer.getVCPU() >= cpu && (int) offer.getMemory() >= mem)
+                .collect(Collectors.toList());
+        log.debug("Filtered out {} instance offers.", offers.size() - filteredOffers.size());
+        return filteredOffers;
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -563,6 +563,10 @@ public class SystemPreferences {
                 .map(CloudInstancePriceService.TermType::getName)
                 .collect(Collectors.joining(",")),
         CLUSTER_GROUP, pass);
+    public static final IntPreference CLUSTER_INSTANCE_OFFER_FILTER_CPU_MIN = new IntPreference(
+        "instance.offer.filter.cpu.min", 2, CLUSTER_GROUP, pass);
+    public static final IntPreference CLUSTER_INSTANCE_OFFER_FILTER_MEM_MIN = new IntPreference(
+        "instance.offer.filter.mem.min", 3, CLUSTER_GROUP, pass);
     public static final IntPreference CLUSTER_INSTANCE_OFFER_INSERT_BATCH_SIZE = new IntPreference(
         "instance.offer.insert.batch.size", 10_000, CLUSTER_GROUP, isGreaterThan(0));
 


### PR DESCRIPTION
Relates #1019.

The pull request introduces filtering based on minimum requirements to price list refresh operations.

The following system preferences are introduced:

- `instance.offer.filter.cpu.min` specifies a minimum cpu number of instance offers. Defaults to *2*.
- `instance.offer.filter.mem.min` specifies a minimum memory of instance offers in GB. Defaults to *3*.
