### PR TITLE
Introduce mount storages retries support

### DIFF
--- a/deploy/contents/install/preferences/launch.system.parameters.json
+++ b/deploy/contents/install/preferences/launch.system.parameters.json
@@ -597,5 +597,26 @@
         "defaultValue": "true",
         "description": "Changes default mail client if favor to pipe_mail script.",
         "passToWorkers": true
+    },
+    {
+        "name": "CP_CAP_MOUNT_STORAGE_ATTEMPTS",
+        "type": "int",
+        "defaultValue": "1",
+        "description": "Specifies a number of single storage mount attempts",
+        "passToWorkers": true
+    },
+    {
+        "name": "CP_CAP_MOUNT_STORAGE_RETRY_DELAY_SECONDS",
+        "type": "int",
+        "defaultValue": "1",
+        "description": "Specifies a delay in seconds between single storage mount retries",
+        "passToWorkers": true
+    },
+    {
+        "name": "CP_CAP_MOUNT_STORAGE_LOGGING_LEVEL",
+        "type": "string",
+        "defaultValue": "INFO",
+        "description": "Specifies mount storages task logging level",
+        "passToWorkers": true
     }
 ]

--- a/workflows/pipe-common/pipeline/utils/retry.py
+++ b/workflows/pipe-common/pipeline/utils/retry.py
@@ -1,0 +1,34 @@
+#  Copyright 2017-2023 EPAM Systems, Inc. (https://www.epam.com/)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import time
+
+
+def retry(func, attempts, delay_seconds, logger):
+    delay_seconds = max(delay_seconds, 0)
+    attempts = max(attempts, 1)
+    attempt = 0
+    exceptions = []
+    while attempt < attempts:
+        attempt += 1
+        try:
+            return func(attempt, attempts)
+        except Exception as e:
+            exceptions.append(e)
+        if attempt >= attempts:
+            raise exceptions[-1]
+        logger.debug('Attempt {attempt}/{attempts} has failed. It will be retried in {delay_seconds} s.'
+                     .format(attempt=attempt, attempts=attempts, delay_seconds=delay_seconds),
+                     trace=True)
+        time.sleep(delay_seconds)

--- a/workflows/pipe-common/shell/mount_storages
+++ b/workflows/pipe-common/shell/mount_storages
@@ -49,7 +49,7 @@ if [ -z "$MOUNT_TASK_NAME" ]
 	exit 1
 fi
 
-MOUNT_RESULT=$(eval "$CP_PYTHON2_PATH ${COMMON_REPO_DIR}/scripts/mount_storage.py --mount-root ${MOUNT_ROOT} --tmp-dir ${TMP_DIR} --task ${MOUNT_TASK_NAME}")
+"$CP_PYTHON2_PATH" "${COMMON_REPO_DIR}/scripts/mount_storage.py" --mount-root "${MOUNT_ROOT}" --tmp-dir "${TMP_DIR}" --task "${MOUNT_TASK_NAME}"
 
 if [ $? -ne 0 ]
 then


### PR DESCRIPTION
Relates #3383.

The pull request brings support for retries support to storage mounting process.

Additionally, it improves logging capabilities of mount storages task.

The following system parameters are introduced:
- `CP_CAP_MOUNT_STORAGE_ATTEMPTS` specifies a number of single storage mount attempts. Defaults to *1*.
- `CP_CAP_MOUNT_STORAGE_RETRY_DELAY_SECONDS` specifies a delay in seconds between single storage mount retries. Defaults to *1*.
- `CP_CAP_MOUNT_STORAGE_LOGGING_LEVEL` specifies mount storages task logging level. Defaults to *INFO*.
