### PR TITLE
Issue #3381: Allow to set list of allowed instances at region level

### DIFF
--- a/api/src/main/java/com/epam/pipeline/app/ContextualPreferenceConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/ContextualPreferenceConfiguration.java
@@ -19,15 +19,17 @@ package com.epam.pipeline.app;
 import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.dao.contextual.ContextualPreferenceDao;
 import com.epam.pipeline.dao.datastorage.DataStorageDao;
+import com.epam.pipeline.dao.region.CloudRegionDao;
 import com.epam.pipeline.dao.tool.ToolDao;
 import com.epam.pipeline.dao.user.RoleDao;
 import com.epam.pipeline.dao.user.UserDao;
 import com.epam.pipeline.entity.preference.PreferenceType;
 import com.epam.pipeline.manager.contextual.handler.ArrayContextualPreferenceReducer;
+import com.epam.pipeline.manager.contextual.handler.BooleanContextualPreferenceReducer;
 import com.epam.pipeline.manager.contextual.handler.ContextualPreferenceHandler;
 import com.epam.pipeline.manager.contextual.handler.ContextualPreferenceReducer;
 import com.epam.pipeline.manager.contextual.handler.DefaultContextualPreferenceReducer;
-import com.epam.pipeline.manager.contextual.handler.BooleanContextualPreferenceReducer;
+import com.epam.pipeline.manager.contextual.handler.RegionContextualPreferenceHandler;
 import com.epam.pipeline.manager.contextual.handler.RoleContextualPreferenceHandler;
 import com.epam.pipeline.manager.contextual.handler.StorageContextualPreferenceHandler;
 import com.epam.pipeline.manager.contextual.handler.SystemPreferenceHandler;
@@ -75,8 +77,17 @@ public class ContextualPreferenceConfiguration {
     public StorageContextualPreferenceHandler storageContextualPreferenceHandler(
             final DataStorageDao storageDao,
             final ContextualPreferenceDao contextualPreferenceDao,
+            final RegionContextualPreferenceHandler regionContextualPreferenceHandler) {
+        return new StorageContextualPreferenceHandler(storageDao, contextualPreferenceDao,
+                regionContextualPreferenceHandler);
+    }
+
+    @Bean
+    public RegionContextualPreferenceHandler regionContextualPreferenceHandler(
+            final CloudRegionDao cloudRegionDao,
+            final ContextualPreferenceDao contextualPreferenceDao,
             final SystemPreferenceHandler systemPreferenceHandler) {
-        return new StorageContextualPreferenceHandler(storageDao, contextualPreferenceDao, systemPreferenceHandler);
+        return new RegionContextualPreferenceHandler(cloudRegionDao, contextualPreferenceDao, systemPreferenceHandler);
     }
 
     @Bean

--- a/api/src/main/java/com/epam/pipeline/entity/contextual/ContextualPreferenceLevel.java
+++ b/api/src/main/java/com/epam/pipeline/entity/contextual/ContextualPreferenceLevel.java
@@ -61,7 +61,14 @@ public enum ContextualPreferenceLevel {
      *
      * It is associated with a single storage.
      */
-    STORAGE(4);
+    STORAGE(4),
+
+    /**
+     * Cloud Region preference level.
+     *
+     * It is associated with a single region.
+     */
+    REGION(5);
 
     private final long id;
 

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/InstanceOfferManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/InstanceOfferManager.java
@@ -178,7 +178,7 @@ public class InstanceOfferManager {
         final boolean isSpot = isSpotRequest(spot);
         final Long actualRegionId = defaultRegionIfNull(regionId);
         Assert.isTrue(isInstanceAllowed(instanceType, actualRegionId, isSpot) ||
-                        isToolInstanceAllowed(instanceType, null, actualRegionId, isSpot),
+                        isToolInstanceAllowed(instanceType, actualRegionId, isSpot),
                 messageHelper.getMessage(MessageConstants.ERROR_INSTANCE_TYPE_IS_NOT_ALLOWED,
                         instanceType));
         double computePricePerHour = getPricePerHourForInstance(instanceType, isSpot, actualRegionId);
@@ -278,20 +278,52 @@ public class InstanceOfferManager {
     }
 
     /**
+     * Checks if the given instance type is allowed for the authorized user in the specified or default region.
+     * Also checks if the instance type is one of the offered instance types.
+     *
+     * @param instanceType To be checked.
+     * @param resources List of preference resources: tool, region, etc.
+     * @param regionId If specified then instance types for the specified region will be used.
+     */
+    public boolean isInstanceAllowed(final String instanceType,
+                                     final List<ContextualPreferenceExternalResource> resources,
+                                     final Long regionId,
+                                     final boolean spot) {
+        return isInstanceTypeAllowed(instanceType, resources, defaultRegionIfNull(regionId),
+                INSTANCE_TYPES_PREFERENCES, spot);
+    }
+
+    /**
      * Checks if the given tool instance type is allowed for the authorized user and the requested tool
      * in the specified or default region.
      *
      * Also checks if the instance type is one of the offered instance types.
      *
      * @param instanceType To be checked.
-     * @param toolResource Optional tool resource.
+     * @param resources List of preference resources: tool, region, etc.
      * @param regionId If specified then instance types for the specified region will be used.
      */
     public boolean isToolInstanceAllowed(final String instanceType,
-                                         final ContextualPreferenceExternalResource toolResource,
+                                         final List<ContextualPreferenceExternalResource> resources,
                                          final Long regionId,
                                          final boolean spot) {
-        return isInstanceTypeAllowed(instanceType, toolResource, defaultRegionIfNull(regionId),
+        return isInstanceTypeAllowed(instanceType, resources, defaultRegionIfNull(regionId),
+                TOOL_INSTANCE_TYPES_PREFERENCES, spot);
+    }
+
+    /**
+     * Checks if the given tool instance type is allowed for the authorized user and the requested tool
+     * in the specified or default region.
+     *
+     * Also checks if the instance type is one of the offered instance types.
+     *
+     * @param instanceType To be checked.
+     * @param regionId If specified then instance types for the specified region will be used.
+     */
+    public boolean isToolInstanceAllowed(final String instanceType,
+                                         final Long regionId,
+                                         final boolean spot) {
+        return isInstanceTypeAllowed(instanceType, null, defaultRegionIfNull(regionId),
                 TOOL_INSTANCE_TYPES_PREFERENCES, spot);
     }
 
@@ -306,24 +338,25 @@ public class InstanceOfferManager {
      */
     public boolean isToolInstanceAllowedInAnyRegion(final String instanceType,
                                                     final ContextualPreferenceExternalResource toolResource) {
-        return isInstanceTypeAllowed(instanceType, toolResource, null, TOOL_INSTANCE_TYPES_PREFERENCES, false)
-                || isInstanceTypeAllowed(instanceType, toolResource, null, TOOL_INSTANCE_TYPES_PREFERENCES, true);
+        final List<ContextualPreferenceExternalResource> resources = Collections.singletonList(toolResource);
+        return isInstanceTypeAllowed(instanceType, resources, null, TOOL_INSTANCE_TYPES_PREFERENCES, false)
+                || isInstanceTypeAllowed(instanceType, resources, null, TOOL_INSTANCE_TYPES_PREFERENCES, true);
     }
 
     private boolean isInstanceTypeAllowed(final String instanceType,
-                                          final ContextualPreferenceExternalResource resource,
+                                          final List<ContextualPreferenceExternalResource> resources,
                                           final Long regionId,
                                           final List<String> instanceTypesPreferences,
                                           final boolean spot) {
         return !StringUtils.isEmpty(instanceType)
-                && isInstanceTypeMatchesAllowedPatterns(instanceType, resource, instanceTypesPreferences)
+                && isInstanceTypeMatchesAllowedPatterns(instanceType, resources, instanceTypesPreferences)
                 && isInstanceTypeOffered(instanceType, regionId, spot);
     }
 
     private boolean isInstanceTypeMatchesAllowedPatterns(final String instanceType,
-                                                         final ContextualPreferenceExternalResource resource,
+                                                         final List<ContextualPreferenceExternalResource> resources,
                                                          final List<String> instanceTypesPreferences) {
-        return getContextualPreferenceValueAsList(resource, instanceTypesPreferences).stream()
+        return getContextualPreferenceValueAsList(resources, instanceTypesPreferences).stream()
                 .anyMatch(pattern -> matcher.match(pattern, instanceType));
     }
 
@@ -331,22 +364,21 @@ public class InstanceOfferManager {
      * Checks if the given price type is allowed for the authorized user and tool.
      *
      * @param priceType To be checked.
-     * @param toolResource Optional tool resource.
+     * @param resources List of resources.
      * @param isMaster is checking node a master in cluster run
      */
     public boolean isPriceTypeAllowed(final String priceType,
-                                      final ContextualPreferenceExternalResource toolResource,
+                                      final List<ContextualPreferenceExternalResource> resources,
                                       final boolean isMaster) {
         final List<String> priceTypesPreferences = isMaster
                                      ? MASTER_PRICE_TYPES_PREFERENCES
                                      : PRICE_TYPES_PREFERENCES;
-        return getContextualPreferenceValueAsList(toolResource, priceTypesPreferences).stream()
-            .anyMatch(priceType::equals);
+        return getContextualPreferenceValueAsList(resources, priceTypesPreferences).stream()
+                .anyMatch(priceType::equals);
     }
 
-    public boolean isPriceTypeAllowed(final String priceType,
-                                      final ContextualPreferenceExternalResource toolResource) {
-        return isPriceTypeAllowed(priceType, toolResource, false);
+    public boolean isPriceTypeAllowed(final String priceType) {
+        return isPriceTypeAllowed(priceType, null, false);
     }
 
     public void refreshPriceList() {
@@ -553,12 +585,15 @@ public class InstanceOfferManager {
         final List<String> preferenceNames = Arrays.stream(preferences)
                 .map(AbstractSystemPreference::getKey)
                 .collect(toList());
-        return getContextualPreferenceValueAsList(resource, preferenceNames);
+        return getContextualPreferenceValueAsList(Optional.ofNullable(resource)
+                .map(Collections::singletonList)
+                .orElse(null), preferenceNames);
     }
 
-    private List<String> getContextualPreferenceValueAsList(final ContextualPreferenceExternalResource resource,
+    private List<String> getContextualPreferenceValueAsList(final List<ContextualPreferenceExternalResource> resources,
                                                             final List<String> preferences) {
-        return Arrays.asList(contextualPreferenceManager.search(preferences, resource).getValue().split(DELIMITER));
+        return Arrays.asList(contextualPreferenceManager
+                .searchList(preferences, resources).getValue().split(DELIMITER));
     }
 
     private boolean isInstanceTypeOffered(final String instanceType, final Long regionId, final boolean spot) {

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/pool/NodePoolValidator.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/pool/NodePoolValidator.java
@@ -63,13 +63,13 @@ public class NodePoolValidator {
 
         Assert.notNull(vo.getPriceType(),
                 messageHelper.getMessage(MessageConstants.ERROR_NODE_POOL_MISSING_PRICE_TYPE));
-        Assert.isTrue(instanceOfferManager.isPriceTypeAllowed(vo.getPriceType().getLiteral(), null),
+        Assert.isTrue(instanceOfferManager.isPriceTypeAllowed(vo.getPriceType().getLiteral()),
                 messageHelper.getMessage(MessageConstants.ERROR_NODE_POOL_PRICE_TYPE_NOT_ALLOWED,
                         vo.getPriceType()));
 
         Assert.isTrue(StringUtils.isNotBlank(vo.getInstanceType()),
                 messageHelper.getMessage(MessageConstants.ERROR_NODE_POOL_MISSING_INSTANCE_TYPE));
-        Assert.isTrue(instanceOfferManager.isToolInstanceAllowed(vo.getInstanceType(), null, vo.getRegionId(),
+        Assert.isTrue(instanceOfferManager.isToolInstanceAllowed(vo.getInstanceType(), vo.getRegionId(),
                 PriceType.SPOT.equals(vo.getPriceType())),
                 messageHelper.getMessage(MessageConstants.ERROR_NODE_POOL_INSTANCE_TYPE_NOT_ALLOWED,
                         vo.getInstanceType()));

--- a/api/src/main/java/com/epam/pipeline/manager/contextual/ContextualPreferenceManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/contextual/ContextualPreferenceManager.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
@@ -122,6 +123,33 @@ public class ContextualPreferenceManager {
 
     /**
      * Searches for a contextual preference with the given parameters
+     * Returns a first found preference from the list of preferences.
+     * Method takes into account the context preference was searched in. It includes
+     * user, its role, requested resource, etc.
+     *
+     * @param preferences List of preference names.
+     * @param resources List of external resource preferences.
+     * @throws IllegalArgumentException if preference with such parameters wasn't found.
+     */
+    public ContextualPreference searchList(final List<String> preferences,
+                                           final List<ContextualPreferenceExternalResource> resources) {
+        if (CollectionUtils.isEmpty(resources)) {
+            return search(preferences);
+        }
+        validateNames(preferences);
+        resources.forEach(this::validateResource);
+        final List<ContextualPreferenceExternalResource> allResources = userAndRolesResources();
+        allResources.addAll(resources);
+        return contextualPreferenceHandler.search(preferences, allResources)
+                .orElseThrow(() -> new IllegalArgumentException(messageHelper.getMessage(
+                        MessageConstants.ERROR_CONTEXTUAL_PREFERENCE_NOT_FOUND, preferences, resources.stream()
+                                .map(resource -> String.format("%s=%s",
+                                        resource.getLevel().toString(), resource.getResourceId()))
+                                .collect(Collectors.toList()))));
+    }
+
+    /**
+     * Searches for a contextual preference with the given parameters
      *
      * Returns a first found preference from the list of preferences.
      *
@@ -150,13 +178,18 @@ public class ContextualPreferenceManager {
     }
 
     private List<ContextualPreferenceExternalResource> resources(final ContextualPreferenceExternalResource resource) {
+        final List<ContextualPreferenceExternalResource> allResources = userAndRolesResources();
+        if (resource != null) {
+            allResources.add(resource);
+        }
+        return allResources;
+    }
+
+    private List<ContextualPreferenceExternalResource> userAndRolesResources() {
         final Optional<PipelineUser> currentUser = retrieveCurrentUser();
         final List<ContextualPreferenceExternalResource> allResources = new ArrayList<>();
         currentUser.map(this::userResource).ifPresent(allResources::add);
         currentUser.map(PipelineUser::getRoles).map(this::rolesResources).ifPresent(allResources::addAll);
-        if (resource != null) {
-            allResources.add(resource);
-        }
         return allResources;
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/contextual/handler/RegionContextualPreferenceHandler.java
+++ b/api/src/main/java/com/epam/pipeline/manager/contextual/handler/RegionContextualPreferenceHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.contextual.handler;
+
+import com.epam.pipeline.dao.contextual.ContextualPreferenceDao;
+import com.epam.pipeline.dao.region.CloudRegionDao;
+import com.epam.pipeline.entity.contextual.ContextualPreference;
+import com.epam.pipeline.entity.contextual.ContextualPreferenceLevel;
+import com.epam.pipeline.entity.region.AbstractCloudRegion;
+
+/**
+ * Region contextual preference handler.
+ * It handles preferences with {@link ContextualPreferenceLevel#REGION} level.
+ * Handler associates preference with a single {@link AbstractCloudRegion} entity.
+ */
+public class RegionContextualPreferenceHandler extends AbstractDaoContextualPreferenceHandler{
+
+    private final CloudRegionDao cloudRegionDao;
+
+    public RegionContextualPreferenceHandler(final CloudRegionDao cloudRegionDao,
+                                             final ContextualPreferenceDao contextualPreferenceDao,
+                                             final ContextualPreferenceHandler nextHandler) {
+        super(ContextualPreferenceLevel.REGION, nextHandler, contextualPreferenceDao);
+        this.cloudRegionDao = cloudRegionDao;
+    }
+
+    @Override
+    boolean externalEntityExists(final ContextualPreference preference) {
+        return cloudRegionDao.loadById(Long.parseLong(preference.getResource().getResourceId())).isPresent();
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/InstanceOfferManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/InstanceOfferManagerTest.java
@@ -19,7 +19,6 @@ package com.epam.pipeline.manager.cluster;
 import com.epam.pipeline.dao.cluster.InstanceOfferDao;
 import com.epam.pipeline.dao.region.CloudRegionDao;
 import com.epam.pipeline.entity.cluster.InstanceOffer;
-import com.epam.pipeline.entity.contextual.ContextualPreferenceExternalResource;
 import com.epam.pipeline.entity.preference.Preference;
 import com.epam.pipeline.entity.region.AwsRegion;
 import com.epam.pipeline.entity.region.CloudProvider;
@@ -45,7 +44,6 @@ public class InstanceOfferManagerTest extends AbstractManagerTest {
     private static final String M5_LARGE_INSTANCE_TYPE = "m5.xlarge";
     private static final String M5_PATTERN = "m5.*";
     private static final String M5_X5_PATTERN = "m5.*,x5.*";
-    private static final ContextualPreferenceExternalResource NO_TOOL = null;
     private static final int BATCH_SIZE = 10_000;
 
     @Autowired
@@ -111,14 +109,14 @@ public class InstanceOfferManagerTest extends AbstractManagerTest {
         allowedToolTypesPreference.setValue(M5_PATTERN);
         preferenceManager.update(Collections.singletonList(allowedToolTypesPreference));
 
-        Assert.assertTrue(instanceOfferManager.isToolInstanceAllowed(M5_INSTANCE_TYPE, NO_TOOL, region.getId(), false));
+        Assert.assertTrue(instanceOfferManager.isToolInstanceAllowed(M5_INSTANCE_TYPE, region.getId(), false));
         Assert.assertFalse(instanceOfferManager
-                .isToolInstanceAllowed(X5_INSTANCE_TYPE, NO_TOOL, region.getId(), false));
+                .isToolInstanceAllowed(X5_INSTANCE_TYPE, region.getId(), false));
 
         allowedToolTypesPreference.setValue(M5_X5_PATTERN);
         preferenceManager.update(Collections.singletonList(allowedToolTypesPreference));
 
-        Assert.assertTrue(instanceOfferManager.isToolInstanceAllowed(M5_INSTANCE_TYPE, NO_TOOL, region.getId(), false));
-        Assert.assertTrue(instanceOfferManager.isToolInstanceAllowed(X5_INSTANCE_TYPE, NO_TOOL, region.getId(), false));
+        Assert.assertTrue(instanceOfferManager.isToolInstanceAllowed(M5_INSTANCE_TYPE, region.getId(), false));
+        Assert.assertTrue(instanceOfferManager.isToolInstanceAllowed(X5_INSTANCE_TYPE, region.getId(), false));
     }
 }

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/InstanceOfferManagerUnitTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/InstanceOfferManagerUnitTest.java
@@ -63,6 +63,8 @@ public class InstanceOfferManagerUnitTest {
     private static final Long ANOTHER_REGION_ID = 2L;
     private static final ContextualPreferenceExternalResource TOOL_RESOURCE =
             new ContextualPreferenceExternalResource(ContextualPreferenceLevel.TOOL, TOOL_ID.toString());
+    private static final List<ContextualPreferenceExternalResource> TOOL_RESOURCES =
+            Collections.singletonList(TOOL_RESOURCE);
     private static final String ALLOWED_INSTANCE_TYPES_PREFERENCE =
             SystemPreferences.CLUSTER_ALLOWED_INSTANCE_TYPES.getKey();
     private static final String ALLOWED_DOCKER_INSTANCE_TYPES_PREFERENCE =
@@ -130,16 +132,16 @@ public class InstanceOfferManagerUnitTest {
         final List<InstanceType> allInstanceTypes = Arrays.asList(m4InstanceType, m5InstanceType, t2InstanceType);
         final List<InstanceType> allowedInstanceTypes = Arrays.asList(m4InstanceType, m5InstanceType);
         final List<InstanceType> allowedInstanceDockerTypes = Collections.singletonList(m4InstanceType);
-        when(contextualPreferenceManager.search(eq(INSTANCE_TYPES_PREFERENCES), eq(null)))
+        when(contextualPreferenceManager.searchList(eq(INSTANCE_TYPES_PREFERENCES), eq(null)))
                 .thenReturn(new ContextualPreference(ALLOWED_INSTANCE_TYPES_PREFERENCE, M4_M5_PATTERNS));
-        when(contextualPreferenceManager.search(eq(Arrays.asList(ALLOWED_DOCKER_INSTANCE_TYPES_PREFERENCE,
+        when(contextualPreferenceManager.searchList(eq(Arrays.asList(ALLOWED_DOCKER_INSTANCE_TYPES_PREFERENCE,
                 ALLOWED_INSTANCE_TYPES_PREFERENCE)), eq(null)))
                 .thenReturn(new ContextualPreference(ALLOWED_DOCKER_INSTANCE_TYPES_PREFERENCE, M4_PATTERN));
-        when(contextualPreferenceManager.search(eq(Collections.singletonList(ALLOWED_PRICE_TYPES_PREFERENCE)),
+        when(contextualPreferenceManager.searchList(eq(Collections.singletonList(ALLOWED_PRICE_TYPES_PREFERENCE)),
                 eq(null)))
                 .thenReturn(new ContextualPreference(ALLOWED_PRICE_TYPES_PREFERENCE, SPOT_AND_ON_DEMAND_TYPES));
-        when(contextualPreferenceManager.search(eq(Collections.singletonList(ALLOWED_MASTER_PRICE_TYPES_PREFERENCES)),
-                eq(null)))
+        when(contextualPreferenceManager.searchList(eq(
+                Collections.singletonList(ALLOWED_MASTER_PRICE_TYPES_PREFERENCES)), eq(null)))
                 .thenReturn(new ContextualPreference(ALLOWED_MASTER_PRICE_TYPES_PREFERENCES, SPOT_AND_ON_DEMAND_TYPES));
         when(cloudFacade.getAllInstanceTypes(any(), anyBoolean())).thenReturn(allInstanceTypes);
 
@@ -157,16 +159,16 @@ public class InstanceOfferManagerUnitTest {
         final List<InstanceType> allInstanceTypes = Arrays.asList(m4InstanceType, m5InstanceType, t2InstanceType);
         final List<InstanceType> allowedInstanceTypes = Arrays.asList(m4InstanceType, m5InstanceType);
         final List<InstanceType> allowedInstanceDockerTypes = Collections.singletonList(m4InstanceType);
-        when(contextualPreferenceManager.search(eq(INSTANCE_TYPES_PREFERENCES), eq(TOOL_RESOURCE)))
+        when(contextualPreferenceManager.searchList(eq(INSTANCE_TYPES_PREFERENCES), eq(TOOL_RESOURCES)))
                 .thenReturn(new ContextualPreference(ALLOWED_INSTANCE_TYPES_PREFERENCE, M4_M5_PATTERNS));
-        when(contextualPreferenceManager.search(eq(Arrays.asList(ALLOWED_DOCKER_INSTANCE_TYPES_PREFERENCE,
-                ALLOWED_INSTANCE_TYPES_PREFERENCE)), eq(TOOL_RESOURCE)))
+        when(contextualPreferenceManager.searchList(eq(Arrays.asList(ALLOWED_DOCKER_INSTANCE_TYPES_PREFERENCE,
+                ALLOWED_INSTANCE_TYPES_PREFERENCE)), eq(TOOL_RESOURCES)))
                 .thenReturn(new ContextualPreference(ALLOWED_DOCKER_INSTANCE_TYPES_PREFERENCE, M4_PATTERN));
-        when(contextualPreferenceManager.search(eq(Collections.singletonList(ALLOWED_PRICE_TYPES_PREFERENCE)),
-                eq(TOOL_RESOURCE)))
+        when(contextualPreferenceManager.searchList(eq(Collections.singletonList(ALLOWED_PRICE_TYPES_PREFERENCE)),
+                eq(TOOL_RESOURCES)))
                 .thenReturn(new ContextualPreference(ALLOWED_PRICE_TYPES_PREFERENCE, SPOT_AND_ON_DEMAND_TYPES));
-        when(contextualPreferenceManager.search(eq(Collections.singletonList(ALLOWED_MASTER_PRICE_TYPES_PREFERENCES)),
-                eq(TOOL_RESOURCE)))
+        when(contextualPreferenceManager.searchList(eq(
+                Collections.singletonList(ALLOWED_MASTER_PRICE_TYPES_PREFERENCES)), eq(TOOL_RESOURCES)))
                 .thenReturn(new ContextualPreference(ALLOWED_MASTER_PRICE_TYPES_PREFERENCES, SPOT_AND_ON_DEMAND_TYPES));
         when(cloudFacade.getAllInstanceTypes(any(), anyBoolean())).thenReturn(allInstanceTypes);
 
@@ -181,7 +183,7 @@ public class InstanceOfferManagerUnitTest {
     @Test
     public void getAllowedInstanceAndPriceTypesShouldLoadInstanceTypesForSingleRegionIfItIsSpecified() {
         when(cloudFacade.getAllInstanceTypes(any(), anyBoolean())).thenReturn(Collections.emptyList());
-        when(contextualPreferenceManager.search(any(), any()))
+        when(contextualPreferenceManager.searchList(any(), any()))
                 .thenReturn(new ContextualPreference(ALLOWED_INSTANCE_TYPES_PREFERENCE, ANY_PATTERN));
 
         instanceOfferManager.getAllowedInstanceAndPriceTypes(null, REGION_ID, false);
@@ -194,148 +196,150 @@ public class InstanceOfferManagerUnitTest {
 
     @Test
     public void isInstanceAllowedShouldReturnTrueIfInstanceTypeMatchesOneOfTheAllowedPatterns() {
-        when(contextualPreferenceManager.search(eq(INSTANCE_TYPES_PREFERENCES), eq(null)))
+        when(contextualPreferenceManager.searchList(eq(INSTANCE_TYPES_PREFERENCES), eq(null)))
                 .thenReturn(new ContextualPreference(ALLOWED_INSTANCE_TYPES_PREFERENCE, M4_M5_PATTERNS));
 
         assertTrue(instanceOfferManager.isInstanceAllowed(M4_LARGE, REGION_ID, false));
-        verify(contextualPreferenceManager).search(eq(INSTANCE_TYPES_PREFERENCES), eq(null));
+        verify(contextualPreferenceManager).searchList(eq(INSTANCE_TYPES_PREFERENCES), eq(null));
     }
 
     @Test
     public void isInstanceAllowedShouldReturnFalseIfInstanceTypeDoesNotMatchAnyOfTheAllowedPatterns() {
-        when(contextualPreferenceManager.search(eq(INSTANCE_TYPES_PREFERENCES), eq(null)))
+        when(contextualPreferenceManager.searchList(eq(INSTANCE_TYPES_PREFERENCES), eq(null)))
                 .thenReturn(new ContextualPreference(ALLOWED_INSTANCE_TYPES_PREFERENCE, M4_M5_PATTERNS));
 
         assertFalse(instanceOfferManager.isInstanceAllowed(T2_LARGE, REGION_ID, false));
-        verify(contextualPreferenceManager).search(eq(INSTANCE_TYPES_PREFERENCES), eq(null));
+        verify(contextualPreferenceManager).searchList(eq(INSTANCE_TYPES_PREFERENCES), eq(null));
     }
 
     @Test
     public void isInstanceAllowedShouldReturnFalseIfInstanceTypeIsNotOffered() {
-        when(contextualPreferenceManager.search(eq(INSTANCE_TYPES_PREFERENCES), eq(null)))
+        when(contextualPreferenceManager.searchList(eq(INSTANCE_TYPES_PREFERENCES), eq(null)))
                 .thenReturn(new ContextualPreference(ALLOWED_INSTANCE_TYPES_PREFERENCE, S2_PATTERN));
 
         assertFalse(instanceOfferManager.isInstanceAllowed(S2_LARGE, REGION_ID, false));
-        verify(contextualPreferenceManager).search(eq(INSTANCE_TYPES_PREFERENCES), eq(null));
+        verify(contextualPreferenceManager).searchList(eq(INSTANCE_TYPES_PREFERENCES), eq(null));
     }
 
     @Test
     public void isInstanceAllowedShouldReturnFalseIfInstanceTypeIsNotAllowedInTheSpecifiedRegion() {
-        when(contextualPreferenceManager.search(eq(INSTANCE_TYPES_PREFERENCES), eq(null)))
+        when(contextualPreferenceManager.searchList(eq(INSTANCE_TYPES_PREFERENCES), eq(null)))
                 .thenReturn(new ContextualPreference(ALLOWED_INSTANCE_TYPES_PREFERENCE, ANY_PATTERN));
 
         assertFalse(instanceOfferManager.isInstanceAllowed(DV3, REGION_ID, false));
-        verify(contextualPreferenceManager).search(eq(INSTANCE_TYPES_PREFERENCES), eq(null));
+        verify(contextualPreferenceManager).searchList(eq(INSTANCE_TYPES_PREFERENCES), eq(null));
     }
 
     @Test
     public void isInstanceAllowedShouldReturnTrueIfInstanceTypeIsAllowedInTheSpecifiedRegion() {
-        when(contextualPreferenceManager.search(eq(INSTANCE_TYPES_PREFERENCES), eq(null)))
+        when(contextualPreferenceManager.searchList(eq(INSTANCE_TYPES_PREFERENCES), eq(null)))
                 .thenReturn(new ContextualPreference(ALLOWED_INSTANCE_TYPES_PREFERENCE, ANY_PATTERN));
 
         assertTrue(instanceOfferManager.isInstanceAllowed(DV3, ANOTHER_REGION_ID, false));
-        verify(contextualPreferenceManager).search(eq(INSTANCE_TYPES_PREFERENCES), eq(null));
+        verify(contextualPreferenceManager).searchList(eq(INSTANCE_TYPES_PREFERENCES), eq(null));
     }
 
     @Test
     public void isInstanceAllowedShouldCheckInstanceTypesAllowedInDefaultRegionIfNoRegionIsSpecified() {
-        when(contextualPreferenceManager.search(eq(INSTANCE_TYPES_PREFERENCES), eq(null)))
+        when(contextualPreferenceManager.searchList(eq(INSTANCE_TYPES_PREFERENCES), eq(null)))
                 .thenReturn(new ContextualPreference(ALLOWED_INSTANCE_TYPES_PREFERENCE, ANY_PATTERN));
 
         assertFalse(instanceOfferManager.isInstanceAllowed(DV3, null, false));
         assertTrue(instanceOfferManager.isInstanceAllowed(M4_LARGE, null, false));
-        verify(contextualPreferenceManager, times(2)).search(eq(INSTANCE_TYPES_PREFERENCES), eq(null));
+        verify(contextualPreferenceManager, times(2))
+                .searchList(eq(INSTANCE_TYPES_PREFERENCES), eq(null));
     }
 
     @Test
     public void isToolInstanceAllowedShouldReturnTrueIfInstanceTypeMatchesOneOfTheAllowedPatterns() {
-        when(contextualPreferenceManager.search(eq(DOCKER_INSTANCE_TYPES_PREFERENCES), eq(TOOL_RESOURCE)))
+        when(contextualPreferenceManager.searchList(eq(DOCKER_INSTANCE_TYPES_PREFERENCES), eq(TOOL_RESOURCES)))
                 .thenReturn(new ContextualPreference(ALLOWED_DOCKER_INSTANCE_TYPES_PREFERENCE, M4_M5_PATTERNS));
 
-        assertTrue(instanceOfferManager.isToolInstanceAllowed(M4_LARGE, TOOL_RESOURCE, REGION_ID, false));
-        verify(contextualPreferenceManager).search(eq(DOCKER_INSTANCE_TYPES_PREFERENCES), eq(TOOL_RESOURCE));
+        assertTrue(instanceOfferManager.isToolInstanceAllowed(M4_LARGE, TOOL_RESOURCES, REGION_ID, false));
+        verify(contextualPreferenceManager).searchList(eq(DOCKER_INSTANCE_TYPES_PREFERENCES), eq(TOOL_RESOURCES));
     }
 
     @Test
     public void isToolInstanceAllowedShouldReturnFalseIfInstanceTypeDoesNotMatchAnyOfTheAllowedPatterns() {
-        when(contextualPreferenceManager.search(eq(DOCKER_INSTANCE_TYPES_PREFERENCES), eq(TOOL_RESOURCE)))
+        when(contextualPreferenceManager.searchList(eq(DOCKER_INSTANCE_TYPES_PREFERENCES), eq(TOOL_RESOURCES)))
                 .thenReturn(new ContextualPreference(ALLOWED_DOCKER_INSTANCE_TYPES_PREFERENCE, M4_M5_PATTERNS));
 
-        assertFalse(instanceOfferManager.isToolInstanceAllowed(T2_LARGE, TOOL_RESOURCE, REGION_ID, false));
-        verify(contextualPreferenceManager).search(eq(DOCKER_INSTANCE_TYPES_PREFERENCES), eq(TOOL_RESOURCE));
+        assertFalse(instanceOfferManager.isToolInstanceAllowed(T2_LARGE, TOOL_RESOURCES, REGION_ID, false));
+        verify(contextualPreferenceManager).searchList(eq(DOCKER_INSTANCE_TYPES_PREFERENCES), eq(TOOL_RESOURCES));
     }
 
     @Test
     public void isToolInstanceAllowedReturnResultIfResourceIsNull() {
-        when(contextualPreferenceManager.search(eq(DOCKER_INSTANCE_TYPES_PREFERENCES), eq(null)))
+        when(contextualPreferenceManager.searchList(eq(DOCKER_INSTANCE_TYPES_PREFERENCES), eq(null)))
                 .thenReturn(new ContextualPreference(ALLOWED_DOCKER_INSTANCE_TYPES_PREFERENCE, M4_M5_PATTERNS));
 
         assertTrue(instanceOfferManager.isToolInstanceAllowed(M4_LARGE, null, REGION_ID, false));
-        verify(contextualPreferenceManager).search(eq(DOCKER_INSTANCE_TYPES_PREFERENCES), eq(null));
+        verify(contextualPreferenceManager).searchList(eq(DOCKER_INSTANCE_TYPES_PREFERENCES), eq(null));
     }
 
     @Test
     public void isToolInstanceAllowedShouldReturnFalseIfInstanceTypeIsNotOffered() {
-        when(contextualPreferenceManager.search(eq(DOCKER_INSTANCE_TYPES_PREFERENCES), eq(TOOL_RESOURCE)))
+        when(contextualPreferenceManager.searchList(eq(DOCKER_INSTANCE_TYPES_PREFERENCES), eq(TOOL_RESOURCES)))
                 .thenReturn(new ContextualPreference(ALLOWED_DOCKER_INSTANCE_TYPES_PREFERENCE, S2_PATTERN));
 
-        assertFalse(instanceOfferManager.isToolInstanceAllowed(S2_LARGE, TOOL_RESOURCE, REGION_ID, false));
-        verify(contextualPreferenceManager).search(eq(DOCKER_INSTANCE_TYPES_PREFERENCES), eq(TOOL_RESOURCE));
+        assertFalse(instanceOfferManager.isToolInstanceAllowed(S2_LARGE, TOOL_RESOURCES, REGION_ID, false));
+        verify(contextualPreferenceManager).searchList(eq(DOCKER_INSTANCE_TYPES_PREFERENCES), eq(TOOL_RESOURCES));
     }
 
     @Test
     public void isToolInstanceAllowedShouldReturnFalseIfInstanceTypeIsNotAllowedInTheSpecifiedRegion() {
-        when(contextualPreferenceManager.search(eq(DOCKER_INSTANCE_TYPES_PREFERENCES), eq(TOOL_RESOURCE)))
+        when(contextualPreferenceManager.searchList(eq(DOCKER_INSTANCE_TYPES_PREFERENCES), eq(TOOL_RESOURCES)))
                 .thenReturn(new ContextualPreference(ALLOWED_DOCKER_INSTANCE_TYPES_PREFERENCE, ANY_PATTERN));
 
-        assertFalse(instanceOfferManager.isToolInstanceAllowed(DV3, TOOL_RESOURCE, REGION_ID, false));
-        verify(contextualPreferenceManager).search(eq(DOCKER_INSTANCE_TYPES_PREFERENCES), eq(TOOL_RESOURCE));
+        assertFalse(instanceOfferManager.isToolInstanceAllowed(DV3, TOOL_RESOURCES, REGION_ID, false));
+        verify(contextualPreferenceManager).searchList(eq(DOCKER_INSTANCE_TYPES_PREFERENCES), eq(TOOL_RESOURCES));
     }
 
     @Test
     public void isToolInstanceAllowedShouldReturnTrueIfInstanceTypeIsAllowedInTheSpecifiedRegion() {
-        when(contextualPreferenceManager.search(eq(DOCKER_INSTANCE_TYPES_PREFERENCES), eq(TOOL_RESOURCE)))
+        when(contextualPreferenceManager.searchList(eq(DOCKER_INSTANCE_TYPES_PREFERENCES), eq(TOOL_RESOURCES)))
                 .thenReturn(new ContextualPreference(ALLOWED_DOCKER_INSTANCE_TYPES_PREFERENCE, ANY_PATTERN));
 
-        assertTrue(instanceOfferManager.isToolInstanceAllowed(DV3, TOOL_RESOURCE, ANOTHER_REGION_ID, false));
-        verify(contextualPreferenceManager).search(eq(DOCKER_INSTANCE_TYPES_PREFERENCES), eq(TOOL_RESOURCE));
+        assertTrue(instanceOfferManager.isToolInstanceAllowed(DV3, TOOL_RESOURCES, ANOTHER_REGION_ID, false));
+        verify(contextualPreferenceManager).searchList(eq(DOCKER_INSTANCE_TYPES_PREFERENCES), eq(TOOL_RESOURCES));
     }
 
     @Test
     public void isToolInstanceAllowedShouldCheckInstanceTypesAllowedInDefaultRegionIfNoRegionIsSpecified() {
-        when(contextualPreferenceManager.search(eq(DOCKER_INSTANCE_TYPES_PREFERENCES), eq(TOOL_RESOURCE)))
+        when(contextualPreferenceManager.searchList(eq(DOCKER_INSTANCE_TYPES_PREFERENCES), eq(TOOL_RESOURCES)))
                 .thenReturn(new ContextualPreference(ALLOWED_DOCKER_INSTANCE_TYPES_PREFERENCE, ANY_PATTERN));
 
-        assertFalse(instanceOfferManager.isToolInstanceAllowed(DV3, TOOL_RESOURCE, null, false));
-        assertTrue(instanceOfferManager.isToolInstanceAllowed(M4_LARGE, TOOL_RESOURCE, null, false));
-        verify(contextualPreferenceManager, times(2)).search(eq(DOCKER_INSTANCE_TYPES_PREFERENCES), eq(TOOL_RESOURCE));
+        assertFalse(instanceOfferManager.isToolInstanceAllowed(DV3, TOOL_RESOURCES, null, false));
+        assertTrue(instanceOfferManager.isToolInstanceAllowed(M4_LARGE, TOOL_RESOURCES, null, false));
+        verify(contextualPreferenceManager, times(2))
+                .searchList(eq(DOCKER_INSTANCE_TYPES_PREFERENCES), eq(TOOL_RESOURCES));
     }
 
     @Test
     public void isPriceTypeAllowedShouldReturnTrueIfGivenPriceTypeEqualsToOneOfTheAllowedPriceTypes() {
-        when(contextualPreferenceManager.search(eq(PRICE_TYPES_PREFERENCES), eq(TOOL_RESOURCE)))
+        when(contextualPreferenceManager.searchList(eq(PRICE_TYPES_PREFERENCES), eq(TOOL_RESOURCES)))
                 .thenReturn(new ContextualPreference(ALLOWED_PRICE_TYPES_PREFERENCE, SPOT_AND_ON_DEMAND_TYPES));
 
-        assertTrue(instanceOfferManager.isPriceTypeAllowed(SPOT, TOOL_RESOURCE));
-        verify(contextualPreferenceManager).search(eq(PRICE_TYPES_PREFERENCES), eq(TOOL_RESOURCE));
+        assertTrue(instanceOfferManager.isPriceTypeAllowed(SPOT, TOOL_RESOURCES, false));
+        verify(contextualPreferenceManager).searchList(eq(PRICE_TYPES_PREFERENCES), eq(TOOL_RESOURCES));
     }
 
     @Test
     public void isPriceTypeAllowedShouldReturnFalseIfGivenPriceTypeDoesNotEqualToAnyOfTheAllowedPriceTypes() {
-        when(contextualPreferenceManager.search(eq(PRICE_TYPES_PREFERENCES), eq(TOOL_RESOURCE)))
+        when(contextualPreferenceManager.searchList(eq(PRICE_TYPES_PREFERENCES), eq(TOOL_RESOURCES)))
                 .thenReturn(new ContextualPreference(ALLOWED_PRICE_TYPES_PREFERENCE, ON_DEMAND));
 
-        assertFalse(instanceOfferManager.isPriceTypeAllowed(SPOT, TOOL_RESOURCE));
-        verify(contextualPreferenceManager).search(eq(PRICE_TYPES_PREFERENCES), eq(TOOL_RESOURCE));
+        assertFalse(instanceOfferManager.isPriceTypeAllowed(SPOT, TOOL_RESOURCES, false));
+        verify(contextualPreferenceManager).searchList(eq(PRICE_TYPES_PREFERENCES), eq(TOOL_RESOURCES));
     }
 
     @Test
     public void isPriceTypeAllowedShouldReturnResultIfResourceIsNull() {
-        when(contextualPreferenceManager.search(eq(PRICE_TYPES_PREFERENCES), eq(null)))
+        when(contextualPreferenceManager.searchList(eq(PRICE_TYPES_PREFERENCES), eq(null)))
                 .thenReturn(new ContextualPreference(ALLOWED_PRICE_TYPES_PREFERENCE, SPOT_AND_ON_DEMAND_TYPES));
 
-        assertTrue(instanceOfferManager.isPriceTypeAllowed(SPOT, null));
-        verify(contextualPreferenceManager).search(eq(PRICE_TYPES_PREFERENCES), eq(null));
+        assertTrue(instanceOfferManager.isPriceTypeAllowed(SPOT));
+        verify(contextualPreferenceManager).searchList(eq(PRICE_TYPES_PREFERENCES), eq(null));
     }
 
     private InstanceType instanceType(final String name, final AbstractCloudRegion region) {

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunManagerLaunchTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunManagerLaunchTest.java
@@ -54,6 +54,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.epam.pipeline.entity.contextual.ContextualPreferenceLevel.REGION;
 import static com.epam.pipeline.entity.contextual.ContextualPreferenceLevel.TOOL;
 import static com.epam.pipeline.manager.preference.SystemPreferences.CLUSTER_DOCKER_EXTRA_MULTI;
 import static com.epam.pipeline.manager.preference.SystemPreferences.CLUSTER_INSTANCE_HDD_EXTRA_MULTI;
@@ -176,8 +177,15 @@ public class PipelineRunManagerLaunchTest {
     private final InstancePrice price = new InstancePrice(configuration.getInstanceType(),
             parseInt(configuration.getInstanceDisk()), PRICE_PER_HOUR, COMPUTE_PRICE_PER_HOUR, DISK_PRICE_PER_HOUR);
     private final PipelineRun parentRun = getPipelineRunWithInstance(PARENT_RUN_ID, TEST_USER, NON_DEFAULT_REGION_ID);
-    private final ContextualPreferenceExternalResource resource = new ContextualPreferenceExternalResource(
+    private final ContextualPreferenceExternalResource toolResource = new ContextualPreferenceExternalResource(
             TOOL, tool.getId().toString());
+    private final ContextualPreferenceExternalResource defaultRegionResource =
+            new ContextualPreferenceExternalResource(REGION, defaultAwsRegion.getId().toString());
+    private final ContextualPreferenceExternalResource nonAllowedRegionResource =
+            new ContextualPreferenceExternalResource(REGION, nonAllowedAwsRegion.getId().toString());
+    private final List<ContextualPreferenceExternalResource> defaultRegionResources =
+            singletonList(defaultRegionResource);
+    private final List<ContextualPreferenceExternalResource> resources = asList(toolResource, defaultRegionResource);
     public static final PipelineStartNotificationRequest NOTIFICATION_REQUEST = new PipelineStartNotificationRequest(
             NotificationType.PIPELINE_RUN_STATUS, emptyList(), emptyList(), TEST_STRING, TEST_STRING);
     public static final List<PipelineStartNotificationRequest> NOTIFICATION_REQUESTS =
@@ -200,6 +208,8 @@ public class PipelineRunManagerLaunchTest {
         mock(notDefaultAwsRegion);
         doReturn(defaultAwsRegion).when(cloudRegionManager).loadDefaultRegion();
 
+        doReturn(true).when(instanceOfferManager)
+                .isInstanceAllowed(anyString(), any(), any(), anyBoolean());
         doReturn(true).when(instanceOfferManager).isPriceTypeAllowed(anyString(), any(), anyBoolean());
         doReturn(true).when(permissionHelper).isAllowed(any(), any());
     }
@@ -208,23 +218,25 @@ public class PipelineRunManagerLaunchTest {
     public void launchPipelineShouldValidateToolInstanceType() {
         launchTool(configuration, INSTANCE_TYPE);
 
-        verify(instanceOfferManager).isToolInstanceAllowed(eq(INSTANCE_TYPE), eq(resource), eq(REGION_ID), eq(true));
+        verify(instanceOfferManager).isToolInstanceAllowed(eq(INSTANCE_TYPE),
+                eq(resources), eq(REGION_ID), eq(true));
     }
 
     @Test
     public void launchPipelineShouldValidatePriceType() {
         launchTool(configuration, INSTANCE_TYPE);
 
-        verify(instanceOfferManager).isPriceTypeAllowed(eq(SPOT), eq(resource), eq(false));
+        verify(instanceOfferManager).isPriceTypeAllowed(eq(SPOT), eq(resources), eq(false));
     }
 
     @Test
     public void launchPipelineShouldFailOnNotAllowedToolInstanceType() {
         doReturn(false).when(instanceOfferManager)
-                .isToolInstanceAllowed(eq(INSTANCE_TYPE), eq(resource), eq(REGION_ID), eq(true));
+                .isToolInstanceAllowed(eq(INSTANCE_TYPE), eq(resources), eq(REGION_ID), eq(true));
 
         assertThrows(() -> launchTool(configuration, INSTANCE_TYPE));
-        verify(instanceOfferManager).isToolInstanceAllowed(eq(INSTANCE_TYPE), eq(resource), eq(REGION_ID), eq(true));
+        verify(instanceOfferManager)
+                .isToolInstanceAllowed(eq(INSTANCE_TYPE), eq(resources), eq(REGION_ID), eq(true));
     }
 
     @Test
@@ -240,31 +252,37 @@ public class PipelineRunManagerLaunchTest {
         configuration.setCloudRegionId(NON_ALLOWED_REGION_ID);
 
         assertThrows(() -> launchTool(configuration, INSTANCE_TYPE));
-        verify(instanceOfferManager)
-                .isToolInstanceAllowed(eq(INSTANCE_TYPE), eq(resource), eq(NON_ALLOWED_REGION_ID), eq(true));
+        verify(instanceOfferManager).isToolInstanceAllowed(eq(INSTANCE_TYPE),
+                eq(asList(toolResource, nonAllowedRegionResource)), eq(NON_ALLOWED_REGION_ID), eq(true));
     }
 
     @Test
     public void launchPipelineShouldValidatePipelineInstanceType() {
         launchPipeline(configuration, INSTANCE_TYPE);
 
-        verify(instanceOfferManager).isInstanceAllowed(eq(INSTANCE_TYPE), eq(REGION_ID), eq(true));
+        verify(instanceOfferManager).isInstanceAllowed(eq(INSTANCE_TYPE),
+                eq(defaultRegionResources), eq(REGION_ID), eq(true));
     }
 
     @Test
     public void launchPipelineShouldValidatePipelineInstanceTypeInTheSpecifiedRegion() {
         configuration.setCloudRegionId(NON_ALLOWED_REGION_ID);
+        doReturn(false).when(instanceOfferManager).isInstanceAllowed(eq(INSTANCE_TYPE),
+                eq(singletonList(nonAllowedRegionResource)), eq(NON_ALLOWED_REGION_ID), eq(true));
 
         assertThrows(() -> launchPipeline(configuration, INSTANCE_TYPE));
-        verify(instanceOfferManager).isInstanceAllowed(eq(INSTANCE_TYPE), eq(NON_ALLOWED_REGION_ID), eq(true));
+        verify(instanceOfferManager).isInstanceAllowed(eq(INSTANCE_TYPE),
+                eq(singletonList(nonAllowedRegionResource)), eq(NON_ALLOWED_REGION_ID), eq(true));
     }
 
     @Test
     public void launchPipelineShouldFailOnNotAllowedInstanceType() {
-        doReturn(false).when(instanceOfferManager).isInstanceAllowed(eq(INSTANCE_TYPE), eq(REGION_ID), eq(true));
+        doReturn(false).when(instanceOfferManager).isInstanceAllowed(eq(INSTANCE_TYPE),
+                eq(defaultRegionResources), eq(REGION_ID), eq(true));
 
         assertThrows(() -> launchPipeline(configuration, INSTANCE_TYPE));
-        verify(instanceOfferManager).isInstanceAllowed(eq(INSTANCE_TYPE), eq(REGION_ID), eq(true));
+        verify(instanceOfferManager).isInstanceAllowed(eq(INSTANCE_TYPE),
+                eq(defaultRegionResources), eq(REGION_ID), eq(true));
     }
 
     @Test
@@ -279,15 +297,16 @@ public class PipelineRunManagerLaunchTest {
         configuration.setIsSpot(null);
 
         launchPipeline(configuration, INSTANCE_TYPE);
-        verify(instanceOfferManager).isPriceTypeAllowed(eq(ON_DEMAND), eq(null), eq(false));
+        verify(instanceOfferManager).isPriceTypeAllowed(eq(ON_DEMAND), eq(defaultRegionResources), eq(false));
     }
 
     @Test
     public void launchPipelineShouldFailOnNotAllowedPriceType() {
-        doReturn(false).when(instanceOfferManager).isPriceTypeAllowed(eq(SPOT), eq(null), eq(false));
+        doReturn(false).when(instanceOfferManager).isPriceTypeAllowed(eq(SPOT),
+                eq(defaultRegionResources), eq(false));
 
         assertThrows(() -> launchPipeline(configuration, INSTANCE_TYPE));
-        verify(instanceOfferManager).isPriceTypeAllowed(eq(SPOT), eq(null), eq(false));
+        verify(instanceOfferManager).isPriceTypeAllowed(eq(SPOT), eq(defaultRegionResources), eq(false));
     }
 
     @Test

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/runner/RunConfigurationProviderTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/runner/RunConfigurationProviderTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.dao.region.CloudRegionDao;
 import com.epam.pipeline.entity.configuration.PipelineConfiguration;
 import com.epam.pipeline.entity.configuration.RunConfigurationEntry;
 import com.epam.pipeline.entity.contextual.ContextualPreferenceExternalResource;
@@ -37,6 +38,10 @@ import com.epam.pipeline.manager.security.CheckPermissionHelper;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
 @SuppressWarnings("PMD.TooManyStaticImports")
 public class RunConfigurationProviderTest {
 
@@ -48,6 +53,10 @@ public class RunConfigurationProviderTest {
     private static final Long NO_REGION = null;
     private static final ContextualPreferenceExternalResource TOOL_RESOURCE =
             new ContextualPreferenceExternalResource(ContextualPreferenceLevel.TOOL, TOOL_ID);
+    private static final ContextualPreferenceExternalResource REGION_RESOURCE =
+            new ContextualPreferenceExternalResource(ContextualPreferenceLevel.REGION, REGION_ID.toString());
+    private static final List<ContextualPreferenceExternalResource> RESOURCES =
+            Arrays.asList(TOOL_RESOURCE, REGION_RESOURCE);
 
     private final PipelineManager pipelineManager = mock(PipelineManager.class);
     private final ToolManager toolManager = mock(ToolManager.class);
@@ -56,8 +65,10 @@ public class RunConfigurationProviderTest {
     private final InstanceOfferManager instanceOfferManager = mock(InstanceOfferManager.class);
     private final MessageHelper messageHelper = mock(MessageHelper.class);
     private final CloudPlatformRunner runner = mock(CloudPlatformRunner.class);
+    private final CloudRegionDao cloudRegionDao = mock(CloudRegionDao.class);
     private final RunConfigurationProvider runConfigurationProvider = new RunConfigurationProvider(pipelineManager,
-            toolManager, permissionsHelper, pipelineConfigurationManager, instanceOfferManager, messageHelper, runner);
+            toolManager, permissionsHelper, pipelineConfigurationManager, instanceOfferManager, messageHelper, runner,
+            cloudRegionDao);
 
     @Before
     public void setUp() {
@@ -65,6 +76,7 @@ public class RunConfigurationProviderTest {
                 .thenReturn(true);
         when(instanceOfferManager.isToolInstanceAllowed(eq(NOT_ALLOWED_INSTANCE_TYPE), any(), any(), eq(false)))
                 .thenReturn(false);
+        when(cloudRegionDao.loadDefaultRegion()).thenReturn(Optional.empty());
 
         final Tool tool = new Tool();
         tool.setName(TOOL_IMAGE);
@@ -109,7 +121,7 @@ public class RunConfigurationProviderTest {
 
         runConfigurationProvider.validateEntry(runConfigurationEntry);
 
-        verify(instanceOfferManager).isToolInstanceAllowed(any(), eq(TOOL_RESOURCE), eq(REGION_ID), eq(false));
+        verify(instanceOfferManager).isToolInstanceAllowed(any(), eq(RESOURCES), eq(REGION_ID), eq(false));
     }
 
     @Test


### PR DESCRIPTION
The current PR provides implementation for issue #3381 

The following changes were added:
- a new contextual preference level `REGION` added
- added `REGION` preference support for allowed instance types and allowed price types calculations during tool run, pipeline run and configuration run