### PR TITLE
Support standard streams in pipe storage cp

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1298,6 +1298,8 @@ def storage_copy_item(source, destination, recursive, force, exclude, include, q
 
     [Linux] Upload a stream from standard input (-) to a storage (s3://storage/file.txt):
 
+        pipe storage cp - s3://storage/file.txt < file.txt
+
         cat file.txt | pipe storage cp - s3://storage/file.txt
 
     II. Examples of copying remote storage data locally.
@@ -1313,6 +1315,8 @@ def storage_copy_item(source, destination, recursive, force, exclude, include, q
     [Linux] Download a storage file (s3://storage/file.txt) as a stream to standard output (-):
 
         pipe storage cp s3://storage/file.txt - > file.txt
+
+        pipe storage cp s3://storage/file.txt - | tee file.txt >/dev/null 2>&1
 
     """
     DataStorageOperations.cp(source, destination, recursive, force,

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1185,6 +1185,29 @@ def storage_move_item(source, destination, recursive, force, exclude, include, q
                       on_failures, verify_destination):
     """
     Moves files/directories between data storages or between a local filesystem and a data storage.
+
+    Examples:
+
+    I. Examples of moving local data to a remote storage.
+
+    Upload a local file (file.txt) to a storage (s3://storage/file.txt):
+
+        pipe storage mv file.txt s3://storage/file.txt
+
+    Upload a local directory (dir) to a storage (s3://storage/dir):
+
+        pipe storage mv -r dir s3://storage/dir
+
+    II. Examples of moving remote storage data locally.
+
+    Download a storage file (s3://storage/file.txt) as a local file (file.txt):
+
+        pipe storage mv s3://storage/file.txt file.txt
+
+    Download a storage directory (/common/workdir/dir) as a local directory (dir):
+
+        pipe storage mv -r s3://storage/dir dir
+
     """
     DataStorageOperations.cp(source, destination, recursive, force, exclude, include, quiet, tags, file_list,
                              symlinks, threads, io_threads,
@@ -1260,6 +1283,37 @@ def storage_copy_item(source, destination, recursive, force, exclude, include, q
                       on_failures, skip_existing, verify_destination):
     """
     Copies files/directories between data storages or between a local filesystem and a data storage.
+
+    Examples:
+
+    I. Examples of copying local data to a remote storage.
+
+    Upload a local file (file.txt) to a storage (s3://storage/file.txt):
+
+        pipe storage cp file.txt s3://storage/file.txt
+
+    Upload a local directory (dir) to a storage (s3://storage/dir):
+
+        pipe storage cp -r dir s3://storage/dir
+
+    [Linux] Upload a stream from standard input (-) to a storage (s3://storage/file.txt):
+
+        cat file.txt | pipe storage cp - s3://storage/file.txt
+
+    II. Examples of copying remote storage data locally.
+
+    Download a storage file (s3://storage/file.txt) as a local file (file.txt):
+
+        pipe storage cp s3://storage/file.txt file.txt
+
+    Download a storage directory (/common/workdir/dir) as a local directory (dir):
+
+        pipe storage cp -r s3://storage/dir dir
+
+    [Linux] Download a storage file (s3://storage/file.txt) as a stream to standard output (-):
+
+        pipe storage cp s3://storage/file.txt - > file.txt
+
     """
     DataStorageOperations.cp(source, destination, recursive, force,
                              exclude, include, quiet, tags, file_list, symlinks, threads, io_threads,
@@ -2265,6 +2319,7 @@ def clean(force):
     CleanOperationsManager().clean(force=force)
 
 
-# Used to run a PyInstaller "freezed" version
-if getattr(sys, 'frozen', False):
+if __name__ == '__main__':
+    cli(sys.argv[1:])
+elif getattr(sys, 'frozen', False):
     cli(sys.argv[1:])

--- a/pipe-cli/src/model/data_storage_wrapper.py
+++ b/pipe-cli/src/model/data_storage_wrapper.py
@@ -104,6 +104,8 @@ class DataStorageWrapper(object):
         (WrapperType.LOCAL, WrapperType.GS): GsBucketOperations.get_upload_manager,
         (WrapperType.FTP, WrapperType.GS): GsBucketOperations.get_transfer_from_http_or_ftp_manager,
         (WrapperType.HTTP, WrapperType.GS): GsBucketOperations.get_transfer_from_http_or_ftp_manager,
+        (WrapperType.GS, WrapperType.STREAM): GsBucketOperations.get_download_stream_manager,
+        (WrapperType.STREAM, WrapperType.GS): GsBucketOperations.get_upload_stream_manager,
 
         (WrapperType.FTP, WrapperType.LOCAL): LocalOperations.get_transfer_from_http_or_ftp_manager,
         (WrapperType.HTTP, WrapperType.LOCAL): LocalOperations.get_transfer_from_http_or_ftp_manager

--- a/pipe-cli/src/model/data_storage_wrapper.py
+++ b/pipe-cli/src/model/data_storage_wrapper.py
@@ -90,6 +90,8 @@ class DataStorageWrapper(object):
         (WrapperType.LOCAL, WrapperType.S3): S3BucketOperations.get_upload_manager,
         (WrapperType.FTP, WrapperType.S3): S3BucketOperations.get_transfer_from_http_or_ftp_manager,
         (WrapperType.HTTP, WrapperType.S3): S3BucketOperations.get_transfer_from_http_or_ftp_manager,
+        (WrapperType.S3, WrapperType.STREAM): S3BucketOperations.get_download_stream_manager,
+        (WrapperType.STREAM, WrapperType.S3): S3BucketOperations.get_upload_stream_manager,
 
         (WrapperType.AZURE, WrapperType.AZURE): AzureBucketOperations.get_transfer_between_buckets_manager,
         (WrapperType.AZURE, WrapperType.LOCAL): AzureBucketOperations.get_download_manager,

--- a/pipe-cli/src/model/data_storage_wrapper_type.py
+++ b/pipe-cli/src/model/data_storage_wrapper_type.py
@@ -20,6 +20,7 @@ class WrapperType(object):
     GS = 'GS'
     FTP = 'FTP'
     HTTP = 'HTTP'
+    STREAM = 'STREAM'
 
     __cloud_types = [S3, AZURE, GS]
     __dynamic_cloud_scheme = 'cp'

--- a/pipe-cli/src/utilities/datastorage_operations.py
+++ b/pipe-cli/src/utilities/datastorage_operations.py
@@ -83,6 +83,9 @@ class DataStorageOperations(object):
         destination_type = destination_wrapper.get_type()
         logging.debug('Transferring files {} -> {}...'.format(source_type, destination_type))
 
+        if source_type in [WrapperType.STREAM] or destination_type in [WrapperType.STREAM]:
+            quiet = True
+
         if not source_wrapper.exists():
             click.echo("Source {} doesn't exist".format(source), err=True)
             sys.exit(1)

--- a/pipe-cli/src/utilities/datastorage_operations.py
+++ b/pipe-cli/src/utilities/datastorage_operations.py
@@ -90,23 +90,23 @@ class DataStorageOperations(object):
             click.echo("Source {} doesn't exist".format(source), err=True)
             sys.exit(1)
         if not recursive and not source_wrapper.is_file():
-            click.echo('--recursive (-r) is required to copy folders.', err=True)
+            click.echo('Flag --recursive (-r) is required to copy folders.', err=True)
             sys.exit(1)
         if recursive and source_type in [WrapperType.STREAM]:
-            click.echo('--recursive (-r) is not supported for {} sources.'.format(source_type), err=True)
+            click.echo('Flag --recursive (-r) is not supported for {} sources.'.format(source_type), err=True)
             sys.exit(1)
         if recursive and destination_type in [WrapperType.STREAM]:
-            click.echo('--recursive (-r) is not supported for {} destinations.'.format(destination_type), err=True)
+            click.echo('Flag --recursive (-r) is not supported for {} destinations.'.format(destination_type), err=True)
             sys.exit(1)
         if clean and source_type in [WrapperType.STREAM, WrapperType.HTTP, WrapperType.FTP]:
             click.echo('Cannot perform \'mv\' operation due to deletion remote files '
                        'is not supported for {} sources.'.format(source_type), err=True)
             sys.exit(1)
         if file_list and source_type in [WrapperType.STREAM]:
-            click.echo('--file-list (-l) is not supported for {} sources.'.format(source_type), err=True)
+            click.echo('Option --file-list (-l) is not supported for {} sources.'.format(source_type), err=True)
             sys.exit(1)
         if file_list and source_wrapper.is_file():
-            click.echo('--file-list (-l) is allowed for folders copy only.', err=True)
+            click.echo('Option --file-list (-l) allowed for folders copy only.', err=True)
             sys.exit(1)
         if file_list and not os.path.exists(file_list):
             click.echo('Specified --file-list file does not exist.', err=True)

--- a/pipe-cli/src/utilities/datastorage_operations.py
+++ b/pipe-cli/src/utilities/datastorage_operations.py
@@ -90,16 +90,17 @@ class DataStorageOperations(object):
             click.echo('--recursive (-r) is required to copy folders.', err=True)
             sys.exit(1)
         if recursive and source_type in [WrapperType.STREAM]:
-            click.echo('--recursive (-r) is not allowed for {} sources.'.format(source_type), err=True)
+            click.echo('--recursive (-r) is not supported for {} sources.'.format(source_type), err=True)
             sys.exit(1)
         if recursive and destination_type in [WrapperType.STREAM]:
-            click.echo('--recursive (-r) is not allowed for {} destinations.'.format(destination_type), err=True)
+            click.echo('--recursive (-r) is not supported for {} destinations.'.format(destination_type), err=True)
             sys.exit(1)
         if clean and source_type in [WrapperType.STREAM, WrapperType.HTTP, WrapperType.FTP]:
-            click.echo('Moving is not allowed for {} sources.' .format(source_type), err=True)
+            click.echo('Cannot perform \'mv\' operation due to deletion remote files '
+                       'is not supported for {} sources.'.format(source_type), err=True)
             sys.exit(1)
         if file_list and source_type in [WrapperType.STREAM]:
-            click.echo('--file-list (-l) is not allowed for {} sources.'.format(source_type), err=True)
+            click.echo('--file-list (-l) is not supported for {} sources.'.format(source_type), err=True)
             sys.exit(1)
         if file_list and source_wrapper.is_file():
             click.echo('--file-list (-l) is allowed for folders copy only.', err=True)

--- a/pipe-cli/src/utilities/datastorage_operations.py
+++ b/pipe-cli/src/utilities/datastorage_operations.py
@@ -75,22 +75,39 @@ class DataStorageOperations(object):
         if source_wrapper is None:
             click.echo('Could not resolve path {}'.format(source), err=True)
             sys.exit(1)
-        if not source_wrapper.exists():
-            click.echo("Source {} doesn't exist".format(source), err=True)
-            sys.exit(1)
         if destination_wrapper is None:
             click.echo('Could not resolve path {}'.format(destination), err=True)
             sys.exit(1)
+
+        source_type = source_wrapper.get_type()
+        destination_type = destination_wrapper.get_type()
+        logging.debug('Transferring files {} -> {}...'.format(source_type, destination_type))
+
+        if not source_wrapper.exists():
+            click.echo("Source {} doesn't exist".format(source), err=True)
+            sys.exit(1)
         if not recursive and not source_wrapper.is_file():
-            click.echo('Flag --recursive (-r) is required to copy folders.', err=True)
+            click.echo('--recursive (-r) is required to copy folders.', err=True)
+            sys.exit(1)
+        if recursive and source_type in [WrapperType.STREAM]:
+            click.echo('--recursive (-r) is not allowed for {} sources.'.format(source_type), err=True)
+            sys.exit(1)
+        if recursive and destination_type in [WrapperType.STREAM]:
+            click.echo('--recursive (-r) is not allowed for {} destinations.'.format(destination_type), err=True)
+            sys.exit(1)
+        if clean and source_type in [WrapperType.STREAM, WrapperType.HTTP, WrapperType.FTP]:
+            click.echo('Moving is not allowed for {} sources.' .format(source_type), err=True)
+            sys.exit(1)
+        if file_list and source_type in [WrapperType.STREAM]:
+            click.echo('--file-list (-l) is not allowed for {} sources.'.format(source_type), err=True)
+            sys.exit(1)
+        if file_list and source_wrapper.is_file():
+            click.echo('--file-list (-l) is allowed for folders copy only.', err=True)
+            sys.exit(1)
+        if file_list and not os.path.exists(file_list):
+            click.echo('Specified --file-list file does not exist.', err=True)
             sys.exit(1)
         if file_list:
-            if source_wrapper.is_file():
-                click.echo('Option --file-list (-l) allowed for folders copy only.', err=True)
-                sys.exit(1)
-            if not os.path.exists(file_list):
-                click.echo('Specified --file-list file does not exist.', err=True)
-                sys.exit(1)
             files_to_copy = cls.__get_file_to_copy(file_list, source_wrapper.path)
         if threads and not recursive:
             click.echo('-n (--threads) is allowed for folders only.', err=True)
@@ -125,9 +142,10 @@ class DataStorageOperations(object):
         manager = DataStorageWrapper.get_operation_manager(source_wrapper, destination_wrapper,
                                                            events=audit_ctx.container, command=command)
         items = files_to_copy if file_list else source_wrapper.get_items(quiet=quiet)
-        items = cls._filter_items(items, manager, source_wrapper, destination_wrapper, permission_to_check,
-                                  include, exclude, force, quiet, skip_existing, verify_destination,
-                                  on_unsafe_chars, on_unsafe_chars_replacement, on_empty_files)
+        if source_type not in [WrapperType.STREAM]:
+            items = cls._filter_items(items, manager, source_wrapper, destination_wrapper, permission_to_check,
+                                      include, exclude, force, quiet, skip_existing, verify_destination,
+                                      on_unsafe_chars, on_unsafe_chars_replacement, on_empty_files)
         if threads:
             cls._multiprocess_transfer_items(items, threads, manager, source_wrapper, destination_wrapper,
                                              audit_ctx, clean, quiet, tags, io_threads, on_failures)


### PR DESCRIPTION
Relates #3388.

The pull request brings support for standard streams to _pipe storage cp_ for _AWS_ and _GCP_.

Check pipe storage cp --help output to found out details:

```
Usage: pipe.py storage cp [OPTIONS] SOURCE DESTINATION

  Copies files/directories between data storages or between a local
  filesystem and a data storage.

  Examples:

  I. Examples of copying local data to a remote storage.

  Upload a local file (file.txt) to a storage (s3://storage/file.txt):

      pipe storage cp file.txt s3://storage/file.txt

  Upload a local directory (dir) to a storage (s3://storage/dir):

      pipe storage cp -r dir s3://storage/dir

  [Linux] Upload a stream from standard input (-) to a storage
  (s3://storage/file.txt):

      cat file.txt | pipe storage cp - s3://storage/file.txt

  II. Examples of copying remote storage data locally.

  Download a storage file (s3://storage/file.txt) as a local file
  (file.txt):

      pipe storage cp s3://storage/file.txt file.txt

  Download a storage directory (/common/workdir/dir) as a local directory
  (dir):

      pipe storage cp -r s3://storage/dir dir

  [Linux] Download a storage file (s3://storage/file.txt) as a stream to
  standard output (-):

      pipe storage cp s3://storage/file.txt - > file.txt

```