### PR TITLE
Introduce issue visibility system preference

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/git/GitlabIssueVisibility.java
+++ b/api/src/main/java/com/epam/pipeline/entity/git/GitlabIssueVisibility.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2023 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.epam.pipeline.entity.git;
+
+public enum GitlabIssueVisibility {
+
+    /**
+     * Gitlab issues are visible to their owners and admins.
+     */
+    OWNER,
+
+    /**
+     * Gitlab issues are visible to everybody.
+     */
+    ALL
+}

--- a/api/src/main/java/com/epam/pipeline/manager/git/GitManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/GitManager.java
@@ -659,8 +659,11 @@ public class GitManager {
             }
         }
         if (!authManager.isAdmin()) {
-            final String authorizedUser = authManager.getCurrentUser().getUserName();
-            labels.add(String.format(ON_BEHALF_OF, authorizedUser));
+            switch (preferenceManager.getPreference(SystemPreferences.GITLAB_ISSUE_VISIBILITY)) {
+                case OWNER: labels.add(String.format(ON_BEHALF_OF, authManager.getCurrentUser().getUserName()));
+                case ALL:
+                default:
+            }
         }
         return getDefaultGitlabClient().getIssues(getProjectForIssues(), labels, notLabels, page, pageSize,
                 filter.getSearch(), preferenceManager.getPreference(SystemPreferences.GITLAB_SERVER_FILTERING));

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -33,6 +33,7 @@ import com.epam.pipeline.entity.datastorage.StorageQuotaAction;
 import com.epam.pipeline.entity.datastorage.nfs.NFSMountPolicy;
 import com.epam.pipeline.entity.execution.OSSpecificLaunchCommandTemplate;
 import com.epam.pipeline.entity.git.GitlabIssueLabelsFilter;
+import com.epam.pipeline.entity.git.GitlabIssueVisibility;
 import com.epam.pipeline.entity.git.GitlabVersion;
 import com.epam.pipeline.entity.ldap.LdapBlockedUserSearchMethod;
 import com.epam.pipeline.entity.monitoring.IdleRunAction;
@@ -66,6 +67,7 @@ import com.epam.pipeline.manager.preference.AbstractSystemPreference.IntPreferen
 import com.epam.pipeline.manager.preference.AbstractSystemPreference.LongPreference;
 import com.epam.pipeline.manager.preference.AbstractSystemPreference.ObjectPreference;
 import com.epam.pipeline.manager.preference.AbstractSystemPreference.StringPreference;
+import com.epam.pipeline.manager.preference.AbstractSystemPreference.EnumPreference;
 import com.epam.pipeline.security.ExternalServiceEndpoint;
 import com.epam.pipeline.utils.CommonUtils;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -351,6 +353,8 @@ public class SystemPreferences {
     public static final ObjectPreference<List<String>> GITLAB_DEFAULT_LABELS = new ObjectPreference<>(
             "git.gitlab.default.labels", null, new TypeReference<List<String>>() {}, GIT_GROUP,
             isNullOrValidJson(new TypeReference<List<String>>() {}), true);
+    public static final EnumPreference<GitlabIssueVisibility> GITLAB_ISSUE_VISIBILITY = new EnumPreference<>(
+            "git.gitlab.issue.visibility", GitlabIssueVisibility.OWNER, GIT_GROUP);
     public static final ObjectPreference<GitlabIssueLabelsFilter> GITLAB_ISSUE_DEFAULT_FILTER = new ObjectPreference<>(
             "git.gitlab.issue.default.filter", null, new TypeReference<GitlabIssueLabelsFilter>() {},
             GIT_GROUP, isNullOrValidJson(new TypeReference<GitlabIssueLabelsFilter>() {}), true);


### PR DESCRIPTION
Relates #3124.

The pull request adds the following system preference:
- _git.gitlab.issue.visibility_ specifies a visibility scope of issues. Defaults to **OWNER**. Allowed values:
  - _OWNER_, issues are visible to their owners and admins
  - _ALL_, issues are visible to everybody
 