### PR TITLE
Add support for launch capabilities API management

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/cluster/LaunchCapability.java
+++ b/api/src/main/java/com/epam/pipeline/entity/cluster/LaunchCapability.java
@@ -16,14 +16,22 @@
 package com.epam.pipeline.entity.cluster;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Builder;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data
+@Builder
 public class LaunchCapability {
-
+    private String name;
     private String description;
+    private Boolean visible;
+    private String cloud;
+    private String os;
+    private Map<String, String> params;
     private List<String> commands;
+    private Map<String, LaunchCapability> capabilities;
 }

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineConfigurationLaunchCapabilitiesProcessor.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineConfigurationLaunchCapabilitiesProcessor.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2017-2023 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.epam.pipeline.manager.pipeline;
+
+import com.epam.pipeline.entity.cluster.LaunchCapability;
+import com.epam.pipeline.entity.configuration.PipeConfValueVO;
+import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.epam.pipeline.manager.preference.SystemPreferences;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Service
+@RequiredArgsConstructor
+public class PipelineConfigurationLaunchCapabilitiesProcessor {
+
+    private static final String COMMA = ",";
+    private static final String CAPABILITY_PARAM_PREFIX = "CP_CAP_CUSTOM_";
+    private static final List<String> BOOLEAN_PARAM_VALUES = Arrays.asList("true", "false", "yes", "no", "on", "off");
+
+    private final PreferenceManager preferenceManager;
+
+    public Map<String, PipeConfValueVO> process(final Map<String, PipeConfValueVO> params) {
+        final List<LaunchCapability> capabilities = extractCapabilities(params);
+        final List<Map<String, PipeConfValueVO>> capabilitiesParams = extractParams(capabilities);
+
+        return Stream.concat(
+                        Stream.of(params),
+                        capabilitiesParams.stream())
+                .reduce(this::mergeParams)
+                .orElseGet(Collections::emptyMap);
+    }
+
+    private List<LaunchCapability> extractCapabilities(final Map<String, PipeConfValueVO> params) {
+        final Map<String, LaunchCapability> capabilities = getCapabilities();
+        return extractEnabledCapabilities(normalizeKeys(params), normalizeKeys(capabilities));
+    }
+
+    private Map<String, LaunchCapability> getCapabilities() {
+        return flatten(getCapabilitiesTree());
+    }
+
+    private Map<String, LaunchCapability> getCapabilitiesTree() {
+        return Optional.of(SystemPreferences.LAUNCH_CAPABILITIES)
+                .map(preferenceManager::getPreference)
+                .orElseGet(Collections::emptyMap);
+    }
+
+    private Map<String, LaunchCapability> flatten(final Map<String, LaunchCapability> capabilities) {
+        return capabilities.entrySet()
+                .stream()
+                .flatMap(this::flatten)
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private Stream<Map.Entry<String, LaunchCapability>> flatten(final Map.Entry<String, LaunchCapability> entry) {
+        return Optional.of(entry)
+                .map(Map.Entry::getValue)
+                .map(LaunchCapability::getCapabilities)
+                .map(this::flatten)
+                .filter(MapUtils::isNotEmpty)
+                .map(Map::entrySet)
+                .map(Collection::stream)
+                .orElseGet(() -> Stream.of(entry));
+    }
+
+    private <V> Map<String, V> normalizeKeys(final Map<String, V> params) {
+        return params.entrySet().stream()
+                .filter(entry -> StringUtils.isNotBlank(entry.getKey()))
+                .collect(Collectors.toMap(entry -> StringUtils.upperCase(entry.getKey()), Map.Entry::getValue));
+    }
+
+    private List<LaunchCapability> extractEnabledCapabilities(final Map<String, PipeConfValueVO> params,
+                                                              final Map<String, LaunchCapability> capabilities) {
+        return capabilities.entrySet().stream()
+                .filter(entry -> isCapabilityEnabled(params, entry.getKey()))
+                .sorted(Map.Entry.comparingByKey())
+                .map(Map.Entry::getValue)
+                .collect(Collectors.toList());
+    }
+
+    private boolean isCapabilityEnabled(final Map<String, PipeConfValueVO> params, final String name) {
+        return Optional.ofNullable(name)
+                .map(it -> CAPABILITY_PARAM_PREFIX + it)
+                .map(params::get)
+                .map(PipeConfValueVO::getValue)
+                .map(BooleanUtils::toBoolean)
+                .orElse(false);
+    }
+
+    private List<Map<String, PipeConfValueVO>> extractParams(final List<LaunchCapability> capabilities) {
+        return capabilities.stream().map(this::extractParams).collect(Collectors.toList());
+    }
+
+    private Map<String, PipeConfValueVO> extractParams(final LaunchCapability capability) {
+        return Optional.ofNullable(capability)
+                .map(LaunchCapability::getParams)
+                .map(Map::entrySet)
+                .map(Collection::stream)
+                .orElseGet(Stream::empty)
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> new PipeConfValueVO(entry.getValue())));
+    }
+
+    private Map<String, PipeConfValueVO> mergeParams(final Map<String, PipeConfValueVO> left,
+                                                     final Map<String, PipeConfValueVO> right) {
+        final Map<String, PipeConfValueVO> params = new HashMap<>(left);
+        right.forEach((key, value) -> params.merge(key, value, this::mergeParams));
+        return params;
+    }
+
+    private PipeConfValueVO mergeParams(final PipeConfValueVO left, final PipeConfValueVO right) {
+        final String type = resolveType(left);
+        if (StringUtils.equalsIgnoreCase(type, PipeConfValueVO.STRING_TYPE)) {
+            return new PipeConfValueVO(mergeStringParamsValues(left, right), type);
+        }
+        return new PipeConfValueVO(right.getValue(), type);
+    }
+
+    private String resolveType(final PipeConfValueVO value) {
+        return Optional.ofNullable(value)
+                .map(PipeConfValueVO::getType)
+                .flatMap(type -> StringUtils.equalsIgnoreCase(type, PipeConfValueVO.STRING_TYPE)
+                        ? resolveImplicitType(value)
+                        : Optional.of(type))
+                .orElse(PipeConfValueVO.STRING_TYPE);
+    }
+
+    private Optional<String> resolveImplicitType(final PipeConfValueVO value) {
+        return Optional.ofNullable(value)
+                .map(PipeConfValueVO::getValue)
+                .filter(StringUtils::isNotBlank)
+                .map(StringUtils::strip)
+                .map(StringUtils::lowerCase)
+                .map(it -> BOOLEAN_PARAM_VALUES.contains(it) ? PipeConfValueVO.BOOLEAN_TYPE : null);
+    }
+
+    private String mergeStringParamsValues(final PipeConfValueVO left, final PipeConfValueVO right) {
+        return Stream.of(left, right)
+                .map(PipeConfValueVO::getValue)
+                .map(value -> StringUtils.split(value, COMMA))
+                .flatMap(Arrays::stream)
+                .distinct()
+                .sorted()
+                .collect(Collectors.joining(COMMA));
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineConfigurationForRunnerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineConfigurationForRunnerTest.java
@@ -36,12 +36,14 @@ import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.util.Arrays;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyString;
@@ -84,6 +86,8 @@ public class PipelineConfigurationForRunnerTest extends AbstractManagerTest {
     @MockBean
     @SuppressWarnings("PMD.UnusedPrivateField")
     private PipelineRunManager pipelineRunManager;
+    @MockBean
+    private PipelineConfigurationLaunchCapabilitiesProcessor launchCapabilitiesProcessor;
 
     @Mock
     @SuppressWarnings("PMD.UnusedPrivateField")
@@ -116,6 +120,7 @@ public class PipelineConfigurationForRunnerTest extends AbstractManagerTest {
         when(toolVersionManagerMock.loadToolVersionSettings(anyLong(), anyString()))
                 .thenReturn(Collections.singletonList(ToolVersion.builder()
                         .settings(Collections.singletonList(configurationEntry)).build()));
+        when(launchCapabilitiesProcessor.process(any())).thenReturn(Collections.emptyMap());
     }
 
     @Test

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineConfigurationLaunchCapabilitiesProcessorTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineConfigurationLaunchCapabilitiesProcessorTest.java
@@ -1,0 +1,489 @@
+/*
+ * Copyright 2017-2023 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.epam.pipeline.manager.pipeline;
+
+import com.epam.pipeline.entity.cluster.LaunchCapability;
+import com.epam.pipeline.entity.configuration.PipeConfValueVO;
+import com.epam.pipeline.manager.preference.AbstractSystemPreference;
+import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.epam.pipeline.manager.preference.SystemPreferences;
+import com.epam.pipeline.utils.CommonUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+public class PipelineConfigurationLaunchCapabilitiesProcessorTest {
+
+    private static final String INTEGER_TYPE = PipeConfValueVO.INTEGER_TYPE;
+    private static final String STRING_TYPE = PipeConfValueVO.STRING_TYPE;
+    private static final String BOOLEAN_TYPE = PipeConfValueVO.BOOLEAN_TYPE;
+
+    private static final Map<String, PipeConfValueVO> INITIAL_PARAMS = mapOf(
+            Pair.of("initial_string_param", new PipeConfValueVO("value", STRING_TYPE)),
+            Pair.of("initial_boolean_param", new PipeConfValueVO("true", BOOLEAN_TYPE))
+    );
+
+    private final PreferenceManager preferenceManager = mock(PreferenceManager.class);
+    private final PipelineConfigurationLaunchCapabilitiesProcessor launchCapabilitiesProcessor =
+            new PipelineConfigurationLaunchCapabilitiesProcessor(preferenceManager);
+
+    @Test
+    public void processShouldReturnOriginalParamsIfThereAreNoCapabilities() {
+        set(SystemPreferences.LAUNCH_CAPABILITIES, null);
+
+        final Map<String, PipeConfValueVO> actual = launchCapabilitiesProcessor.process(INITIAL_PARAMS);
+
+        assertEquals(actual, INITIAL_PARAMS);
+    }
+
+    @Test
+    public void processShouldReturnOriginalParams() {
+        set(SystemPreferences.LAUNCH_CAPABILITIES, mapOf(
+                Pair.of("capability", LaunchCapability.builder()
+                        .params(mapOf(
+                                Pair.of("capability_first_param", "first_value"),
+                                Pair.of("capability_second_param", "second_value")
+                        ))
+                        .build())
+        ));
+
+        final Map<String, PipeConfValueVO> actual = launchCapabilitiesProcessor.process(INITIAL_PARAMS);
+
+        assertEquals(actual, INITIAL_PARAMS);
+    }
+
+    @Test
+    public void processShouldReturnCapabilityParams() {
+        set(SystemPreferences.LAUNCH_CAPABILITIES, mapOf(
+                Pair.of("capability", LaunchCapability.builder()
+                        .params(mapOf(
+                                Pair.of("capability_first_param", "first_value"),
+                                Pair.of("capability_second_param", "second_value")
+                        ))
+                        .build())
+        ));
+
+        final Map<String, PipeConfValueVO> actual = launchCapabilitiesProcessor.process(mapOf(
+                Pair.of("CP_CAP_CUSTOM_capability", new PipeConfValueVO("true", BOOLEAN_TYPE))
+        ));
+
+        assertEquals(actual, mapOf(
+                Pair.of("CP_CAP_CUSTOM_capability", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                Pair.of("capability_first_param", new PipeConfValueVO("first_value", STRING_TYPE)),
+                Pair.of("capability_second_param", new PipeConfValueVO("second_value", STRING_TYPE))
+        ));
+    }
+
+    @Test
+    public void processShouldReturnCapabilityParamsIgnoringCase() {
+        set(SystemPreferences.LAUNCH_CAPABILITIES, mapOf(
+                Pair.of("CAPABILITY_FIRST", LaunchCapability.builder()
+                        .params(mapOf(
+                                Pair.of("capability_first_param", "first_value")
+                        ))
+                        .build()),
+                Pair.of("capability_second", LaunchCapability.builder()
+                        .params(mapOf(
+                                Pair.of("capability_second_param", "second_value")
+                        ))
+                        .build())
+        ));
+
+        final Map<String, PipeConfValueVO> actual = launchCapabilitiesProcessor.process(mapOf(
+                Pair.of("CP_CAP_CUSTOM_capability_first", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                Pair.of("CP_CAP_CUSTOM_CAPABILITY_SECOND", new PipeConfValueVO("true", BOOLEAN_TYPE))
+        ));
+
+        assertEquals(actual, mapOf(
+                Pair.of("CP_CAP_CUSTOM_capability_first", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                Pair.of("CP_CAP_CUSTOM_CAPABILITY_SECOND", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                Pair.of("capability_first_param", new PipeConfValueVO("first_value", STRING_TYPE)),
+                Pair.of("capability_second_param", new PipeConfValueVO("second_value", STRING_TYPE))
+        ));
+    }
+
+    @Test
+    public void processShouldNotReturnParentCapabilityParams() {
+        set(SystemPreferences.LAUNCH_CAPABILITIES, mapOf(
+                Pair.of("capability_parent", LaunchCapability.builder()
+                        .params(mapOf(
+                                Pair.of("capability_parent_param", "parent_value")
+                        ))
+                        .capabilities(mapOf(
+                                Pair.of("capability_child", LaunchCapability.builder()
+                                        .params(mapOf(
+                                                Pair.of("capability_child_param", "child_value")
+                                        ))
+                                        .build())
+                        ))
+                        .build())
+        ));
+
+        final Map<String, PipeConfValueVO> actual = launchCapabilitiesProcessor.process(mapOf(
+                Pair.of("CP_CAP_CUSTOM_capability_parent", new PipeConfValueVO("true", BOOLEAN_TYPE))
+        ));
+
+        assertEquals(actual, mapOf(
+                Pair.of("CP_CAP_CUSTOM_capability_parent", new PipeConfValueVO("true", BOOLEAN_TYPE))
+        ));
+    }
+
+    @Test
+    public void processShouldReturnChildCapabilityParams() {
+        set(SystemPreferences.LAUNCH_CAPABILITIES, mapOf(
+                Pair.of("capability_parent", LaunchCapability.builder()
+                        .params(mapOf(
+                                Pair.of("capability_parent_param", "parent_value")
+                        ))
+                        .capabilities(mapOf(
+                                Pair.of("capability_child", LaunchCapability.builder()
+                                        .params(mapOf(
+                                                Pair.of("capability_child_param", "child_value")
+                                        ))
+                                        .build())
+                        ))
+                        .build())
+        ));
+
+        final Map<String, PipeConfValueVO> actual = launchCapabilitiesProcessor.process(mapOf(
+                Pair.of("CP_CAP_CUSTOM_capability_child", new PipeConfValueVO("true", BOOLEAN_TYPE))
+        ));
+
+        assertEquals(actual, mapOf(
+                Pair.of("CP_CAP_CUSTOM_capability_child", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                Pair.of("capability_child_param", new PipeConfValueVO("child_value", STRING_TYPE))
+        ));
+    }
+
+    @Test
+    public void processShouldReturnMultipleChildCapabilityParams() {
+        set(SystemPreferences.LAUNCH_CAPABILITIES, mapOf(
+                Pair.of("capability_parent", LaunchCapability.builder()
+                        .params(mapOf(
+                                Pair.of("capability_parent_param", "parent_value")
+                        ))
+                        .capabilities(mapOf(
+                                Pair.of("capability_child_first", LaunchCapability.builder()
+                                        .params(mapOf(
+                                                Pair.of("capability_child_first_param", "first_value")
+                                        ))
+                                        .build()),
+                                Pair.of("capability_child_second", LaunchCapability.builder()
+                                        .params(mapOf(
+                                                Pair.of("capability_child_second_param", "second_value")
+                                        ))
+                                        .build())
+                        ))
+                        .build())
+        ));
+
+        final Map<String, PipeConfValueVO> actual = launchCapabilitiesProcessor.process(mapOf(
+                Pair.of("CP_CAP_CUSTOM_capability_child_first", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                Pair.of("CP_CAP_CUSTOM_capability_child_second", new PipeConfValueVO("true", BOOLEAN_TYPE))
+        ));
+
+        assertEquals(actual, mapOf(
+                Pair.of("CP_CAP_CUSTOM_capability_child_first", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                Pair.of("CP_CAP_CUSTOM_capability_child_second", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                Pair.of("capability_child_first_param", new PipeConfValueVO("first_value", STRING_TYPE)),
+                Pair.of("capability_child_second_param", new PipeConfValueVO("second_value", STRING_TYPE))
+        ));
+    }
+
+    @Test
+    public void processShouldReturnOriginalParamsAndCapabilityParams() {
+        set(SystemPreferences.LAUNCH_CAPABILITIES, mapOf(
+                Pair.of("capability", LaunchCapability.builder()
+                        .params(mapOf(
+                                Pair.of("capability_first_param", "first_value"),
+                                Pair.of("capability_second_param", "second_value")
+                        ))
+                        .build())
+        ));
+
+        final Map<String, PipeConfValueVO> actual = launchCapabilitiesProcessor.process(CommonUtils.mergeMaps(
+                INITIAL_PARAMS, mapOf(
+                        Pair.of("CP_CAP_CUSTOM_capability", new PipeConfValueVO("true", BOOLEAN_TYPE))
+                )));
+
+        assertEquals(actual, CommonUtils.mergeMaps(INITIAL_PARAMS, mapOf(
+                Pair.of("CP_CAP_CUSTOM_capability", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                Pair.of("capability_first_param", new PipeConfValueVO("first_value", STRING_TYPE)),
+                Pair.of("capability_second_param", new PipeConfValueVO("second_value", STRING_TYPE))
+        )));
+    }
+
+    @Test
+    public void processShouldOverrideOriginalIntegerParamsWithCapabilityIntegerParams() {
+        set(SystemPreferences.LAUNCH_CAPABILITIES, mapOf(
+                Pair.of("capability", LaunchCapability.builder()
+                        .params(mapOf(
+                                Pair.of("integer_param", "2")
+                        ))
+                        .build())
+        ));
+
+        final Map<String, PipeConfValueVO> actual = launchCapabilitiesProcessor.process(CommonUtils.mergeMaps(
+                INITIAL_PARAMS, mapOf(
+                        Pair.of("CP_CAP_CUSTOM_capability", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                        Pair.of("integer_param", new PipeConfValueVO("1", INTEGER_TYPE))
+                )));
+
+        assertEquals(actual, CommonUtils.mergeMaps(INITIAL_PARAMS, mapOf(
+                Pair.of("CP_CAP_CUSTOM_capability", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                Pair.of("integer_param", new PipeConfValueVO("2", INTEGER_TYPE))
+        )));
+    }
+
+    @Test
+    public void processShouldOverrideOriginalIntegerParamsWithMultipleCapabilityIntegerParams() {
+        set(SystemPreferences.LAUNCH_CAPABILITIES, mapOf(
+                Pair.of("capability_first", LaunchCapability.builder()
+                        .params(mapOf(
+                                Pair.of("integer_param", "2")
+                        ))
+                        .build()),
+                Pair.of("capability_second", LaunchCapability.builder()
+                        .params(mapOf(
+                                Pair.of("integer_param", "3")
+                        ))
+                        .build())
+        ));
+
+        final Map<String, PipeConfValueVO> actual = launchCapabilitiesProcessor.process(CommonUtils.mergeMaps(
+                INITIAL_PARAMS, mapOf(
+                        Pair.of("CP_CAP_CUSTOM_capability_first", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                        Pair.of("CP_CAP_CUSTOM_capability_second", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                        Pair.of("integer_param", new PipeConfValueVO("1", INTEGER_TYPE))
+                )));
+
+        assertEquals(actual, CommonUtils.mergeMaps(INITIAL_PARAMS, mapOf(
+                Pair.of("CP_CAP_CUSTOM_capability_first", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                Pair.of("CP_CAP_CUSTOM_capability_second", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                Pair.of("integer_param", new PipeConfValueVO("3", INTEGER_TYPE))
+        )));
+    }
+
+    @Test
+    public void processShouldOverrideOriginalBooleanParamsWithCapabilityBooleanParams() {
+        set(SystemPreferences.LAUNCH_CAPABILITIES, mapOf(
+                Pair.of("capability", LaunchCapability.builder()
+                        .params(mapOf(
+                                Pair.of("boolean_param", "true")
+                        ))
+                        .build())
+        ));
+
+        final Map<String, PipeConfValueVO> actual = launchCapabilitiesProcessor.process(CommonUtils.mergeMaps(
+                INITIAL_PARAMS, mapOf(
+                        Pair.of("CP_CAP_CUSTOM_capability", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                        Pair.of("boolean_param", new PipeConfValueVO("false", BOOLEAN_TYPE))
+                )));
+
+        assertEquals(actual, CommonUtils.mergeMaps(INITIAL_PARAMS, mapOf(
+                Pair.of("CP_CAP_CUSTOM_capability", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                Pair.of("boolean_param", new PipeConfValueVO("true", BOOLEAN_TYPE))
+        )));
+    }
+
+    @Test
+    public void processShouldOverrideOriginalBooleanParamsWithMultipleCapabilityBooleanParams() {
+        set(SystemPreferences.LAUNCH_CAPABILITIES, mapOf(
+                Pair.of("capability_first", LaunchCapability.builder()
+                        .params(mapOf(
+                                Pair.of("boolean_param", "true")
+                        ))
+                        .build()),
+                Pair.of("capability_second", LaunchCapability.builder()
+                        .params(mapOf(
+                                Pair.of("boolean_param", "false")
+                        ))
+                        .build())
+        ));
+
+        final Map<String, PipeConfValueVO> actual = launchCapabilitiesProcessor.process(CommonUtils.mergeMaps(
+                INITIAL_PARAMS, mapOf(
+                        Pair.of("CP_CAP_CUSTOM_capability_first", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                        Pair.of("CP_CAP_CUSTOM_capability_second", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                        Pair.of("boolean_param", new PipeConfValueVO("true", BOOLEAN_TYPE))
+                )));
+
+        assertEquals(actual, CommonUtils.mergeMaps(INITIAL_PARAMS, mapOf(
+                Pair.of("CP_CAP_CUSTOM_capability_first", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                Pair.of("CP_CAP_CUSTOM_capability_second", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                Pair.of("boolean_param", new PipeConfValueVO("false", BOOLEAN_TYPE))
+        )));
+    }
+
+    @Test
+    public void processShouldOverrideMultipleCapabilityImplicitBooleanParams() {
+        set(SystemPreferences.LAUNCH_CAPABILITIES, mapOf(
+                Pair.of("capability_first", LaunchCapability.builder()
+                        .params(mapOf(
+                                Pair.of("boolean_param", "true")
+                        ))
+                        .build()),
+                Pair.of("capability_second", LaunchCapability.builder()
+                        .params(mapOf(
+                                Pair.of("boolean_param", "false")
+                        ))
+                        .build())
+        ));
+
+        final Map<String, PipeConfValueVO> actual = launchCapabilitiesProcessor.process(mapOf(
+                        Pair.of("CP_CAP_CUSTOM_capability_first", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                        Pair.of("CP_CAP_CUSTOM_capability_second", new PipeConfValueVO("true", BOOLEAN_TYPE))
+                ));
+
+        assertEquals(actual, mapOf(
+                Pair.of("CP_CAP_CUSTOM_capability_first", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                Pair.of("CP_CAP_CUSTOM_capability_second", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                Pair.of("boolean_param", new PipeConfValueVO("false", BOOLEAN_TYPE))
+        ));
+    }
+
+    @Test
+    public void processShouldMergeOriginalStringParamsWithCapabilityStringParams() {
+        set(SystemPreferences.LAUNCH_CAPABILITIES, mapOf(
+                Pair.of("capability", LaunchCapability.builder()
+                        .params(mapOf(
+                                Pair.of("string_param", "2")
+                        ))
+                        .build())
+        ));
+
+        final Map<String, PipeConfValueVO> actual = launchCapabilitiesProcessor.process(CommonUtils.mergeMaps(
+                INITIAL_PARAMS, mapOf(
+                        Pair.of("CP_CAP_CUSTOM_capability", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                        Pair.of("string_param", new PipeConfValueVO("1", STRING_TYPE))
+                )));
+
+        assertEquals(actual, CommonUtils.mergeMaps(INITIAL_PARAMS, mapOf(
+                Pair.of("CP_CAP_CUSTOM_capability", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                Pair.of("string_param", new PipeConfValueVO("1,2", STRING_TYPE))
+        )));
+    }
+
+    @Test
+    public void processShouldMergeOriginalStringParamsWithMultipleCapabilityStringParams() {
+        set(SystemPreferences.LAUNCH_CAPABILITIES, mapOf(
+                Pair.of("capability_first", LaunchCapability.builder()
+                        .params(mapOf(
+                                Pair.of("string_param", "2")
+                        ))
+                        .build()),
+                Pair.of("capability_second", LaunchCapability.builder()
+                        .params(mapOf(
+                                Pair.of("string_param", "3")
+                        ))
+                        .build())
+        ));
+
+        final Map<String, PipeConfValueVO> actual = launchCapabilitiesProcessor.process(CommonUtils.mergeMaps(
+                INITIAL_PARAMS, mapOf(
+                        Pair.of("CP_CAP_CUSTOM_capability_first", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                        Pair.of("CP_CAP_CUSTOM_capability_second", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                        Pair.of("string_param", new PipeConfValueVO("1", STRING_TYPE))
+                )));
+
+        assertEquals(actual, CommonUtils.mergeMaps(INITIAL_PARAMS, mapOf(
+                Pair.of("CP_CAP_CUSTOM_capability_first", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                Pair.of("CP_CAP_CUSTOM_capability_second", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                Pair.of("string_param", new PipeConfValueVO("1,2,3", STRING_TYPE))
+        )));
+    }
+
+    @Test
+    public void processShouldSplitMergeOriginalStringParamsWithCapabilityStringParamsIfThereIsEnabledCapability() {
+        set(SystemPreferences.LAUNCH_CAPABILITIES, mapOf(
+                Pair.of("capability", LaunchCapability.builder()
+                        .params(mapOf(
+                                Pair.of("string_param", "2,3")
+                        ))
+                        .build())
+        ));
+
+        final Map<String, PipeConfValueVO> actual = launchCapabilitiesProcessor.process(CommonUtils.mergeMaps(
+                INITIAL_PARAMS, mapOf(
+                        Pair.of("CP_CAP_CUSTOM_capability", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                        Pair.of("string_param", new PipeConfValueVO("1,2", STRING_TYPE))
+                )));
+
+        assertEquals(actual, CommonUtils.mergeMaps(INITIAL_PARAMS, mapOf(
+                Pair.of("CP_CAP_CUSTOM_capability", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                Pair.of("string_param", new PipeConfValueVO("1,2,3", STRING_TYPE))
+        )));
+    }
+
+    @Test
+    public void processShouldSplitMergeOriginalStringParamsWithMultipleCapabilityStringParams() {
+        set(SystemPreferences.LAUNCH_CAPABILITIES, mapOf(
+                Pair.of("capability_first", LaunchCapability.builder()
+                        .params(mapOf(
+                                Pair.of("string_param", "2,3")
+                        ))
+                        .build()),
+                Pair.of("capability_second", LaunchCapability.builder()
+                        .params(mapOf(
+                                Pair.of("string_param", "3,4")
+                        ))
+                        .build())
+        ));
+
+        final Map<String, PipeConfValueVO> actual = launchCapabilitiesProcessor.process(CommonUtils.mergeMaps(
+                INITIAL_PARAMS, mapOf(
+                        Pair.of("CP_CAP_CUSTOM_capability_first", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                        Pair.of("CP_CAP_CUSTOM_capability_second", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                        Pair.of("string_param", new PipeConfValueVO("1,2", STRING_TYPE))
+                )));
+
+        assertEquals(actual, CommonUtils.mergeMaps(INITIAL_PARAMS, mapOf(
+                Pair.of("CP_CAP_CUSTOM_capability_first", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                Pair.of("CP_CAP_CUSTOM_capability_second", new PipeConfValueVO("true", BOOLEAN_TYPE)),
+                Pair.of("string_param", new PipeConfValueVO("1,2,3,4", STRING_TYPE))
+        )));
+    }
+
+    @SafeVarargs
+    private static <K, V> Map<K, V> mapOf(final Pair<K, V>... items) {
+        return Arrays.stream(items)
+                .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
+    }
+
+    private <T> void set(final AbstractSystemPreference<T> preference, final T value) {
+        doReturn(value).when(preferenceManager).getPreference(preference);
+    }
+
+    private void assertEquals(final Map<String, PipeConfValueVO> actual, final Map<String, PipeConfValueVO> expected) {
+        expected.forEach((key, value) -> assertEquals(actual.get(key), value));
+    }
+
+    private void assertEquals(final PipeConfValueVO actual, final PipeConfValueVO expected) {
+        assertNotNull(actual);
+        assertThat(actual.getType(), is(expected.getType()));
+        assertThat(actual.getValue(), is(expected.getValue()));
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineConfigurationManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineConfigurationManagerTest.java
@@ -43,6 +43,7 @@ import static com.epam.pipeline.test.creator.datastorage.DatastorageCreatorUtils
 import static com.epam.pipeline.test.creator.datastorage.DatastorageCreatorUtils.getS3bucketDataStorage;
 import static com.epam.pipeline.test.creator.pipeline.PipelineCreatorUtils.getPipelineStart;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
@@ -81,6 +82,9 @@ public class PipelineConfigurationManagerTest {
     @SuppressWarnings("PMD.UnusedPrivateField")
     private PreferenceManager preferenceManager;
 
+    @Mock
+    private PipelineConfigurationLaunchCapabilitiesProcessor launchCapabilitiesProcessor;
+
     @InjectMocks
     private final PipelineConfigurationManager pipelineConfigurationManager = new PipelineConfigurationManager();
 
@@ -93,6 +97,7 @@ public class PipelineConfigurationManagerTest {
         dataStorages.add(getS3bucketDataStorage(S3_ID_1, TEST_PATH_2, OWNER1));
         dataStorages.add(getNfsDataStorage(NFS_ID_2, TEST_PATH_3, TEST_OPTIONS_2, "", OWNER2));
         dataStorages.add(getS3bucketDataStorage(S3_ID_2, TEST_PATH_4, OWNER2));
+        doReturn(Collections.emptyMap()).when(launchCapabilitiesProcessor).process(any());
     }
 
     @Test

--- a/core/src/main/java/com/epam/pipeline/entity/configuration/PipeConfValueVO.java
+++ b/core/src/main/java/com/epam/pipeline/entity/configuration/PipeConfValueVO.java
@@ -29,7 +29,10 @@ import java.util.Map;
 @Getter
 public class PipeConfValueVO {
 
-    public static final String DEFAULT_TYPE = "string";
+    public static final String INTEGER_TYPE = "int";
+    public static final String STRING_TYPE = "string";
+    public static final String BOOLEAN_TYPE = "boolean";
+    public static final String DEFAULT_TYPE = STRING_TYPE;
     public static final String DEFAULT_VALUE = "";
     public static final boolean DEFAULT_REQUIRED = false;
     protected static final  List<String> DEFAULT_AVAIL_VALUES = new ArrayList<>();


### PR DESCRIPTION
Relates #1393.

The pull request brings launch capabilities management to API. Essentially, from now on launch capabilities are applied in API which allows seamless capabilities usage from all types of clients including GUI, CLI and REST.
