### PR TITLE
Wait until run is completely initialized to redirect to the endpoint

### DIFF
--- a/deploy/docker/cp-edge/sync-routes.py
+++ b/deploy/docker/cp-edge/sync-routes.py
@@ -543,12 +543,13 @@ def get_service_list(active_runs_list, pod_id, pod_run_id, pod_ip):
                         do_log('Status for pipeline with id: {}, is not RUNNING. Service urls will not be proxied'.format(pod_run_id))
                         return {}
                 edge_endpoint_tag_name = [rp for rp in run_info["pipelineRunParameters"]
-                                          if rp["name"] == CP_EDGE_ENDPOINT_TAG_NAME]
-                if edge_endpoint_tag_name:
-                        if not (run_info.get("tags") and run_info.get("tags").get(edge_endpoint_tag_name[0]["value"])):
+                                          if 'name' in rp and rp["name"] == CP_EDGE_ENDPOINT_TAG_NAME]
+                if edge_endpoint_tag_name and len(edge_endpoint_tag_name) > 0:
+                        run_info_tags = run_info.get("tags")
+                        if not (run_info_tags and "value" in edge_endpoint_tag_name[0] and run_info_tags.get(edge_endpoint_tag_name[0]["value"])):
                                 do_log('Pipeline with id {} and run tag {} has not yet been initialized. '
                                        'Service urls will not be proxied'
-                                       .format(pod_run_id, edge_endpoint_tag_name[0]["name"]))
+                                       .format(pod_run_id, edge_endpoint_tag_name[0]["value"]))
                                 return {}
                 pod_owner = run_info["owner"]
                 docker_image = run_info["dockerImage"]


### PR DESCRIPTION
This PR updates sync-routes.py to wait for pipeline to initialize at run tag. 