### PR TITLE
Support offline execution of launch scripts on debian and ubuntu distributions

### DIFF
--- a/workflows/pipe-common/scripts/cluster_wait_for_node.py
+++ b/workflows/pipe-common/scripts/cluster_wait_for_node.py
@@ -12,20 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pipeline import Logger, TaskStatus, PipelineAPI, StatusEntry
 import argparse
 import os
+import traceback
+
 import time
 
-
-class Task:
-    def __init__(self):
-        self.task_name = 'Task'
-
-    def fail_task(self, message):
-        error_text = '{} task failed: {}.'.format(self.task_name, message)
-        Logger.fail(error_text, task_name=self.task_name)
-        raise RuntimeError(error_text)
+from pipeline import Logger, PipelineAPI
 
 
 class Node:
@@ -38,9 +31,9 @@ class Node:
             self.ip = None
 
 
-class WaitForNode(Task):
+class WaitForNode:
+
     def __init__(self):
-        Task.__init__(self)
         self.task_name = 'WaitForNode'
         self.pipe_api = PipelineAPI(os.environ['API'], 'logs')
 
@@ -60,9 +53,12 @@ class WaitForNode(Task):
                 raise RuntimeError('Failed to attach to master node')
 
             Logger.success('Attached to node (run id {})'.format(master.name), task_name=self.task_name)
+            if not master.name or not master.ip:
+                Logger.warn('Master name or ip cannot be determined. IP: {}. Name: {}'.format(master.ip, master.name), task_name=self.task_name)
             return master
-        except Exception as e:
-            self.fail_task(e.message)
+        except Exception:
+            Logger.fail('{} task failed: {}.'.format(self.task_name, traceback.format_exc()), task_name=self.task_name)
+            raise
 
     def get_node_info(self, task_name, run_id, parameters=None):
         if not parameters:
@@ -118,6 +114,7 @@ class WaitForNode(Task):
                 return False
         return True
 
+
 def check_if_self_master(run_id):
     if os.getenv('RUN_ID', '') != str(run_id):
         return None
@@ -129,13 +126,13 @@ def check_if_self_master(run_id):
     except:
         return None
 
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--parameter', type=str, default=None, nargs='*')
     parser.add_argument('--task-name', required=True)
     parser.add_argument('--run-id', required=True, type=int)
     args = parser.parse_args()
-    status = StatusEntry(TaskStatus.SUCCESS)
 
     # FIXME: This is a "temp" solution to return self IP and host if the run id matches with the current job
     # Shall be refactored some day
@@ -144,17 +141,8 @@ def main():
         print(self_info[0] + " " + self_info[1])
         exit(0)
 
-    try:
-        node = WaitForNode().await_node_start(args.task_name, args.run_id, parameters=args.parameter)
-        if not node.name or not node.ip:
-            Logger.warn('Master name or ip cannot be determined. IP: {}. Name: {}'.format(node.ip, node.name))
-        print(node.name + " " + node.ip)
-        exit(0)
-    except Exception as e:
-        Logger.warn(e.message)
-        status = StatusEntry(TaskStatus.FAILURE)
-    if status.status == TaskStatus.FAILURE:
-        raise RuntimeError('Failed to setup cluster')
+    node = WaitForNode().await_node_start(args.task_name, args.run_id, parameters=args.parameter)
+    print(node.name + " " + node.ip)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Relates #3420 and #1705.

The pull request removes certain limitations of launch scripts which prevented debian and ubuntu distributions from running in offline mode (without global internet access).

The following run parameter has been introduced:
- `CP_CAP_OFFLINE` enables offline launch support. Disabled by default.

Additionally, improves error logging of cluster wait scripts.
