### PR TITLE
Add host whitelist support to proxy auth

### DIFF
--- a/deploy/docker/cp-edge/nginx.conf
+++ b/deploy/docker/cp-edge/nginx.conf
@@ -29,6 +29,7 @@ env API_TOKEN;
 env EDGE_EXTERNAL;
 env EDGE_EXTERNAL_SCHEMA;
 env CP_API_SRV_SAML_ALLOW_ANONYMOUS_USER;
+env CP_EDGE_CONNECT_PROXY_AUTHENTICATION_WHITELIST;
 
 # - if Cloud Pipeline is NOT in maintenance mode, traffic will be proxied to the port 8181 (HTTP Reverse proxy
 #   for interactive web and in-browser sessions); otherwise, in maintenance mode, SSL/TLS traffic will go to


### PR DESCRIPTION
Relates #2699.

The pull request brings support for proxy auth host whitelist.

The following parameter has been added:
- `CP_EDGE_CONNECT_PROXY_AUTHENTICATION_WHITELIST` specifies a comma-separated list of allowed connection hosts. Defaults to no hosts.
