### PR TITLE
Deploy: Register app in basic IdP with provided Endpoint ID

### DIFF
--- a/deploy/contents/install/app/install-utils.sh
+++ b/deploy/contents/install/app/install-utils.sh
@@ -1526,10 +1526,8 @@ function configure_idp_metadata {
     local idp_external_port="${4}"
     local idp_internal_host="${5}"
     local idp_internal_port="${6}"
-    local service_external_host="${7}"
-    local service_external_port="${8}"
-    local certificate_dir="${9}"
-    local context_path="${10}"
+    local service_sso_endpoint_id="${7}"
+    local certificate_dir="${8}"
 
     local metadata_exists=0
     local metadata_dir=$(dirname "${metadata_file}")
@@ -1549,14 +1547,7 @@ function configure_idp_metadata {
                     -k
         if [ $? -eq 0 ] && [ -f "${metadata_file}" ]; then
             metadata_exists=1
-            if [ "${service_external_port}" -eq "443" ]; then
-                idp_register_app "https://${service_external_host}/${context_path}/" \
-                                                 "${certificate_dir}/sso-public-cert.pem"
-            else
-                idp_register_app "https://${service_external_host}:${service_external_port}/${context_path}/" \
-                                                 "${certificate_dir}/sso-public-cert.pem"
-            fi
-
+            idp_register_app "${service_sso_endpoint_id}" "${certificate_dir}/sso-public-cert.pem"
         fi
     fi
 

--- a/deploy/contents/install/app/install.sh
+++ b/deploy/contents/install/app/install.sh
@@ -521,10 +521,8 @@ if is_service_requested cp-api-srv; then
                                 "${CP_IDP_EXTERNAL_PORT}" \
                                 "${CP_IDP_INTERNAL_HOST}" \
                                 "${CP_IDP_INTERNAL_PORT}" \
-                                "${CP_API_SRV_EXTERNAL_HOST}" \
-                                "${CP_API_SRV_EXTERNAL_PORT}" \
-                                "${CP_API_SRV_CERT_DIR}" \
-                                "pipeline"
+                                "${CP_API_SRV_SSO_ENDPOINT_ID:-https://${CP_API_SRV_EXTERNAL_HOST}:${CP_API_SRV_EXTERNAL_PORT}/pipeline/}" \
+                                "${CP_API_SRV_CERT_DIR}"
 
         print_info "-> Creating RSA key pair (JWT signing)"
         generate_rsa_key_pair   $CP_API_SRV_CERT_DIR/jwt.key.private \
@@ -933,7 +931,7 @@ if is_service_requested cp-git; then
                 sleep $CP_GITLAB_INIT_TIMEOUT
                 api_register_gitlab "$GITLAB_IMP_TOKEN"
 
-                idp_register_app "https://${CP_GITLAB_EXTERNAL_HOST}:${CP_GITLAB_EXTERNAL_PORT}" \
+                idp_register_app "${CP_GITLAB_SSO_ENDPOINT_ID:-https://${CP_GITLAB_EXTERNAL_HOST}:${CP_GITLAB_EXTERNAL_PORT}}" \
                                  "$CP_GITLAB_CERT_DIR/sso-public-cert.pem"
 
                 print_info "-> Registering DataTransfer pipeline"
@@ -1213,10 +1211,8 @@ if is_service_requested cp-share-srv; then
                                 "${CP_IDP_EXTERNAL_PORT}" \
                                 "${CP_IDP_INTERNAL_HOST}" \
                                 "${CP_IDP_INTERNAL_PORT}" \
-                                "${CP_SHARE_SRV_EXTERNAL_HOST}" \
-                                "${CP_SHARE_SRV_EXTERNAL_PORT}" \
-                                "${CP_SHARE_SRV_CERT_DIR}" \
-                                "proxy"
+                                "${CP_SHARE_SRV_SAML_ENDPOINT_ID:-https://${CP_SHARE_SRV_EXTERNAL_HOST}:${CP_SHARE_SRV_EXTERNAL_PORT}/proxy/}" \
+                                "${CP_SHARE_SRV_CERT_DIR}"
 
         print_info "-> Deploying Share Service service"
 


### PR DESCRIPTION
In case when we deploy Cloud-Pipeline with basic IdP and additionally providing SSO_ENDPOINT_ID for services such as
 - api-srv
 - git

The deployment script would behave unexpectedly. Despite we specify ENDPOINT_ID explicitly it will still register these apps with default value like `https://{external_host}:{external_port}/<context-path>`

This changes modify this behaviour to use SSO_ENDPOINT_ID if provided, otherwise use default value