### PR TITLE
Deployment: change way of installing kube 

### DIFF
--- a/deploy/contents/install/app/install-common.sh
+++ b/deploy/contents/install/app/install-common.sh
@@ -25,7 +25,8 @@ yum install -y \
             wget \
             git \
             gettext \
-            iproute-tc
+            iproute-tc \
+            openssl
 
 git config --global http.sslVerify "false"
 

--- a/deploy/contents/install/app/install-master.sh
+++ b/deploy/contents/install/app/install-master.sh
@@ -27,23 +27,7 @@ check_enough_disk "${CP_KUBE_MASTER_ETCD_MIN_DISK_MB:-20480}" \
                   "$CP_KUBE_MASTER_ETCD_HOST_PATH" "/var/lib/etcd"
 
 
-
 # 1
-cat <<EOF >/etc/yum.repos.d/kubernetes.repo
-[kubernetes]
-name=Kubernetes
-baseurl=http://yum.kubernetes.io/repos/kubernetes-el7-x86_64
-enabled=1
-gpgcheck=1
-repo_gpgcheck=1
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
-       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
-EOF
-
-# 2
-yum -q makecache -y --enablerepo kubernetes --nogpg
-
-# 3
 cat <<EOF >/etc/sysctl.d/k8s.conf
 net.bridge.bridge-nf-call-ip6tables = 1
 net.bridge.bridge-nf-call-iptables = 1
@@ -51,11 +35,11 @@ net.ipv4.ip_forward = 1
 EOF
 sysctl --system
 
-# 4
+# 2
 setenforce 0 || true
 sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
 
-#6.1 - Docker
+#3.1 - Docker
 set +e
 yum install -y yum-utils \
   device-mapper-persistent-data \
@@ -127,26 +111,15 @@ sysctl --system
 setenforce 0 || true
 sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
 
-# Add Kubernetes repository to yum
-cat <<EOF >/etc/yum.repos.d/kubernetes.repo
-[kubernetes]
-name=Kubernetes
-baseurl=http://yum.kubernetes.io/repos/kubernetes-el7-x86_64
-enabled=1
-gpgcheck=1
-repo_gpgcheck=1
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
-       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
-EOF
-yum -q makecache -y --enablerepo kubernetes --nogpg
 
-#6.2 - Kube
-yum install -y \
-            kubeadm-1.15.4-0.x86_64 \
-            kubectl-1.15.4-0.x86_64 \
-            kubelet-1.15.4-0.x86_64
+#3.2 - Kube
+echo "Installing Kube: yum localisntall from https://cloud-pipeline-oss-builds.s3.amazonaws.com/tools/kube/1.15.4/rpm/kube-1.15.4.el7.tgz"
+wget https://cloud-pipeline-oss-builds.s3.amazonaws.com/tools/kube/1.15.4/rpm/kube-1.15.4.el7.tgz -O kube.tgz && \
+     tar -xf kube.tgz && \
+     cd kube && yum localinstall *kube*.rpm *cri-tools*.rpm -y && \
+     cd .. && rm -rf kube/ && rm -rf kube.tgz
 
-#8
+#4
 systemctl daemon-reload
 systemctl enable docker
 systemctl enable kubelet
@@ -156,7 +129,7 @@ systemctl start kubelet
 # FIXME: here and further - implement a smarter approach to wait for the kube service to init
 sleep 10
 
-#9
+#5
 # If another directory for etcd is specified via CP_KUBE_MASTER_ETCD_HOST_PATH - it will be symlinked to the default location at /var/lib/etcd
 # This allows to use different drive for etcd wal/data dirs to overcome any I/O latencies which may cause control plane pods failures
 if [ "$CP_KUBE_MASTER_ETCD_HOST_PATH" ]; then
@@ -205,7 +178,7 @@ export https_proxy="$bkp_https_proxy"
 export no_proxy="$bkp_no_proxy"
 unset bkp_http_proxy bkp_https_proxy bkp_no_proxy
 
-#10
+#6
 CP_KUBE_NETWORK_YAML="$K8S_SPECS_HOME/kube-system/canal.yaml"
 if [ ! -f "$CP_KUBE_NETWORK_YAML" ]; then
   echo "Unable to find flannel spec file at ${CP_KUBE_NETWORK_YAML}, exiting"
@@ -214,7 +187,7 @@ fi
 envsubst '${CP_KUBE_FLANNEL_CIDR}' < "$CP_KUBE_NETWORK_YAML" | kubectl apply -f -
 sleep 10
 
-#11
+#7
 CP_KUBE_NETWORK_POLICY_PATH=${CP_KUBE_NETWORK_POLICY_PATH:-"$K8S_SPECS_HOME/kube-system/network-policy"}
 if [ ! -d "$CP_KUBE_NETWORK_POLICY_PATH" ] || [ ! -d "$CP_KUBE_NETWORK_POLICY_PATH" ]; then
   print_warn "Network policies are not provided in the directory $CP_KUBE_NETWORK_POLICY_PATH"
@@ -227,13 +200,13 @@ fi
 # label kube-system namespace, label is required for sensitive network policy
 kubectl label namespace kube-system name=kube-system
 
-#12
+#8
 kubectl create clusterrolebinding owner-cluster-admin-binding \
     --clusterrole cluster-admin \
     --user system:serviceaccount:default:default
 sleep 10
 
-#13
+#9
 # Allow services to bind to 80+ ports, as the default range is 30000-32767
 # --service-node-port-range option is added as a next line after init command "- kube-apiserver"
 # kubelet monitors /etc/kubernetes/manifests folder, so kube-api pod will be recreated automatically


### PR DESCRIPTION
Now we are installing kube from pre-downloaded packages, because kube 1.15 was deleted from community repo 

link to the info page: https://kubernetes.io/blog/2023/08/31/legacy-package-repository-deprecation/