### PR TITLE
GUI issue 3469 aws omics store support #3469

### DIFF
--- a/client/src/components/pipelines/browser/Folder.js
+++ b/client/src/components/pipelines/browser/Folder.js
@@ -1622,12 +1622,16 @@ export default class Folder extends localization.LocalizedReactComponent {
               key={`${storageKey}_new`}>
               Create new object storage
             </MenuItem>
-            <MenuItem
-              id="create-omics-store-button"
-              className="create-omics-store-button"
-              key={`${storageKey}_${omicsStoreKey}`}>
-              Create Omics store
-            </MenuItem>
+            {
+              this.isAnyAwsRegion && (
+                <MenuItem
+                  id="create-omics-store-button"
+                  className="create-omics-store-button"
+                  key={`${storageKey}_${omicsStoreKey}`}>
+                  Create Omics store
+                </MenuItem>
+              )
+            }
             <MenuItem
               id="add-existing-storage-button"
               className="add-existing-storage-button"
@@ -2048,6 +2052,13 @@ export default class Folder extends localization.LocalizedReactComponent {
     } else {
       return !!this.state.issuesItem;
     }
+  }
+
+  get isAnyAwsRegion () {
+    const regions = this.props.awsRegions.loaded
+      ? (this.props.awsRegions.value || []).map(r => r) : [];
+    const awsRegions = regions.filter(region => region.provider === 'AWS');
+    return awsRegions && awsRegions.length;
   }
 
   render () {

--- a/client/src/components/pipelines/browser/data-storage/index.js
+++ b/client/src/components/pipelines/browser/data-storage/index.js
@@ -2620,14 +2620,14 @@ export default class DataStorage extends React.Component {
               }
               fileIsEmpty={this.isFileSelectedEmpty}
               extraKeys={[
-                /^nfs$/i.test(type)
+                (/^nfs$/i.test(type) && !this.isOmicsStore)
                   ? FS_MOUNTS_NOTIFICATIONS_ATTRIBUTE
                   : false,
-                !/^nfs$/i.test(type) && !this.state.selectedFile
+                ((!/^nfs$/i.test(type) && !this.state.selectedFile) && !this.isOmicsStore)
                   ? REQUEST_DAV_ACCESS_ATTRIBUTE
                   : false
               ].filter(Boolean)}
-              extraInfo={[
+              extraInfo={!this.isOmicsStore ? [
                 <LifeCycleCounter
                   storage={this.storage.info}
                   path={this.props.path}
@@ -2640,7 +2640,7 @@ export default class DataStorage extends React.Component {
                   )}
                 />,
                 <StorageSize storage={this.storage.info} />
-              ]}
+              ] : []}
               specialTagsProperties={{
                 storageType: this.fileShareMount ? this.fileShareMount.mountType : undefined,
                 storageMask: mask,

--- a/client/src/components/pipelines/browser/forms/DataStorageEditDialog.js
+++ b/client/src/components/pipelines/browser/forms/DataStorageEditDialog.js
@@ -554,11 +554,13 @@ export class DataStorageEditDialog extends React.Component {
                         style={{width: '100%'}}
                         disabled={!!this.props.dataStorage || isReadOnly}
                       >
-                        {this.awsRegions.map(region => {
-                          return <Select.Option key={region.id.toString()} title={region.name}>
-                            <AWSRegionTag regionUID={region.regionId} /> {region.name}
-                          </Select.Option>;
-                        })}
+                        {this.awsRegions
+                          .filter(region => (!this.omicsStore || region.provider === 'AWS'))
+                          .map(region => {
+                            return <Select.Option key={region.id.toString()} title={region.name}>
+                              <AWSRegionTag regionUID={region.regionId} /> {region.name}
+                            </Select.Option>;
+                          })}
                       </Select>
                     )}
                   </Form.Item>

--- a/client/src/components/pipelines/browser/forms/DataStorageNavigation.js
+++ b/client/src/components/pipelines/browser/forms/DataStorageNavigation.js
@@ -32,6 +32,11 @@ export default class DataStorageNavigation extends React.Component {
 
   state = {editable: false};
 
+  get isOmicsStore () {
+    const {type} = this.props.storage || {};
+    return type === 'AWS_OMICS_SEQ' || type === 'AWS_OMICS_REF';
+  }
+
   navigate = (event, path) => {
     event.stopPropagation();
     if (this.props.navigate && this.props.storage) {
@@ -50,7 +55,7 @@ export default class DataStorageNavigation extends React.Component {
 
   getRootPath = () => {
     if (this.props.storage) {
-      if (this.props.storage.type === 'AWS_OMICS_REF' || this.props.storage.type === 'AWS_OMICS_SEQ') {
+      if (this.isOmicsStore) {
         return `${this.props.storage.pathMask.toLowerCase()}`;
       }
       return `${this.props.storage.type.toLowerCase()}://${this.props.storage.path}`;
@@ -98,7 +103,11 @@ export default class DataStorageNavigation extends React.Component {
     if (!mode) {
       this.control = false;
     }
-    this.setState({editable: mode});
+    if (this.isOmicsStore) {
+      this.setState({editable: false});
+    } else {
+      this.setState({editable: mode});
+    }
   };
 
   initializeInput = (input) => {

--- a/client/src/components/pipelines/browser/forms/DataStorageNavigation.js
+++ b/client/src/components/pipelines/browser/forms/DataStorageNavigation.js
@@ -50,6 +50,9 @@ export default class DataStorageNavigation extends React.Component {
 
   getRootPath = () => {
     if (this.props.storage) {
+      if (this.props.storage.type === 'AWS_OMICS_REF' || this.props.storage.type === 'AWS_OMICS_SEQ') {
+        return `${this.props.storage.pathMask.toLowerCase()}`;
+      }
       return `${this.props.storage.type.toLowerCase()}://${this.props.storage.path}`;
     }
     return '';

--- a/client/src/components/pipelines/browser/forms/OmicsStorageImportDialog.css
+++ b/client/src/components/pipelines/browser/forms/OmicsStorageImportDialog.css
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2020 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.omics-storage-form-item {
+  margin-bottom: 5px;
+}
+
+.custom-label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: end;
+}

--- a/client/src/components/pipelines/browser/forms/OmicsStorageImportDialog.js
+++ b/client/src/components/pipelines/browser/forms/OmicsStorageImportDialog.js
@@ -1,0 +1,518 @@
+/*
+ * Copyright 2017-2021 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {computed} from 'mobx';
+import {
+  Button,
+  Form,
+  Input,
+  Modal,
+  Row,
+  Select,
+  Spin,
+  Icon
+} from 'antd';
+import roleModel from '../../../../utils/roleModel';
+import BucketBrowser from '../../launch/dialogs/BucketBrowser';
+import dataStorageRestrictedAccessCheck from '../../../../utils/data-storage-restricted-access';
+import styles from './OmicsStorageImportDialog.css';
+
+export const ServiceTypes = {
+  omicsRef: 'AWS_OMICS_REF',
+  omicsSeq: 'AWS_OMICS_SEQ'
+};
+
+const FileTypes = {
+  [ServiceTypes.omicsRef]: {
+    REFERENCE: 'REFERENCE'
+  },
+  [ServiceTypes.omicsSeq]: {
+    FASTQ: 'FASTQ',
+    BAM: 'BAM',
+    UBAM: 'UBAM',
+    CRAM: 'CRAM'
+  }
+};
+
+const Fields = {
+  name: 'name',
+  subjectId: 'subjectId',
+  sampleId: 'sampleId',
+  description: 'description',
+  generatedFrom: 'generatedFrom',
+  sourceFileType: 'sourceFileType',
+  sourceFile1: 'sourceFile1',
+  sourceFile2: 'sourceFile2',
+  referencePath: 'referencePath'
+};
+
+const FieldLabel = {
+  [Fields.name]: 'Name',
+  [Fields.subjectId]: 'Subject id',
+  [Fields.sampleId]: 'Sample id',
+  [Fields.description]: 'Description',
+  [Fields.generatedFrom]: 'Generated from',
+  [Fields.sourceFileType]: 'Source file type',
+  [Fields.sourceFile1]: 'Source file',
+  [Fields.sourceFile2]: 'Source file 2',
+  [Fields.referencePath]: 'Reference path'
+};
+
+const FieldValid = {
+  [Fields.name]: 'nameValid',
+  [Fields.subjectId]: 'subjectIdValid',
+  [Fields.sampleId]: 'sampleIdValid',
+  [Fields.sourceFileType]: 'sourceFileTypeValid',
+  [Fields.sourceFile1]: 'sourceFile1Valid',
+  [Fields.referencePath]: 'referencePathValid'
+};
+
+const CommonRequiredFields = [
+  Fields.name,
+  Fields.subjectId,
+  Fields.sampleId,
+  Fields.sourceFileType,
+  Fields.sourceFile1
+];
+
+const PlaceHolder = {
+  [Fields.sourceFile1]: 'Source',
+  [Fields.sourceFile2]: 'Source',
+  [Fields.referencePath]: 'Reference'
+};
+
+@roleModel.authenticationInfo
+@Form.create()
+export class OmicsStorageImportDialog extends React.Component {
+  static propTypes = {
+    visible: PropTypes.bool,
+    dataStorage: PropTypes.object,
+    pending: PropTypes.bool,
+    policySupported: PropTypes.bool,
+    onCancel: PropTypes.func,
+    onSubmit: PropTypes.func
+  };
+
+  state = {
+    nameValid: false,
+    subjectIdValid: false,
+    sampleIdValid: false,
+    sourceFileTypeValid: this.isReferenceStorage,
+    restrictedAccessCheckInProgress: false,
+    restrictedAccess: true,
+    bucketBrowserVisible: false
+  };
+
+  formItemLayout = {
+    labelCol: {
+      xs: {span: 24},
+      sm: {span: 6}
+    },
+    wrapperCol: {
+      xs: {span: 24},
+      sm: {span: 18}
+    }
+  };
+
+  @computed
+  get sourceFileTypes () {
+    return Object.values(FileTypes[this.storageType] || {}) || [];
+  }
+
+  @computed
+  get storageType () {
+    return this.props.dataStorage && this.props.dataStorage.type;
+  }
+
+  get isSequenceStorage () {
+    return this.storageType === ServiceTypes.omicsSeq;
+  }
+
+  get isReferenceStorage () {
+    return this.storageType === ServiceTypes.omicsRef;
+  }
+
+  get isReferencePathRequired () {
+    return this.isSequenceStorage &&
+      (this.state.sourceFileType === FileTypes[ServiceTypes.omicsSeq].BAM ||
+      this.state.sourceFileType === FileTypes[ServiceTypes.omicsSeq].CRAM);
+  }
+
+  get requiredFields () {
+    if (this.isSequenceStorage && this.isReferencePathRequired) {
+      return [...CommonRequiredFields, Fields.referencePath];
+    }
+    return CommonRequiredFields;
+  }
+
+  get isImportButtonDisabled () {
+    return this.requiredFields.some(field => {
+      return !this.state[FieldValid[field]];
+    });
+  }
+
+  get isFASTQ () {
+    return this.state.sourceFileType === FileTypes[ServiceTypes.omicsSeq].FASTQ;
+  }
+
+  handleSubmit = (e) => {
+    e && e.preventDefault();
+    this.props.form.validateFieldsAndScroll((err, values) => {
+      if (!err) {
+        const sources = {
+          name: values.name,
+          subjectId: values.subjectId,
+          sampleId: values.sampleId,
+          sourceFileType: values.sourceFileType,
+          sourceFiles: {
+            source1: values.sourceFile1
+          }
+        };
+        if (values.description) {
+          sources.description = values.description;
+        }
+        if (values.generatedFrom) {
+          sources.generatedFrom = values.generatedFrom;
+        }
+        if (this.isFASTQ && values.sourceFile2) {
+          sources.sourceFiles.source2 = values.sourceFile2;
+        }
+        if (values.referencePath) {
+          sources.referencePath = values.referencePath;
+        }
+        this.props.onSubmit(sources);
+      }
+    });
+  };
+
+  validateRequiredField = (field, value, callback) => {
+    if (!value) {
+      this.setState({[FieldValid[field]]: false});
+      // eslint-disable-next-line standard/no-callback-literal
+      callback(`${FieldLabel[field]} is required`);
+    } else {
+      this.setState({[FieldValid[field]]: true});
+    }
+    callback();
+  }
+
+  renderRequiredStringField = (field) => {
+    const {getFieldDecorator} = this.props.form;
+    return (
+      <Form.Item
+        className={styles.omicsStorageFormItem}
+        {...this.formItemLayout}
+        label={FieldLabel[field]}>
+        {getFieldDecorator(field, {
+          initialValue: undefined,
+          rules: [{
+            required: true,
+            validator: (rule, value, callback) => this.validateRequiredField(
+              field,
+              value,
+              callback
+            )
+          }]
+        })(
+          <Input
+            style={{width: '100%'}}
+            disabled={this.props.pending} />
+        )}
+      </Form.Item>
+    );
+  }
+
+  renderFileInput = (field) => {
+    const {getFieldDecorator} = this.props.form;
+    const isSourceFile1 = field === Fields.sourceFile1;
+    const isReferencePath = field === Fields.referencePath;
+    const rules = isSourceFile1 || (isReferencePath && this.isReferencePathRequired)
+      ? ([{
+        required: true,
+        validator: (rule, value, callback) => (
+          this.validateRequiredField(field, value, callback)
+        )
+      }])
+      : undefined;
+    const label = (isSourceFile1 &&
+      this.isFASTQ &&
+      this.props.form.getFieldValue([Fields.sourceFile1]))
+      ? `${FieldLabel[field]} 1` : FieldLabel[field];
+    return (
+      <Form.Item
+        className={styles.omicsStorageFormItem}
+        {...this.formItemLayout}
+        label={label}>
+        {getFieldDecorator(field, {
+          initialValue: undefined,
+          rules
+        })(
+          <Input
+            style={{width: '100%'}}
+            disabled={this.props.pending}
+            placeholder={PlaceHolder[field]}
+            addonBefore={
+              <div
+                className={styles.pathType}
+                onClick={() => this.openBucketBrowser(field)}>
+                <Icon type="folder" />
+              </div>
+            }
+          />
+        )}
+      </Form.Item>
+    );
+  }
+
+  getFooter = () => {
+    const getCancelFooter = () => {
+      return (
+        <Row>
+          <Button
+            id="omics-storage-dialog-cancel-button"
+            onClick={this.props.onCancel}
+          >
+            Cancel
+          </Button>
+        </Row>
+      );
+    };
+    const getImportFooter = () => {
+      return (
+        <Row>
+          <Button
+            id="omics-storage-dialog-cancel-button"
+            onClick={this.props.onCancel}
+          >
+            Cancel
+          </Button>
+          <Button
+            id="omics-storage-dialog-create-button"
+            type="primary"
+            htmlType="submit"
+            disabled={this.isImportButtonDisabled}
+            onClick={this.handleSubmit}
+          >
+            Import
+          </Button>
+        </Row>
+      );
+    };
+    const footer = (this.props.pending || this.state.restrictedAccessCheckInProgress)
+      ? false
+      : (this.props.dataStorage &&
+        !this.props.dataStorage.locked &&
+        !this.state.restrictedAccess
+        ? getImportFooter()
+        : getCancelFooter()
+      );
+    return footer;
+  };
+
+  render () {
+    const {getFieldDecorator, resetFields} = this.props.form;
+    const bucketTypes = ['S3'];
+    const refType = ['AWS_OMICS_REF'];
+    const title = this.storageType === ServiceTypes.omicsRef
+      ? 'Import to reference store'
+      : 'Import to sequence store';
+    return (
+      <Modal
+        maskClosable={!this.props.pending && !this.state.restrictedAccessCheckInProgress}
+        afterClose={() => resetFields()}
+        closable={!this.props.pending && !this.state.restrictedAccessCheckInProgress}
+        visible={this.props.visible}
+        title={title}
+        onCancel={this.props.onCancel}
+        style={{transition: 'width 0.2s ease'}}
+        width={'50%'}
+        footer={this.getFooter()}>
+        <Spin spinning={this.props.pending || this.state.restrictedAccessCheckInProgress}>
+          <Form id="edit-storage-form">
+            {this.renderRequiredStringField(Fields.name)}
+            {this.renderRequiredStringField(Fields.subjectId)}
+            {this.renderRequiredStringField(Fields.sampleId)}
+            <Form.Item
+              className={styles.omicsStorageFormItem}
+              {...this.formItemLayout}
+              label={FieldLabel[Fields.description]}>
+              {getFieldDecorator(Fields.description, {
+                initialValue: undefined
+              })(
+                <Input
+                  type="textarea"
+                  disabled={this.props.pending} />
+              )}
+            </Form.Item>
+            <Form.Item
+              className={styles.omicsStorageFormItem}
+              {...this.formItemLayout}
+              label={FieldLabel[Fields.generatedFrom]}>
+              {getFieldDecorator(Fields.generatedFrom, {
+                initialValue: undefined
+              })(
+                <Input
+                  style={{width: '100%'}}
+                  disabled={this.props.pending} />
+              )}
+            </Form.Item>
+            <Form.Item
+              className={styles.omicsStorageFormItem}
+              {...this.formItemLayout}
+              label={FieldLabel[Fields.sourceFileType]}>
+              {getFieldDecorator(Fields.sourceFileType, {
+                initialValue: this.isReferenceStorage
+                  ? FileTypes[ServiceTypes.omicsRef].REFERENCE : undefined,
+                rules: [{
+                  required: true,
+                  validator: (rule, value, callback) => (
+                    this.validateRequiredField(Fields.sourceFileType, value, callback)
+                  )
+                }]
+              })(
+                <Select
+                  style={{width: '100%'}}
+                  disabled={!this.storageType}
+                  onChange={(type) => this.setState({sourceFileType: type})}
+                >
+                  {this.sourceFileTypes.map((type) => {
+                    return (
+                      <Select.Option key={type} title={type}>
+                        {type}
+                      </Select.Option>
+                    );
+                  })}
+                </Select>
+              )}
+            </Form.Item>
+            {this.renderFileInput(Fields.sourceFile1)}
+            {
+              this.isFASTQ &&
+              this.props.form.getFieldValue([Fields.sourceFile1]) &&
+              this.renderFileInput(Fields.sourceFile2)
+            }
+            {this.isSequenceStorage && this.renderFileInput(Fields.referencePath)}
+            <BucketBrowser
+              onSelect={this.selectBucketPath}
+              onCancel={this.closeBucketBrowser}
+              visible={this.state.sourceBrowserVisible}
+              selectOnlyFiles
+              checkWritePermissions
+              bucketTypes={bucketTypes} />
+            <BucketBrowser
+              onSelect={this.selectBucketPath}
+              onCancel={this.closeBucketBrowser}
+              visible={this.state.referenceBrowserVisible}
+              showOnlyFolder
+              checkWritePermissions
+              bucketTypes={refType} />
+          </Form>
+        </Spin>
+      </Modal>
+    );
+  }
+
+  openBucketBrowser = (field) => {
+    if (field === Fields.referencePath) {
+      this.setState({
+        referenceBrowserVisible: true,
+        referencePathField: field
+      });
+    } else {
+      this.setState({
+        sourceBrowserVisible: true,
+        sourceFileField: field
+      });
+    }
+  };
+
+  closeBucketBrowser = () => {
+    this.setState({
+      sourceBrowserVisible: false,
+      sourceFileField: null,
+      referenceBrowserVisible: false,
+      referencePathField: null
+    });
+  };
+
+  selectBucketPath = (path) => {
+    const {sourceFileField, referencePathField} = this.state;
+    if (sourceFileField) {
+      this.props.form.setFieldsValue({[Fields[sourceFileField]]: path});
+    }
+    if (referencePathField) {
+      this.props.form.setFieldsValue({[Fields[referencePathField]]: path});
+    }
+    this.props.form.validateFieldsAndScroll();
+    this.closeBucketBrowser();
+  };
+
+  componentDidMount () {
+    this.checkRestrictedAccess();
+  }
+
+  componentDidUpdate (prevProps) {
+    const dataStorageChanged = (a, b) => {
+      const {
+        id: aID
+      } = a || {};
+      const {
+        id: bID
+      } = b || {};
+      return aID !== bID;
+    };
+    if (dataStorageChanged(this.props.dataStorage, prevProps.dataStorage)) {
+      this.checkRestrictedAccess();
+    }
+  }
+
+  componentWillUnmount () {
+    this.increaseCheckRestrictedAccessToken();
+  }
+
+  increaseCheckRestrictedAccessToken = () => {
+    this.checkRestrictedAccessToken = (this.checkRestrictedAccessToken || 0) + 1;
+    return this.checkRestrictedAccessToken;
+  };
+
+  checkRestrictedAccess = () => {
+    const {dataStorage} = this.props;
+    const {id} = dataStorage || {};
+    const token = this.increaseCheckRestrictedAccessToken();
+    this.setState({
+      restrictedAccessCheckInProgress: true,
+      restrictedAccess: true
+    }, async () => {
+      const state = {
+        restrictedAccessCheckInProgress: false
+      };
+      try {
+        state.restrictedAccess = await dataStorageRestrictedAccessCheck(id);
+      } catch (_) {
+        state.restrictedAccess = true;
+      } finally {
+        if (token === this.checkRestrictedAccessToken) {
+          if (state.restrictedAccess) {
+            console.log(`Storage #${id} is in the restricted access mode for current user`);
+          }
+          this.setState(state);
+        }
+      }
+    });
+  };
+}

--- a/client/src/components/pipelines/launch/dialogs/BucketBrowser.js
+++ b/client/src/components/pipelines/launch/dialogs/BucketBrowser.js
@@ -72,6 +72,7 @@ export default class BucketBrowser extends React.Component {
     onCancel: PropTypes.func,
     multiple: PropTypes.bool,
     showOnlyFolder: PropTypes.bool,
+    selectOnlyFiles: PropTypes.bool,
     allowBucketSelection: PropTypes.bool,
     checkWritePermissions: PropTypes.bool,
     bucketTypes: PropTypes.arrayOf(
@@ -406,6 +407,14 @@ export default class BucketBrowser extends React.Component {
             readOnly: this.props.checkWritePermissions && !roleModel.writeAllowed({mask: i.permission})
           };
         } else {
+          if (this.props.selectOnlyFiles) {
+            const selectable = i.type.toLowerCase() === 'file';
+            return {
+              ...i,
+              selectable,
+              readOnly: false
+            };
+          }
           return {
             ...i,
             selectable: true,

--- a/client/src/components/pipelines/launch/dialogs/BucketBrowser.js
+++ b/client/src/components/pipelines/launch/dialogs/BucketBrowser.js
@@ -51,6 +51,8 @@ const S3_BUCKET_TYPE = 'S3';
 const NFS_BUCKET_TYPE = 'NFS';
 const AZ_BUCKET_TYPE = 'AZ';
 const GS_BUCKET_TYPE = 'GS';
+const OMICS_REF_BUCKET_TYPE = 'AWS_OMICS_REF';
+const OMICS_SEQ_BUCKET_TYPE = 'AWS_OMICS_SEQ';
 
 @connect({
   pipelinesLibrary
@@ -78,7 +80,9 @@ export default class BucketBrowser extends React.Component {
         S3_BUCKET_TYPE,
         GS_BUCKET_TYPE,
         NFS_BUCKET_TYPE,
-        DTS_ITEM_TYPE
+        DTS_ITEM_TYPE,
+        OMICS_REF_BUCKET_TYPE,
+        OMICS_SEQ_BUCKET_TYPE
       ])
     )
   };
@@ -223,7 +227,9 @@ export default class BucketBrowser extends React.Component {
         this.state.bucket.type === S3_BUCKET_TYPE ||
         this.state.bucket.type === AZ_BUCKET_TYPE ||
         this.state.bucket.type === GS_BUCKET_TYPE ||
-        this.state.bucket.type === NFS_BUCKET_TYPE
+        this.state.bucket.type === NFS_BUCKET_TYPE ||
+        this.state.bucket.type === OMICS_REF_BUCKET_TYPE ||
+        this.state.bucket.type === OMICS_SEQ_BUCKET_TYPE
     )) {
       const type = this.state.bucket.storageType || this.state.bucket.type;
       const buildPath = (root) => item && item.path ? `${root}/${item.path}` : root;
@@ -235,6 +241,9 @@ export default class BucketBrowser extends React.Component {
             : this.state.bucket.mountPoint
           : null;
         return buildPath(mountPoint || `/cloud-data/${storagePath}`);
+      }
+      if (type === OMICS_REF_BUCKET_TYPE || type === OMICS_SEQ_BUCKET_TYPE) {
+        return buildPath(`${this.state.bucket.pathMask}`);
       }
       return buildPath(`${type.toLowerCase()}://${this.state.bucket.path}`);
     } else if (this.state.bucket && this.state.bucket.type === DTS_ROOT_ITEM_TYPE) {

--- a/client/src/components/pipelines/launch/form/LaunchPipelineForm.js
+++ b/client/src/components/pipelines/launch/form/LaunchPipelineForm.js
@@ -356,7 +356,8 @@ class LaunchPipelineForm extends localization.LocalizedReactComponent {
     userRunCapabilitiesPending: true,
     useResolvedParameters: false,
     runNameAlias: undefined,
-    isRawEditEnabled: false
+    isRawEditEnabled: false,
+    parameterType: undefined
   };
 
   formItemLayout = {
@@ -2161,7 +2162,8 @@ class LaunchPipelineForm extends localization.LocalizedReactComponent {
       bucketPathParameterKey: key,
       bucketPathParameterSection: sectionName,
       showOnlyFolderInBucketBrowser: type === 'output',
-      allowBucketSelectionInBucketBrowser: /^path$/i.test(type)
+      allowBucketSelectionInBucketBrowser: /^path$/i.test(type),
+      parameterType: type
     });
   };
 
@@ -2172,7 +2174,8 @@ class LaunchPipelineForm extends localization.LocalizedReactComponent {
       bucketPathParameterKey: null,
       bucketPathParameterSection: null,
       showOnlyFolderInBucketBrowser: false,
-      allowBucketSelectionInBucketBrowser: false
+      allowBucketSelectionInBucketBrowser: false,
+      parameterType: undefined
     });
   };
 
@@ -5612,6 +5615,10 @@ class LaunchPipelineForm extends localization.LocalizedReactComponent {
         ];
       }
     };
+    const bucketTypes = ['AZ', 'S3', 'GS', 'DTS', 'NFS'];
+    if (this.state.parameterType === 'path' || this.state.parameterType === 'input') {
+      bucketTypes.push('AWS_OMICS_SEQ', 'AWS_OMICS_REF');
+    }
     return (
       <Form onSubmit={this.handleSubmit}>
         <div className={styles.layout}>
@@ -5800,7 +5807,7 @@ class LaunchPipelineForm extends localization.LocalizedReactComponent {
           showOnlyFolder={this.state.showOnlyFolderInBucketBrowser}
           allowBucketSelection={this.state.allowBucketSelectionInBucketBrowser}
           checkWritePermissions={this.state.showOnlyFolderInBucketBrowser}
-          bucketTypes={['AZ', 'S3', 'GS', 'DTS', 'NFS']} />
+          bucketTypes={bucketTypes} />
         <PipelineBrowser
           multiple={false}
           onCancel={this.closePipelineBrowser}

--- a/client/src/components/settings/AWSRegionsForm.js
+++ b/client/src/components/settings/AWSRegionsForm.js
@@ -774,6 +774,8 @@ class AWSRegionForm extends React.Component {
       'sshKeyName',
       'iamRole',
       'tempCredentialsRole',
+      'omicsServiceRole',
+      'omicsEcrUrl',
       {
         key: 'backupDuration',
         visible: form => form.getFieldValue('versioningEnabled'),
@@ -1075,6 +1077,8 @@ class AWSRegionForm extends React.Component {
       check('azurePolicy', checkIPRangeValue) ||
       check('iamRole', checkStringValue) ||
       check('tempCredentialsRole', checkStringValue) ||
+      check('omicsServiceRole', checkStringValue) ||
+      check('omicsEcrUrl', checkStringValue) ||
       check('backupDuration', checkIntegerValue) ||
       check('versioningEnabled', checkBOOLValue) ||
       check('sshPublicKeyPath', checkStringValue) ||
@@ -2094,6 +2098,32 @@ class AWSRegionForm extends React.Component {
               {getFieldDecorator('tempCredentialsRole', {
                 initialValue: this.props.region.tempCredentialsRole,
                 rules: [{required: this.providerSupportsField('tempCredentialsRole'), message: 'Temp Credentials Role is required'}]
+              })(
+                <Input
+                  size="small"
+                  disabled={this.props.pending} />
+              )}
+            </Form.Item>
+            <Form.Item
+              label="AWS Omics Service role"
+              {...this.formItemLayout}
+              className={this.getFieldClassName('omicsServiceRole', 'edit-region-omicsServiceRole-container')}
+            >
+              {getFieldDecorator('omicsServiceRole', {
+                initialValue: this.props.region.omicsServiceRole
+              })(
+                <Input
+                  size="small"
+                  disabled={this.props.pending} />
+              )}
+            </Form.Item>
+            <Form.Item
+              label="AWS Omics ECR Url"
+              {...this.formItemLayout}
+              className={this.getFieldClassName('omicsEcrUrl', 'edit-region-omicsEcrUrl-container')}
+            >
+              {getFieldDecorator('omicsEcrUrl', {
+                initialValue: this.props.region.omicsEcrUrl
               })(
                 <Input
                   size="small"

--- a/client/src/models/dataStorage/OmicsActivate.js
+++ b/client/src/models/dataStorage/OmicsActivate.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import RemotePost from '../basic/RemotePost';
+
+export default class OmicsActivate extends RemotePost {
+  constructor (id) {
+    super();
+    this.url = `/omicsstore/${id}/activate`;
+  }
+}

--- a/client/src/models/dataStorage/OmicsStoreImport.js
+++ b/client/src/models/dataStorage/OmicsStoreImport.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import RemotePost from '../basic/RemotePost';
+
+export default class OmicsStoreImport extends RemotePost {
+  constructor (id) {
+    super();
+    this.url = `/omicsstore/${id}/import`;
+  }
+}


### PR DESCRIPTION
This PR:
Changes UI for creating and listing Omics storage:
 - creates and edit Omics store with the relevant fields;
 - fixes path view for storages;
 - disables some controls for Omics storage, e.g., download, create, rename, share;
 - set delete button only for folders.

Supports AWS Omics storage path as a Input parameter in pipelines.
Adds new fields AWS Omics Service role and AWS Omics ECR Url to AWS region.
[Initiate Omics Import Job for the omics storage from UI.](https://github.com/epam/cloud-pipeline/issues/3474)
Support restores from archive for sequence store.