### PR TITLE
Implement grace period support to grid engine autoscaler

### DIFF
--- a/workflows/pipe-common/pipeline/hpc/engine/gridengine.py
+++ b/workflows/pipe-common/pipeline/hpc/engine/gridengine.py
@@ -16,6 +16,7 @@ import math
 from datetime import datetime
 
 from pipeline.hpc.logger import Logger
+from pipeline.hpc.valid import WorkerValidatorHandler
 
 
 def _perform_command(action, msg, error_msg, skip_on_failure):
@@ -117,7 +118,7 @@ class GridEngineJob:
         return str(self.__dict__)
 
 
-class GridEngine:
+class GridEngine(WorkerValidatorHandler):
 
     def get_jobs(self):
         pass

--- a/workflows/pipe-common/pipeline/hpc/engine/kube.py
+++ b/workflows/pipe-common/pipeline/hpc/engine/kube.py
@@ -188,10 +188,11 @@ class KubeGridEngine(GridEngine):
                 if node_condition_status == 'True':
                     return True
                 Logger.warn('Execution host {host} is not ready which makes host invalid'
-                            .format(host=host))
+                            .format(host=host),
+                            crucial=True)
                 return False
         except Exception:
-            Logger.warn('Execution host {host} validation has failed'.format(host=host), trace=True)
+            Logger.warn('Execution host {host} validation has failed'.format(host=host), crucial=True, trace=True)
             return False
 
     def kill_jobs(self, jobs, force=False):

--- a/workflows/pipe-common/pipeline/hpc/engine/sge.py
+++ b/workflows/pipe-common/pipeline/hpc/engine/sge.py
@@ -291,14 +291,17 @@ class SunGridEngine(GridEngine):
                     for host_state in host_states:
                         if host_state in self._BAD_HOST_STATES:
                             Logger.warn('Execution host %s GE state is %s which makes host invalid.'
-                                        % (host, host_state))
+                                        % (host, host_state),
+                                        crucial=True)
                             return False
                     if host_states:
                         Logger.warn('Execution host %s GE state is not empty but is considered valid: %s.'
-                                    % (host, host_states))
+                                    % (host, host_states),
+                                    crucial=True)
             return True
         except RuntimeError as e:
-            Logger.warn('Execution host %s validation has failed in GE: %s' % (host, e))
+            Logger.warn('Execution host %s validation has failed in GE: %s' % (host, e),
+                        crucial=True, trace=True)
             return False
 
     def kill_jobs(self, jobs, force=False):

--- a/workflows/pipe-common/pipeline/hpc/engine/slurm.py
+++ b/workflows/pipe-common/pipeline/hpc/engine/slurm.py
@@ -91,7 +91,8 @@ class SlurmGridEngine(GridEngine):
         node_state = self._get_host_state(host)
         for bad_state in SlurmGridEngine._NODE_BAD_STATES:
             if bad_state in node_state:
-                Logger.warn('Execution host %s GE state is %s which makes host invalid.' % (host, bad_state))
+                Logger.warn('Execution host %s GE state is %s which makes host invalid.' % (host, bad_state),
+                            crucial=True)
                 return False
         return True
 
@@ -105,7 +106,7 @@ class SlurmGridEngine(GridEngine):
                 if "NodeName" in line:
                     return self._parse_dict(line).get("State", "UNKNOWN")
         except ExecutionError as e:
-            Logger.warn("Problems with getting host '%s' info: %s" % (host, e))
+            Logger.warn("Problems with getting host '%s' info: %s" % (host, e), crucial=True, trace=True)
             return "UNKNOWN"
 
     def _parse_jobs(self, scontrol_jobs_output):

--- a/workflows/pipe-common/pipeline/hpc/param.py
+++ b/workflows/pipe-common/pipeline/hpc/param.py
@@ -189,6 +189,10 @@ class GridEngineAutoscalingParametersGroup(GridEngineParametersGroup):
             name='CP_CAP_AUTOSCALE_IDLE_TIMEOUT', type=PARAM_INT, default=30,
             help='Specifies a timeout in seconds after which an inactive worker is considered idled.\n'
                  'If an autoscaling worker is idle then it is scaled down.')
+        self.scale_down_invalid_timeout = GridEngineParameter(
+            name='CP_CAP_AUTOSCALE_INVALID_TIMEOUT', type=PARAM_INT, default=60 * 60,
+            help='Specifies a timeout in seconds after which an unavailable worker is considered invalid.\n'
+                 'If an autoscaling worker is invalid then it is scaled down.')
         self.log_dir = GridEngineParameter(
             name='CP_CAP_AUTOSCALE_LOGDIR', type=PARAM_STR, default=os.getenv('LOG_DIR', '/var/log'),
             help='Specifies logging directory.')

--- a/workflows/pipe-common/pipeline/hpc/valid.py
+++ b/workflows/pipe-common/pipeline/hpc/valid.py
@@ -1,0 +1,68 @@
+#  Copyright 2017-2024 EPAM Systems, Inc. (https://www.epam.com/)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import datetime
+
+from pipeline.hpc.logger import Logger
+
+
+class WorkerValidator:
+
+    def validate(self):
+        pass
+
+
+class WorkerValidatorHandler:
+
+    def is_valid(self, host):
+        pass
+
+
+class GracePeriodWorkerValidatorHandler(WorkerValidatorHandler):
+
+    def __init__(self, inner, grace_period, clock):
+        self._inner = inner
+        self._grace_period = datetime.timedelta(seconds=grace_period)
+        self._clock = clock
+        self._unavailable_hosts = {}
+
+    def is_valid(self, host):
+        if self._inner.is_valid(host):
+            unavailability_period_start = self._unavailable_hosts.pop(host, None)
+            if unavailability_period_start:
+                Logger.warn('Additional host %s has become available.' % host, crucial=True)
+            return True
+        now = self._clock.now()
+        if host not in self._unavailable_hosts:
+            Logger.warn('Additional host %s has become unavailable.' % host, crucial=True)
+            self._unavailable_hosts[host] = now
+        unavailability_period_start = self._unavailable_hosts[host]
+        if now >= unavailability_period_start + self._grace_period:
+            Logger.warn('Additional host %s became unavailable more than %s seconds ago.'
+                        % (host, self._grace_period.seconds),
+                        crucial=True)
+            return False
+        return True

--- a/workflows/pipe-common/test/test_worker_validator.py
+++ b/workflows/pipe-common/test/test_worker_validator.py
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 import logging
+from datetime import datetime
 
 from mock import Mock, MagicMock
 
 from pipeline.hpc.engine.gridengine import GridEngineJob
 from pipeline.hpc.host import MemoryHostStorage
-from pipeline.hpc.pipe import CloudPipelineWorkerValidator
+from pipeline.hpc.pipe import CloudPipelineWorkerValidator, CloudPipelineWorkerValidatorHandler
 from utils import assert_first_argument_contained, assert_first_argument_not_contained
 
 logging.basicConfig(level=logging.DEBUG, format='%(asctime)s [%(threadName)s] [%(levelname)s] %(message)s')
@@ -29,6 +30,13 @@ HOST3 = 'HOST-3'
 HOST1_RUN_ID = '1'
 HOST2_RUN_ID = '2'
 HOST3_RUN_ID = '3'
+host_run_id_dict = {
+    HOST1: HOST1_RUN_ID,
+    HOST2: HOST2_RUN_ID,
+    HOST3: HOST3_RUN_ID,
+}
+
+now = datetime(2018, 12, 21, 11, 10, 00)
 
 executor = Mock()
 host_storage = MemoryHostStorage()
@@ -36,8 +44,14 @@ grid_engine = Mock()
 api = Mock()
 scale_down_handler = Mock()
 common_utils = Mock()
-worker_validator = CloudPipelineWorkerValidator(cmd_executor=executor, api=api, host_storage=host_storage,
+clock = Mock()
+worker_validator_handlers = [
+    CloudPipelineWorkerValidatorHandler(api=api, common_utils=common_utils),
+    grid_engine
+]
+worker_validator = CloudPipelineWorkerValidator(cmd_executor=executor, host_storage=host_storage,
                                                 grid_engine=grid_engine, scale_down_handler=scale_down_handler,
+                                                handlers=worker_validator_handlers,
                                                 common_utils=common_utils, dry_run=False)
 
 
@@ -49,7 +63,8 @@ def setup_function():
     grid_engine.is_valid = MagicMock(side_effect=[True, False, True])
     grid_engine.get_jobs = MagicMock(return_value=[])
     grid_engine.kill_jobs = MagicMock()
-    common_utils.get_run_id_from_host = MagicMock(side_effect=[HOST1_RUN_ID, HOST2_RUN_ID, HOST3_RUN_ID])
+    common_utils.get_run_id_from_host = MagicMock(side_effect=host_run_id_dict.get)
+    clock.now = MagicMock(return_value=now)
 
 
 def test_stopping_hosts_that_are_invalid_in_grid_engine():

--- a/workflows/pipe-common/test/test_worker_validator_handler_grace.py
+++ b/workflows/pipe-common/test/test_worker_validator_handler_grace.py
@@ -1,0 +1,80 @@
+#  Copyright 2017-2024 EPAM Systems, Inc. (https://www.epam.com/)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import datetime
+
+from mock import Mock, MagicMock
+
+from pipeline.hpc.valid import GracePeriodWorkerValidatorHandler
+
+logging.basicConfig(level=logging.DEBUG, format='%(asctime)s [%(threadName)s] [%(levelname)s] %(message)s')
+
+HOST = 'HOST'
+
+now = datetime.datetime(2018, 12, 21, 11, 10, 00)
+
+invalid_timeout = 30
+
+clock = Mock()
+inner = Mock()
+worker_validator_handler = GracePeriodWorkerValidatorHandler(inner=inner, grace_period=invalid_timeout, clock=clock)
+
+
+def setup_function():
+    clock.now = MagicMock(return_value=now)
+
+
+def test_valid_job():
+    inner.is_valid = MagicMock(return_value=True)
+
+    assert worker_validator_handler.is_valid(HOST)
+
+
+def test_invalid_job():
+    inner.is_valid = MagicMock(return_value=False)
+
+    assert worker_validator_handler.is_valid(HOST)
+
+
+def test_invalid_job_inside_grace_period():
+    inner.is_valid = MagicMock(return_value=False)
+
+    assert worker_validator_handler.is_valid(HOST)
+
+    clock.now = MagicMock(return_value=now + datetime.timedelta(seconds=invalid_timeout - 1))
+
+    assert worker_validator_handler.is_valid(HOST)
+
+
+def test_invalid_job_outside_grace_period():
+    inner.is_valid = MagicMock(return_value=False)
+
+    assert worker_validator_handler.is_valid(HOST)
+
+    clock.now = MagicMock(return_value=now + datetime.timedelta(seconds=invalid_timeout + 1))
+
+    assert not worker_validator_handler.is_valid(HOST)

--- a/workflows/pipe-common/test/test_worker_validator_handler_pipe.py
+++ b/workflows/pipe-common/test/test_worker_validator_handler_pipe.py
@@ -1,0 +1,63 @@
+#  Copyright 2017-2024 EPAM Systems, Inc. (https://www.epam.com/)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import datetime
+
+from mock import Mock, MagicMock
+
+from pipeline.hpc.pipe import CloudPipelineWorkerValidatorHandler
+
+logging.basicConfig(level=logging.DEBUG, format='%(asctime)s [%(threadName)s] [%(levelname)s] %(message)s')
+
+HOST = 'HOST'
+
+now = datetime.datetime(2018, 12, 21, 11, 10, 00)
+
+invalid_timeout = 30
+
+
+api = Mock()
+common_utils = Mock()
+worker_validator_handler = CloudPipelineWorkerValidatorHandler(api=api, common_utils=common_utils)
+
+
+def test_run_status_running():
+    api.load_run = MagicMock(return_value={'status': 'RUNNING'})
+
+    assert worker_validator_handler.is_valid(HOST)
+
+
+def test_run_status_failure():
+    api.load_run = MagicMock(return_value={'status': 'FAILURE'})
+
+    assert not worker_validator_handler.is_valid(HOST)
+
+
+def test_run_status_stopped():
+    api.load_run = MagicMock(return_value={'status': 'STOPPED'})
+
+    assert not worker_validator_handler.is_valid(HOST)


### PR DESCRIPTION
Resolves #3476.

The pull request brings support for grace period to grid engine autoscaler.

The following run parameters have been added:
- `CP_CAP_AUTOSCALE_INVALID_TIMEOUT` specifies a timeout in seconds after which an unavailable worker is considered invalid. If an autoscaling worker is invalid then it is scaled down. Defaults to **3600** seconds (1 hour).
