### PR TITLE
Data Storages: Support filter for listing items

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/datastorage/DataStorageApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/datastorage/DataStorageApiService.java
@@ -34,6 +34,7 @@ import com.epam.pipeline.entity.datastorage.DataStorageFile;
 import com.epam.pipeline.entity.datastorage.DataStorageItemContent;
 import com.epam.pipeline.entity.datastorage.DataStorageItemType;
 import com.epam.pipeline.entity.datastorage.DataStorageListing;
+import com.epam.pipeline.entity.datastorage.DataStorageListingFilter;
 import com.epam.pipeline.entity.datastorage.DataStorageStreamingContent;
 import com.epam.pipeline.entity.datastorage.DataStorageWithShareMount;
 import com.epam.pipeline.entity.datastorage.PathDescription;
@@ -135,12 +136,28 @@ public class DataStorageApiService {
         return dataStorageManager.getDataStorageItems(id, path, showVersion, pageSize, marker, showArchived);
     }
 
+    @PreAuthorize(AclExpressions.STORAGE_ID_READ + AclExpressions.AND
+            + AclExpressions.STORAGE_SHOW_ARCHIVED_PERMISSIONS)
+    public DataStorageListing filterDataStorageItems(final Long id, final String path, final boolean showVersion,
+                                                     final boolean showArchived,
+                                                     final DataStorageListingFilter filter) {
+        return dataStorageManager.filterDataStorageItems(id, path, showVersion, showArchived, filter);
+    }
+
     @PreAuthorize(AclExpressions.STORAGE_ID_OWNER + AclExpressions.AND
             + AclExpressions.STORAGE_SHOW_ARCHIVED_PERMISSIONS)
     public DataStorageListing getDataStorageItemsOwner(final Long id, final String path,
                                                        final Boolean showVersion, final Integer pageSize,
                                                        final String marker, final boolean showArchived) {
         return dataStorageManager.getDataStorageItems(id, path, showVersion, pageSize, marker, showArchived);
+    }
+
+    @PreAuthorize(AclExpressions.STORAGE_ID_OWNER + AclExpressions.AND
+            + AclExpressions.STORAGE_SHOW_ARCHIVED_PERMISSIONS)
+    public DataStorageListing filterDataStorageItemsOwner(final Long id, final String path, final boolean showVersion,
+                                                          final boolean showArchived,
+                                                          final DataStorageListingFilter filter) {
+        return dataStorageManager.filterDataStorageItems(id, path, showVersion, showArchived, filter);
     }
 
     @PreAuthorize(AclExpressions.STORAGE_ID_WRITE)

--- a/api/src/main/java/com/epam/pipeline/controller/datastorage/DataStorageController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/datastorage/DataStorageController.java
@@ -221,6 +221,26 @@ public class DataStorageController extends AbstractRestController {
         }
     }
 
+    @PostMapping(value = "/datastorage/{id}/list/filter")
+    @ResponseBody
+    @ApiOperation(
+            value = "Returns filtered data storage's items.",
+            notes = "Returns filtered data storage's items",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public Result<DataStorageListing> filterDataStorageItems(
+            @PathVariable(value = ID) final Long id,
+            @RequestParam(value = PATH, required = false) final String path,
+            @RequestParam(defaultValue = FALSE) final boolean showVersion,
+            @RequestParam(defaultValue = FALSE) final boolean showArchived,
+            @RequestBody final DataStorageListingFilter filter) {
+        return Result.success(showVersion
+                ? dataStorageApiService.filterDataStorageItemsOwner(id, path, showVersion, showArchived, filter)
+                : dataStorageApiService.filterDataStorageItems(id, path, showVersion, showArchived, filter));
+    }
+
     @RequestMapping(value = "/datastorage/{id}/list/page", method = RequestMethod.GET)
     @ResponseBody
     @ApiOperation(

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageListingFilterUtils.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageListingFilterUtils.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2024 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.datastorage;
+
+import com.epam.pipeline.entity.datastorage.AbstractDataStorageItem;
+import com.epam.pipeline.entity.datastorage.DataStorageException;
+import com.epam.pipeline.entity.datastorage.DataStorageFile;
+import com.epam.pipeline.entity.datastorage.DataStorageListingFilter;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@SuppressWarnings("HideUtilityClassConstructor")
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class DataStorageListingFilterUtils {
+
+    public static List<AbstractDataStorageItem> filterStorageItems(final List<AbstractDataStorageItem> items,
+                                                                   final DataStorageListingFilter filter) {
+        final DateFormat dateParser = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+        if (Objects.isNull(filter)) {
+            return items;
+        }
+
+        return ListUtils.emptyIfNull(items).stream()
+                .filter(item -> item instanceof DataStorageFile)
+                .map(item -> (DataStorageFile) item)
+                .filter(item -> matchNameFilter(item, filter))
+                .filter(item -> matchDateFilters(item, filter, dateParser))
+                .filter(item -> matchSizeFilters(item, filter))
+                .collect(Collectors.toList());
+    }
+
+    private static boolean matchNameFilter(final DataStorageFile item, final DataStorageListingFilter filter) {
+        if (StringUtils.isBlank(filter.getNameFilter())) {
+            return true;
+        }
+        if (StringUtils.isBlank(item.getName())) {
+            return false;
+        }
+        return StringUtils.containsIgnoreCase(item.getName(), filter.getNameFilter());
+    }
+
+    private static boolean matchDateFilters(final DataStorageFile item, final DataStorageListingFilter filter,
+                                            final DateFormat dateParser) {
+        if (Objects.isNull(filter.getDateAfter()) && Objects.isNull(filter.getDateBefore())) {
+            return true;
+        }
+        if (StringUtils.isBlank(item.getChanged())) {
+            return false;
+        }
+        try {
+            final Date itemChangedDate = dateParser.parse(item.getChanged());
+            if (Objects.nonNull(filter.getDateAfter()) && itemChangedDate.before(filter.getDateAfter())) {
+                return false;
+            }
+            return !Objects.nonNull(filter.getDateBefore()) || !itemChangedDate.after(filter.getDateBefore());
+        } catch (ParseException e) {
+            throw new DataStorageException(e);
+        }
+    }
+
+    private static boolean matchSizeFilters(final DataStorageFile item, final DataStorageListingFilter filter) {
+        if (Objects.isNull(filter.getSizeGreaterThan()) && Objects.isNull(filter.getSizeLessThan())) {
+            return true;
+        }
+        final Long itemSize = item.getSize();
+        if (Objects.isNull(itemSize)) {
+            return false;
+        }
+        if (Objects.nonNull(filter.getSizeGreaterThan()) && itemSize < filter.getSizeGreaterThan()) {
+            return false;
+        }
+        return !Objects.nonNull(filter.getSizeLessThan()) || itemSize <= filter.getSizeLessThan();
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
@@ -41,6 +41,7 @@ import com.epam.pipeline.entity.datastorage.DataStorageFolder;
 import com.epam.pipeline.entity.datastorage.DataStorageItemContent;
 import com.epam.pipeline.entity.datastorage.DataStorageItemType;
 import com.epam.pipeline.entity.datastorage.DataStorageListing;
+import com.epam.pipeline.entity.datastorage.DataStorageListingFilter;
 import com.epam.pipeline.entity.datastorage.DataStorageStreamingContent;
 import com.epam.pipeline.entity.datastorage.DataStorageType;
 import com.epam.pipeline.entity.datastorage.DataStorageWithShareMount;
@@ -563,6 +564,16 @@ public class DataStorageManager implements SecuredEntityManager {
                     restoredListing);
         }
         return storageProviderManager.getItems(dataStorage, path, showVersion, pageSize, marker);
+    }
+
+    public DataStorageListing filterDataStorageItems(final Long storageId, final String path,
+                                                     final boolean showVersion, final boolean showArchived,
+                                                     final DataStorageListingFilter filter) {
+        final int limit = preferenceManager.getPreference(SystemPreferences.STORAGE_LS_FILTER_ITEMS_LIMIT);
+        final DataStorageListing listing = getDataStorageItems(storageId, path, showVersion, limit, null,
+                showArchived);
+        listing.setResults(DataStorageListingFilterUtils.filterStorageItems(listing.getResults(), filter));
+        return listing;
     }
 
     @Transactional

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -251,6 +251,8 @@ public class SystemPreferences {
             null, DATA_STORAGE_GROUP, pass);
     public static final LongPreference STORAGE_LISTING_TIME_LIMIT =
             new LongPreference("storage.listing.time.limit", 3000L, DATA_STORAGE_GROUP, pass);
+    public static final IntPreference STORAGE_LS_FILTER_ITEMS_LIMIT = new IntPreference(
+            "storage.listing.filter.items.limit", 500, DATA_STORAGE_GROUP, isGreaterThan(0));
     public static final IntPreference STORAGE_INCOMPLETE_UPLOAD_CLEAN_DAYS =
             new IntPreference("storage.incomplete.upload.clean.days", 5, DATA_STORAGE_GROUP,
                     isNullOrGreaterThan(0));

--- a/core/src/main/java/com/epam/pipeline/entity/datastorage/DataStorageListingFilter.java
+++ b/core/src/main/java/com/epam/pipeline/entity/datastorage/DataStorageListingFilter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.datastorage;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Data
+@NoArgsConstructor
+public class DataStorageListingFilter {
+
+    private Date dateBefore;
+    private Date dateAfter;
+    private Long sizeGreaterThan;
+    private Long sizeLessThan;
+    private String nameFilter;
+}


### PR DESCRIPTION
The current PR brings a new method `POST /datastorage/<ID>/list/filter?path=<relative path>&showVersion=<true|false>&showArchived<true|false>`
```
{
  "dateAfter": "2023-08-14 23:04:15.000",
  "dateBefore": "2023-08-15 00:07:15.000"
  "nameFilter": "substring",  # find case insensitive substring in file name
  "sizeGreaterThan": 0,
  "sizeLessThan": 0
}
```
This method returns files located at the `path` prefix that match the requested filters. 

Additionally, since the number of files can be large a new system preference `storage.listing.filter.items.limit` has been introduced (default: 500). This option restricts the number of items requested from cloud provider.

The non-empty `nextPageMarker` indicates that there are still files that were not included in the response list (it might be worth increasing the `storage.listing.filter.items.limit` setting).