### PR TITLE
Implement ACL cache refresh

### DIFF
--- a/api/src/main/java/com/epam/pipeline/security/acl/AclRefreshService.java
+++ b/api/src/main/java/com/epam/pipeline/security/acl/AclRefreshService.java
@@ -22,11 +22,9 @@ import org.springframework.security.acls.model.Acl;
 import org.springframework.security.acls.model.AclCache;
 import org.springframework.security.acls.model.MutableAcl;
 import org.springframework.security.acls.model.ObjectIdentity;
-import org.springframework.stereotype.Service;
 
 import java.util.Map;
 
-@Service
 @Slf4j
 @EnableScheduling
 public class AclRefreshService {

--- a/api/src/main/java/com/epam/pipeline/security/acl/AclRefreshService.java
+++ b/api/src/main/java/com/epam/pipeline/security/acl/AclRefreshService.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-2024 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.epam.pipeline.security.acl;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.security.acls.model.Acl;
+import org.springframework.security.acls.model.AclCache;
+import org.springframework.security.acls.model.MutableAcl;
+import org.springframework.security.acls.model.ObjectIdentity;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+@Slf4j
+@EnableScheduling
+public class AclRefreshService {
+
+    private final LookupStrategyImpl lookupStrategy;
+    private final AclCache aclCache;
+
+    public AclRefreshService(final LookupStrategyImpl lookupStrategy,
+                             final AclCache aclCache) {
+        this.lookupStrategy = lookupStrategy;
+        this.aclCache = aclCache;
+    }
+
+    @Scheduled(fixedDelayString = "${security.acl.cache.ttl:60000}")
+    public void refresh() {
+        log.info("Receiving ACLs...");
+        final Map<ObjectIdentity, Acl> acls = lookupStrategy.lookupObjectIdentities();
+        log.info("Received {} ACLs", acls.size());
+        log.info("Persisting ACLs...");
+        acls.forEach((key, value) -> aclCache.putInCache((MutableAcl) value));
+        log.info("Persisted {} ACLs", acls.size());
+    }
+}

--- a/deploy/docker/cp-api-srv/config/application.properties
+++ b/deploy/docker/cp-api-srv/config/application.properties
@@ -189,6 +189,10 @@ log.security.elastic.index.prefix=${CP_SECURITY_LOGS_ELASTIC_PREFIX:security_log
 
 migration.alias.file=${CP_API_MIGRATION_ALIAS_FILE:}
 
+security.acl.cache.type=${CP_API_ACL_CACHE_TYPE:MEMORY}
+security.acl.cache.refresh={CP_API_ACL_CACHE_REFRESH:false}
+security.acl.cache.ttl=${CP_API_ACL_CACHE_TTL:60000}
+
 #Cache
 cache.type=${CP_API_CACHE_TYPE:MEMORY}
 redis.host=${CP_REDIS_INTERNAL_HOST:}


### PR DESCRIPTION
Resolves #3509.

The pull request brings support for ACL cache refreshing.

The following application properties have been added:
- `security.acl.cache.type` / `CP_API_ACL_CACHE_TYPE` specifies ACL entities cache type. Supported values are *MEMORY* and *REDIS*. Defaults to *MEMORY*.
- `security.acl.cache.refresh` / `CP_API_ACL_CACHE_REFRESH` enables ACL entries cache refresh. Disabled by default.
- `security.acl.cache.ttl` / `CP_API_ACL_CACHE_TTL` specifies ACL entries cache ttl. Defaults to *60000 ms (60 s)*.

The following application properties have been updated:
- `cache.type` / `CP_API_CACHE_TYPE` specifies system preferences cache type. Supported values are *MEMORY* and *REDIS*. Defaults to *MEMORY*.