### PR TITLE
Pipe CLI: respect modification date when syncing

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1132,6 +1132,9 @@ def storage_remove_item(path, yes, version, hard_delete, recursive, exclude, inc
 @click.option('-q', '--quiet', is_flag=True, help='Quiet mode')
 @click.option('-s', '--skip-existing', is_flag=True, help='Skip files existing in destination, if they have '
                                                           'size matching source')
+@click.option('--sync-newer', is_flag=True, help='Do not skip files existing in destination, if source file is newer '
+                                                 'than destination and sizes are equal. Can only be applied in '
+                                                 'combination with -s (--skip-existing) option')
 @click.option('-t', '--tags', required=False, multiple=True, help="Set object tags during copy. Tags can be specified "
                                                                   "as single KEY=VALUE pair or a list of them. "
                                                                   "If --tags option specified all existent tags will "
@@ -1183,9 +1186,9 @@ def storage_remove_item(path, yes, version, hard_delete, recursive, exclude, inc
 @click.option('-vd', '--verify-destination', is_flag=True, required=False,
               help=STORAGE_VERIFY_DESTINATION_OPTION_DESCRIPTION)
 @common_options
-def storage_move_item(source, destination, recursive, force, exclude, include, quiet, skip_existing, tags, file_list,
-                      symlinks, threads, io_threads, on_unsafe_chars, on_unsafe_chars_replacement, on_empty_files,
-                      on_failures, verify_destination):
+def storage_move_item(source, destination, recursive, force, exclude, include, quiet, skip_existing, sync_newer,
+                      tags, file_list, symlinks, threads, io_threads, on_unsafe_chars, on_unsafe_chars_replacement,
+                      on_empty_files, on_failures, verify_destination):
     """
     Moves files/directories between data storages or between a local filesystem and a data storage.
 
@@ -1215,7 +1218,8 @@ def storage_move_item(source, destination, recursive, force, exclude, include, q
     DataStorageOperations.cp(source, destination, recursive, force, exclude, include, quiet, tags, file_list,
                              symlinks, threads, io_threads,
                              on_unsafe_chars, on_unsafe_chars_replacement, on_empty_files, on_failures,
-                             clean=True, skip_existing=skip_existing, verify_destination=verify_destination)
+                             clean=True, skip_existing=skip_existing, sync_newer=sync_newer,
+                             verify_destination=verify_destination)
 
 
 @storage.command('cp')
@@ -1278,12 +1282,15 @@ def storage_move_item(source, destination, recursive, force, exclude, include, q
                    '[skip] skips all failures.')
 @click.option('-s', '--skip-existing', is_flag=True, help='Skip files existing in destination, if they have '
                                                           'size matching source')
+@click.option('--sync-newer', is_flag=True, help='Do not skip files existing in destination, if source file is newer '
+                                                 'than destination and sizes are equal. Can only be applied in '
+                                                 'combination with -s (--skip-existing) option')
 @click.option('-vd', '--verify-destination', is_flag=True, required=False,
               help=STORAGE_VERIFY_DESTINATION_OPTION_DESCRIPTION)
 @common_options
 def storage_copy_item(source, destination, recursive, force, exclude, include, quiet, tags, file_list,
                       symlinks, threads, io_threads, on_unsafe_chars, on_unsafe_chars_replacement, on_empty_files,
-                      on_failures, skip_existing, verify_destination):
+                      on_failures, skip_existing, sync_newer, verify_destination):
     """
     Copies files/directories between data storages or between a local filesystem and a data storage.
 
@@ -1325,7 +1332,8 @@ def storage_copy_item(source, destination, recursive, force, exclude, include, q
     DataStorageOperations.cp(source, destination, recursive, force,
                              exclude, include, quiet, tags, file_list, symlinks, threads, io_threads,
                              on_unsafe_chars, on_unsafe_chars_replacement, on_empty_files, on_failures,
-                             clean=False, skip_existing=skip_existing, verify_destination=verify_destination)
+                             clean=False, skip_existing=skip_existing, sync_newer=sync_newer,
+                             verify_destination=verify_destination)
 
 
 @storage.command('du')

--- a/pipe-cli/src/utilities/datastorage_operations.py
+++ b/pipe-cli/src/utilities/datastorage_operations.py
@@ -216,15 +216,18 @@ class DataStorageOperations(object):
                 continue
 
             destination_key = manager.get_destination_key(destination_wrapper, relative_path)
-            destination_size = manager.get_destination_size(destination_wrapper, destination_key)
+            if skip_existing and sync_newer:
+                destination_size, destination_modification_datetime = \
+                    manager.get_destination_object_head(destination_wrapper, destination_key)
+            else:
+                destination_size = manager.get_destination_size(destination_wrapper, destination_key)
+                destination_modification_datetime = None
             destination_is_empty = destination_size is None
             if destination_is_empty:
                 filtered_items.append(item)
                 continue
             if skip_existing:
                 source_key = manager.get_source_key(source_wrapper, full_path)
-                destination_modification_datetime = None if not sync_newer else \
-                    manager.get_destination_modification_datetime(destination_wrapper, destination_key)
                 source_modification_datetime = None if not sync_newer or len(item) < 4 else item[4]
                 need_to_overwrite = not manager.skip_existing(source_key, source_size, source_modification_datetime,
                                                               destination_key, destination_size,

--- a/pipe-cli/src/utilities/datastorage_operations.py
+++ b/pipe-cli/src/utilities/datastorage_operations.py
@@ -228,7 +228,7 @@ class DataStorageOperations(object):
                 source_modification_datetime = None if not sync_newer or len(item) < 4 else item[4]
                 need_to_overwrite = not manager.skip_existing(source_key, source_size, source_modification_datetime,
                                                               destination_key, destination_size,
-                                                              destination_modification_datetime, quiet)
+                                                              destination_modification_datetime, sync_newer, quiet)
                 if need_to_overwrite and not force:
                     cls._force_required()
                 if need_to_overwrite:

--- a/pipe-cli/src/utilities/storage/azure.py
+++ b/pipe-cli/src/utilities/storage/azure.py
@@ -217,8 +217,8 @@ class TransferBetweenAzureBucketsManager(AzureManager, AbstractTransferManager):
     def get_destination_size(self, destination_wrapper, destination_key):
         return destination_wrapper.get_list_manager().get_file_size(destination_key)
 
-    def get_destination_modification_datetime(self, destination_wrapper, destination_key):
-        return destination_wrapper.get_list_manager().get_file_modification_datetime(destination_key)
+    def get_destination_object_head(self, destination_wrapper, destination_key):
+        return destination_wrapper.get_list_manager().get_file_object_head(destination_key)
 
     def get_source_key(self, source_wrapper, source_path):
         return source_path
@@ -280,8 +280,9 @@ class AzureDownloadManager(AzureManager, AbstractTransferManager):
     def get_destination_size(self, destination_wrapper, destination_key):
         return StorageOperations.get_local_file_size(destination_key)
 
-    def get_destination_modification_datetime(self, destination_wrapper, destination_key):
-        return StorageOperations.get_local_file_modification_datetime(destination_key)
+    def get_destination_object_head(self, destination_wrapper, destination_key):
+        return StorageOperations.get_local_file_size(destination_key), \
+            StorageOperations.get_local_file_modification_datetime(destination_key)
 
     def get_source_key(self, source_wrapper, source_path):
         return source_path or source_wrapper.path
@@ -309,8 +310,8 @@ class AzureUploadManager(AzureManager, AbstractTransferManager):
     def get_destination_size(self, destination_wrapper, destination_key):
         return destination_wrapper.get_list_manager().get_file_size(destination_key)
 
-    def get_destination_modification_datetime(self, destination_wrapper, destination_key):
-        return destination_wrapper.get_list_manager().get_file_modification_datetime(destination_key)
+    def get_destination_object_head(self, destination_wrapper, destination_key):
+        return destination_wrapper.get_list_manager().get_file_object_head(destination_key)
 
     def get_source_key(self, source_wrapper, source_path):
         if source_path:
@@ -358,8 +359,8 @@ class TransferFromHttpOrFtpToAzureManager(AzureManager, AbstractTransferManager)
     def get_destination_size(self, destination_wrapper, destination_key):
         return destination_wrapper.get_list_manager().get_file_size(destination_key)
 
-    def get_destination_modification_datetime(self, destination_wrapper, destination_key):
-        return None
+    def get_destination_object_head(self, destination_wrapper, destination_key):
+        return destination_wrapper.get_list_manager().get_file_object_head(destination_key)
 
     def get_source_key(self, source_wrapper, source_path):
         return source_path or source_wrapper.path

--- a/pipe-cli/src/utilities/storage/azure.py
+++ b/pipe-cli/src/utilities/storage/azure.py
@@ -217,6 +217,9 @@ class TransferBetweenAzureBucketsManager(AzureManager, AbstractTransferManager):
     def get_destination_size(self, destination_wrapper, destination_key):
         return destination_wrapper.get_list_manager().get_file_size(destination_key)
 
+    def get_destination_modification_datetime(self, destination_wrapper, destination_key):
+        return destination_wrapper.get_list_manager().get_file_modification_datetime(destination_key)
+
     def get_source_key(self, source_wrapper, source_path):
         return source_path
 
@@ -277,6 +280,9 @@ class AzureDownloadManager(AzureManager, AbstractTransferManager):
     def get_destination_size(self, destination_wrapper, destination_key):
         return StorageOperations.get_local_file_size(destination_key)
 
+    def get_destination_modification_datetime(self, destination_wrapper, destination_key):
+        return StorageOperations.get_local_file_modification_datetime(destination_key)
+
     def get_source_key(self, source_wrapper, source_path):
         return source_path or source_wrapper.path
 
@@ -302,6 +308,9 @@ class AzureUploadManager(AzureManager, AbstractTransferManager):
 
     def get_destination_size(self, destination_wrapper, destination_key):
         return destination_wrapper.get_list_manager().get_file_size(destination_key)
+
+    def get_destination_modification_datetime(self, destination_wrapper, destination_key):
+        return destination_wrapper.get_list_manager().get_file_modification_datetime(destination_key)
 
     def get_source_key(self, source_wrapper, source_path):
         if source_path:
@@ -348,6 +357,9 @@ class TransferFromHttpOrFtpToAzureManager(AzureManager, AbstractTransferManager)
 
     def get_destination_size(self, destination_wrapper, destination_key):
         return destination_wrapper.get_list_manager().get_file_size(destination_key)
+
+    def get_destination_modification_datetime(self, destination_wrapper, destination_key):
+        return None
 
     def get_source_key(self, source_wrapper, source_path):
         return source_path or source_wrapper.path

--- a/pipe-cli/src/utilities/storage/common.py
+++ b/pipe-cli/src/utilities/storage/common.py
@@ -262,12 +262,14 @@ class AbstractTransferManager:
     def get_destination_size(self, destination_wrapper, destination_key):
         pass
 
-    def get_destination_modification_datetime(self, destination_wrapper, destination_key):
+    def get_destination_object_head(self, destination_wrapper, destination_key):
         """
-        Returns destination file last modification datetime in UTC format
+        Returns:
+        - destination file size
+        - destination file last modification datetime in UTC format
 
         """
-        return None
+        return None, None
 
     @abstractmethod
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False,
@@ -394,12 +396,12 @@ class AbstractListingManager:
                 return item.size
         return None
 
-    def get_file_modification_datetime(self, relative_path):
+    def get_file_object_head(self, relative_path):
         items = self.list_items(relative_path, show_all=True, recursive=True)
         for item in items:
             if item.name == relative_path:
-                return StorageOperations.get_item_modification_datetime_utc(item)
-        return None
+                return item.size, StorageOperations.get_item_modification_datetime_utc(item)
+        return None, None
 
 
 class AbstractDeleteManager:

--- a/pipe-cli/src/utilities/storage/common.py
+++ b/pipe-cli/src/utilities/storage/common.py
@@ -294,15 +294,14 @@ class AbstractTransferManager:
 
     @staticmethod
     def skip_existing(source_key, source_size, source_modification_datetime, destination_key, destination_size,
-                      destination_modification_datetime, quiet):
-        if destination_size is not None \
-                and destination_size == source_size \
-                and destination_modification_datetime is not None \
-                and source_modification_datetime is not None \
-                and source_modification_datetime < destination_modification_datetime:
-            if not quiet:
-                click.echo('Skipping file %s since it exists in the destination %s' % (source_key, destination_key))
-            return True
+                      destination_modification_datetime, sync_newer, quiet):
+        if destination_size is not None and destination_size == source_size:
+            if not sync_newer or sync_newer and (destination_modification_datetime is not None
+                                                 and source_modification_datetime is not None
+                                                 and source_modification_datetime < destination_modification_datetime):
+                if not quiet:
+                    click.echo('Skipping file %s since it exists in the destination %s' % (source_key, destination_key))
+                return True
         return False
 
     @staticmethod

--- a/pipe-cli/src/utilities/storage/gs.py
+++ b/pipe-cli/src/utilities/storage/gs.py
@@ -717,6 +717,9 @@ class TransferBetweenGsBucketsManager(GsManager, AbstractTransferManager):
     def get_destination_size(self, destination_wrapper, destination_path):
         return destination_wrapper.get_list_manager().get_file_size(destination_path)
 
+    def get_destination_modification_datetime(self, destination_wrapper, destination_path):
+        return destination_wrapper.get_list_manager().get_file_modification_datetime(destination_path)
+
     def get_source_key(self, source_wrapper, source_path):
         return source_path
 
@@ -781,6 +784,9 @@ class GsDownloadManager(GsManager, AbstractTransferManager):
 
     def get_destination_size(self, destination_wrapper, destination_key):
         return StorageOperations.get_local_file_size(destination_key)
+
+    def get_destination_modification_datetime(self, destination_wrapper, destination_key):
+        return StorageOperations.get_local_file_modification_datetime(destination_key)
 
     def get_source_key(self, source_wrapper, source_path):
         return source_path or source_wrapper.path
@@ -857,6 +863,9 @@ class GsDownloadStreamManager(GsManager, AbstractTransferManager):
     def get_destination_size(self, destination_wrapper, destination_key):
         return 0
 
+    def get_destination_modification_datetime(self, destination_wrapper, destination_key):
+        return None
+
     def get_source_key(self, source_wrapper, source_path):
         return source_path or source_wrapper.path
 
@@ -903,6 +912,9 @@ class GsUploadManager(GsManager, AbstractTransferManager):
 
     def get_destination_size(self, destination_wrapper, destination_key):
         return destination_wrapper.get_list_manager().get_file_size(destination_key)
+
+    def get_destination_modification_datetime(self, destination_wrapper, destination_key):
+        return destination_wrapper.get_list_manager().get_file_modification_datetime(destination_key)
 
     def get_source_key(self, source_wrapper, source_path):
         if source_path:
@@ -988,6 +1000,9 @@ class GSUploadStreamManager(GsManager, AbstractTransferManager):
 
     def get_destination_size(self, destination_wrapper, destination_key):
         return destination_wrapper.get_list_manager().get_file_size(destination_key)
+
+    def get_destination_modification_datetime(self, destination_wrapper, destination_key):
+        return destination_wrapper.get_list_manager().get_file_modification_datetime(destination_key)
 
     def get_source_key(self, source_wrapper, source_path):
         return source_path or source_wrapper.path

--- a/pipe-cli/src/utilities/storage/gs.py
+++ b/pipe-cli/src/utilities/storage/gs.py
@@ -717,8 +717,8 @@ class TransferBetweenGsBucketsManager(GsManager, AbstractTransferManager):
     def get_destination_size(self, destination_wrapper, destination_path):
         return destination_wrapper.get_list_manager().get_file_size(destination_path)
 
-    def get_destination_modification_datetime(self, destination_wrapper, destination_path):
-        return destination_wrapper.get_list_manager().get_file_modification_datetime(destination_path)
+    def get_destination_object_head(self, destination_wrapper, destination_path):
+        return destination_wrapper.get_list_manager().get_file_object_head(destination_path)
 
     def get_source_key(self, source_wrapper, source_path):
         return source_path
@@ -785,8 +785,9 @@ class GsDownloadManager(GsManager, AbstractTransferManager):
     def get_destination_size(self, destination_wrapper, destination_key):
         return StorageOperations.get_local_file_size(destination_key)
 
-    def get_destination_modification_datetime(self, destination_wrapper, destination_key):
-        return StorageOperations.get_local_file_modification_datetime(destination_key)
+    def get_destination_object_head(self, destination_wrapper, destination_key):
+        return StorageOperations.get_local_file_size(destination_key), \
+            StorageOperations.get_local_file_modification_datetime(destination_key)
 
     def get_source_key(self, source_wrapper, source_path):
         return source_path or source_wrapper.path
@@ -863,8 +864,8 @@ class GsDownloadStreamManager(GsManager, AbstractTransferManager):
     def get_destination_size(self, destination_wrapper, destination_key):
         return 0
 
-    def get_destination_modification_datetime(self, destination_wrapper, destination_key):
-        return None
+    def get_destination_object_head(self, destination_wrapper, destination_key):
+        return 0, None
 
     def get_source_key(self, source_wrapper, source_path):
         return source_path or source_wrapper.path
@@ -913,8 +914,8 @@ class GsUploadManager(GsManager, AbstractTransferManager):
     def get_destination_size(self, destination_wrapper, destination_key):
         return destination_wrapper.get_list_manager().get_file_size(destination_key)
 
-    def get_destination_modification_datetime(self, destination_wrapper, destination_key):
-        return destination_wrapper.get_list_manager().get_file_modification_datetime(destination_key)
+    def get_destination_object_head(self, destination_wrapper, destination_key):
+        return destination_wrapper.get_list_manager().get_file_object_head(destination_key)
 
     def get_source_key(self, source_wrapper, source_path):
         if source_path:
@@ -1001,8 +1002,8 @@ class GSUploadStreamManager(GsManager, AbstractTransferManager):
     def get_destination_size(self, destination_wrapper, destination_key):
         return destination_wrapper.get_list_manager().get_file_size(destination_key)
 
-    def get_destination_modification_datetime(self, destination_wrapper, destination_key):
-        return destination_wrapper.get_list_manager().get_file_modification_datetime(destination_key)
+    def get_destination_object_head(self, destination_wrapper, destination_key):
+        return destination_wrapper.get_list_manager().get_file_object_head(destination_key)
 
     def get_source_key(self, source_wrapper, source_path):
         return source_path or source_wrapper.path

--- a/pipe-cli/src/utilities/storage/local.py
+++ b/pipe-cli/src/utilities/storage/local.py
@@ -42,11 +42,14 @@ class TransferFromHttpOrFtpToLocal(AbstractTransferManager):
     def get_destination_size(self, destination_wrapper, destination_key):
         return StorageOperations.get_local_file_size(destination_key)
 
+    def get_destination_modification_datetime(self, destination_wrapper, destination_key):
+        return StorageOperations.get_local_file_modification_datetime(destination_key)
+
     def get_source_key(self, source_wrapper, source_path):
         return source_path or source_wrapper.path
 
-    def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False,
-                 quiet=False, size=None, tags=(), lock=None):
+    def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False, quiet=False,
+                 size=None, tags=(), lock=None, **kwargs):
         """
         Transfers data from remote resource (only ftp(s) or http(s) protocols supported) to local file system.
         :param source_wrapper: wrapper for ftp or http resource

--- a/pipe-cli/src/utilities/storage/local.py
+++ b/pipe-cli/src/utilities/storage/local.py
@@ -42,8 +42,9 @@ class TransferFromHttpOrFtpToLocal(AbstractTransferManager):
     def get_destination_size(self, destination_wrapper, destination_key):
         return StorageOperations.get_local_file_size(destination_key)
 
-    def get_destination_modification_datetime(self, destination_wrapper, destination_key):
-        return StorageOperations.get_local_file_modification_datetime(destination_key)
+    def get_destination_object_head(self, destination_wrapper, destination_key):
+        return StorageOperations.get_local_file_size(destination_key), \
+            StorageOperations.get_local_file_modification_datetime(destination_key)
 
     def get_source_key(self, source_wrapper, source_path):
         return source_path or source_wrapper.path

--- a/pipe-cli/src/utilities/storage/s3.py
+++ b/pipe-cli/src/utilities/storage/s3.py
@@ -245,7 +245,7 @@ class DownloadStreamManager(StorageItemManager, AbstractTransferManager):
         return 0
 
     def get_destination_object_head(self, destination_wrapper, destination_key):
-        return None, 0
+        return 0, None
 
     def transfer(self, source_wrapper, destination_wrapper, path=None,
                  relative_path=None, clean=False, quiet=False, size=None, tags=None, io_threads=None, lock=None):


### PR DESCRIPTION
The current PR provides implementation for issue #3511 

A new option `--sync-newer` added to `pipe storage cp/mv` command. 

This option shall be applied for object storages only. 