### PR TITLE
Pipe CLI: respect modification date when syncing - fix for local files and folders

### DIFF
--- a/pipe-cli/src/model/data_storage_wrapper.py
+++ b/pipe-cli/src/model/data_storage_wrapper.py
@@ -523,8 +523,7 @@ class LocalFileSystemWrapper(DataStorageWrapper):
         if os.path.isfile(self.path):
             if os.path.islink(self.path) and self.symlinks == AllowedSymlinkValues.SKIP:
                 return []
-            return [(FILE, self.path, self._leaf_path(self.path), os.path.getsize(self.path),
-                     StorageOperations.get_local_file_modification_datetime(self.path))]
+            return [(FILE, self.path, self._leaf_path(self.path), os.path.getsize(self.path), None)]
 
         return self._list_items(self.path, self._leaf_path(self.path), result=[], visited_symlinks=set(),
                                 root=True, quiet=quiet)
@@ -603,7 +602,7 @@ class LocalFileSystemWrapper(DataStorageWrapper):
 
         if os.path.isfile(to_string(absolute_path)):
             logging.debug(u'Collected file {}.'.format(safe_absolute_path))
-            result.append((FILE, absolute_path, relative_path, os.path.getsize(to_string(absolute_path))))
+            result.append((FILE, absolute_path, relative_path, os.path.getsize(to_string(absolute_path)), None))
         elif os.path.isdir(to_string(absolute_path)):
             self._list_items(absolute_path, relative_path, result, visited_symlinks, root=False, quiet=quiet)
 

--- a/pipe-cli/src/utilities/datastorage_operations.py
+++ b/pipe-cli/src/utilities/datastorage_operations.py
@@ -34,7 +34,7 @@ from src.utilities.datastorage_du_operation import DataUsageHelper, DataUsageCom
 from src.utilities.encoding_utilities import to_string, is_safe_chars, to_ascii
 from src.utilities.hidden_object_manager import HiddenObjectManager
 from src.utilities.patterns import PatternMatcher
-from src.utilities.storage.common import TransferResult
+from src.utilities.storage.common import TransferResult, StorageOperations
 from src.utilities.storage.mount import Mount
 from src.utilities.storage.umount import Umount
 from src.utilities.user_operations_manager import UserOperationsManager
@@ -228,7 +228,9 @@ class DataStorageOperations(object):
                 continue
             if skip_existing:
                 source_key = manager.get_source_key(source_wrapper, full_path)
-                source_modification_datetime = None if not sync_newer or len(item) < 4 else item[4]
+                source_modification_datetime = item[4] if sync_newer and len(item) >= 5 else None
+                if sync_newer and source_modification_datetime is None and source_wrapper.is_local():
+                    source_modification_datetime = StorageOperations.get_local_file_modification_datetime(source_key)
                 need_to_overwrite = not manager.skip_existing(source_key, source_size, source_modification_datetime,
                                                               destination_key, destination_size,
                                                               destination_modification_datetime, sync_newer, quiet)

--- a/pipe-cli/src/utilities/storage/common.py
+++ b/pipe-cli/src/utilities/storage/common.py
@@ -363,6 +363,8 @@ class AbstractListingManager:
         """
         Returns all files under the given relative path in forms of tuples with the following structure:
         ('File', full_path, relative_path, size, modification_date)
+        where <modification_date> - a file last modification datetime in UTC format or None if not applicable
+        NOTE: shall be calculated for cloud sources only
 
         :param relative_path: Path to a folder or a file.
         :return: Generator of file tuples.


### PR DESCRIPTION
This PR provides fixes for issue #3511

- Fix for local folder source
- Do not pre-calculate last modification date for local files: this make sense for cloud sources since head object request has already been received but for local files this leads to overhead in cases where the option --sync-newer is disabled which is most often the case.