### PR TITLE
Pipe CLI: enable checksum calculation for S3

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1185,10 +1185,13 @@ def storage_remove_item(path, yes, version, hard_delete, recursive, exclude, inc
                    '[skip] skips empty files transferring.')
 @click.option('-vd', '--verify-destination', is_flag=True, required=False,
               help=STORAGE_VERIFY_DESTINATION_OPTION_DESCRIPTION)
+@click.option('--checksum-algorithm', required=False, type=click.Choice(['crc32', 'sha256']),
+              help='Indicates algorithm used to create the checksum for the objects. '
+                   'Allowed values: crc32, sha256')
 @common_options
 def storage_move_item(source, destination, recursive, force, exclude, include, quiet, skip_existing, sync_newer,
                       tags, file_list, symlinks, threads, io_threads, on_unsafe_chars, on_unsafe_chars_replacement,
-                      on_empty_files, on_failures, verify_destination):
+                      on_empty_files, on_failures, verify_destination, checksum_algorithm):
     """
     Moves files/directories between data storages or between a local filesystem and a data storage.
 
@@ -1219,7 +1222,7 @@ def storage_move_item(source, destination, recursive, force, exclude, include, q
                              symlinks, threads, io_threads,
                              on_unsafe_chars, on_unsafe_chars_replacement, on_empty_files, on_failures,
                              clean=True, skip_existing=skip_existing, sync_newer=sync_newer,
-                             verify_destination=verify_destination)
+                             verify_destination=verify_destination, checksum_algorithm=checksum_algorithm)
 
 
 @storage.command('cp')
@@ -1287,10 +1290,13 @@ def storage_move_item(source, destination, recursive, force, exclude, include, q
                                                  'combination with -s (--skip-existing) option')
 @click.option('-vd', '--verify-destination', is_flag=True, required=False,
               help=STORAGE_VERIFY_DESTINATION_OPTION_DESCRIPTION)
+@click.option('--checksum-algorithm', required=False, type=click.Choice(['crc32', 'sha256']),
+              help='Indicates algorithm used to create the checksum for the objects. '
+                   'Allowed values: crc32, sha256')
 @common_options
 def storage_copy_item(source, destination, recursive, force, exclude, include, quiet, tags, file_list,
                       symlinks, threads, io_threads, on_unsafe_chars, on_unsafe_chars_replacement, on_empty_files,
-                      on_failures, skip_existing, sync_newer, verify_destination):
+                      on_failures, skip_existing, sync_newer, verify_destination, checksum_algorithm):
     """
     Copies files/directories between data storages or between a local filesystem and a data storage.
 
@@ -1333,7 +1339,7 @@ def storage_copy_item(source, destination, recursive, force, exclude, include, q
                              exclude, include, quiet, tags, file_list, symlinks, threads, io_threads,
                              on_unsafe_chars, on_unsafe_chars_replacement, on_empty_files, on_failures,
                              clean=False, skip_existing=skip_existing, sync_newer=sync_newer,
-                             verify_destination=verify_destination)
+                             verify_destination=verify_destination, checksum_algorithm=checksum_algorithm)
 
 
 @storage.command('du')

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -1185,13 +1185,14 @@ def storage_remove_item(path, yes, version, hard_delete, recursive, exclude, inc
                    '[skip] skips empty files transferring.')
 @click.option('-vd', '--verify-destination', is_flag=True, required=False,
               help=STORAGE_VERIFY_DESTINATION_OPTION_DESCRIPTION)
-@click.option('--checksum-algorithm', required=False, type=click.Choice(['crc32', 'sha256']),
+@click.option('--checksum-algorithm', required=False, default='md5', type=click.Choice(['crc32', 'sha256', 'md5']),
               help='Indicates algorithm used to create the checksum for the objects. '
-                   'Allowed values: crc32, sha256')
+                   'Allowed values: md5, crc32, sha256. Default: md5.')
+@click.option('--checksum-skip', is_flag=True, required=False, help='Disables objects integrity checks.')
 @common_options
 def storage_move_item(source, destination, recursive, force, exclude, include, quiet, skip_existing, sync_newer,
                       tags, file_list, symlinks, threads, io_threads, on_unsafe_chars, on_unsafe_chars_replacement,
-                      on_empty_files, on_failures, verify_destination, checksum_algorithm):
+                      on_empty_files, on_failures, verify_destination, checksum_algorithm, checksum_skip):
     """
     Moves files/directories between data storages or between a local filesystem and a data storage.
 
@@ -1222,7 +1223,8 @@ def storage_move_item(source, destination, recursive, force, exclude, include, q
                              symlinks, threads, io_threads,
                              on_unsafe_chars, on_unsafe_chars_replacement, on_empty_files, on_failures,
                              clean=True, skip_existing=skip_existing, sync_newer=sync_newer,
-                             verify_destination=verify_destination, checksum_algorithm=checksum_algorithm)
+                             verify_destination=verify_destination, checksum_algorithm=checksum_algorithm,
+                             checksum_skip=checksum_skip)
 
 
 @storage.command('cp')
@@ -1290,13 +1292,14 @@ def storage_move_item(source, destination, recursive, force, exclude, include, q
                                                  'combination with -s (--skip-existing) option')
 @click.option('-vd', '--verify-destination', is_flag=True, required=False,
               help=STORAGE_VERIFY_DESTINATION_OPTION_DESCRIPTION)
-@click.option('--checksum-algorithm', required=False, type=click.Choice(['crc32', 'sha256']),
+@click.option('--checksum-algorithm', required=False, default='md5', type=click.Choice(['crc32', 'sha256', 'md5']),
               help='Indicates algorithm used to create the checksum for the objects. '
-                   'Allowed values: crc32, sha256')
+                   'Allowed values: md5, crc32, sha256. Default: md5.')
+@click.option('--checksum-skip', is_flag=True, required=False, help='Disables objects integrity checks.')
 @common_options
 def storage_copy_item(source, destination, recursive, force, exclude, include, quiet, tags, file_list,
                       symlinks, threads, io_threads, on_unsafe_chars, on_unsafe_chars_replacement, on_empty_files,
-                      on_failures, skip_existing, sync_newer, verify_destination, checksum_algorithm):
+                      on_failures, skip_existing, sync_newer, verify_destination, checksum_algorithm, checksum_skip):
     """
     Copies files/directories between data storages or between a local filesystem and a data storage.
 
@@ -1339,7 +1342,8 @@ def storage_copy_item(source, destination, recursive, force, exclude, include, q
                              exclude, include, quiet, tags, file_list, symlinks, threads, io_threads,
                              on_unsafe_chars, on_unsafe_chars_replacement, on_empty_files, on_failures,
                              clean=False, skip_existing=skip_existing, sync_newer=sync_newer,
-                             verify_destination=verify_destination, checksum_algorithm=checksum_algorithm)
+                             verify_destination=verify_destination, checksum_algorithm=checksum_algorithm,
+                             checksum_skip=checksum_skip)
 
 
 @storage.command('du')

--- a/pipe-cli/src/utilities/datastorage_operations.py
+++ b/pipe-cli/src/utilities/datastorage_operations.py
@@ -63,11 +63,14 @@ class EmptyFilesValues(object):
     SKIP = 'skip'
 
 
+ALLOWED_CHECKSUM_ALGORITHMS = ['sha256', 'crc32']
+
+
 class DataStorageOperations(object):
     @classmethod
     def cp(cls, source, destination, recursive, force, exclude, include, quiet, tags, file_list, symlinks, threads,
            io_threads, on_unsafe_chars, on_unsafe_chars_replacement, on_empty_files, on_failures,
-           clean=False, skip_existing=False, sync_newer=False, verify_destination=False):
+           clean=False, skip_existing=False, sync_newer=False, verify_destination=False, checksum_algorithm=None):
         source_wrapper = DataStorageWrapper.get_wrapper(source, symlinks)
         destination_wrapper = DataStorageWrapper.get_wrapper(destination)
         files_to_copy = []
@@ -128,6 +131,13 @@ class DataStorageOperations(object):
                        '--verify-destination (-vd) flag to enable existence check for each destination path.',
                        err=True)
             sys.exit(1)
+        if checksum_algorithm and source_type not in [WrapperType.LOCAL]:
+            click.echo('Option --checksum-algorithm is not supported for {} sources.'.format(source_type), err=True)
+            sys.exit(1)
+        if checksum_algorithm and destination_type not in [WrapperType.S3]:
+            click.echo('Option --checksum-algorithm is not supported for {} destinations.'
+                       .format(source_type), err=True)
+            sys.exit(1)
 
         # append slashes to path to correctly determine file/folder type
         if not source_wrapper.is_file():
@@ -158,7 +168,8 @@ class DataStorageOperations(object):
                                              audit_ctx, clean, quiet, tags, io_threads, on_failures)
         else:
             cls._transfer_items(items, manager, source_wrapper, destination_wrapper,
-                                audit_ctx, clean, quiet, tags, io_threads, on_failures)
+                                audit_ctx, clean, quiet, tags, io_threads, on_failures,
+                                checksum_algorithm=checksum_algorithm)
 
     @classmethod
     def _filter_items(cls, items, manager, source_wrapper, destination_wrapper, permission_to_check,
@@ -646,7 +657,7 @@ class DataStorageOperations(object):
 
     @classmethod
     def _transfer_items(cls, items, manager, source_wrapper, destination_wrapper,
-                        audit_ctx, clean, quiet, tags, io_threads, on_failures, lock=None):
+                        audit_ctx, clean, quiet, tags, io_threads, on_failures, lock=None, checksum_algorithm=None):
         with audit_ctx:
             transfer_results = []
             fail_after_exception = None
@@ -655,7 +666,7 @@ class DataStorageOperations(object):
                                                                             source_wrapper, destination_wrapper,
                                                                             transfer_results,
                                                                             clean, quiet, tags, io_threads,
-                                                                            on_failures, lock)
+                                                                            on_failures, lock, checksum_algorithm)
             if not destination_wrapper.is_local():
                 cls._flush_transfer_results(source_wrapper, destination_wrapper,
                                             transfer_results, clean=clean, flush_size=1)
@@ -664,7 +675,7 @@ class DataStorageOperations(object):
 
     @classmethod
     def _transfer_item(cls, item, manager, source_wrapper, destination_wrapper, transfer_results,
-                       clean, quiet, tags, io_threads, on_failures, lock):
+                       clean, quiet, tags, io_threads, on_failures, lock, checksum_algorithm=None):
         full_path = item[1]
         relative_path = item[2]
         size = item[3]
@@ -672,7 +683,8 @@ class DataStorageOperations(object):
         try:
             transfer_result = manager.transfer(source_wrapper, destination_wrapper, path=full_path,
                                                relative_path=relative_path, clean=clean, quiet=quiet, size=size,
-                                               tags=tags, io_threads=io_threads, lock=lock)
+                                               tags=tags, io_threads=io_threads, lock=lock,
+                                               checksum_algorithm=checksum_algorithm)
             if not destination_wrapper.is_local() and transfer_result:
                 transfer_results.append(transfer_result)
                 transfer_results = cls._flush_transfer_results(source_wrapper, destination_wrapper,

--- a/pipe-cli/src/utilities/datastorage_operations.py
+++ b/pipe-cli/src/utilities/datastorage_operations.py
@@ -129,11 +129,19 @@ class DataStorageOperations(object):
                        '--verify-destination (-vd) flag to enable existence check for each destination path.',
                        err=True)
             sys.exit(1)
-        if checksum_algorithm and source_type not in [WrapperType.LOCAL]:
-            click.echo('Option --checksum-algorithm is not supported for {} sources.'.format(source_type), err=True)
+        if not checksum_algorithm == 'md5' and source_type not in [WrapperType.LOCAL]:
+            click.echo('Checksum algorithm {} is not supported for {} sources.'
+                       .format(checksum_algorithm, source_type), err=True)
             sys.exit(1)
-        if checksum_algorithm and destination_type not in [WrapperType.S3]:
-            click.echo('Option --checksum-algorithm is not supported for {} destinations.'
+        if not checksum_algorithm == 'md5' and destination_type not in [WrapperType.S3]:
+            click.echo('Checksum algorithm {} is not supported for {} destinations.'
+                       .format(checksum_algorithm, source_type), err=True)
+            sys.exit(1)
+        if checksum_skip and source_type not in [WrapperType.LOCAL]:
+            click.echo('Option --checksum-skip is not supported for {} sources.'.format(source_type), err=True)
+            sys.exit(1)
+        if checksum_skip and destination_type not in [WrapperType.S3]:
+            click.echo('Option --checksum-skip is not supported for {} destinations.'
                        .format(source_type), err=True)
             sys.exit(1)
 

--- a/pipe-cli/src/utilities/storage/azure.py
+++ b/pipe-cli/src/utilities/storage/azure.py
@@ -224,7 +224,7 @@ class TransferBetweenAzureBucketsManager(AzureManager, AbstractTransferManager):
         return source_path
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False, quiet=False,
-                 size=None, tags=(), io_threads=None, lock=None, checksum_algorithm=None):
+                 size=None, tags=(), io_threads=None, lock=None, checksum_algorithm='md5', checksum_skip=False):
         full_path = path
         destination_path = self.get_destination_key(destination_wrapper, relative_path)
 
@@ -288,7 +288,7 @@ class AzureDownloadManager(AzureManager, AbstractTransferManager):
         return source_path or source_wrapper.path
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False, quiet=False,
-                 size=None, tags=None, io_threads=None, lock=None, checksum_algorithm=None):
+                 size=None, tags=None, io_threads=None, lock=None, checksum_algorithm='md5', checksum_skip=False):
         source_key = self.get_source_key(source_wrapper, path)
         destination_key = self.get_destination_key(destination_wrapper, relative_path)
 
@@ -320,7 +320,7 @@ class AzureUploadManager(AzureManager, AbstractTransferManager):
             return source_wrapper.path
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False, quiet=False,
-                 size=None, tags=(), io_threads=None, lock=None, checksum_algorithm=None):
+                 size=None, tags=(), io_threads=None, lock=None, checksum_algorithm='md5', checksum_skip=False):
         source_key = self.get_source_key(source_wrapper, path)
         destination_key = self.get_destination_key(destination_wrapper, relative_path)
 
@@ -366,7 +366,7 @@ class TransferFromHttpOrFtpToAzureManager(AzureManager, AbstractTransferManager)
         return source_path or source_wrapper.path
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False, quiet=False,
-                 size=None, tags=(), io_threads=None, lock=None, checksum_algorithm=None):
+                 size=None, tags=(), io_threads=None, lock=None, checksum_algorithm='md5', checksum_skip=False):
         if clean:
             raise AttributeError('Cannot perform \'mv\' operation due to deletion remote files '
                                  'is not supported for ftp/http sources.')

--- a/pipe-cli/src/utilities/storage/azure.py
+++ b/pipe-cli/src/utilities/storage/azure.py
@@ -223,8 +223,8 @@ class TransferBetweenAzureBucketsManager(AzureManager, AbstractTransferManager):
     def get_source_key(self, source_wrapper, source_path):
         return source_path
 
-    def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False,
-                 quiet=False, size=None, tags=(), io_threads=None, lock=None):
+    def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False, quiet=False,
+                 size=None, tags=(), io_threads=None, lock=None, checksum_algorithm=None):
         full_path = path
         destination_path = self.get_destination_key(destination_wrapper, relative_path)
 
@@ -287,8 +287,8 @@ class AzureDownloadManager(AzureManager, AbstractTransferManager):
     def get_source_key(self, source_wrapper, source_path):
         return source_path or source_wrapper.path
 
-    def transfer(self, source_wrapper, destination_wrapper, path=None,
-                 relative_path=None, clean=False, quiet=False, size=None, tags=None, io_threads=None, lock=None):
+    def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False, quiet=False,
+                 size=None, tags=None, io_threads=None, lock=None, checksum_algorithm=None):
         source_key = self.get_source_key(source_wrapper, path)
         destination_key = self.get_destination_key(destination_wrapper, relative_path)
 
@@ -320,7 +320,7 @@ class AzureUploadManager(AzureManager, AbstractTransferManager):
             return source_wrapper.path
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False, quiet=False,
-                 size=None, tags=(), io_threads=None, lock=None):
+                 size=None, tags=(), io_threads=None, lock=None, checksum_algorithm=None):
         source_key = self.get_source_key(source_wrapper, path)
         destination_key = self.get_destination_key(destination_wrapper, relative_path)
 
@@ -366,7 +366,7 @@ class TransferFromHttpOrFtpToAzureManager(AzureManager, AbstractTransferManager)
         return source_path or source_wrapper.path
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False, quiet=False,
-                 size=None, tags=(), io_threads=None, lock=None):
+                 size=None, tags=(), io_threads=None, lock=None, checksum_algorithm=None):
         if clean:
             raise AttributeError('Cannot perform \'mv\' operation due to deletion remote files '
                                  'is not supported for ftp/http sources.')

--- a/pipe-cli/src/utilities/storage/common.py
+++ b/pipe-cli/src/utilities/storage/common.py
@@ -273,7 +273,8 @@ class AbstractTransferManager:
 
     @abstractmethod
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False,
-                 quiet=False, size=None, tags=(), io_threads=None, lock=None, checksum_algorithm=None):
+                 quiet=False, size=None, tags=(), io_threads=None, lock=None, checksum_algorithm='md5',
+                 checksum_skip=False):
         """
         Transfers data from the source storage to the destination storage.
 
@@ -292,6 +293,7 @@ class AbstractTransferManager:
         :param lock: The lock object if multithreaded transfer is requested
         :type lock: multiprocessing.Lock
         :param checksum_algorithm: The name of the algorithm to create checksums for objects
+        :param checksum_skip: Enables ability to skip objects integrity checks
         """
         pass
 

--- a/pipe-cli/src/utilities/storage/common.py
+++ b/pipe-cli/src/utilities/storage/common.py
@@ -273,7 +273,7 @@ class AbstractTransferManager:
 
     @abstractmethod
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False,
-                 quiet=False, size=None, tags=(), io_threads=None, lock=None):
+                 quiet=False, size=None, tags=(), io_threads=None, lock=None, checksum_algorithm=None):
         """
         Transfers data from the source storage to the destination storage.
 
@@ -291,6 +291,7 @@ class AbstractTransferManager:
         :param io_threads: Number of threads to be used for a single file io operations.
         :param lock: The lock object if multithreaded transfer is requested
         :type lock: multiprocessing.Lock
+        :param checksum_algorithm: The name of the algorithm to create checksums for objects
         """
         pass
 

--- a/pipe-cli/src/utilities/storage/gs.py
+++ b/pipe-cli/src/utilities/storage/gs.py
@@ -724,7 +724,7 @@ class TransferBetweenGsBucketsManager(GsManager, AbstractTransferManager):
         return source_path
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False, quiet=False,
-                 size=None, tags=(), io_threads=None, lock=None):
+                 size=None, tags=(), io_threads=None, lock=None, checksum_algorithm=None):
         full_path = path
         destination_path = self.get_destination_key(destination_wrapper, relative_path)
         source_client = GsBucketOperations.get_client(source_wrapper.bucket, read=True, write=clean)
@@ -793,7 +793,7 @@ class GsDownloadManager(GsManager, AbstractTransferManager):
         return source_path or source_wrapper.path
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False, quiet=False,
-                 size=None, tags=(), io_threads=None, lock=None):
+                 size=None, tags=(), io_threads=None, lock=None, checksum_algorithm=None):
         source_key = self.get_source_key(source_wrapper, path)
         destination_key = self.get_destination_key(destination_wrapper, relative_path)
 
@@ -871,7 +871,7 @@ class GsDownloadStreamManager(GsManager, AbstractTransferManager):
         return source_path or source_wrapper.path
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False, quiet=False,
-                 size=None, tags=(), io_threads=None, lock=None):
+                 size=None, tags=(), io_threads=None, lock=None, checksum_algorithm=None):
         source_key = self.get_source_key(source_wrapper, path)
         destination_key = self.get_destination_key(destination_wrapper, relative_path)
 
@@ -924,7 +924,7 @@ class GsUploadManager(GsManager, AbstractTransferManager):
             return source_wrapper.path
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False, quiet=False,
-                 size=None, tags=(), io_threads=None, lock=None):
+                 size=None, tags=(), io_threads=None, lock=None, checksum_algorithm=None):
         source_key = self.get_source_key(source_wrapper, path)
         destination_key = self.get_destination_key(destination_wrapper, relative_path)
 
@@ -1009,7 +1009,7 @@ class GSUploadStreamManager(GsManager, AbstractTransferManager):
         return source_path or source_wrapper.path
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False, quiet=False,
-                 size=None, tags=(), io_threads=None, lock=None):
+                 size=None, tags=(), io_threads=None, lock=None, checksum_algorithm=None):
         source_key = self.get_source_key(source_wrapper, path)
         destination_key = self.get_destination_key(destination_wrapper, relative_path)
 

--- a/pipe-cli/src/utilities/storage/gs.py
+++ b/pipe-cli/src/utilities/storage/gs.py
@@ -724,7 +724,7 @@ class TransferBetweenGsBucketsManager(GsManager, AbstractTransferManager):
         return source_path
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False, quiet=False,
-                 size=None, tags=(), io_threads=None, lock=None, checksum_algorithm=None):
+                 size=None, tags=(), io_threads=None, lock=None, checksum_algorithm='md5', checksum_skip=False):
         full_path = path
         destination_path = self.get_destination_key(destination_wrapper, relative_path)
         source_client = GsBucketOperations.get_client(source_wrapper.bucket, read=True, write=clean)
@@ -793,7 +793,7 @@ class GsDownloadManager(GsManager, AbstractTransferManager):
         return source_path or source_wrapper.path
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False, quiet=False,
-                 size=None, tags=(), io_threads=None, lock=None, checksum_algorithm=None):
+                 size=None, tags=(), io_threads=None, lock=None, checksum_algorithm='md5', checksum_skip=False):
         source_key = self.get_source_key(source_wrapper, path)
         destination_key = self.get_destination_key(destination_wrapper, relative_path)
 
@@ -871,7 +871,7 @@ class GsDownloadStreamManager(GsManager, AbstractTransferManager):
         return source_path or source_wrapper.path
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False, quiet=False,
-                 size=None, tags=(), io_threads=None, lock=None, checksum_algorithm=None):
+                 size=None, tags=(), io_threads=None, lock=None, checksum_algorithm='md5', checksum_skip=False):
         source_key = self.get_source_key(source_wrapper, path)
         destination_key = self.get_destination_key(destination_wrapper, relative_path)
 
@@ -924,7 +924,7 @@ class GsUploadManager(GsManager, AbstractTransferManager):
             return source_wrapper.path
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False, quiet=False,
-                 size=None, tags=(), io_threads=None, lock=None, checksum_algorithm=None):
+                 size=None, tags=(), io_threads=None, lock=None, checksum_algorithm='md5', checksum_skip=False):
         source_key = self.get_source_key(source_wrapper, path)
         destination_key = self.get_destination_key(destination_wrapper, relative_path)
 
@@ -1009,7 +1009,7 @@ class GSUploadStreamManager(GsManager, AbstractTransferManager):
         return source_path or source_wrapper.path
 
     def transfer(self, source_wrapper, destination_wrapper, path=None, relative_path=None, clean=False, quiet=False,
-                 size=None, tags=(), io_threads=None, lock=None, checksum_algorithm=None):
+                 size=None, tags=(), io_threads=None, lock=None, checksum_algorithm='md5', checksum_skip=False):
         source_key = self.get_source_key(source_wrapper, path)
         destination_key = self.get_destination_key(destination_wrapper, relative_path)
 

--- a/pipe-cli/src/utilities/storage/s3_checksum.py
+++ b/pipe-cli/src/utilities/storage/s3_checksum.py
@@ -103,8 +103,8 @@ class ChecksumProcessor:
         decoded_parts = None
         root = ET.fromstring(mpu_parts_xml_string)
         for part in root.findall('{http://s3.amazonaws.com/doc/2006-03-01/}Part'):
-            checksum_crc32 = part.find('{http://s3.amazonaws.com/doc/2006-03-01/}%s' % field).text
-            decoded_checksum = base64.b64decode(checksum_crc32)
+            checksum_value = part.find('{http://s3.amazonaws.com/doc/2006-03-01/}%s' % field).text
+            decoded_checksum = base64.b64decode(checksum_value)
             if decoded_parts:
                 decoded_parts = decoded_parts + decoded_checksum
             else:

--- a/pipe-cli/src/utilities/storage/s3_checksum.py
+++ b/pipe-cli/src/utilities/storage/s3_checksum.py
@@ -1,0 +1,132 @@
+# Copyright 2017-2024 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+import zlib
+import struct
+import hashlib
+from abc import ABCMeta, abstractmethod
+from botocore.model import StringShape
+import xml.etree.ElementTree as ET
+
+
+class ChecksumProcessor:
+
+    def __init__(self):
+        self.algorithm = None
+        self.enabled = False
+        self.calculator = None
+        self.checksum_header = None
+        self.boto_field = None
+
+    def init(self, algorithm):
+        self.algorithm = algorithm.lower()
+        self.enabled = True
+        self.checksum_header = 'x-amz-checksum-%s' % self.algorithm
+        self.boto_field = 'Checksum%s' % algorithm.upper()
+        if self.algorithm == 'crc32':
+            self.calculator = CRC32ChecksumCalculator()
+        elif self.algorithm == 'sha256':
+            self.calculator = SHA256ChecksumCalculator()
+        else:
+            raise NotImplementedError("Checksum algorithm '%s' is not supported yet" % algorithm)
+
+    def add_checksum_algorithm_header(self, request):
+        request.headers.add_header('x-amz-checksum-algorithm', self.algorithm)
+
+    def remove_checksum_algorithm_header(self, request):
+        self.remove_header(request, 'x-amz-checksum-algorithm')
+
+    def add_checksum_header(self, request, checksum_value):
+        request.headers.add_header(self.checksum_header, checksum_value)
+
+    def remove_checksum_header(self, request):
+        self.remove_header(request, self.checksum_header)
+
+    def calculate_checksum(self, chunk):
+        return self.calculator.calculate_checksum(chunk.read())
+
+    def calculate_checksum_of_checksums(self, mpu_parts):
+        decoded_parts = self.decode_mpu_parts(mpu_parts, self.boto_field)
+        return self.calculator.calculate_checksum(decoded_parts)
+
+    def add_checksum_shape_to_model(self, client):
+        checksum_field = self.boto_field
+        client.meta.service_model.operation_model('CompleteMultipartUpload') \
+            .input_shape.members['MultipartUpload'].members['Parts'].member.members[checksum_field] =\
+            StringShape(checksum_field, {
+                'type': 'string',
+                'documentation': '',
+                'location': 'uri',
+                'locationName': checksum_field
+            })
+
+    @staticmethod
+    def decode_mpu_parts(mpu_parts_xml_string, field):
+        decoded_parts = None
+        root = ET.fromstring(mpu_parts_xml_string)
+        for part in root.findall('{http://s3.amazonaws.com/doc/2006-03-01/}Part'):
+            checksum_crc32 = part.find('{http://s3.amazonaws.com/doc/2006-03-01/}%s' % field).text
+            decoded_checksum = base64.b64decode(checksum_crc32)
+            if decoded_parts:
+                decoded_parts = decoded_parts + decoded_checksum
+            else:
+                decoded_parts = decoded_checksum
+        return decoded_parts
+
+    @staticmethod
+    def remove_header(request, header):
+        all_headers = request.headers._headers
+        new_headers = []
+        for header_name, header_value in all_headers:
+            if not header_name.lower() == header:
+                new_headers.append((header_name, header_value))
+        request.headers._headers = new_headers
+
+
+class ChecksumCalculator:
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def calculate_checksum(self, chunk):
+        pass
+
+
+class CRC32ChecksumCalculator(ChecksumCalculator):
+
+    def __init__(self):
+        pass
+
+    def calculate_checksum(self, chunk):
+        crc_raw = zlib.crc32(chunk)
+        crc_bytes = struct.pack('>i', crc_raw)
+        return base64.b64encode(crc_bytes).decode('utf-8')
+
+
+class SHA256ChecksumCalculator(ChecksumCalculator):
+
+    def __init__(self):
+        pass
+
+    def calculate_checksum(self, data):
+        sha256_hex = hashlib.sha256(data).hexdigest()
+        sha256_int = int(sha256_hex, 16)
+
+        sha256_bytes = bytearray()
+        while sha256_int:
+            sha256_bytes.append(sha256_int & 0xFF)
+            sha256_int >>= 8
+        sha256_bytes.reverse()
+
+        return base64.b64encode(sha256_bytes).decode('utf-8')


### PR DESCRIPTION
This PR provides initial implementation for issue #3512 

- supported for local sources and s3 provider destinations only

To enable additional checksum calculation a new option `--checksum-algorithm`  has been introduced. 

Supported algorithms: `sha256`, `crc32` and `md5` (default)

Also, a new option `--checksum-skip` has been implemented. This flag allows to disable data integrity validations. 