### PR TITLE
Improve node readiness timeouts for resume run operation 

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesManager.java
@@ -97,6 +97,7 @@ public class KubernetesManager {
     private static final String EMPTY = "";
     private static final int MILLIS_TO_SECONDS = 1000;
     private static final int CONNECTION_TIMEOUT_MS = 2 * MILLIS_TO_SECONDS;
+    private static final int NODE_READY_POLLING_DELAY = 5000;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KubernetesManager.class);
     private static final int NODE_PULL_TIMEOUT = 200;
@@ -702,14 +703,12 @@ public class KubernetesManager {
     public void waitForNodeReady(String nodeName, String runId, String cloudRegion) throws InterruptedException {
         KubernetesClient client = getKubernetesClient();
         final int nodeReadyTimeout = preferenceManager.getPreference(SystemPreferences.CLUSTER_NODE_READY_TIMEOUT);
-        final int nodeReadyPollingTimeout = preferenceManager.getPreference(
-                SystemPreferences.CLUSTER_NODE_READY_POLLING_TIMEOUT);
-        final int attemptsStatusNode = nodeReadyTimeout / nodeReadyPollingTimeout;
+        final int attemptsStatusNode = nodeReadyTimeout / NODE_READY_POLLING_DELAY;
         int attempts = attemptsStatusNode;
         while (!isReadyNode(nodeName, client)) {
             LOGGER.debug("Waiting for node {} is ready.", nodeName);
             attempts -= 1;
-            Thread.sleep(nodeReadyPollingTimeout);
+            Thread.sleep(NODE_READY_POLLING_DELAY);
             if (attempts <= 0) {
                 throw new IllegalStateException(String.format(
                         "Node %s doesn't match the ready status over than %d times.", nodeName, attemptsStatusNode));

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesManager.java
@@ -95,10 +95,8 @@ public class KubernetesManager {
     private static final String DUMMY_EMAIL = "test@email.com";
     private static final String DOCKER_PREFIX = "docker://";
     private static final String EMPTY = "";
-    private static final int NODE_READY_TIMEOUT = 5000;
     private static final int MILLIS_TO_SECONDS = 1000;
     private static final int CONNECTION_TIMEOUT_MS = 2 * MILLIS_TO_SECONDS;
-    private static final int ATTEMPTS_STATUS_NODE = 60;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KubernetesManager.class);
     private static final int NODE_PULL_TIMEOUT = 200;
@@ -703,14 +701,18 @@ public class KubernetesManager {
 
     public void waitForNodeReady(String nodeName, String runId, String cloudRegion) throws InterruptedException {
         KubernetesClient client = getKubernetesClient();
-        int attempts = ATTEMPTS_STATUS_NODE;
+        final int nodeReadyTimeout = preferenceManager.getPreference(SystemPreferences.CLUSTER_NODE_READY_TIMEOUT);
+        final int nodeReadyStatusCheckTimeout = preferenceManager.getPreference(
+                SystemPreferences.CLUSTER_NODE_READY_STATUS_CHECK_TIMEOUT);
+        final int attemptsStatusNode = nodeReadyTimeout / nodeReadyStatusCheckTimeout;
+        int attempts = attemptsStatusNode;
         while (!isReadyNode(nodeName, client)) {
             LOGGER.debug("Waiting for node {} is ready.", nodeName);
             attempts -= 1;
-            Thread.sleep(NODE_READY_TIMEOUT);
+            Thread.sleep(nodeReadyStatusCheckTimeout);
             if (attempts <= 0) {
                 throw new IllegalStateException(String.format(
-                        "Node %s doesn't match the ready status over than %d times.", nodeName, attempts));
+                        "Node %s doesn't match the ready status over than %d times.", nodeName, attemptsStatusNode));
             }
         }
         LOGGER.debug("Labeling node with run id {}", runId);

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesManager.java
@@ -702,14 +702,14 @@ public class KubernetesManager {
     public void waitForNodeReady(String nodeName, String runId, String cloudRegion) throws InterruptedException {
         KubernetesClient client = getKubernetesClient();
         final int nodeReadyTimeout = preferenceManager.getPreference(SystemPreferences.CLUSTER_NODE_READY_TIMEOUT);
-        final int nodeReadyStatusCheckTimeout = preferenceManager.getPreference(
-                SystemPreferences.CLUSTER_NODE_READY_STATUS_CHECK_TIMEOUT);
-        final int attemptsStatusNode = nodeReadyTimeout / nodeReadyStatusCheckTimeout;
+        final int nodeReadyPollingTimeout = preferenceManager.getPreference(
+                SystemPreferences.CLUSTER_NODE_READY_POLLING_TIMEOUT);
+        final int attemptsStatusNode = nodeReadyTimeout / nodeReadyPollingTimeout;
         int attempts = attemptsStatusNode;
         while (!isReadyNode(nodeName, client)) {
             LOGGER.debug("Waiting for node {} is ready.", nodeName);
             attempts -= 1;
-            Thread.sleep(nodeReadyStatusCheckTimeout);
+            Thread.sleep(nodeReadyPollingTimeout);
             if (attempts <= 0) {
                 throw new IllegalStateException(String.format(
                         "Node %s doesn't match the ready status over than %d times.", nodeName, attemptsStatusNode));

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -649,10 +649,8 @@ public class SystemPreferences {
             new ObjectPreference<>("cluster.run.parameters.mapping", null,
                     new TypeReference<Map<String, RuntimeParameter>>() {}, CLUSTER_GROUP,
                     isNullOrValidJson(new TypeReference<Map<String, RuntimeParameter>>() {}));
-    public static final IntPreference CLUSTER_NODE_READY_TIMEOUT = new IntPreference("cluster.node.ready.timeout",
-            300000, CLUSTER_GROUP, isGreaterThan(0));
-    public static final IntPreference CLUSTER_NODE_READY_POLLING_TIMEOUT = new IntPreference(
-            "cluster.node.ready.polling.timeout", 5000, CLUSTER_GROUP, isGreaterThan(0));
+    public static final IntPreference CLUSTER_NODE_READY_TIMEOUT = new IntPreference(
+            "cluster.node.ready.polling.timeout", 300000, CLUSTER_GROUP, isGreaterThan(0));
 
     //LAUNCH_GROUP
     public static final StringPreference LAUNCH_CMD_TEMPLATE = new StringPreference("launch.cmd.template",

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -651,8 +651,8 @@ public class SystemPreferences {
                     isNullOrValidJson(new TypeReference<Map<String, RuntimeParameter>>() {}));
     public static final IntPreference CLUSTER_NODE_READY_TIMEOUT = new IntPreference("cluster.node.ready.timeout",
             300000, CLUSTER_GROUP, isGreaterThan(0));
-    public static final IntPreference CLUSTER_NODE_READY_STATUS_CHECK_TIMEOUT = new IntPreference(
-            "cluster.node.ready.status.check.timeout", 5000, CLUSTER_GROUP, isGreaterThan(0));
+    public static final IntPreference CLUSTER_NODE_READY_POLLING_TIMEOUT = new IntPreference(
+            "cluster.node.ready.polling.timeout", 5000, CLUSTER_GROUP, isGreaterThan(0));
 
     //LAUNCH_GROUP
     public static final StringPreference LAUNCH_CMD_TEMPLATE = new StringPreference("launch.cmd.template",

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -649,6 +649,10 @@ public class SystemPreferences {
             new ObjectPreference<>("cluster.run.parameters.mapping", null,
                     new TypeReference<Map<String, RuntimeParameter>>() {}, CLUSTER_GROUP,
                     isNullOrValidJson(new TypeReference<Map<String, RuntimeParameter>>() {}));
+    public static final IntPreference CLUSTER_NODE_READY_TIMEOUT = new IntPreference("cluster.node.ready.timeout",
+            300000, CLUSTER_GROUP, isGreaterThan(0));
+    public static final IntPreference CLUSTER_NODE_READY_STATUS_CHECK_TIMEOUT = new IntPreference(
+            "cluster.node.ready.status.check.timeout", 5000, CLUSTER_GROUP, isGreaterThan(0));
 
     //LAUNCH_GROUP
     public static final StringPreference LAUNCH_CMD_TEMPLATE = new StringPreference("launch.cmd.template",


### PR DESCRIPTION
This PR brings enhancements to resume run operation: move node readiness timeouts to system preferences instead of hardcode.

- a new preference `cluster.node.ready.polling.timeout` indicates how many milliseconds to spend waiting for node.  Default: 300 000