### PR TITLE
GUI RunTable - add additional filters

### DIFF
--- a/client/src/components/runs/AllRuns.js
+++ b/client/src/components/runs/AllRuns.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2017-2024 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -182,6 +182,10 @@ class AllRuns extends React.Component {
       .find((aFilter) => aFilter.key.toLowerCase() === (status || '').toLowerCase());
   }
 
+  get additionalFilters () {
+    return (this.currentFilters || {}).additionalFilters;
+  }
+
   navigateToRuns = (status, my = false) => {
     SessionStorageWrapper.setItem(SessionStorageWrapper.ACTIVE_RUNS_KEY, my);
     SessionStorageWrapper.navigateToRuns(this.props.router, status);
@@ -266,6 +270,7 @@ class AllRuns extends React.Component {
     }
     return (
       <RunTable
+        additionalFilters={this.additionalFilters}
         filters={filters}
         autoUpdate={current.autoUpdate}
         disableFilters={current.showPersonalRuns && !all ? [Columns.owner] : []}

--- a/client/src/components/runs/run-table/index.js
+++ b/client/src/components/runs/run-table/index.js
@@ -18,7 +18,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {inject, observer} from 'mobx-react';
 import classNames from 'classnames';
-import {Alert, Pagination, Table} from 'antd';
+import {Alert, Pagination, Table, Row, Button} from 'antd';
 import {isObservableArray, observable} from 'mobx';
 import {
   filtersAreEqual,
@@ -193,6 +193,15 @@ function runIsService (run) {
     run.initialized;
 }
 
+function extractTagsFromFilter (filter = {}) {
+  const tags = [...new Set((filter.tags || []).filter(Boolean))];
+  return tags.reduce((acc, tag) => {
+    const [tagName, value = true] = tag.split('=');
+    acc[tagName] = value;
+    return acc;
+  }, {});
+};
+
 @inject('localization', 'routing')
 @runPipelineActions
 @observer
@@ -206,6 +215,7 @@ class RunTable extends localization.LocalizedReactComponent {
     total: 0,
     runs: [],
     filters: {},
+    additionalFilters: undefined,
     filtersState: {},
     expandedRows: []
   }
@@ -273,6 +283,7 @@ class RunTable extends localization.LocalizedReactComponent {
       error: undefined,
       expandedRows: [],
       filters: {},
+      additionalFilters: {},
       filtersState: {},
       runs: [],
       total: 0
@@ -295,7 +306,8 @@ class RunTable extends localization.LocalizedReactComponent {
       this.finishFetching();
       const {
         page,
-        filters: userFilters = {}
+        filters: userFilters = {},
+        additionalFilters
       } = this.state;
       this.fetchToken += 1;
       let token = this.fetchToken;
@@ -317,6 +329,7 @@ class RunTable extends localization.LocalizedReactComponent {
         runs: [],
         error: undefined
       };
+      const tags = extractTagsFromFilter(additionalFilters);
       if (search) {
         if (searchFilters) {
           fetchRunsPromise = () => new Promise((resolve, reject) => {
@@ -352,6 +365,7 @@ class RunTable extends localization.LocalizedReactComponent {
           const payload = getFiltersPayload({
             ...filters,
             ...userFilters,
+            tags,
             page: page + 1,
             pageSize
           });
@@ -527,7 +541,22 @@ class RunTable extends localization.LocalizedReactComponent {
         }
       );
     }
-  }
+  };
+
+  onAdditionalFiltersChange = (filter) => {
+    const {additionalFilters} = this.state;
+    const checked = additionalFilters && additionalFilters.title === filter.title;
+    if (checked) {
+      return this.clearAdditionalFilters();
+    }
+    this.setState({
+      additionalFilters: filter
+    }, () => this.onPageChanged(0, true));
+  };
+
+  clearAdditionalFilters = () => {
+    this.setState({additionalFilters: {}}, () => this.onPageChanged(0, true));
+  };
 
   renderCustomTable = (runs) => {
     const {
@@ -648,6 +677,32 @@ class RunTable extends localization.LocalizedReactComponent {
     );
   };
 
+  renderAdditionalFilters = () => {
+    const {additionalFilters, pending} = this.state;
+    const {additionalFilters: additionalFiltersProps} = this.props;
+    if (!additionalFiltersProps?.length) {
+      return null;
+    }
+    return (
+      <Row
+        style={{gap: 5, padding: 2, marginBottom: 9}} align="middle"
+        type="flex"
+      >
+        {additionalFiltersProps.map((filter) => (
+          <Button
+            size="small"
+            key={filter.title}
+            onClick={() => this.onAdditionalFiltersChange(filter)}
+            type={additionalFilters?.title === filter.title ? 'primary' : null}
+            disabled={pending}
+          >
+            {filter.title}
+          </Button>
+        ))}
+      </Row>
+    );
+  };
+
   render () {
     const {
       className,
@@ -687,6 +742,7 @@ class RunTable extends localization.LocalizedReactComponent {
             />
           )
         }
+        {this.renderAdditionalFilters()}
         {
           typeof customRunRenderer === 'function'
             ? this.renderCustomTable(runs)
@@ -762,7 +818,11 @@ RunTable.propTypes = {
   ]),
   beforeTable: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   onRunClick: PropTypes.func,
-  runRowClassName: PropTypes.func
+  runRowClassName: PropTypes.func,
+  additionalFilters: PropTypes.arrayOf(PropTypes.shape({
+    title: PropTypes.string,
+    tags: PropTypes.arrayOf(PropTypes.string)
+  }))
 };
 
 RunTable.defaultProps = {

--- a/client/src/components/runs/run-table/index.js
+++ b/client/src/components/runs/run-table/index.js
@@ -196,8 +196,13 @@ function runIsService (run) {
 function extractTagsFromFilter (filter = {}) {
   const tags = [...new Set((filter.tags || []).filter(Boolean))];
   return tags.reduce((acc, tag) => {
-    const [tagName, value = true] = tag.split('=');
-    acc[tagName] = value;
+    const [tagName, ...rest] = tag.split('=');
+    let value = rest.join('=') || true;
+    if (value === 'true' || value === 'false') {
+      acc[tagName] = value === 'true';
+    } else {
+      acc[tagName] = value;
+    }
     return acc;
   }, {});
 };


### PR DESCRIPTION
To enable additional filters by tags, an existing preference `ui.runs.filters` shall be used. Each tab configuration may optionally define additional filters via `additionalFilters` property:
- type: array of objects
- each array item defines "Filter toggle" (button), with the following properties:
  - title - filter name (will be displayed in GUI)
  - tags: array of strings - tags filter. Each tag can be either `TAG_NAME` (transforms to `TAG_NAME=true` filter) or `TAG_NAME=VALUE` (transforms to `TAG_NAME=VALUE` filter).

Example of `ui.runs.filters` preference with additional tags for "Active Runs" tab:

```json
{
  "key": "active",
  "title": "Active Runs",
  "filters": {
   "statuses": [
    "RUNNING",
    "PAUSED"
   ],
   "onlyMasterJobs": false
  },
  "autoUpdate": true,
  "showCount": true,
  "showPersonalRuns": true,
  "additionalFilters": [
   {
    "title": "Idle runs",
    "tags": [
     "IDLE"
    ]
   },
   {
    "title": "Long Running",
    "tags": [
     "LONG_RUNNING"
    ]
   },
   {
    "title": "Node unavailable",
    "tags": [
     "NODE_UNAVAILABLE"
    ]
   }
  ]
 }
```