### PR TITLE
Allow access to swagger endpoint only for specific roles

### DIFF
--- a/api/profiles/dev/application.properties
+++ b/api/profiles/dev/application.properties
@@ -18,6 +18,7 @@ spring.lifecycle.timeout-per-shutdown-phase=${CP_API_SRV_SHUTDOWN_TIMEOUT:30}s
 api.security.anonymous.urls=${CP_API_SRV_ANONYMOUS_URLS:/restapi/route,/restapi/whoami,/restapi/static-resources/**}
 api.security.impersonation.operations.root.url=${CP_API_SECURITY_IMPERSONATION_ROOT_URL:/restapi/user/impersonation}
 api.security.public.urls=${CP_API_SECURITY_PUBLIC_URLS:/init.sh,/launch.sh,/launch.py,/PipelineCLI.tar.gz,/pipe-common.tar.gz,/commit-run-scripts/**,/pipe,/fsbrowser.tar.gz,/gpustat.tar.gz,/pipe.zip,/pipe.tar.gz,/pipe-el6,/pipe-el6.tar.gz,/pipe-osx,/pipe-osx.tar.gz,/cloud-data-linux.tar.gz,/cloud-data-win64.zip,/fsautoscale.sh,/data-transfer-service.jar,/data-transfer-service-windows.zip,/data-transfer-service-linux.zip,/DeployDts.ps1,/deploy_dts.sh}
+api.security.swagger.access.roles=${CP_API_SECURITY_SWAGGER_ACCESS_ROLES:ROLE_ADMIN,ROLE_USER}
 
 #db configuration
 database.url=jdbc:postgresql://localhost:5432/pipeline

--- a/api/profiles/release/application.properties
+++ b/api/profiles/release/application.properties
@@ -13,6 +13,7 @@ server.session.timeout=1800
 #Security
 api.security.anonymous.urls=${CP_API_SRV_ANONYMOUS_URLS:/restapi/route}
 api.security.impersonation.operations.root.url=${CP_API_SECURITY_IMPERSONATION_ROOT_URL:/restapi/user/impersonation}
+api.security.swagger.access.roles=${CP_API_SECURITY_SWAGGER_ACCESS_ROLES:ROLE_ADMIN,ROLE_USER}
 
 #db configuration
 database.url=

--- a/api/src/main/java/com/epam/pipeline/app/JWTSecurityConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/JWTSecurityConfiguration.java
@@ -109,6 +109,8 @@ public class JWTSecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .antMatchers(getAnonymousResources())
                     .hasAnyAuthority(DefaultRoles.ROLE_ADMIN.getName(), DefaultRoles.ROLE_USER.getName(), 
                             DefaultRoles.ROLE_ANONYMOUS_USER.getName())
+                .antMatchers(getSwaggerResources())
+                .hasAnyAuthority(DefaultRoles.ROLE_ADMIN.getName(), DefaultRoles.ROLE_ADVANCED_USER.getName())
                 .antMatchers(getSecuredResources())
                     .hasAnyAuthority(DefaultRoles.ROLE_ADMIN.getName(), DefaultRoles.ROLE_USER.getName())
                 .and()
@@ -151,6 +153,15 @@ public class JWTSecurityConfiguration extends WebSecurityConfigurerAdapter {
                 "/restapi/proxy/**",
                 "/error",
                 "/error/**");
+        return ListUtils.union(excludePaths, ListUtils.emptyIfNull(excludeScripts)).toArray(new String[0]);
+    }
+
+    protected String[] getSwaggerResources() {
+        final List<String> excludePaths = Arrays.asList(
+                "/restapi/swagger-resources/**",
+                "/restapi/swagger-ui.html",
+                "/restapi/webjars/springfox-swagger-ui/**",
+                "/restapi/v2/api-docs/**");
         return ListUtils.union(excludePaths, ListUtils.emptyIfNull(excludeScripts)).toArray(new String[0]);
     }
 

--- a/api/src/main/java/com/epam/pipeline/app/JWTSecurityConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/JWTSecurityConfiguration.java
@@ -74,6 +74,9 @@ public class JWTSecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Value("#{'${api.security.public.urls}'.split(',')}")
     private List<String> excludeScripts;
 
+    @Value("${api.security.swagger.access.roles:ROLE_ADMIN,ROLE_USER}")
+    private String[] swaggerAccessRoles;
+
     @Autowired
     private SAMLAuthenticationProvider samlAuthenticationProvider;
 
@@ -110,7 +113,7 @@ public class JWTSecurityConfiguration extends WebSecurityConfigurerAdapter {
                     .hasAnyAuthority(DefaultRoles.ROLE_ADMIN.getName(), DefaultRoles.ROLE_USER.getName(), 
                             DefaultRoles.ROLE_ANONYMOUS_USER.getName())
                 .antMatchers(getSwaggerResources())
-                .hasAnyAuthority(DefaultRoles.ROLE_ADMIN.getName(), DefaultRoles.ROLE_ADVANCED_USER.getName())
+                .hasAnyAuthority(swaggerAccessRoles)
                 .antMatchers(getSecuredResources())
                     .hasAnyAuthority(DefaultRoles.ROLE_ADMIN.getName(), DefaultRoles.ROLE_USER.getName())
                 .and()
@@ -146,10 +149,6 @@ public class JWTSecurityConfiguration extends WebSecurityConfigurerAdapter {
     protected String[] getUnsecuredResources() {
         final List<String> excludePaths = Arrays.asList(
                 "/restapi/dockerRegistry/oauth",
-                "/restapi/swagger-resources/**",
-                "/restapi/swagger-ui.html",
-                "/restapi/webjars/springfox-swagger-ui/**",
-                "/restapi/v2/api-docs/**",
                 "/restapi/proxy/**",
                 "/error",
                 "/error/**");

--- a/api/src/main/java/com/epam/pipeline/app/SAMLSecurityConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/SAMLSecurityConfiguration.java
@@ -178,6 +178,8 @@ public class SAMLSecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .antMatchers(getAnonymousResources())
                     .hasAnyAuthority(DefaultRoles.ROLE_ADMIN.getName(), DefaultRoles.ROLE_USER.getName(), 
                             DefaultRoles.ROLE_ANONYMOUS_USER.getName())
+                .antMatchers(getSwaggerResources())
+                .hasAnyAuthority(DefaultRoles.ROLE_ADMIN.getName(), DefaultRoles.ROLE_ADVANCED_USER.getName())
                 .antMatchers(getSecuredResourcesRoot())
                     .hasAnyAuthority(DefaultRoles.ROLE_ADMIN.getName(), DefaultRoles.ROLE_USER.getName());
         http.logout().logoutSuccessUrl("/");
@@ -189,6 +191,15 @@ public class SAMLSecurityConfiguration extends WebSecurityConfigurerAdapter {
                 "/restapi/**",
                 "/error",
                 "/error/**");
+        return ListUtils.union(excludePaths, ListUtils.emptyIfNull(excludeScripts)).toArray(new String[0]);
+    }
+
+    protected String[] getSwaggerResources() {
+        final List<String> excludePaths = Arrays.asList(
+                "/restapi/swagger-resources/**",
+                "/restapi/swagger-ui.html",
+                "/restapi/webjars/springfox-swagger-ui/**",
+                "/restapi/v2/api-docs/**");
         return ListUtils.union(excludePaths, ListUtils.emptyIfNull(excludeScripts)).toArray(new String[0]);
     }
 

--- a/api/src/main/java/com/epam/pipeline/app/SAMLSecurityConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/SAMLSecurityConfiguration.java
@@ -156,6 +156,9 @@ public class SAMLSecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Value("${saml.validate.message.inresponse:true}")
     private boolean validateMessageInResponse;
 
+    @Value("${api.security.swagger.access.roles:ROLE_ADMIN,ROLE_USER}")
+    private String[] swaggerAccessRoles;
+
     @Autowired
     private SAMLUserDetailsService samlUserDetailsService;
 
@@ -179,7 +182,7 @@ public class SAMLSecurityConfiguration extends WebSecurityConfigurerAdapter {
                     .hasAnyAuthority(DefaultRoles.ROLE_ADMIN.getName(), DefaultRoles.ROLE_USER.getName(), 
                             DefaultRoles.ROLE_ANONYMOUS_USER.getName())
                 .antMatchers(getSwaggerResources())
-                .hasAnyAuthority(DefaultRoles.ROLE_ADMIN.getName(), DefaultRoles.ROLE_ADVANCED_USER.getName())
+                .hasAnyAuthority(swaggerAccessRoles)
                 .antMatchers(getSecuredResourcesRoot())
                     .hasAnyAuthority(DefaultRoles.ROLE_ADMIN.getName(), DefaultRoles.ROLE_USER.getName());
         http.logout().logoutSuccessUrl("/");

--- a/api/src/main/java/com/epam/pipeline/entity/user/DefaultRoles.java
+++ b/api/src/main/java/com/epam/pipeline/entity/user/DefaultRoles.java
@@ -41,7 +41,7 @@ public enum DefaultRoles {
     ROLE_PIPELINE_MANAGER(new Role(null, "ROLE_PIPELINE_MANAGER", true, false, null, null, null, null)),
     ROLE_VERSIONED_STORAGE_MANAGER(new Role(null, "ROLE_VERSIONED_STORAGE_MANAGER", true, false,
             null, null, null, null)),
-    ROLE_STORAGE_ADMIN(new Role(null, "ROLE_STORAGE_ADMIN", true, false, null, null, null, null)),;
+    ROLE_STORAGE_ADMIN(new Role(null, "ROLE_STORAGE_ADMIN", true, false, null, null, null, null));
 
     private Role role;
 

--- a/deploy/docker/cp-api-srv/config/application.properties
+++ b/deploy/docker/cp-api-srv/config/application.properties
@@ -17,6 +17,7 @@ api.security.redirected.urls=${CP_API_SRV_REDIRECTED_URLS:/restapi/route,/restap
 api.security.anonymous.urls=${CP_API_SRV_ANONYMOUS_URLS:/restapi/route,/restapi/static-resources/**}
 api.security.impersonation.operations.root.url=${CP_API_SECURITY_IMPERSONATION_ROOT_URL:/restapi/user/impersonation}
 api.security.public.urls=${CP_API_SECURITY_PUBLIC_URLS:/init.sh,/launch.sh,/launch.py,/PipelineCLI.tar.gz,/pipe-common.tar.gz,/commit-run-scripts/**,/pipe,/fsbrowser.tar.gz,/gpustat.tar.gz,/pipe.zip,/pipe.tar.gz,/pipe-el6,/pipe-el6.tar.gz,/pipe-osx,/pipe-osx.tar.gz,/cloud-data-linux.tar.gz,/cloud-data-win64.zip,/cloud-data-cli-linux,/cloud-data-cli-macos,/cloud-data-cli-win.exe,/fsautoscale.sh,/data-transfer-service.jar,/data-transfer-service-windows.zip,/data-transfer-service-linux.zip,/DeployDts.ps1,/deploy_dts.sh}
+api.security.swagger.access.roles=${CP_API_SECURITY_SWAGGER_ACCESS_ROLES:ROLE_ADMIN,ROLE_USER}
 # supported values - jdbc, HASH_MAP
 spring.session.store-type=${CP_API_SRV_SESSION_STORE_TYPE:jdbc}
 server.session.timeout=${CP_API_SRV_SESSION_TIMEOUT_SEC:1800}


### PR DESCRIPTION
New application property `api.security.swagger.access.roles` (comma separated list of groups and roles) is available for api-srv server.
During deployment it can be configured with `CP_API_SECURITY_SWAGGER_ACCESS_ROLES` env variable.
Only roles defined in this property will have access to the swagger endpoint (default value: ROLE_ADMIN,ROLE_USER which is basically any authorized user)

example:
```
api.security.swagger.access.roles=ROLE_ADMIN,ROLE_<GROUP-NAME>,ROLE_ADVANCED_USER
```