### PR TITLE
API for active runs charts

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
@@ -27,6 +27,7 @@ import com.epam.pipeline.controller.vo.PipelineRunFilterVO;
 import com.epam.pipeline.controller.vo.PipelineRunServiceUrlVO;
 import com.epam.pipeline.controller.vo.TagsVO;
 import com.epam.pipeline.controller.vo.configuration.RunConfigurationWithEntitiesVO;
+import com.epam.pipeline.controller.vo.run.RunChartFilterVO;
 import com.epam.pipeline.dao.filter.FilterRunParameters;
 import com.epam.pipeline.entity.cluster.PipelineRunPrice;
 import com.epam.pipeline.entity.cluster.ServiceDescription;
@@ -42,6 +43,7 @@ import com.epam.pipeline.entity.pipeline.RunLog;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.epam.pipeline.entity.pipeline.run.PipeRunCmdStartVO;
 import com.epam.pipeline.entity.pipeline.run.PipelineStart;
+import com.epam.pipeline.entity.pipeline.run.RunChartInfo;
 import com.epam.pipeline.entity.pipeline.run.RunInfo;
 import com.epam.pipeline.entity.pipeline.run.parameter.RunSid;
 import com.epam.pipeline.entity.utils.DefaultSystemParameter;
@@ -370,5 +372,10 @@ public class RunApiService {
     @PreAuthorize(RUN_ID_READ)
     public List<RunInfo> loadRunsByParentId(final Long runId) {
         return runManager.loadRunsByParentId(runId);
+    }
+
+    @AclFilter
+    public RunChartInfo loadActiveRunsCharts(final RunChartFilterVO filter) {
+        return runManager.loadActiveRunsCharts(filter);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
@@ -30,6 +30,7 @@ import com.epam.pipeline.controller.vo.RunCommitVO;
 import com.epam.pipeline.controller.vo.RunStatusVO;
 import com.epam.pipeline.controller.vo.TagsVO;
 import com.epam.pipeline.controller.vo.configuration.RunConfigurationWithEntitiesVO;
+import com.epam.pipeline.controller.vo.run.RunChartFilterVO;
 import com.epam.pipeline.entity.cluster.PipelineRunPrice;
 import com.epam.pipeline.entity.cluster.ServiceDescription;
 import com.epam.pipeline.entity.pipeline.DiskAttachRequest;
@@ -42,6 +43,7 @@ import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.RunLog;
 import com.epam.pipeline.entity.pipeline.run.PipeRunCmdStartVO;
 import com.epam.pipeline.entity.pipeline.run.PipelineStart;
+import com.epam.pipeline.entity.pipeline.run.RunChartInfo;
 import com.epam.pipeline.entity.pipeline.run.RunInfo;
 import com.epam.pipeline.entity.pipeline.run.parameter.RunSid;
 import com.epam.pipeline.entity.utils.DefaultSystemParameter;
@@ -585,5 +587,15 @@ public class PipelineRunController extends AbstractRestController {
     @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
     public Result<List<RunInfo>> loadRunsByParentId(@PathVariable(RUN_ID) final Long parentId) {
         return Result.success(runApiService.loadRunsByParentId(parentId));
+    }
+
+    @PostMapping("/runs/charts")
+    @ApiOperation(
+            value = "Loads active runs charts info",
+            notes = "Loads active runs charts info",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<RunChartInfo> loadActiveRunsCharts(@RequestBody final RunChartFilterVO filter) {
+        return Result.success(runApiService.loadActiveRunsCharts(filter));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/vo/run/RunChartFilterVO.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/run/RunChartFilterVO.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2024 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.controller.vo.run;
+
+import com.epam.pipeline.entity.filter.AclSecuredFilter;
+import com.epam.pipeline.entity.pipeline.TaskStatus;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RunChartFilterVO implements AclSecuredFilter {
+    private List<String> owners;
+    private List<String> dockerImages;
+    private List<String> instanceTypes;
+    private List<String> tags;
+    private List<TaskStatus> statuses;
+
+    //these filter is used for ACL filtering
+    @JsonIgnore
+    private List<Long> allowedPipelines;
+    @JsonIgnore
+    private String ownershipFilter;
+}

--- a/api/src/main/java/com/epam/pipeline/controller/vo/run/RunChartFilterVO.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/run/RunChartFilterVO.java
@@ -19,8 +19,6 @@ package com.epam.pipeline.controller.vo.run;
 import com.epam.pipeline.entity.filter.AclSecuredFilter;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -28,8 +26,6 @@ import java.util.List;
 
 @Data
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
 public class RunChartFilterVO implements AclSecuredFilter {
     private List<String> owners;
     private List<String> dockerImages;

--- a/api/src/main/java/com/epam/pipeline/entity/run/RunChartInfoEntity.java
+++ b/api/src/main/java/com/epam/pipeline/entity/run/RunChartInfoEntity.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2024 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.run;
+
+import com.epam.pipeline.entity.pipeline.TaskStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RunChartInfoEntity {
+
+    public enum ColumnName {
+        owner, docker_image, node_type, tags
+    }
+
+    private TaskStatus status;
+    private ColumnName columnName;
+    private String value;
+    private Long count;
+}

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -1326,6 +1326,7 @@ public class PipelineRunManager {
         }
         final Map<RunChartInfoEntity.ColumnName, Map<TaskStatus, Map<String, Long>>> charts =
                 pipelineRunDao.loadRunsCharts(filter).stream()
+                        .filter(entity -> Objects.nonNull(entity.getValue()))
                         .collect(Collectors.groupingBy(RunChartInfoEntity::getColumnName,
                                 Collectors.groupingBy(RunChartInfoEntity::getStatus,
                                         Collectors.toMap(RunChartInfoEntity::getValue, RunChartInfoEntity::getCount))));

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -25,6 +25,7 @@ import com.epam.pipeline.controller.vo.PagingRunFilterVO;
 import com.epam.pipeline.controller.vo.PipelineRunFilterVO;
 import com.epam.pipeline.controller.vo.PipelineRunServiceUrlVO;
 import com.epam.pipeline.controller.vo.TagsVO;
+import com.epam.pipeline.controller.vo.run.RunChartFilterVO;
 import com.epam.pipeline.dao.pipeline.PipelineRunDao;
 import com.epam.pipeline.entity.AbstractSecuredEntity;
 import com.epam.pipeline.entity.BaseEntity;
@@ -59,11 +60,13 @@ import com.epam.pipeline.entity.pipeline.run.PipelineStart;
 import com.epam.pipeline.entity.pipeline.run.PipelineStartNotificationRequest;
 import com.epam.pipeline.entity.pipeline.run.RestartRun;
 import com.epam.pipeline.entity.pipeline.run.RunAssignPolicy;
+import com.epam.pipeline.entity.pipeline.run.RunChartInfo;
 import com.epam.pipeline.entity.pipeline.run.RunInfo;
 import com.epam.pipeline.entity.pipeline.run.RunStatus;
 import com.epam.pipeline.entity.pipeline.run.parameter.PipelineRunParameter;
 import com.epam.pipeline.entity.pipeline.run.parameter.RunSid;
 import com.epam.pipeline.entity.region.AbstractCloudRegion;
+import com.epam.pipeline.entity.run.RunChartInfoEntity;
 import com.epam.pipeline.entity.security.acl.AclClass;
 import com.epam.pipeline.entity.user.PipelineUser;
 import com.epam.pipeline.entity.utils.DateUtils;
@@ -1313,6 +1316,25 @@ public class PipelineRunManager {
                         .endDate(run.getEndDate())
                         .build())
                 .collect(Collectors.toList());
+    }
+
+    public RunChartInfo loadActiveRunsCharts(final RunChartFilterVO filter) {
+        if (CollectionUtils.isEmpty(filter.getStatuses())) {
+            filter.setStatuses(Arrays.stream(TaskStatus.values())
+                    .filter(status -> !status.isFinal())
+                    .collect(Collectors.toList()));
+        }
+        final Map<RunChartInfoEntity.ColumnName, Map<TaskStatus, Map<String, Long>>> charts =
+                pipelineRunDao.loadRunsCharts(filter).stream()
+                        .collect(Collectors.groupingBy(RunChartInfoEntity::getColumnName,
+                                Collectors.groupingBy(RunChartInfoEntity::getStatus,
+                                        Collectors.toMap(RunChartInfoEntity::getValue, RunChartInfoEntity::getCount))));
+        return RunChartInfo.builder()
+                .owners(charts.get(RunChartInfoEntity.ColumnName.owner))
+                .dockerImages(charts.get(RunChartInfoEntity.ColumnName.docker_image))
+                .instanceTypes(charts.get(RunChartInfoEntity.ColumnName.node_type))
+                .tags(charts.get(RunChartInfoEntity.ColumnName.tags))
+                .build();
     }
 
     private int getTotalSize(final List<InstanceDisk> disks) {

--- a/api/src/main/resources/dao/pipeline-run-dao.xml
+++ b/api/src/main/resources/dao/pipeline-run-dao.xml
@@ -2179,14 +2179,14 @@
                            'docker_image' as type,
                            docker_image as value,
                            COUNT(*) as count
-                    FROM filtered
+                    FROM filtered WHERE docker_image IS NOT NULL
                     GROUP BY status, docker_image
                     UNION ALL
                     SELECT status,
                            'node_type' as type,
                             node_type as value,
                             COUNT(*) as count
-                    FROM filtered
+                    FROM filtered WHERE node_type IS NOT NULL
                     GROUP BY status, node_type
                     UNION ALL
                     SELECT status,

--- a/api/src/main/resources/dao/pipeline-run-dao.xml
+++ b/api/src/main/resources/dao/pipeline-run-dao.xml
@@ -2156,5 +2156,48 @@
                 ]]>
             </value>
         </property>
+        <property name="loadRunsChartsQuery">
+            <value>
+                <![CDATA[
+                    WITH filtered AS (
+                        SELECT status,
+                               owner,
+                               docker_image,
+                               node_type,
+                               tags
+                        FROM pipeline.pipeline_run as r
+                        @WHERE@
+                    )
+                    SELECT status,
+                           'owner' as type,
+                           owner as value,
+                           COUNT(*) as count
+                    FROM filtered
+                    GROUP BY status, owner
+                    UNION ALL
+                    SELECT status,
+                           'docker_image' as type,
+                           docker_image as value,
+                           COUNT(*) as count
+                    FROM filtered
+                    GROUP BY status, docker_image
+                    UNION ALL
+                    SELECT status,
+                           'node_type' as type,
+                            node_type as value,
+                            COUNT(*) as count
+                    FROM filtered
+                    GROUP BY status, node_type
+                    UNION ALL
+                    SELECT status,
+                           'tags' as type,
+                           tags.key as value,
+                           COUNT(*) as count
+                    FROM filtered, jsonb_each(filtered.tags) AS tags
+                    @WHERE_TAGS@
+                    GROUP BY status, tags.key
+                ]]>
+            </value>
+        </property>
     </bean>
 </beans>

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
@@ -1160,9 +1160,9 @@ public class PipelineRunDaoTest extends AbstractJdbcTest {
         final PipelineRun stopped = toolRun(TaskStatus.STOPPED, DOCKER_IMAGE, NODE_TYPE, USER, tags);
         pipelineRunDao.createPipelineRun(stopped);
 
-        final List<RunChartInfoEntity> charts = pipelineRunDao.loadRunsCharts(RunChartFilterVO.builder()
-                .statuses(Collections.singletonList(TaskStatus.RUNNING))
-                .build());
+        final RunChartFilterVO filter = new RunChartFilterVO();
+        filter.setStatuses(Collections.singletonList(TaskStatus.RUNNING));
+        final List<RunChartInfoEntity> charts = pipelineRunDao.loadRunsCharts(filter);
         assertEquals(charts.size(), 4);
         charts.stream()
                 .peek(chart -> assertEquals(chart.getStatus(), TaskStatus.RUNNING))
@@ -1189,13 +1189,13 @@ public class PipelineRunDaoTest extends AbstractJdbcTest {
                 Collections.singletonMap(TAG_KEY_2, TAG_VALUE_2));
         pipelineRunDao.createPipelineRun(run6);
 
-        final List<RunChartInfoEntity> charts = pipelineRunDao.loadRunsCharts(RunChartFilterVO.builder()
-                .statuses(Collections.singletonList(TaskStatus.RUNNING))
-                .dockerImages(Collections.singletonList(DOCKER_IMAGE))
-                .instanceTypes(Collections.singletonList(NODE_TYPE))
-                .owners(Collections.singletonList(USER))
-                .tags(Collections.singletonList(TAG_KEY_1))
-                .build());
+        final RunChartFilterVO filter = new RunChartFilterVO();
+        filter.setStatuses(Collections.singletonList(TaskStatus.RUNNING));
+        filter.setDockerImages(Collections.singletonList(DOCKER_IMAGE));
+        filter.setInstanceTypes(Collections.singletonList(NODE_TYPE));
+        filter.setOwners(Collections.singletonList(USER));
+        filter.setTags(Collections.singletonList(TAG_KEY_1));
+        final List<RunChartInfoEntity> charts = pipelineRunDao.loadRunsCharts(filter);
         assertEquals(4, charts.size());
         charts.stream()
                 .peek(chart -> assertEquals(chart.getStatus(), TaskStatus.RUNNING))
@@ -1224,14 +1224,14 @@ public class PipelineRunDaoTest extends AbstractJdbcTest {
         final PipelineRun run7 = toolRun(TaskStatus.RUNNING, DOCKER_IMAGE, NODE_TYPE, TEST_USER, tags);
         pipelineRunDao.createPipelineRun(run7);
 
-        final List<RunChartInfoEntity> charts = pipelineRunDao.loadRunsCharts(RunChartFilterVO.builder()
-                .statuses(Collections.singletonList(TaskStatus.RUNNING))
-                .dockerImages(Collections.singletonList(DOCKER_IMAGE))
-                .instanceTypes(Collections.singletonList(NODE_TYPE))
-                .owners(Collections.singletonList(USER))
-                .tags(Collections.singletonList(TAG_KEY_1))
-                .ownershipFilter(USER)
-                .build());
+        final RunChartFilterVO filter = new RunChartFilterVO();
+        filter.setStatuses(Collections.singletonList(TaskStatus.RUNNING));
+        filter.setDockerImages(Collections.singletonList(DOCKER_IMAGE));
+        filter.setInstanceTypes(Collections.singletonList(NODE_TYPE));
+        filter.setOwners(Collections.singletonList(USER));
+        filter.setTags(Collections.singletonList(TAG_KEY_1));
+        filter.setOwnershipFilter(USER);
+        final List<RunChartInfoEntity> charts = pipelineRunDao.loadRunsCharts(filter);
         assertEquals(4, charts.size());
         charts.stream()
                 .peek(chart -> assertEquals(chart.getStatus(), TaskStatus.RUNNING))
@@ -1269,15 +1269,15 @@ public class PipelineRunDaoTest extends AbstractJdbcTest {
                 notAllowedPipelineId);
         pipelineRunDao.createPipelineRun(run7);
 
-        final List<RunChartInfoEntity> charts = pipelineRunDao.loadRunsCharts(RunChartFilterVO.builder()
-                .statuses(Collections.singletonList(TaskStatus.RUNNING))
-                .dockerImages(Collections.singletonList(DOCKER_IMAGE))
-                .instanceTypes(Collections.singletonList(NODE_TYPE))
-                .owners(Collections.singletonList(USER))
-                .tags(Collections.singletonList(TAG_KEY_1))
-                .ownershipFilter(TEST_USER)
-                .allowedPipelines(Collections.singletonList(allowedPipelineId))
-                .build());
+        final RunChartFilterVO filter = new RunChartFilterVO();
+        filter.setStatuses(Collections.singletonList(TaskStatus.RUNNING));
+        filter.setDockerImages(Collections.singletonList(DOCKER_IMAGE));
+        filter.setInstanceTypes(Collections.singletonList(NODE_TYPE));
+        filter.setOwners(Collections.singletonList(USER));
+        filter.setTags(Collections.singletonList(TAG_KEY_1));
+        filter.setOwnershipFilter(TEST_USER);
+        filter.setAllowedPipelines(Collections.singletonList(allowedPipelineId));
+        final List<RunChartInfoEntity> charts = pipelineRunDao.loadRunsCharts(filter);
         assertEquals(4, charts.size());
         charts.stream()
                 .peek(chart -> assertEquals(chart.getStatus(), TaskStatus.RUNNING))

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
@@ -18,6 +18,7 @@ package com.epam.pipeline.dao.pipeline;
 
 import com.epam.pipeline.controller.vo.PagingRunFilterVO;
 import com.epam.pipeline.controller.vo.PipelineRunFilterVO;
+import com.epam.pipeline.controller.vo.run.RunChartFilterVO;
 import com.epam.pipeline.dao.filter.FilterDao;
 import com.epam.pipeline.dao.region.CloudRegionDao;
 import com.epam.pipeline.dao.run.RunServiceUrlDao;
@@ -35,6 +36,7 @@ import com.epam.pipeline.entity.pipeline.run.parameter.RunAccessType;
 import com.epam.pipeline.entity.pipeline.run.parameter.RunSid;
 import com.epam.pipeline.entity.region.AbstractCloudRegion;
 import com.epam.pipeline.entity.region.CloudProvider;
+import com.epam.pipeline.entity.run.RunChartInfoEntity;
 import com.epam.pipeline.entity.user.PipelineUser;
 import com.epam.pipeline.entity.utils.DateUtils;
 import com.epam.pipeline.manager.ObjectCreatorUtils;
@@ -135,6 +137,8 @@ public class PipelineRunDaoTest extends AbstractJdbcTest {
     private static final String NODE_NAME = "node-12323";
     private static final String TEST_PLATFORM = "linux";
     private static final String TEST_REGION = "region";
+    private static final String NODE_TYPE = "m5.xlarge";
+    private static final String NODE_TYPE_2 = "r5.2xlarge";
 
     private static final BigDecimal INITIAL_CLUSTER_PRICE_1 = BigDecimal.valueOf(1.9511111);
     private static final BigDecimal INITIAL_CLUSTER_PRICE_2 = BigDecimal.valueOf(123456.5666);
@@ -1146,6 +1150,140 @@ public class PipelineRunDaoTest extends AbstractJdbcTest {
         assertThat(pipelineRunDao.loadPipelineRun(run1.getId()).getPipelineId(), is(nullValue()));
     }
 
+    @Test
+    public void shouldLoadRunsChartsWithStatusFilter() {
+        final Map<String, String> tags = Collections.singletonMap(TAG_KEY_1, TAG_VALUE_1);
+
+        final PipelineRun running = toolRun(TaskStatus.RUNNING, DOCKER_IMAGE, NODE_TYPE, USER, tags);
+        pipelineRunDao.createPipelineRun(running);
+
+        final PipelineRun stopped = toolRun(TaskStatus.STOPPED, DOCKER_IMAGE, NODE_TYPE, USER, tags);
+        pipelineRunDao.createPipelineRun(stopped);
+
+        final List<RunChartInfoEntity> charts = pipelineRunDao.loadRunsCharts(RunChartFilterVO.builder()
+                .statuses(Collections.singletonList(TaskStatus.RUNNING))
+                .build());
+        assertEquals(charts.size(), 4);
+        charts.stream()
+                .peek(chart -> assertEquals(chart.getStatus(), TaskStatus.RUNNING))
+                .forEach(chart -> assertEquals(chart.getCount().longValue(), 1L));
+    }
+
+    @Test
+    public void shouldLoadRunsChartsWithFullFilter() {
+        final HashMap<String, String> tags = new HashMap<>();
+        tags.put(TAG_KEY_1, TAG_VALUE_1);
+        tags.put(TAG_KEY_2, TAG_VALUE_2);
+
+        final PipelineRun run1 = toolRun(TaskStatus.RUNNING, DOCKER_IMAGE, NODE_TYPE, USER, tags);
+        pipelineRunDao.createPipelineRun(run1);
+        final PipelineRun run2 = toolRun(TaskStatus.RUNNING, ACTUAL_DOCKER_IMAGE, NODE_TYPE, USER, tags);
+        pipelineRunDao.createPipelineRun(run2);
+        final PipelineRun run3 = toolRun(TaskStatus.RUNNING, DOCKER_IMAGE, NODE_TYPE_2, USER, tags);
+        pipelineRunDao.createPipelineRun(run3);
+        final PipelineRun run4 = toolRun(TaskStatus.RUNNING, DOCKER_IMAGE, NODE_TYPE, TEST_USER, tags);
+        pipelineRunDao.createPipelineRun(run4);
+        final PipelineRun run5 = toolRun(TaskStatus.RUNNING, DOCKER_IMAGE, NODE_TYPE, USER, null);
+        pipelineRunDao.createPipelineRun(run5);
+        final PipelineRun run6 = toolRun(TaskStatus.RUNNING, DOCKER_IMAGE, NODE_TYPE, USER,
+                Collections.singletonMap(TAG_KEY_2, TAG_VALUE_2));
+        pipelineRunDao.createPipelineRun(run6);
+
+        final List<RunChartInfoEntity> charts = pipelineRunDao.loadRunsCharts(RunChartFilterVO.builder()
+                .statuses(Collections.singletonList(TaskStatus.RUNNING))
+                .dockerImages(Collections.singletonList(DOCKER_IMAGE))
+                .instanceTypes(Collections.singletonList(NODE_TYPE))
+                .owners(Collections.singletonList(USER))
+                .tags(Collections.singletonList(TAG_KEY_1))
+                .build());
+        assertEquals(4, charts.size());
+        charts.stream()
+                .peek(chart -> assertEquals(chart.getStatus(), TaskStatus.RUNNING))
+                .forEach(chart -> assertEquals(chart.getCount().longValue(), 1L));
+    }
+
+    @Test
+    public void shouldLoadRunsChartsWithFilterWithAclOwner() {
+        final HashMap<String, String> tags = new HashMap<>();
+        tags.put(TAG_KEY_1, TAG_VALUE_1);
+        tags.put(TAG_KEY_2, TAG_VALUE_2);
+
+        final PipelineRun run1 = toolRun(TaskStatus.RUNNING, DOCKER_IMAGE, NODE_TYPE, USER, tags);
+        pipelineRunDao.createPipelineRun(run1);
+        final PipelineRun run2 = toolRun(TaskStatus.RUNNING, ACTUAL_DOCKER_IMAGE, NODE_TYPE, USER, tags);
+        pipelineRunDao.createPipelineRun(run2);
+        final PipelineRun run3 = toolRun(TaskStatus.RUNNING, DOCKER_IMAGE, NODE_TYPE_2, USER, tags);
+        pipelineRunDao.createPipelineRun(run3);
+        final PipelineRun run4 = toolRun(TaskStatus.RUNNING, DOCKER_IMAGE, NODE_TYPE, TEST_USER, tags);
+        pipelineRunDao.createPipelineRun(run4);
+        final PipelineRun run5 = toolRun(TaskStatus.RUNNING, DOCKER_IMAGE, NODE_TYPE, USER, null);
+        pipelineRunDao.createPipelineRun(run5);
+        final PipelineRun run6 = toolRun(TaskStatus.RUNNING, DOCKER_IMAGE, NODE_TYPE, USER,
+                Collections.singletonMap(TAG_KEY_2, TAG_VALUE_2));
+        pipelineRunDao.createPipelineRun(run6);
+        final PipelineRun run7 = toolRun(TaskStatus.RUNNING, DOCKER_IMAGE, NODE_TYPE, TEST_USER, tags);
+        pipelineRunDao.createPipelineRun(run7);
+
+        final List<RunChartInfoEntity> charts = pipelineRunDao.loadRunsCharts(RunChartFilterVO.builder()
+                .statuses(Collections.singletonList(TaskStatus.RUNNING))
+                .dockerImages(Collections.singletonList(DOCKER_IMAGE))
+                .instanceTypes(Collections.singletonList(NODE_TYPE))
+                .owners(Collections.singletonList(USER))
+                .tags(Collections.singletonList(TAG_KEY_1))
+                .ownershipFilter(USER)
+                .build());
+        assertEquals(4, charts.size());
+        charts.stream()
+                .peek(chart -> assertEquals(chart.getStatus(), TaskStatus.RUNNING))
+                .forEach(chart -> assertEquals(chart.getCount().longValue(), 1L));
+    }
+
+    @Test
+    public void shouldLoadRunsChartsWithFilterWithAclPipeline() {
+        final Long allowedPipelineId = getPipeline().getId();
+        final Long notAllowedPipelineId = getPipeline().getId();
+
+        final HashMap<String, String> tags = new HashMap<>();
+        tags.put(TAG_KEY_1, TAG_VALUE_1);
+        tags.put(TAG_KEY_2, TAG_VALUE_2);
+
+        final PipelineRun run1 = pipelineRun(TaskStatus.RUNNING, DOCKER_IMAGE, NODE_TYPE, USER, tags,
+                allowedPipelineId);
+        pipelineRunDao.createPipelineRun(run1);
+        final PipelineRun run2 = pipelineRun(TaskStatus.RUNNING, ACTUAL_DOCKER_IMAGE, NODE_TYPE, USER, tags,
+                allowedPipelineId);
+        pipelineRunDao.createPipelineRun(run2);
+        final PipelineRun run3 = pipelineRun(TaskStatus.RUNNING, DOCKER_IMAGE, NODE_TYPE_2, USER, tags,
+                allowedPipelineId);
+        pipelineRunDao.createPipelineRun(run3);
+        final PipelineRun run4 = pipelineRun(TaskStatus.RUNNING, DOCKER_IMAGE, NODE_TYPE, TEST_USER, tags,
+                allowedPipelineId);
+        pipelineRunDao.createPipelineRun(run4);
+        final PipelineRun run5 = pipelineRun(TaskStatus.RUNNING, DOCKER_IMAGE, NODE_TYPE, USER, null,
+                allowedPipelineId);
+        pipelineRunDao.createPipelineRun(run5);
+        final PipelineRun run6 = pipelineRun(TaskStatus.RUNNING, DOCKER_IMAGE, NODE_TYPE, USER,
+                Collections.singletonMap(TAG_KEY_2, TAG_VALUE_2), allowedPipelineId);
+        pipelineRunDao.createPipelineRun(run6);
+        final PipelineRun run7 = pipelineRun(TaskStatus.RUNNING, DOCKER_IMAGE, NODE_TYPE, USER, tags,
+                notAllowedPipelineId);
+        pipelineRunDao.createPipelineRun(run7);
+
+        final List<RunChartInfoEntity> charts = pipelineRunDao.loadRunsCharts(RunChartFilterVO.builder()
+                .statuses(Collections.singletonList(TaskStatus.RUNNING))
+                .dockerImages(Collections.singletonList(DOCKER_IMAGE))
+                .instanceTypes(Collections.singletonList(NODE_TYPE))
+                .owners(Collections.singletonList(USER))
+                .tags(Collections.singletonList(TAG_KEY_1))
+                .ownershipFilter(TEST_USER)
+                .allowedPipelines(Collections.singletonList(allowedPipelineId))
+                .build());
+        assertEquals(4, charts.size());
+        charts.stream()
+                .peek(chart -> assertEquals(chart.getStatus(), TaskStatus.RUNNING))
+                .forEach(chart -> assertEquals(chart.getCount().longValue(), 1L));
+    }
+
     private PipelineRun createTestPipelineRun() {
         return createTestPipelineRun(testPipeline.getId());
     }
@@ -1346,6 +1484,32 @@ public class PipelineRunDaoTest extends AbstractJdbcTest {
         pipelineRun.setSensitive(true);
         pipelineRun.setRunSids(sids);
         return pipelineRun;
+    }
+
+    private PipelineRun toolRun(final TaskStatus status, final String dockerImage, final String instanceType,
+                                final String owner, final Map<String, String> tags) {
+        return pipelineRun(status, dockerImage, instanceType, owner, tags, null);
+    }
+
+    private PipelineRun pipelineRun(final TaskStatus status, final String dockerImage, final String instanceType,
+                                    final String owner, final Map<String, String> tags, final Long pipelineId) {
+        final PipelineRun pipelineRun = buildPipelineRun(null);
+        pipelineRun.setStatus(status);
+        pipelineRun.setDockerImage(dockerImage);
+        pipelineRun.setInstance(runInstance(instanceType));
+        pipelineRun.setOwner(owner);
+        pipelineRun.setTags(tags);
+        pipelineRun.setPipelineId(pipelineId);
+        return pipelineRun;
+    }
+
+    private RunInstance runInstance(final String instanceType) {
+        final RunInstance runInstance = new RunInstance();
+        runInstance.setCloudProvider(CloudProvider.AWS);
+        runInstance.setCloudRegionId(cloudRegion.getId());
+        runInstance.setNodePlatform(TEST_PLATFORM);
+        runInstance.setNodeType(instanceType);
+        return runInstance;
     }
 
     private RunSid runSid(final String sidName, final boolean principal) {

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunManagerUnitTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunManagerUnitTest.java
@@ -474,9 +474,9 @@ public class PipelineRunManagerUnitTest {
         final RunChartInfoEntity runningTags2 = runningChart(RunChartInfoEntity.ColumnName.tags, TEST_NAME_2);
         final RunChartInfoEntity pausingTags = pausingChart(RunChartInfoEntity.ColumnName.tags, TEST_NAME);
 
-        final RunChartFilterVO runChartFilterVO = RunChartFilterVO.builder()
-                .statuses(Arrays.asList(TaskStatus.RUNNING, TaskStatus.PAUSING, TaskStatus.PAUSED, TaskStatus.RESUMING))
-                .build();
+        final RunChartFilterVO runChartFilterVO = new RunChartFilterVO();
+        runChartFilterVO.setStatuses(Arrays.asList(TaskStatus.RUNNING, TaskStatus.PAUSING, TaskStatus.PAUSED,
+                        TaskStatus.RESUMING));
         final List<RunChartInfoEntity> entities = Arrays.asList(
                 runningUser1, runningUser2, pausingUser,
                 runningDocker1, runningDocker2, pausingDocker,

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunManagerUnitTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunManagerUnitTest.java
@@ -66,7 +66,14 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static com.epam.pipeline.test.creator.CommonCreatorConstants.*;
+import static com.epam.pipeline.test.creator.CommonCreatorConstants.ID;
+import static com.epam.pipeline.test.creator.CommonCreatorConstants.ID_2;
+import static com.epam.pipeline.test.creator.CommonCreatorConstants.ID_3;
+import static com.epam.pipeline.test.creator.CommonCreatorConstants.TEST_DATE;
+import static com.epam.pipeline.test.creator.CommonCreatorConstants.TEST_DATE_STRING;
+import static com.epam.pipeline.test.creator.CommonCreatorConstants.TEST_NAME;
+import static com.epam.pipeline.test.creator.CommonCreatorConstants.TEST_NAME_2;
+import static com.epam.pipeline.test.creator.CommonCreatorConstants.TEST_STRING;
 import static com.epam.pipeline.test.creator.docker.DockerCreatorUtils.IMAGE1;
 import static com.epam.pipeline.test.creator.docker.DockerCreatorUtils.IMAGE2;
 import static com.epam.pipeline.test.creator.docker.DockerCreatorUtils.REGISTRY1;

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunManagerUnitTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunManagerUnitTest.java
@@ -22,6 +22,7 @@ import com.epam.pipeline.config.JsonMapper;
 import com.epam.pipeline.controller.vo.PagingRunFilterVO;
 import com.epam.pipeline.controller.vo.PipelineRunFilterVO;
 import com.epam.pipeline.controller.vo.TagsVO;
+import com.epam.pipeline.controller.vo.run.RunChartFilterVO;
 import com.epam.pipeline.dao.pipeline.PipelineRunDao;
 import com.epam.pipeline.entity.configuration.RunConfiguration;
 import com.epam.pipeline.entity.metadata.MetadataEntity;
@@ -37,7 +38,9 @@ import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.epam.pipeline.entity.pipeline.Tool;
 import com.epam.pipeline.entity.pipeline.run.RestartRun;
+import com.epam.pipeline.entity.pipeline.run.RunChartInfo;
 import com.epam.pipeline.entity.pipeline.run.parameter.PipelineRunParameter;
+import com.epam.pipeline.entity.run.RunChartInfoEntity;
 import com.epam.pipeline.entity.utils.DateUtils;
 import com.epam.pipeline.manager.cluster.NodesManager;
 import com.epam.pipeline.manager.datastorage.DataStorageManager;
@@ -46,6 +49,7 @@ import com.epam.pipeline.manager.metadata.MetadataEntityManager;
 import com.epam.pipeline.manager.metadata.MetadataManager;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.security.run.RunPermissionManager;
+import com.google.common.collect.Maps;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -62,12 +66,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static com.epam.pipeline.test.creator.CommonCreatorConstants.ID;
-import static com.epam.pipeline.test.creator.CommonCreatorConstants.ID_2;
-import static com.epam.pipeline.test.creator.CommonCreatorConstants.ID_3;
-import static com.epam.pipeline.test.creator.CommonCreatorConstants.TEST_DATE;
-import static com.epam.pipeline.test.creator.CommonCreatorConstants.TEST_DATE_STRING;
-import static com.epam.pipeline.test.creator.CommonCreatorConstants.TEST_STRING;
+import static com.epam.pipeline.test.creator.CommonCreatorConstants.*;
 import static com.epam.pipeline.test.creator.docker.DockerCreatorUtils.IMAGE1;
 import static com.epam.pipeline.test.creator.docker.DockerCreatorUtils.IMAGE2;
 import static com.epam.pipeline.test.creator.docker.DockerCreatorUtils.REGISTRY1;
@@ -450,6 +449,41 @@ public class PipelineRunManagerUnitTest {
                 .contains(expectedRestartRun2);
     }
 
+    @Test
+    public void shouldLoadActiveRunsChart() {
+        final RunChartInfoEntity runningUser1 = runningChart(RunChartInfoEntity.ColumnName.owner, TEST_NAME);
+        final RunChartInfoEntity runningUser2 = runningChart(RunChartInfoEntity.ColumnName.owner, TEST_NAME_2);
+        final RunChartInfoEntity pausingUser = pausingChart(RunChartInfoEntity.ColumnName.owner, TEST_NAME);
+
+        final RunChartInfoEntity runningDocker1 = runningChart(RunChartInfoEntity.ColumnName.docker_image, TEST_NAME);
+        final RunChartInfoEntity runningDocker2 = runningChart(RunChartInfoEntity.ColumnName.docker_image, TEST_NAME_2);
+        final RunChartInfoEntity pausingDocker = pausingChart(RunChartInfoEntity.ColumnName.docker_image, TEST_NAME);
+
+        final RunChartInfoEntity runningInstance1 = runningChart(RunChartInfoEntity.ColumnName.node_type, TEST_NAME);
+        final RunChartInfoEntity runningInstance2 = runningChart(RunChartInfoEntity.ColumnName.node_type, TEST_NAME_2);
+        final RunChartInfoEntity pausingInstance = pausingChart(RunChartInfoEntity.ColumnName.node_type, TEST_NAME);
+
+        final RunChartInfoEntity runningTags1 = runningChart(RunChartInfoEntity.ColumnName.tags, TEST_NAME);
+        final RunChartInfoEntity runningTags2 = runningChart(RunChartInfoEntity.ColumnName.tags, TEST_NAME_2);
+        final RunChartInfoEntity pausingTags = pausingChart(RunChartInfoEntity.ColumnName.tags, TEST_NAME);
+
+        final RunChartFilterVO runChartFilterVO = RunChartFilterVO.builder()
+                .statuses(Arrays.asList(TaskStatus.RUNNING, TaskStatus.PAUSING, TaskStatus.PAUSED, TaskStatus.RESUMING))
+                .build();
+        final List<RunChartInfoEntity> entities = Arrays.asList(
+                runningUser1, runningUser2, pausingUser,
+                runningDocker1, runningDocker2, pausingDocker,
+                runningInstance1, runningInstance2, pausingInstance,
+                runningTags1, runningTags2, pausingTags);
+        doReturn(entities).when(pipelineRunDao).loadRunsCharts(runChartFilterVO);
+
+        final RunChartInfo resultChart = pipelineRunManager.loadActiveRunsCharts(new RunChartFilterVO());
+        assertRunChartElements(resultChart.getOwners());
+        assertRunChartElements(resultChart.getDockerImages());
+        assertRunChartElements(resultChart.getInstanceTypes());
+        assertRunChartElements(resultChart.getTags());
+    }
+
     private void assertEnvVarsReplacement(final String paramValuePattern, final String expectedValuePattern) {
         final String paramValue = String.format(paramValuePattern, ENV_VAR_NAME);
         final String expectedValue = String.format(expectedValuePattern, ENV_VAR_VALUE);
@@ -533,5 +567,36 @@ public class PipelineRunManagerUnitTest {
 
     private String buildDockerImage(final String registry, final String image) {
         return String.format("%s/%s", registry, image);
+    }
+
+    private RunChartInfoEntity runChart(final TaskStatus status, final RunChartInfoEntity.ColumnName columnName,
+                                        final String value) {
+        return RunChartInfoEntity.builder()
+                .columnName(columnName)
+                .status(status)
+                .value(value)
+                .count(SIZE)
+                .build();
+    }
+
+    private RunChartInfoEntity runningChart(final RunChartInfoEntity.ColumnName columnName, final String value) {
+        return runChart(TaskStatus.RUNNING, columnName, value);
+    }
+
+    private RunChartInfoEntity pausingChart(final RunChartInfoEntity.ColumnName columnName, final String value) {
+        return runChart(TaskStatus.PAUSING, columnName, value);
+    }
+
+    private void assertRunChartElements(final Map<TaskStatus, Map<String, Long>> elements) {
+        assertThat(elements)
+                .hasSize(2)
+                .containsKeys(TaskStatus.RUNNING, TaskStatus.PAUSING);
+        assertThat(elements.get(TaskStatus.RUNNING))
+                .hasSize(2)
+                .contains(Maps.immutableEntry(TEST_NAME, SIZE))
+                .contains(Maps.immutableEntry(TEST_NAME_2, SIZE));
+        assertThat(elements.get(TaskStatus.PAUSING))
+                .hasSize(1)
+                .contains(Maps.immutableEntry(TEST_NAME, SIZE));
     }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/run/RunChartInfo.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/run/RunChartInfo.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2024 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.pipeline.run;
+
+import com.epam.pipeline.entity.pipeline.TaskStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RunChartInfo {
+    private Map<TaskStatus, Map<String, Long>> owners;
+    private Map<TaskStatus, Map<String, Long>> dockerImages;
+    private Map<TaskStatus, Map<String, Long>> instanceTypes;
+    private Map<TaskStatus, Map<String, Long>> tags;
+}


### PR DESCRIPTION
This PR brings a new API method `POST /runs/charts` that returns runs counts collected by each unique value for owner, dockerImage, instanceType and tag run properties.
