### PR TITLE
Allow to specify a grace period for unavailable nodes directly for run

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/ScaleDownHandler.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/ScaleDownHandler.java
@@ -460,7 +460,7 @@ public class ScaleDownHandler {
                 .map(run -> MapUtils.emptyIfNull(run.getEnvVars()).get(NODE_UNAVAILABLE_GRACE_PERIOD_MINUTES))
                 .filter(StringUtils::isNotBlank)
                 .filter(StringUtils::isNumeric)
-                .map(Integer::valueOf)
+                .map(NumberUtils::toInt)
                 .map(Duration::ofMinutes)
                 .orElse(defaultDuration);
     }

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/ScaleDownHandler.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/ScaleDownHandler.java
@@ -461,6 +461,7 @@ public class ScaleDownHandler {
                 .filter(StringUtils::isNotBlank)
                 .filter(StringUtils::isNumeric)
                 .map(NumberUtils::toInt)
+                .filter(intValue -> intValue >= 0)
                 .map(Duration::ofMinutes)
                 .orElse(defaultDuration);
     }

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/ScaleDownHandler.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/autoscale/ScaleDownHandler.java
@@ -68,7 +68,7 @@ public class ScaleDownHandler {
     private static final Duration FALLBACK_CLUSTER_NODE_UNAVAILABLE_GRACE_PERIOD = Duration.ofMinutes(30);
     private static final String NODE_UNAVAILABLE_TAG = "NODE_UNAVAILABLE";
     private static final String NODE_AVAILABILITY_MONITOR = "NodeAvailabilityMonitor";
-    public static final String EMPTY_TERMINATION_STATE = "empty";
+    private static final String NODE_UNAVAILABLE_GRACE_PERIOD_MINUTES = "NODE_UNAVAILABLE_GRACE_PERIOD_MINUTES";
 
     private final AutoscalerService autoscalerService;
     private final CloudFacade cloudFacade;
@@ -164,16 +164,21 @@ public class ScaleDownHandler {
         return kubernetesManager.isNodeUnavailable(node);
     }
 
-    private void processUnavailableNode(final KubernetesClient client, final Node node, final Duration grace) {
+    private void processUnavailableNode(final KubernetesClient client, final Node node, final Duration defaultGrace) {
         final LocalDateTime now = DateUtils.nowUTC();
         final LocalDateTime timestamp = kubernetesManager.getLastConditionDateTime(node).orElse(now);
+
+        final Optional<PipelineRun> pipelineRun = findRun(node);
+        final Duration grace = findNodeUnavailableGraceDuration(pipelineRun, defaultGrace);
+
         if (now.minus(grace).isBefore(timestamp)) {
             if (isUnavailableNodeLabeled(client, node)) {
                 return;
             }
             log.debug("Marking unavailable node {} #{}", getNodeName(node), getNodeLabel(node));
             labelUnavailableNode(node, timestamp);
-            findRun(node).ifPresent(run -> {
+
+            pipelineRun.ifPresent(run -> {
                 labelUnavailableNodeRun(run, timestamp);
                 logUnavailableNodeRun(run, timestamp);
             });
@@ -447,5 +452,16 @@ public class ScaleDownHandler {
                 .map(preferenceManager::getPreference)
                 .filter(StringUtils::isNotEmpty)
                 .map(suffix -> name + suffix);
+    }
+
+    private Duration findNodeUnavailableGraceDuration(final Optional<PipelineRun> pipelineRun,
+                                                      final Duration defaultDuration) {
+        return pipelineRun
+                .map(run -> MapUtils.emptyIfNull(run.getEnvVars()).get(NODE_UNAVAILABLE_GRACE_PERIOD_MINUTES))
+                .filter(StringUtils::isNotBlank)
+                .filter(StringUtils::isNumeric)
+                .map(Integer::valueOf)
+                .map(Duration::ofMinutes)
+                .orElse(defaultDuration);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -459,6 +459,9 @@ public class SystemPreferences {
         "cluster.kill.not.matching.nodes", true, CLUSTER_GROUP, pass);
     public static final BooleanPreference CLUSTER_ENABLE_AUTOSCALING = new BooleanPreference(
         "cluster.enable.autoscaling", true, CLUSTER_GROUP, pass);
+    /**
+     * This preference can be specified for run directly viy NODE_UNAVAILABLE_GRACE_PERIOD_MINUTES system parameter.
+     */
     public static final IntPreference CLUSTER_NODE_UNAVAILABLE_GRACE_PERIOD_MINUTES = new IntPreference(
         "cluster.node.unavailable.grace.period.minutes", 30, CLUSTER_GROUP, isGreaterThanOrEquals(0));
 

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -460,7 +460,8 @@ public class SystemPreferences {
     public static final BooleanPreference CLUSTER_ENABLE_AUTOSCALING = new BooleanPreference(
         "cluster.enable.autoscaling", true, CLUSTER_GROUP, pass);
     /**
-     * This preference can be specified for run directly viy NODE_UNAVAILABLE_GRACE_PERIOD_MINUTES system parameter.
+     * Configures a grace period in minutes after which unavailable nodes are terminated.
+     * This value can be specified directly for run using NODE_UNAVAILABLE_GRACE_PERIOD_MINUTES system parameter.
      */
     public static final IntPreference CLUSTER_NODE_UNAVAILABLE_GRACE_PERIOD_MINUTES = new IntPreference(
         "cluster.node.unavailable.grace.period.minutes", 30, CLUSTER_GROUP, isGreaterThanOrEquals(0));

--- a/deploy/contents/install/preferences/launch.system.parameters.json
+++ b/deploy/contents/install/preferences/launch.system.parameters.json
@@ -629,8 +629,8 @@
     },
     {
         "name": "NODE_UNAVAILABLE_GRACE_PERIOD_MINUTES",
-        "type": "Indicates how many minutes node will be in running state with NODE_UNAVAILABLE state.",
-        "description": ".",
+        "type": "int",
+        "description": "Configures a grace period in minutes after which unavailable nodes are terminated.",
         "defaultValue": "30",
         "passToWorkers": true
     }

--- a/deploy/contents/install/preferences/launch.system.parameters.json
+++ b/deploy/contents/install/preferences/launch.system.parameters.json
@@ -626,5 +626,12 @@
         "description": "Specifies run network policy type. Allowed values are: common and internal.",
         "defaultValue": "common",
         "passToWorkers": true
+    },
+    {
+        "name": "NODE_UNAVAILABLE_GRACE_PERIOD_MINUTES",
+        "type": "Indicates how many minutes node will be in running state with NODE_UNAVAILABLE state.",
+        "description": ".",
+        "defaultValue": "30",
+        "passToWorkers": true
     }
 ]


### PR DESCRIPTION
Extends #3297

This PR brings ability to specify a grace period after which unavailable nodes are terminated for run using  NODE_UNAVAILABLE_GRACE_PERIOD_MINUTES system parameter.