### PR TITLE
Skip storage in SLS lifecycle if tagged with specific metadata

### DIFF
--- a/deploy/contents/install/app/configure-utils.sh
+++ b/deploy/contents/install/app/configure-utils.sh
@@ -757,7 +757,8 @@ read -r -d '' payload <<-EOF
         "batch_operation_job_report_bucket": "${CP_PREF_STORAGE_SYSTEM_STORAGE_NAME}",
         "batch_operation_job_report_bucket_prefix": "${CP_PREF_STORAGE_LIFECYCLE_SERVICE_REPORT_BUCKET_PREFIX:-storage-lifecycle-service/tagging-job-reports}",
         "batch_operation_job_poll_status_retry_count": 30,
-        "batch_operation_job_poll_status_sleep_sec": 5
+        "batch_operation_job_poll_status_sleep_sec": 5,
+        "storage_skip_archiving_tag": "disable_storage_lifecycle"
       }
     }
 }

--- a/storage-lifecycle-service/sls/app/synchronizer/archiving_synchronizer_impl.py
+++ b/storage-lifecycle-service/sls/app/synchronizer/archiving_synchronizer_impl.py
@@ -62,6 +62,12 @@ class StorageLifecycleArchivingSynchronizer(StorageLifecycleSynchronizer):
             )
             return
 
+        if not self.cloud_bridge.should_be_skipped(storage):
+            self.logger.log(
+                "Lifecycle rules are disabled for the storage {} with id {}, skipping.".format(storage.path, storage.id)
+            )
+            return
+
         file_listing_cache = {}
         self.cloud_bridge.prepare_bucket_if_needed(storage)
         for rule in rules:

--- a/storage-lifecycle-service/sls/pipelineapi/cp_api_interface_impl.py
+++ b/storage-lifecycle-service/sls/pipelineapi/cp_api_interface_impl.py
@@ -137,6 +137,13 @@ class RESTApiCloudPipelineDataSource(CloudPipelineDataSource):
     def load_entity_permissions(self, entity_id, entity_class):
         return self.api.get_entity_permissions(entity_id, entity_class)
 
+    def load_entity_metadata(self, entity_id, entity_class):
+        try:
+            return self.api.load_metadata(entity_id, entity_class)
+        except Exception as e:
+            self.logger.log("Fail to load metadata for class: {} by id: {}.".format(entity_class, str(entity_id)))
+            return None
+
     def _load_default_lifecycle_rule_notification(self):
         notification = self.load_notification(self.DATASTORAGE_LIFECYCLE_ACTION_NOTIFICATION_TYPE)
         default_rule_prolong_days = self.load_preference("storage.lifecycle.prolong.days")

--- a/workflows/pipe-common/pipeline/api/region.py
+++ b/workflows/pipe-common/pipeline/api/region.py
@@ -49,6 +49,11 @@ class StorageLifecycleServiceProperties:
         else:
             self.properties = {}
 
+    def get(self, key):
+        if self.properties and key in self.properties:
+            return self.properties[key]
+        return None
+
 
 class AWSRegionAttributes:
 


### PR DESCRIPTION
Related to #2721 
New `storage_skip_archiving_tag` option for SLS configuration or AWS region.

If storage is tagged with metadata key from `storage_skip_archiving_tag` option - such storage will be skipped from SLS lifecycle 