### PR TITLE
Implement paging in run logs retrieval methods

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
@@ -20,6 +20,7 @@ import com.epam.pipeline.aspect.run.QuotaLaunchCheck;
 import com.epam.pipeline.common.MessageConstants;
 import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.controller.PagedResult;
+import com.epam.pipeline.controller.ResultWriter;
 import com.epam.pipeline.controller.vo.FilterFieldVO;
 import com.epam.pipeline.controller.vo.PagingRunFilterExpressionVO;
 import com.epam.pipeline.controller.vo.PagingRunFilterVO;
@@ -27,6 +28,7 @@ import com.epam.pipeline.controller.vo.PipelineRunFilterVO;
 import com.epam.pipeline.controller.vo.PipelineRunServiceUrlVO;
 import com.epam.pipeline.controller.vo.TagsVO;
 import com.epam.pipeline.controller.vo.configuration.RunConfigurationWithEntitiesVO;
+import com.epam.pipeline.controller.vo.run.OffsetPagingFilter;
 import com.epam.pipeline.controller.vo.run.RunChartFilterVO;
 import com.epam.pipeline.dao.filter.FilterRunParameters;
 import com.epam.pipeline.entity.cluster.PipelineRunPrice;
@@ -149,8 +151,8 @@ public class RunApiService {
     }
 
     @PreAuthorize(RUN_ID_READ)
-    public List<RunLog> loadAllLogsByRunId(Long runId) {
-        return logManager.loadAllLogsByRunId(runId);
+    public List<RunLog> loadLogsByRunId(Long runId, OffsetPagingFilter filter) {
+        return logManager.loadLogsByRunId(runId, filter);
     }
 
     @PreAuthorize(RUN_ID_READ)
@@ -159,8 +161,8 @@ public class RunApiService {
     }
 
     @PreAuthorize(RUN_ID_READ)
-    public String downloadLogs(Long runId) {
-        return logManager.downloadLogs(runCRUDService.loadRunById(runId));
+    public ResultWriter exportLogs(Long runId) {
+        return logManager.exportLogs(runId);
     }
 
     @PreAuthorize(RUN_ID_READ)
@@ -181,8 +183,9 @@ public class RunApiService {
     }
 
     @PreAuthorize(RUN_ID_READ)
-    public List<RunLog> loadAllLogsForTask(Long runId, String taskName, String parameters) {
-        return logManager.loadAllLogsForTask(runId, taskName, parameters);
+    public List<RunLog> loadLogsForTask(Long runId, String taskName, String parameters,
+                                        OffsetPagingFilter filter) {
+        return logManager.loadLogsForTask(runId, taskName, parameters, filter);
     }
 
     @PreAuthorize("hasRole('ADMIN') OR @runPermissionManager.runStatusPermission(#runId, #status, 'EXECUTE')")

--- a/api/src/main/java/com/epam/pipeline/controller/ResultWriter.java
+++ b/api/src/main/java/com/epam/pipeline/controller/ResultWriter.java
@@ -27,7 +27,11 @@ public class ResultWriter {
     }
 
     public void write(final HttpServletResponse response) throws IOException {
-        consumer.accept(response.getOutputStream());
+        write(response.getOutputStream());
+    }
+
+    public void write(final OutputStream os) throws IOException {
+        consumer.accept(os);
     }
 
     public interface IOConsumer<T> {

--- a/api/src/main/java/com/epam/pipeline/controller/vo/run/OffsetPagingFilter.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/run/OffsetPagingFilter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2024 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.epam.pipeline.controller.vo.run;
+
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+
+@Value
+@Builder
+@RequiredArgsConstructor
+public class OffsetPagingFilter {
+    Integer offset;
+    Integer limit;
+    OffsetPagingOrder order;
+}

--- a/api/src/main/java/com/epam/pipeline/controller/vo/run/OffsetPagingOrder.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/run/OffsetPagingOrder.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017-2024 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.epam.pipeline.controller.vo.run;
+
+public enum OffsetPagingOrder {
+    ASC, DESC
+}

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/RunLogDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/RunLogDao.java
@@ -22,10 +22,15 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import com.epam.pipeline.controller.vo.run.OffsetPagingFilter;
 import com.epam.pipeline.entity.pipeline.PipelineTask;
 import com.epam.pipeline.entity.pipeline.RunLog;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
+import com.epam.pipeline.exception.pipeline.RunLogException;
+import com.epam.pipeline.utils.CommonUtils;
+import lombok.Setter;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.ListUtils;
 import org.springframework.beans.factory.annotation.Required;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -35,12 +40,14 @@ import org.springframework.transaction.annotation.Transactional;
 
 public class RunLogDao extends NamedParameterJdbcDaoSupport {
 
-    private String createPipelineLogQuery;
-    private String loadAllLogsByRunIdQuery;
-    private String loadAllLogsForTaskQuery;
-    private String loadTasksByRunIdQuery;
-    private String loadTaskForInstanceQuery;
-    private String loadTaskStatusQuery;
+    @Setter(onMethod_={@Required}) private String createPipelineLogQuery;
+    @Setter(onMethod_={@Required}) private String loadLogsByRunIdQueryDesc;
+    @Setter(onMethod_={@Required}) private String loadLogsByRunIdQueryAsc;
+    @Setter(onMethod_={@Required}) private String loadLogsForTaskQueryDesc;
+    @Setter(onMethod_={@Required}) private String loadLogsForTaskQueryAsc;
+    @Setter(onMethod_={@Required}) private String loadTasksByRunIdQuery;
+    @Setter(onMethod_={@Required}) private String loadTaskForInstanceQuery;
+    @Setter(onMethod_={@Required}) private String loadTaskStatusQuery;
 
     @Transactional(propagation = Propagation.MANDATORY)
     public void createRunLog(RunLog runLog) {
@@ -49,24 +56,51 @@ public class RunLogDao extends NamedParameterJdbcDaoSupport {
     }
 
     @Transactional(propagation = Propagation.SUPPORTS)
-    public List<RunLog> loadAllLogsForRun(Long runId) {
-        return getJdbcTemplate().query(loadAllLogsByRunIdQuery,
-                PipelineLogParameters.getRowMapper(), runId);
+    public List<RunLog> loadLogsForRun(Long runId, OffsetPagingFilter filter) {
+        MapSqlParameterSource params = new MapSqlParameterSource();
+        params.addValue(PipelineLogParameters.RUN_ID.name(), runId);
+        params.addValue(PipelineLogParameters.OFFSET.name(), filter.getOffset());
+        params.addValue(PipelineLogParameters.LIMIT.name(), filter.getLimit());
+        switch (filter.getOrder()) {
+            case ASC:
+                return ListUtils.emptyIfNull(getNamedParameterJdbcTemplate()
+                        .query(loadLogsByRunIdQueryAsc, params, PipelineLogParameters.getRowMapper()));
+            case DESC:
+                return CommonUtils.reversed(ListUtils.emptyIfNull(getNamedParameterJdbcTemplate()
+                        .query(loadLogsByRunIdQueryDesc, params, PipelineLogParameters.getRowMapper())));
+            default:
+                throw new RunLogException("Unsupported order");
+        }
     }
 
     @Transactional(propagation = Propagation.SUPPORTS)
-    public List<RunLog> loadAllLogsForTask(Long runId, String taskName) {
-        return getJdbcTemplate().query(loadAllLogsForTaskQuery,
-                PipelineLogParameters.getRowMapper(), runId, taskName);
+    public List<RunLog> loadLogsForTask(Long runId, String taskName, OffsetPagingFilter filter) {
+        MapSqlParameterSource params = new MapSqlParameterSource();
+        params.addValue(PipelineLogParameters.RUN_ID.name(), runId);
+        params.addValue(PipelineLogParameters.TASK_NAME.name(), taskName);
+        params.addValue(PipelineLogParameters.OFFSET.name(), filter.getOffset());
+        params.addValue(PipelineLogParameters.LIMIT.name(), filter.getLimit());
+        switch (filter.getOrder()) {
+            case ASC:
+                return ListUtils.emptyIfNull(getNamedParameterJdbcTemplate()
+                        .query(loadLogsForTaskQueryAsc, params, PipelineLogParameters.getRowMapper()));
+            case DESC:
+                return CommonUtils.reversed(ListUtils.emptyIfNull(getNamedParameterJdbcTemplate()
+                        .query(loadLogsForTaskQueryDesc, params, PipelineLogParameters.getRowMapper())));
+            default:
+                throw new RunLogException("Unsupported order");
+        }
     }
 
     @Transactional(propagation = Propagation.SUPPORTS)
     public List<PipelineTask> loadTasksForRun(Long runId) {
         MapSqlParameterSource params = new MapSqlParameterSource();
         params.addValue(PipelineLogParameters.RUN_ID.name(), runId);
-        List<PipelineTask> result =  getNamedParameterJdbcTemplate().query(loadTasksByRunIdQuery,
-                params, PipelineLogParameters.getTaskRowMapper(true));
-        return result.stream().filter(Objects::nonNull).collect(Collectors.toList());
+        return ListUtils.emptyIfNull(getNamedParameterJdbcTemplate()
+                .query(loadTasksByRunIdQuery, params, PipelineLogParameters.getTaskRowMapper(true)))
+                .stream()
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     @Transactional(propagation = Propagation.SUPPORTS)
@@ -89,6 +123,8 @@ public class RunLogDao extends NamedParameterJdbcDaoSupport {
         LOG_TEXT,
         TASK_NAME,
         INSTANCE,
+        OFFSET,
+        LIMIT,
         CREATED,
         STARTED,
         FINISHED;
@@ -158,35 +194,4 @@ public class RunLogDao extends NamedParameterJdbcDaoSupport {
             };
         }
     }
-
-    @Required
-    public void setCreatePipelineLogQuery(String createPipelineLogQuery) {
-        this.createPipelineLogQuery = createPipelineLogQuery;
-    }
-
-    @Required
-    public void setLoadAllLogsByRunIdQuery(String loadAllLogsByRunIdQuery) {
-        this.loadAllLogsByRunIdQuery = loadAllLogsByRunIdQuery;
-    }
-
-    @Required
-    public void setLoadTasksByRunIdQuery(String loadTasksByRunIdQuery) {
-        this.loadTasksByRunIdQuery = loadTasksByRunIdQuery;
-    }
-
-    @Required
-    public void setLoadAllLogsForTaskQuery(String loadAllLogsForTaskQuery) {
-        this.loadAllLogsForTaskQuery = loadAllLogsForTaskQuery;
-    }
-
-    @Required
-    public void setLoadTaskForInstanceQuery(String loadTaskForInstanceQuery) {
-        this.loadTaskForInstanceQuery = loadTaskForInstanceQuery;
-    }
-
-    @Required
-    public void setLoadTaskStatusQuery(String loadTaskStatusQuery) {
-        this.loadTaskStatusQuery = loadTaskStatusQuery;
-    }
-
 }

--- a/api/src/main/java/com/epam/pipeline/exception/pipeline/RunLogException.java
+++ b/api/src/main/java/com/epam/pipeline/exception/pipeline/RunLogException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2024 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.epam.pipeline.exception.pipeline;
+
+public class RunLogException extends RuntimeException {
+
+    public RunLogException(final String message) {
+        super(message);
+    }
+
+    public RunLogException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PagingRunLogExporter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PagingRunLogExporter.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017-2024 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.epam.pipeline.manager.pipeline;
+
+import com.epam.pipeline.controller.vo.run.OffsetPagingFilter;
+import com.epam.pipeline.controller.vo.run.OffsetPagingOrder;
+import com.epam.pipeline.dao.pipeline.RunLogDao;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.pipeline.RunLog;
+import com.epam.pipeline.exception.pipeline.RunLogException;
+import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.epam.pipeline.manager.preference.SystemPreferences;
+import com.epam.pipeline.utils.LogsFormatter;
+import com.epam.pipeline.utils.StreamUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.List;
+import java.util.stream.Stream;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PagingRunLogExporter implements RunLogExporter {
+
+    private final RunLogDao runLogDao;
+    private final PreferenceManager preferenceManager;
+
+    private final LogsFormatter logsFormatter = new LogsFormatter();
+
+    public void export(final PipelineRun run, final Writer writer) {
+        log.info("Exporting run logs #{}...", run.getId());
+        try {
+            logs(run).forEach(entry -> write(writer, entry));
+        } finally {
+            try {
+                writer.flush();
+            } catch (IOException e) {
+                log.error(e.getMessage(), e);
+            }
+        }
+    }
+
+    private void write(final Writer writer, final RunLog entry) {
+        try {
+            writer.write(logsFormatter.formatLog(entry));
+        } catch (IOException e) {
+            log.error(e.getMessage(), e);
+            throw new RunLogException(e.getMessage(), e);
+        }
+    }
+
+    private Stream<RunLog> logs(final PipelineRun run) {
+        final int limit = getRunLogDefaultLimit();
+        return StreamUtils.takeWhile(logsPages(run, limit), page -> page.size() >= limit)
+                .peek(page -> log.info("Writing run logs #{} ({} lines)...",
+                        run.getId(), page.size()))
+                .flatMap(List::stream);
+    }
+
+    private Stream<List<RunLog>> logsPages(final PipelineRun run, final int limit) {
+        return Stream.iterate(0, offset -> offset + limit)
+                .map(offset -> new OffsetPagingFilter(offset, limit, OffsetPagingOrder.ASC))
+                .peek(filter -> log.info("Reading run logs #{} ({} lines starting from {})...",
+                        run.getId(), filter.getLimit(), filter.getOffset()))
+                .map(filter -> runLogDao.loadLogsForRun(run.getId(), filter));
+    }
+
+    private int getRunLogDefaultLimit() {
+        return preferenceManager.findPreference(SystemPreferences.SYSTEM_LIMIT_LOG_LINES)
+                .orElseGet(SystemPreferences.SYSTEM_LIMIT_LOG_LINES::getDefaultValue);
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunDockerOperationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunDockerOperationManager.java
@@ -264,7 +264,7 @@ public class PipelineRunDockerOperationManager {
         if (!lastStatusUpdateDate.isPresent()) {
             return false;
         }
-        final List<RunLog> runLogs = runLogManager.loadAllLogsForTask(run.getId(),
+        final List<RunLog> runLogs = runLogManager.loadLogsForTask(run.getId(),
                 DockerContainerOperationManager.PAUSE_RUN_TASK);
         final Optional<Date> lastSuccessTaskDate = ListUtils.emptyIfNull(runLogs).stream()
                 .filter(log -> TaskStatus.SUCCESS.equals(log.getStatus()))

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/RunLogExporter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/RunLogExporter.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017-2024 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.epam.pipeline.manager.pipeline;
+
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+
+import java.io.Writer;
+
+public interface RunLogExporter {
+
+    void export(PipelineRun run, Writer writer);
+}

--- a/api/src/main/java/com/epam/pipeline/utils/CommonUtils.java
+++ b/api/src/main/java/com/epam/pipeline/utils/CommonUtils.java
@@ -119,4 +119,10 @@ public final class CommonUtils {
         result.removeAll(right);
         return result;
     }
+
+    public static <T> List<T> reversed(final List<T> items) {
+        final List<T> result = new ArrayList<>(items);
+        Collections.reverse(result);
+        return result;
+    }
 }

--- a/api/src/main/resources/dao/pipeline-run-log-dao.xml
+++ b/api/src/main/resources/dao/pipeline-run-log-dao.xml
@@ -39,7 +39,7 @@
                 ]]>
             </value>
         </property>
-        <property name="loadAllLogsByRunIdQuery">
+        <property name="loadLogsByRunIdQueryDesc">
             <value>
                 <![CDATA[
                     SELECT
@@ -52,13 +52,15 @@
                     FROM
                         pipeline.pipeline_run_log
                     WHERE
-                        run_id = ?
+                        run_id = :RUN_ID
                     ORDER BY
-                        log_date
+                        log_date DESC
+                    LIMIT :LIMIT
+                    OFFSET :OFFSET
                 ]]>
             </value>
         </property>
-        <property name="loadAllLogsForTaskQuery">
+        <property name="loadLogsByRunIdQueryAsc">
             <value>
                 <![CDATA[
                     SELECT
@@ -71,9 +73,53 @@
                     FROM
                         pipeline.pipeline_run_log
                     WHERE
-                        run_id = ? and task_name = ?
+                        run_id = :RUN_ID
                     ORDER BY
-                        log_date
+                        log_date ASC
+                    LIMIT :LIMIT
+                    OFFSET :OFFSET
+                ]]>
+            </value>
+        </property>
+        <property name="loadLogsForTaskQueryDesc">
+            <value>
+                <![CDATA[
+                    SELECT
+                        run_id,
+                        log_date,
+                        status,
+                        log_text,
+                        task_name,
+                        instance
+                    FROM
+                        pipeline.pipeline_run_log
+                    WHERE
+                        run_id = :RUN_ID and task_name = :TASK_NAME
+                    ORDER BY
+                        log_date DESC
+                    LIMIT :LIMIT
+                    OFFSET :OFFSET
+                ]]>
+            </value>
+        </property>
+        <property name="loadLogsForTaskQueryAsc">
+            <value>
+                <![CDATA[
+                    SELECT
+                        run_id,
+                        log_date,
+                        status,
+                        log_text,
+                        task_name,
+                        instance
+                    FROM
+                        pipeline.pipeline_run_log
+                    WHERE
+                        run_id = :RUN_ID and task_name = :TASK_NAME
+                    ORDER BY
+                        log_date ASC
+                    LIMIT :LIMIT
+                    OFFSET :OFFSET
                 ]]>
             </value>
         </property>

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunDockerOperationManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunDockerOperationManagerTest.java
@@ -197,13 +197,13 @@ public class PipelineRunDockerOperationManagerTest {
         when(runStatusManager.loadRunStatus(RUN_ID)).thenReturn(Arrays.asList(
                 pausingRunStatus(convertDateToLocalDateTime(DATE_1)),
                 pausingRunStatus(convertDateToLocalDateTime(DATE_2))));
-        when(runLogManager.loadAllLogsForTask(RUN_ID, PAUSE_TASK_NAME)).thenReturn(Arrays.asList(
+        when(runLogManager.loadLogsForTask(RUN_ID, PAUSE_TASK_NAME)).thenReturn(Arrays.asList(
                 pauseRunLog(DATE_1, TaskStatus.SUCCESS), pauseRunLog(DATE_3, TaskStatus.SUCCESS)));
     }
 
     private void mockNoNeedToRerunPauseSituation() {
         when(runStatusManager.loadRunStatus(RUN_ID)).thenReturn(Collections.singletonList(
                 pausingRunStatus(convertDateToLocalDateTime(DATE_1))));
-        when(runLogManager.loadAllLogsForTask(RUN_ID, PAUSE_TASK_NAME)).thenReturn(Collections.emptyList());
+        when(runLogManager.loadLogsForTask(RUN_ID, PAUSE_TASK_NAME)).thenReturn(Collections.emptyList());
     }
 }

--- a/core/src/main/java/com/epam/pipeline/utils/IteratorUtils.java
+++ b/core/src/main/java/com/epam/pipeline/utils/IteratorUtils.java
@@ -2,6 +2,7 @@ package com.epam.pipeline.utils;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Predicate;
 
 public final class IteratorUtils {
 
@@ -13,5 +14,9 @@ public final class IteratorUtils {
 
     public static <T> Iterator<List<T>> chunked(final Iterator<T> iterator, final int chunkSize) {
         return new ChunkedIterator<>(iterator, chunkSize);
+    }
+
+    public static <T> Iterator<T> takeWhile(final Iterator<T> iterator, final Predicate<T> predicate) {
+        return new TakeWhileIterator<>(iterator, predicate);
     }
 }

--- a/core/src/main/java/com/epam/pipeline/utils/StreamUtils.java
+++ b/core/src/main/java/com/epam/pipeline/utils/StreamUtils.java
@@ -56,4 +56,8 @@ public final class StreamUtils {
         return t -> seen.add(keyExtractor.apply(t));
     }
 
+    public static <T> Stream<T> takeWhile(final Stream<T> stream, final Predicate<T> predicate) {
+        return from(IteratorUtils.takeWhile(stream.iterator(), predicate));
+    }
+
 }

--- a/core/src/main/java/com/epam/pipeline/utils/TakeWhileIterator.java
+++ b/core/src/main/java/com/epam/pipeline/utils/TakeWhileIterator.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2024 EPAM Systems, Inc. (https://www.epam.com/)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.epam.pipeline.utils;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.Iterator;
+import java.util.function.Predicate;
+
+@RequiredArgsConstructor
+public class TakeWhileIterator<T> implements Iterator<T> {
+
+    private final Iterator<T> iterator;
+    private final Predicate<T> predicate;
+
+    private T item;
+
+    @Override
+    public boolean hasNext() {
+        return item == null || predicate.test(item);
+    }
+
+    @Override
+    public T next() {
+        item = iterator.next();
+        return item;
+    }
+}


### PR DESCRIPTION
Relates #3562.

The pull request introduces paging in run logs retrieval methods. The changes are backward-compatible so that any clients (GUI, Billing) will still be able to work as before to retrieve a first page.

The following system preference is used for default page size:
- `system.log.line.limit` specifies default page size. Defaults to *8000*.

Additionally, run logs exporting method has been reworked to use paging.
