### PR TITLE
Automatically refresh API tokens in pipe common

### DIFF
--- a/workflows/pipe-common/pipeline/api/token.py
+++ b/workflows/pipe-common/pipeline/api/token.py
@@ -1,0 +1,148 @@
+#  Copyright 2017-2024 EPAM Systems, Inc. (https://www.epam.com/)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import json
+import logging
+import os
+import time
+from threading import Thread
+
+import requests
+
+
+class TokenError(RuntimeError):
+    pass
+
+
+class Token:
+
+    def get(self):
+        pass
+
+
+class StaticToken(Token):
+
+    def __init__(self, value=None):
+        self._value = value or os.environ['API_TOKEN']
+
+    def get(self):
+        return self._value
+
+
+class RefreshingToken(Token):
+
+    def __init__(self, value=None, api_url=None, refresh_duration=None, refresh_factor=None):
+        self._value = value or os.environ['API_TOKEN']
+        self._daemon = _RefreshingTokenDaemon(token=self, api_url=api_url,
+                                              refresh_duration=refresh_duration, refresh_factor=refresh_factor)
+        self._daemon.start()
+
+    def get(self):
+        return self._value
+
+    def set(self, token):
+        self._value = token
+
+
+class _RefreshingTokenDaemon:
+
+    def __init__(self, token, api_url=None, refresh_duration=None, refresh_factor=None):
+        self._token = token
+        self._api_url = api_url or os.environ['API']
+        self._refresh_duration = refresh_duration or int(os.getenv('CP_CAP_API_TOKEN_REFRESH_DURATION', 2592000))
+        self._refresh_factor = refresh_factor or float(os.getenv('CP_CAP_API_TOKEN_REFRESH_FACTOR', 0.75))
+        self._logger = self._get_logger()
+        self._thread = Thread(name='TokenRefreshing', target=self.run)
+        self._thread.daemon = True
+        self._polling_delay = 30
+        self._polling_connection_timeout = 30
+
+    def _get_logger(self):
+        logging_dir = os.getenv('CP_CAP_API_TOKEN_REFRESH_LOG_DIR', os.getenv('LOG_DIR', '/var/log'))
+        logging_level_file = os.getenv('CP_CAP_API_TOKEN_REFRESH_LOGGING_LEVEL_FILE', 'DEBUG')
+        logging_format = os.getenv('CP_CAP_API_TOKEN_REFRESH_LOGGING_FORMAT',
+                                   '%(asctime)s:%(levelname)s:%(process)d: %(message)s')
+        logging_task = os.getenv('CP_CAP_API_TOKEN_REFRESH_LOGGING_TASK', 'TokenRefreshing')
+        logging_file = os.path.join(logging_dir, 'token_refreshing.log')
+
+        logging_formatter = logging.Formatter(logging_format)
+
+        logging_logger_root = logging.getLogger()
+        logging_logger_root.setLevel(logging.WARNING)
+
+        logging_logger = logging.getLogger(name=logging_task)
+        logging_logger.setLevel(logging.DEBUG)
+
+        if not logging_logger.handlers:
+            file_handler = logging.FileHandler(logging_file)
+            file_handler.setLevel(logging_level_file)
+            file_handler.setFormatter(logging_formatter)
+            logging_logger.addHandler(file_handler)
+
+        return logging_logger
+
+    def start(self):
+        self._thread.start()
+
+    def join(self, timeout=None):
+        self._logger.debug('Closing refreshing token daemon...')
+        self._thread.join(timeout=timeout)
+
+    def run(self):
+        self._logger.debug('Initiating token refresh daemon...')
+        while True:
+            try:
+                self._logger.debug('Refreshing token...')
+                self._token.set(self._retrieve_token())
+                self._logger.debug('Token has been refreshed')
+                time.sleep(int(self._refresh_duration * self._refresh_factor))
+            except KeyboardInterrupt:
+                self._logger.warning('Interrupted.')
+                raise
+            except Exception:
+                self._logger.warning('Token refresh daemon step has failed.', exc_info=True)
+
+    def _retrieve_token(self):
+        while True:
+            try:
+                token_json = self._request_token(duration=self._refresh_duration)
+                token = token_json.get('token')
+                if token:
+                    return token
+                self._logger.warning('Token has not been retrieved.')
+            except Exception:
+                self._logger.error('Token retrieval has failed.', exc_info=True)
+            time.sleep(self._polling_delay)
+
+    def _request_token(self, duration):
+        return self._request('GET', '/user/token?duration={}'.format(duration)) or {}
+
+    def _request(self, http_method, endpoint, data=None):
+        url = '{}/{}'.format(self._api_url, endpoint)
+        headers = {
+            'content-type': 'application/json',
+            'Authorization': 'Bearer {}'.format(self._token.get())
+        }
+        response = requests.request(method=http_method, url=url, data=json.dumps(data),
+                                    headers=headers, verify=False,
+                                    timeout=self._polling_connection_timeout)
+        if response.status_code != 200:
+            raise TokenError('API responded with http status %s.' % str(response.status_code))
+        response_data = response.json()
+        status = response_data.get('status') or 'ERROR'
+        message = response_data.get('message') or 'No message'
+        if status != 'OK':
+            raise TokenError('%s: %s' % (status, message))
+        return response_data.get('payload')
+

--- a/workflows/pipe-common/pipeline/hpc/autoscaler.py
+++ b/workflows/pipe-common/pipeline/hpc/autoscaler.py
@@ -14,6 +14,7 @@
 
 import functools
 import operator
+import os
 import threading
 import traceback
 from collections import namedtuple
@@ -214,6 +215,7 @@ class GridEngineScaleUpHandler:
         instance_dynamic_launch_params = {
             self.owner_param_name: owner
         }
+        # todo: Use api client here
         pipe_run_command = 'pipe run --yes --quiet ' \
                            '--instance-disk %s ' \
                            '--instance-type %s ' \
@@ -230,6 +232,7 @@ class GridEngineScaleUpHandler:
                               self._pipe_cli_price_type(self.price_type), self.region_id,
                               self._parameters_str(self.instance_launch_params),
                               self._parameters_str(instance_dynamic_launch_params))
+        os.environ['API_TOKEN'] = self.api.token.get()
         run_id = int(self.executor.execute_to_lines(pipe_run_command)[0])
         Logger.info('Additional worker #%s (%s) has been launched.' % (run_id, instance))
         return run_id
@@ -246,7 +249,7 @@ class GridEngineScaleUpHandler:
 
     def _retrieve_pod_name(self, run_id):
         Logger.info('Retrieving pod name of additional worker #%s...' % run_id)
-        run = self.api.load_run(run_id)
+        run = self.api.load_run_efficiently(run_id)
         if 'podId' in run:
             name = run['podId']
             Logger.info('Additional worker #%s pod name %s has been retrieved.' % (run_id, name))
@@ -261,7 +264,7 @@ class GridEngineScaleUpHandler:
         attempts = self.polling_timeout / self.polling_delay if self.polling_delay \
             else GridEngineScaleUpHandler._POLL_ATTEMPTS
         while attempts != 0:
-            run = self.api.load_run(run_id)
+            run = self.api.load_run_efficiently(run_id)
             if run.get('status', 'RUNNING') != 'RUNNING':
                 error_msg = 'Additional worker #%s is not running. Probably it has failed.' % run_id
                 Logger.warn(error_msg, crucial=True)
@@ -287,7 +290,7 @@ class GridEngineScaleUpHandler:
         attempts = self.polling_timeout / self.polling_delay if self.polling_delay \
             else GridEngineScaleUpHandler._POLL_ATTEMPTS
         while attempts > 0:
-            run = self.api.load_run(run_id)
+            run = self.api.load_run_efficiently(run_id)
             if run.get('status', 'RUNNING') != 'RUNNING':
                 error_msg = 'Additional worker #%s is not running. Probably it has failed.' % run_id
                 Logger.warn(error_msg, crucial=True)
@@ -338,17 +341,19 @@ class DoNothingScaleDownHandler:
 
 class GridEngineScaleDownHandler:
 
-    def __init__(self, cmd_executor, grid_engine, common_utils):
+    def __init__(self, cmd_executor, api, grid_engine, common_utils):
         """
         Grid engine scale down handler.
 
         Manages additional workers scaling down.
 
         :param cmd_executor: Cmd executor.
+        :param api: Cloud pipeline client.
         :param grid_engine: Grid engine client.
         :param common_utils: helpful stuff
         """
         self.executor = cmd_executor
+        self.api = api
         self.grid_engine = grid_engine
         self.common_utils = common_utils
 
@@ -387,7 +392,7 @@ class GridEngineScaleDownHandler:
     def _stop_run(self, host):
         run_id = self.common_utils.get_run_id_from_host(host)
         Logger.info('Stopping run #%s...' % run_id)
-        self.executor.execute('pipe stop --yes %s' % run_id)
+        self.api.stop_run(run_id)
         Logger.info('Run #%s was stopped.' % run_id)
 
     def _remove_host_from_hosts(self, host):

--- a/workflows/pipe-common/scripts/autoscale_grid_engine.py
+++ b/workflows/pipe-common/scripts/autoscale_grid_engine.py
@@ -55,6 +55,7 @@ from pipeline.hpc.resource import ResourceSupply
 from pipeline.hpc.utils import Clock, ScaleCommonUtils
 from pipeline.hpc.valid import GracePeriodWorkerValidatorHandler
 from pipeline.api.api import PipelineAPI
+from pipeline.api.token import RefreshingToken
 from pipeline.log.logger import RunLogger, TaskLogger, LevelLogger, LocalLogger, ResilientLogger
 from pipeline.utils.path import mkdir
 
@@ -196,7 +197,7 @@ def get_daemon():
         logging_level_run = 'DEBUG'
 
     # TODO: Git rid of CloudPipelineAPI usage in favor of PipelineAPI
-    pipe = PipelineAPI(api_url=api_url, log_dir=logging_dir)
+    pipe = PipelineAPI(api_url=api_url, log_dir=logging_dir, token=RefreshingToken())
     api = CloudPipelineAPI(pipe=pipe)
 
     mkdir(os.path.dirname(logging_file))

--- a/workflows/pipe-common/scripts/sync_users.py
+++ b/workflows/pipe-common/scripts/sync_users.py
@@ -25,6 +25,7 @@ import sys
 import time
 
 from pipeline.api import PipelineAPI, APIError
+from pipeline.api.token import RefreshingToken
 from pipeline.log.logger import LocalLogger, RunLogger, TaskLogger, LevelLogger, ResilientLogger
 from pipeline.utils.account import create_user
 from pipeline.utils.path import mkdir
@@ -457,7 +458,7 @@ def get_daemon():
         file_handler.setFormatter(logging_formatter)
         logging_logger.addHandler(file_handler)
 
-    api = PipelineAPI(api_url=api_url, log_dir=logging_dir)
+    api = PipelineAPI(api_url=api_url, log_dir=logging_dir, token=RefreshingToken())
     logger = RunLogger(api=api, run_id=run_id)
     logger = TaskLogger(task=logging_task, inner=logger)
     logger = LevelLogger(level=logging_level_run, inner=logger)


### PR DESCRIPTION
Relates #3583.

Adds support for refreshable API tokens to pipe common. Additionally, it updates grid engine autoscaler and user synchronisation to use the new functionality.

```python
from pipeline.api.api import PipelineAPI
from pipeline.api.token import StaticToken, RefreshingToken

# using a static token which will eventually expire
api = PipelineAPI()
api = PipelineAPI(token=StaticToken())

# using a refreshing token which will automatically update itself
api = PipelineAPI(token=RefreshingToken())
```