### PR TITLE
Use ssh extra args during cluster workers initialization

### DIFF
--- a/deploy/contents/install/preferences/launch.system.parameters.json
+++ b/deploy/contents/install/preferences/launch.system.parameters.json
@@ -633,5 +633,12 @@
         "description": "Configures a grace period in minutes after which unavailable nodes are terminated.",
         "defaultValue": "30",
         "passToWorkers": true
+    },
+    {
+        "name": "CP_SSH_EXTRA_ARGS",
+        "type": "string",
+        "description": "Configures ssh extra args.",
+        "defaultValue": "-o ConnectTimeout=10 -o ConnectionAttempts=30 -v",
+        "passToWorkers": true
     }
 ]

--- a/workflows/pipe-common/shell/kube_setup_worker
+++ b/workflows/pipe-common/shell/kube_setup_worker
@@ -40,7 +40,7 @@ unset KUBERNETES_SERVICE_HOST
 unset KUBERNETES_SERVICE_PORT
 
 # Kubeadm config
-CP_CAP_KUBE_MASTER_TOKEN=$(ssh $_kube_master_ip "set -o pipefail; http_proxy= https_proxy= kubeadm token list | tail -n 1 | cut -f1 -d' '")
+CP_CAP_KUBE_MASTER_TOKEN=$(ssh $CP_SSH_EXTRA_ARGS $_kube_master_ip "set -o pipefail; http_proxy= https_proxy= kubeadm token list | tail -n 1 | cut -f1 -d' '")
 if [ $? -ne 0 ]; then
     pipe_log_fail "Cannot get the kubeadm authentication token from the master" "$_kube_worker_setup_task"
     exit 1

--- a/workflows/pipe-common/shell/sge_setup_sbm_host
+++ b/workflows/pipe-common/shell/sge_setup_sbm_host
@@ -21,7 +21,7 @@ add_submission_host() {
     _MASTER_NAME=$1
 
     if [ "$LINUX_DISTRIBUTION" = "debian" ]; then
-        ssh -o "StrictHostKeyChecking=no" -t "$_MASTER_NAME" bash -c "'
+        ssh $CP_SSH_EXTRA_ARGS -o "StrictHostKeyChecking=no" -t "$_MASTER_NAME" bash -c "'
         qconf -as $HOSTNAME
         qconf -ah $HOSTNAME
         '"
@@ -30,7 +30,7 @@ add_submission_host() {
         check_last_exit_code $? "Host was added as a submission host to the SGE cluster" "Failed to add SGE submission host"
     elif [ "$LINUX_DISTRIBUTION" = "redhat" ]; then
         cd "$SGE_ROOT"
-        ssh -o "StrictHostKeyChecking=no" "$_MASTER_NAME" bash --login -c "'qconf -ah $HOSTNAME'"
+        ssh $CP_SSH_EXTRA_ARGS -o "StrictHostKeyChecking=no" "$_MASTER_NAME" bash --login -c "'qconf -ah $HOSTNAME'"
         copy_qmaster_configuration $_MASTER_NAME
         run_redhat_installation "submission host"
     fi

--- a/workflows/pipe-common/shell/sge_setup_worker
+++ b/workflows/pipe-common/shell/sge_setup_worker
@@ -31,7 +31,7 @@ add_worker() {
     local _MASTER_NAME=$4
 
     if [ "$LINUX_DISTRIBUTION" = "debian" ]; then
-        ssh -t "$_MASTER_NAME" bash -c "'
+        ssh $CP_SSH_EXTRA_ARGS -t "$_MASTER_NAME" bash -c "'
         # add to the execution host list
         TMPFILE=/tmp/sge.hostname-$HOSTNAME
         echo -e \"hostname $HOSTNAME\nload_scaling NONE\ncomplex_values NONE\nuser_lists NONE\nxuser_lists NONE\nprojects NONE\nxprojects NONE\nusage_scaling NONE\nreport_variables NONE\" > \$TMPFILE
@@ -58,7 +58,7 @@ add_worker() {
         '"
     elif [ "$LINUX_DISTRIBUTION" = "redhat" ]; then
         cd "$SGE_ROOT"
-        ssh -o "StrictHostKeyChecking=no" "$_MASTER_NAME" bash --login -c "'qconf -ah $HOSTNAME'"
+        ssh $CP_SSH_EXTRA_ARGS -o "StrictHostKeyChecking=no" "$_MASTER_NAME" bash --login -c "'qconf -ah $HOSTNAME'"
         copy_qmaster_configuration $_MASTER_NAME
         run_redhat_installation "worker"
 


### PR DESCRIPTION
Relates #3583.

The pull request brings support for the following system parameter:
- `CP_SSH_EXTRA_ARGS` specifies additional ssh arguments which will be used by cluster workers during cluster attachment. Defaults to **-o ConnectTimeout=10 -o ConnectionAttempts=30 -v**.
