### PR TITLE
Issue 3568 Fixing parsing for docker image history

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerClient.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerClient.java
@@ -207,11 +207,6 @@ public class DockerClient {
             }).collect(Collectors.toList());
     }
 
-    public List<String> getCommands(final DockerRegistry registry, final String imageName, final String tag) {
-        final RawImageDescription rawImage = getRawImageDescription(registry, imageName, tag, getAuthHeaders());
-        return DockerParsingUtils.getBuildHistory(rawImage);
-    }
-
     public Map<String, String> getImageLabels(final DockerRegistry registry, final String imageName, final String tag) {
         final RawImageDescription rawImage = getRawImageDescription(registry, imageName, tag, getAuthHeaders());
         return DockerParsingUtils.getLabels(rawImage);

--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerParsingUtils.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerParsingUtils.java
@@ -150,7 +150,7 @@ public final class DockerParsingUtils {
             } else if (COMMANDS.stream().noneMatch(command::startsWith)) {
                 command = String.format(RUN_TEMPLATE, command.trim());
             }
-            result.add(command.replaceAll("\\|[0-9]* ", StringUtils.EMPTY).trim());
+            result.add(command.replaceAll("\\|[0-9]+ ", StringUtils.EMPTY).trim());
         }
         if (StringUtils.isNotBlank(lastCmd)) {
             result.add(lastCmd);

--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerParsingUtils.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerParsingUtils.java
@@ -55,7 +55,8 @@ public final class DockerParsingUtils {
             .toFormatter();
     private static final String NOP_PREFIX = "#(nop)";
     private static final ObjectMapper MAPPER = new ObjectMapper();
-    private static final String ADD_TO_FROM_COMMAND_PATTERN = "ADD (file|multi|dir):[a-zA-Z0-9]* in /";
+    private static final String SPACE = " ";
+    private static final String ADD_TO_FROM_COMMAND_PATTERN = "(ADD|COPY) (file|multi|dir):[a-zA-Z0-9]* in /";
     private static final List<String> COMMANDS = Arrays.asList("ADD", "ARG", "CMD", "COPY", "ENTRYPOINT", "ENV",
             "EXPOSE", "FROM", "HEALTHCHECK", "LABEL", "MAINTAINER", "ONBUILD", "RUN", "SHELL", "STOPSIGNAL", "USER",
             "VOLUME", "WORKDIR");
@@ -91,7 +92,8 @@ public final class DockerParsingUtils {
             .filter(CollectionUtils::isNotEmpty)
             .map(commands -> String.join(StringUtils.EMPTY, commands))
             .map(DockerParsingUtils::cropNopPrefix)
-            .map(command -> command.replaceAll("\\t", StringUtils.EMPTY))
+            .map(String::trim)
+            .map(command -> command.replaceAll("\\t+", SPACE))
             .collect(Collectors.toList());
         Collections.reverse(commandsHistory);
         return commandsHistory;
@@ -111,7 +113,7 @@ public final class DockerParsingUtils {
         final List<String> result = new ArrayList<>();
 
         result.add(String.format(FROM_TEMPLATE, from));
-        // ONLY THE FIRST "ADD file:... / " line in the file has to be changed to "FROM <from>"
+        // ONLY THE FIRST "ADD file:... / " or "COPY file:... / " line in the file has to be changed to "FROM <from>"
         final int startIndex = prettifyCommand(commands.get(0)).matches(ADD_TO_FROM_COMMAND_PATTERN) ? 1 : 0;
 
         if (CollectionUtils.isEmpty(commands)) {
@@ -160,7 +162,7 @@ public final class DockerParsingUtils {
     }
 
     private static String prettifyCommand(final String command) {
-        return command.replaceAll("\\s+", " ").trim();
+        return command.replaceAll("\\s+", SPACE).trim();
     }
 
     public static String getLaunchPodPattern(final String command) {
@@ -209,7 +211,7 @@ public final class DockerParsingUtils {
     }
 
     private static LocalDateTime extractDateTime(String date, String time) {
-        return LocalDateTime.parse(date + " " + time, FORMATTER);
+        return LocalDateTime.parse(date + SPACE + time, FORMATTER);
     }
 
     private static <T> T getMinElement(Stream<T> stream, Comparator<T> comparator) {

--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerParsingUtils.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerParsingUtils.java
@@ -90,10 +90,10 @@ public final class DockerParsingUtils {
             .map(HistoryEntryV1::getContainerConfig)
             .map(ContainerConfig::getCommands)
             .filter(CollectionUtils::isNotEmpty)
-            .map(commands -> String.join(StringUtils.EMPTY, commands))
+            .map(commands -> String.join(SPACE, commands))
             .map(DockerParsingUtils::cropNopPrefix)
             .map(String::trim)
-            .map(command -> command.replaceAll("\\t+", SPACE))
+            .map(command -> command.replaceAll("\\s+", SPACE))
             .collect(Collectors.toList());
         Collections.reverse(commandsHistory);
         return commandsHistory;
@@ -135,7 +135,7 @@ public final class DockerParsingUtils {
                 args.add(command.replace(ARG, StringUtils.EMPTY).split("=")[0]);
             } else if (args.stream().anyMatch(command::contains)) {
                 for (String arg: args) {
-                    command = command.replaceAll(String.format("%s=[^ ]* ", arg), StringUtils.EMPTY);
+                    command = command.replaceAll(String.format(" %s=[^ ]* ", arg), SPACE);
                 }
             } else if (command.startsWith(CMD)) {
                 lastCmd = command;
@@ -150,7 +150,7 @@ public final class DockerParsingUtils {
             } else if (COMMANDS.stream().noneMatch(command::startsWith)) {
                 command = String.format(RUN_TEMPLATE, command.trim());
             }
-            result.add(command.replaceAll("\\|[0-9]+ ", StringUtils.EMPTY).trim());
+            result.add(prettifyCommand(command.replaceAll(" \\|[0-9]+ ", SPACE)));
         }
         if (StringUtils.isNotBlank(lastCmd)) {
             result.add(lastCmd);


### PR DESCRIPTION
#3568 
 Instead of replacing tabs with empty string - trim the string and replace tabs tabs with one space.
Should fix cases when we have resulted string in the history as:
```
|1LIBREOFFICE_DISTR_URL=/bin/sh-ccp /usr/NX/etc/server.cfg /usr/NX/etc/server.cfg.template
```