### PR TITLE
Issue 3596: Reading docker-manifest file from poit-in-time configuration

### DIFF
--- a/deploy/contents/install/app/docker-utils.sh
+++ b/deploy/contents/install/app/docker-utils.sh
@@ -121,25 +121,7 @@ function docker_push_manifest {
     local push_result=0
     while IFS=, read -r docker_name docker_pretty_name
     do
-    # Docker manifest in point-in-time configuration has a different structure than the default one.
-    #
-    # Point-in-time configuration:
-    #  - <docker-manifest-dir>/
-    #     - manifest.txt
-    #     - <docker-registry>/
-    #       - <library>/
-    #         - <tool>/
-    #           - icon.png
-    #           - ...
-    #           
-    # Default:
-    #  - <docker-manifest-dir>/
-    #     - manifest.txt
-    #     - <library>/
-    #       - <tool>/
-    #         - icon.png
-    #         - ...
-    #         
+    # Docker manifest dir can have different structure. For example, in point-in-time configuration has an additional layer of folders for the registry path.
     # So, due to this difference, we need to check which path to the tool metadata files to use:
         if  does_docker_tool_subdir_exist "$manifest_dir/$docker_name"; then
             local docker_tool_manifest_path="$manifest_dir/$docker_name"

--- a/deploy/contents/install/app/docker-utils.sh
+++ b/deploy/contents/install/app/docker-utils.sh
@@ -80,15 +80,6 @@ function docker_register_image {
     fi
 }
 
-function does_docker_tool_subdir_exist {
-    local docker_tool_subdir_path="$1"
-    if [ -d "$docker_tool_subdir_path" ]; then
-        echo "$docker_tool_subdir_path"
-        return 0
-    fi
-    return 1
-}
-
 function docker_push_manifest {
     local manifest_dir="$1"
     local registry_id="$2"
@@ -123,7 +114,7 @@ function docker_push_manifest {
     do
     # Docker manifest dir can have different structure. For example, in point-in-time configuration has an additional layer of folders for the registry path.
     # So, due to this difference, we need to check which path to the tool metadata files to use:
-        if  does_docker_tool_subdir_exist "$manifest_dir/$docker_name"; then
+        if [ -d "$manifest_dir/$docker_name" ]; then
             local docker_tool_manifest_path="$manifest_dir/$docker_name"
         else
             local docker_tool_manifest_path="$manifest_dir/$docker_pretty_name"

--- a/deploy/contents/install/app/install.sh
+++ b/deploy/contents/install/app/install.sh
@@ -683,7 +683,12 @@ if is_service_requested cp-docker-registry; then
         fi
 
         print_info "-> Push base tools images into the docker registry"
-        CP_DOCKER_MANIFEST_PATH=${CP_DOCKER_MANIFEST_PATH:-"$INSTALL_SCRIPT_PATH/../../dockers-manifest"}
+        if [ -z $CP_POINT_IN_TIME_CONFIGURATION_DIR ]; then 
+           CP_DOCKER_MANIFEST_PATH=${CP_DOCKER_MANIFEST_PATH:-"$INSTALL_SCRIPT_PATH/../../dockers-manifest"}
+        else 
+           CP_DOCKER_MANIFEST_PATH=${CP_DOCKER_MANIFEST_PATH:-"$CP_POINT_IN_TIME_CONFIGURATION_DIR/dockers-manifest"}
+        fi 
+
         if [ $CP_DOCKER_INSTALLED -eq 0 ] && [ -d "$CP_DOCKER_MANIFEST_PATH" ]; then
             docker_push_manifest "$(realpath $CP_DOCKER_MANIFEST_PATH)" "$CP_DOCKER_REGISTRY_ID"
             if [ $? -ne 0 ]; then


### PR DESCRIPTION
Added functionality to read docker-manifest file from point-in-time configuration that has different structure. Default docker-manifest file must be replaced by manifest from poin-in-time configuration directory before run redeploy process. 
Related to issue https://github.com/epam/cloud-pipeline/issues/3596