### PR TITLE
GPU Stat: support nvidia-smi for node reporter

### DIFF
--- a/deploy/contents/k8s/cp-node-reporter/cp-node-reporter.yaml
+++ b/deploy/contents/k8s/cp-node-reporter/cp-node-reporter.yaml
@@ -60,6 +60,10 @@ spec:
           value: "10"
         - name: CP_RESOURCES_DIR
           value: "/opt/node-reporter/resources"
+        - name: NVIDIA_VISIBLE_DEVICES
+          value: "all"
+        - name: NVIDIA_DRIVER_CAPABILITIES
+          value: "compute,utility"
       volumes:
       - name: cp-node-reporter-logs
         hostPath:


### PR DESCRIPTION
Relates #3576 

To support `nvidia-smi` for node reporter service the following environment variable shall be specified:
- `NVIDIA_VISIBLE_DEVICES=all`
- `NVIDIA_DRIVER_CAPABILITIES=compute,utility` 