### PR TITLE
Allow to limit `run as` for specific tools and pipelines

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/user/UserApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/user/UserApiService.java
@@ -18,6 +18,7 @@ package com.epam.pipeline.acl.user;
 
 import com.epam.pipeline.controller.vo.PipelineUserExportVO;
 import com.epam.pipeline.controller.vo.PipelineUserVO;
+import com.epam.pipeline.controller.vo.user.RunnerSidVO;
 import com.epam.pipeline.dto.user.OnlineUsers;
 import com.epam.pipeline.entity.info.UserInfo;
 import com.epam.pipeline.entity.security.JwtRawToken;
@@ -251,7 +252,7 @@ public class UserApiService {
      * @return the list of the runners
      */
     @PreAuthorize(ADMIN_ONLY)
-    public List<RunnerSid> updateRunners(final Long id, final List<RunnerSid> runners) {
+    public List<RunnerSidVO> updateRunners(final Long id, final List<RunnerSidVO> runners) {
         return userRunnersManager.saveRunners(id, runners);
     }
 

--- a/api/src/main/java/com/epam/pipeline/app/MappersConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/MappersConfiguration.java
@@ -38,6 +38,7 @@ import com.epam.pipeline.mapper.PermissionGrantVOMapper;
 import com.epam.pipeline.mapper.PipelineWithPermissionsMapper;
 import com.epam.pipeline.mapper.ToolGroupWithIssuesMapper;
 import com.epam.pipeline.mapper.user.OnlineUsersMapper;
+import com.epam.pipeline.mapper.user.RunnerSidMapper;
 import org.mapstruct.factory.Mappers;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -153,5 +154,10 @@ public class MappersConfiguration {
     @Bean
     public KubernetesMapper kubernetesMapper() {
         return Mappers.getMapper(KubernetesMapper.class);
+    }
+
+    @Bean
+    public RunnerSidMapper runnerSidMapper() {
+        return Mappers.getMapper(RunnerSidMapper.class);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -183,6 +183,10 @@ public final class MessageConstants {
     public static final String ERROR_STOP_START_INSTANCE_TERMINATED = "error.stop.start.instance.reason.terminated";
     public static final String WARN_INSTANCE_STOPPING = "warn.instance.stopping";
     public static final String ERROR_RUN_ALLOWED_SID_NOT_FOUND = "error.run.allowed.sid.not.found";
+    public static final String ERROR_RUN_AS_PIPELINES_NOT_ALLOWED = "error.run.as.pipelines.not.allowed";
+    public static final String ERROR_RUN_AS_PIPELINE_NOT_ALLOWED = "error.run.as.pipeline.not.allowed";
+    public static final String ERROR_RUN_AS_TOOLS_NOT_ALLOWED = "error.run.as.tools.not.allowed";
+    public static final String ERROR_RUN_AS_TOOL_NOT_ALLOWED = "error.run.as.tool.not.allowed";
     public static final String ERROR_RUN_ALLOWED_SID_NAME_NOT_FOUND = "error.run.allowed.sid.name.not.found";
     public static final String ERROR_IMAGE_NOT_FOUND_FOR_VERSIONED_STORAGE =
             "error.image.not.found.for.versioned.storage";

--- a/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
@@ -21,6 +21,7 @@ import com.epam.pipeline.controller.Result;
 import com.epam.pipeline.controller.vo.PipelineUserExportVO;
 import com.epam.pipeline.controller.vo.PipelineUserVO;
 import com.epam.pipeline.controller.vo.RouteType;
+import com.epam.pipeline.controller.vo.user.RunnerSidVO;
 import com.epam.pipeline.dto.user.OnlineUsers;
 import com.epam.pipeline.entity.info.UserInfo;
 import com.epam.pipeline.entity.security.JwtRawToken;
@@ -422,8 +423,8 @@ public class UserController extends AbstractRestController {
             notes = "Updates runners to user",
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
-    public Result<List<RunnerSid>> updateRunners(@PathVariable final Long id,
-                                                 @RequestBody final List<RunnerSid> runners) {
+    public Result<List<RunnerSidVO>> updateRunners(@PathVariable final Long id,
+                                                 @RequestBody final List<RunnerSidVO> runners) {
         return Result.success(userApiService.updateRunners(id, runners));
     }
 

--- a/api/src/main/java/com/epam/pipeline/controller/vo/user/RunnerSidVO.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/user/RunnerSidVO.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2024 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.controller.vo.user;
+
+import com.epam.pipeline.entity.pipeline.run.parameter.RunAccessType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RunnerSidVO {
+    private String name;
+    private boolean principal = true;
+    private RunAccessType accessType = RunAccessType.ENDPOINT;
+    private Boolean pipelinesAllowed;
+    private Boolean toolsAllowed;
+    private List<Long> pipelines;
+    private List<Long> tools;
+}

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunAsManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunAsManager.java
@@ -162,19 +162,27 @@ public class PipelineRunAsManager {
                 MessageConstants.ERROR_RUN_ALLOWED_SID_NOT_FOUND, runAsUser));
         final Long pipelineId = runVO.getPipelineId();
         if (Objects.nonNull(pipelineId)) {
-            Assert.isTrue(isNullOrTrue(allowedRunnerSid.getPipelinesAllowed()),
-                    messageHelper.getMessage(
-                            MessageConstants.ERROR_RUN_AS_PIPELINES_NOT_ALLOWED, currentUser, runAsUser));
-            if (CollectionUtils.isNotEmpty(allowedRunnerSid.getPipelines())) {
-                Assert.isTrue(allowedRunnerSid.getPipelines().contains(pipelineId),
-                        messageHelper.getMessage(MessageConstants.ERROR_RUN_AS_PIPELINE_NOT_ALLOWED,
-                                currentUser, pipelineId, runAsUser));
-            }
-            final PipelineConfiguration currentUserConfiguration = configurationManager.getPipelineConfiguration(runVO);
-            validateTool(currentUserConfiguration.getDockerImage(), runAsUser, allowedRunnerSid, currentUser);
+            validatePipeline(runVO, runAsUser, allowedRunnerSid, currentUser, pipelineId);
         } else {
             validateTool(runVO.getDockerImage(), runAsUser, allowedRunnerSid, currentUser);
         }
+    }
+
+    private void validatePipeline(final PipelineStart runVO,
+                                  final String runAsUser,
+                                  final RunnerSid allowedRunnerSid,
+                                  final String currentUser,
+                                  final Long pipelineId) {
+        Assert.isTrue(isNullOrTrue(allowedRunnerSid.getPipelinesAllowed()),
+                messageHelper.getMessage(
+                        MessageConstants.ERROR_RUN_AS_PIPELINES_NOT_ALLOWED, currentUser, runAsUser));
+        if (CollectionUtils.isNotEmpty(allowedRunnerSid.getPipelines())) {
+            Assert.isTrue(allowedRunnerSid.getPipelines().contains(pipelineId),
+                    messageHelper.getMessage(MessageConstants.ERROR_RUN_AS_PIPELINE_NOT_ALLOWED,
+                            currentUser, pipelineId, runAsUser));
+        }
+        final PipelineConfiguration currentUserConfiguration = configurationManager.getPipelineConfiguration(runVO);
+        validateTool(currentUserConfiguration.getDockerImage(), runAsUser, allowedRunnerSid, currentUser);
     }
 
     private void validateTool(final String dockerImage,

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunAsManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunAsManager.java
@@ -21,6 +21,7 @@ import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.entity.configuration.PipeConfValueVO;
 import com.epam.pipeline.entity.configuration.PipelineConfiguration;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.pipeline.Tool;
 import com.epam.pipeline.entity.pipeline.run.PipelineStart;
 import com.epam.pipeline.entity.pipeline.run.parameter.RunAccessType;
 import com.epam.pipeline.entity.pipeline.run.parameter.RunSid;
@@ -34,6 +35,7 @@ import com.epam.pipeline.manager.user.UserManager;
 import com.epam.pipeline.manager.user.UserRunnersManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.springframework.security.concurrent.DelegatingSecurityContextCallable;
@@ -46,6 +48,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -69,6 +72,7 @@ public class PipelineRunAsManager {
     private final CheckPermissionHelper permissionHelper;
     private final Executor runAsExecutor;
     private final PreferenceManager preferenceManager;
+    private final ToolManager toolManager;
 
     public boolean runAsAnotherUser(final PipelineStart runVO) {
         return !StringUtils.isEmpty(getRunAsUserName(runVO));
@@ -146,9 +150,45 @@ public class PipelineRunAsManager {
     private void configureRunnerSids(final PipelineStart runVO, final String runAsUser) {
         final String currentUser = authManager.getAuthorizedUser();
         final RunnerSid allowedRunnerSid = userRunnersManager.findRunnerSid(currentUser, runAsUser);
+        validateRunner(runVO, runAsUser, allowedRunnerSid, currentUser);
+        runVO.setRunSids(buildRunSids(runVO.getRunSids(), currentUser, allowedRunnerSid.getAccessType()));
+    }
+
+    private void validateRunner(final PipelineStart runVO,
+                                final String runAsUser,
+                                final RunnerSid allowedRunnerSid,
+                                final String currentUser) {
         Assert.notNull(allowedRunnerSid, messageHelper.getMessage(
                 MessageConstants.ERROR_RUN_ALLOWED_SID_NOT_FOUND, runAsUser));
-        runVO.setRunSids(buildRunSids(runVO.getRunSids(), currentUser, allowedRunnerSid.getAccessType()));
+        final Long pipelineId = runVO.getPipelineId();
+        if (Objects.nonNull(pipelineId)) {
+            Assert.isTrue(isNullOrTrue(allowedRunnerSid.getPipelinesAllowed()),
+                    messageHelper.getMessage(
+                            MessageConstants.ERROR_RUN_AS_PIPELINES_NOT_ALLOWED, currentUser, runAsUser));
+            if (CollectionUtils.isNotEmpty(allowedRunnerSid.getPipelines())) {
+                Assert.isTrue(allowedRunnerSid.getPipelines().contains(pipelineId),
+                        messageHelper.getMessage(MessageConstants.ERROR_RUN_AS_PIPELINE_NOT_ALLOWED,
+                                currentUser, pipelineId, runAsUser));
+            }
+            final PipelineConfiguration currentUserConfiguration = configurationManager.getPipelineConfiguration(runVO);
+            validateTool(currentUserConfiguration.getDockerImage(), runAsUser, allowedRunnerSid, currentUser);
+        } else {
+            validateTool(runVO.getDockerImage(), runAsUser, allowedRunnerSid, currentUser);
+        }
+    }
+
+    private void validateTool(final String dockerImage,
+                              final String runAsUser,
+                              final RunnerSid allowedRunnerSid,
+                              final String currentUser) {
+        Assert.isTrue(isNullOrTrue(allowedRunnerSid.getToolsAllowed()),
+                messageHelper.getMessage(MessageConstants.ERROR_RUN_AS_TOOLS_NOT_ALLOWED, currentUser, runAsUser));
+        if (CollectionUtils.isNotEmpty(allowedRunnerSid.getTools())) {
+            final Tool tool = toolManager.loadByNameOrId(dockerImage);
+            Assert.isTrue(allowedRunnerSid.getTools().contains(tool.getId()),
+                    messageHelper.getMessage(MessageConstants.ERROR_RUN_AS_TOOL_NOT_ALLOWED,
+                            currentUser, dockerImage, runAsUser));
+        }
     }
 
     private List<RunSid> buildRunSids(final List<RunSid> runSidsFromVO, final String currentUser,
@@ -162,5 +202,9 @@ public class PipelineRunAsManager {
         runSids.add(runSid);
 
         return new ArrayList<>(runSids);
+    }
+
+    private boolean isNullOrTrue(final Boolean value) {
+        return Objects.isNull(value) || value;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/mapper/user/RunnerSidMapper.java
+++ b/api/src/main/java/com/epam/pipeline/mapper/user/RunnerSidMapper.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017-2024 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.mapper.user;
+
+import com.epam.pipeline.controller.vo.user.RunnerSidVO;
+import com.epam.pipeline.entity.user.RunnerSid;
+import org.apache.commons.collections4.ListUtils;
+import org.mapstruct.AfterMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@Mapper(componentModel = "spring")
+public interface RunnerSidMapper {
+
+    @Mapping(target = "pipelines", ignore = true)
+    @Mapping(target = "tools", ignore = true)
+    RunnerSid toEntity(RunnerSidVO vo);
+
+    @AfterMapping
+    default void fillLists(final RunnerSidVO dto,
+                           final @MappingTarget RunnerSid entity) {
+        entity.setPipelinesList(collectIds(dto.getPipelines()));
+        entity.setToolsList(collectIds(dto.getTools()));
+    }
+
+    default String collectIds(List<Long> ids) {
+        return ListUtils.emptyIfNull(ids)
+                .stream()
+                .map(String::valueOf)
+                .collect(Collectors.joining(","));
+    }
+}

--- a/api/src/main/resources/db/migration/v2024.07.30_15.00__issue_3622_limit_run_as_permission.sql
+++ b/api/src/main/resources/db/migration/v2024.07.30_15.00__issue_3622_limit_run_as_permission.sql
@@ -1,0 +1,5 @@
+ALTER TABLE pipeline.pipeline_user_allowed_runners ADD COLUMN pipelines_allowed BOOL;
+ALTER TABLE pipeline.pipeline_user_allowed_runners ADD COLUMN tools_allowed BOOL;
+ALTER TABLE pipeline.pipeline_user_allowed_runners ADD COLUMN pipelines_list TEXT;
+ALTER TABLE pipeline.pipeline_user_allowed_runners ADD COLUMN tools_list TEXT;
+

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -137,6 +137,10 @@ info.log.pause.completed=[INFO] Pause run script completed successfully
 error.stop.start.instance.reason.terminated="Cannot {} instance: instance terminated"
 error.run.allowed.sid.not.found=Cannot find allowed user or group for runner ''{0}''
 error.run.allowed.sid.name.not.found=User or role shall be specified
+error.run.as.pipelines.not.allowed={0} is not allowed to run pipelines as {1}
+error.run.as.pipeline.not.allowed={0} is not allowed to run pipeline {1} as {2}
+error.run.as.tools.not.allowed={0} is not allowed to run tools as {1}
+error.run.as.tool.not.allowed={0} is not allowed to run tool {1} as {2}
 error.image.not.found.for.versioned.storage=Docker image must be specified for versioned storage
 warn.instance.stopping=Instance is still in STOPPING status
 

--- a/api/src/test/java/com/epam/pipeline/manager/user/UserRunnersManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/user/UserRunnersManagerTest.java
@@ -17,9 +17,11 @@
 package com.epam.pipeline.manager.user;
 
 import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.controller.vo.user.RunnerSidVO;
 import com.epam.pipeline.entity.user.PipelineUser;
 import com.epam.pipeline.entity.user.Role;
 import com.epam.pipeline.entity.user.RunnerSid;
+import com.epam.pipeline.mapper.user.RunnerSidMapper;
 import com.epam.pipeline.repository.user.PipelineUserRepository;
 import com.epam.pipeline.test.creator.user.UserCreatorUtils;
 import org.junit.Test;
@@ -44,9 +46,11 @@ public class UserRunnersManagerTest {
 
     private final PipelineUserRepository pipelineUserRepository = mock(PipelineUserRepository.class);
     private final MessageHelper messageHelper = mock(MessageHelper.class);
-    private final UserRunnersManager manager = new UserRunnersManager(pipelineUserRepository, messageHelper);
-
+    private final RunnerSidMapper runnerSidMapper = mock(RunnerSidMapper.class);
+    private final UserRunnersManager manager = new UserRunnersManager(
+            pipelineUserRepository, messageHelper, runnerSidMapper);
     private final RunnerSid userRunnerSid = RunnerSid.builder().name(USER_NAME).principal(true).build();
+    private final RunnerSidVO userRunnerSidVO = RunnerSidVO.builder().name(USER_NAME).principal(true).build();
     private final RunnerSid roleRunnerSid = RunnerSid.builder().name(ROLE_NAME).principal(false).build();
 
     @Test
@@ -61,11 +65,11 @@ public class UserRunnersManagerTest {
     @Test
     public void shouldSaveRunners() {
         when(pipelineUserRepository.findOne(ID)).thenReturn(UserCreatorUtils.getPipelineUser());
-
-        final List<RunnerSid> runners = manager.saveRunners(ID, Collections.singletonList(userRunnerSid));
+        when(runnerSidMapper.toEntity(userRunnerSidVO)).thenReturn(userRunnerSid);
+        final List<RunnerSidVO> runners = manager.saveRunners(ID, Collections.singletonList(userRunnerSidVO));
 
         verify(pipelineUserRepository).save((PipelineUser) any());
-        assertThat(runners).hasSize(1).contains(userRunnerSid);
+        assertThat(runners).hasSize(1).contains(userRunnerSidVO);
     }
 
     @Test

--- a/core/src/main/java/com/epam/pipeline/entity/user/RunnerSid.java
+++ b/core/src/main/java/com/epam/pipeline/entity/user/RunnerSid.java
@@ -17,15 +17,23 @@
 package com.epam.pipeline.entity.user;
 
 import com.epam.pipeline.entity.pipeline.run.parameter.RunAccessType;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 
 import javax.persistence.Embeddable;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Embeddable
 @Getter
@@ -40,4 +48,29 @@ public class RunnerSid {
 
     @Enumerated(EnumType.STRING)
     private RunAccessType accessType = RunAccessType.ENDPOINT;
+    private Boolean pipelinesAllowed;
+    private Boolean toolsAllowed;
+    @JsonIgnore
+    private String pipelinesList;
+    @JsonIgnore
+    private String toolsList;
+
+    public List<Long> getPipelines() {
+        return parse(pipelinesList);
+    }
+
+    public List<Long> getTools() {
+        return parse(toolsList);
+    }
+
+    private List<Long> parse(String pipelinesList) {
+        if (StringUtils.isBlank(pipelinesList)) {
+            return Collections.emptyList();
+        }
+        return Arrays.stream(pipelinesList.split(","))
+                .map(item -> StringUtils.defaultString(item, "").trim())
+                .filter(NumberUtils::isDigits)
+                .map(Long::parseLong)
+                .collect(Collectors.toList());
+    }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/user/RunnerSid.java
+++ b/core/src/main/java/com/epam/pipeline/entity/user/RunnerSid.java
@@ -18,7 +18,6 @@ package com.epam.pipeline.entity.user;
 
 import com.epam.pipeline.entity.pipeline.run.parameter.RunAccessType;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -40,7 +39,6 @@ import java.util.stream.Collectors;
 @Setter
 @NoArgsConstructor
 @Builder
-@AllArgsConstructor
 public class RunnerSid {
 
     private String name;
@@ -54,6 +52,23 @@ public class RunnerSid {
     private String pipelinesList;
     @JsonIgnore
     private String toolsList;
+
+    // All args constructor added manually due to incompatibility between jackson and lombok annotations
+    public RunnerSid(final String name,
+                     final boolean principal,
+                     final RunAccessType accessType,
+                     final Boolean pipelinesAllowed,
+                     final Boolean toolsAllowed,
+                     final String pipelinesList,
+                     final String toolsList) {
+        this.name = name;
+        this.principal = principal;
+        this.accessType = accessType;
+        this.pipelinesAllowed = pipelinesAllowed;
+        this.toolsAllowed = toolsAllowed;
+        this.pipelinesList = pipelinesList;
+        this.toolsList = toolsList;
+    }
 
     public List<Long> getPipelines() {
         return parse(pipelinesList);


### PR DESCRIPTION
Provides implementation for #3622 
- New fields added to `RunnerSid` entity, db scheme update
- Added tools/pipelines check when tool or pipeline is launched using `run as` feature

**_Note:_** Lists of allowed pipelines and tools are stored in DB as a comma-delimited list, as converting `@Embeddable` object to an `@Entity` would require more changes and potentially cause backwards compatibility issues.