### PR TITLE
Fix storage size calculation for GCP Buckets and Azure Blobs

### DIFF
--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/AzureBlobManager.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/AzureBlobManager.java
@@ -113,10 +113,6 @@ public class AzureBlobManager implements ObjectStorageFileManager {
         file.setPath(blob.name());
         file.setSize(blob.properties().contentLength());
         file.setChanged(ESConstants.FILE_DATE_FORMAT.format(Date.from(blob.properties().lastModified().toInstant())));
-        if (blob.properties().accessTier() != null) {
-            file.setLabels(Collections.singletonMap(ESConstants.STORAGE_CLASS_LABEL,
-                    blob.properties().accessTier().toString()));
-        }
         file.setTags(blob.metadata());
         return file;
     }

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/GsBucketFileManager.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/GsBucketFileManager.java
@@ -26,7 +26,6 @@ import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageClass;
 import com.google.cloud.storage.StorageOptions;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/GsBucketFileManager.java
+++ b/elasticsearch-agent/src/main/java/com/epam/pipeline/elasticsearchagent/service/impl/GsBucketFileManager.java
@@ -143,10 +143,6 @@ public class GsBucketFileManager implements ObjectStorageFileManager {
         file.setVersion(null);
         file.setDeleteMarker(null);
         final Map<String, String> labels = new HashMap<>(MapUtils.emptyIfNull(blob.getMetadata()));
-        final StorageClass storageClass = blob.getStorageClass();
-        if (storageClass != null) {
-            labels.put(ESConstants.STORAGE_CLASS_LABEL, storageClass.name());
-        }
         file.setLabels(labels);
         return file;
     }


### PR DESCRIPTION
With implementation of #2721 we are considering storage class of a file for size and cost reporting. Since SLS management is implemented only for AWS S3 storages, for GCP and AZ storages we should consider all files as being stored in default (`STANDARD`) tier.