### PR TITLE
API: Show GPU stats on the node utilization page - fixes

### DIFF
--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/HeapsterElasticRestHighLevelClient.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/HeapsterElasticRestHighLevelClient.java
@@ -50,7 +50,7 @@ public class HeapsterElasticRestHighLevelClient extends RestHighLevelClient {
         request.addParameter("allow_no_indices", "true");
         request.addParameter("expand_wildcards", "open,closed");
         request.addParameter("search_type", "query_then_fetch");
-        request.addParameter("ignore_unavailable", "false");
+        request.addParameter("ignore_unavailable", "true");
         request.addParameter("batched_reduce_size", "512");
         if (searchRequest.source() != null) {
             request.setEntity(createEntity(searchRequest.source(), XContentType.JSON));

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/client/pipeline/CloudPipelineAPI.java
@@ -17,6 +17,7 @@
 package com.epam.pipeline.client.pipeline;
 
 import com.epam.pipeline.entity.app.ApplicationInfo;
+import com.epam.pipeline.entity.cluster.AllowedInstanceAndPriceTypes;
 import com.epam.pipeline.entity.cluster.InstanceType;
 import com.epam.pipeline.entity.cluster.NodeDisk;
 import com.epam.pipeline.entity.cluster.NodeInstance;
@@ -296,6 +297,10 @@ public interface CloudPipelineAPI {
 
     @GET("cluster/instance/loadAll")
     Call<Result<List<InstanceType>>> loadAllInstanceTypes();
+
+    @GET("cluster/instance/allowed")
+    Call<Result<AllowedInstanceAndPriceTypes>> loadAllowedInstanceAndPriceTypesForRegion(
+            @Query(REGION_ID) Long regionId);
 
     @GET("cluster/node/{id}/disks")
     Call<Result<List<NodeDisk>>> loadNodeDisks(@Path(ID) String nodeId);

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/AllowedInstanceAndPriceTypes.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/cluster/AllowedInstanceAndPriceTypes.java
@@ -23,12 +23,12 @@ import lombok.Value;
 @Value
 public class AllowedInstanceAndPriceTypes {
 
-    @JsonProperty("allowed.instance.types")
-    private final List<InstanceType> allowedInstanceTypes;
+    @JsonProperty("cluster.allowed.instance.types")
+    List<InstanceType> allowedInstanceTypes;
 
-    @JsonProperty("allowed.instance.docker.types")
-    private final List<InstanceType> allowedInstanceDockerTypes;
+    @JsonProperty("cluster.allowed.instance.types.docker")
+    List<InstanceType> allowedInstanceDockerTypes;
 
-    @JsonProperty("allowed.price.types")
-    private final List<String> allowedPriceTypes;
+    @JsonProperty("cluster.allowed.price.types")
+    List<String> allowedPriceTypes;
 }

--- a/monitoring-service/src/main/java/com/epam/pipeline/monitor/rest/CloudPipelineAPIClient.java
+++ b/monitoring-service/src/main/java/com/epam/pipeline/monitor/rest/CloudPipelineAPIClient.java
@@ -19,10 +19,12 @@ package com.epam.pipeline.monitor.rest;
 import com.epam.pipeline.client.pipeline.CloudPipelineAPI;
 import com.epam.pipeline.client.pipeline.CloudPipelineApiBuilder;
 import com.epam.pipeline.client.pipeline.CloudPipelineApiExecutor;
+import com.epam.pipeline.entity.cluster.AllowedInstanceAndPriceTypes;
 import com.epam.pipeline.entity.cluster.InstanceType;
 import com.epam.pipeline.entity.cluster.pool.NodePool;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.preference.Preference;
+import com.epam.pipeline.entity.region.AbstractCloudRegion;
 import com.epam.pipeline.vo.cluster.pool.NodePoolUsage;
 import com.epam.pipeline.vo.user.OnlineUsers;
 import org.apache.commons.collections4.ListUtils;
@@ -94,6 +96,14 @@ public class CloudPipelineAPIClient {
 
     public List<InstanceType> loadAllInstanceTypes() {
         return ListUtils.emptyIfNull(executor.execute(cloudPipelineAPI.loadAllInstanceTypes()));
+    }
+
+    public List<? extends AbstractCloudRegion> loadAllRegions() {
+        return ListUtils.emptyIfNull(executor.execute(cloudPipelineAPI.loadAllRegions()));
+    }
+
+    public AllowedInstanceAndPriceTypes loadAllowedInstanceAndPriceTypesForRegion(final Long regionId) {
+        return executor.execute(cloudPipelineAPI.loadAllowedInstanceAndPriceTypesForRegion(regionId));
     }
 
     public void archiveRuns() {


### PR DESCRIPTION
relates #3576 

The current PR provides the following fixes:

- fix for non-existing indices
- fix for overlapping intervals
- fix for GPU instance types loading during monitoring process