### PR TITLE
Respect node memory reservations in grid engine autoscaler

### DIFF
--- a/workflows/pipe-common/pipeline/hpc/param.py
+++ b/workflows/pipe-common/pipeline/hpc/param.py
@@ -259,6 +259,9 @@ class GridEngineAdvancedAutoscalingParametersGroup(GridEngineParametersGroup):
         self.custom_requirements_purge = GridEngineParameter(
             name='CP_CAP_AUTOSCALE_CUSTOM_REQUIREMENTS_PURGE', type=PARAM_BOOL, default=False,
             help='Enables custom requirements purge.')
+        self.node_mem_reservations = GridEngineParameter(
+            name='CP_CAP_AUTOSCALE_NODE_MEM_RESERVATIONS', type=PARAM_BOOL, default=False,
+            help='Enables node memory reservations processing.')
         self.grid_engine = GridEngineParameter(
             name='CP_CAP_AUTOSCALE_GRID_ENGINE', type=PARAM_STR, default=None,
             help='Specifies grid engine type.\n'

--- a/workflows/pipe-common/test/test_reservation_instance_provider.py
+++ b/workflows/pipe-common/test/test_reservation_instance_provider.py
@@ -1,0 +1,128 @@
+# Copyright 2017-2022 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import sys
+from datetime import datetime
+
+import pytest
+from mock import MagicMock, Mock
+
+from pipeline.hpc.instance.provider import Instance
+from pipeline.hpc.pipe import CloudPipelineReservationInstanceProvider
+from pipeline.hpc.resource import ResourceSupply
+
+logging.basicConfig(level=logging.DEBUG, format='%(asctime)s [%(threadName)s] [%(levelname)s] %(message)s')
+
+unavailability_delay = 3600
+started = datetime(2018, 12, 21, 11, 00, 00)
+stopped = datetime(2018, 12, 21, 11, 5, 00)
+run_id = 12345
+worker_name = 'pipeline-12345'
+price_type = 'spot'
+
+inner_instance_provider = Mock()
+availability_manager = Mock()
+instance_provider = CloudPipelineReservationInstanceProvider(inner=inner_instance_provider,
+                                                             kube_mem_ratio=0.025,
+                                                             kube_mem_min_mib=256,
+                                                             kube_mem_max_mib=1024,
+                                                             system_mem_ratio=0.025,
+                                                             system_mem_min_mib=256,
+                                                             system_mem_max_mib=1024,
+                                                             extra_mem_ratio=0.05,
+                                                             extra_mem_min_mib=512,
+                                                             extra_mem_max_mib=sys.maxsize)
+
+instance_2cpu_0mem = Instance(name='t3.nano', price_type=price_type, cpu=2, mem=0, gpu=0)
+instance_2cpu_1mem = Instance(name='t3.micro', price_type=price_type, cpu=2, mem=1, gpu=0)
+instance_2cpu_2mem = Instance(name='t3.small', price_type=price_type, cpu=2, mem=2, gpu=0)
+instance_2cpu_4mem = Instance(name='t3.medium', price_type=price_type, cpu=2, mem=4, gpu=0)
+instance_2cpu_8mem = Instance(name='m5.large', price_type=price_type, cpu=2, mem=8, gpu=0)
+instance_4cpu_16mem = Instance(name='m5.xlarge', price_type=price_type, cpu=4, mem=16, gpu=0)
+instance_8cpu_32mem = Instance(name='m5.2xlarge', price_type=price_type, cpu=8, mem=32, gpu=0)
+instance_16cpu_64mem = Instance(name='m5.4xlarge', price_type=price_type, cpu=16, mem=64, gpu=0)
+instance_32cpu_128mem = Instance(name='m5.8xlarge', price_type=price_type, cpu=32, mem=128, gpu=0)
+instance_32cpu_244mem = Instance(name='p3.8xlarge', price_type=price_type, cpu=32, mem=244, gpu=0)
+instance_32cpu_256mem = Instance(name='r6i.8xlarge', price_type=price_type, cpu=32, mem=256, gpu=0)
+instance_48cpu_384mem = Instance(name='r5.12xlarge', price_type=price_type, cpu=48, mem=384, gpu=0)
+instance_96cpu_768mem = Instance(name='r5.24xlarge', price_type=price_type, cpu=96, mem=768, gpu=0)
+instance_128cpu_1024mem = Instance(name='r6i.32xlarge', price_type=price_type, cpu=128, mem=1024, gpu=0)
+
+test_cases = [
+    ['2cpu,0mem instance',
+     [instance_2cpu_0mem],
+     [ResourceSupply(cpu=2, mem=0, exc=1)]],
+
+    ['2cpu,1mem instance',
+     [instance_2cpu_1mem],
+     [ResourceSupply(cpu=2, mem=0, exc=1)]],
+
+    ['2cpu,2mem instance',
+     [instance_2cpu_2mem],
+     [ResourceSupply(cpu=2, mem=1, exc=1)]],
+
+    ['2cpu,4mem instance',
+     [instance_2cpu_4mem],
+     [ResourceSupply(cpu=2, mem=3, exc=1)]],
+
+    ['2cpu,8mem instance',
+     [instance_2cpu_8mem],
+     [ResourceSupply(cpu=2, mem=7, exc=1)]],
+
+    ['4cpu,16mem instance',
+     [instance_4cpu_16mem],
+     [ResourceSupply(cpu=4, mem=14, exc=1)]],
+
+    ['8cpu,32mem instance',
+     [instance_8cpu_32mem],
+     [ResourceSupply(cpu=8, mem=28, exc=1)]],
+
+    ['16cpu,64mem instance',
+     [instance_16cpu_64mem],
+     [ResourceSupply(cpu=16, mem=58, exc=1)]],
+
+    ['32cpu,128mem instance',
+     [instance_32cpu_128mem],
+     [ResourceSupply(cpu=32, mem=119, exc=1)]],
+
+    ['32cpu,244mem instance',
+     [instance_32cpu_244mem],
+     [ResourceSupply(cpu=32, mem=229, exc=1)]],
+
+    ['32cpu, 256mem instance',
+     [instance_32cpu_256mem],
+     [ResourceSupply(cpu=32, mem=241, exc=1)]],
+
+    ['48cpu,384mem instance',
+     [instance_48cpu_384mem],
+     [ResourceSupply(cpu=48, mem=362, exc=1)]],
+
+    ['96cpu,768mem instance',
+     [instance_96cpu_768mem],
+     [ResourceSupply(cpu=96, mem=727, exc=1)]],
+
+    ['128cpu,1024mem instance',
+     [instance_128cpu_1024mem],
+     [ResourceSupply(cpu=128, mem=970, exc=1)]],
+]
+
+@pytest.mark.parametrize('instances,required_resource_supplies',
+                         [test_case[1:] for test_case in test_cases],
+                         ids=[test_case[0] for test_case in test_cases])
+def test_select(instances, required_resource_supplies):
+    inner_instance_provider.provide = MagicMock(return_value=instances)
+    actual_instances = list(instance_provider.provide())
+    actual_resource_supplies = [ResourceSupply.of(instance) for instance in actual_instances]
+    assert actual_resource_supplies == required_resource_supplies

--- a/workflows/pipe-common/test/test_scale_down_handler.py
+++ b/workflows/pipe-common/test/test_scale_down_handler.py
@@ -30,9 +30,10 @@ RUN_ID = '12345'
 
 cmd_executor = Mock()
 grid_engine = Mock()
+api = Mock()
 instance_cores = 4
 common_utils = Mock()
-scale_down_handler = GridEngineScaleDownHandler(cmd_executor=cmd_executor, grid_engine=grid_engine,
+scale_down_handler = GridEngineScaleDownHandler(cmd_executor=cmd_executor, api=api, grid_engine=grid_engine,
                                                 common_utils=common_utils)
 
 
@@ -42,6 +43,7 @@ def setup_function():
     grid_engine.disable_host = MagicMock()
     grid_engine.delete_host = MagicMock()
     cmd_executor.execute = MagicMock()
+    api.stop_run = MagicMock()
     grid_engine.get_host_resource = MagicMock(return_value=ComputeResource(instance_cores))
 
 
@@ -65,6 +67,7 @@ def test_not_scaling_down_if_host_has_running_jobs():
     grid_engine.disable_host.assert_called()
     grid_engine.enable_host.assert_called()
     grid_engine.delete_host.assert_not_called()
+    api.stop_run.assert_not_called()
     assert_first_argument_not_contained(cmd_executor.execute, HOSTNAME)
 
 
@@ -117,7 +120,7 @@ def test_scaling_down_if_host_has_completed_jobs():
 def test_scaling_down_stops_pipeline():
     scale_down_handler.scale_down(HOSTNAME)
 
-    assert_first_argument_contained(cmd_executor.execute, 'pipe stop')
+    api.stop_run.assert_called()
 
 
 def test_scaling_down_updates_hosts():

--- a/workflows/pipe-common/test/test_scale_up_handler.py
+++ b/workflows/pipe-common/test/test_scale_up_handler.py
@@ -67,8 +67,10 @@ def setup_function():
     not_initialized_run = {'initialized': False, 'podId': HOSTNAME}
     initialized_pod_run = {'initialized': False, 'podId': HOSTNAME, 'podIP': POD_IP}
     initialized_run = {'initialized': True, 'podId': HOSTNAME, 'podIP': POD_IP}
-    api.load_run = MagicMock(side_effect=[not_initialized_run] * 4 + [initialized_pod_run] * 4 + [initialized_run])
+    api.load_run_efficiently = MagicMock(side_effect=[not_initialized_run] * 4 + [initialized_pod_run] * 4 + [initialized_run])
     api.load_task = MagicMock(return_value=[{'status': 'SUCCESS'}])
+    api.token = Mock()
+    api.token.get = MagicMock(return_value='token')
     cmd_executor.execute_to_lines = MagicMock(return_value=[RUN_ID])
     instance_helper.select_instance = MagicMock(return_value=
         Instance.from_cp_response({
@@ -91,8 +93,8 @@ def setup_function():
 def test_waiting_for_run_to_initialize():
     scale_up_handler.scale_up(instance, owner, run_id_queue)
 
-    api.load_run.assert_called()
-    assert api.load_run.call_count == 9
+    api.load_run_efficiently.assert_called()
+    assert api.load_run_efficiently.call_count == 9
 
 
 def test_enabling_worker_in_grid_engine():

--- a/workflows/pipe-common/test/test_worker_recorder.py
+++ b/workflows/pipe-common/test/test_worker_recorder.py
@@ -43,7 +43,7 @@ def setup_function():
 
 
 def test_record_sufficient_instance_type():
-    api.load_run = MagicMock(return_value=_sufficient_capacity_run())
+    api.load_run_efficiently = MagicMock(return_value=_sufficient_capacity_run())
 
     worker_recorder.record(run_id)
 
@@ -52,7 +52,7 @@ def test_record_sufficient_instance_type():
 
 
 def test_record_insufficient_instance_type():
-    api.load_run = MagicMock(return_value=_insufficient_capacity_run())
+    api.load_run_efficiently = MagicMock(return_value=_insufficient_capacity_run())
 
     worker_recorder.record(run_id)
 
@@ -61,7 +61,7 @@ def test_record_insufficient_instance_type():
 
 
 def test_record_failing_instance_type():
-    api.load_run = MagicMock(return_value=_failing_run())
+    api.load_run_efficiently = MagicMock(return_value=_failing_run())
 
     worker_recorder.record(run_id)
 

--- a/workflows/pipe-common/test/test_worker_validator_handler_pipe.py
+++ b/workflows/pipe-common/test/test_worker_validator_handler_pipe.py
@@ -44,18 +44,18 @@ handler = CloudPipelineWorkerValidatorHandler(api=api, common_utils=common_utils
 
 
 def test_run_status_running():
-    api.load_run = MagicMock(return_value={'status': 'RUNNING'})
+    api.load_run_efficiently = MagicMock(return_value={'status': 'RUNNING'})
 
     assert handler.is_valid(HOST)
 
 
 def test_run_status_failure():
-    api.load_run = MagicMock(return_value={'status': 'FAILURE'})
+    api.load_run_efficiently = MagicMock(return_value={'status': 'FAILURE'})
 
     assert not handler.is_valid(HOST)
 
 
 def test_run_status_stopped():
-    api.load_run = MagicMock(return_value={'status': 'STOPPED'})
+    api.load_run_efficiently = MagicMock(return_value={'status': 'STOPPED'})
 
     assert not handler.is_valid(HOST)


### PR DESCRIPTION
Relates #3354.

The pull request brings support for node memory reservations to grid engine autoscaler.

The following run parameters have been introduced:
- `CP_CAP_AUTOSCALE_NODE_MEM_RESERVATIONS` enables node memory reservations support. Disabled by default.