### PR TITLE
Add support for parameter pretty names and icons in API

### DIFF
--- a/api/src/test/java/com/epam/pipeline/entity/PipelineConfigurationTest.java
+++ b/api/src/test/java/com/epam/pipeline/entity/PipelineConfigurationTest.java
@@ -32,13 +32,17 @@ import static org.junit.Assert.*;
 public class PipelineConfigurationTest {
 
     private static final String GENERAL_SECTION = "General";
+    private static final String PRETTY_NAME = "PrettyName";
+    private static final String ICON = "icon";
     private static final String WITH_TYPE_OF_PARAMS_JSON =
             "{" +
                 "\"parameters\": {" +
                     "\"main_file\" : {" +
+                        "\"pretty_name\" : \"" + PRETTY_NAME + "\"," +
                         "\"value\" : \"\"," +
                         "\"required\" : \"true\"," +
                         "\"type\" : \"string\"," +
+                        "\"icon\" : \"" + ICON + "\"," +
                         "\"section\" : \"" + GENERAL_SECTION + "\"," +
                         "\"enum\" : [{\"name\": \"v1\"}, {\"name\": \"v2\"}]" +
                     "}," +
@@ -88,6 +92,8 @@ public class PipelineConfigurationTest {
         assertEquals(STRING_TYPE, mainFile.getType());
         assertTrue(mainFile.isRequired());
         assertEquals(mainFile.getSection(), GENERAL_SECTION);
+        assertEquals(mainFile.getPrettyName(), PRETTY_NAME);
+        assertEquals(mainFile.getIcon(), ICON);
 
         final PipeConfValueVO mainClass = pipelineConfiguration.getParameters().get("main_class");
         assertEquals(CLASS_TYPE, mainClass.getType());

--- a/core/src/main/java/com/epam/pipeline/entity/configuration/PipeConfValueVO.java
+++ b/core/src/main/java/com/epam/pipeline/entity/configuration/PipeConfValueVO.java
@@ -37,11 +37,17 @@ public class PipeConfValueVO {
     public static final boolean DEFAULT_REQUIRED = false;
     protected static final  List<String> DEFAULT_AVAIL_VALUES = new ArrayList<>();
 
+    @JsonProperty(value = "pretty_name")
+    private String prettyName;
+
     @JsonProperty(value = "value")
     private String value;
 
     @JsonProperty(value = "type")
     private String type;
+
+    @JsonProperty(value = "icon")
+    private String icon;
 
     @JsonProperty(value = "section")
     private String section;

--- a/core/src/main/java/com/epam/pipeline/entity/configuration/PipelineConfValuesMapDeserializer.java
+++ b/core/src/main/java/com/epam/pipeline/entity/configuration/PipelineConfValuesMapDeserializer.java
@@ -37,8 +37,10 @@ import java.util.Map;
 @Slf4j
 public class PipelineConfValuesMapDeserializer extends JsonDeserializer<Map<String, PipeConfValueVO>> {
 
+    private static final String PRETTY_NAME_FIELD = "pretty_name";
     private static final String VALUE_FIELD = "value";
     private static final String TYPE_FIELD = "type";
+    private static final String ICON_FIELD = "icon";
     private static final String SECTION_FIELD = "section";
     private static final String REQUIRED_FIELD = "required";
     private static final String NO_OVERRIDE_FIELD = "no_override";
@@ -68,6 +70,10 @@ public class PipelineConfValuesMapDeserializer extends JsonDeserializer<Map<Stri
             if (child.isValueNode()) {
                 parameter.setValue(child.asText().trim());
             } else {
+                JsonNode prettyName = child.get(PRETTY_NAME_FIELD);
+                if (hasValue(prettyName)) {
+                    parameter.setPrettyName(prettyName.asText());
+                }
                 JsonNode value = child.get(VALUE_FIELD);
                 if (hasValue(value)) {
                     parameter.setValue(value.asText().trim());
@@ -75,6 +81,10 @@ public class PipelineConfValuesMapDeserializer extends JsonDeserializer<Map<Stri
                 JsonNode type = child.get(TYPE_FIELD);
                 if (hasValue(type)) {
                     parameter.setType(type.asText());
+                }
+                JsonNode icon = child.get(ICON_FIELD);
+                if (hasValue(icon)) {
+                    parameter.setIcon(icon.asText());
                 }
                 JsonNode section = child.get(SECTION_FIELD);
                 if (hasValue(section)) {


### PR DESCRIPTION
Relates #3645.

The pull request brings the following new fields to run parameter structure:
- `pretty_name` specifies parameter pretty name.
- `icon` specifies parameter icon name.
