### PR TITLE
Migrate runs to archive table according to user/group configuration - dry-run

### DIFF
--- a/api/src/main/java/com/epam/pipeline/dao/DryRunJdbcDaoSupport.java
+++ b/api/src/main/java/com/epam/pipeline/dao/DryRunJdbcDaoSupport.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.dao;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcDaoSupport;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+/**
+ * Enables ability to execute queries in read-only mode
+ */
+public class DryRunJdbcDaoSupport extends NamedParameterJdbcDaoSupport {
+
+    @Autowired
+    private JdbcTemplateDryRunWrapper jdbcTemplateDryRunWrapper;
+
+    protected NamedParameterJdbcTemplate getNamedParameterJdbcTemplate(final boolean dryRun) {
+        return dryRun ? jdbcTemplateDryRunWrapper : getNamedParameterJdbcTemplate();
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/dao/JdbcTemplateDryRunWrapper.java
+++ b/api/src/main/java/com/epam/pipeline/dao/JdbcTemplateDryRunWrapper.java
@@ -33,9 +33,9 @@ import java.util.List;
  */
 @Service
 @Slf4j
-public class JdbcTemplateReadOnlyWrapper extends NamedParameterJdbcTemplate {
+public class JdbcTemplateDryRunWrapper extends NamedParameterJdbcTemplate {
 
-    public JdbcTemplateReadOnlyWrapper(final DataSource dataSource) {
+    public JdbcTemplateDryRunWrapper(final DataSource dataSource) {
         super(dataSource);
     }
 

--- a/api/src/main/java/com/epam/pipeline/dao/JdbcTemplateReadOnlyWrapper.java
+++ b/api/src/main/java/com/epam/pipeline/dao/JdbcTemplateReadOnlyWrapper.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.dao;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.PreparedStatementCreator;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.SqlProvider;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Service;
+
+import javax.sql.DataSource;
+import java.util.List;
+
+/**
+ * Wraps methods to operate in read-only mode and print the DB queries.
+ */
+@Service
+@Slf4j
+public class JdbcTemplateReadOnlyWrapper extends NamedParameterJdbcTemplate {
+
+    public JdbcTemplateReadOnlyWrapper(final DataSource dataSource) {
+        super(dataSource);
+    }
+
+    @Override
+    public <T> List<T> query(final String sql, final SqlParameterSource paramSource, final RowMapper<T> rowMapper)
+            throws DataAccessException {
+        final PreparedStatementCreator psc = getPreparedStatementCreator(sql, paramSource);
+        logQuery(psc);
+        return getJdbcOperations().query(psc, rowMapper);
+    }
+
+    @Override
+    public int update(final String sql, final SqlParameterSource paramSource) throws DataAccessException {
+        final PreparedStatementCreator psc = getPreparedStatementCreator(sql, paramSource);
+        log.debug("Skipping update operation for query:");
+        logQuery(psc);
+        return 0;
+    }
+
+    private void logQuery(final PreparedStatementCreator sqlProvider) {
+        if (sqlProvider instanceof SqlProvider) {
+            log.debug(sqlProvider.toString());
+        }
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
@@ -22,7 +22,7 @@ import com.epam.pipeline.controller.vo.PipelineRunFilterVO;
 import com.epam.pipeline.controller.vo.run.RunChartFilterVO;
 import com.epam.pipeline.dao.DaoHelper;
 import com.epam.pipeline.dao.DaoUtils;
-import com.epam.pipeline.dao.JdbcTemplateReadOnlyWrapper;
+import com.epam.pipeline.dao.DryRunJdbcDaoSupport;
 import com.epam.pipeline.dao.run.RunServiceUrlDao;
 import com.epam.pipeline.entity.BaseEntity;
 import com.epam.pipeline.entity.filter.AclSecuredFilter;
@@ -52,8 +52,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcDaoSupport;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -77,7 +75,7 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
+public class PipelineRunDao extends DryRunJdbcDaoSupport {
 
     private Pattern wherePattern = Pattern.compile("@WHERE@");
     private Pattern whereTagsPattern = Pattern.compile("@WHERE_TAGS@");
@@ -95,9 +93,6 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
 
     @Autowired
     private RunServiceUrlDao serviceUrlDao;
-
-    @Autowired
-    private JdbcTemplateReadOnlyWrapper jdbcTemplateReadOnlyWrapper;
 
     @Value("${run.pipeline.init.task.name?:InitializeEnvironment}")
     private String initTaskName;
@@ -1682,9 +1677,5 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setDeleteRunSidsByRunIdsQuery(final String deleteRunSidsByRunIdsQuery) {
         this.deleteRunSidsByRunIdsQuery = deleteRunSidsByRunIdsQuery;
-    }
-
-    private NamedParameterJdbcTemplate getNamedParameterJdbcTemplate(final boolean dryRun) {
-        return dryRun ? jdbcTemplateReadOnlyWrapper : getNamedParameterJdbcTemplate();
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineRunDao.java
@@ -22,6 +22,7 @@ import com.epam.pipeline.controller.vo.PipelineRunFilterVO;
 import com.epam.pipeline.controller.vo.run.RunChartFilterVO;
 import com.epam.pipeline.dao.DaoHelper;
 import com.epam.pipeline.dao.DaoUtils;
+import com.epam.pipeline.dao.JdbcTemplateReadOnlyWrapper;
 import com.epam.pipeline.dao.run.RunServiceUrlDao;
 import com.epam.pipeline.entity.BaseEntity;
 import com.epam.pipeline.entity.filter.AclSecuredFilter;
@@ -52,6 +53,7 @@ import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcDaoSupport;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -85,6 +87,7 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     private static final int STRING_BUFFER_SIZE = 70;
     private static final String LIST_PARAMETER = "list";
     private static final String LIMIT = "LIMIT";
+    private static final String OFFSET = "OFFSET";
     private static final int CLAUSE_LENGTH = 200;
 
     @Autowired
@@ -92,6 +95,9 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
 
     @Autowired
     private RunServiceUrlDao serviceUrlDao;
+
+    @Autowired
+    private JdbcTemplateReadOnlyWrapper jdbcTemplateReadOnlyWrapper;
 
     @Value("${run.pipeline.init.task.name?:InitializeEnvironment}")
     private String initTaskName;
@@ -462,9 +468,9 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     }
 
     @Transactional(propagation = Propagation.MANDATORY)
-    public void deleteRunSidsByRunIdIn(final List<Long> runIds) {
+    public void deleteRunSidsByRunIdIn(final List<Long> runIds, final boolean dryRun) {
         final MapSqlParameterSource params = DaoUtils.longListParams(runIds);
-        getNamedParameterJdbcTemplate().update(deleteRunSidsByRunIdsQuery, params);
+        getNamedParameterJdbcTemplate(dryRun).update(deleteRunSidsByRunIdsQuery, params);
     }
 
     @Transactional(propagation = Propagation.SUPPORTS)
@@ -525,6 +531,10 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     }
 
     public List<PipelineRun> loadRunsByParentRuns(final Collection<Long> parentIds) {
+        return loadRunsByParentRuns(parentIds, false);
+    }
+
+    public List<PipelineRun> loadRunsByParentRuns(final Collection<Long> parentIds, final boolean dryRun) {
         if (CollectionUtils.isEmpty(parentIds)) {
             return Collections.emptyList();
         }
@@ -532,7 +542,7 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
         final MapSqlParameterSource params = new MapSqlParameterSource();
         params.addValue(LIST_PARAMETER, parentIds);
 
-        return getNamedParameterJdbcTemplate()
+        return getNamedParameterJdbcTemplate(dryRun)
                 .query(loadRunsByParentRunsIdsQuery, params, PipelineRunParameters.getRowMapper());
     }
 
@@ -560,35 +570,36 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     }
 
     public List<PipelineRun> loadRunsByOwnerAndEndDateBeforeAndStatusIn(final Map<String, Date> ownersAndDates,
-                                                                        final List<Long> statuses, final int limit) {
+                                                                        final List<Long> statuses, final int limit,
+                                                                        final boolean dryRun, final int offset) {
         if (MapUtils.isEmpty(ownersAndDates)) {
             return Collections.emptyList();
         }
         final MapSqlParameterSource params = new MapSqlParameterSource();
         params.addValue(LIST_PARAMETER, statuses);
         params.addValue(LIMIT, limit);
+        params.addValue(OFFSET, offset);
 
         final String query = wherePattern.matcher(loadRunsByOwnerAndEndDateBeforeAndStatusInQuery)
                 .replaceFirst(buildOwnersAndDatesClause(ownersAndDates));
-
-        return ListUtils.emptyIfNull(getNamedParameterJdbcTemplate()
+        return ListUtils.emptyIfNull(getNamedParameterJdbcTemplate(dryRun)
                 .query(query, params, PipelineRunParameters.getRowMapper()));
     }
 
     @Transactional(propagation = Propagation.MANDATORY)
-    public void deleteRunByIdIn(final List<Long> runIds) {
+    public void deleteRunByIdIn(final List<Long> runIds, final boolean dryRun) {
         if (CollectionUtils.isEmpty(runIds)) {
             return;
         }
 
-        getNamedParameterJdbcTemplate().update(deleteRunsByIdInQuery,
+        getNamedParameterJdbcTemplate(dryRun).update(deleteRunsByIdInQuery,
                 new MapSqlParameterSource(LIST_PARAMETER, runIds));
     }
 
     private MapSqlParameterSource getPagingParameters(PagingRunFilterVO filter) {
         MapSqlParameterSource params = new MapSqlParameterSource();
-        params.addValue("LIMIT", filter.getPageSize());
-        params.addValue("OFFSET", (filter.getPage() - 1) * filter.getPageSize());
+        params.addValue(LIMIT, filter.getPageSize());
+        params.addValue(OFFSET, (filter.getPage() - 1) * filter.getPageSize());
         addTaskStatusParams(params);
         return params;
     }
@@ -1671,5 +1682,9 @@ public class PipelineRunDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setDeleteRunSidsByRunIdsQuery(final String deleteRunSidsByRunIdsQuery) {
         this.deleteRunSidsByRunIdsQuery = deleteRunSidsByRunIdsQuery;
+    }
+
+    private NamedParameterJdbcTemplate getNamedParameterJdbcTemplate(final boolean dryRun) {
+        return dryRun ? jdbcTemplateReadOnlyWrapper : getNamedParameterJdbcTemplate();
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/RestartRunDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/RestartRunDao.java
@@ -17,15 +17,13 @@
 package com.epam.pipeline.dao.pipeline;
 
 import com.epam.pipeline.dao.DaoUtils;
-import com.epam.pipeline.dao.JdbcTemplateReadOnlyWrapper;
+import com.epam.pipeline.dao.DryRunJdbcDaoSupport;
 import com.epam.pipeline.entity.pipeline.run.RestartRun;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.ListUtils;
 import org.springframework.beans.factory.annotation.Required;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcDaoSupport;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
@@ -37,9 +35,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 @RequiredArgsConstructor
-public class RestartRunDao extends NamedParameterJdbcDaoSupport {
-
-    private final JdbcTemplateReadOnlyWrapper jdbcTemplateReadOnlyWrapper;
+public class RestartRunDao extends DryRunJdbcDaoSupport {
 
     private String createPipelineRestartRunQuery;
     private String countPipelineRestartRunQuery;
@@ -147,9 +143,5 @@ public class RestartRunDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setDeleteRestartRunByIdsQuery(final String deleteRestartRunByIdsQuery) {
         this.deleteRestartRunByIdsQuery = deleteRestartRunByIdsQuery;
-    }
-
-    private NamedParameterJdbcTemplate getNamedParameterJdbcTemplate(final boolean dryRun) {
-        return dryRun ? jdbcTemplateReadOnlyWrapper : getNamedParameterJdbcTemplate();
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/RestartRunDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/RestartRunDao.java
@@ -17,12 +17,15 @@
 package com.epam.pipeline.dao.pipeline;
 
 import com.epam.pipeline.dao.DaoUtils;
+import com.epam.pipeline.dao.JdbcTemplateReadOnlyWrapper;
 import com.epam.pipeline.entity.pipeline.run.RestartRun;
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.ListUtils;
 import org.springframework.beans.factory.annotation.Required;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcDaoSupport;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
@@ -33,7 +36,10 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+@RequiredArgsConstructor
 public class RestartRunDao extends NamedParameterJdbcDaoSupport {
+
+    private final JdbcTemplateReadOnlyWrapper jdbcTemplateReadOnlyWrapper;
 
     private String createPipelineRestartRunQuery;
     private String countPipelineRestartRunQuery;
@@ -76,9 +82,9 @@ public class RestartRunDao extends NamedParameterJdbcDaoSupport {
     }
 
     @Transactional(propagation = Propagation.MANDATORY)
-    public void deleteRestartRunByIdsIn(final List<Long> runIds) {
+    public void deleteRestartRunByIdsIn(final List<Long> runIds, final boolean dryRun) {
         final MapSqlParameterSource params = DaoUtils.longListParams(runIds);
-        getNamedParameterJdbcTemplate().update(deleteRestartRunByIdsQuery, params);
+        getNamedParameterJdbcTemplate(dryRun).update(deleteRestartRunByIdsQuery, params);
     }
 
     enum PipelineRestartRunParameters {
@@ -141,5 +147,9 @@ public class RestartRunDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setDeleteRestartRunByIdsQuery(final String deleteRestartRunByIdsQuery) {
         this.deleteRestartRunByIdsQuery = deleteRestartRunByIdsQuery;
+    }
+
+    private NamedParameterJdbcTemplate getNamedParameterJdbcTemplate(final boolean dryRun) {
+        return dryRun ? jdbcTemplateReadOnlyWrapper : getNamedParameterJdbcTemplate();
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/RunLogDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/RunLogDao.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 
 import com.epam.pipeline.controller.vo.run.OffsetPagingFilter;
 import com.epam.pipeline.dao.DaoUtils;
-import com.epam.pipeline.dao.JdbcTemplateReadOnlyWrapper;
+import com.epam.pipeline.dao.DryRunJdbcDaoSupport;
 import com.epam.pipeline.entity.pipeline.PipelineTask;
 import com.epam.pipeline.entity.pipeline.RunLog;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
@@ -37,15 +37,11 @@ import org.apache.commons.collections4.ListUtils;
 import org.springframework.beans.factory.annotation.Required;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcDaoSupport;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
-public class RunLogDao extends NamedParameterJdbcDaoSupport {
-
-    private final JdbcTemplateReadOnlyWrapper jdbcTemplateReadOnlyWrapper;
+public class RunLogDao extends DryRunJdbcDaoSupport {
 
     @Setter(onMethod_={@Required}) private String createPipelineLogQuery;
     @Setter(onMethod_={@Required}) private String loadLogsByRunIdQueryDesc;
@@ -208,9 +204,5 @@ public class RunLogDao extends NamedParameterJdbcDaoSupport {
                 return runLog;
             };
         }
-    }
-
-    private NamedParameterJdbcTemplate getNamedParameterJdbcTemplate(final boolean dryRun) {
-        return dryRun ? jdbcTemplateReadOnlyWrapper : getNamedParameterJdbcTemplate();
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/RunStatusDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/RunStatusDao.java
@@ -17,18 +17,24 @@
 package com.epam.pipeline.dao.pipeline;
 
 import com.epam.pipeline.dao.DaoUtils;
+import com.epam.pipeline.dao.JdbcTemplateReadOnlyWrapper;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.epam.pipeline.entity.pipeline.run.RunStatus;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Required;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcDaoSupport;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@RequiredArgsConstructor
 public class RunStatusDao extends NamedParameterJdbcDaoSupport {
+
+    private final JdbcTemplateReadOnlyWrapper jdbcTemplateReadOnlyWrapper;
 
     private String createRunStatusQuery;
     private String loadRunStatusQuery;
@@ -48,6 +54,10 @@ public class RunStatusDao extends NamedParameterJdbcDaoSupport {
     }
 
     public List<RunStatus> loadRunStatus(final List<Long> runIds, final boolean archive) {
+        return loadRunStatus(runIds, archive, false);
+    }
+
+    public List<RunStatus> loadRunStatus(final List<Long> runIds, final boolean archive, final boolean dryRun) {
         final MapSqlParameterSource params = new MapSqlParameterSource();
         params.addValue("IDS", runIds);
 
@@ -55,7 +65,7 @@ public class RunStatusDao extends NamedParameterJdbcDaoSupport {
                 ? loadRunStatusByListWithArchivedQuery
                 : loadRunStatusByListQuery;
 
-        return getNamedParameterJdbcTemplate().query(query, params, RunStatusParameters.getRowMapper());
+        return getNamedParameterJdbcTemplate(dryRun).query(query, params, RunStatusParameters.getRowMapper());
     }
 
     @Transactional(propagation = Propagation.MANDATORY)
@@ -64,9 +74,9 @@ public class RunStatusDao extends NamedParameterJdbcDaoSupport {
     }
 
     @Transactional(propagation = Propagation.MANDATORY)
-    public void deleteRunStatusByRunIdsIn(final List<Long> runIds) {
+    public void deleteRunStatusByRunIdsIn(final List<Long> runIds, final boolean dryRun) {
         final MapSqlParameterSource params = DaoUtils.longListParams(runIds);
-        getNamedParameterJdbcTemplate().update(deleteRunStatusByIdsQuery, params);
+        getNamedParameterJdbcTemplate(dryRun).update(deleteRunStatusByIdsQuery, params);
     }
 
     enum RunStatusParameters {
@@ -130,5 +140,9 @@ public class RunStatusDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setLoadRunStatusByListWithArchivedQuery(final String loadRunStatusByListWithArchivedQuery) {
         this.loadRunStatusByListWithArchivedQuery = loadRunStatusByListWithArchivedQuery;
+    }
+
+    private NamedParameterJdbcTemplate getNamedParameterJdbcTemplate(final boolean dryRun) {
+        return dryRun ? jdbcTemplateReadOnlyWrapper : getNamedParameterJdbcTemplate();
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/RunStatusDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/RunStatusDao.java
@@ -17,24 +17,20 @@
 package com.epam.pipeline.dao.pipeline;
 
 import com.epam.pipeline.dao.DaoUtils;
-import com.epam.pipeline.dao.JdbcTemplateReadOnlyWrapper;
+import com.epam.pipeline.dao.DryRunJdbcDaoSupport;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.epam.pipeline.entity.pipeline.run.RunStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Required;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcDaoSupport;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @RequiredArgsConstructor
-public class RunStatusDao extends NamedParameterJdbcDaoSupport {
-
-    private final JdbcTemplateReadOnlyWrapper jdbcTemplateReadOnlyWrapper;
+public class RunStatusDao extends DryRunJdbcDaoSupport {
 
     private String createRunStatusQuery;
     private String loadRunStatusQuery;
@@ -140,9 +136,5 @@ public class RunStatusDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setLoadRunStatusByListWithArchivedQuery(final String loadRunStatusByListWithArchivedQuery) {
         this.loadRunStatusByListWithArchivedQuery = loadRunStatusByListWithArchivedQuery;
-    }
-
-    private NamedParameterJdbcTemplate getNamedParameterJdbcTemplate(final boolean dryRun) {
-        return dryRun ? jdbcTemplateReadOnlyWrapper : getNamedParameterJdbcTemplate();
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/StopServerlessRunDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/StopServerlessRunDao.java
@@ -18,6 +18,7 @@ package com.epam.pipeline.dao.pipeline;
 
 import com.epam.pipeline.dao.DaoHelper;
 import com.epam.pipeline.dao.DaoUtils;
+import com.epam.pipeline.dao.JdbcTemplateReadOnlyWrapper;
 import com.epam.pipeline.entity.pipeline.StopServerlessRun;
 import org.apache.commons.collections4.ListUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,6 +26,7 @@ import org.springframework.beans.factory.annotation.Required;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcDaoSupport;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,6 +37,9 @@ public class StopServerlessRunDao extends NamedParameterJdbcDaoSupport {
 
     @Autowired
     private DaoHelper daoHelper;
+
+    @Autowired
+    private JdbcTemplateReadOnlyWrapper jdbcTemplateReadOnlyWrapper;
 
     private String serverlessRunSequenceQuery;
     private String saveServerlessRunQuery;
@@ -85,9 +90,9 @@ public class StopServerlessRunDao extends NamedParameterJdbcDaoSupport {
     }
 
     @Transactional(propagation = Propagation.MANDATORY)
-    public void deleteByRunIdIn(final List<Long> runIds) {
+    public void deleteByRunIdIn(final List<Long> runIds, final boolean dryRun) {
         final MapSqlParameterSource params = DaoUtils.longListParams(runIds);
-        getNamedParameterJdbcTemplate().update(deleteByRunIdsServerlessRunQuery, params);
+        getNamedParameterJdbcTemplate(dryRun).update(deleteByRunIdsServerlessRunQuery, params);
     }
 
     public enum StopServerlessRunParameters {
@@ -155,5 +160,9 @@ public class StopServerlessRunDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setDeleteByRunIdsServerlessRunQuery(final String deleteByRunIdsServerlessRunQuery) {
         this.deleteByRunIdsServerlessRunQuery = deleteByRunIdsServerlessRunQuery;
+    }
+
+    private NamedParameterJdbcTemplate getNamedParameterJdbcTemplate(final boolean dryRun) {
+        return dryRun ? jdbcTemplateReadOnlyWrapper : getNamedParameterJdbcTemplate();
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/StopServerlessRunDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/StopServerlessRunDao.java
@@ -18,28 +18,23 @@ package com.epam.pipeline.dao.pipeline;
 
 import com.epam.pipeline.dao.DaoHelper;
 import com.epam.pipeline.dao.DaoUtils;
-import com.epam.pipeline.dao.JdbcTemplateReadOnlyWrapper;
+import com.epam.pipeline.dao.DryRunJdbcDaoSupport;
 import com.epam.pipeline.entity.pipeline.StopServerlessRun;
 import org.apache.commons.collections4.ListUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Required;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcDaoSupport;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
 
-public class StopServerlessRunDao extends NamedParameterJdbcDaoSupport {
+public class StopServerlessRunDao extends DryRunJdbcDaoSupport {
 
     @Autowired
     private DaoHelper daoHelper;
-
-    @Autowired
-    private JdbcTemplateReadOnlyWrapper jdbcTemplateReadOnlyWrapper;
 
     private String serverlessRunSequenceQuery;
     private String saveServerlessRunQuery;
@@ -160,9 +155,5 @@ public class StopServerlessRunDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setDeleteByRunIdsServerlessRunQuery(final String deleteByRunIdsServerlessRunQuery) {
         this.deleteByRunIdsServerlessRunQuery = deleteByRunIdsServerlessRunQuery;
-    }
-
-    private NamedParameterJdbcTemplate getNamedParameterJdbcTemplate(final boolean dryRun) {
-        return dryRun ? jdbcTemplateReadOnlyWrapper : getNamedParameterJdbcTemplate();
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/run/RunServiceUrlDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/run/RunServiceUrlDao.java
@@ -17,12 +17,14 @@
 package com.epam.pipeline.dao.run;
 
 import com.epam.pipeline.dao.DaoUtils;
+import com.epam.pipeline.dao.JdbcTemplateReadOnlyWrapper;
 import com.epam.pipeline.entity.pipeline.run.PipelineRunServiceUrl;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.ListUtils;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcDaoSupport;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.transaction.annotation.Propagation;
@@ -34,6 +36,8 @@ import java.util.Optional;
 
 @RequiredArgsConstructor
 public class RunServiceUrlDao extends NamedParameterJdbcDaoSupport {
+
+    private final JdbcTemplateReadOnlyWrapper jdbcTemplateReadOnlyWrapper;
 
     private final String loadByRunIdsQuery;
     private final String loadByRunIdQuery;
@@ -97,9 +101,9 @@ public class RunServiceUrlDao extends NamedParameterJdbcDaoSupport {
     }
 
     @Transactional(propagation = Propagation.MANDATORY)
-    public void deleteByRunIdsIn(final List<Long> runIds) {
+    public void deleteByRunIdsIn(final List<Long> runIds, final boolean dryRun) {
         final MapSqlParameterSource params = DaoUtils.longListParams(runIds);
-        getNamedParameterJdbcTemplate().update(deleteServiceUrlByRunIdsQuery, params);
+        getNamedParameterJdbcTemplate(dryRun).update(deleteServiceUrlByRunIdsQuery, params);
     }
 
     enum Parameters {
@@ -127,5 +131,9 @@ public class RunServiceUrlDao extends NamedParameterJdbcDaoSupport {
                 return pipelineRunServiceUrl;
             };
         }
+    }
+
+    private NamedParameterJdbcTemplate getNamedParameterJdbcTemplate(final boolean dryRun) {
+        return dryRun ? jdbcTemplateReadOnlyWrapper : getNamedParameterJdbcTemplate();
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/run/RunServiceUrlDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/run/RunServiceUrlDao.java
@@ -17,14 +17,12 @@
 package com.epam.pipeline.dao.run;
 
 import com.epam.pipeline.dao.DaoUtils;
-import com.epam.pipeline.dao.JdbcTemplateReadOnlyWrapper;
+import com.epam.pipeline.dao.DryRunJdbcDaoSupport;
 import com.epam.pipeline.entity.pipeline.run.PipelineRunServiceUrl;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.ListUtils;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcDaoSupport;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.transaction.annotation.Propagation;
@@ -35,9 +33,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 @RequiredArgsConstructor
-public class RunServiceUrlDao extends NamedParameterJdbcDaoSupport {
-
-    private final JdbcTemplateReadOnlyWrapper jdbcTemplateReadOnlyWrapper;
+public class RunServiceUrlDao extends DryRunJdbcDaoSupport {
 
     private final String loadByRunIdsQuery;
     private final String loadByRunIdQuery;
@@ -131,9 +127,5 @@ public class RunServiceUrlDao extends NamedParameterJdbcDaoSupport {
                 return pipelineRunServiceUrl;
             };
         }
-    }
-
-    private NamedParameterJdbcTemplate getNamedParameterJdbcTemplate(final boolean dryRun) {
-        return dryRun ? jdbcTemplateReadOnlyWrapper : getNamedParameterJdbcTemplate();
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/ArchiveRunAsynchronousService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/ArchiveRunAsynchronousService.java
@@ -33,7 +33,8 @@ public class ArchiveRunAsynchronousService {
 
     @Async("backgroundJobsExecutor")
     public void archiveRunsAsynchronous(final Map<String, Date> ownersAndDates, final List<Long> terminalStates,
-                                        final Integer runsChunkSize, final Integer ownersChunkSize) {
-        archiveRunCoreService.archiveRuns(ownersAndDates, terminalStates, runsChunkSize, ownersChunkSize);
+                                        final Integer runsChunkSize, final Integer ownersChunkSize,
+                                        final boolean dryRun) {
+        archiveRunCoreService.archiveRuns(ownersAndDates, terminalStates, runsChunkSize, ownersChunkSize, dryRun);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/ArchiveRunService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/ArchiveRunService.java
@@ -101,8 +101,10 @@ public class ArchiveRunService {
                 SystemPreferences.SYSTEM_ARCHIVE_RUN_RUNS_CHUNK_SIZE);
         final Integer ownersChunkSize = preferenceManager.getPreference(
                 SystemPreferences.SYSTEM_ARCHIVE_RUN_OWNERS_CHUNK_SIZE);
+        final boolean dryRun = preferenceManager.getPreference(SystemPreferences.SYSTEM_ARCHIVE_RUN_DRY_RUN_REGIME);
 
-        archiveRunAsyncService.archiveRunsAsynchronous(ownersAndDates, terminalStates, runsChunkSize, ownersChunkSize);
+        archiveRunAsyncService.archiveRunsAsynchronous(ownersAndDates, terminalStates, runsChunkSize, ownersChunkSize,
+                dryRun);
     }
 
     private Integer metadataToDays(final Map<String, PipeConfValue> metadata, final String key,

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunCRUDService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunCRUDService.java
@@ -101,6 +101,6 @@ public class PipelineRunCRUDService {
 
     @Transactional(propagation = Propagation.REQUIRED)
     public void deleteRunsByIdIn(final List<Long> ids) {
-        pipelineRunDao.deleteRunByIdIn(ids);
+        pipelineRunDao.deleteRunByIdIn(ids, false);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -1180,7 +1180,8 @@ public class SystemPreferences {
             "system.archive.run.runs.chunk.size", 1000, SYSTEM_GROUP, isGreaterThan(0));
     public static final IntPreference SYSTEM_ARCHIVE_RUN_OWNERS_CHUNK_SIZE = new IntPreference(
             "system.archive.run.owners.chunk.size", 100, SYSTEM_GROUP, isGreaterThan(0));
-
+    public static final BooleanPreference SYSTEM_ARCHIVE_RUN_DRY_RUN_REGIME = new BooleanPreference(
+            "system.archive.run.dry-run.regime", false, SYSTEM_GROUP, pass);
 
     // FireCloud Integration
     public static final ObjectPreference<List<String>> FIRECLOUD_SCOPES = new ObjectPreference<>(

--- a/api/src/main/resources/dao/pipeline-run-dao.xml
+++ b/api/src/main/resources/dao/pipeline-run-dao.xml
@@ -2424,6 +2424,7 @@
                         pipeline.pipeline_run
                     WHERE parent_id ISNULL AND status IN (:list) AND ( @WHERE@ )
                     LIMIT :LIMIT
+                    OFFSET :OFFSET
                 ]]>
             </value>
         </property>

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineRunDaoTest.java
@@ -1359,7 +1359,7 @@ public class PipelineRunDaoTest extends AbstractJdbcTest {
 
         final List<PipelineRun> runs = pipelineRunDao.loadRunsByOwnerAndEndDateBeforeAndStatusIn(
                 Collections.singletonMap(USER, testDate),
-                Collections.singletonList(TaskStatus.RUNNING.getId()), TEST_PAGE_SIZE);
+                Collections.singletonList(TaskStatus.RUNNING.getId()), TEST_PAGE_SIZE, false, 0);
         assertThat(runs.size(), is(1));
     }
 

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/ArchiveRunServiceSpringTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/ArchiveRunServiceSpringTest.java
@@ -16,7 +16,7 @@
 package com.epam.pipeline.manager.pipeline;
 
 import com.epam.pipeline.controller.vo.EntityVO;
-import com.epam.pipeline.dao.JdbcTemplateReadOnlyWrapper;
+import com.epam.pipeline.dao.JdbcTemplateDryRunWrapper;
 import com.epam.pipeline.dao.metadata.MetadataDao;
 import com.epam.pipeline.dao.pipeline.ArchiveRunDao;
 import com.epam.pipeline.dao.pipeline.PipelineRunDao;
@@ -150,7 +150,7 @@ public class ArchiveRunServiceSpringTest extends AbstractManagerTest {
     @SpyBean
     private PipelineRunDao pipelineRunDao;
     @SpyBean
-    private JdbcTemplateReadOnlyWrapper jdbcTemplateReadOnlyWrapper;
+    private JdbcTemplateDryRunWrapper jdbcTemplateDryRunWrapper;
     @Autowired
     private ArchiveRunDao archiveRunDao;
     @Autowired
@@ -596,8 +596,8 @@ public class ArchiveRunServiceSpringTest extends AbstractManagerTest {
     }
 
     private void verifyDryRunInvoked(final int queryTimes, final int updateTimes) {
-        verify(jdbcTemplateReadOnlyWrapper, times(queryTimes))
+        verify(jdbcTemplateDryRunWrapper, times(queryTimes))
                 .query(anyString(), (SqlParameterSource) any(), (RowMapper<Object>) any());
-        verify(jdbcTemplateReadOnlyWrapper, times(updateTimes)).update(anyString(), (SqlParameterSource) any());
+        verify(jdbcTemplateDryRunWrapper, times(updateTimes)).update(anyString(), (SqlParameterSource) any());
     }
 }

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/ArchiveRunServiceSpringTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/ArchiveRunServiceSpringTest.java
@@ -144,6 +144,8 @@ public class ArchiveRunServiceSpringTest extends AbstractManagerTest {
     private BlockedUsersMonitoringService blockedUsersMonitoringService;
     @MockBean
     private InactiveUsersMonitoringService inactiveUsersMonitoringService;
+    @MockBean
+    private BandwidthMonitoringService bandwidthMonitoringService;
 
     @SpyBean
     private PipelineRunDao pipelineRunDao;

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/ArchiveRunServiceUnitTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/ArchiveRunServiceUnitTest.java
@@ -42,8 +42,7 @@ import java.util.Map;
 
 import static com.epam.pipeline.util.CustomAssertions.notInvoked;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -77,6 +76,8 @@ public class ArchiveRunServiceUnitTest {
         doReturn(TEST).when(preferenceManager).getPreference(SystemPreferences.SYSTEM_ARCHIVE_RUN_METADATA_KEY);
         doReturn(CHUNK_SIZE).when(preferenceManager)
                 .getPreference(SystemPreferences.SYSTEM_ARCHIVE_RUN_RUNS_CHUNK_SIZE);
+        doReturn(false).when(preferenceManager)
+                .getPreference(SystemPreferences.SYSTEM_ARCHIVE_RUN_DRY_RUN_REGIME);
     }
 
     @Test
@@ -160,7 +161,7 @@ public class ArchiveRunServiceUnitTest {
 
         archiveRunService.archiveRuns(GROUP1, false, INPUT_DAYS);
 
-        notInvoked(archiveRunAsyncService).archiveRunsAsynchronous(any(), any(), anyInt(), anyInt());
+        notInvoked(archiveRunAsyncService).archiveRunsAsynchronous(any(), any(), anyInt(), anyInt(), anyBoolean());
     }
 
     @Test
@@ -205,7 +206,7 @@ public class ArchiveRunServiceUnitTest {
 
     private void verifyDays(final int expectedDays) {
         final ArgumentCaptor<Map<String, Date>> argument = ArgumentCaptor.forClass((Class) Map.class);
-        verify(archiveRunAsyncService).archiveRunsAsynchronous(argument.capture(), any(), any(), any());
+        verify(archiveRunAsyncService).archiveRunsAsynchronous(argument.capture(), any(), any(), any(), anyBoolean());
         final Map<String, Date> results = argument.getValue();
         assertThat(results).hasSize(1);
         assertDays(results.get(USER1), expectedDays);

--- a/api/src/test/java/com/epam/pipeline/test/repository/JpaTestBeans.java
+++ b/api/src/test/java/com/epam/pipeline/test/repository/JpaTestBeans.java
@@ -17,6 +17,7 @@
 package com.epam.pipeline.test.repository;
 
 import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.dao.JdbcTemplateReadOnlyWrapper;
 import com.epam.pipeline.dao.region.CloudRegionDao;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Configuration;
@@ -28,4 +29,7 @@ public class JpaTestBeans {
 
     @MockBean
     protected CloudRegionDao cloudRegionDao;
+
+    @MockBean
+    protected JdbcTemplateReadOnlyWrapper jdbcTemplateReadOnlyWrapper;
 }

--- a/api/src/test/java/com/epam/pipeline/test/repository/JpaTestBeans.java
+++ b/api/src/test/java/com/epam/pipeline/test/repository/JpaTestBeans.java
@@ -17,7 +17,7 @@
 package com.epam.pipeline.test.repository;
 
 import com.epam.pipeline.common.MessageHelper;
-import com.epam.pipeline.dao.JdbcTemplateReadOnlyWrapper;
+import com.epam.pipeline.dao.JdbcTemplateDryRunWrapper;
 import com.epam.pipeline.dao.region.CloudRegionDao;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Configuration;
@@ -31,5 +31,5 @@ public class JpaTestBeans {
     protected CloudRegionDao cloudRegionDao;
 
     @MockBean
-    protected JdbcTemplateReadOnlyWrapper jdbcTemplateReadOnlyWrapper;
+    protected JdbcTemplateDryRunWrapper jdbcTemplateDryRunWrapper;
 }


### PR DESCRIPTION
relates #3619

Provides ability to enable `dry-run` regime using `system.archive.run.dry-run.regime` system property (default: off). 

- all load queries shall be logged
- all update queries shall be logged (excluding batch queries) and omitted 
