### PR TITLE
Fixed docker manifest path after is_module_available_in_point_in_time_configuration function

### DIFF
--- a/deploy/contents/install/app/install.sh
+++ b/deploy/contents/install/app/install.sh
@@ -687,9 +687,9 @@ if is_service_requested cp-docker-registry; then
         # if CP_DOCKER_MANIFEST_PATH provided explicitly - use it, otherwise check for the manifest
         # from point-in-time configuration or use default value
         if [ -z "${CP_DOCKER_MANIFEST_PATH}" ]; then
-          docker_manifest_import_users_from_point_in_time_configuration=$(is_module_available_in_point_in_time_configuration tools)
-          if [ "${docker_manifest_import_users_from_point_in_time_configuration}" ]; then
-             CP_DOCKER_MANIFEST_PATH=$(dirname "$docker_manifest_import_users_from_point_in_time_configuration")
+          docker_manifest_from_point_in_time_configuration=$(is_module_available_in_point_in_time_configuration tools)
+          if [ "${docker_manifest_from_point_in_time_configuration}" ]; then
+             CP_DOCKER_MANIFEST_PATH=$(dirname "$docker_manifest_from_point_in_time_configuration")
           else
              CP_DOCKER_MANIFEST_PATH="$INSTALL_SCRIPT_PATH/../../dockers-manifest"
           fi   

--- a/deploy/contents/install/app/install.sh
+++ b/deploy/contents/install/app/install.sh
@@ -687,8 +687,12 @@ if is_service_requested cp-docker-registry; then
         # if CP_DOCKER_MANIFEST_PATH provided explicitly - use it, otherwise check for the manifest
         # from point-in-time configuration or use default value
         if [ -z "${CP_DOCKER_MANIFEST_PATH}" ]; then
-          docker_manifest_import_users_from_point_in_time_configuration=$(dirname "$(is_module_available_in_point_in_time_configuration tools)")
-          CP_DOCKER_MANIFEST_PATH=${docker_manifest_import_users_from_point_in_time_configuration:-"$INSTALL_SCRIPT_PATH/../../dockers-manifest"}
+          docker_manifest_import_users_from_point_in_time_configuration=$(is_module_available_in_point_in_time_configuration tools)
+          if [ "${docker_manifest_import_users_from_point_in_time_configuration}" ]; then
+             CP_DOCKER_MANIFEST_PATH=$(dirname "$docker_manifest_import_users_from_point_in_time_configuration")
+          else
+             CP_DOCKER_MANIFEST_PATH="$INSTALL_SCRIPT_PATH/../../dockers-manifest"
+          fi   
         fi
 
         if [ $CP_DOCKER_INSTALLED -eq 0 ] && [ -d "$CP_DOCKER_MANIFEST_PATH" ]; then


### PR DESCRIPTION
Added check in file exist for is_module_available_in_point_in_time_configuration function to prevent path to current directory and false positive for if [ "${docker_manifest_import_users_from_point_in_time_configuration}" ]; then statement. 