### PR TITLE
PipeCLI: refresh temporary credentials with retryable API call

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -296,6 +296,8 @@ def cli():
       CP_CLI_STORAGE_ASYNC_BATCH_ENABLE      Enables asynchronous batch transfer
       CP_CLI_STORAGE_LIST_API_PAGE_SIZE      The number of storage items allowed to be loaded from the API
                                              in one request (Default: 1000)
+      CP_CLI_API_CALL_RETRY_ATTEMPTS         The number of retries to call API (Default: 3)
+      CP_CLI_API_CALL_RETRY_TIMEOUT          The time interval in seconds between API call attempts (Default: 5)
     """
     pass
 

--- a/pipe-cli/src/api/base.py
+++ b/pipe-cli/src/api/base.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import os
 import sys
 import time
 
@@ -47,8 +48,8 @@ class API(object):
             self.__proxies__ = self.__config__.resolve_proxy()
         else:
             self.__proxies__ = None
-        self.__attempts__ = 3
-        self.__timeout__ = 5
+        self.__attempts__ = int(os.getenv('CP_CLI_API_CALL_RETRY_ATTEMPTS') or 3)
+        self.__timeout__ = int(os.getenv('CP_CLI_API_CALL_RETRY_TIMEOUT') or 5)
         self.__connection_timeout__ = 10
 
     def get_url_for_method(self, method):

--- a/pipe-cli/src/api/data_storage.py
+++ b/pipe-cli/src/api/data_storage.py
@@ -250,13 +250,7 @@ class DataStorage(API):
     @classmethod
     def _get_temporary_credentials(cls, data):
         api = cls.instance()
-        response_data = api.call('datastorage/tempCredentials/', data=json.dumps(data))
-        if 'payload' in response_data:
-            return TemporaryCredentialsModel.load(response_data['payload'])
-        elif 'message' in response_data:
-            raise RuntimeError(response_data['message'])
-        else:
-            raise RuntimeError('Failed to load credentials from server.')
+        return TemporaryCredentialsModel.load(api.retryable_call('POST', 'datastorage/tempCredentials/', data=data))
 
     @staticmethod
     def create_operation_info(source_bucket, destination_bucket, command, versioning=False):


### PR DESCRIPTION
#### Background
At the moment, `pipe storage cp/mp` operations cannot process file properly if API does not respond for some period of time. It would be nice to implement retryable API calls during long copy operation.

#### Approach
There are two possible types of API call inside copy processing:
- tags applying (already retryable)
- temporary credentials refreshing  - need to be done

Also, a new environment variables shall be supported to manage API waiting period:
- `CP_CLI_API_CALL_RETRY_ATTEMPTS ` - the number of retries to call API
-  `CP_CLI_API_CALL_RETRY_TIMEOUT ` - the time interval in seconds between API call attempts