### PR TITLE
Changes in launch.sh: fix execution command syntax

### DIFF
--- a/scripts/pipeline-launch/launch.sh
+++ b/scripts/pipeline-launch/launch.sh
@@ -2651,8 +2651,8 @@ if [ "${CP_EXEC_TIMEOUT}" ] && [ "${CP_EXEC_TIMEOUT}" -gt 0 ]; then
     _TIMEOUT_COMMAND_PREFIX="timeout ${CP_EXEC_TIMEOUT}m"
 fi
 
-echo "$_RUN_AS_OWNER_COMMAND_PREFIX" \
-        "$_TIMEOUT_COMMAND_PREFIX" \
+echo "$_TIMEOUT_COMMAND_PREFIX" \
+        "$_RUN_AS_OWNER_COMMAND_PREFIX" \
         "${SCRIPT}" \
         "$_RUN_AS_OWNER_COMMAND_SUFFIX" > "$CP_EXEC_SCRIPT_PATH"
 

--- a/scripts/pipeline-launch/launch.sh
+++ b/scripts/pipeline-launch/launch.sh
@@ -2638,6 +2638,10 @@ custom_cap_setup
 # Tell the environment that initilization phase is finished and a source script is going to be executed
 pipe_log SUCCESS "Environment initialization finished" "InitializeEnvironment"
 
+CP_EXEC_COMMAND_PATH="/cp-command.sh"
+echo "${SCRIPT}" > "$CP_EXEC_COMMAND_PATH"
+
+echo "Command is located in: $CP_EXEC_COMMAND_PATH"
 echo "Command text:"
 echo "${SCRIPT}"
 
@@ -2651,9 +2655,9 @@ if [ "${CP_EXEC_TIMEOUT}" ] && [ "${CP_EXEC_TIMEOUT}" -gt 0 ]; then
     _TIMEOUT_COMMAND_PREFIX="timeout ${CP_EXEC_TIMEOUT}m"
 fi
 
-echo "$_TIMEOUT_COMMAND_PREFIX" \
-        "$_RUN_AS_OWNER_COMMAND_PREFIX" \
-        "${SCRIPT}" \
+echo "$_RUN_AS_OWNER_COMMAND_PREFIX" \
+        "$_TIMEOUT_COMMAND_PREFIX" \
+        "bash ${CP_EXEC_COMMAND_PATH}" \
         "$_RUN_AS_OWNER_COMMAND_SUFFIX" > "$CP_EXEC_SCRIPT_PATH"
 
 echo "Warapped command text:"

--- a/scripts/pipeline-launch/launch.sh
+++ b/scripts/pipeline-launch/launch.sh
@@ -2653,7 +2653,7 @@ fi
 
 echo "$_RUN_AS_OWNER_COMMAND_PREFIX" \
         "$_TIMEOUT_COMMAND_PREFIX" \
-        "bash -c \"${SCRIPT}\"" \
+        "${SCRIPT}" \
         "$_RUN_AS_OWNER_COMMAND_SUFFIX" > "$CP_EXEC_SCRIPT_PATH"
 
 echo "Warapped command text:"


### PR DESCRIPTION
Explanation of the bug:

With previous realization it was possible that initial execution cmd will be parsed wrong. F.e:
```
cmd: echo "some input"
wrapped cmd: bash -c "echo "some input"" 
```
So, because of double quoting we will have wrong result of the command.