### PR TITLE
Issue 3716 cp-edge update base image to rockylinux:8 and nodejs

### DIFF
--- a/deploy/docker/cp-edge/Dockerfile
+++ b/deploy/docker/cp-edge/Dockerfile
@@ -157,4 +157,4 @@ RUN wget -q https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/filebeat/fi
     && rpm -vi filebeat-6.8.3-x86_64.rpm && rm -rf filebeat-6.8.3-x86_64.rpm
 
 COPY filebeat-config/* /etc/filebeat/
-RUN chown -R root:root /etc/filebeat/
+RUN chmod go-w /etc/filebeat/*

--- a/deploy/docker/cp-edge/Dockerfile
+++ b/deploy/docker/cp-edge/Dockerfile
@@ -35,27 +35,29 @@ ENV PATH $PATH:/usr/local/openresty/bin:/usr/local/openresty/nginx/sbin:/etc/ssh
 ENV JWT_PUB_KEY /etc/nginx/jwt-public-key.pem
 
 # Install common
-RUN yum install -y wget \
-                   bzip2 \
-                   gcc \
-                   zlib-devel \
-                   bzip2-devel \
-                   xz-devel \
-                   make \
-                   ncurses-devel \
+RUN yum install -y python2 \
+                   python3 \
                    unzip \
                    git \
                    curl \
-                   procps \
-                   patch \
+                   wget \
+                   epel-release \
+                   zlib-devel \
+                   cronie \
                    sshpass \
+                   perl \
+                   nc \
                    gcc \
+                   make \
+                   bzip2 \
+                   bzip2-devel \
                    xz \
-                   python3 \
-                   epel-release && \
-    yum groupinstall 'Development Tools' -y && \
+                   xz-devel \
+                   ncurses-devel \
+                   procps \
+                   patch && \
+    yum group install -y "Development Tools" && \
     yum clean all && \
-    yum install -y python2 && \
     ln -sf /usr/bin/python2 /usr/bin/python && \
     curl https://cloud-pipeline-oss-builds.s3.amazonaws.com/tools/pip/2.7/get-pip.py | python - && \
     pip install rsa==4.0 \

--- a/deploy/docker/cp-edge/Dockerfile
+++ b/deploy/docker/cp-edge/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Building 'maintenance' page
-FROM node:14-alpine AS maintenance
+FROM node:20-alpine AS maintenance
 
 ENV CP_MAINTENANCE_PUBLIC_URL="/maintenance"
 
@@ -27,31 +27,36 @@ COPY ./maintenance/ui .
 
 RUN npm run build
 
-FROM library/centos:7
+FROM rockylinux:8
 
-RUN sed -i 's/^#baseurl=/baseurl=/g' /etc/yum.repos.d/*.repo && \
-    sed -i 's/^metalink=/#metalink=/g' /etc/yum.repos.d/*.repo && \
-    sed -i 's/^mirrorlist=/#mirrorlist=/g' /etc/yum.repos.d/*.repo && \
-    sed -i 's/mirror.centos.org/vault.centos.org/g' /etc/yum.repos.d/*.repo
-
-ENV PATH $PATH:/usr/local/openresty/bin:/usr/local/openresty/nginx/sbin:/etc/ssh-proxy/node-v6.11.3-linux-x64/bin/
+ENV PATH $PATH:/usr/local/openresty/bin:/usr/local/openresty/nginx/sbin:/etc/ssh-proxy/node-v20.17.0-linux-x64/bin/
 
 # This shall be set during deployment
 ENV JWT_PUB_KEY /etc/nginx/jwt-public-key.pem
 
 # Install common
-RUN yum install -y python \
+RUN yum install -y wget \
+                   bzip2 \
+                   gcc \
+                   zlib-devel \
+                   bzip2-devel \
+                   xz-devel \
+                   make \
+                   ncurses-devel \
                    unzip \
                    git \
                    curl \
-                   wget \
-                   epel-release \
-                   zlib-devel \
-                   cronie \
+                   procps \
+                   patch \
                    sshpass \
-                   perl \
-                   netcat && \
-    yum group install -y "Development Tools" && \
+                   gcc \
+                   xz \
+                   python3 \
+                   epel-release && \
+    yum groupinstall 'Development Tools' -y && \
+    yum clean all && \
+    yum install -y python2 && \
+    ln -sf /usr/bin/python2 /usr/bin/python && \
     curl https://cloud-pipeline-oss-builds.s3.amazonaws.com/tools/pip/2.7/get-pip.py | python - && \
     pip install rsa==4.0 \
                 pykube==0.15.0
@@ -120,9 +125,9 @@ ADD dav-auth /etc/nginx/dav/webdav/auth-sso
 ## Install node.js
 RUN mkdir -p /etc/ssh-proxy/  && \
     cd /etc/ssh-proxy/ && \
-    wget -q https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/nodejs/node-v6.11.3-linux-x64.tar.xz && \
-    tar xfJ node-v6.11.3-linux-x64.tar.xz && \
-    rm -f node-v6.11.3-linux-x64.tar.xz
+    wget -q https://cloud-pipeline-oss-builds.s3.amazonaws.com/tools/nodejs/node-v20.17.0-linux-x64.tar.xz && \
+    tar xfJ node-v20.17.0-linux-x64.tar.xz && \
+    rm -f node-v20.17.0-linux-x64.tar.xz
 
 ## Install wetty
 ADD wetty /etc/ssh-proxy/wetty
@@ -152,3 +157,4 @@ RUN wget -q https://s3.amazonaws.com/cloud-pipeline-oss-builds/tools/filebeat/fi
     && rpm -vi filebeat-6.8.3-x86_64.rpm && rm -rf filebeat-6.8.3-x86_64.rpm
 
 COPY filebeat-config/* /etc/filebeat/
+RUN chown -R root:root /etc/filebeat/

--- a/deploy/docker/cp-edge/wetty/app.js
+++ b/deploy/docker/cp-edge/wetty/app.js
@@ -2,7 +2,7 @@ var express = require('express');
 var http = require('http');
 var path = require('path');
 var server = require('socket.io');
-var pty = require('pty.js');
+var pty = require('node-pty');
 var request = require("sync-request");
 var child_process = require('child_process');
 

--- a/deploy/docker/cp-edge/wetty/package.json
+++ b/deploy/docker/cp-edge/wetty/package.json
@@ -4,7 +4,7 @@
     "dependencies": {
         "express": "3.5.1",
         "socket.io": "^1.3.7",
-        "pty.js": "^0.3.0",
+        "node-pty": "^1.0.0",
         "optimist": "^0.6",
         "sync-request": "^4.1.0"
     },


### PR DESCRIPTION
#3716 

`pty.js` also was changed to `node-pty` since it is deprecated and can be built with new nodejs