### PR TITLE
issue #3733 Check on backend side if we need to warn about execution for tool version

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/scan/ToolOSVersionExecutionPermit.java
+++ b/api/src/main/java/com/epam/pipeline/entity/scan/ToolOSVersionExecutionPermit.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.scan;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ToolOSVersionExecutionPermit {
+
+    // true if tool allowed to be executed
+    private final boolean isAllowed;
+
+    // true if warning should be shown
+    private final boolean isAllowedWarning;
+
+}

--- a/api/src/main/java/com/epam/pipeline/entity/scan/ToolOSVersionView.java
+++ b/api/src/main/java/com/epam/pipeline/entity/scan/ToolOSVersionView.java
@@ -24,16 +24,22 @@ public class ToolOSVersionView {
     private final String distribution;
     private final String version;
     private final Boolean isAllowed;
+    private final Boolean isAllowedWarning;
 
-    public ToolOSVersionView(String distribution, String version, Boolean isAllowed) {
+    public ToolOSVersionView(String distribution, String version, Boolean isAllowed, Boolean isAllowedWarning) {
         this.distribution = distribution;
         this.version = version;
         this.isAllowed = isAllowed;
+        this.isAllowedWarning = isAllowedWarning;
     }
 
-    public static ToolOSVersionView from(final ToolOSVersion osVersion, final boolean isAllowed) {
+    public static ToolOSVersionView from(final ToolOSVersion osVersion,
+                                         final ToolOSVersionExecutionPermit executionPermit) {
         return osVersion != null
-                ? new ToolOSVersionView(osVersion.getDistribution(), osVersion.getVersion(), isAllowed)
+                ? new ToolOSVersionView(
+                        osVersion.getDistribution(), osVersion.getVersion(),
+                        executionPermit.isAllowed(), executionPermit.isAllowedWarning()
+                )
                 : null;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/entity/scan/ToolVersionScanResultView.java
+++ b/api/src/main/java/com/epam/pipeline/entity/scan/ToolVersionScanResultView.java
@@ -47,12 +47,13 @@ public class ToolVersionScanResultView {
     private Integer layersCount;
     private Map<VulnerabilitySeverity, Integer> vulnerabilitiesCount;
 
-    public static ToolVersionScanResultView from(final ToolVersionScanResult scanResult, final boolean isOSAllowed) {
+    public static ToolVersionScanResultView from(final ToolVersionScanResult scanResult,
+                                                 final ToolOSVersionExecutionPermit executionPermit) {
         return Optional.ofNullable(scanResult).map(scan ->
             ToolVersionScanResultView.builder()
                     .toolId(scan.getToolId())
                     .version(scan.getVersion())
-                    .toolOSVersion(ToolOSVersionView.from(scan.getToolOSVersion(), isOSAllowed))
+                    .toolOSVersion(ToolOSVersionView.from(scan.getToolOSVersion(), executionPermit))
                     .status(scan.getStatus())
                     .scanDate(scan.getScanDate())
                     .successScanDate(scan.getSuccessScanDate())

--- a/api/src/main/java/com/epam/pipeline/manager/docker/scan/AggregatingToolScanManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/scan/AggregatingToolScanManager.java
@@ -270,7 +270,7 @@ public class AggregatingToolScanManager implements ToolScanManager {
 
             LOGGER.debug("Tool: {} version: {} Check tool os version.", tool.getId(), tag);
             if (toolVersionScanResult.getToolOSVersion() != null
-                    && !toolManager.isToolOSVersionAllowed(toolVersionScanResult.getToolOSVersion())) {
+                    && !toolManager.isToolOSVersionAllowed(toolVersionScanResult.getToolOSVersion()).isAllowed()) {
                 LOGGER.warn("Tool: {} version: {}. Tool os version isn't allowed, check preference {} ! Cancel run.",
                         tool.getId(), tag, SystemPreferences.DOCKER_SECURITY_TOOL_OS.getKey());
                 return ToolExecutionCheckStatus.fail("This type of OS is not supported.");

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/ToolManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/ToolManager.java
@@ -38,6 +38,7 @@ import com.epam.pipeline.entity.pipeline.ToolScanStatus;
 import com.epam.pipeline.entity.pipeline.ToolWithIssuesCount;
 import com.epam.pipeline.entity.scan.ToolDependency;
 import com.epam.pipeline.entity.scan.ToolOSVersion;
+import com.epam.pipeline.entity.scan.ToolOSVersionExecutionPermit;
 import com.epam.pipeline.entity.scan.ToolScanResult;
 import com.epam.pipeline.entity.scan.ToolVersionScanResult;
 import com.epam.pipeline.entity.scan.ToolVersionScanResultView;
@@ -824,14 +825,18 @@ public class ToolManager implements SecuredEntityManager {
                 loadToolVersionAttributes(tool, version);
     }
 
-    public boolean isToolOSVersionAllowed(final ToolOSVersion toolOSVersion) {
+    public ToolOSVersionExecutionPermit isToolOSVersionAllowed(final ToolOSVersion toolOSVersion) {
         final String allowedOSes = preferenceManager.getPreference(SystemPreferences.DOCKER_SECURITY_TOOL_OS);
         final String allowedWithWarningOSes = preferenceManager.getPreference(
                 SystemPreferences.DOCKER_SECURITY_TOOL_OS_WITH_WARNING);
+        boolean allowedWithWarning = toolOSVersion != null && toolOSVersion.isMatched(allowedWithWarningOSes);
         if (StringUtils.isEmpty(allowedOSes) || toolOSVersion == null) {
-            return true;
+            return new ToolOSVersionExecutionPermit(true, allowedWithWarning);
         }
-        return toolOSVersion.isMatched(allowedOSes) || toolOSVersion.isMatched(allowedWithWarningOSes);
+        return new ToolOSVersionExecutionPermit(
+                toolOSVersion.isMatched(allowedOSes) || allowedWithWarning,
+                allowedWithWarning
+        );
     }
 
     /**

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -963,6 +963,8 @@ public class SystemPreferences {
     public static final ObjectPreference<List<Object>> UI_RUNS_TAGS = new ObjectPreference<>(
             "ui.runs.tags", Collections.emptyList(), new TypeReference<List<Object>>() {},
             UI_GROUP, isNullOrValidJson(new TypeReference<List<Object>>() {}), true);
+    public static final StringPreference UI_TOOLS_OS_WITH_WARNING = new StringPreference("ui.tools.os.with.warning",
+            "", UI_GROUP, pass, true);
 
     // Facet Filters
     public static final ObjectPreference<Map<String, Object>> FACETED_FILTER_DICT = new ObjectPreference<>(

--- a/api/src/test/java/com/epam/pipeline/manager/docker/scan/AggregatingToolScanManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/docker/scan/AggregatingToolScanManagerTest.java
@@ -455,6 +455,10 @@ public class AggregatingToolScanManagerTest {
         TestUtils.generateScanResult(MAX_CRITICAL_VULNERABILITIES, MAX_HIGH_VULNERABILITIES,
                 ONE, toolScanResult, new ToolOSVersion(CENTOS_OS, "7"));
         Assert.assertTrue(aggregatingToolScanManager.checkTool(testTool, LATEST_VERSION).isAllowed());
+        final ToolOSVersionExecutionPermit executionPermit = toolManager.isToolOSVersionAllowed(
+                ToolOSVersion.builder().distribution(CENTOS_OS).version("7").build());
+        Assert.assertTrue(executionPermit.isAllowed());
+        Assert.assertFalse(executionPermit.isAllowedWarning());
     }
 
     @Test
@@ -466,6 +470,10 @@ public class AggregatingToolScanManagerTest {
         TestUtils.generateScanResult(0, 0,
                 ONE, toolScanResult, new ToolOSVersion(UBUNTU_OS, "14"));
         Assert.assertTrue(aggregatingToolScanManager.checkTool(testTool, LATEST_VERSION).isAllowed());
+        final ToolOSVersionExecutionPermit executionPermit = toolManager.isToolOSVersionAllowed(
+                ToolOSVersion.builder().distribution(UBUNTU_OS).version("14").build());
+        Assert.assertTrue(executionPermit.isAllowed());
+        Assert.assertTrue(executionPermit.isAllowedWarning());
     }
 
     @Test
@@ -475,6 +483,10 @@ public class AggregatingToolScanManagerTest {
         TestUtils.generateScanResult(0, 0,
                 ONE, toolScanResult, new ToolOSVersion(UBUNTU_OS, "14"));
         Assert.assertTrue(aggregatingToolScanManager.checkTool(testTool, LATEST_VERSION).isAllowed());
+        final ToolOSVersionExecutionPermit executionPermit = toolManager.isToolOSVersionAllowed(
+                ToolOSVersion.builder().distribution(UBUNTU_OS).version("14").build());
+        Assert.assertTrue(executionPermit.isAllowed());
+        Assert.assertTrue(executionPermit.isAllowedWarning());
     }
 
     @Test
@@ -484,6 +496,21 @@ public class AggregatingToolScanManagerTest {
         TestUtils.generateScanResult(0, 0,
                 ONE, toolScanResult, new ToolOSVersion(UBUNTU_OS, "14"));
         Assert.assertTrue(aggregatingToolScanManager.checkTool(testTool, LATEST_VERSION).isAllowed());
+    }
+
+    @Test
+    public void testAllowAndWarnIfBothAllowedOSAndAllowedOSWithWarningMatched() {
+        when(preferenceManager.getPreference(SystemPreferences.DOCKER_SECURITY_TOOL_OS))
+                .thenReturn(UBUNTU_OS);
+        when(preferenceManager.getPreference(SystemPreferences.DOCKER_SECURITY_TOOL_OS_WITH_WARNING))
+                .thenReturn(UBUNTU_OS);
+        TestUtils.generateScanResult(0, 0,
+                ONE, toolScanResult, new ToolOSVersion(UBUNTU_OS, "14"));
+        Assert.assertTrue(aggregatingToolScanManager.checkTool(testTool, LATEST_VERSION).isAllowed());
+        final ToolOSVersionExecutionPermit executionPermit = toolManager.isToolOSVersionAllowed(
+                ToolOSVersion.builder().distribution(UBUNTU_OS).version("14").build());
+        Assert.assertTrue(executionPermit.isAllowed());
+        Assert.assertTrue(executionPermit.isAllowedWarning());
     }
 
     @Test


### PR DESCRIPTION
#3733 

- New `system preference` `ui.tools.os.with.warning` with template for the warning (empty by default)
- For `/tool/{id}/info` in `toolOSVersion` object server now is returning new filed `isAllowedWarning` which defines if warning should be shown for the user