### PR TITLE
Issue #3743: Support filter by tags for pipelines and data storages loading

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/datastorage/DataStorageApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/datastorage/DataStorageApiService.java
@@ -20,6 +20,7 @@ import com.epam.pipeline.common.MessageConstants;
 import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.controller.vo.DataStorageVO;
 import com.epam.pipeline.controller.vo.data.storage.UpdateDataStorageItemVO;
+import com.epam.pipeline.controller.vo.metadata.MetadataTagsFilterVO;
 import com.epam.pipeline.controller.vo.security.EntityWithPermissionVO;
 import com.epam.pipeline.entity.AbstractSecuredEntity;
 import com.epam.pipeline.entity.SecuredEntityWithAction;
@@ -88,6 +89,11 @@ public class DataStorageApiService {
     @StorageAclRead
     public List<AbstractDataStorage> getDataStorages() {
         return dataStorageManager.getDataStorages();
+    }
+
+    @StorageAclRead
+    public List<AbstractDataStorage> getDataStorages(final MetadataTagsFilterVO filter) {
+        return dataStorageManager.getDataStorages(filter);
     }
 
     @StorageAclReadAndWrite

--- a/api/src/main/java/com/epam/pipeline/acl/datastorage/DataStorageApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/datastorage/DataStorageApiService.java
@@ -20,7 +20,7 @@ import com.epam.pipeline.common.MessageConstants;
 import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.controller.vo.DataStorageVO;
 import com.epam.pipeline.controller.vo.data.storage.UpdateDataStorageItemVO;
-import com.epam.pipeline.controller.vo.metadata.MetadataTagsFilterVO;
+import com.epam.pipeline.controller.vo.EntityFilterVO;
 import com.epam.pipeline.controller.vo.security.EntityWithPermissionVO;
 import com.epam.pipeline.entity.AbstractSecuredEntity;
 import com.epam.pipeline.entity.SecuredEntityWithAction;
@@ -92,7 +92,7 @@ public class DataStorageApiService {
     }
 
     @StorageAclRead
-    public List<AbstractDataStorage> getDataStorages(final MetadataTagsFilterVO filter) {
+    public List<AbstractDataStorage> getDataStorages(final EntityFilterVO filter) {
         return dataStorageManager.getDataStorages(filter);
     }
 

--- a/api/src/main/java/com/epam/pipeline/acl/pipeline/PipelineApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/pipeline/PipelineApiService.java
@@ -26,6 +26,7 @@ import com.epam.pipeline.controller.vo.PipelinesWithPermissionsVO;
 import com.epam.pipeline.controller.vo.RegisterPipelineVersionVO;
 import com.epam.pipeline.controller.vo.TaskGraphVO;
 import com.epam.pipeline.controller.vo.UploadFileMetadata;
+import com.epam.pipeline.controller.vo.metadata.MetadataTagsFilterVO;
 import com.epam.pipeline.entity.cluster.InstancePrice;
 import com.epam.pipeline.entity.git.GitCommitEntry;
 import com.epam.pipeline.entity.git.GitCommitsFilter;
@@ -129,6 +130,12 @@ public class PipelineApiService {
     @AclMaskList
     public List<Pipeline> loadAllPipelines(boolean loadVersions) {
         return pipelineManager.loadAllPipelines(loadVersions);
+    }
+
+    @PostFilter("hasRole('ADMIN') OR hasPermission(filterObject, 'READ')")
+    @AclMaskList
+    public List<Pipeline> filterPipeline(final boolean loadVersions, final MetadataTagsFilterVO filter) {
+        return pipelineManager.loadAllPipelines(loadVersions, filter);
     }
 
     @PreAuthorize(ADMIN_ONLY)

--- a/api/src/main/java/com/epam/pipeline/acl/pipeline/PipelineApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/pipeline/PipelineApiService.java
@@ -26,7 +26,7 @@ import com.epam.pipeline.controller.vo.PipelinesWithPermissionsVO;
 import com.epam.pipeline.controller.vo.RegisterPipelineVersionVO;
 import com.epam.pipeline.controller.vo.TaskGraphVO;
 import com.epam.pipeline.controller.vo.UploadFileMetadata;
-import com.epam.pipeline.controller.vo.metadata.MetadataTagsFilterVO;
+import com.epam.pipeline.controller.vo.EntityFilterVO;
 import com.epam.pipeline.entity.cluster.InstancePrice;
 import com.epam.pipeline.entity.git.GitCommitEntry;
 import com.epam.pipeline.entity.git.GitCommitsFilter;
@@ -134,7 +134,7 @@ public class PipelineApiService {
 
     @PostFilter("hasRole('ADMIN') OR hasPermission(filterObject, 'READ')")
     @AclMaskList
-    public List<Pipeline> filterPipeline(final boolean loadVersions, final MetadataTagsFilterVO filter) {
+    public List<Pipeline> filterPipelines(final boolean loadVersions, final EntityFilterVO filter) {
         return pipelineManager.loadAllPipelines(loadVersions, filter);
     }
 

--- a/api/src/main/java/com/epam/pipeline/controller/datastorage/DataStorageController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/datastorage/DataStorageController.java
@@ -23,7 +23,7 @@ import com.epam.pipeline.controller.vo.GenerateDownloadUrlVO;
 import com.epam.pipeline.controller.vo.UploadFileMetadata;
 import com.epam.pipeline.controller.vo.data.storage.DataStorageMountVO;
 import com.epam.pipeline.controller.vo.data.storage.UpdateDataStorageItemVO;
-import com.epam.pipeline.controller.vo.metadata.MetadataTagsFilterVO;
+import com.epam.pipeline.controller.vo.EntityFilterVO;
 import com.epam.pipeline.controller.vo.security.EntityWithPermissionVO;
 import com.epam.pipeline.entity.AbstractSecuredEntity;
 import com.epam.pipeline.entity.SecuredEntityWithAction;
@@ -99,7 +99,7 @@ public class DataStorageController extends AbstractRestController {
         return Result.success(dataStorageApiService.getDataStorages());
     }
 
-    @PostMapping("/datastorage/loadAll")
+    @PostMapping("/datastorage/filter")
     @ResponseBody
     @ApiOperation(
             value = "Loads all data storages with specified filters.",
@@ -108,7 +108,7 @@ public class DataStorageController extends AbstractRestController {
     @ApiResponses(
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
             })
-    public Result<List<AbstractDataStorage>> filterDataStorages(@RequestBody final MetadataTagsFilterVO filter) {
+    public Result<List<AbstractDataStorage>> filterDataStorages(@RequestBody final EntityFilterVO filter) {
         return Result.success(dataStorageApiService.getDataStorages(filter));
     }
 

--- a/api/src/main/java/com/epam/pipeline/controller/datastorage/DataStorageController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/datastorage/DataStorageController.java
@@ -99,7 +99,7 @@ public class DataStorageController extends AbstractRestController {
         return Result.success(dataStorageApiService.getDataStorages());
     }
 
-    @PostMapping("/datastorage/filter")
+    @PostMapping("/datastorage/loadAll")
     @ResponseBody
     @ApiOperation(
             value = "Loads all data storages with specified filters.",

--- a/api/src/main/java/com/epam/pipeline/controller/datastorage/DataStorageController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/datastorage/DataStorageController.java
@@ -23,6 +23,7 @@ import com.epam.pipeline.controller.vo.GenerateDownloadUrlVO;
 import com.epam.pipeline.controller.vo.UploadFileMetadata;
 import com.epam.pipeline.controller.vo.data.storage.DataStorageMountVO;
 import com.epam.pipeline.controller.vo.data.storage.UpdateDataStorageItemVO;
+import com.epam.pipeline.controller.vo.metadata.MetadataTagsFilterVO;
 import com.epam.pipeline.controller.vo.security.EntityWithPermissionVO;
 import com.epam.pipeline.entity.AbstractSecuredEntity;
 import com.epam.pipeline.entity.SecuredEntityWithAction;
@@ -96,6 +97,19 @@ public class DataStorageController extends AbstractRestController {
             })
     public Result<List<AbstractDataStorage>> getDataStorages() {
         return Result.success(dataStorageApiService.getDataStorages());
+    }
+
+    @PostMapping("/datastorage/filter")
+    @ResponseBody
+    @ApiOperation(
+            value = "Loads all data storages with specified filters.",
+            notes = "Loads all data storages with specified filters.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public Result<List<AbstractDataStorage>> filterDataStorages(@RequestBody final MetadataTagsFilterVO filter) {
+        return Result.success(dataStorageApiService.getDataStorages(filter));
     }
 
     @RequestMapping(value = "/datastorage/available", method = RequestMethod.GET)

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineController.java
@@ -168,7 +168,7 @@ public class PipelineController extends AbstractRestController {
         return Result.success(pipelineApiService.loadAllPipelines(loadVersion));
     }
 
-    @PostMapping("/pipeline/filter")
+    @PostMapping("/pipeline/loadAll")
     @ResponseBody
     @ApiOperation(
             value = "Loads all registered pipelines with specified filters.",

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineController.java
@@ -29,7 +29,7 @@ import com.epam.pipeline.controller.vo.PipelinesWithPermissionsVO;
 import com.epam.pipeline.controller.vo.RegisterPipelineVersionVO;
 import com.epam.pipeline.controller.vo.TaskGraphVO;
 import com.epam.pipeline.controller.vo.UploadFileMetadata;
-import com.epam.pipeline.controller.vo.metadata.MetadataTagsFilterVO;
+import com.epam.pipeline.controller.vo.EntityFilterVO;
 import com.epam.pipeline.entity.cluster.InstancePrice;
 import com.epam.pipeline.entity.git.GitCommitEntry;
 import com.epam.pipeline.entity.git.GitCommitsFilter;
@@ -168,7 +168,7 @@ public class PipelineController extends AbstractRestController {
         return Result.success(pipelineApiService.loadAllPipelines(loadVersion));
     }
 
-    @PostMapping("/pipeline/loadAll")
+    @PostMapping("/pipeline/filter")
     @ResponseBody
     @ApiOperation(
             value = "Loads all registered pipelines with specified filters.",
@@ -177,10 +177,10 @@ public class PipelineController extends AbstractRestController {
     @ApiResponses(
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
             })
-    public Result<List<Pipeline>> loadPipelineWithFilter(
-            @RequestBody final MetadataTagsFilterVO filter,
+    public Result<List<Pipeline>> filterPipelines(
+            @RequestBody final EntityFilterVO filter,
             @RequestParam(defaultValue = "false") final Boolean loadVersion) {
-        return Result.success(pipelineApiService.filterPipeline(loadVersion, filter));
+        return Result.success(pipelineApiService.filterPipelines(loadVersion, filter));
     }
 
     @GetMapping(value = "/pipeline/permissions")

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineController.java
@@ -29,6 +29,7 @@ import com.epam.pipeline.controller.vo.PipelinesWithPermissionsVO;
 import com.epam.pipeline.controller.vo.RegisterPipelineVersionVO;
 import com.epam.pipeline.controller.vo.TaskGraphVO;
 import com.epam.pipeline.controller.vo.UploadFileMetadata;
+import com.epam.pipeline.controller.vo.metadata.MetadataTagsFilterVO;
 import com.epam.pipeline.entity.cluster.InstancePrice;
 import com.epam.pipeline.entity.git.GitCommitEntry;
 import com.epam.pipeline.entity.git.GitCommitsFilter;
@@ -165,6 +166,21 @@ public class PipelineController extends AbstractRestController {
     public Result<List<Pipeline>> loadAllPipelines(
             @RequestParam(defaultValue = "false") Boolean loadVersion) {
         return Result.success(pipelineApiService.loadAllPipelines(loadVersion));
+    }
+
+    @PostMapping("/pipeline/filter")
+    @ResponseBody
+    @ApiOperation(
+            value = "Loads all registered pipelines with specified filters.",
+            notes = "Loads all registered pipelines with specified filters.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public Result<List<Pipeline>> loadPipelineWithFilter(
+            @RequestBody final MetadataTagsFilterVO filter,
+            @RequestParam(defaultValue = "false") final Boolean loadVersion) {
+        return Result.success(pipelineApiService.filterPipeline(loadVersion, filter));
     }
 
     @GetMapping(value = "/pipeline/permissions")

--- a/api/src/main/java/com/epam/pipeline/controller/vo/EntityFilterVO.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/EntityFilterVO.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.controller.vo.metadata;
+package com.epam.pipeline.controller.vo;
 
 import lombok.Data;
 
@@ -22,6 +22,6 @@ import java.util.List;
 import java.util.Map;
 
 @Data
-public class MetadataTagsFilterVO {
+public class EntityFilterVO {
     private Map<String, List<String>> tags;
 }

--- a/api/src/main/java/com/epam/pipeline/controller/vo/metadata/MetadataTagsFilterVO.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/metadata/MetadataTagsFilterVO.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.controller.vo.metadata;
+
+import lombok.Data;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+public class MetadataTagsFilterVO {
+    private Map<String, List<String>> tags;
+}

--- a/api/src/main/java/com/epam/pipeline/dao/MetadataTagsUtils.java
+++ b/api/src/main/java/com/epam/pipeline/dao/MetadataTagsUtils.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.dao;
+
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public interface MetadataTagsUtils {
+    Pattern FILTER_PATTERN = Pattern.compile("@FILTER@");
+
+    static String buildTagsFilterClause(final String query, final Map<String, List<String>> tags) {
+        return FILTER_PATTERN.matcher(query).replaceFirst(tags.entrySet().stream()
+                .map(entry -> tagFilterQuery(entry.getKey(), entry.getValue()))
+                .collect(Collectors.joining(" AND ")));
+    }
+
+    static String tagFilterQuery(final String key, final List<String> values) {
+        return String.format("(m.data->'%s'->>'value' IN (%s))", key,
+                values.stream()
+                        .map(value -> String.format("'%s'", value))
+                        .collect(Collectors.joining(", ")));
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/dao/MetadataTagsUtils.java
+++ b/api/src/main/java/com/epam/pipeline/dao/MetadataTagsUtils.java
@@ -34,6 +34,6 @@ public interface MetadataTagsUtils {
         return String.format("(m.data->'%s'->>'value' IN (%s))", key,
                 values.stream()
                         .map(value -> String.format("'%s'", value))
-                        .collect(Collectors.joining(", ")));
+                        .collect(Collectors.joining(",")));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/datastorage/DataStorageDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/datastorage/DataStorageDao.java
@@ -17,7 +17,9 @@
 package com.epam.pipeline.dao.datastorage;
 
 import com.epam.pipeline.config.JsonMapper;
+import com.epam.pipeline.controller.vo.metadata.MetadataTagsFilterVO;
 import com.epam.pipeline.dao.DaoHelper;
+import com.epam.pipeline.dao.MetadataTagsUtils;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorageFactory;
 import com.epam.pipeline.entity.datastorage.DataStorageRoot;
@@ -98,6 +100,7 @@ public class DataStorageDao extends NamedParameterJdbcDaoSupport {
     private String deleteToolsToMountQuery;
     private String addToolVersionToMountQuery;
     private String loadDataStoragesByRootIdsQuery;
+    private String loadDataStoragesFilterQuery;
 
     @Autowired
     private DaoHelper daoHelper;
@@ -179,6 +182,12 @@ public class DataStorageDao extends NamedParameterJdbcDaoSupport {
 
     public List<AbstractDataStorage> loadAllDataStorages() {
         return getNamedParameterJdbcTemplate().query(loadAllDataStoragesQuery,
+                DataStorageParameters.getRowMapper());
+    }
+
+    public List<AbstractDataStorage> loadAllDataStorages(final MetadataTagsFilterVO filter) {
+        return getNamedParameterJdbcTemplate()
+                .query(MetadataTagsUtils.buildTagsFilterClause(loadDataStoragesFilterQuery, filter.getTags()),
                 DataStorageParameters.getRowMapper());
     }
 
@@ -455,7 +464,10 @@ public class DataStorageDao extends NamedParameterJdbcDaoSupport {
         this.loadDataStoragesByRootIdsQuery = loadDataStoragesByRootIdsQuery;
     }
 
-
+    @Required
+    public void setLoadDataStoragesFilterQuery(final String loadDataStoragesFilterQuery) {
+        this.loadDataStoragesFilterQuery = loadDataStoragesFilterQuery;
+    }
 
     public enum DataStorageParameters {
         DATASTORAGE_ID,

--- a/api/src/main/java/com/epam/pipeline/dao/datastorage/DataStorageDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/datastorage/DataStorageDao.java
@@ -17,7 +17,7 @@
 package com.epam.pipeline.dao.datastorage;
 
 import com.epam.pipeline.config.JsonMapper;
-import com.epam.pipeline.controller.vo.metadata.MetadataTagsFilterVO;
+import com.epam.pipeline.controller.vo.EntityFilterVO;
 import com.epam.pipeline.dao.DaoHelper;
 import com.epam.pipeline.dao.MetadataTagsUtils;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
@@ -185,7 +185,7 @@ public class DataStorageDao extends NamedParameterJdbcDaoSupport {
                 DataStorageParameters.getRowMapper());
     }
 
-    public List<AbstractDataStorage> loadAllDataStorages(final MetadataTagsFilterVO filter) {
+    public List<AbstractDataStorage> loadAllDataStorages(final EntityFilterVO filter) {
         return getNamedParameterJdbcTemplate()
                 .query(MetadataTagsUtils.buildTagsFilterClause(loadDataStoragesFilterQuery, filter.getTags()),
                 DataStorageParameters.getRowMapper());

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineDao.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import com.epam.pipeline.controller.vo.metadata.MetadataTagsFilterVO;
+import com.epam.pipeline.controller.vo.EntityFilterVO;
 import com.epam.pipeline.dao.DaoHelper;
 import com.epam.pipeline.dao.MetadataTagsUtils;
 import com.epam.pipeline.entity.pipeline.Folder;
@@ -88,7 +88,7 @@ public class PipelineDao extends NamedParameterJdbcDaoSupport {
                 PipelineParameters.getRowMapper());
     }
 
-    public List<Pipeline> loadAllPipelines(final MetadataTagsFilterVO filter) {
+    public List<Pipeline> loadAllPipelines(final EntityFilterVO filter) {
         return getNamedParameterJdbcTemplate().query(
                 MetadataTagsUtils.buildTagsFilterClause(loadPipelinesFiltersQuery, filter.getTags()),
                 PipelineParameters.getRowMapper());

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/PipelineDao.java
@@ -27,7 +27,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import com.epam.pipeline.controller.vo.metadata.MetadataTagsFilterVO;
 import com.epam.pipeline.dao.DaoHelper;
+import com.epam.pipeline.dao.MetadataTagsUtils;
 import com.epam.pipeline.entity.pipeline.Folder;
 import com.epam.pipeline.entity.pipeline.Pipeline;
 import com.epam.pipeline.entity.pipeline.PipelineType;
@@ -63,6 +65,7 @@ public class PipelineDao extends NamedParameterJdbcDaoSupport {
     private String loadAllPipelinesWithParentsQuery;
     private String loadPipelinesCountQuery;
     private String loadPipelineWithParentsQuery;
+    private String loadPipelinesFiltersQuery;
 
     @Transactional(propagation = Propagation.MANDATORY)
     public Long createPipelineId() {
@@ -82,6 +85,12 @@ public class PipelineDao extends NamedParameterJdbcDaoSupport {
 
     public List<Pipeline> loadAllPipelines() {
         return getNamedParameterJdbcTemplate().query(loadAllPipelinesQuery,
+                PipelineParameters.getRowMapper());
+    }
+
+    public List<Pipeline> loadAllPipelines(final MetadataTagsFilterVO filter) {
+        return getNamedParameterJdbcTemplate().query(
+                MetadataTagsUtils.buildTagsFilterClause(loadPipelinesFiltersQuery, filter.getTags()),
                 PipelineParameters.getRowMapper());
     }
 
@@ -314,5 +323,10 @@ public class PipelineDao extends NamedParameterJdbcDaoSupport {
     @Required
     public void setLoadPipelineWithParentsQuery(String loadPipelineWithParentsQuery) {
         this.loadPipelineWithParentsQuery = loadPipelineWithParentsQuery;
+    }
+
+    @Required
+    public void setLoadPipelinesFiltersQuery(final String loadPipelinesFiltersQuery) {
+        this.loadPipelinesFiltersQuery = loadPipelinesFiltersQuery;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
@@ -23,7 +23,7 @@ import com.epam.pipeline.controller.vo.DataStorageVO;
 import com.epam.pipeline.controller.vo.EntityVO;
 import com.epam.pipeline.controller.vo.MetadataVO;
 import com.epam.pipeline.controller.vo.data.storage.UpdateDataStorageItemVO;
-import com.epam.pipeline.controller.vo.metadata.MetadataTagsFilterVO;
+import com.epam.pipeline.controller.vo.EntityFilterVO;
 import com.epam.pipeline.dao.datastorage.DataStorageDao;
 import com.epam.pipeline.dto.datastorage.lifecycle.restore.StorageRestoreAction;
 import com.epam.pipeline.dto.datastorage.lifecycle.restore.StorageRestorePathType;
@@ -226,7 +226,7 @@ public class DataStorageManager implements SecuredEntityManager {
         return dataStorageDao.loadAllDataStorages();
     }
 
-    public List<AbstractDataStorage> getDataStorages(final MetadataTagsFilterVO filter) {
+    public List<AbstractDataStorage> getDataStorages(final EntityFilterVO filter) {
         return Objects.isNull(filter) || MapUtils.isEmpty(filter.getTags())
                 ? dataStorageDao.loadAllDataStorages()
                 : dataStorageDao.loadAllDataStorages(filter);

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
@@ -23,6 +23,7 @@ import com.epam.pipeline.controller.vo.DataStorageVO;
 import com.epam.pipeline.controller.vo.EntityVO;
 import com.epam.pipeline.controller.vo.MetadataVO;
 import com.epam.pipeline.controller.vo.data.storage.UpdateDataStorageItemVO;
+import com.epam.pipeline.controller.vo.metadata.MetadataTagsFilterVO;
 import com.epam.pipeline.dao.datastorage.DataStorageDao;
 import com.epam.pipeline.dto.datastorage.lifecycle.restore.StorageRestoreAction;
 import com.epam.pipeline.dto.datastorage.lifecycle.restore.StorageRestorePathType;
@@ -223,6 +224,12 @@ public class DataStorageManager implements SecuredEntityManager {
 
     public List<AbstractDataStorage> getDataStorages() {
         return dataStorageDao.loadAllDataStorages();
+    }
+
+    public List<AbstractDataStorage> getDataStorages(final MetadataTagsFilterVO filter) {
+        return Objects.isNull(filter) || MapUtils.isEmpty(filter.getTags())
+                ? dataStorageDao.loadAllDataStorages()
+                : dataStorageDao.loadAllDataStorages(filter);
     }
 
     public List<AbstractDataStorage> getDataStoragesWithToolsToMount() {

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineManager.java
@@ -22,7 +22,7 @@ import com.epam.pipeline.config.Constants;
 import com.epam.pipeline.controller.vo.CheckRepositoryVO;
 import com.epam.pipeline.controller.vo.EntityVO;
 import com.epam.pipeline.controller.vo.PipelineVO;
-import com.epam.pipeline.controller.vo.metadata.MetadataTagsFilterVO;
+import com.epam.pipeline.controller.vo.EntityFilterVO;
 import com.epam.pipeline.dao.datastorage.rules.DataStorageRuleDao;
 import com.epam.pipeline.dao.pipeline.PipelineDao;
 import com.epam.pipeline.dao.pipeline.PipelineRunDao;
@@ -290,7 +290,7 @@ public class PipelineManager implements SecuredEntityManager {
         return result;
     }
 
-    public List<Pipeline> loadAllPipelines(final boolean loadVersions, final MetadataTagsFilterVO filter) {
+    public List<Pipeline> loadAllPipelines(final boolean loadVersions, final EntityFilterVO filter) {
         final List<Pipeline> result = Objects.isNull(filter) || MapUtils.isEmpty(filter.getTags())
                 ? pipelineDao.loadAllPipelines()
                 : pipelineDao.loadAllPipelines(filter);

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineManager.java
@@ -22,6 +22,7 @@ import com.epam.pipeline.config.Constants;
 import com.epam.pipeline.controller.vo.CheckRepositoryVO;
 import com.epam.pipeline.controller.vo.EntityVO;
 import com.epam.pipeline.controller.vo.PipelineVO;
+import com.epam.pipeline.controller.vo.metadata.MetadataTagsFilterVO;
 import com.epam.pipeline.dao.datastorage.rules.DataStorageRuleDao;
 import com.epam.pipeline.dao.pipeline.PipelineDao;
 import com.epam.pipeline.dao.pipeline.PipelineRunDao;
@@ -44,6 +45,7 @@ import com.epam.pipeline.manager.security.acl.AclSync;
 import com.epam.pipeline.utils.GitUtils;
 import com.epam.pipeline.utils.PasswordGenerator;
 import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,6 +58,7 @@ import org.springframework.util.Assert;
 import org.springframework.web.client.HttpClientErrorException;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -281,6 +284,16 @@ public class PipelineManager implements SecuredEntityManager {
 
     public List<Pipeline> loadAllPipelines(boolean loadVersions) {
         List<Pipeline> result = pipelineDao.loadAllPipelines();
+        if (loadVersions) {
+            result.forEach(this::setCurrentVersion);
+        }
+        return result;
+    }
+
+    public List<Pipeline> loadAllPipelines(final boolean loadVersions, final MetadataTagsFilterVO filter) {
+        final List<Pipeline> result = Objects.isNull(filter) || MapUtils.isEmpty(filter.getTags())
+                ? pipelineDao.loadAllPipelines()
+                : pipelineDao.loadAllPipelines(filter);
         if (loadVersions) {
             result.forEach(this::setCurrentVersion);
         }

--- a/api/src/main/resources/dao/datastorage-dao.xml
+++ b/api/src/main/resources/dao/datastorage-dao.xml
@@ -154,6 +154,47 @@
                 ]]>
             </value>
         </property>
+        <property name="loadDataStoragesFilterQuery">
+            <value>
+                <![CDATA[
+                    SELECT
+                        d.datastorage_id,
+                        d.datastorage_name,
+                        d.description,
+                        d.datastorage_type,
+                        d.path,
+                        d.datastorage_root_id,
+                        d.sts_duration,
+                        d.lts_duration,
+                        d.incomplete_upload_cleanup_days,
+                        d.folder_id,
+                        d.created_date,
+                        d.owner,
+                        d.enable_versioning,
+                        d.backup_duration,
+                        d.locked as datastorage_locked,
+                        d.mount_point,
+                        d.mount_options,
+                        d.shared,
+                        d.allowed_cidrs,
+                        d.region_id as region_id,
+                        d.file_share_mount_id,
+                        d.sensitive,
+                        d.mount_disabled,
+                        d.s3_kms_key_arn,
+                        d.s3_use_assumed_creds,
+                        s3_temp_creds_role,
+                        d.mount_status,
+                        d.source_datastorage_id,
+                        d.masking_rules
+                    FROM
+                        pipeline.datastorage d
+                    LEFT JOIN pipeline.metadata m ON d.datastorage_id = m.entity_id
+                    WHERE m.entity_class = 'DATA_STORAGE' AND @FILTER@
+                    ORDER BY d.datastorage_id
+                ]]>
+            </value>
+        </property>
         <property name="loadDataStoragesByIdsQuery">
             <value>
                 <![CDATA[

--- a/api/src/main/resources/dao/pipeline-dao.xml
+++ b/api/src/main/resources/dao/pipeline-dao.xml
@@ -110,6 +110,35 @@
                 ]]>
             </value>
         </property>
+        <property name="loadPipelinesFiltersQuery">
+            <value>
+                <![CDATA[
+                    SELECT
+                        p.pipeline_id,
+                        p.pipeline_name,
+                        p.repository,
+                        p.repository_ssh,
+                        p.description,
+                        p.folder_id,
+                        p.created_date,
+                        p.owner,
+                        p.repository_token,
+                        p.repository_type,
+                        p.pipeline_type,
+                        p.config,
+                        p.locked as pipeline_locked,
+                        p.branch,
+                        p.visibility,
+                        p.code_path,
+                        p.docs_path
+                    FROM
+                        pipeline.pipeline p
+                    LEFT JOIN pipeline.metadata m ON p.pipeline_id = m.entity_id
+                    WHERE m.entity_class = 'PIPELINE' AND @FILTER@
+                    ORDER BY pipeline_id
+                ]]>
+            </value>
+        </property>
         <property name="deletePipelineQuery">
             <value>
                 <![CDATA[

--- a/api/src/test/java/com/epam/pipeline/dao/datastorage/DataStorageDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/datastorage/DataStorageDaoTest.java
@@ -17,7 +17,7 @@
 package com.epam.pipeline.dao.datastorage;
 
 import com.epam.pipeline.controller.vo.EntityVO;
-import com.epam.pipeline.controller.vo.metadata.MetadataTagsFilterVO;
+import com.epam.pipeline.controller.vo.EntityFilterVO;
 import com.epam.pipeline.dao.metadata.MetadataDao;
 import com.epam.pipeline.dao.pipeline.FolderDao;
 import com.epam.pipeline.dao.region.CloudRegionDao;
@@ -395,7 +395,7 @@ public class DataStorageDaoTest extends AbstractJdbcTest {
         createStorageWithMetadata();
         dataStorageDao.createDataStorage(getS3Storage());
 
-        final MetadataTagsFilterVO filter = new MetadataTagsFilterVO();
+        final EntityFilterVO filter = new EntityFilterVO();
         filter.setTags(Collections.singletonMap(KEY_1, Collections.singletonList(VALUE_1)));
 
         final List<AbstractDataStorage> actual = dataStorageDao.loadAllDataStorages(filter);
@@ -409,7 +409,7 @@ public class DataStorageDaoTest extends AbstractJdbcTest {
         final S3bucketDataStorage storage2 = createStorageWithMetadata(VALUE_1, VALUE_3);
         createStorageWithMetadata(VALUE_2, VALUE_3);
 
-        final MetadataTagsFilterVO filter = new MetadataTagsFilterVO();
+        final EntityFilterVO filter = new EntityFilterVO();
         filter.setTags(Collections.singletonMap(KEY_1, Collections.singletonList(VALUE_1)));
 
         final List<AbstractDataStorage> actual = dataStorageDao.loadAllDataStorages(filter);
@@ -425,7 +425,7 @@ public class DataStorageDaoTest extends AbstractJdbcTest {
         createStorageWithMetadata(VALUE_3, VALUE_2);
         final S3bucketDataStorage storage3 = createStorageWithMetadata(VALUE_2, VALUE_1);
 
-        final MetadataTagsFilterVO filter = new MetadataTagsFilterVO();
+        final EntityFilterVO filter = new EntityFilterVO();
         filter.setTags(Collections.singletonMap(KEY_1, Arrays.asList(VALUE_1, VALUE_2)));
 
         final List<AbstractDataStorage> actual = dataStorageDao.loadAllDataStorages(filter);
@@ -441,7 +441,7 @@ public class DataStorageDaoTest extends AbstractJdbcTest {
         createStorageWithMetadata();
         dataStorageDao.createDataStorage(getS3Storage());
 
-        final MetadataTagsFilterVO filter = new MetadataTagsFilterVO();
+        final EntityFilterVO filter = new EntityFilterVO();
         filter.setTags(Collections.singletonMap(KEY_2, Collections.singletonList(VALUE_1)));
 
         final List<AbstractDataStorage> actual = dataStorageDao.loadAllDataStorages(filter);
@@ -455,7 +455,7 @@ public class DataStorageDaoTest extends AbstractJdbcTest {
         createStorageWithMetadata();
         dataStorageDao.createDataStorage(getS3Storage());
 
-        final MetadataTagsFilterVO filter = new MetadataTagsFilterVO();
+        final EntityFilterVO filter = new EntityFilterVO();
         filter.setTags(Collections.singletonMap(KEY_1, Collections.singletonList(VALUE_2)));
 
         final List<AbstractDataStorage> actual = dataStorageDao.loadAllDataStorages(filter);

--- a/api/src/test/java/com/epam/pipeline/dao/datastorage/DataStorageDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/datastorage/DataStorageDaoTest.java
@@ -16,6 +16,9 @@
 
 package com.epam.pipeline.dao.datastorage;
 
+import com.epam.pipeline.controller.vo.EntityVO;
+import com.epam.pipeline.controller.vo.metadata.MetadataTagsFilterVO;
+import com.epam.pipeline.dao.metadata.MetadataDao;
 import com.epam.pipeline.dao.pipeline.FolderDao;
 import com.epam.pipeline.dao.region.CloudRegionDao;
 import com.epam.pipeline.entity.AbstractSecuredEntity;
@@ -24,20 +27,26 @@ import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
 import com.epam.pipeline.entity.datastorage.StoragePolicy;
 import com.epam.pipeline.entity.datastorage.aws.S3bucketDataStorage;
 import com.epam.pipeline.entity.datastorage.nfs.NFSDataStorage;
+import com.epam.pipeline.entity.metadata.MetadataEntry;
+import com.epam.pipeline.entity.metadata.PipeConfValue;
 import com.epam.pipeline.entity.pipeline.Folder;
 import com.epam.pipeline.entity.region.AwsRegion;
+import com.epam.pipeline.entity.security.acl.AclClass;
 import com.epam.pipeline.manager.ObjectCreatorUtils;
 import com.epam.pipeline.test.jdbc.AbstractJdbcTest;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.epam.pipeline.assertions.ProjectAssertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -52,6 +61,12 @@ public class DataStorageDaoTest extends AbstractJdbcTest {
     private static final int LTS_DURATION = 2;
     private static final int STS_DURATION = 3;
     private static final String UPDATED_VALUE = "UPDATED";
+    private static final String STRING = "string";
+    private static final String KEY_1 = "key1";
+    private static final String VALUE_1 = "value1";
+    private static final String VALUE_2 = "value2";
+    private static final String VALUE_3 = "value3";
+    private static final String KEY_2 = "key2";
 
     @Autowired
     private DataStorageDao dataStorageDao;
@@ -61,6 +76,9 @@ public class DataStorageDaoTest extends AbstractJdbcTest {
 
     @Autowired
     private CloudRegionDao cloudRegionDao;
+
+    @Autowired
+    private MetadataDao metadataDao;
 
     private Folder testFolder;
     private S3bucketDataStorage s3Bucket;
@@ -370,6 +388,80 @@ public class DataStorageDaoTest extends AbstractJdbcTest {
         verifyFolderTree(parent, loaded.getParent());
     }
 
+    @Test
+    @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
+    public void shouldLoadStoragesByTagsFilter() {
+        createStorageWithMetadata();
+        createStorageWithMetadata();
+        dataStorageDao.createDataStorage(getS3Storage());
+
+        final MetadataTagsFilterVO filter = new MetadataTagsFilterVO();
+        filter.setTags(Collections.singletonMap(KEY_1, Collections.singletonList(VALUE_1)));
+
+        final List<AbstractDataStorage> actual = dataStorageDao.loadAllDataStorages(filter);
+        assertThat(actual).hasSize(2);
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
+    public void shouldLoadStoragesByTagsFilterWithMultipleMetadataValues() {
+        final S3bucketDataStorage storage1 = createStorageWithMetadata(VALUE_1, VALUE_2);
+        final S3bucketDataStorage storage2 = createStorageWithMetadata(VALUE_1, VALUE_3);
+        createStorageWithMetadata(VALUE_2, VALUE_3);
+
+        final MetadataTagsFilterVO filter = new MetadataTagsFilterVO();
+        filter.setTags(Collections.singletonMap(KEY_1, Collections.singletonList(VALUE_1)));
+
+        final List<AbstractDataStorage> actual = dataStorageDao.loadAllDataStorages(filter);
+        assertThat(actual).hasSize(2);
+        assertThat(actual.stream().map(AbstractDataStorage::getId).collect(Collectors.toList()))
+                .containsOnly(storage1.getId(), storage2.getId());
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
+    public void shouldLoadPipelinesByTagsFilterWithMultipleFilterValues() {
+        final S3bucketDataStorage storage1 = createStorageWithMetadata(VALUE_1, VALUE_2);
+        createStorageWithMetadata(VALUE_3, VALUE_2);
+        final S3bucketDataStorage storage3 = createStorageWithMetadata(VALUE_2, VALUE_1);
+
+        final MetadataTagsFilterVO filter = new MetadataTagsFilterVO();
+        filter.setTags(Collections.singletonMap(KEY_1, Arrays.asList(VALUE_1, VALUE_2)));
+
+        final List<AbstractDataStorage> actual = dataStorageDao.loadAllDataStorages(filter);
+        assertThat(actual).hasSize(2);
+        assertThat(actual.stream().map(AbstractDataStorage::getId).collect(Collectors.toList()))
+                .containsOnly(storage1.getId(), storage3.getId());
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
+    public void shouldNotLoadPipelinesByTagsFilterIfNotSuchKey() {
+        createStorageWithMetadata();
+        createStorageWithMetadata();
+        dataStorageDao.createDataStorage(getS3Storage());
+
+        final MetadataTagsFilterVO filter = new MetadataTagsFilterVO();
+        filter.setTags(Collections.singletonMap(KEY_2, Collections.singletonList(VALUE_1)));
+
+        final List<AbstractDataStorage> actual = dataStorageDao.loadAllDataStorages(filter);
+        assertThat(actual).hasSize(0);
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
+    public void shouldNotLoadPipelinesByTagsFilterIfNotSuchValue() {
+        createStorageWithMetadata();
+        createStorageWithMetadata();
+        dataStorageDao.createDataStorage(getS3Storage());
+
+        final MetadataTagsFilterVO filter = new MetadataTagsFilterVO();
+        filter.setTags(Collections.singletonMap(KEY_1, Collections.singletonList(VALUE_2)));
+
+        final List<AbstractDataStorage> actual = dataStorageDao.loadAllDataStorages(filter);
+        assertThat(actual).hasSize(0);
+    }
+
     private void validateCreatedStorage(AbstractDataStorage actual) {
         assertThat(actual.getId())
                 .isNotNull()
@@ -430,5 +522,38 @@ public class DataStorageDaoTest extends AbstractJdbcTest {
         if (expected.getParent() != null) {
             verifyFolderTree(expected.getParent(), actual.getParent());
         }
+    }
+
+    private void createStorageWithMetadata() {
+        final S3bucketDataStorage storage = getS3Storage();
+        dataStorageDao.createDataStorage(storage);
+
+        final MetadataEntry metadata = new MetadataEntry();
+        metadata.setEntity(new EntityVO(storage.getId(), AclClass.DATA_STORAGE));
+        metadata.setData(Collections.singletonMap(KEY_1, new PipeConfValue(STRING, VALUE_1)));
+        metadataDao.registerMetadataItem(metadata);
+    }
+
+    private S3bucketDataStorage createStorageWithMetadata(final String value1, final String value2) {
+        final S3bucketDataStorage storage = getS3Storage();
+        dataStorageDao.createDataStorage(storage);
+
+        final MetadataEntry metadata = new MetadataEntry();
+        metadata.setEntity(new EntityVO(storage.getId(), AclClass.DATA_STORAGE));
+        metadata.setData(new HashMap<String, PipeConfValue>() {{
+                put(KEY_1, new PipeConfValue(STRING, value1));
+                put(KEY_2, new PipeConfValue(STRING, value2));
+            }});
+        metadataDao.registerMetadataItem(metadata);
+
+        return storage;
+    }
+
+    private S3bucketDataStorage getS3Storage() {
+        final S3bucketDataStorage storage = new S3bucketDataStorage(null, TEST_STORAGE_NAME, TEST_STORAGE_PATH);
+        storage.setDescription("testDescription");
+        storage.setRegionId(awsRegion.getId());
+        storage.setOwner(TEST_OWNER);
+        return storage;
     }
 }

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineDaoTest.java
@@ -17,7 +17,7 @@
 package com.epam.pipeline.dao.pipeline;
 
 import com.epam.pipeline.controller.vo.EntityVO;
-import com.epam.pipeline.controller.vo.metadata.MetadataTagsFilterVO;
+import com.epam.pipeline.controller.vo.EntityFilterVO;
 import com.epam.pipeline.dao.metadata.MetadataDao;
 import com.epam.pipeline.entity.metadata.MetadataEntry;
 import com.epam.pipeline.entity.metadata.PipeConfValue;
@@ -180,7 +180,7 @@ public class PipelineDaoTest extends AbstractJdbcTest {
         createPipelineWithMetadata();
         pipelineDao.createPipeline(getPipeline(TEST_NAME));
 
-        final MetadataTagsFilterVO filter = new MetadataTagsFilterVO();
+        final EntityFilterVO filter = new EntityFilterVO();
         filter.setTags(Collections.singletonMap(KEY_1, Collections.singletonList(VALUE_1)));
 
         final List<Pipeline> actual = pipelineDao.loadAllPipelines(filter);
@@ -194,7 +194,7 @@ public class PipelineDaoTest extends AbstractJdbcTest {
         final Pipeline pipeline2 = createPipelineWithMetadata(VALUE_1, VALUE_3);
         createPipelineWithMetadata(VALUE_2, VALUE_3);
 
-        final MetadataTagsFilterVO filter = new MetadataTagsFilterVO();
+        final EntityFilterVO filter = new EntityFilterVO();
         filter.setTags(Collections.singletonMap(KEY_1, Collections.singletonList(VALUE_1)));
 
         final List<Pipeline> actual = pipelineDao.loadAllPipelines(filter);
@@ -210,7 +210,7 @@ public class PipelineDaoTest extends AbstractJdbcTest {
         createPipelineWithMetadata(VALUE_3, VALUE_2);
         final Pipeline pipeline3 = createPipelineWithMetadata(VALUE_2, VALUE_1);
 
-        final MetadataTagsFilterVO filter = new MetadataTagsFilterVO();
+        final EntityFilterVO filter = new EntityFilterVO();
         filter.setTags(Collections.singletonMap(KEY_1, Arrays.asList(VALUE_1, VALUE_2)));
 
         final List<Pipeline> actual = pipelineDao.loadAllPipelines(filter);
@@ -226,7 +226,7 @@ public class PipelineDaoTest extends AbstractJdbcTest {
         createPipelineWithMetadata();
         pipelineDao.createPipeline(getPipeline(TEST_NAME));
 
-        final MetadataTagsFilterVO filter = new MetadataTagsFilterVO();
+        final EntityFilterVO filter = new EntityFilterVO();
         filter.setTags(Collections.singletonMap(KEY_2, Collections.singletonList(VALUE_1)));
 
         final List<Pipeline> actual = pipelineDao.loadAllPipelines(filter);
@@ -240,7 +240,7 @@ public class PipelineDaoTest extends AbstractJdbcTest {
         createPipelineWithMetadata();
         pipelineDao.createPipeline(getPipeline(TEST_NAME));
 
-        final MetadataTagsFilterVO filter = new MetadataTagsFilterVO();
+        final EntityFilterVO filter = new EntityFilterVO();
         filter.setTags(Collections.singletonMap(KEY_1, Collections.singletonList(VALUE_2)));
 
         final List<Pipeline> actual = pipelineDao.loadAllPipelines(filter);

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineDaoTest.java
@@ -54,11 +54,11 @@ public class PipelineDaoTest extends AbstractJdbcTest {
     private static final String TEST_CODE_PATH = "/src";
     private static final String TEST_DOCS_PATH = "/docs";
     private static final String STRING = "string";
-    public static final String KEY_1 = "key1";
-    public static final String VALUE_1 = "value1";
-    public static final String VALUE_2 = "value2";
-    public static final String VALUE_3 = "value3";
-    public static final String KEY_2 = "key2";
+    private static final String KEY_1 = "key1";
+    private static final String VALUE_1 = "value1";
+    private static final String VALUE_2 = "value2";
+    private static final String VALUE_3 = "value3";
+    private static final String KEY_2 = "key2";
 
     @Autowired
     private PipelineDao pipelineDao;
@@ -176,8 +176,8 @@ public class PipelineDaoTest extends AbstractJdbcTest {
     @Test
     @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
     public void shouldLoadPipelinesByTagsFilter() {
-        createPipelineWithMetadata(VALUE_1);
-        createPipelineWithMetadata(VALUE_1);
+        createPipelineWithMetadata();
+        createPipelineWithMetadata();
         pipelineDao.createPipeline(getPipeline(TEST_NAME));
 
         final MetadataTagsFilterVO filter = new MetadataTagsFilterVO();
@@ -222,8 +222,8 @@ public class PipelineDaoTest extends AbstractJdbcTest {
     @Test
     @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
     public void shouldNotLoadPipelinesByTagsFilterIfNotSuchKey() {
-        createPipelineWithMetadata(VALUE_1);
-        createPipelineWithMetadata(VALUE_1);
+        createPipelineWithMetadata();
+        createPipelineWithMetadata();
         pipelineDao.createPipeline(getPipeline(TEST_NAME));
 
         final MetadataTagsFilterVO filter = new MetadataTagsFilterVO();
@@ -236,8 +236,8 @@ public class PipelineDaoTest extends AbstractJdbcTest {
     @Test
     @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
     public void shouldNotLoadPipelinesByTagsFilterIfNotSuchValue() {
-        createPipelineWithMetadata(VALUE_1);
-        createPipelineWithMetadata(VALUE_1);
+        createPipelineWithMetadata();
+        createPipelineWithMetadata();
         pipelineDao.createPipeline(getPipeline(TEST_NAME));
 
         final MetadataTagsFilterVO filter = new MetadataTagsFilterVO();
@@ -296,15 +296,13 @@ public class PipelineDaoTest extends AbstractJdbcTest {
         }
     }
 
-    private Pipeline createPipelineWithMetadata(final String value) {
+    private void createPipelineWithMetadata() {
         final Pipeline pipeline = getPipeline(TEST_NAME);
         pipelineDao.createPipeline(pipeline);
         final MetadataEntry metadata = new MetadataEntry();
         metadata.setEntity(new EntityVO(pipeline.getId(), AclClass.PIPELINE));
-        metadata.setData(Collections.singletonMap(KEY_1, new PipeConfValue(STRING, value)));
+        metadata.setData(Collections.singletonMap(KEY_1, new PipeConfValue(STRING, VALUE_1)));
         metadataDao.registerMetadataItem(metadata);
-
-        return pipeline;
     }
 
     private Pipeline createPipelineWithMetadata(final String value1, final String value2) {

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/PipelineDaoTest.java
@@ -16,15 +16,24 @@
 
 package com.epam.pipeline.dao.pipeline;
 
+import com.epam.pipeline.controller.vo.EntityVO;
+import com.epam.pipeline.controller.vo.metadata.MetadataTagsFilterVO;
+import com.epam.pipeline.dao.metadata.MetadataDao;
+import com.epam.pipeline.entity.metadata.MetadataEntry;
+import com.epam.pipeline.entity.metadata.PipeConfValue;
 import com.epam.pipeline.entity.pipeline.Folder;
 import com.epam.pipeline.entity.pipeline.Pipeline;
 import com.epam.pipeline.entity.pipeline.run.RunVisibilityPolicy;
+import com.epam.pipeline.entity.security.acl.AclClass;
 import com.epam.pipeline.test.jdbc.AbstractJdbcTest;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -32,6 +41,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -43,12 +53,21 @@ public class PipelineDaoTest extends AbstractJdbcTest {
     private static final String TEST_REPO_SSH = "git@test";
     private static final String TEST_CODE_PATH = "/src";
     private static final String TEST_DOCS_PATH = "/docs";
+    private static final String STRING = "string";
+    public static final String KEY_1 = "key1";
+    public static final String VALUE_1 = "value1";
+    public static final String VALUE_2 = "value2";
+    public static final String VALUE_3 = "value3";
+    public static final String KEY_2 = "key2";
 
     @Autowired
     private PipelineDao pipelineDao;
 
     @Autowired
     private FolderDao folderDao;
+
+    @Autowired
+    private MetadataDao metadataDao;
 
     @Test
     @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
@@ -154,6 +173,80 @@ public class PipelineDaoTest extends AbstractJdbcTest {
         verifyFolderTree(loaded.getParent(), parent);
     }
 
+    @Test
+    @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
+    public void shouldLoadPipelinesByTagsFilter() {
+        createPipelineWithMetadata(VALUE_1);
+        createPipelineWithMetadata(VALUE_1);
+        pipelineDao.createPipeline(getPipeline(TEST_NAME));
+
+        final MetadataTagsFilterVO filter = new MetadataTagsFilterVO();
+        filter.setTags(Collections.singletonMap(KEY_1, Collections.singletonList(VALUE_1)));
+
+        final List<Pipeline> actual = pipelineDao.loadAllPipelines(filter);
+        assertThat(actual).hasSize(2);
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
+    public void shouldLoadPipelinesByTagsFilterWithMultipleMetadataValues() {
+        final Pipeline pipeline1 = createPipelineWithMetadata(VALUE_1, VALUE_2);
+        final Pipeline pipeline2 = createPipelineWithMetadata(VALUE_1, VALUE_3);
+        createPipelineWithMetadata(VALUE_2, VALUE_3);
+
+        final MetadataTagsFilterVO filter = new MetadataTagsFilterVO();
+        filter.setTags(Collections.singletonMap(KEY_1, Collections.singletonList(VALUE_1)));
+
+        final List<Pipeline> actual = pipelineDao.loadAllPipelines(filter);
+        assertThat(actual).hasSize(2);
+        assertThat(actual.stream().map(Pipeline::getId).collect(Collectors.toList()))
+                .containsOnly(pipeline1.getId(), pipeline2.getId());
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
+    public void shouldLoadPipelinesByTagsFilterWithMultipleFilterValues() {
+        final Pipeline pipeline1 = createPipelineWithMetadata(VALUE_1, VALUE_2);
+        createPipelineWithMetadata(VALUE_3, VALUE_2);
+        final Pipeline pipeline3 = createPipelineWithMetadata(VALUE_2, VALUE_1);
+
+        final MetadataTagsFilterVO filter = new MetadataTagsFilterVO();
+        filter.setTags(Collections.singletonMap(KEY_1, Arrays.asList(VALUE_1, VALUE_2)));
+
+        final List<Pipeline> actual = pipelineDao.loadAllPipelines(filter);
+        assertThat(actual).hasSize(2);
+        assertThat(actual.stream().map(Pipeline::getId).collect(Collectors.toList()))
+                .containsOnly(pipeline1.getId(), pipeline3.getId());
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
+    public void shouldNotLoadPipelinesByTagsFilterIfNotSuchKey() {
+        createPipelineWithMetadata(VALUE_1);
+        createPipelineWithMetadata(VALUE_1);
+        pipelineDao.createPipeline(getPipeline(TEST_NAME));
+
+        final MetadataTagsFilterVO filter = new MetadataTagsFilterVO();
+        filter.setTags(Collections.singletonMap(KEY_2, Collections.singletonList(VALUE_1)));
+
+        final List<Pipeline> actual = pipelineDao.loadAllPipelines(filter);
+        assertThat(actual).hasSize(0);
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
+    public void shouldNotLoadPipelinesByTagsFilterIfNotSuchValue() {
+        createPipelineWithMetadata(VALUE_1);
+        createPipelineWithMetadata(VALUE_1);
+        pipelineDao.createPipeline(getPipeline(TEST_NAME));
+
+        final MetadataTagsFilterVO filter = new MetadataTagsFilterVO();
+        filter.setTags(Collections.singletonMap(KEY_1, Collections.singletonList(VALUE_2)));
+
+        final List<Pipeline> actual = pipelineDao.loadAllPipelines(filter);
+        assertThat(actual).hasSize(0);
+    }
+
     private void assertPipelineWithParameters(List<Pipeline> expected, Integer pageNum, Integer pageSize) {
         Set<Pipeline> loaded = pipelineDao.loadAllPipelinesWithParents(pageNum, pageSize);
         assertEquals(expected.size(), loaded.size());
@@ -201,5 +294,30 @@ public class PipelineDaoTest extends AbstractJdbcTest {
         if (expected.getParent() != null) {
             verifyFolderTree(expected.getParent(), actual.getParent());
         }
+    }
+
+    private Pipeline createPipelineWithMetadata(final String value) {
+        final Pipeline pipeline = getPipeline(TEST_NAME);
+        pipelineDao.createPipeline(pipeline);
+        final MetadataEntry metadata = new MetadataEntry();
+        metadata.setEntity(new EntityVO(pipeline.getId(), AclClass.PIPELINE));
+        metadata.setData(Collections.singletonMap(KEY_1, new PipeConfValue(STRING, value)));
+        metadataDao.registerMetadataItem(metadata);
+
+        return pipeline;
+    }
+
+    private Pipeline createPipelineWithMetadata(final String value1, final String value2) {
+        final Pipeline pipeline = getPipeline(TEST_NAME);
+        pipelineDao.createPipeline(pipeline);
+        final MetadataEntry metadata = new MetadataEntry();
+        metadata.setEntity(new EntityVO(pipeline.getId(), AclClass.PIPELINE));
+        metadata.setData(new HashMap<String, PipeConfValue>() {{
+                put(KEY_1, new PipeConfValue(STRING, value1));
+                put(KEY_2, new PipeConfValue(STRING, value2));
+            }});
+        metadataDao.registerMetadataItem(metadata);
+
+        return pipeline;
     }
 }


### PR DESCRIPTION
implements #3743

The following methods added:
- `POST /pipeline/filter` to load all pipelines that satisfy the tag filters
- `POST /datastorage/filter` to load all data storages that satisfy the tag filters