### PR TITLE
Issue #3737: [API] Add support to export faceted search result with template file

### DIFF
--- a/api/src/main/java/com/epam/pipeline/controller/vo/search/FacetedSearchRequest.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/search/FacetedSearchRequest.java
@@ -36,4 +36,5 @@ public class FacetedSearchRequest {
     private List<String> metadataFields;
     private ScrollingParameters scrollingParameters;
     private List<SearchRequestSort> sorts;
+    private List<SearchStorageFilesRequest> files;
 }

--- a/api/src/main/java/com/epam/pipeline/controller/vo/search/SearchStorageFilesRequest.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/search/SearchStorageFilesRequest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.epam.pipeline.controller.vo.search;
+
+import lombok.Data;
+
+@Data
+public class SearchStorageFilesRequest {
+    private String path;
+    private Long storageId;
+}

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchExportManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchExportManager.java
@@ -27,6 +27,7 @@ import com.epam.pipeline.entity.search.SearchTemplateExportInfo;
 import com.epam.pipeline.manager.datastorage.DataStorageManager;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
+import com.epam.pipeline.manager.security.AuthManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -54,6 +55,7 @@ public class SearchExportManager {
     private static final String EXPORT_DATE = "Export_Date";
     private static final String EXPORT_DATE_PLACEHOLDER = String.format("{%s}", EXPORT_DATE);
     private static final String EXPORT_DATE_REGEX = String.format("\\{%s:([^}]+)\\}", EXPORT_DATE);
+    private static final String CURRENT_USER_PLACEHOLDER = "{User}";
     private static final String S3_SCHEMA = "s3://";
     private static final String CP_SCHEMA = "cp://";
     private static final String AZ_SCHEMA = "az://";
@@ -67,6 +69,7 @@ public class SearchExportManager {
     private final MessageHelper messageHelper;
     private final PreferenceManager preferenceManager;
     private final SearchResultExportManager resultExportManager;
+    private final AuthManager authManager;
 
     public byte[] export(final FacetedSearchExportRequest request) {
         final FacetedSearchRequest facetedSearchRequest = request.getFacetedSearchRequest();
@@ -123,6 +126,9 @@ public class SearchExportManager {
                         String.format("{%s:%s}", EXPORT_DATE, dateTimePattern),
                         LocalDateTime.now().format(DateTimeFormatter.ofPattern(dateTimePattern)));
             }
+        }
+        if (pathToSave.contains(CURRENT_USER_PLACEHOLDER)) {
+            resolvedPath = resolvedPath.replace(CURRENT_USER_PLACEHOLDER, authManager.getAuthorizedUser());
         }
         return resolvedPath;
     }

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchRequestBuilder.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchRequestBuilder.java
@@ -52,7 +52,6 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.MatchQueryBuilder;
-import org.elasticsearch.index.query.Operator;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.QueryStringQueryBuilder;

--- a/api/src/main/java/com/epam/pipeline/manager/search/SearchRequestBuilder.java
+++ b/api/src/main/java/com/epam/pipeline/manager/search/SearchRequestBuilder.java
@@ -426,8 +426,8 @@ public class SearchRequestBuilder {
         }
         ListUtils.emptyIfNull(filesRequests)
                 .forEach(file -> boolQueryBuilder.should(QueryBuilders.boolQuery()
-                        .must(QueryBuilders.matchQuery(ES_PATH_FIELD, file.getPath()).operator(Operator.AND))
-                        .must(QueryBuilders.matchQuery(ES_STORAGE_ID_FIELD, file.getStorageId()).operator(Operator.AND))
+                        .filter(QueryBuilders.termQuery(buildKeywordName(ES_PATH_FIELD), file.getPath()))
+                        .filter(QueryBuilders.termQuery(ES_STORAGE_ID_FIELD, file.getStorageId()))
                 ));
         return boolQueryBuilder;
     }


### PR DESCRIPTION
implements #3737 

- a new field `files` added to request body. If `files` specified `query` and `filters` will be ignored.
- a new placeholder `User` added to `save_to` mapping  filed. If `{User}` specified the current user name shall be resolved to `save_to` path.