### PR TITLE
PipeCLI: fix for restored files listing

### DIFF
--- a/pipe-cli/src/utilities/datastorage_lifecycle_manager.py
+++ b/pipe-cli/src/utilities/datastorage_lifecycle_manager.py
@@ -22,6 +22,7 @@ class DataStorageLifecycleManager:
         self.path = path
         self.is_file = is_file
         self.items = None
+        self.file_item = None
         self.sorted_paths = []
 
     def find_lifecycle_status(self, file_path):
@@ -29,24 +30,32 @@ class DataStorageLifecycleManager:
             self.load_items()
         if not file_path.startswith('/'):
             file_path = '/' + file_path
+        if self.file_item is not None and self.file_item.path == file_path:
+            return self.get_path_restore_state(self.file_item)
         for path in self.sorted_paths:
             if path == file_path or file_path.startswith(path):
-                item = self.items.get(path)
-                if not item:
-                    return None, None
-                if item.status == 'SUCCEEDED':
-                    restored_till = ' till %s' % item.restored_till\
-                        if item.restored_till else ''
-                    return ' (Restored%s)' % restored_till, item.restore_versions
-                else:
-                    return None, item.restore_versions
+                return self.get_path_restore_state(self.items.get(path))
         return None, None
 
     def load_items(self):
-        items = DataStorageLifecycle.load_hierarchy(self.storage_id, self.path, self.is_file)
+        if not self.is_file:
+            file_items = DataStorageLifecycle.load_hierarchy(self.storage_id, self.path, is_file=True)
+            if file_items:
+                self.file_item = file_items[0]
+        items = DataStorageLifecycle.load_hierarchy(self.storage_id, self.path)
         self.items = {}
         if not items:
             return
         for item in items:
             self.items.update({item.path: item})
         self.sorted_paths = sorted([item.path for item in items], key=len, reverse=True)
+
+    @staticmethod
+    def get_path_restore_state(item):
+        if not item:
+            return None, None
+        if item.status == 'SUCCEEDED':
+            restored_till = ' till %s' % item.restored_till if item.restored_till else ''
+            return ' (Restored%s)' % restored_till, item.restore_versions
+        else:
+            return None, item.restore_versions

--- a/pipe-cli/src/utilities/storage/s3.py
+++ b/pipe-cli/src/utilities/storage/s3.py
@@ -910,7 +910,7 @@ class ListingManager(StorageItemManager, AbstractListingManager):
                     name = self.get_file_name(version, prefix, recursive)
                     restore_status = None
                     if version['StorageClass'] != 'STANDARD' and version['StorageClass'] != 'INTELLIGENT_TIERING':
-                        restore_status, versions_restored = lifecycle_manager.find_lifecycle_status(name)
+                        restore_status, versions_restored = lifecycle_manager.find_lifecycle_status(version['Key'])
                         version_not_restored = restore_status and not version['IsLatest'] and not versions_restored
                         if not show_archive:
                             if not restore_status or version_not_restored:
@@ -964,7 +964,7 @@ class ListingManager(StorageItemManager, AbstractListingManager):
                     name = self.get_file_name(file, prefix, recursive)
                     lifecycle_status = None
                     if file['StorageClass'] != 'STANDARD' and file['StorageClass'] != 'INTELLIGENT_TIERING':
-                        lifecycle_status, _ = lifecycle_manager.find_lifecycle_status(name)
+                        lifecycle_status, _ = lifecycle_manager.find_lifecycle_status(file['Key'])
                         if not show_archive and not lifecycle_status:
                             continue
                     item = self.get_file_object(file, name, lifecycle_status=lifecycle_status)
@@ -993,7 +993,7 @@ class ListingManager(StorageItemManager, AbstractListingManager):
                     name = self.get_file_name(file, prefix, recursive)
                     lifecycle_status = None
                     if file['StorageClass'] != 'STANDARD' and file['StorageClass'] != 'INTELLIGENT_TIERING':
-                        lifecycle_status, _ = lifecycle_manager.find_lifecycle_status(name)
+                        lifecycle_status, _ = lifecycle_manager.find_lifecycle_status(file['Key'])
                         if not show_archive and not lifecycle_status:
                             continue
                     item = self.get_file_object(file, name, lifecycle_status=lifecycle_status)


### PR DESCRIPTION
`pipe storage ls s3://<bucket-name>/` shall be able to list restored files. The following issues were discovered:
- currently, `pipe` shows restored files with `--recursive` option only
- `pipe storage ls s3://<bucket-name>/<restored file path>` does not show restored file via full cloud path
- `pipe storage ls s3://<bucket-name>/<restored file path>` does not show single-restored files (those files that have `type = FILE` )

This PR brings fixes for issues above.