### PR TITLE
Disabling of /ebs/runs and /ebs/refernce mounts if configured

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesConstants.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesConstants.java
@@ -51,6 +51,7 @@ public final class KubernetesConstants {
 
     public static final String CP_CAP_DIND_NATIVE = "CP_CAP_DIND_NATIVE";
     public static final String CP_CAP_SYSTEMD_CONTAINER = "CP_CAP_SYSTEMD_CONTAINER";
+    public static final String CP_CAP_EBS_VOLUMES_MOUNT_DISABLED = "CP_CAP_EBS_VOLUMES_MOUNT_DISABLED";
 
     public static final String KUBE_NAME_REGEXP = "[^a-z0-9\\-]+";
     public static final String KUBE_NAME_FULL_REGEXP = "[^a-zA-Z0-9\\-._]+";

--- a/api/src/main/java/com/epam/pipeline/manager/execution/PipelineExecutor.java
+++ b/api/src/main/java/com/epam/pipeline/manager/execution/PipelineExecutor.java
@@ -61,6 +61,7 @@ import okhttp3.OkHttpClient;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.slf4j.Logger;
@@ -265,13 +266,16 @@ public class PipelineExecutor {
         final boolean isDockerInDockerEnabled = authManager.isAdmin() && isParameterEnabled(envVars,
                 KubernetesConstants.CP_CAP_DIND_NATIVE);
         final boolean isSystemdEnabled = isParameterEnabled(envVars, KubernetesConstants.CP_CAP_SYSTEMD_CONTAINER);
+        final boolean isEBSVolumesEnabled = BooleanUtils.isNotTrue(
+                isParameterEnabled(envVars, KubernetesConstants.CP_CAP_EBS_VOLUMES_MOUNT_DISABLED)
+        );
 
         spec.setServiceAccountName(kubeServiceAccount);
         final List<DockerMount> commonMounts = getMountPreference(run);
         if (KubernetesConstants.WINDOWS.equals(run.getPlatform())) {
             spec.setVolumes(getWindowsVolumes());
         } else {
-            spec.setVolumes(getVolumes(isDockerInDockerEnabled, isSystemdEnabled, commonMounts));
+            spec.setVolumes(getVolumes(isDockerInDockerEnabled, isSystemdEnabled, isEBSVolumesEnabled, commonMounts));
         }
 
         Optional.of(PodSpecMapperHelper.buildTolerations(nodeTolerances))
@@ -282,9 +286,12 @@ public class PipelineExecutor {
             spec.setHostNetwork(true);
         }
 
-        spec.setContainers(Collections.singletonList(getContainer(run,
-                envVars, dockerImage, command, imagePullPolicy,
-                isDockerInDockerEnabled, isSystemdEnabled, isParentPod, template, commonMounts)));
+        spec.setContainers(Collections.singletonList(
+                getContainer(
+                        run, envVars, dockerImage, command, imagePullPolicy, isDockerInDockerEnabled,
+                        isSystemdEnabled, isEBSVolumesEnabled, isParentPod, template, commonMounts
+                )
+        ));
         return spec;
     }
 
@@ -348,6 +355,7 @@ public class PipelineExecutor {
                                    final ImagePullPolicy imagePullPolicy,
                                    final boolean isDockerInDockerEnabled,
                                    final boolean isSystemdEnabled,
+                                   final boolean isEBSVolumesEnabled,
                                    final boolean isParentPod,
                                    final OSSpecificLaunchCommandTemplate template,
                                    final List<DockerMount> commonMounts) {
@@ -375,7 +383,9 @@ public class PipelineExecutor {
                 mergedArgs.add(command);
                 container.setArgs(mergedArgs);
             }
-            container.setVolumeMounts(getMounts(isDockerInDockerEnabled, isSystemdEnabled, commonMounts));
+            container.setVolumeMounts(
+                    getMounts(isDockerInDockerEnabled, isSystemdEnabled, isEBSVolumesEnabled, commonMounts)
+            );
             container.setTerminationMessagePath("/dev/termination-log");
         }
         container.setImagePullPolicy(imagePullPolicy.getName());
@@ -444,10 +454,13 @@ public class PipelineExecutor {
 
     private List<Volume> getVolumes(final boolean isDockerInDockerEnabled,
                                     final boolean isSystemdEnabled,
+                                    final boolean isEBSVolumesEnabled,
                                     final List<DockerMount> commonMounts) {
         final List<Volume> volumes = new ArrayList<>();
-        volumes.add(createVolume(REF_DATA_MOUNT, "/ebs/reference"));
-        volumes.add(createVolume(RUNS_DATA_MOUNT, "/ebs/runs"));
+        if (isEBSVolumesEnabled) {
+            volumes.add(createVolume(REF_DATA_MOUNT, "/ebs/reference"));
+            volumes.add(createVolume(RUNS_DATA_MOUNT, "/ebs/runs"));
+        }
         volumes.add(createEmptyVolume(EMPTY_MOUNT, "Memory"));
         final List<DockerMount> dockerMounts = preferenceManager.getPreference(
                 SystemPreferences.DOCKER_IN_DOCKER_MOUNTS);
@@ -471,10 +484,13 @@ public class PipelineExecutor {
 
     private List<VolumeMount> getMounts(final boolean isDockerInDockerEnabled,
                                         final boolean isSystemdEnabled,
+                                        final boolean isEBSVolumesEnabled,
                                         final List<DockerMount> commonMounts) {
         final List<VolumeMount> mounts = new ArrayList<>();
-        mounts.add(getVolumeMount(REF_DATA_MOUNT, "/common"));
-        mounts.add(getVolumeMount(RUNS_DATA_MOUNT, "/runs"));
+        if (isEBSVolumesEnabled) {
+            mounts.add(getVolumeMount(REF_DATA_MOUNT, "/common"));
+            mounts.add(getVolumeMount(RUNS_DATA_MOUNT, "/runs"));
+        }
         mounts.add(getVolumeMount(EMPTY_MOUNT, "/dev/shm"));
         final List<DockerMount> dockerMounts = preferenceManager.getPreference(
                 SystemPreferences.DOCKER_IN_DOCKER_MOUNTS);

--- a/deploy/contents/install/preferences/launch.system.parameters.json
+++ b/deploy/contents/install/preferences/launch.system.parameters.json
@@ -660,5 +660,12 @@
         "description": "Keeps job running even if storages mounting has failed.",
         "defaultValue": "true",
         "passToWorkers": true
+    },
+    {
+        "name": "CP_CAP_EBS_VOLUMES_MOUNT_DISABLED",
+        "type": "boolean",
+        "description": "Disable mount of /ebs/runs and /ebs/reference folders to the run file system.",
+        "defaultValue": "false",
+        "passToWorkers": false
     }
 ]


### PR DESCRIPTION
for some cases it will be better to not to mount ebs for:
 - /runs
 - /common

in case when system parameter for run `CP_CAP_EBS_VOLUMES_MOUNT_DISABLED` set to true, such mounts will not be added to pod spec