### PR TITLE
Deployment autoscaler enhancements 

### DIFF
--- a/deploy/contents/k8s/cp-deployment-autoscaler/config.json
+++ b/deploy/contents/k8s/cp-deployment-autoscaler/config.json
@@ -39,11 +39,13 @@
     "memory_utilization": {
       "max": 90,
       "monitoring_period": 600
-    }
+    },
+    "pods_utilization": 70
   },
   "rules": {
     "on_lost_instances" : "SKIP",
     "on_lost_nodes": "SKIP",
+    "on_not_running_pods": "SKIP",
     "on_threshold_trigger": {
       "extra_replicas": 2,
       "extra_nodes": 2

--- a/deploy/contents/k8s/cp-deployment-autoscaler/config.json
+++ b/deploy/contents/k8s/cp-deployment-autoscaler/config.json
@@ -45,7 +45,7 @@
   "rules": {
     "on_lost_instances" : "SKIP",
     "on_lost_nodes": "SKIP",
-    "on_not_running_pods": "SKIP",
+    "on_not_running_target_pods": "SKIP",
     "on_threshold_trigger": {
       "extra_replicas": 2,
       "extra_nodes": 2

--- a/deploy/docker/cp-deployment-autoscaler/autoscale_deploy.py
+++ b/deploy/docker/cp-deployment-autoscaler/autoscale_deploy.py
@@ -31,12 +31,13 @@ from autoscaler.instance.provider import InstanceProvider
 from autoscaler.limit import ScaleIntervalLimit, AutoscalingLimit, TriggerDurationLimit, ScaleNodesLimit, \
     ScaleDeploymentsLimit
 from autoscaler.model import NodesContainer, InstancesContainer, DeploymentsContainer
-from autoscaler.rule import AutoscalingRule, LostTransientInstancesRule, LostTransientNodesRule
+from autoscaler.rule import AutoscalingRule, LostTransientInstancesRule, LostTransientNodesRule, NoRunningPodsOnNodeRule
 from autoscaler.scaler import NodeScaler, DeploymentScaler
 from autoscaler.timer import AutoscalingTimer
 from autoscaler.trigger import AutoscalingTrigger, ClusterNodesPerTargetReplicasCoefficientTrigger, \
     TargetReplicasPerTargetNodesCoefficientTrigger, \
-    NodeDiskPressureTrigger, NodeMemoryPressureTrigger, NodePidPressureTrigger, NodeHeapsterElasticMetricTrigger
+    NodeDiskPressureTrigger, NodeMemoryPressureTrigger, NodePidPressureTrigger, NodeHeapsterElasticMetricTrigger, \
+    PodsUtilizationTrigger
 
 
 class AutoscalingDaemon:
@@ -246,7 +247,8 @@ if __name__ == '__main__':
 
         rules = [
             LostTransientInstancesRule(configuration=configuration, instance_provider=instance_provider),
-            LostTransientNodesRule(configuration=configuration, node_provider=node_provider)
+            LostTransientNodesRule(configuration=configuration, node_provider=node_provider),
+            NoRunningPodsOnNodeRule(configuration=configuration, node_provider=node_provider, node_scaler=node_scaler)
         ]
 
         triggers = [
@@ -255,7 +257,8 @@ if __name__ == '__main__':
             NodeDiskPressureTrigger(configuration, node_provider),
             NodeMemoryPressureTrigger(configuration, node_provider),
             NodePidPressureTrigger(configuration, node_provider),
-            NodeHeapsterElasticMetricTrigger(configuration, elastic_client)
+            NodeHeapsterElasticMetricTrigger(configuration, elastic_client),
+            PodsUtilizationTrigger(configuration, pod_provider)
         ]
 
         limits = [

--- a/deploy/docker/cp-deployment-autoscaler/autoscale_deploy.py
+++ b/deploy/docker/cp-deployment-autoscaler/autoscale_deploy.py
@@ -31,7 +31,8 @@ from autoscaler.instance.provider import InstanceProvider
 from autoscaler.limit import ScaleIntervalLimit, AutoscalingLimit, TriggerDurationLimit, ScaleNodesLimit, \
     ScaleDeploymentsLimit
 from autoscaler.model import NodesContainer, InstancesContainer, DeploymentsContainer
-from autoscaler.rule import AutoscalingRule, LostTransientInstancesRule, LostTransientNodesRule, NoRunningPodsOnNodeRule
+from autoscaler.rule import AutoscalingRule, LostTransientInstancesRule, LostTransientNodesRule, \
+    NoRunningTargetPodsOnNodeRule
 from autoscaler.scaler import NodeScaler, DeploymentScaler
 from autoscaler.timer import AutoscalingTimer
 from autoscaler.trigger import AutoscalingTrigger, ClusterNodesPerTargetReplicasCoefficientTrigger, \
@@ -248,7 +249,8 @@ if __name__ == '__main__':
         rules = [
             LostTransientInstancesRule(configuration=configuration, instance_provider=instance_provider),
             LostTransientNodesRule(configuration=configuration, node_provider=node_provider),
-            NoRunningPodsOnNodeRule(configuration=configuration, node_provider=node_provider, node_scaler=node_scaler)
+            NoRunningTargetPodsOnNodeRule(configuration=configuration, node_provider=node_provider,
+                                          node_scaler=node_scaler, timer=timer)
         ]
 
         triggers = [

--- a/deploy/docker/cp-deployment-autoscaler/autoscaler/cluster/kube.py
+++ b/deploy/docker/cp-deployment-autoscaler/autoscaler/cluster/kube.py
@@ -72,18 +72,18 @@ class KubeProvider(NodeProvider, PodProvider, DeploymentProvider):
         for node in nodes:
             yield self._get_node(node, used_node_names, reserved_node_names)
 
-    def has_running_pods(self, node_name: str):
-        for kube_pod in pykube.Pod.objects(self._kube):
-            if kube_pod.obj.get('spec', {}).get('nodeName', '') != node_name:
+    def has_running_target_pods(self, node_name: str, target_pods: [Pod]):
+        for pod in target_pods:
+            if pod.node_name != node_name:
                 continue
-            if self._is_pod_terminated(kube_pod):
+            if pod.state in ['Succeeded', 'Failed']:
                 continue
             return True
         return False
 
     @staticmethod
     def _is_pod_terminated(kube_pod: pykube.Pod) -> bool:
-        return kube_pod.obj.get('status', {}).get('phase', {}) in ['Succeeded', 'Failed']
+        return kube_pod.obj.get('status', {}).get('phase', '') in ['Succeeded', 'Failed']
 
     def _is_owned_by_daemon_set(self, child):
         for child_owner in child.metadata.get('ownerReferences', []):
@@ -99,8 +99,7 @@ class KubeProvider(NodeProvider, PodProvider, DeploymentProvider):
             persistence=Persistence.TRANSIENT if self._is_transient(kube_node) else Persistence.PERSISTENT,
             reserved=kube_node.name in reserved_node_names,
             used=kube_node.name in used_node_names,
-            allocatable_pods=self._get_allocatable_pods_number(kube_node)
-        )
+            allocatable_pods=self._get_allocatable_pods_number(kube_node))
 
     def _is_transient(self, kube_node):
         return any(kube_node.labels.get(key) == value for key, value in self._configuration.target.transient_labels.items())
@@ -197,7 +196,9 @@ class KubeProvider(NodeProvider, PodProvider, DeploymentProvider):
             name=kube_pod.name,
             namespace=kube_pod.namespace,
             node_name=kube_pod.obj.get('spec', {}).get('nodeName', ''),
-            reserved=kube_pod.name in reserved_pod_names)
+            reserved=kube_pod.name in reserved_pod_names,
+            state=kube_pod.obj.get('status', {}).get('phase', '')
+        )
 
     def get_pod_conditions(self, pod: Pod) -> Iterator[Condition]:
         yield from self._get_conditions(pykube.Pod, pod.name, pod.namespace)

--- a/deploy/docker/cp-deployment-autoscaler/autoscaler/cluster/kube.py
+++ b/deploy/docker/cp-deployment-autoscaler/autoscaler/cluster/kube.py
@@ -72,6 +72,19 @@ class KubeProvider(NodeProvider, PodProvider, DeploymentProvider):
         for node in nodes:
             yield self._get_node(node, used_node_names, reserved_node_names)
 
+    def has_running_pods(self, node_name: str):
+        for kube_pod in pykube.Pod.objects(self._kube):
+            if kube_pod.obj.get('spec', {}).get('nodeName', '') != node_name:
+                continue
+            if self._is_pod_terminated(kube_pod):
+                continue
+            return True
+        return False
+
+    @staticmethod
+    def _is_pod_terminated(kube_pod: pykube.Pod) -> bool:
+        return kube_pod.obj.get('status', {}).get('phase', {}) in ['Succeeded', 'Failed']
+
     def _is_owned_by_daemon_set(self, child):
         for child_owner in child.metadata.get('ownerReferences', []):
             if child_owner.get('kind', '') == 'DaemonSet':
@@ -85,10 +98,16 @@ class KubeProvider(NodeProvider, PodProvider, DeploymentProvider):
             name=kube_node.name,
             persistence=Persistence.TRANSIENT if self._is_transient(kube_node) else Persistence.PERSISTENT,
             reserved=kube_node.name in reserved_node_names,
-            used=kube_node.name in used_node_names)
+            used=kube_node.name in used_node_names,
+            allocatable_pods=self._get_allocatable_pods_number(kube_node)
+        )
 
     def _is_transient(self, kube_node):
         return any(kube_node.labels.get(key) == value for key, value in self._configuration.target.transient_labels.items())
+
+    def _get_allocatable_pods_number(self, kube_node):
+        pods_count = kube_node.obj.get('status', {}).get('allocatable', {}).get('pods')
+        return int(pods_count) if pods_count else 0
 
     def get_node_conditions(self, node: Node) -> Iterator[Condition]:
         yield from self._get_conditions(pykube.Node, node.name)
@@ -182,6 +201,22 @@ class KubeProvider(NodeProvider, PodProvider, DeploymentProvider):
 
     def get_pod_conditions(self, pod: Pod) -> Iterator[Condition]:
         yield from self._get_conditions(pykube.Pod, pod.name, pod.namespace)
+
+    def get_non_terminated_pods_number(self, node_names: [str]) -> int:
+        system_pods = pykube.Pod.objects(self._kube, namespace='kube-system')
+        default_pods = pykube.Pod.objects(self._kube)
+        return (self._find_non_terminated_pods_by_node_count(system_pods, node_names)
+                + self._find_non_terminated_pods_by_node_count(default_pods, node_names))
+
+    def _find_non_terminated_pods_by_node_count(self, pods: pykube.query.Query, node_names: [str]):
+        pods_count = 0
+        for kube_pod in pods:
+            if kube_pod.obj.get('spec', {}).get('nodeName', '') not in node_names:
+                continue
+            if self._is_pod_terminated(kube_pod):
+                continue
+            pods_count = pods_count + 1
+        return pods_count
 
     def _get_conditions(self, entity_type, entity_name, entity_namespace=None):
         kube_entity = entity_type.objects(self._kube, namespace=entity_namespace).get_by_name(entity_name)

--- a/deploy/docker/cp-deployment-autoscaler/autoscaler/cluster/kube.py
+++ b/deploy/docker/cp-deployment-autoscaler/autoscaler/cluster/kube.py
@@ -72,15 +72,6 @@ class KubeProvider(NodeProvider, PodProvider, DeploymentProvider):
         for node in nodes:
             yield self._get_node(node, used_node_names, reserved_node_names)
 
-    def has_running_target_pods(self, node_name: str, target_pods: [Pod]):
-        for pod in target_pods:
-            if pod.node_name != node_name:
-                continue
-            if pod.state in ['Succeeded', 'Failed']:
-                continue
-            return True
-        return False
-
     @staticmethod
     def _is_pod_terminated(kube_pod: pykube.Pod) -> bool:
         return kube_pod.obj.get('status', {}).get('phase', '') in ['Succeeded', 'Failed']

--- a/deploy/docker/cp-deployment-autoscaler/autoscaler/cluster/provider.py
+++ b/deploy/docker/cp-deployment-autoscaler/autoscaler/cluster/provider.py
@@ -46,7 +46,7 @@ class NodeProvider(ABC):
         pass
 
     @abstractmethod
-    def has_running_pods(self, node_name: str) -> bool:
+    def has_running_target_pods(self, node_name: str, target_pods: [Pod]) -> bool:
         pass
 
 

--- a/deploy/docker/cp-deployment-autoscaler/autoscaler/cluster/provider.py
+++ b/deploy/docker/cp-deployment-autoscaler/autoscaler/cluster/provider.py
@@ -45,6 +45,10 @@ class NodeProvider(ABC):
     def delete_node(self, node: Node):
         pass
 
+    @abstractmethod
+    def has_running_pods(self, node_name: str) -> bool:
+        pass
+
 
 class PodProvider(ABC):
 
@@ -58,6 +62,14 @@ class PodProvider(ABC):
 
     @abstractmethod
     def get_pod_conditions(self, pod: Pod) -> Iterator[Condition]:
+        pass
+
+    @abstractmethod
+    def get_non_terminated_pods_number(self, nodes: [Node]) -> int:
+        """
+        Iterates over all pods belonging to the specified nodes and returns non-terminated pods count.
+        Collects pods from all namespaces
+        """
         pass
 
 

--- a/deploy/docker/cp-deployment-autoscaler/autoscaler/cluster/provider.py
+++ b/deploy/docker/cp-deployment-autoscaler/autoscaler/cluster/provider.py
@@ -45,10 +45,6 @@ class NodeProvider(ABC):
     def delete_node(self, node: Node):
         pass
 
-    @abstractmethod
-    def has_running_target_pods(self, node_name: str, target_pods: [Pod]) -> bool:
-        pass
-
 
 class PodProvider(ABC):
 

--- a/deploy/docker/cp-deployment-autoscaler/autoscaler/config.py
+++ b/deploy/docker/cp-deployment-autoscaler/autoscaler/config.py
@@ -40,13 +40,13 @@ TriggerConfiguration = collections.namedtuple('TriggerConfiguration',
                                               'cpu_utilization, memory_utilization, pods_utilization')
 OnLostInstancesStrategy = Enum('OnLostInstancesStrategy', 'SKIP, STOP')
 OnLostNodesStrategy = Enum('OnLostNodesStrategy', 'SKIP, STOP')
-OnNotRunningPodsStrategy = Enum('OnNotRunningPodsStrategy', 'SKIP, STOP')
+OnNotRunningTargetPodsStrategy = Enum('OnNotRunningTargetPodsStrategy', 'SKIP, STOP')
 ThresholdTriggerRuleConfiguration = NamedTuple('ThresholdTrigger', [('extra_replicas', int), ('extra_nodes', int)])
 RulesConfiguration = NamedTuple('RulesConfiguration',
                                 [('on_lost_instances', OnLostInstancesStrategy),
                                  ('on_lost_nodes', OnLostNodesStrategy),
                                  ('on_threshold_trigger', ThresholdTriggerRuleConfiguration),
-                                 ('on_not_running_pods', OnNotRunningPodsStrategy)])
+                                 ('on_not_running_target_pods', OnNotRunningTargetPodsStrategy)])
 LimitConfiguration = collections.namedtuple('LimitConfiguration',
                                             'min_nodes_number, max_nodes_number, '
                                             'min_replicas_number, max_replicas_number, '
@@ -194,9 +194,9 @@ class LocalFileAutoscalingConfiguration(AutoscalingConfiguration, RefreshableCon
             on_threshold_trigger=ThresholdTriggerRuleConfiguration(
                 extra_replicas=self._get_number(configuration, 'rules.on_threshold_trigger.extra_replicas', 1),
                 extra_nodes=self._get_number(configuration, 'rules.on_threshold_trigger.extra_nodes', 1)),
-            on_not_running_pods=OnNotRunningPodsStrategy[self._get_string(configuration,
+            on_not_running_pods=OnNotRunningTargetPodsStrategy[self._get_string(configuration,
                                                                           'rules.on_not_running_pods',
-                                                                          OnNotRunningPodsStrategy.SKIP.name)])
+                                                                                OnNotRunningTargetPodsStrategy.SKIP.name)])
         self._limit = LimitConfiguration(
             min_nodes_number=self._get_number(configuration, 'limit.min_nodes_number', 1),
             max_nodes_number=self._get_number(configuration, 'limit.max_nodes_number', 10),

--- a/deploy/docker/cp-deployment-autoscaler/autoscaler/config.py
+++ b/deploy/docker/cp-deployment-autoscaler/autoscaler/config.py
@@ -37,14 +37,16 @@ UtilizationTriggerConfiguration = collections.namedtuple('UtilizationTriggerConf
 TriggerConfiguration = collections.namedtuple('TriggerConfiguration',
                                               'cluster_nodes_per_target_replicas, target_replicas_per_target_nodes, '
                                               'memory_pressured_nodes, disk_pressured_nodes, pid_pressured_nodes, '
-                                              'cpu_utilization, memory_utilization')
+                                              'cpu_utilization, memory_utilization, pods_utilization')
 OnLostInstancesStrategy = Enum('OnLostInstancesStrategy', 'SKIP, STOP')
 OnLostNodesStrategy = Enum('OnLostNodesStrategy', 'SKIP, STOP')
+OnNotRunningPodsStrategy = Enum('OnNotRunningPodsStrategy', 'SKIP, STOP')
 ThresholdTriggerRuleConfiguration = NamedTuple('ThresholdTrigger', [('extra_replicas', int), ('extra_nodes', int)])
 RulesConfiguration = NamedTuple('RulesConfiguration',
                                 [('on_lost_instances', OnLostInstancesStrategy),
                                  ('on_lost_nodes', OnLostNodesStrategy),
-                                 ('on_threshold_trigger', ThresholdTriggerRuleConfiguration)])
+                                 ('on_threshold_trigger', ThresholdTriggerRuleConfiguration),
+                                 ('on_not_running_pods', OnNotRunningPodsStrategy)])
 LimitConfiguration = collections.namedtuple('LimitConfiguration',
                                             'min_nodes_number, max_nodes_number, '
                                             'min_replicas_number, max_replicas_number, '
@@ -182,7 +184,8 @@ class LocalFileAutoscalingConfiguration(AutoscalingConfiguration, RefreshableCon
                 monitoring_period=self._get_number(configuration, 'trigger.cpu_utilization.monitoring_period', 600)),
             memory_utilization=UtilizationTriggerConfiguration(
                 max=self._get_number(configuration, 'trigger.memory_utilization.max', 90),
-                monitoring_period=self._get_number(configuration, 'trigger.memory_utilization.monitoring_period', 600)))
+                monitoring_period=self._get_number(configuration, 'trigger.memory_utilization.monitoring_period', 600)),
+            pods_utilization=self._get_number(configuration, 'trigger.allocatable_pods', 70))
         self._rules = RulesConfiguration(
             on_lost_instances=OnLostInstancesStrategy[self._get_string(configuration, 'rules.on_lost_instances',
                                                                        OnLostInstancesStrategy.SKIP.name)],
@@ -190,7 +193,10 @@ class LocalFileAutoscalingConfiguration(AutoscalingConfiguration, RefreshableCon
                                                                OnLostInstancesStrategy.SKIP.name)],
             on_threshold_trigger=ThresholdTriggerRuleConfiguration(
                 extra_replicas=self._get_number(configuration, 'rules.on_threshold_trigger.extra_replicas', 1),
-                extra_nodes=self._get_number(configuration, 'rules.on_threshold_trigger.extra_nodes', 1)))
+                extra_nodes=self._get_number(configuration, 'rules.on_threshold_trigger.extra_nodes', 1)),
+            on_not_running_pods=OnNotRunningPodsStrategy[self._get_string(configuration,
+                                                                          'rules.on_not_running_pods',
+                                                                          OnNotRunningPodsStrategy.SKIP.name)])
         self._limit = LimitConfiguration(
             min_nodes_number=self._get_number(configuration, 'limit.min_nodes_number', 1),
             max_nodes_number=self._get_number(configuration, 'limit.max_nodes_number', 10),

--- a/deploy/docker/cp-deployment-autoscaler/autoscaler/config.py
+++ b/deploy/docker/cp-deployment-autoscaler/autoscaler/config.py
@@ -194,9 +194,9 @@ class LocalFileAutoscalingConfiguration(AutoscalingConfiguration, RefreshableCon
             on_threshold_trigger=ThresholdTriggerRuleConfiguration(
                 extra_replicas=self._get_number(configuration, 'rules.on_threshold_trigger.extra_replicas', 1),
                 extra_nodes=self._get_number(configuration, 'rules.on_threshold_trigger.extra_nodes', 1)),
-            on_not_running_pods=OnNotRunningTargetPodsStrategy[self._get_string(configuration,
-                                                                          'rules.on_not_running_pods',
-                                                                                OnNotRunningTargetPodsStrategy.SKIP.name)])
+            on_not_running_target_pods=OnNotRunningTargetPodsStrategy[
+                self._get_string(configuration, 'rules.on_not_running_target_pods',
+                                 OnNotRunningTargetPodsStrategy.SKIP.name)])
         self._limit = LimitConfiguration(
             min_nodes_number=self._get_number(configuration, 'limit.min_nodes_number', 1),
             max_nodes_number=self._get_number(configuration, 'limit.max_nodes_number', 10),

--- a/deploy/docker/cp-deployment-autoscaler/autoscaler/config.py
+++ b/deploy/docker/cp-deployment-autoscaler/autoscaler/config.py
@@ -185,7 +185,7 @@ class LocalFileAutoscalingConfiguration(AutoscalingConfiguration, RefreshableCon
             memory_utilization=UtilizationTriggerConfiguration(
                 max=self._get_number(configuration, 'trigger.memory_utilization.max', 90),
                 monitoring_period=self._get_number(configuration, 'trigger.memory_utilization.monitoring_period', 600)),
-            pods_utilization=self._get_number(configuration, 'trigger.allocatable_pods', 70))
+            pods_utilization=self._get_number(configuration, 'trigger.pods_utilization', 70))
         self._rules = RulesConfiguration(
             on_lost_instances=OnLostInstancesStrategy[self._get_string(configuration, 'rules.on_lost_instances',
                                                                        OnLostInstancesStrategy.SKIP.name)],

--- a/deploy/docker/cp-deployment-autoscaler/autoscaler/model.py
+++ b/deploy/docker/cp-deployment-autoscaler/autoscaler/model.py
@@ -31,7 +31,8 @@ Node = NamedTuple('Node',
                   [('name', str),
                    ('persistence', Persistence),
                    ('reserved', bool),
-                   ('used', bool)])
+                   ('used', bool),
+                   ('allocatable_pods', int)])
 Condition = Enum('Condition', 'MEMORY_PRESSURE, DISK_PRESSURE, PID_PRESSURE, READY')
 
 

--- a/deploy/docker/cp-deployment-autoscaler/autoscaler/model.py
+++ b/deploy/docker/cp-deployment-autoscaler/autoscaler/model.py
@@ -24,7 +24,8 @@ Deployment = NamedTuple('Deployment', [('name', str),
 Pod = NamedTuple('Pod', [('name', str),
                          ('namespace', str),
                          ('node_name', str),
-                         ('reserved', bool)])
+                         ('reserved', bool),
+                         ('state', str)])
 Instance = NamedTuple('Instance', [('name', str),
                                    ('persistence', Persistence)])
 Node = NamedTuple('Node',

--- a/deploy/docker/cp-deployment-autoscaler/autoscaler/rule.py
+++ b/deploy/docker/cp-deployment-autoscaler/autoscaler/rule.py
@@ -18,7 +18,7 @@ import time
 
 from autoscaler.cluster.provider import NodeProvider
 from autoscaler.config import OnLostInstancesStrategy, AutoscalingConfiguration, OnLostNodesStrategy, \
-    OnNotRunningPodsStrategy
+    OnNotRunningTargetPodsStrategy
 from autoscaler.exception import AbortScalingError
 from autoscaler.instance.provider import InstanceProvider
 from autoscaler.model import DeploymentsContainer, NodesContainer, InstancesContainer, Node
@@ -95,7 +95,7 @@ class NoRunningTargetPodsOnNodeRule(AutoscalingRule):
 
     def apply(self, deployments_container: DeploymentsContainer, nodes_container: NodesContainer,
               instances_container: InstancesContainer):
-        logging.info('Searching for nodes without running target pods')
+        logging.info('Searching for nodes without running target pods...')
         empty_nodes = []
         for node in nodes_container.transient_nodes:
             if self._node_provider.has_running_target_pods(node.name, deployments_container.pods):
@@ -123,8 +123,10 @@ class NoRunningTargetPodsOnNodeRule(AutoscalingRule):
                 return
             available_to_scale_down_count = min(available_to_scale_down_count, len(empty_nodes))
             empty_nodes = empty_nodes[:available_to_scale_down_count]
-            if self._configuration.rules.on_not_running_pods == OnNotRunningPodsStrategy.STOP:
+            if self._configuration.rules.on_not_running_target_pods == OnNotRunningTargetPodsStrategy.STOP:
                 self._node_scaler.scale_down(empty_nodes)
                 raise AbortScalingError()
+            else:
+                logging.info("Skipping scaling nodes ↓")
         else:
             logging.debug('No nodes without running target pods found.')

--- a/deploy/docker/cp-deployment-autoscaler/autoscaler/rule.py
+++ b/deploy/docker/cp-deployment-autoscaler/autoscaler/rule.py
@@ -21,7 +21,7 @@ from autoscaler.config import OnLostInstancesStrategy, AutoscalingConfiguration,
     OnNotRunningTargetPodsStrategy
 from autoscaler.exception import AbortScalingError
 from autoscaler.instance.provider import InstanceProvider
-from autoscaler.model import DeploymentsContainer, NodesContainer, InstancesContainer, Node
+from autoscaler.model import DeploymentsContainer, NodesContainer, InstancesContainer, Node, Pod
 from autoscaler.scaler import NodeScaler
 from autoscaler.timer import AutoscalingTimer
 
@@ -98,7 +98,7 @@ class NoRunningTargetPodsOnNodeRule(AutoscalingRule):
         logging.info('Searching for nodes without running target pods...')
         empty_nodes = []
         for node in nodes_container.transient_nodes:
-            if self._node_provider.has_running_target_pods(node.name, deployments_container.pods):
+            if self._has_running_target_pods(node.name, deployments_container.pods):
                 continue
             if node.name in self._configuration.target.forbidden_nodes:
                 logging.warning(f"Node '{node.name}' hasn't running target pods but forbidden to scale down. "
@@ -106,7 +106,7 @@ class NoRunningTargetPodsOnNodeRule(AutoscalingRule):
                 continue
             empty_nodes.append(node)
         if empty_nodes:
-            logging.info(f"Found '{len(empty_nodes)}'/'{nodes_container.nodes_number}' nodes without running "
+            logging.info(f"Found {len(empty_nodes)}/{nodes_container.nodes_number} nodes without running "
                          "target pods: %s", empty_nodes)
             if self._timer.last_scale_operation_time:
                 current_scale_operation = time.time()
@@ -130,3 +130,13 @@ class NoRunningTargetPodsOnNodeRule(AutoscalingRule):
                 logging.info("Skipping scaling nodes ↓")
         else:
             logging.debug('No nodes without running target pods found.')
+
+    @staticmethod
+    def _has_running_target_pods(node_name: str, target_pods: [Pod]):
+        for pod in target_pods:
+            if pod.node_name != node_name:
+                continue
+            if pod.state in ['Succeeded', 'Failed']:
+                continue
+            return True
+        return False

--- a/deploy/docker/cp-deployment-autoscaler/autoscaler/rule.py
+++ b/deploy/docker/cp-deployment-autoscaler/autoscaler/rule.py
@@ -107,7 +107,7 @@ class NoRunningTargetPodsOnNodeRule(AutoscalingRule):
             empty_nodes.append(node)
         if empty_nodes:
             logging.info(f"Found '{len(empty_nodes)}'/'{nodes_container.nodes_number}' nodes without running "
-                         f"target pods.")
+                         "target pods: %s", empty_nodes)
             if self._timer.last_scale_operation_time:
                 current_scale_operation = time.time()
                 scale_interval = current_scale_operation - self._timer.last_scale_operation_time

--- a/deploy/docker/cp-deployment-autoscaler/autoscaler/rule.py
+++ b/deploy/docker/cp-deployment-autoscaler/autoscaler/rule.py
@@ -14,6 +14,7 @@
 
 import logging
 from abc import ABC, abstractmethod
+import time
 
 from autoscaler.cluster.provider import NodeProvider
 from autoscaler.config import OnLostInstancesStrategy, AutoscalingConfiguration, OnLostNodesStrategy, \
@@ -22,6 +23,7 @@ from autoscaler.exception import AbortScalingError
 from autoscaler.instance.provider import InstanceProvider
 from autoscaler.model import DeploymentsContainer, NodesContainer, InstancesContainer, Node
 from autoscaler.scaler import NodeScaler
+from autoscaler.timer import AutoscalingTimer
 
 
 class AutoscalingRule(ABC):
@@ -76,36 +78,48 @@ class LostTransientNodesRule(AutoscalingRule):
                 raise AbortScalingError()
 
 
-class NoRunningPodsOnNodeRule(AutoscalingRule):
+class NoRunningTargetPodsOnNodeRule(AutoscalingRule):
     """
-    The current rule implements scaling down nodes with no not-terminated pods (excluding kube-system namespace).
+    The current rule implements scaling down nodes with no not-terminated target pods.
     Forbidden nodes (configuration.target.forbidden_nodes) shall not be scaled down.
     The minimum cluster size shall be kept up.
+    Scaling down shall not be applied if interval between last scaling process is nor greater than minimum acceptable
+    (config.limit.min_scale_interval)
     """
     def __init__(self, configuration: AutoscalingConfiguration, node_provider: NodeProvider,
-                 node_scaler: NodeScaler):
+                 node_scaler: NodeScaler, timer: AutoscalingTimer):
         self._configuration = configuration
         self._node_provider = node_provider
         self._node_scaler = node_scaler
+        self._timer = timer
 
     def apply(self, deployments_container: DeploymentsContainer, nodes_container: NodesContainer,
               instances_container: InstancesContainer):
-        logging.info('Searching for nodes without running pods')
+        logging.info('Searching for nodes without running target pods')
         empty_nodes = []
-        # todo: or manageable_nodes?
         for node in nodes_container.transient_nodes:
-            if self._node_provider.has_running_pods(node.name):
+            if self._node_provider.has_running_target_pods(node.name, deployments_container.pods):
                 continue
             if node.name in self._configuration.target.forbidden_nodes:
-                logging.warning(f"Node '{node.name}' hasn't running pods but forbidden to scale down. Skipping node.")
+                logging.warning(f"Node '{node.name}' hasn't running target pods but forbidden to scale down. "
+                                f"Skipping node.")
                 continue
             empty_nodes.append(node)
         if empty_nodes:
-            logging.warning(f"Found '{len(empty_nodes)}'/'{nodes_container.nodes_number}' nodes without running pods.")
+            logging.info(f"Found '{len(empty_nodes)}'/'{nodes_container.nodes_number}' nodes without running "
+                         f"target pods.")
+            if self._timer.last_scale_operation_time:
+                current_scale_operation = time.time()
+                scale_interval = current_scale_operation - self._timer.last_scale_operation_time
+                if scale_interval <= self._configuration.limit.min_scale_interval:
+                    logging.info('Scale interval (%.1f) < minimum scale interval (%.1f). '
+                                 'Scaling nodes ↓ is aborted.',
+                                 scale_interval, self._configuration.limit.min_scale_interval)
+                    return
             available_to_scale_down_count = nodes_container.nodes_number - self._configuration.limit.min_nodes_number
             if available_to_scale_down_count <= 0:
-                logging.warning("Scaling down forbidden: minimum nodes number is "
-                                f"'{self._configuration.limit.min_nodes_number}'.")
+                logging.info("Scaling nodes ↓ forbidden: minimum nodes number is "
+                             f"'{self._configuration.limit.min_nodes_number}'.")
                 return
             available_to_scale_down_count = min(available_to_scale_down_count, len(empty_nodes))
             empty_nodes = empty_nodes[:available_to_scale_down_count]
@@ -113,4 +127,4 @@ class NoRunningPodsOnNodeRule(AutoscalingRule):
                 self._node_scaler.scale_down(empty_nodes)
                 raise AbortScalingError()
         else:
-            logging.debug('No nodes without running pods found.')
+            logging.debug('No nodes without running target pods found.')

--- a/deploy/docker/cp-deployment-autoscaler/autoscaler/rule.py
+++ b/deploy/docker/cp-deployment-autoscaler/autoscaler/rule.py
@@ -16,9 +16,12 @@ import logging
 from abc import ABC, abstractmethod
 
 from autoscaler.cluster.provider import NodeProvider
-from autoscaler.config import OnLostInstancesStrategy, AutoscalingConfiguration, OnLostNodesStrategy
+from autoscaler.config import OnLostInstancesStrategy, AutoscalingConfiguration, OnLostNodesStrategy, \
+    OnNotRunningPodsStrategy
 from autoscaler.exception import AbortScalingError
 from autoscaler.instance.provider import InstanceProvider
+from autoscaler.model import DeploymentsContainer, NodesContainer, InstancesContainer, Node
+from autoscaler.scaler import NodeScaler
 
 
 class AutoscalingRule(ABC):
@@ -71,3 +74,43 @@ class LostTransientNodesRule(AutoscalingRule):
                     self._node_provider.drain_node(node)
                     self._node_provider.delete_node(node)
                 raise AbortScalingError()
+
+
+class NoRunningPodsOnNodeRule(AutoscalingRule):
+    """
+    The current rule implements scaling down nodes with no not-terminated pods (excluding kube-system namespace).
+    Forbidden nodes (configuration.target.forbidden_nodes) shall not be scaled down.
+    The minimum cluster size shall be kept up.
+    """
+    def __init__(self, configuration: AutoscalingConfiguration, node_provider: NodeProvider,
+                 node_scaler: NodeScaler):
+        self._configuration = configuration
+        self._node_provider = node_provider
+        self._node_scaler = node_scaler
+
+    def apply(self, deployments_container: DeploymentsContainer, nodes_container: NodesContainer,
+              instances_container: InstancesContainer):
+        logging.info('Searching for nodes without running pods')
+        empty_nodes = []
+        # todo: or manageable_nodes?
+        for node in nodes_container.transient_nodes:
+            if self._node_provider.has_running_pods(node.name):
+                continue
+            if node.name in self._configuration.target.forbidden_nodes:
+                logging.warning(f"Node '{node.name}' hasn't running pods but forbidden to scale down. Skipping node.")
+                continue
+            empty_nodes.append(node)
+        if empty_nodes:
+            logging.warning(f"Found '{len(empty_nodes)}'/'{nodes_container.nodes_number}' nodes without running pods.")
+            available_to_scale_down_count = nodes_container.nodes_number - self._configuration.limit.min_nodes_number
+            if available_to_scale_down_count <= 0:
+                logging.warning("Scaling down forbidden: minimum nodes number is "
+                                f"'{self._configuration.limit.min_nodes_number}'.")
+                return
+            available_to_scale_down_count = min(available_to_scale_down_count, len(empty_nodes))
+            empty_nodes = empty_nodes[:available_to_scale_down_count]
+            if self._configuration.rules.on_not_running_pods == OnNotRunningPodsStrategy.STOP:
+                self._node_scaler.scale_down(empty_nodes)
+                raise AbortScalingError()
+        else:
+            logging.debug('No nodes without running pods found.')

--- a/deploy/docker/cp-deployment-autoscaler/autoscaler/rule.py
+++ b/deploy/docker/cp-deployment-autoscaler/autoscaler/rule.py
@@ -97,7 +97,7 @@ class NoRunningTargetPodsOnNodeRule(AutoscalingRule):
               instances_container: InstancesContainer):
         logging.info('Searching for nodes without running target pods...')
         empty_nodes = []
-        for node in nodes_container.transient_nodes:
+        for node in nodes_container.manageable_nodes:
             if self._has_running_target_pods(node.name, deployments_container.pods):
                 continue
             if node.name in self._configuration.target.forbidden_nodes:

--- a/deploy/docker/cp-deployment-autoscaler/autoscaler/trigger.py
+++ b/deploy/docker/cp-deployment-autoscaler/autoscaler/trigger.py
@@ -20,6 +20,7 @@ import logging
 import sys
 from abc import ABC, abstractmethod
 
+from autoscaler.cluster.kube import KubeProvider
 from autoscaler.cluster.provider import NodeProvider
 from autoscaler.config import AutoscalingConfiguration
 from autoscaler.model import Condition
@@ -263,4 +264,32 @@ class NodeHeapsterElasticMetricTrigger(AutoscalingTrigger):
                      + _scaling_msg('nodes', nodes_number, required_nodes_number)
                      + _scaling_msg('replicas', replicas_number, required_replicas_number),
                      trigger_name, current_utilization, target_utilization)
+        return required_nodes_number, required_replicas_number
+
+
+class PodsUtilizationTrigger(AutoscalingTrigger):
+    """
+    Scales up node if pods utilization is greater than threshold (configuration.trigger.pods_utilization) where
+    pods utilization = current running pods count / sum(node.allocatable_pods)
+    """
+
+    def __init__(self, configuration, pod_provider):
+        self._configuration: AutoscalingConfiguration = configuration
+        self._pod_provider: KubeProvider = pod_provider
+
+    def apply(self, deployments_container, nodes_container, instances_container,
+              nodes_number, required_nodes_number,
+              replicas_number, required_replicas_number) -> Tuple[int, int]:
+        logging.info('Resolving pods utilization...')
+        non_terminated_pods_number = self._pod_provider.get_non_terminated_pods_number(
+            nodes_container.target_node_names)
+        allocatable_pods_number = sum([node.allocatable_pods for node in nodes_container.target_nodes])
+        target_utilization = self._configuration.trigger.pods_utilization
+        current_utilization = 100 * (non_terminated_pods_number / allocatable_pods_number)
+        if current_utilization >= target_utilization:
+            required_nodes_number = _at_least(nodes_number, required_nodes_number,
+                                              self._configuration.rules.on_threshold_trigger.extra_nodes)
+            logging.info('[TRIGGER] %s (%s%%) >= target (%s%%). '
+                         + _scaling_msg('nodes', nodes_number, required_nodes_number),
+                         'pods utilization', current_utilization, target_utilization)
         return required_nodes_number, required_replicas_number

--- a/deploy/docker/cp-deployment-autoscaler/autoscaler/trigger.py
+++ b/deploy/docker/cp-deployment-autoscaler/autoscaler/trigger.py
@@ -289,7 +289,10 @@ class PodsUtilizationTrigger(AutoscalingTrigger):
         if current_utilization >= target_utilization:
             required_nodes_number = _at_least(nodes_number, required_nodes_number,
                                               self._configuration.rules.on_threshold_trigger.extra_nodes)
-            logging.info('[TRIGGER] %s (%s%%) >= target (%s%%). '
-                         + _scaling_msg('nodes', nodes_number, required_nodes_number),
+            required_replicas_number = _at_least(replicas_number, required_replicas_number,
+                                                 self._configuration.rules.on_threshold_trigger.extra_replicas)
+            logging.info('[TRIGGER] %s (%.1f%%) >= target (%s%%). '
+                         + _scaling_msg('nodes', nodes_number, required_nodes_number)
+                         + _scaling_msg('replicas', replicas_number, required_replicas_number),
                          'pods utilization', current_utilization, target_utilization)
         return required_nodes_number, required_replicas_number


### PR DESCRIPTION
relates to #2639

This PR brings the following changes:
- a new trigger that provides ability to scale up node/replicas if pods utilisation is greater than config provided threshold (`config.trigger.pods_utilization`)
- a new rule that implements scaling down for transient nodes with no not-terminated target pods. The scale down process shall not applied if:
  * current cluster size is <= minimum cluster size (`config.limit.min_nodes_number`)
  * interval between last scaling process is nor greater than minimum acceptable (`config.limit.min_scale_interval`)
  * node is forbidden (`configuration.target.forbidden_nodes`)

To manage node scale strategy (`SKIP/STOP`) `config.rules.on_not_running_target_pods` can be used (Default: `SKIP`)