### PR TITLE
issue 3859 pipe storage cp: change filter item function

### DIFF
--- a/pipe-cli/src/utilities/datastorage_operations.py
+++ b/pipe-cli/src/utilities/datastorage_operations.py
@@ -303,10 +303,6 @@ class DataStorageOperations(object):
             if not item:
                 continue
 
-            if relative_path.endswith(FOLDER_MARKER):
-                filtered_items.append(item)
-                continue
-
             if relative_path.endswith('/'):
                 continue
 
@@ -333,6 +329,10 @@ class DataStorageOperations(object):
                 if not quiet:
                     click.echo(u"Skipping file {} since it matches exclude patterns [{}]."
                                .format(full_path, ",".join(exclude)))
+                continue
+
+            if relative_path.endswith(FOLDER_MARKER):
+                filtered_items.append(item)
                 continue
 
             if not skip_existing and (force or not verify_destination):


### PR DESCRIPTION
related to #3859 

Main idea is to move check for FOLDER_MARKER after include/exclude checks, so it .DS_Store file isn't matched with  include/exclude - it will be filtered out