### PR TITLE
Issue #3864: [API] Allow to show engine tasks stats on run details page - persist tasks method

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
@@ -43,6 +43,7 @@ import com.epam.pipeline.entity.pipeline.PipelineTask;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.RunLog;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
+import com.epam.pipeline.entity.pipeline.run.EngineRunTask;
 import com.epam.pipeline.entity.pipeline.run.PipeRunCmdStartVO;
 import com.epam.pipeline.entity.pipeline.run.PipelineStart;
 import com.epam.pipeline.entity.pipeline.run.RunChartInfo;
@@ -56,6 +57,7 @@ import com.epam.pipeline.manager.cluster.EdgeServiceManager;
 import com.epam.pipeline.manager.cluster.InstanceOfferManager;
 import com.epam.pipeline.manager.filter.FilterManager;
 import com.epam.pipeline.manager.filter.WrongFilterException;
+import com.epam.pipeline.manager.pipeline.EngineRunTaskService;
 import com.epam.pipeline.manager.pipeline.ArchiveRunService;
 import com.epam.pipeline.manager.pipeline.PipelineRunAsManager;
 import com.epam.pipeline.manager.pipeline.PipelineRunCRUDService;
@@ -110,6 +112,7 @@ public class RunApiService {
     private final RunPermissionManager runPermissionManager;
     private final EdgeServiceManager edgeServiceManager;
     private final ArchiveRunService archiveRunService;
+    private final EngineRunTaskService engineRunTaskService;
 
     @AclMask
     @QuotaLaunchCheck
@@ -418,5 +421,10 @@ public class RunApiService {
     public RunRuntimeData getPipelineRunRuntimeData(final Long runId, final RunSyncRuntimeDataType type,
                                                     final Map<String, String> parameters) {
         return runRuntimeDataManager.getPipelineRunRuntimeData(runId, type, parameters);
+    }
+
+    @PreAuthorize(RUN_ID_EXECUTE)
+    public int consumeRunEngineTaskEvents(final Long runId, final List<EngineRunTask> tasks) {
+        return engineRunTaskService.upsertTasks(runId, tasks);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
+++ b/api/src/main/java/com/epam/pipeline/common/MessageConstants.java
@@ -196,6 +196,7 @@ public final class MessageConstants {
     public static final String ERROR_ARCHIVE_RUN_METADATA_NOT_FOUND = "error.archive.run.metadata.not.found";
     public static final String ERROR_ARCHIVE_RUN_METADATA_NOT_NUMERIC = "error.archive.run.metadata.not.numeric";
     public static final String ERROR_MAX_PAGE_SIZE_EXCEEDED = "error.max.page.size.exceeded";
+    public static final String ERROR_ENGINE_RUN_TASK_SETTING_NOT_FOUND = "error.engine.run.task.setting.not.found";
 
     //Run schedule
     public static final String CRON_EXPRESSION_IS_NOT_PROVIDED = "cron.expression.is.not.provided";

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
@@ -43,6 +43,7 @@ import com.epam.pipeline.entity.pipeline.PipelineRunWithTool;
 import com.epam.pipeline.entity.pipeline.PipelineTask;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.RunLog;
+import com.epam.pipeline.entity.pipeline.run.EngineRunTask;
 import com.epam.pipeline.entity.pipeline.run.PipeRunCmdStartVO;
 import com.epam.pipeline.entity.pipeline.run.PipelineStart;
 import com.epam.pipeline.entity.pipeline.run.RunChartInfo;
@@ -665,5 +666,16 @@ public class PipelineRunController extends AbstractRestController {
             @RequestParam final RunSyncRuntimeDataType type,
             @RequestBody(required = false) final Map<String, String> parameters) {
         return Result.success(runApiService.getPipelineRunRuntimeData(runId, type, parameters));
+    }
+
+    @PostMapping("/run/{runId}/engine/tasks")
+    @ApiOperation(
+            value = "Registers run engine events for run",
+            notes = "Registers run engine events for run",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<Integer> consumeRunEngineTaskEvents(@PathVariable(value = RUN_ID) final Long runId,
+                                                      @RequestBody final List<EngineRunTask> tasks) {
+        return Result.success(runApiService.consumeRunEngineTaskEvents(runId, tasks));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
@@ -670,8 +670,8 @@ public class PipelineRunController extends AbstractRestController {
 
     @PostMapping("/run/{runId}/engine/tasks")
     @ApiOperation(
-            value = "Registers run engine events for run",
-            notes = "Registers run engine events for run",
+            value = "Consumes engine task events for run",
+            notes = "Consumes engine task events for run",
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
     public Result<Integer> consumeRunEngineTaskEvents(@PathVariable(value = RUN_ID) final Long runId,

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/EngineRunTaskDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/EngineRunTaskDao.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2025 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.dao.pipeline;
+
+import com.epam.pipeline.dao.DaoUtils;
+import com.epam.pipeline.dao.DryRunJdbcDaoSupport;
+import com.epam.pipeline.entity.pipeline.run.EngineRunTask;
+import com.epam.pipeline.entity.pipeline.run.EngineTaskStatus;
+import com.epam.pipeline.entity.pipeline.run.EngineType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Required;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class EngineRunTaskDao extends DryRunJdbcDaoSupport {
+
+    private String upsertEngineRunTaskQuery;
+    private String deleteEngineRunTaskByRunIdsQuery;
+    private String findEngineRunTaskByRunIdQuery;
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public List<EngineRunTask> batchUpsert(final List<EngineRunTask> tasks) {
+        getNamedParameterJdbcTemplate().batchUpdate(upsertEngineRunTaskQuery,
+                EngineRunTaskDao.Parameters.getBatchParameters(tasks));
+        return tasks;
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void deleteByRunIdIn(final List<Long> runIds, final boolean dryRun) {
+        final MapSqlParameterSource params = DaoUtils.longListParams(runIds);
+        getNamedParameterJdbcTemplate(dryRun).update(deleteEngineRunTaskByRunIdsQuery, params);
+    }
+
+    public List<EngineRunTask> findByRunId(final Long runId) {
+        return getNamedParameterJdbcTemplate().query(findEngineRunTaskByRunIdQuery,
+                new MapSqlParameterSource().addValue(Parameters.RUN_ID.name(), runId),
+                Parameters.getRowMapper());
+    }
+
+    enum Parameters {
+        TASK_ID,
+        TASK_NAME,
+        TASK_KEY,
+        TASK_GROUP,
+        PARENT_ID,
+        ENGINE_TYPE,
+        STATUS,
+        DATA,
+        START_DATE,
+        END_DATE,
+        RUN_ID,
+        DURATION;
+
+        private static MapSqlParameterSource[] getBatchParameters(final List<EngineRunTask> tasks) {
+            return tasks.stream()
+                    .map(Parameters::getParameters)
+                    .toArray(MapSqlParameterSource[]::new);
+        }
+
+        private static MapSqlParameterSource getParameters(final EngineRunTask task) {
+            return new MapSqlParameterSource()
+                    .addValue(TASK_ID.name(), task.getTaskId())
+                    .addValue(TASK_NAME.name(), task.getTaskName())
+                    .addValue(TASK_KEY.name(), task.getTaskKey())
+                    .addValue(TASK_GROUP.name(), task.getTaskGroup())
+                    .addValue(PARENT_ID.name(), task.getParentId())
+                    .addValue(ENGINE_TYPE.name(), task.getEngineType().name())
+                    .addValue(STATUS.name(), task.getStatus().name())
+                    .addValue(DATA.name(), task.getAttributes())
+                    .addValue(START_DATE.name(), task.getStartDateTime())
+                    .addValue(END_DATE.name(), task.getEndDateTime())
+                    .addValue(RUN_ID.name(), task.getRunId())
+                    .addValue(DURATION.name(), task.getDuration());
+        }
+
+        private static RowMapper<EngineRunTask> getRowMapper() {
+            return (rs, rowNum) -> EngineRunTask.builder()
+                    .runId(rs.getLong(RUN_ID.name()))
+                    .taskId(rs.getString(TASK_ID.name()))
+                    .taskName(rs.getString(TASK_NAME.name()))
+                    .taskKey(rs.getString(TASK_KEY.name()))
+                    .taskGroup(rs.getString(TASK_GROUP.name()))
+                    .parentId(rs.getString(PARENT_ID.name()))
+                    .engineType(EngineType.valueOf(rs.getString(ENGINE_TYPE.name())))
+                    .status(EngineTaskStatus.valueOf(rs.getString(STATUS.name())))
+                    .duration(rs.getLong(DURATION.name()))
+                    .startDateTime(rs.getDate(START_DATE.name()))
+                    .endDateTime(rs.getDate(END_DATE.name()))
+                    .build();
+        }
+    }
+
+    @Required
+    public void setUpsertEngineRunTaskQuery(final String upsertEngineRunTaskQuery) {
+        this.upsertEngineRunTaskQuery = upsertEngineRunTaskQuery;
+    }
+
+    @Required
+    public void setDeleteEngineRunTaskByRunIdsQuery(final String deleteEngineRunTaskByRunIdsQuery) {
+        this.deleteEngineRunTaskByRunIdsQuery = deleteEngineRunTaskByRunIdsQuery;
+    }
+
+    @Required
+    public void setFindEngineRunTaskByRunIdQuery(final String findEngineRunTaskByRunIdQuery) {
+        this.findEngineRunTaskByRunIdQuery = findEngineRunTaskByRunIdQuery;
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/ArchiveRunCoreService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/ArchiveRunCoreService.java
@@ -16,6 +16,7 @@
 package com.epam.pipeline.manager.pipeline;
 
 import com.epam.pipeline.dao.pipeline.ArchiveRunDao;
+import com.epam.pipeline.dao.pipeline.EngineRunTaskDao;
 import com.epam.pipeline.dao.pipeline.PipelineRunDao;
 import com.epam.pipeline.dao.pipeline.RestartRunDao;
 import com.epam.pipeline.dao.pipeline.RunLogDao;
@@ -50,6 +51,7 @@ public class ArchiveRunCoreService {
     private final RunServiceUrlDao runServiceUrlDao;
     private final RunStatusDao runStatusDao;
     private final StopServerlessRunDao stopServerlessRunDao;
+    private final EngineRunTaskDao engineRunTaskDao;
 
     @Transactional(propagation = Propagation.REQUIRED)
     public void archiveRuns(final Map<String, Date> ownersAndDates, final List<Long> terminalStates,
@@ -123,7 +125,9 @@ public class ArchiveRunCoreService {
         runStatusDao.deleteRunStatusByRunIdsIn(runIds, dryRun);
         log.debug("Run statuses deleted. Deleting stop serverless runs info...");
         stopServerlessRunDao.deleteByRunIdIn(runIds, dryRun);
-        log.debug("Stop serverless runs info deleted. Deleting runs...");
+        log.debug("Stop serverless runs info deleted. Deleting engine run tasks...");
+        engineRunTaskDao.deleteByRunIdIn(runIds, dryRun);
+        log.debug("Engine run logs deleted. Deleting runs...");
         pipelineRunDao.deleteRunByIdIn(runIds, dryRun);
         log.debug("'{}' runs deleted.", runIds.size());
     }

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/EngineRunTaskService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/EngineRunTaskService.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.pipeline;
+
+import com.epam.pipeline.common.MessageConstants;
+import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.dao.pipeline.EngineRunTaskDao;
+import com.epam.pipeline.entity.pipeline.run.EngineRunTask;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.Assert;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class EngineRunTaskService {
+
+    private final PipelineRunCRUDService runCRUDService;
+    private final EngineRunTaskDao engineRunTaskDao;
+    private final MessageHelper messageHelper;
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public int upsertTasks(final Long runId, final List<EngineRunTask> tasks) {
+        runCRUDService.loadRunById(runId);
+        return CollectionUtils.isEmpty(tasks)
+                ? 0
+                : engineRunTaskDao.batchUpsert(tasks.stream()
+                        .peek(task -> task.setRunId(runId))
+                        .map(this::validate)
+                        .collect(Collectors.toList())
+                ).size();
+    }
+
+    private EngineRunTask validate(final EngineRunTask task) {
+        Assert.notNull(task.getTaskId(), messageHelper.getMessage(
+                MessageConstants.ERROR_ENGINE_RUN_TASK_SETTING_NOT_FOUND, "taskId"));
+        Assert.notNull(task.getEngineType(), messageHelper.getMessage(
+                MessageConstants.ERROR_ENGINE_RUN_TASK_SETTING_NOT_FOUND, "engineType"));
+        Assert.notNull(task.getStatus(), messageHelper.getMessage(
+                MessageConstants.ERROR_ENGINE_RUN_TASK_SETTING_NOT_FOUND, "status"));
+        return task;
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/EngineRunTaskService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/EngineRunTaskService.java
@@ -40,14 +40,15 @@ public class EngineRunTaskService {
 
     @Transactional(propagation = Propagation.REQUIRED)
     public int upsertTasks(final Long runId, final List<EngineRunTask> tasks) {
+        if (CollectionUtils.isEmpty(tasks)) {
+            return 0;
+        }
         runCRUDService.loadRunById(runId);
-        return CollectionUtils.isEmpty(tasks)
-                ? 0
-                : engineRunTaskDao.batchUpsert(tasks.stream()
+        return engineRunTaskDao.batchUpsert(tasks.stream()
                         .peek(task -> task.setRunId(runId))
                         .map(this::validate)
-                        .collect(Collectors.toList())
-                ).size();
+                        .collect(Collectors.toList()))
+                .size();
     }
 
     private EngineRunTask validate(final EngineRunTask task) {

--- a/api/src/main/resources/dao/engine-run-tasks.xml
+++ b/api/src/main/resources/dao/engine-run-tasks.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2025 EPAM Systems, Inc. (https://www.epam.com/)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <bean class="com.epam.pipeline.dao.pipeline.EngineRunTaskDao" id="engineRunTaskDao" autowire="byName">
+        <property name="upsertEngineRunTaskQuery">
+            <value>
+                <![CDATA[
+                    INSERT INTO pipeline.engine_run_task (
+                        task_id,
+                        task_name,
+                        task_key,
+                        task_group,
+                        parent_id,
+                        engine_type,
+                        status,
+                        data,
+                        start_date,
+                        end_date,
+                        run_id,
+                        duration
+                    ) VALUES (
+                        :TASK_ID,
+                        :TASK_NAME,
+                        :TASK_KEY,
+                        :TASK_GROUP,
+                        :PARENT_ID,
+                        :ENGINE_TYPE,
+                        :STATUS,
+                        to_jsonb(:DATA::jsonb),
+                        :START_DATE,
+                        :END_DATE,
+                        :RUN_ID,
+                        :DURATION
+                    ) ON CONFLICT (task_id, engine_type) DO UPDATE SET
+                        status = :STATUS,
+                        data = to_jsonb(:DATA::jsonb),
+                        end_date = :END_DATE,
+                        duration = :DURATION
+                ]]>
+            </value>
+        </property>
+        <property name="deleteEngineRunTaskByRunIdsQuery">
+            <value>
+                <![CDATA[
+                    DELETE FROM pipeline.engine_run_task WHERE run_id IN (:list)
+                ]]>
+            </value>
+        </property>
+        <property name="findEngineRunTaskByRunIdQuery">
+            <value>
+                <![CDATA[
+                    SELECT
+                        r.task_id,
+                        r.task_name,
+                        r.task_key,
+                        r.task_group,
+                        r.parent_id,
+                        r.engine_type,
+                        r.status,
+                        r.start_date,
+                        r.end_date,
+                        r.run_id,
+                        r.duration
+                    FROM pipeline.engine_run_task r
+                    WHERE r.run_id = :RUN_ID
+                ]]>
+            </value>
+        </property>
+    </bean>
+</beans>

--- a/api/src/main/resources/dao/engine-run-tasks.xml
+++ b/api/src/main/resources/dao/engine-run-tasks.xml
@@ -48,7 +48,7 @@
                         :END_DATE,
                         :RUN_ID,
                         :DURATION
-                    ) ON CONFLICT (task_id, engine_type) DO UPDATE SET
+                    ) ON CONFLICT (run_id, task_id, engine_type) DO UPDATE SET
                         status = :STATUS,
                         data = to_jsonb(:DATA::jsonb),
                         end_date = :END_DATE,

--- a/api/src/main/resources/db/migration/v2025.01.20_14.00__engine_run_task.sql
+++ b/api/src/main/resources/db/migration/v2025.01.20_14.00__engine_run_task.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS pipeline.engine_run_task (
+	task_id         TEXT        NOT NULL,
+	task_name       TEXT,
+	task_key        TEXT,
+	task_group      TEXT,
+	parent_id       TEXT,
+	engine_type     TEXT        NOT NULL,
+	status          TEXT        NOT NULL,
+	data            JSONB,
+	start_date      TIMESTAMP WITH TIME ZONE,
+	end_date        TIMESTAMP WITH TIME ZONE,
+	run_id          BIGINT      NOT NULL REFERENCES pipeline.pipeline_run(run_id),
+	duration        BIGINT,
+	CONSTRAINT engine_run_task_constrain UNIQUE(task_id, engine_type)
+);

--- a/api/src/main/resources/db/migration/v2025.01.20_19.00__issue_3864_engine_run_task.sql
+++ b/api/src/main/resources/db/migration/v2025.01.20_19.00__issue_3864_engine_run_task.sql
@@ -11,5 +11,5 @@ CREATE TABLE IF NOT EXISTS pipeline.engine_run_task (
 	end_date        TIMESTAMP WITH TIME ZONE,
 	run_id          BIGINT      NOT NULL REFERENCES pipeline.pipeline_run(run_id),
 	duration        BIGINT,
-	CONSTRAINT engine_run_task_constrain UNIQUE(task_id, engine_type)
+	CONSTRAINT engine_run_task_constrain UNIQUE(run_id, task_id, engine_type)
 );

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -148,6 +148,7 @@ warn.instance.stopping=Instance is still in STOPPING status
 error.archive.run.metadata.not.found=Failed to archive runs: metadata ''{0}'' not found for entity ''{1}''=''{2}''.
 error.archive.run.metadata.not.numeric=Failed to archive runs: metadata value for key ''{0}'' is not numeric.
 error.max.page.size.exceeded=Max page size {0} exceeded.
+error.engine.run.task.setting.not.found=Attribute ''{0}'' shall be provided for engine run task.
 
 #Run schedule
 cron.expression.is.not.provided=Cron expression for {0} id ''{1}'' is not provided.

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/EngineRunTaskDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/EngineRunTaskDaoTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.dao.pipeline;
+
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.pipeline.TaskStatus;
+import com.epam.pipeline.entity.pipeline.run.EngineRunTask;
+import com.epam.pipeline.entity.pipeline.run.EngineTaskStatus;
+import com.epam.pipeline.entity.pipeline.run.EngineType;
+import com.epam.pipeline.test.jdbc.AbstractJdbcTest;
+import com.epam.pipeline.util.TestUtils;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@Transactional
+public class EngineRunTaskDaoTest extends AbstractJdbcTest {
+    private static final String TEST = "TEST";
+    private static final String TEST2 = "TEST2";
+
+    @Autowired
+    private PipelineRunDao pipelineRunDao;
+    @Autowired
+    private EngineRunTaskDao engineRunTaskDao;
+
+    @Test
+    public void shouldBatchInsertEngineRunLogs() {
+        final PipelineRun run = run();
+        pipelineRunDao.createPipelineRun(run);
+
+        final EngineRunTask log1 = log(run.getId(), TEST);
+        engineRunTaskDao.batchUpsert(Collections.singletonList(log1));
+
+        log1.setStatus(EngineTaskStatus.COMPLETED);
+        log1.setEndDateTime(new Date());
+        final EngineRunTask log2 = log(run.getId(), TEST2);
+        engineRunTaskDao.batchUpsert(Arrays.asList(log1, log2));
+
+        assertThat(engineRunTaskDao.findByRunId(run.getId()).size(), is(2));
+    }
+
+    private EngineRunTask log(final Long runId, final String task) {
+        return EngineRunTask.builder()
+                .runId(runId)
+                .taskGroup(task)
+                .taskId(task)
+                .taskKey(task)
+                .taskName(task)
+                .status(EngineTaskStatus.CREATED)
+                .engineType(EngineType.NEXTFLOW)
+                .startDateTime(new Date())
+                .attributes("{\"test\": \"JSON object\"}")
+                .build();
+    }
+
+    private PipelineRun run() {
+        return TestUtils.createPipelineRun(null, null, TaskStatus.RUNNING, "USER",
+                null, null, true, null, null, "POD", 1L);
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/ArchiveRunServiceSpringTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/ArchiveRunServiceSpringTest.java
@@ -499,7 +499,7 @@ public class ArchiveRunServiceSpringTest extends AbstractManagerTest {
                 Arrays.asList(run1.getId(), run2.getId(), run3.getId(), runAfterTestDate.getId())))
                 .hasSize(4);
 
-        verifyDryRunInvoked(7, 6 * 2);
+        verifyDryRunInvoked(7, 7 * 2);
     }
 
     private PipelineRun run() {

--- a/api/src/test/java/com/epam/pipeline/test/acl/AclTestBeans.java
+++ b/api/src/test/java/com/epam/pipeline/test/acl/AclTestBeans.java
@@ -101,6 +101,7 @@ import com.epam.pipeline.manager.notification.NotificationTemplateManager;
 import com.epam.pipeline.manager.notification.SystemNotificationManager;
 import com.epam.pipeline.manager.notification.UserNotificationManager;
 import com.epam.pipeline.manager.ontology.OntologyManager;
+import com.epam.pipeline.manager.pipeline.EngineRunTaskService;
 import com.epam.pipeline.manager.pipeline.ArchiveRunService;
 import com.epam.pipeline.manager.pipeline.DocumentGenerationPropertyManager;
 import com.epam.pipeline.manager.pipeline.FolderCrudManager;
@@ -115,6 +116,7 @@ import com.epam.pipeline.manager.pipeline.PipelineRunCRUDService;
 import com.epam.pipeline.manager.pipeline.PipelineRunDockerOperationManager;
 import com.epam.pipeline.manager.pipeline.PipelineRunKubernetesManager;
 import com.epam.pipeline.manager.pipeline.PipelineRunManager;
+import com.epam.pipeline.manager.pipeline.PipelineRunRuntimeDataManager;
 import com.epam.pipeline.manager.pipeline.PipelineVersionManager;
 import com.epam.pipeline.manager.pipeline.RestartRunManager;
 import com.epam.pipeline.manager.pipeline.RunLogManager;
@@ -605,6 +607,12 @@ public class AclTestBeans {
 
     @MockBean
     protected AWSOmicsStoreManager omicsStoreManager;
+
+    @MockBean
+    protected PipelineRunRuntimeDataManager pipelineRunRuntimeDataManager;
+
+    @MockBean
+    protected EngineRunTaskService engineRunTaskService;
 
     @Bean
     public GrantPermissionManager grantPermissionManager() {

--- a/api/src/test/java/com/epam/pipeline/test/aspect/AspectTestBeans.java
+++ b/api/src/test/java/com/epam/pipeline/test/aspect/AspectTestBeans.java
@@ -51,6 +51,7 @@ import com.epam.pipeline.dao.notification.NotificationSettingsDao;
 import com.epam.pipeline.dao.notification.NotificationTemplateDao;
 import com.epam.pipeline.dao.pipeline.ArchiveRunDao;
 import com.epam.pipeline.dao.pipeline.DocumentGenerationPropertyDao;
+import com.epam.pipeline.dao.pipeline.EngineRunTaskDao;
 import com.epam.pipeline.dao.pipeline.FolderDao;
 import com.epam.pipeline.dao.pipeline.PipelineDao;
 import com.epam.pipeline.dao.pipeline.PipelineRunDao;
@@ -505,4 +506,7 @@ public class AspectTestBeans {
 
     @MockBean
     protected ArchiveRunDao archiveRunDao;
+
+    @MockBean
+    protected EngineRunTaskDao engineRunTaskDao;
 }

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/run/EngineRunTask.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/run/EngineRunTask.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.pipeline.run;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.Date;
+
+@Data
+@AllArgsConstructor
+@Builder
+public class EngineRunTask {
+    private String taskGroup;
+    private String taskId;
+    private String taskName;
+    private String taskKey;
+    private String parentId;
+    private EngineType engineType;
+    private EngineTaskStatus status;
+    private Long runId;
+    private Long duration;
+    private Date startDateTime;
+    private Date endDateTime;
+    private String attributes;
+}

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/run/EngineTaskStatus.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/run/EngineTaskStatus.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.pipeline.run;
+
+public enum EngineTaskStatus {
+    CREATED,
+    SUBMITTED,
+    CACHED,
+    RUNNING,
+    COMPLETED,
+    FAILED,
+    ABORTED
+}

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/run/EngineType.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/run/EngineType.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.pipeline.run;
+
+public enum EngineType {
+    NEXTFLOW
+}


### PR DESCRIPTION
relates to #3864

This PR provides API implementation for persisting engine run logs.
- a new API method `POST /run/<runID>/engine/tasks` added
```
Request Body:
{
    # Required values:
    "taskId": "<Task ID>",  
    "engineType": "NEXTFLOW",  
    "status": "SUBMITTED",  # allowed options: CREATED|SUBMITTED|CACHED|RUNNING|COMPLETED|FAILED|ABORTED
    # Optional values:
    "taskGroup": "<>",
    "taskName": "<>",
    "taskKey": "<>",
    "parentId": "<>",
    "duration": 0,
    "startDateTime": "2025-01-20 10:14:24.221",
    "endDateTime": "2025-01-20 10:14:24.221",
    "attributes": "{\"test\": \"JSON object\"}"
}
```
- a new DB table `engine_run_task` added for storing entities