### PR TITLE
Issue #3864: [API] Allow to show engine tasks stats on run details page - `taskTag` field support

### DIFF
--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/EngineRunTaskDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/EngineRunTaskDao.java
@@ -68,7 +68,8 @@ public class EngineRunTaskDao extends DryRunJdbcDaoSupport {
         START_DATE,
         END_DATE,
         RUN_ID,
-        DURATION;
+        DURATION,
+        TASK_TAG;
 
         private static MapSqlParameterSource[] getBatchParameters(final List<EngineRunTask> tasks) {
             return tasks.stream()
@@ -81,6 +82,7 @@ public class EngineRunTaskDao extends DryRunJdbcDaoSupport {
                     .addValue(TASK_ID.name(), task.getTaskId())
                     .addValue(TASK_NAME.name(), task.getTaskName())
                     .addValue(TASK_KEY.name(), task.getTaskKey())
+                    .addValue(TASK_TAG.name(), task.getTaskTag())
                     .addValue(TASK_GROUP.name(), task.getTaskGroup())
                     .addValue(PARENT_ID.name(), task.getParentId())
                     .addValue(ENGINE_TYPE.name(), task.getEngineType().name())
@@ -98,6 +100,7 @@ public class EngineRunTaskDao extends DryRunJdbcDaoSupport {
                     .taskId(rs.getString(TASK_ID.name()))
                     .taskName(rs.getString(TASK_NAME.name()))
                     .taskKey(rs.getString(TASK_KEY.name()))
+                    .taskTag(rs.getString(TASK_TAG.name()))
                     .taskGroup(rs.getString(TASK_GROUP.name()))
                     .parentId(rs.getString(PARENT_ID.name()))
                     .engineType(EngineType.valueOf(rs.getString(ENGINE_TYPE.name())))

--- a/api/src/main/resources/dao/engine-run-tasks.xml
+++ b/api/src/main/resources/dao/engine-run-tasks.xml
@@ -26,6 +26,7 @@
                         task_id,
                         task_name,
                         task_key,
+                        task_tag,
                         task_group,
                         parent_id,
                         engine_type,
@@ -39,6 +40,7 @@
                         :TASK_ID,
                         :TASK_NAME,
                         :TASK_KEY,
+                        :TASK_TAG,
                         :TASK_GROUP,
                         :PARENT_ID,
                         :ENGINE_TYPE,
@@ -52,7 +54,8 @@
                         status = :STATUS,
                         data = to_jsonb(:DATA::jsonb),
                         end_date = :END_DATE,
-                        duration = :DURATION
+                        duration = :DURATION,
+                        task_tag = :TASK_TAG
                 ]]>
             </value>
         </property>
@@ -70,6 +73,7 @@
                         r.task_id,
                         r.task_name,
                         r.task_key,
+                        r.task_tag,
                         r.task_group,
                         r.parent_id,
                         r.engine_type,

--- a/api/src/main/resources/db/migration/v2025.01.21_17.00__issue_3864_engine_run_task_tag_field.sql
+++ b/api/src/main/resources/db/migration/v2025.01.21_17.00__issue_3864_engine_run_task_tag_field.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pipeline.engine_run_task ADD COLUMN task_tag TEXT;

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/run/EngineRunTask.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/run/EngineRunTask.java
@@ -30,6 +30,7 @@ public class EngineRunTask {
     private String taskId;
     private String taskName;
     private String taskKey;
+    private String taskTag;
     private String parentId;
     private EngineType engineType;
     private EngineTaskStatus status;


### PR DESCRIPTION
relates to #3864 