### PR TITLE
Issue #3864: [API] Allow to show engine tasks stats on run details page - load stats method

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
@@ -44,6 +44,8 @@ import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.RunLog;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.epam.pipeline.entity.pipeline.run.EngineRunTask;
+import com.epam.pipeline.entity.pipeline.run.EngineTaskStatus;
+import com.epam.pipeline.entity.pipeline.run.EngineType;
 import com.epam.pipeline.entity.pipeline.run.PipeRunCmdStartVO;
 import com.epam.pipeline.entity.pipeline.run.PipelineStart;
 import com.epam.pipeline.entity.pipeline.run.RunChartInfo;
@@ -426,5 +428,10 @@ public class RunApiService {
     @PreAuthorize(RUN_ID_EXECUTE)
     public int consumeRunEngineTaskEvents(final Long runId, final List<EngineRunTask> tasks) {
         return engineRunTaskService.upsertTasks(runId, tasks);
+    }
+
+    @PreAuthorize(RUN_ID_READ)
+    public Map<EngineType, Map<String, Map<EngineTaskStatus, Long>>> loadEngineRunTasksStats(final Long runId) {
+        return engineRunTaskService.loadTasksStats(runId);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
@@ -431,7 +431,8 @@ public class RunApiService {
     }
 
     @PreAuthorize(RUN_ID_READ)
-    public Map<EngineType, Map<String, Map<EngineTaskStatus, Long>>> loadEngineRunTasksStats(final Long runId) {
-        return engineRunTaskService.loadTasksStats(runId);
+    public Map<String, Map<EngineTaskStatus, Long>> loadEngineRunTasksStats(final Long runId,
+                                                                            final EngineType engineType) {
+        return engineRunTaskService.loadTasksStats(runId, engineType);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
@@ -44,6 +44,8 @@ import com.epam.pipeline.entity.pipeline.PipelineTask;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.RunLog;
 import com.epam.pipeline.entity.pipeline.run.EngineRunTask;
+import com.epam.pipeline.entity.pipeline.run.EngineTaskStatus;
+import com.epam.pipeline.entity.pipeline.run.EngineType;
 import com.epam.pipeline.entity.pipeline.run.PipeRunCmdStartVO;
 import com.epam.pipeline.entity.pipeline.run.PipelineStart;
 import com.epam.pipeline.entity.pipeline.run.RunChartInfo;
@@ -677,5 +679,16 @@ public class PipelineRunController extends AbstractRestController {
     public Result<Integer> consumeRunEngineTaskEvents(@PathVariable(value = RUN_ID) final Long runId,
                                                       @RequestBody final List<EngineRunTask> tasks) {
         return Result.success(runApiService.consumeRunEngineTaskEvents(runId, tasks));
+    }
+
+    @GetMapping("run/{runId}/engine/tasks/stats")
+    @ApiOperation(
+            value = "Loads engine task statistics for run",
+            notes = "Loads engine task statistics for run",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<Map<EngineType, Map<String, Map<EngineTaskStatus, Long>>>> loadEngineRunTasksStats(
+            @PathVariable(value = RUN_ID) final Long runId) {
+        return Result.success(runApiService.loadEngineRunTasksStats(runId));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
@@ -86,6 +86,7 @@ public class PipelineRunController extends AbstractRestController {
 
     private static final String RUN_ID = "runId";
     private static final String TRUE = "true";
+    private static final String ENGINE_TYPE = "engineType";
 
     @Autowired
     private RunApiService runApiService;
@@ -681,14 +682,15 @@ public class PipelineRunController extends AbstractRestController {
         return Result.success(runApiService.consumeRunEngineTaskEvents(runId, tasks));
     }
 
-    @GetMapping("run/{runId}/engine/tasks/stats")
+    @GetMapping("run/{runId}/engine/{engineType}/tasks/stats")
     @ApiOperation(
-            value = "Loads engine task statistics for run",
-            notes = "Loads engine task statistics for run",
+            value = "Loads engine task statistics for run and engine type",
+            notes = "Loads engine task statistics for run and engine type",
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
-    public Result<Map<EngineType, Map<String, Map<EngineTaskStatus, Long>>>> loadEngineRunTasksStats(
-            @PathVariable(value = RUN_ID) final Long runId) {
-        return Result.success(runApiService.loadEngineRunTasksStats(runId));
+    public Result<Map<String, Map<EngineTaskStatus, Long>>> loadEngineRunTasksStats(
+            @PathVariable(value = RUN_ID) final Long runId,
+            @PathVariable(value = ENGINE_TYPE) final EngineType engineType) {
+        return Result.success(runApiService.loadEngineRunTasksStats(runId, engineType));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/EngineRunTaskDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/EngineRunTaskDao.java
@@ -19,6 +19,7 @@ package com.epam.pipeline.dao.pipeline;
 import com.epam.pipeline.dao.DaoUtils;
 import com.epam.pipeline.dao.DryRunJdbcDaoSupport;
 import com.epam.pipeline.entity.pipeline.run.EngineRunTask;
+import com.epam.pipeline.entity.pipeline.run.EngineRunTaskStatsEntity;
 import com.epam.pipeline.entity.pipeline.run.EngineTaskStatus;
 import com.epam.pipeline.entity.pipeline.run.EngineType;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +37,7 @@ public class EngineRunTaskDao extends DryRunJdbcDaoSupport {
     private String upsertEngineRunTaskQuery;
     private String deleteEngineRunTaskByRunIdsQuery;
     private String findEngineRunTaskByRunIdQuery;
+    private String loadEngineRunTasksStatsByRunIdQuery;
 
     @Transactional(propagation = Propagation.MANDATORY)
     public List<EngineRunTask> batchUpsert(final List<EngineRunTask> tasks) {
@@ -52,8 +54,12 @@ public class EngineRunTaskDao extends DryRunJdbcDaoSupport {
 
     public List<EngineRunTask> findByRunId(final Long runId) {
         return getNamedParameterJdbcTemplate().query(findEngineRunTaskByRunIdQuery,
-                new MapSqlParameterSource().addValue(Parameters.RUN_ID.name(), runId),
-                Parameters.getRowMapper());
+                Parameters.buildRunIdParameter(runId), Parameters.getRowMapper());
+    }
+
+    public List<EngineRunTaskStatsEntity> loadStats(final Long runId) {
+        return getNamedParameterJdbcTemplate().query(loadEngineRunTasksStatsByRunIdQuery,
+                Parameters.buildRunIdParameter(runId), Parameters.getStatsRowMapper());
     }
 
     enum Parameters {
@@ -69,7 +75,8 @@ public class EngineRunTaskDao extends DryRunJdbcDaoSupport {
         END_DATE,
         RUN_ID,
         DURATION,
-        TASK_TAG;
+        TASK_TAG,
+        TASKS_COUNT;
 
         private static MapSqlParameterSource[] getBatchParameters(final List<EngineRunTask> tasks) {
             return tasks.stream()
@@ -110,6 +117,19 @@ public class EngineRunTaskDao extends DryRunJdbcDaoSupport {
                     .endDateTime(rs.getDate(END_DATE.name()))
                     .build();
         }
+
+        private static RowMapper<EngineRunTaskStatsEntity> getStatsRowMapper() {
+            return (rs, rowNum) -> EngineRunTaskStatsEntity.builder()
+                    .engineType(EngineType.valueOf(rs.getString(ENGINE_TYPE.name())))
+                    .taskGroup(rs.getString(TASK_GROUP.name()))
+                    .status(EngineTaskStatus.valueOf(rs.getString(STATUS.name())))
+                    .tasksCount(rs.getLong(TASKS_COUNT.name()))
+                    .build();
+        }
+
+        private static MapSqlParameterSource buildRunIdParameter(final Long runId) {
+            return new MapSqlParameterSource().addValue(RUN_ID.name(), runId);
+        }
     }
 
     @Required
@@ -125,5 +145,10 @@ public class EngineRunTaskDao extends DryRunJdbcDaoSupport {
     @Required
     public void setFindEngineRunTaskByRunIdQuery(final String findEngineRunTaskByRunIdQuery) {
         this.findEngineRunTaskByRunIdQuery = findEngineRunTaskByRunIdQuery;
+    }
+
+    @Required
+    public void setLoadEngineRunTasksStatsByRunIdQuery(final String loadEngineRunTasksStatsByRunIdQuery) {
+        this.loadEngineRunTasksStatsByRunIdQuery = loadEngineRunTasksStatsByRunIdQuery;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/EngineRunTaskDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/EngineRunTaskDao.java
@@ -19,7 +19,7 @@ package com.epam.pipeline.dao.pipeline;
 import com.epam.pipeline.dao.DaoUtils;
 import com.epam.pipeline.dao.DryRunJdbcDaoSupport;
 import com.epam.pipeline.entity.pipeline.run.EngineRunTask;
-import com.epam.pipeline.entity.pipeline.run.EngineRunTaskStatsEntity;
+import com.epam.pipeline.entity.run.EngineRunTaskStatsEntity;
 import com.epam.pipeline.entity.pipeline.run.EngineTaskStatus;
 import com.epam.pipeline.entity.pipeline.run.EngineType;
 import lombok.RequiredArgsConstructor;
@@ -37,7 +37,7 @@ public class EngineRunTaskDao extends DryRunJdbcDaoSupport {
     private String upsertEngineRunTaskQuery;
     private String deleteEngineRunTaskByRunIdsQuery;
     private String findEngineRunTaskByRunIdQuery;
-    private String loadEngineRunTasksStatsByRunIdQuery;
+    private String loadEngineRunTasksStatsByRunIdAndTypeQuery;
 
     @Transactional(propagation = Propagation.MANDATORY)
     public List<EngineRunTask> batchUpsert(final List<EngineRunTask> tasks) {
@@ -57,9 +57,12 @@ public class EngineRunTaskDao extends DryRunJdbcDaoSupport {
                 Parameters.buildRunIdParameter(runId), Parameters.getRowMapper());
     }
 
-    public List<EngineRunTaskStatsEntity> loadStats(final Long runId) {
-        return getNamedParameterJdbcTemplate().query(loadEngineRunTasksStatsByRunIdQuery,
-                Parameters.buildRunIdParameter(runId), Parameters.getStatsRowMapper());
+    public List<EngineRunTaskStatsEntity> loadStats(final Long runId, final EngineType engineType) {
+        return getNamedParameterJdbcTemplate().query(loadEngineRunTasksStatsByRunIdAndTypeQuery,
+                new MapSqlParameterSource()
+                        .addValue(Parameters.RUN_ID.name(), runId)
+                        .addValue(Parameters.ENGINE_TYPE.name(), engineType.name()),
+                Parameters.getStatsRowMapper());
     }
 
     enum Parameters {
@@ -148,7 +151,7 @@ public class EngineRunTaskDao extends DryRunJdbcDaoSupport {
     }
 
     @Required
-    public void setLoadEngineRunTasksStatsByRunIdQuery(final String loadEngineRunTasksStatsByRunIdQuery) {
-        this.loadEngineRunTasksStatsByRunIdQuery = loadEngineRunTasksStatsByRunIdQuery;
+    public void setLoadEngineRunTasksStatsByRunIdAndTypeQuery(final String loadEngineRunTasksStatsByRunIdAndTypeQuery) {
+        this.loadEngineRunTasksStatsByRunIdAndTypeQuery = loadEngineRunTasksStatsByRunIdAndTypeQuery;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/entity/run/EngineRunTaskStatsEntity.java
+++ b/api/src/main/java/com/epam/pipeline/entity/run/EngineRunTaskStatsEntity.java
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-package com.epam.pipeline.entity.pipeline.run;
+package com.epam.pipeline.entity.run;
 
+import com.epam.pipeline.entity.pipeline.run.EngineTaskStatus;
+import com.epam.pipeline.entity.pipeline.run.EngineType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/EngineRunTaskService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/EngineRunTaskService.java
@@ -20,7 +20,7 @@ import com.epam.pipeline.common.MessageConstants;
 import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.dao.pipeline.EngineRunTaskDao;
 import com.epam.pipeline.entity.pipeline.run.EngineRunTask;
-import com.epam.pipeline.entity.pipeline.run.EngineRunTaskStatsEntity;
+import com.epam.pipeline.entity.run.EngineRunTaskStatsEntity;
 import com.epam.pipeline.entity.pipeline.run.EngineTaskStatus;
 import com.epam.pipeline.entity.pipeline.run.EngineType;
 import lombok.RequiredArgsConstructor;
@@ -57,14 +57,13 @@ public class EngineRunTaskService {
                 .size();
     }
 
-    public Map<EngineType, Map<String, Map<EngineTaskStatus, Long>>> loadTasksStats(final Long runId) {
+    public Map<String, Map<EngineTaskStatus, Long>> loadTasksStats(final Long runId, final EngineType engineType) {
         runCRUDService.loadRunById(runId);
-        return ListUtils.emptyIfNull(engineRunTaskDao.loadStats(runId)).stream()
+        return ListUtils.emptyIfNull(engineRunTaskDao.loadStats(runId, engineType)).stream()
                 .filter(stats -> Objects.nonNull(stats.getTaskGroup()))
-                .collect(Collectors.groupingBy(EngineRunTaskStatsEntity::getEngineType,
-                        Collectors.groupingBy(EngineRunTaskStatsEntity::getTaskGroup,
+                .collect(Collectors.groupingBy(EngineRunTaskStatsEntity::getTaskGroup,
                                 Collectors.toMap(EngineRunTaskStatsEntity::getStatus,
-                                        EngineRunTaskStatsEntity::getTasksCount))));
+                                        EngineRunTaskStatsEntity::getTasksCount)));
     }
 
     private EngineRunTask validate(final EngineRunTask task) {

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/EngineRunTaskService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/EngineRunTaskService.java
@@ -20,14 +20,20 @@ import com.epam.pipeline.common.MessageConstants;
 import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.dao.pipeline.EngineRunTaskDao;
 import com.epam.pipeline.entity.pipeline.run.EngineRunTask;
+import com.epam.pipeline.entity.pipeline.run.EngineRunTaskStatsEntity;
+import com.epam.pipeline.entity.pipeline.run.EngineTaskStatus;
+import com.epam.pipeline.entity.pipeline.run.EngineType;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.ListUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
@@ -49,6 +55,16 @@ public class EngineRunTaskService {
                         .map(this::validate)
                         .collect(Collectors.toList()))
                 .size();
+    }
+
+    public Map<EngineType, Map<String, Map<EngineTaskStatus, Long>>> loadTasksStats(final Long runId) {
+        runCRUDService.loadRunById(runId);
+        return ListUtils.emptyIfNull(engineRunTaskDao.loadStats(runId)).stream()
+                .filter(stats -> Objects.nonNull(stats.getTaskGroup()))
+                .collect(Collectors.groupingBy(EngineRunTaskStatsEntity::getEngineType,
+                        Collectors.groupingBy(EngineRunTaskStatsEntity::getTaskGroup,
+                                Collectors.toMap(EngineRunTaskStatsEntity::getStatus,
+                                        EngineRunTaskStatsEntity::getTasksCount))));
     }
 
     private EngineRunTask validate(final EngineRunTask task) {

--- a/api/src/main/resources/dao/engine-run-tasks.xml
+++ b/api/src/main/resources/dao/engine-run-tasks.xml
@@ -87,5 +87,23 @@
                 ]]>
             </value>
         </property>
+        <property name="loadEngineRunTasksStatsByRunIdQuery">
+            <value>
+                <![CDATA[
+                    SELECT
+                        engine_type,
+                        task_group,
+                        status,
+                        COUNT(*) AS tasks_count
+                    FROM
+                        pipeline.engine_run_task
+                    WHERE run_id = :RUN_ID AND task_group IS NOT NULL
+                    GROUP BY
+                        engine_type,
+                        task_group,
+                        status
+                ]]>
+            </value>
+        </property>
     </bean>
 </beans>

--- a/api/src/main/resources/dao/engine-run-tasks.xml
+++ b/api/src/main/resources/dao/engine-run-tasks.xml
@@ -87,7 +87,7 @@
                 ]]>
             </value>
         </property>
-        <property name="loadEngineRunTasksStatsByRunIdQuery">
+        <property name="loadEngineRunTasksStatsByRunIdAndTypeQuery">
             <value>
                 <![CDATA[
                     SELECT
@@ -97,7 +97,7 @@
                         COUNT(*) AS tasks_count
                     FROM
                         pipeline.engine_run_task
-                    WHERE run_id = :RUN_ID AND task_group IS NOT NULL
+                    WHERE run_id = :RUN_ID AND engine_type = :ENGINE_TYPE AND task_group IS NOT NULL
                     GROUP BY
                         engine_type,
                         task_group,

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/EngineRunTaskDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/EngineRunTaskDaoTest.java
@@ -99,7 +99,7 @@ public class EngineRunTaskDaoTest extends AbstractJdbcTest {
                 runningEvent21, runningEvent22, completedEvent21,
                 emptyGroupEvent));
 
-        assertThat(engineRunTaskDao.loadStats(run.getId())).hasSize(4);
+        assertThat(engineRunTaskDao.loadStats(run.getId(), EngineType.NEXTFLOW)).hasSize(4);
     }
 
     private EngineRunTask event(final Long runId, final String task) {

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/EngineRunTaskDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/EngineRunTaskDaoTest.java
@@ -31,13 +31,14 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Transactional
 public class EngineRunTaskDaoTest extends AbstractJdbcTest {
     private static final String TEST = "TEST";
     private static final String TEST2 = "TEST2";
+    private static final String TASK_GROUP_1 = "Process1";
+    private static final String TASK_GROUP_2 = "Process2";
 
     @Autowired
     private PipelineRunDao pipelineRunDao;
@@ -45,25 +46,67 @@ public class EngineRunTaskDaoTest extends AbstractJdbcTest {
     private EngineRunTaskDao engineRunTaskDao;
 
     @Test
-    public void shouldBatchInsertEngineRunLogs() {
+    public void shouldBatchInsertEngineRunEvents() {
         final PipelineRun run = run();
         pipelineRunDao.createPipelineRun(run);
 
-        final EngineRunTask log1 = log(run.getId(), TEST);
+        final EngineRunTask log1 = event(run.getId(), TEST);
         engineRunTaskDao.batchUpsert(Collections.singletonList(log1));
 
         log1.setStatus(EngineTaskStatus.COMPLETED);
         log1.setEndDateTime(new Date());
-        final EngineRunTask log2 = log(run.getId(), TEST2);
+        final EngineRunTask log2 = event(run.getId(), TEST2);
         engineRunTaskDao.batchUpsert(Arrays.asList(log1, log2));
 
-        assertThat(engineRunTaskDao.findByRunId(run.getId()).size(), is(2));
+        assertThat(engineRunTaskDao.findByRunId(run.getId())).hasSize(2);
     }
 
-    private EngineRunTask log(final Long runId, final String task) {
+    @Test
+    public void shouldLoadEngineRunTasksStats() {
+        final PipelineRun run = run();
+        pipelineRunDao.createPipelineRun(run);
+
+        final EngineRunTask runningEvent11 = event(run.getId(), TEST + "1");
+        runningEvent11.setTaskGroup(TASK_GROUP_1);
+        runningEvent11.setStatus(EngineTaskStatus.RUNNING);
+
+        final EngineRunTask runningEvent12 = event(run.getId(), TEST + "2");
+        runningEvent12.setTaskGroup(TASK_GROUP_1);
+        runningEvent12.setStatus(EngineTaskStatus.RUNNING);
+
+        final EngineRunTask completedEvent11 = event(run.getId(), TEST + "3");
+        completedEvent11.setTaskGroup(TASK_GROUP_1);
+        completedEvent11.setStatus(EngineTaskStatus.COMPLETED);
+
+        final EngineRunTask runningEvent21 = event(run.getId(), TEST + "4");
+        runningEvent21.setTaskGroup(TASK_GROUP_2);
+        runningEvent21.setStatus(EngineTaskStatus.RUNNING);
+
+        final EngineRunTask runningEvent22 = event(run.getId(), TEST + "5");
+        runningEvent22.setTaskGroup(TASK_GROUP_2);
+        runningEvent22.setStatus(EngineTaskStatus.RUNNING);
+
+        final EngineRunTask completedEvent21 = event(run.getId(), TEST + "6");
+        completedEvent21.setTaskGroup(TASK_GROUP_2);
+        completedEvent21.setStatus(EngineTaskStatus.COMPLETED);
+
+        final EngineRunTask emptyGroupEvent = event(run.getId(), TEST + "7");
+        emptyGroupEvent.setTaskGroup(null);
+        emptyGroupEvent.setStatus(EngineTaskStatus.COMPLETED);
+
+        engineRunTaskDao.batchUpsert(Arrays.asList(
+                runningEvent11, runningEvent12, completedEvent11,
+                runningEvent21, runningEvent22, completedEvent21,
+                emptyGroupEvent));
+
+        assertThat(engineRunTaskDao.loadStats(run.getId())).hasSize(4);
+    }
+
+    private EngineRunTask event(final Long runId, final String task) {
         return EngineRunTask.builder()
                 .runId(runId)
                 .taskGroup(task)
+                .taskTag(task)
                 .taskId(task)
                 .taskKey(task)
                 .taskName(task)

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/run/EngineRunTaskStatsEntity.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/run/EngineRunTaskStatsEntity.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.pipeline.run;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+@Builder
+public class EngineRunTaskStatsEntity {
+    private EngineType engineType;
+    private String taskGroup;
+    private EngineTaskStatus status;
+    private Long tasksCount;
+}


### PR DESCRIPTION
relates to #3864 

Provides a new API method `GET run/<runId>/engine/<engineType>/tasks/stats` that loads run engine tasks statistics.
```
Responce Body:
{
  "payload": {
      "Process2": {
        "RUNNING": 1,
        "COMPLETED": 3
      },
      "Process1": {
        "COMPLETED": 2
      },
      "Process3": {
        "ABORTED": 3
      }, ...
  },
  "status": "OK"
}
```