### PR TITLE
Issue #3854: [API] Allow to show engine tasks stats on run details page - filter

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
@@ -44,6 +44,7 @@ import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.RunLog;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.epam.pipeline.entity.pipeline.run.EngineRunTask;
+import com.epam.pipeline.entity.pipeline.run.EngineRunTaskFilter;
 import com.epam.pipeline.entity.pipeline.run.EngineTaskStatus;
 import com.epam.pipeline.entity.pipeline.run.EngineType;
 import com.epam.pipeline.entity.pipeline.run.PipeRunCmdStartVO;
@@ -434,5 +435,11 @@ public class RunApiService {
     public Map<String, Map<EngineTaskStatus, Long>> loadEngineRunTasksStats(final Long runId,
                                                                             final EngineType engineType) {
         return engineRunTaskService.loadTasksStats(runId, engineType);
+    }
+
+    @PreAuthorize(RUN_ID_READ)
+    public PagedResult<List<EngineRunTask>> filterEngineRunTasks(final Long runId, final EngineType engineType,
+                                                                 final EngineRunTaskFilter filter) {
+        return engineRunTaskService.loadTasks(runId, engineType, filter);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
@@ -44,6 +44,7 @@ import com.epam.pipeline.entity.pipeline.PipelineTask;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.RunLog;
 import com.epam.pipeline.entity.pipeline.run.EngineRunTask;
+import com.epam.pipeline.entity.pipeline.run.EngineRunTaskFilter;
 import com.epam.pipeline.entity.pipeline.run.EngineTaskStatus;
 import com.epam.pipeline.entity.pipeline.run.EngineType;
 import com.epam.pipeline.entity.pipeline.run.PipeRunCmdStartVO;
@@ -692,5 +693,18 @@ public class PipelineRunController extends AbstractRestController {
             @PathVariable(value = RUN_ID) final Long runId,
             @PathVariable(value = ENGINE_TYPE) final EngineType engineType) {
         return Result.success(runApiService.loadEngineRunTasksStats(runId, engineType));
+    }
+
+    @PostMapping("run/{runId}/engine/{engineType}/tasks/filter")
+    @ApiOperation(
+            value = "Loads engine task for run with applied filters",
+            notes = "Loads engine task for run with applied filters",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<PagedResult<List<EngineRunTask>>> filterEngineRunTasks(
+            @PathVariable(value = RUN_ID) final Long runId,
+            @PathVariable(value = ENGINE_TYPE) final EngineType engineType,
+            @RequestBody final EngineRunTaskFilter filter) {
+        return Result.success(runApiService.filterEngineRunTasks(runId, engineType, filter));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/EngineRunTaskDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/EngineRunTaskDao.java
@@ -18,11 +18,15 @@ package com.epam.pipeline.dao.pipeline;
 
 import com.epam.pipeline.dao.DaoUtils;
 import com.epam.pipeline.dao.DryRunJdbcDaoSupport;
+import com.epam.pipeline.entity.pipeline.run.EngineRunTaskSortVO;
 import com.epam.pipeline.entity.pipeline.run.EngineRunTask;
+import com.epam.pipeline.entity.pipeline.run.EngineRunTaskFilter;
 import com.epam.pipeline.entity.run.EngineRunTaskStatsEntity;
 import com.epam.pipeline.entity.pipeline.run.EngineTaskStatus;
 import com.epam.pipeline.entity.pipeline.run.EngineType;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Required;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -30,14 +34,21 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 public class EngineRunTaskDao extends DryRunJdbcDaoSupport {
+    private static final Pattern WHERE_PATTERN = Pattern.compile("@WHERE@");
+    private static final Pattern SORT_PATTERN = Pattern.compile("@SORT@");
+    private static final int CLAUSE_LENGTH = 200;
+    private static final String AND = " AND ";
 
     private String upsertEngineRunTaskQuery;
     private String deleteEngineRunTaskByRunIdsQuery;
-    private String findEngineRunTaskByRunIdQuery;
     private String loadEngineRunTasksStatsByRunIdAndTypeQuery;
+    private String findEngineRunTaskByRunIdAndTypeQuery;
+    private String countEngineRunTaskByRunIdAndTypeQuery;
 
     @Transactional(propagation = Propagation.MANDATORY)
     public List<EngineRunTask> batchUpsert(final List<EngineRunTask> tasks) {
@@ -52,17 +63,78 @@ public class EngineRunTaskDao extends DryRunJdbcDaoSupport {
         getNamedParameterJdbcTemplate(dryRun).update(deleteEngineRunTaskByRunIdsQuery, params);
     }
 
-    public List<EngineRunTask> findByRunId(final Long runId) {
-        return getNamedParameterJdbcTemplate().query(findEngineRunTaskByRunIdQuery,
-                Parameters.buildRunIdParameter(runId), Parameters.getRowMapper());
-    }
-
     public List<EngineRunTaskStatsEntity> loadStats(final Long runId, final EngineType engineType) {
         return getNamedParameterJdbcTemplate().query(loadEngineRunTasksStatsByRunIdAndTypeQuery,
-                new MapSqlParameterSource()
-                        .addValue(Parameters.RUN_ID.name(), runId)
-                        .addValue(Parameters.ENGINE_TYPE.name(), engineType.name()),
+                Parameters.buildRunIdAndTypeParameter(runId, engineType),
                 Parameters.getStatsRowMapper());
+    }
+
+    public List<EngineRunTask> filterTasksByRunIdAndTypeAndFilter(final Long runId, final EngineType engineType,
+                                                                  final EngineRunTaskFilter filter) {
+        final MapSqlParameterSource parameters = Parameters.buildRunIdAndTypeParameter(runId, engineType)
+                .addValue(Parameters.LIMIT.name(), filter.getPageSize())
+                .addValue(Parameters.OFFSET.name(), (filter.getPage() - 1) * filter.getPageSize());
+
+        final String query = buildQuerySort(
+                buildQueryFilter(findEngineRunTaskByRunIdAndTypeQuery, filter), filter.getSorts());
+        return getNamedParameterJdbcTemplate().query(query, parameters, Parameters.getRowMapper());
+    }
+
+    public int countTasksByRunIdAndTypeAndFilter(final Long runId, final EngineType engineType,
+                                                 final EngineRunTaskFilter filter) {
+        final MapSqlParameterSource parameters = Parameters.buildRunIdAndTypeParameter(runId, engineType);
+        final String query = buildQueryFilter(countEngineRunTaskByRunIdAndTypeQuery, filter);
+        return getNamedParameterJdbcTemplate().queryForObject(query, parameters, Integer.class);
+    }
+
+    private String buildQueryFilter(final String query, final EngineRunTaskFilter filter) {
+        final StringBuilder whereBuilder = new StringBuilder(CLAUSE_LENGTH);
+        if (CollectionUtils.isNotEmpty(filter.getStatuses())) {
+            whereBuilder
+                    .append(AND)
+                    .append("r.status IN (")
+                    .append(filter.getStatuses().stream()
+                            .map(EngineTaskStatus::name)
+                            .map(status -> "'" + status + "'")
+                            .collect(Collectors.joining(", ")))
+                    .append(')');
+        }
+        if (StringUtils.isNotBlank(filter.getTaskId())) {
+            ilike(whereBuilder.append(AND), "r.task_id", filter.getTaskId());
+        }
+        if (StringUtils.isNotBlank(filter.getTaskGroup())) {
+            ilike(whereBuilder.append(AND), "r.task_group", filter.getTaskGroup());
+        }
+        if (StringUtils.isNotBlank(filter.getTaskTag())) {
+            ilike(whereBuilder.append(AND), "r.task_tag", filter.getTaskTag());
+        }
+        if (StringUtils.isNotBlank(filter.getTaskKey())) {
+            ilike(whereBuilder.append(AND), "r.task_key", filter.getTaskKey());
+        }
+        return WHERE_PATTERN.matcher(query).replaceFirst(whereBuilder.toString());
+    }
+
+    private void ilike(final StringBuilder queryBuilder, final String column, final String keyword) {
+        queryBuilder
+                .append(column)
+                .append(" ILIKE '%")
+                .append(keyword)
+                .append("%'");
+    }
+
+    private String buildQuerySort(final String query, final List<EngineRunTaskSortVO> sorts) {
+        final StringBuilder sortBuilder = new StringBuilder(CLAUSE_LENGTH);
+        if (CollectionUtils.isNotEmpty(sorts)) {
+            sortBuilder.append(" ORDER BY ")
+                    .append(sorts.stream()
+                            .map(this::buildDbSorting)
+                            .collect(Collectors.joining(", ")));
+        }
+        return SORT_PATTERN.matcher(query).replaceFirst(sortBuilder.toString());
+    }
+
+    private String buildDbSorting(final EngineRunTaskSortVO sorting) {
+        return "r." + sorting.getColumn().getDbColumn() + " " + (sorting.isDescending() ? "DESC" : "ASC");
     }
 
     enum Parameters {
@@ -79,7 +151,9 @@ public class EngineRunTaskDao extends DryRunJdbcDaoSupport {
         RUN_ID,
         DURATION,
         TASK_TAG,
-        TASKS_COUNT;
+        TASKS_COUNT,
+        LIMIT,
+        OFFSET;
 
         private static MapSqlParameterSource[] getBatchParameters(final List<EngineRunTask> tasks) {
             return tasks.stream()
@@ -118,6 +192,7 @@ public class EngineRunTaskDao extends DryRunJdbcDaoSupport {
                     .duration(rs.getLong(DURATION.name()))
                     .startDateTime(rs.getDate(START_DATE.name()))
                     .endDateTime(rs.getDate(END_DATE.name()))
+                    .attributes(rs.getString(DATA.name()))
                     .build();
         }
 
@@ -130,8 +205,10 @@ public class EngineRunTaskDao extends DryRunJdbcDaoSupport {
                     .build();
         }
 
-        private static MapSqlParameterSource buildRunIdParameter(final Long runId) {
-            return new MapSqlParameterSource().addValue(RUN_ID.name(), runId);
+        private static MapSqlParameterSource buildRunIdAndTypeParameter(final Long runId, final EngineType type) {
+            return new MapSqlParameterSource()
+                    .addValue(RUN_ID.name(), runId)
+                    .addValue(ENGINE_TYPE.name(), type.name());
         }
     }
 
@@ -146,12 +223,17 @@ public class EngineRunTaskDao extends DryRunJdbcDaoSupport {
     }
 
     @Required
-    public void setFindEngineRunTaskByRunIdQuery(final String findEngineRunTaskByRunIdQuery) {
-        this.findEngineRunTaskByRunIdQuery = findEngineRunTaskByRunIdQuery;
+    public void setLoadEngineRunTasksStatsByRunIdAndTypeQuery(final String loadEngineRunTasksStatsByRunIdAndTypeQuery) {
+        this.loadEngineRunTasksStatsByRunIdAndTypeQuery = loadEngineRunTasksStatsByRunIdAndTypeQuery;
     }
 
     @Required
-    public void setLoadEngineRunTasksStatsByRunIdAndTypeQuery(final String loadEngineRunTasksStatsByRunIdAndTypeQuery) {
-        this.loadEngineRunTasksStatsByRunIdAndTypeQuery = loadEngineRunTasksStatsByRunIdAndTypeQuery;
+    public void setFindEngineRunTaskByRunIdAndTypeQuery(final String findEngineRunTaskByRunIdAndTypeQuery) {
+        this.findEngineRunTaskByRunIdAndTypeQuery = findEngineRunTaskByRunIdAndTypeQuery;
+    }
+
+    @Required
+    public void setCountEngineRunTaskByRunIdAndTypeQuery(final String countEngineRunTaskByRunIdAndTypeQuery) {
+        this.countEngineRunTaskByRunIdAndTypeQuery = countEngineRunTaskByRunIdAndTypeQuery;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/EngineRunTaskService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/EngineRunTaskService.java
@@ -18,8 +18,10 @@ package com.epam.pipeline.manager.pipeline;
 
 import com.epam.pipeline.common.MessageConstants;
 import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.controller.PagedResult;
 import com.epam.pipeline.dao.pipeline.EngineRunTaskDao;
 import com.epam.pipeline.entity.pipeline.run.EngineRunTask;
+import com.epam.pipeline.entity.pipeline.run.EngineRunTaskFilter;
 import com.epam.pipeline.entity.run.EngineRunTaskStatsEntity;
 import com.epam.pipeline.entity.pipeline.run.EngineTaskStatus;
 import com.epam.pipeline.entity.pipeline.run.EngineType;
@@ -52,7 +54,7 @@ public class EngineRunTaskService {
         runCRUDService.loadRunById(runId);
         return engineRunTaskDao.batchUpsert(tasks.stream()
                         .peek(task -> task.setRunId(runId))
-                        .map(this::validate)
+                        .map(this::validateEvent)
                         .collect(Collectors.toList()))
                 .size();
     }
@@ -66,7 +68,17 @@ public class EngineRunTaskService {
                                         EngineRunTaskStatsEntity::getTasksCount)));
     }
 
-    private EngineRunTask validate(final EngineRunTask task) {
+    public PagedResult<List<EngineRunTask>> loadTasks(final Long runId, final EngineType engineType,
+                                                      final EngineRunTaskFilter filter) {
+        Assert.isTrue(filter.getPage() > 0, messageHelper.getMessage(MessageConstants.ERROR_PAGE_INDEX));
+        Assert.isTrue(filter.getPageSize() > 0, messageHelper.getMessage(MessageConstants.ERROR_PAGE_SIZE));
+
+        runCRUDService.loadRunById(runId);
+        return new PagedResult<>(engineRunTaskDao.filterTasksByRunIdAndTypeAndFilter(runId, engineType, filter),
+                engineRunTaskDao.countTasksByRunIdAndTypeAndFilter(runId, engineType, filter));
+    }
+
+    private EngineRunTask validateEvent(final EngineRunTask task) {
         Assert.notNull(task.getTaskId(), messageHelper.getMessage(
                 MessageConstants.ERROR_ENGINE_RUN_TASK_SETTING_NOT_FOUND, "taskId"));
         Assert.notNull(task.getEngineType(), messageHelper.getMessage(

--- a/api/src/main/resources/dao/engine-run-tasks.xml
+++ b/api/src/main/resources/dao/engine-run-tasks.xml
@@ -66,27 +66,6 @@
                 ]]>
             </value>
         </property>
-        <property name="findEngineRunTaskByRunIdQuery">
-            <value>
-                <![CDATA[
-                    SELECT
-                        r.task_id,
-                        r.task_name,
-                        r.task_key,
-                        r.task_tag,
-                        r.task_group,
-                        r.parent_id,
-                        r.engine_type,
-                        r.status,
-                        r.start_date,
-                        r.end_date,
-                        r.run_id,
-                        r.duration
-                    FROM pipeline.engine_run_task r
-                    WHERE r.run_id = :RUN_ID
-                ]]>
-            </value>
-        </property>
         <property name="loadEngineRunTasksStatsByRunIdAndTypeQuery">
             <value>
                 <![CDATA[
@@ -102,6 +81,39 @@
                         engine_type,
                         task_group,
                         status
+                ]]>
+            </value>
+        </property>
+        <property name="findEngineRunTaskByRunIdAndTypeQuery">
+            <value>
+                <![CDATA[
+                    SELECT
+                        r.task_id,
+                        r.task_name,
+                        r.task_key,
+                        r.task_tag,
+                        r.task_group,
+                        r.parent_id,
+                        r.engine_type,
+                        r.status,
+                        r.start_date,
+                        r.end_date,
+                        r.run_id,
+                        r.duration,
+                        r.data
+                    FROM pipeline.engine_run_task r
+                    WHERE r.run_id = :RUN_ID AND r.engine_type = :ENGINE_TYPE @WHERE@
+                    @SORT@
+                    LIMIT :LIMIT OFFSET :OFFSET
+                ]]>
+            </value>
+        </property>
+        <property name="countEngineRunTaskByRunIdAndTypeQuery">
+            <value>
+                <![CDATA[
+                    SELECT count(*)
+                    FROM pipeline.engine_run_task r
+                    WHERE r.run_id = :RUN_ID AND r.engine_type = :ENGINE_TYPE @WHERE@
                 ]]>
             </value>
         </property>

--- a/api/src/test/java/com/epam/pipeline/dao/pipeline/EngineRunTaskDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/pipeline/EngineRunTaskDaoTest.java
@@ -16,9 +16,11 @@
 
 package com.epam.pipeline.dao.pipeline;
 
+import com.epam.pipeline.entity.pipeline.run.EngineRunTaskSortVO;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.epam.pipeline.entity.pipeline.run.EngineRunTask;
+import com.epam.pipeline.entity.pipeline.run.EngineRunTaskFilter;
 import com.epam.pipeline.entity.pipeline.run.EngineTaskStatus;
 import com.epam.pipeline.entity.pipeline.run.EngineType;
 import com.epam.pipeline.test.jdbc.AbstractJdbcTest;
@@ -30,6 +32,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
+import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -39,6 +43,16 @@ public class EngineRunTaskDaoTest extends AbstractJdbcTest {
     private static final String TEST2 = "TEST2";
     private static final String TASK_GROUP_1 = "Process1";
     private static final String TASK_GROUP_2 = "Process2";
+    private static final String TAG = "tag";
+    private static final String HASH = "Hash";
+    private static final String TASK_1 = "Task1";
+    private static final String TASK_2 = "Task2";
+    private static final String TASK_3 = "Task3";
+    private static final String TASK_4 = "Task4";
+    private static final String TASK_5 = "Task5";
+    private static final String TASK_6 = "Task6";
+    private static final String TASK_7 = "Task7";
+    private static final int PAGE_SIZE = 20;
 
     @Autowired
     private PipelineRunDao pipelineRunDao;
@@ -50,15 +64,16 @@ public class EngineRunTaskDaoTest extends AbstractJdbcTest {
         final PipelineRun run = run();
         pipelineRunDao.createPipelineRun(run);
 
-        final EngineRunTask log1 = event(run.getId(), TEST);
-        engineRunTaskDao.batchUpsert(Collections.singletonList(log1));
+        final EngineRunTask event1 = event(run.getId(), TEST);
+        engineRunTaskDao.batchUpsert(Collections.singletonList(event1));
 
-        log1.setStatus(EngineTaskStatus.COMPLETED);
-        log1.setEndDateTime(new Date());
-        final EngineRunTask log2 = event(run.getId(), TEST2);
-        engineRunTaskDao.batchUpsert(Arrays.asList(log1, log2));
+        event1.setStatus(EngineTaskStatus.COMPLETED);
+        event1.setEndDateTime(new Date());
+        final EngineRunTask event2 = event(run.getId(), TEST2);
+        engineRunTaskDao.batchUpsert(Arrays.asList(event1, event2));
 
-        assertThat(engineRunTaskDao.findByRunId(run.getId())).hasSize(2);
+        assertThat(engineRunTaskDao.filterTasksByRunIdAndTypeAndFilter(run.getId(), EngineType.NEXTFLOW,
+                pagingBuilder().build())).hasSize(2);
     }
 
     @Test
@@ -66,40 +81,198 @@ public class EngineRunTaskDaoTest extends AbstractJdbcTest {
         final PipelineRun run = run();
         pipelineRunDao.createPipelineRun(run);
 
-        final EngineRunTask runningEvent11 = event(run.getId(), TEST + "1");
+        engineRunTaskDao.batchUpsert(tasks(run.getId()));
+
+        assertThat(engineRunTaskDao.loadStats(run.getId(), EngineType.NEXTFLOW)).hasSize(4);
+    }
+
+    @Test
+    public void shouldFilterEngineRunTasksByTaskGroup() {
+        final PipelineRun run = run();
+        pipelineRunDao.createPipelineRun(run);
+
+        engineRunTaskDao.batchUpsert(tasks(run.getId()));
+
+        final EngineRunTaskFilter filter = pagingBuilder().taskGroup("1").build();
+        final List<EngineRunTask> actual = engineRunTaskDao.filterTasksByRunIdAndTypeAndFilter(
+                run.getId(), EngineType.NEXTFLOW, filter);
+
+        assertThat(actual).hasSize(3);
+        actual.forEach(task -> assertThat(task.getTaskGroup()).isEqualTo(TASK_GROUP_1));
+        assertThat(engineRunTaskDao.countTasksByRunIdAndTypeAndFilter(run.getId(), EngineType.NEXTFLOW, filter))
+                .isEqualTo(3);
+    }
+
+    @Test
+    public void shouldFilterEngineRunTasksByTaskId() {
+        final PipelineRun run = run();
+        pipelineRunDao.createPipelineRun(run);
+
+        engineRunTaskDao.batchUpsert(tasks(run.getId()));
+
+        final EngineRunTaskFilter filter = pagingBuilder().taskId("1").build();
+        final List<EngineRunTask> actual = engineRunTaskDao
+                .filterTasksByRunIdAndTypeAndFilter(run.getId(), EngineType.NEXTFLOW, filter);
+        assertThat(actual).hasSize(1);
+        assertThat(actual.get(0).getTaskId()).isEqualTo(TASK_1);
+        assertThat(engineRunTaskDao.countTasksByRunIdAndTypeAndFilter(run.getId(), EngineType.NEXTFLOW, filter))
+                .isEqualTo(1);
+    }
+
+    @Test
+    public void shouldFilterEngineRunTasksByTaskKey() {
+        final PipelineRun run = run();
+        pipelineRunDao.createPipelineRun(run);
+
+        engineRunTaskDao.batchUpsert(tasks(run.getId()));
+
+        final EngineRunTaskFilter filter = pagingBuilder().taskKey(HASH).build();
+        final List<EngineRunTask> actual = engineRunTaskDao
+                .filterTasksByRunIdAndTypeAndFilter(run.getId(), EngineType.NEXTFLOW, filter);
+        assertThat(actual).hasSize(2);
+        actual.forEach(task -> assertThat(task.getTaskKey()).containsIgnoringCase(HASH));
+        assertThat(engineRunTaskDao.countTasksByRunIdAndTypeAndFilter(run.getId(), EngineType.NEXTFLOW, filter))
+                .isEqualTo(2);
+    }
+
+    @Test
+    public void shouldFilterEngineRunTasksByTaskTag() {
+        final PipelineRun run = run();
+        pipelineRunDao.createPipelineRun(run);
+
+        engineRunTaskDao.batchUpsert(tasks(run.getId()));
+
+        final EngineRunTaskFilter filter = pagingBuilder().taskTag(TAG).build();
+        final List<EngineRunTask> actual = engineRunTaskDao
+                .filterTasksByRunIdAndTypeAndFilter(run.getId(), EngineType.NEXTFLOW, filter);
+        assertThat(actual).hasSize(1);
+        actual.forEach(task -> assertThat(task.getTaskTag()).containsIgnoringCase(TAG));
+        assertThat(engineRunTaskDao.countTasksByRunIdAndTypeAndFilter(run.getId(), EngineType.NEXTFLOW, filter))
+                .isEqualTo(1);
+    }
+
+    @Test
+    public void shouldFilterEngineRunTasksByStatus() {
+        final PipelineRun run = run();
+        pipelineRunDao.createPipelineRun(run);
+
+        engineRunTaskDao.batchUpsert(tasks(run.getId()));
+
+        final EngineRunTaskFilter filter = pagingBuilder()
+                .statuses(Collections.singletonList(EngineTaskStatus.RUNNING))
+                .build();
+        final List<EngineRunTask> actual = engineRunTaskDao
+                .filterTasksByRunIdAndTypeAndFilter(run.getId(), EngineType.NEXTFLOW, filter);
+        assertThat(actual).hasSize(4);
+        actual.forEach(task -> assertThat(task.getStatus()).isEqualTo(EngineTaskStatus.RUNNING));
+        assertThat(engineRunTaskDao.countTasksByRunIdAndTypeAndFilter(run.getId(), EngineType.NEXTFLOW, filter))
+                .isEqualTo(4);
+    }
+
+    @Test
+    public void shouldFilterEngineRunTasksByNotMatchingStatus() {
+        final PipelineRun run = run();
+        pipelineRunDao.createPipelineRun(run);
+
+        engineRunTaskDao.batchUpsert(tasks(run.getId()));
+
+        final EngineRunTaskFilter filter = pagingBuilder()
+                .statuses(Collections.singletonList(EngineTaskStatus.ABORTED))
+                .build();
+        final List<EngineRunTask> actual = engineRunTaskDao
+                .filterTasksByRunIdAndTypeAndFilter(run.getId(), EngineType.NEXTFLOW, filter);
+        assertThat(actual).hasSize(0);
+        assertThat(engineRunTaskDao.countTasksByRunIdAndTypeAndFilter(run.getId(), EngineType.NEXTFLOW, filter))
+                .isEqualTo(0);
+    }
+
+    @Test
+    public void shouldFilterEngineRunTasksWithSortAndPaging() {
+        final PipelineRun run = run();
+        pipelineRunDao.createPipelineRun(run);
+
+        engineRunTaskDao.batchUpsert(tasks(run.getId()));
+
+        final List<EngineRunTask> page1 = engineRunTaskDao
+                .filterTasksByRunIdAndTypeAndFilter(run.getId(), EngineType.NEXTFLOW,
+                        pagingBuilder()
+                                .pageSize(2)
+                                .sorts(Collections.singletonList(EngineRunTaskSortVO.builder()
+                                        .column(EngineRunTaskSortVO.Columns.taskId)
+                                        .build()))
+                                .build());
+        assertThat(page1).hasSize(2);
+        assertThat(page1.get(0).getTaskId()).isEqualTo(TASK_1);
+        assertThat(page1.get(1).getTaskId()).isEqualTo(TASK_2);
+
+        final List<EngineRunTask> page2 = engineRunTaskDao
+                .filterTasksByRunIdAndTypeAndFilter(run.getId(), EngineType.NEXTFLOW,
+                        EngineRunTaskFilter.builder()
+                                .page(2)
+                                .pageSize(2)
+                                .sorts(Collections.singletonList(EngineRunTaskSortVO.builder()
+                                        .column(EngineRunTaskSortVO.Columns.taskId)
+                                        .build()))
+                                .build());
+        assertThat(page2).hasSize(2);
+        assertThat(page2.get(0).getTaskId()).isEqualTo(TASK_3);
+        assertThat(page2.get(1).getTaskId()).isEqualTo(TASK_4);
+    }
+
+    @Test
+    public void shouldCalculateCountOfEngineRunTasks() {
+        final PipelineRun run = run();
+        pipelineRunDao.createPipelineRun(run);
+
+        engineRunTaskDao.batchUpsert(tasks(run.getId()));
+
+        assertThat(engineRunTaskDao.countTasksByRunIdAndTypeAndFilter(run.getId(), EngineType.NEXTFLOW,
+                EngineRunTaskFilter.builder().build())).isEqualTo(7);
+    }
+
+    private List<EngineRunTask> tasks(final Long runId) {
+        final EngineRunTask runningEvent11 = event(runId, TEST);
+        runningEvent11.setTaskId(TASK_1);
         runningEvent11.setTaskGroup(TASK_GROUP_1);
+        runningEvent11.setTaskTag(TAG);
         runningEvent11.setStatus(EngineTaskStatus.RUNNING);
 
-        final EngineRunTask runningEvent12 = event(run.getId(), TEST + "2");
+        final EngineRunTask runningEvent12 = event(runId, TEST);
+        runningEvent12.setTaskId(TASK_2);
         runningEvent12.setTaskGroup(TASK_GROUP_1);
         runningEvent12.setStatus(EngineTaskStatus.RUNNING);
 
-        final EngineRunTask completedEvent11 = event(run.getId(), TEST + "3");
+        final EngineRunTask completedEvent11 = event(runId, TEST);
+        completedEvent11.setTaskId(TASK_3);
         completedEvent11.setTaskGroup(TASK_GROUP_1);
         completedEvent11.setStatus(EngineTaskStatus.COMPLETED);
 
-        final EngineRunTask runningEvent21 = event(run.getId(), TEST + "4");
+        final EngineRunTask runningEvent21 = event(runId, TEST);
+        runningEvent21.setTaskId(TASK_4);
         runningEvent21.setTaskGroup(TASK_GROUP_2);
+        runningEvent21.setTaskKey(TEST + HASH.toUpperCase(Locale.ROOT));
         runningEvent21.setStatus(EngineTaskStatus.RUNNING);
 
-        final EngineRunTask runningEvent22 = event(run.getId(), TEST + "5");
+        final EngineRunTask runningEvent22 = event(runId, TEST);
+        runningEvent22.setTaskId(TASK_5);
         runningEvent22.setTaskGroup(TASK_GROUP_2);
         runningEvent22.setStatus(EngineTaskStatus.RUNNING);
 
-        final EngineRunTask completedEvent21 = event(run.getId(), TEST + "6");
+        final EngineRunTask completedEvent21 = event(runId, TEST);
+        completedEvent21.setTaskId(TASK_6);
         completedEvent21.setTaskGroup(TASK_GROUP_2);
+        completedEvent21.setTaskKey(TEST + HASH.toLowerCase(Locale.ROOT));
         completedEvent21.setStatus(EngineTaskStatus.COMPLETED);
 
-        final EngineRunTask emptyGroupEvent = event(run.getId(), TEST + "7");
+        final EngineRunTask emptyGroupEvent = event(runId, TEST);
+        emptyGroupEvent.setTaskId(TASK_7);
         emptyGroupEvent.setTaskGroup(null);
         emptyGroupEvent.setStatus(EngineTaskStatus.COMPLETED);
 
-        engineRunTaskDao.batchUpsert(Arrays.asList(
+        return Arrays.asList(
                 runningEvent11, runningEvent12, completedEvent11,
                 runningEvent21, runningEvent22, completedEvent21,
-                emptyGroupEvent));
-
-        assertThat(engineRunTaskDao.loadStats(run.getId(), EngineType.NEXTFLOW)).hasSize(4);
+                emptyGroupEvent);
     }
 
     private EngineRunTask event(final Long runId, final String task) {
@@ -120,5 +293,9 @@ public class EngineRunTaskDaoTest extends AbstractJdbcTest {
     private PipelineRun run() {
         return TestUtils.createPipelineRun(null, null, TaskStatus.RUNNING, "USER",
                 null, null, true, null, null, "POD", 1L);
+    }
+
+    private EngineRunTaskFilter.EngineRunTaskFilterBuilder pagingBuilder() {
+        return EngineRunTaskFilter.builder().page(1).pageSize(PAGE_SIZE);
     }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/run/EngineRunTaskFilter.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/run/EngineRunTaskFilter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.pipeline.run;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@Builder
+public class EngineRunTaskFilter {
+    private String taskGroup;
+    private String taskTag;
+    private String taskId;
+    private String taskKey;
+    private List<EngineTaskStatus> statuses;
+    private List<EngineRunTaskSortVO> sorts;
+    private int pageSize;
+    private int page;
+}

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/run/EngineRunTaskSortVO.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/run/EngineRunTaskSortVO.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.pipeline.run;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+
+@Data
+@AllArgsConstructor
+@Builder
+public class EngineRunTaskSortVO {
+    private Columns column;
+    private boolean descending;
+
+    @Getter
+    public enum Columns {
+        taskGroup("task_group"),
+        taskId("task_id"),
+        taskTag("task_tag"),
+        status("status");
+
+        private final String dbColumn;
+
+        Columns(final String dbColumn) {
+            this.dbColumn = dbColumn;
+        }
+    }
+}


### PR DESCRIPTION
relates to #3854  
A new API method `POST run/<runId>/engine/<engineType>/tasks/filter` implemented
```
Request Body:
{
  # filter by substring in column: 
  "taskGroup": "string",
  "taskTag": "string",
  "taskId": "string",
  "taskKey": "string",
  # filter by exact match to one of specified values
  "statuses": [
    "CREATED", "RUNNING"
  ],
  "sorts": [
    {
      "column": "taskGroup",  # one of taskGroup|taskId|taskTag|status
      "descending": true  # false if not specified
    }
  ],
  "pageSize": 25,
  "page": 1 #  1-based
}
```