### PR TITLE
Hide secret metadata items

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/metadata/MetadataApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/metadata/MetadataApiService.java
@@ -59,6 +59,11 @@ public class MetadataApiService {
         return metadataManager.listMetadataItems(entities);
     }
 
+    @PostFilter(AclExpressions.METADATA_FILTER)
+    public List<MetadataEntry> listMetadataItemsByKey(final String key, final List<EntityVO> entities) {
+        return metadataManager.listMetadataItemsByKey(key, entities);
+    }
+
     @PreAuthorize(AclExpressions.METADATA_UPDATE_KEY)
     public MetadataEntry deleteMetadataItemKey(EntityVO entityVO, String key) {
         return metadataManager.deleteMetadataItemKey(entityVO, key);

--- a/api/src/main/java/com/epam/pipeline/controller/metadata/MetadataController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/metadata/MetadataController.java
@@ -33,6 +33,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -102,6 +103,20 @@ public class MetadataController extends AbstractRestController {
             })
     public Result<List<MetadataEntry>> loadMetadataItems(@RequestBody List<EntityVO> entities) {
         return Result.success(metadataApiService.listMetadataItems(entities));
+    }
+
+    @RequestMapping(value = "/metadata/{key}/load", method = RequestMethod.POST)
+    @ResponseBody
+    @ApiOperation(
+            value = "Returns a list of metadata with only specific key, for entities specified by id and class.",
+            notes = "Returns a list of metadata with only specific key, for entities  specified by id and class.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public Result<List<MetadataEntry>> loadMetadataItems(@PathVariable(value = "key") final String key,
+                                                         @RequestBody final List<EntityVO> entities) {
+        return Result.success(metadataApiService.listMetadataItemsByKey(key, entities));
     }
 
     @RequestMapping(value = "/metadata/keys", method = RequestMethod.GET)

--- a/api/src/main/java/com/epam/pipeline/dao/metadata/MetadataDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/metadata/MetadataDao.java
@@ -139,6 +139,14 @@ public class MetadataDao extends NamedParameterJdbcDaoSupport {
         return items.isEmpty() ? null : items;
     }
 
+    public List<MetadataEntry> loadMetadataItemsByKey(final String key, final List<EntityVO> entities) {
+        List<MetadataEntry> items = getNamedParameterJdbcTemplate().query(
+                convertEntitiesToString(loadMetadataItemsQuery, entities),
+                MetadataParameters.getParametersWithArrays(entities),
+                MetadataParameters.getRowMapper(Collections.singletonList(key)));
+        return items.isEmpty() ? null : items;
+    }
+
     public List<MetadataEntryWithIssuesCount> loadMetadataItemsWithIssues(List<EntityVO> entities) {
         List<MetadataEntryWithIssuesCount> items = getNamedParameterJdbcTemplate()
                 .query(convertEntitiesToString(loadMetadataItemsWithIssuesQuery, entities),
@@ -291,6 +299,8 @@ public class MetadataDao extends NamedParameterJdbcDaoSupport {
         IDS,
         CLASSES;
 
+        public static final String SECRET_METADATA_TYPE = "secret";
+
         static MapSqlParameterSource getParameters(EntityVO entityVO) {
             MapSqlParameterSource params = new MapSqlParameterSource();
             params.addValue(ENTITY_ID.name(), entityVO.getEntityId());
@@ -323,10 +333,14 @@ public class MetadataDao extends NamedParameterJdbcDaoSupport {
         }
 
         static RowMapper<MetadataEntry> getRowMapper() {
+            return getRowMapper(Collections.emptyList());
+        }
+
+        static RowMapper<MetadataEntry> getRowMapper(final List<String> keyToRetrieve) {
             return (rs, rowNum) -> {
                 Long metadataEntityId = rs.getLong(ENTITY_ID.name());
                 String metadataEntityClass = rs.getString(ENTITY_CLASS.name());
-                return initMetadataItem(rs, metadataEntityId, metadataEntityClass);
+                return initMetadataItem(rs, metadataEntityId, metadataEntityClass, keyToRetrieve);
             };
         }
 
@@ -367,16 +381,33 @@ public class MetadataDao extends NamedParameterJdbcDaoSupport {
             };
         }
 
-        private static MetadataEntry initMetadataItem(ResultSet rs, Long metadataItemId, String metadataEntityClass)
+        private static MetadataEntry initMetadataItem(final ResultSet rs, final Long metadataItemId,
+                                                      final String metadataEntityClass,
+                                                      final List<String> keysToRetrieve)
                 throws SQLException {
             MetadataEntry metadataEntry = new MetadataEntry();
             metadataEntry.setEntity(new EntityVO(metadataItemId, AclClass.valueOf(metadataEntityClass)));
-            metadataEntry.setData(parseData(rs.getString(DATA.name())));
+            metadataEntry.setData(parseData(rs.getString(DATA.name()), keysToRetrieve));
             return metadataEntry;
         }
 
-        public static Map<String, PipeConfValue> parseData(String data) {
-            return JsonMapper.parseData(data, new TypeReference<Map<String, PipeConfValue>>() {});
+        public static Map<String, PipeConfValue> parseData(final String data) {
+            return parseData(data, Collections.emptyList());
+        }
+
+        public static Map<String, PipeConfValue> parseData(final String data, final List<String> keysToRetrieve) {
+            final Map<String, PipeConfValue> parsedData = JsonMapper.parseData(
+                    data, new TypeReference<Map<String, PipeConfValue>>() {});
+            if (CollectionUtils.isEmpty(keysToRetrieve)) {
+                return parsedData.entrySet().stream()
+                        .filter(metadataEntry ->
+                                !SECRET_METADATA_TYPE.equalsIgnoreCase(metadataEntry.getValue().getType()))
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            } else {
+                return parsedData.entrySet().stream()
+                        .filter(metadataEntry -> keysToRetrieve.contains(metadataEntry.getKey()))
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            }
         }
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/metadata/MetadataManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/metadata/MetadataManager.java
@@ -164,6 +164,13 @@ public class MetadataManager {
         return metadataDao.loadMetadataItems(entities);
     }
 
+    public List<MetadataEntry> listMetadataItemsByKey(final String key, final List<EntityVO> entities) {
+        if (CollectionUtils.isEmpty(entities)) {
+            return Collections.emptyList();
+        }
+        return metadataDao.loadMetadataItemsByKey(key, entities);
+    }
+
     public boolean hasMetadata(EntityVO entityVO) {
         return metadataDao.hasMetadata(entityVO);
     }

--- a/api/src/test/java/com/epam/pipeline/manager/metadata/MetadataManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/metadata/MetadataManagerTest.java
@@ -76,6 +76,7 @@ public class MetadataManagerTest extends AbstractSpringTest {
     private static final String VALUE_1 = "Test User";
     private static final String VALUE_2 = "Leukocyte";
     private static final String TYPE = "string";
+    private static final String SECRET_TYPE = "secret";
     private static final String TSV_HEADER = "Key\tValue\tType";
     private static final String CSV_HEADER = "Key,Value,Type";
     private static final String TSV_FILE_NAME = "test_file.tsv";
@@ -220,6 +221,37 @@ public class MetadataManagerTest extends AbstractSpringTest {
                 AclClass.PIPELINE_USER, KEY_1, null);
 
         Assert.assertFalse(result.isEmpty());
+    }
+
+    @Test
+    @Transactional
+    public void testThatSecretMetadataWillBeHidedDuringSearch() {
+        Mockito.doReturn(new PipelineUser(TEST_USER)).when(entityManager)
+                .load(eq(AclClass.PIPELINE_USER), Mockito.anyLong());
+
+        final EntityVO entityVO = new EntityVO(USER_ENTITY_ID, AclClass.PIPELINE_USER);
+        final Map<String, PipeConfValue> data = new HashMap<>();
+        data.put(KEY_1, new PipeConfValue(SECRET_TYPE, VALUE_1));
+        final MetadataVO metadataVO = new MetadataVO();
+        metadataVO.setEntity(entityVO);
+        metadataVO.setData(data);
+        metadataManager.updateMetadataItem(metadataVO);
+
+        // We can find entities by specific secret metadata key
+        List<EntityVO> searchResult = metadataManager.searchMetadataByClassAndKeyValue(
+                AclClass.PIPELINE_USER, KEY_1, null);
+        Assert.assertFalse(searchResult.isEmpty());
+
+        // And we can list specific secret metadata by key
+        List<MetadataEntry> loadResultByKey = metadataManager
+                .listMetadataItemsByKey(KEY_1, Collections.singletonList(entityVO));
+        Assert.assertFalse(loadResultByKey.isEmpty());
+        Assert.assertFalse(loadResultByKey.get(0).getData().isEmpty());
+
+        // But we can't see secret value when list all metadata for the entity
+        List<MetadataEntry> loadResult = metadataManager.listMetadataItems(Collections.singletonList(entityVO));
+        Assert.assertFalse(loadResult.isEmpty());
+        Assert.assertTrue(loadResult.get(0).getData().isEmpty());
     }
 
     @Test(expected = MetadataReadingException.class)


### PR DESCRIPTION
For metadata with type `secret` - do not show it when loading whole metadata object.
Instead, method for retrieving such metadata values is provided:

`POST /metadata/{key}/load`
   - key - name of the secret metadata value
   - body - list of EntityVO to seach for the specified secret metadata