### PR TITLE
Issue 3833 sync_to_storage: batch mode

### DIFF
--- a/deploy/docker/cp-tools/base/nextflow/howto.md
+++ b/deploy/docker/cp-tools/base/nextflow/howto.md
@@ -27,6 +27,7 @@ It is also possible to configure this image to use this functionality automatica
        "[ -f /opt/nf-weblog-handler/nf-weblog-handler.sh ] && /opt/nf-weblog-handler/nf-weblog-handler.sh --start --enable-runtime-data -p $CP_NF_WEBLOG_HANDLER_PORT || exit 1"
       ],
       "params": {
+       "CP_SYNC_TO_STORAGE_BATCH_MODE": "1",
        "CP_RUN_ENGINE_TYPE": "NEXTFLOW",
        "CP_NF_WEBLOG_HANDLER_ENABLED": "1",
        "CP_NF_WEBLOG_HANDLER_PORT": "8080",

--- a/pipe-cli/src/utilities/datastorage_operations.py
+++ b/pipe-cli/src/utilities/datastorage_operations.py
@@ -184,6 +184,16 @@ class DataStorageOperations(object):
                                       permission_to_check, include, exclude, force, skip_existing, sync_newer,
                                       verify_destination, on_unsafe_chars, on_unsafe_chars_replacement, on_empty_files)
             sys.exit(0)
+
+        # TODO: rewrite tuple to object
+        # items - collection of items (tuples), each item represents file + additional information about this file
+        # item structure:
+        #  object_type = item[0]
+        #  full_path = item[1]
+        #  relative_path = item[2]
+        #  source_size = item[3]
+        #  source_timestamp = item[4]
+        #  destination_relative_path = item[5]
         items = files_to_copy if file_list else source_wrapper.get_items(quiet=quiet)
         if source_type not in [WrapperType.STREAM]:
             items = cls._filter_items(items, manager, source_wrapper, destination_wrapper, permission_to_check,
@@ -295,14 +305,7 @@ class DataStorageOperations(object):
             relative_path = item[2]
             source_size = item[3]
 
-            # Unused here but added for visibility of the field
-            source_modification_date = None
-            if len(item) >= 5:
-                source_modification_date = item[4]
-
-            destination_relative_path = None
-            if len(item) >= 6:
-                destination_relative_path = item[5]
+            destination_relative_path = cls._get_tuple_item(item, 5, relative_path)
 
             logging.debug(u'Preprocessing path {}...'.format(full_path))
 
@@ -348,7 +351,7 @@ class DataStorageOperations(object):
                 filtered_items.append(item)
                 continue
 
-            destination_key = manager.get_destination_key(destination_wrapper, destination_relative_path if destination_relative_path else relative_path)
+            destination_key = manager.get_destination_key(destination_wrapper, destination_relative_path)
             if skip_existing and sync_newer:
                 destination_size, destination_modification_datetime = \
                     manager.get_destination_object_head(destination_wrapper, destination_key)
@@ -819,15 +822,7 @@ class DataStorageOperations(object):
         relative_path = item[2]
         size = item[3]
 
-        # Unused here but added for visibility of the field
-        source_modification_date = None
-        if len(item) >= 5:
-            source_modification_date = item[4]
-
-        if len(item) >= 6:
-            destination_relative_path = item[5]
-        else:
-            destination_relative_path = relative_path
+        destination_relative_path = cls._get_tuple_item(item, 5, relative_path)
 
         fail_after_exception = None
         try:
@@ -967,3 +962,10 @@ class DataStorageOperations(object):
                     click.echo(msg)
                 return None
         return item
+
+    @classmethod
+    def _get_tuple_item(cls, collection, index, default=None):
+        if len(collection) > index:
+            return collection[index]
+        return default
+

--- a/pipe-cli/src/utilities/datastorage_operations.py
+++ b/pipe-cli/src/utilities/datastorage_operations.py
@@ -295,6 +295,15 @@ class DataStorageOperations(object):
             relative_path = item[2]
             source_size = item[3]
 
+            # Unused here but added for visibility of the field
+            source_modification_date = None
+            if len(item) >= 5:
+                source_modification_date = item[4]
+
+            destination_relative_path = None
+            if len(item) >= 6:
+                destination_relative_path = item[5]
+
             logging.debug(u'Preprocessing path {}...'.format(full_path))
 
             item = cls._process_unsafe_chars(item, quiet, unsafe_chars, unsafe_chars_replacement)
@@ -339,7 +348,7 @@ class DataStorageOperations(object):
                 filtered_items.append(item)
                 continue
 
-            destination_key = manager.get_destination_key(destination_wrapper, relative_path)
+            destination_key = manager.get_destination_key(destination_wrapper, destination_relative_path if destination_relative_path else relative_path)
             if skip_existing and sync_newer:
                 destination_size, destination_modification_datetime = \
                     manager.get_destination_object_head(destination_wrapper, destination_key)
@@ -686,7 +695,14 @@ class DataStorageOperations(object):
                 splitted = line.split('\t')
                 path = splitted[0]
                 size = long(float(splitted[1]))
-                yield ('File', os.path.join(source_path, path), path, size)
+
+                # Ability to overwrite destination path of the file, by forming --file-list file as:
+                # <path>\t<size>\t<destination_path>
+                if len (splitted) > 2:
+                    destination_path = splitted[2]
+                    yield ('File', os.path.join(source_path, path), path, size, None, destination_path)
+                else:
+                    yield ('File', os.path.join(source_path, path), path, size, None)
 
     @classmethod
     def mount_storage(cls, mountpoint, file=False, bucket=None, log_file=None, log_level=None, options=None,
@@ -802,11 +818,22 @@ class DataStorageOperations(object):
         full_path = item[1]
         relative_path = item[2]
         size = item[3]
+
+        # Unused here but added for visibility of the field
+        source_modification_date = None
+        if len(item) >= 5:
+            source_modification_date = item[4]
+
+        if len(item) >= 6:
+            destination_relative_path = item[5]
+        else:
+            destination_relative_path = relative_path
+
         fail_after_exception = None
         try:
             transfer_result = manager.transfer(source_wrapper, destination_wrapper, path=full_path,
-                                               relative_path=relative_path, clean=clean, quiet=quiet, size=size,
-                                               tags=tags, io_threads=io_threads, lock=lock,
+                                               relative_path=destination_relative_path, clean=clean, quiet=quiet,
+                                               size=size, tags=tags, io_threads=io_threads, lock=lock,
                                                checksum_algorithm=checksum_algorithm, checksum_skip=checksum_skip)
             if not destination_wrapper.is_local() and transfer_result:
                 transfer_results.append(transfer_result)

--- a/workflows/pipe-common/shell/sync_to_storage
+++ b/workflows/pipe-common/shell/sync_to_storage
@@ -62,7 +62,7 @@ function remove_from_spec() {
 function wait_for_pids() {
     local _sync_pids=("$@")
     for pid in ${_sync_pids[*]}; do
-        echo_debug "Waiting for pid $pid to finish"
+        echo_debug "[DEBUG] Waiting for pid $pid to finish"
         wait "$pid"
         if [ $? -ne 0 ]; then
             echo "[WARN] Sync process with pid $pid failed"
@@ -75,7 +75,7 @@ function perform_sync() {
 
     local _sync_pids=()
     while read -a _sync_config_entry; do
-        echo_debug "Processing entry ${_sync_config_entry[*]}"
+        echo_debug "[DEBUG] Processing entry ${_sync_config_entry[*]}"
 
         local _source_path=${_sync_config_entry[0]}
         _source_path_trim=${_source_path#/}
@@ -90,13 +90,13 @@ function perform_sync() {
             continue
           fi
           _dest_path="${CP_SYNC_TO_STORAGE_DESTINATION}/${RUN_ID}/$_source_path_trim"
-          echo_debug "Destination path wasn't provided in configuration, will use default one: $_dest_path"
+          echo_debug "[DEBUG] Destination path wasn't provided in configuration, will use default one: $_dest_path"
         fi
 
-        echo_debug "Source path: $_source_path Destination path: $_dest_path"
+        echo_debug "[DEBUG] Source path: $_source_path Destination path: $_dest_path"
 
         if [ ! -d "$_source_path" ] && [ ! -f "$_source_path" ]; then
-            echo_debug "$_source_path not found"
+            echo_debug "[DEBUG] $_source_path not found"
             continue
         fi
 
@@ -107,17 +107,17 @@ function perform_sync() {
         if [ "$CP_SYNC_TO_STORAGE_DEBUG" != "true" ]; then
             _pipe_extra_args="$_pipe_extra_args -q"
         fi
-        echo_debug "pipe extra args: $_pipe_extra_args"
+        echo_debug "[DEBUG] pipe extra args: $_pipe_extra_args"
 
-        echo_debug "destination path: $_dest_path"
+        echo_debug "[DEBUG] destination path: $_dest_path"
 
         local _pipe_command="pipe storage cp -f \"$_source_path\" \"$_dest_path\" $_pipe_extra_args"
-        echo_debug "pipe command: $_pipe_command"
+        echo_debug "[DEBUG] pipe command: $_pipe_command"
 
         if [ "$CP_SYNC_TO_STORAGE_THREADS" -gt 1 ]; then
             eval "$_pipe_command" &
             _sync_process_pid=$!
-            echo_debug "Sync $_source_path to $_dest_path has pid $_sync_process_pid"
+            echo_debug "[DEBUG] Sync $_source_path to $_dest_path has pid $_sync_process_pid"
 
             _sync_pids[${#_sync_pids[@]}]=$_sync_process_pid
             if [ "${#_sync_pids[@]}" -eq "$CP_SYNC_TO_STORAGE_THREADS" ]; then
@@ -189,13 +189,13 @@ function perform_batch_sync() {
           return 1
         fi
         _sync_common_bucket_path="${CP_SYNC_TO_STORAGE_DESTINATION}/${RUN_ID}/"
-        echo_debug "Destination bucket wasn't provided in sync configuration, will use default one: $_sync_common_bucket_path"
+        echo_debug "[DEBUG] Destination bucket wasn't provided in sync configuration, will use default one: $_sync_common_bucket_path"
     fi
 
     _file_list="${_spec_file}.file_list"
     rm -f "$_file_list"
     while read -a _sync_config_entry; do
-        echo_debug "Processing entry ${_sync_config_entry[*]}"
+        echo_debug "[DEBUG] Processing entry ${_sync_config_entry[*]}"
 
         local _source_path=${_sync_config_entry[0]}
         _source_path_trim=${_source_path#/}
@@ -208,19 +208,19 @@ function perform_batch_sync() {
           _dest_path="$_source_path_trim"
         fi
 
-        echo_debug "Source path: $_source_path Destination path: $_dest_path"
+        echo_debug "[DEBUG] Source path: $_source_path Destination path: $_dest_path"
         printf "%s\t%s\t%s\n" "${_source_path_trim}" "$(stat -c%s "${_source_path}")" "${_dest_path}" >> "${_file_list}"
     done <"$_spec_file"
-    echo_debug "Prepare file-list file: ${_file_list} with $(wc -l "$_spec_file") lines"
+    echo_debug "[DEBUG] Prepare file-list file: ${_file_list} with $(wc -l "$_spec_file") lines"
 
     local _pipe_extra_args="${CP_SYNC_TO_STORAGE_PIPE_EXTRA_ARGS}"
     if [ "$CP_SYNC_TO_STORAGE_DEBUG" != "true" ]; then
         _pipe_extra_args="$_pipe_extra_args -q"
     fi
-    echo_debug "pipe extra args: $_pipe_extra_args"
+    echo_debug "[DEBUG] pipe extra args: $_pipe_extra_args"
 
     local _pipe_command="pipe storage cp -f -r / $_sync_common_bucket_path --file-list ${_file_list} $_pipe_extra_args"
-    echo_debug "pipe command: $_pipe_command"
+    echo_debug "[DEBUG] pipe command: $_pipe_command"
     eval "$_pipe_command"
     if [ $? -ne 0 ]; then
         echo "[WARN] Sync $_source_path to $_dest_path failed"
@@ -230,20 +230,22 @@ function perform_batch_sync() {
 
 function start_sync_daemon() {
     while [ -z "$CP_SYNC_TO_STORAGE_STOP" ]; do
+        echo_debug "[DEBUG] Start iteration of sync_to_storage sync cycle"
 
         if [ -f "$CP_SYNC_TO_STORAGE_STOP_FLAG_FILE" ]; then
-            echo "File $CP_SYNC_TO_STORAGE_STOP_FLAG_FILE defined as CP_SYNC_TO_STORAGE_STOP_FLAG_FILES and present. Perform last sync iteration before stop."
+            echo "[INFO] File $CP_SYNC_TO_STORAGE_STOP_FLAG_FILE defined as CP_SYNC_TO_STORAGE_STOP_FLAG_FILES and present. Perform last sync iteration before stop."
             # We need to use such mechanism with additional env var instead of 'while [ -f "$CP_SYNC_TO_STORAGE_STOP_FLAG_FILE" ]'
             # because CP_SYNC_TO_STORAGE_STOP_FLAG_FILE can be created during sleep -> we still need to perform one more sync iteration
             export CP_SYNC_TO_STORAGE_STOP="true"
         fi
 
         if [ ! -f "$CP_SYNC_TO_STORAGE_SPEC" ]; then
-            echo_debug "Spec file not found: $CP_SYNC_TO_STORAGE_SPEC"
+            echo_debug "[DEBUG] Spec file not found: $CP_SYNC_TO_STORAGE_SPEC"
             sleep "$CP_SYNC_TO_STORAGE_TIMEOUT_SEC"
             continue
         fi
 
+        echo_debug "[DEBUG] Creating temp copy of $CP_SYNC_TO_STORAGE_SPEC, $CP_SYNC_TO_STORAGE_REMOVE_SPEC to freez current config state"
         cp -f "$CP_SYNC_TO_STORAGE_SPEC" "${CP_SYNC_TO_STORAGE_SPEC}.tmp"
         cp -f "$CP_SYNC_TO_STORAGE_REMOVE_SPEC" "${CP_SYNC_TO_STORAGE_REMOVE_SPEC}.tmp"
 
@@ -255,13 +257,13 @@ function start_sync_daemon() {
 
         # Check if some file from config marked for deletion
         if [ -f "${CP_SYNC_TO_STORAGE_REMOVE_SPEC}.tmp" ]; then
-            echo "Cleaning up $CP_SYNC_TO_STORAGE_SPEC with respect to $CP_SYNC_TO_STORAGE_REMOVE_SPEC"
+            echo_debug "[DEBUG] Cleaning up $CP_SYNC_TO_STORAGE_SPEC with respect to ${CP_SYNC_TO_STORAGE_REMOVE_SPEC}.tmp"
 
             touch "${CP_SYNC_TO_STORAGE_SPEC}.new"
             while read -a _sync_config_entry; do
                 local _source_path=${_sync_config_entry[0]}
                 if grep -q -F "$_source_path" "${CP_SYNC_TO_STORAGE_SPEC}.tmp" && grep -q -x -F "$_source_path" "${CP_SYNC_TO_STORAGE_REMOVE_SPEC}.tmp"; then
-                    echo_debug "Path $_source_path is configured for the deletion from sync process"
+                    echo_debug "[DEBUG] Path $_source_path is configured for the deletion from sync process"
                     continue
                 fi
                 echo "${_sync_config_entry[@]}" >> "${CP_SYNC_TO_STORAGE_SPEC}.new"
@@ -270,12 +272,14 @@ function start_sync_daemon() {
             mv -f "${CP_SYNC_TO_STORAGE_SPEC}.new" "${CP_SYNC_TO_STORAGE_SPEC}"
             rm -f "${CP_SYNC_TO_STORAGE_SPEC}.new"
 
-            echo "Previous number of entries to sync is: $(wc -l < "${CP_SYNC_TO_STORAGE_SPEC}.tmp") now: $(wc -l < "$CP_SYNC_TO_STORAGE_SPEC")"
+            echo_debug "[DEBUG] Previous number of entries to sync is: $(wc -l < "${CP_SYNC_TO_STORAGE_SPEC}.tmp") now: $(wc -l < "$CP_SYNC_TO_STORAGE_SPEC")"
         fi
 
+        echo_debug "[DEBUG] Removing temp copy of $CP_SYNC_TO_STORAGE_SPEC, $CP_SYNC_TO_STORAGE_REMOVE_SPEC"
         rm -f "${CP_SYNC_TO_STORAGE_SPEC}.tmp"
         rm -f "${CP_SYNC_TO_STORAGE_REMOVE_SPEC}.tmp"
 
+        echo_debug "[DEBUG] Done iteration of sync_to_storage sync cycle"
         if [ -z "$CP_SYNC_TO_STORAGE_STOP" ]; then
             sleep "$CP_SYNC_TO_STORAGE_TIMEOUT_SEC"
         fi

--- a/workflows/pipe-common/shell/sync_to_storage
+++ b/workflows/pipe-common/shell/sync_to_storage
@@ -62,7 +62,7 @@ function remove_from_spec() {
 function wait_for_pids() {
     local _sync_pids=("$@")
     for pid in ${_sync_pids[*]}; do
-        echo_debug "[DEBUG] Waiting for pid $pid to finish"
+        echo_debug "Waiting for pid $pid to finish"
         wait "$pid"
         if [ $? -ne 0 ]; then
             echo "[WARN] Sync process with pid $pid failed"
@@ -75,7 +75,7 @@ function perform_sync() {
 
     local _sync_pids=()
     while read -a _sync_config_entry; do
-        echo_debug "[DEBUG] Processing entry ${_sync_config_entry[*]}"
+        echo_debug "Processing entry ${_sync_config_entry[*]}"
 
         local _source_path=${_sync_config_entry[0]}
         _source_path_trim=${_source_path#/}
@@ -90,13 +90,13 @@ function perform_sync() {
             continue
           fi
           _dest_path="${CP_SYNC_TO_STORAGE_DESTINATION}/${RUN_ID}/$_source_path_trim"
-          echo_debug "[DEBUG] Destination path wasn't provided in configuration, will use default one: $_dest_path"
+          echo_debug "Destination path wasn't provided in configuration, will use default one: $_dest_path"
         fi
 
-        echo_debug "[DEBUG] Source path: $_source_path Destination path: $_dest_path"
+        echo_debug "Source path: $_source_path Destination path: $_dest_path"
 
         if [ ! -d "$_source_path" ] && [ ! -f "$_source_path" ]; then
-            echo_debug "[DEBUG] $_source_path not found"
+            echo_debug "$_source_path not found"
             continue
         fi
 
@@ -107,17 +107,17 @@ function perform_sync() {
         if [ "$CP_SYNC_TO_STORAGE_DEBUG" != "true" ]; then
             _pipe_extra_args="$_pipe_extra_args -q"
         fi
-        echo_debug "[DEBUG] pipe extra args: $_pipe_extra_args"
+        echo_debug "pipe extra args: $_pipe_extra_args"
 
-        echo_debug "[DEBUG] destination path: $_dest_path"
+        echo_debug "destination path: $_dest_path"
 
         local _pipe_command="pipe storage cp -f \"$_source_path\" \"$_dest_path\" $_pipe_extra_args"
-        echo_debug "[DEBUG] pipe command: $_pipe_command"
+        echo_debug "pipe command: $_pipe_command"
 
         if [ "$CP_SYNC_TO_STORAGE_THREADS" -gt 1 ]; then
             eval "$_pipe_command" &
             _sync_process_pid=$!
-            echo_debug "[DEBUG] Sync $_source_path to $_dest_path has pid $_sync_process_pid"
+            echo_debug "Sync $_source_path to $_dest_path has pid $_sync_process_pid"
 
             _sync_pids[${#_sync_pids[@]}]=$_sync_process_pid
             if [ "${#_sync_pids[@]}" -eq "$CP_SYNC_TO_STORAGE_THREADS" ]; then
@@ -142,36 +142,37 @@ function sync_spec_allows_batch_mode() {
 
     _spec_lines=$( wc -l < "$_spec_file")
 
-    if [ "$_spec_lines" -lt "2" ]; then
+    if [ "$_spec_lines" -lt 2 ]; then
+        echo_debug "Only one line in sync config, no need for batch mode."
         return 1
     fi
 
-    _all_entries_are_files=1
+    _all_entries_are_files="true"
     while read -a _sync_config_entry; do
         _source_path=${_sync_config_entry[0]}
         if [ -d "$_source_path" ]; then
-            _all_entries_are_files=0
+            _all_entries_are_files="false"
             break
         fi
     done <"$_spec_file"
 
-    if [ "$_all_entries_are_files" -ne "1" ]; then
+    if [ "$_all_entries_are_files" != "true" ]; then
+        echo_debug "Not all sync entries are files, can't use batch mode!"
         return 1
     fi
 
     _spec_lines_with_default_bucket=$(awk '{ print $2 }' < "$_spec_file" | grep -c "^$")
 
-    _sync_common_bucket_path=$(awk '{ print $2 }' < "$_spec_file" | grep -oP -m 1 "^(\w{2}://\w+/)(?=.+)")
+    _sync_common_bucket_path=$(awk '{ print $2 }' < "$_spec_file" | grep -oP -m 1 "^(\w{2}://[\w-.]+/)(?=.*)")
     _spec_lines_with_same_bucket=$(awk '{ print $2 }' < "$_spec_file" | grep -c "$_sync_common_bucket_path")
 
     _all_entries_for_same_bucket=
-    if [ -n "$_sync_common_bucket_path" ] && [ "$_spec_lines" -ne "$_spec_lines_with_same_bucket" ]; then
-        _all_entries_for_same_bucket="1"
+    if [ -n "$_sync_common_bucket_path" ] && [ "$_spec_lines" == "$_spec_lines_with_same_bucket" ]; then
+        _all_entries_for_same_bucket="true"
     fi
 
-
-
-    if [ "$_spec_lines" -ne "$_spec_lines_with_default_bucket" ] && [ "$_all_entries_for_same_bucket" -ne "1" ]; then
+    if [ "$_spec_lines" != "$_spec_lines_with_default_bucket" ] && [ "$_all_entries_for_same_bucket" != "true" ]; then
+        echo_debug "Sync entries configured for different bucket to be synced, can't use batch mode!"
         return 1
     fi
 
@@ -189,13 +190,16 @@ function perform_batch_sync() {
           return 1
         fi
         _sync_common_bucket_path="${CP_SYNC_TO_STORAGE_DESTINATION}/${RUN_ID}/"
-        echo_debug "[DEBUG] Destination bucket wasn't provided in sync configuration, will use default one: $_sync_common_bucket_path"
+        echo_debug "Destination bucket wasn't provided in sync configuration, will use default one: $_sync_common_bucket_path"
     fi
 
     _file_list="${_spec_file}.file_list"
+
+    # Clean up before the new iteration
     rm -f "$_file_list"
+
     while read -a _sync_config_entry; do
-        echo_debug "[DEBUG] Processing entry ${_sync_config_entry[*]}"
+        echo_debug "Processing entry ${_sync_config_entry[*]}"
 
         local _source_path=${_sync_config_entry[0]}
         _source_path_trim=${_source_path#/}
@@ -208,29 +212,28 @@ function perform_batch_sync() {
           _dest_path="$_source_path_trim"
         fi
 
-        echo_debug "[DEBUG] Source path: $_source_path Destination path: $_dest_path"
+        echo_debug "Source path: $_source_path Destination path: $_dest_path"
         printf "%s\t%s\t%s\n" "${_source_path_trim}" "$(stat -c%s "${_source_path}")" "${_dest_path}" >> "${_file_list}"
     done <"$_spec_file"
-    echo_debug "[DEBUG] Prepare file-list file: ${_file_list} with $(wc -l "$_spec_file") lines"
+    echo_debug "Prepare file-list file: ${_file_list} with $(wc -l "$_spec_file") lines"
 
     local _pipe_extra_args="${CP_SYNC_TO_STORAGE_PIPE_EXTRA_ARGS}"
     if [ "$CP_SYNC_TO_STORAGE_DEBUG" != "true" ]; then
         _pipe_extra_args="$_pipe_extra_args -q"
     fi
-    echo_debug "[DEBUG] pipe extra args: $_pipe_extra_args"
+    echo_debug "pipe extra args: $_pipe_extra_args"
 
     local _pipe_command="pipe storage cp -f -r / $_sync_common_bucket_path --file-list ${_file_list} $_pipe_extra_args"
-    echo_debug "[DEBUG] pipe command: $_pipe_command"
+    echo_debug "pipe command: $_pipe_command"
     eval "$_pipe_command"
     if [ $? -ne 0 ]; then
         echo "[WARN] Sync $_source_path to $_dest_path failed"
     fi
-    #rm -f "$_file_list"
 }
 
 function start_sync_daemon() {
     while [ -z "$CP_SYNC_TO_STORAGE_STOP" ]; do
-        echo_debug "[DEBUG] Start iteration of sync_to_storage sync cycle"
+        echo_debug "Start iteration of sync_to_storage sync cycle"
 
         if [ -f "$CP_SYNC_TO_STORAGE_STOP_FLAG_FILE" ]; then
             echo "[INFO] File $CP_SYNC_TO_STORAGE_STOP_FLAG_FILE defined as CP_SYNC_TO_STORAGE_STOP_FLAG_FILES and present. Perform last sync iteration before stop."
@@ -240,12 +243,12 @@ function start_sync_daemon() {
         fi
 
         if [ ! -f "$CP_SYNC_TO_STORAGE_SPEC" ]; then
-            echo_debug "[DEBUG] Spec file not found: $CP_SYNC_TO_STORAGE_SPEC"
+            echo_debug "Spec file not found: $CP_SYNC_TO_STORAGE_SPEC"
             sleep "$CP_SYNC_TO_STORAGE_TIMEOUT_SEC"
             continue
         fi
 
-        echo_debug "[DEBUG] Creating temp copy of $CP_SYNC_TO_STORAGE_SPEC, $CP_SYNC_TO_STORAGE_REMOVE_SPEC to freez current config state"
+        echo_debug "Creating temp copy of $CP_SYNC_TO_STORAGE_SPEC, $CP_SYNC_TO_STORAGE_REMOVE_SPEC to freez current config state"
         cp -f "$CP_SYNC_TO_STORAGE_SPEC" "${CP_SYNC_TO_STORAGE_SPEC}.tmp"
         cp -f "$CP_SYNC_TO_STORAGE_REMOVE_SPEC" "${CP_SYNC_TO_STORAGE_REMOVE_SPEC}.tmp"
 
@@ -257,29 +260,29 @@ function start_sync_daemon() {
 
         # Check if some file from config marked for deletion
         if [ -f "${CP_SYNC_TO_STORAGE_REMOVE_SPEC}.tmp" ]; then
-            echo_debug "[DEBUG] Cleaning up $CP_SYNC_TO_STORAGE_SPEC with respect to ${CP_SYNC_TO_STORAGE_REMOVE_SPEC}.tmp"
+            echo_debug "Cleaning up $CP_SYNC_TO_STORAGE_SPEC with respect to ${CP_SYNC_TO_STORAGE_REMOVE_SPEC}.tmp"
 
             touch "${CP_SYNC_TO_STORAGE_SPEC}.new"
             while read -a _sync_config_entry; do
                 local _source_path=${_sync_config_entry[0]}
                 if grep -q -F "$_source_path" "${CP_SYNC_TO_STORAGE_SPEC}.tmp" && grep -q -x -F "$_source_path" "${CP_SYNC_TO_STORAGE_REMOVE_SPEC}.tmp"; then
-                    echo_debug "[DEBUG] Path $_source_path is configured for the deletion from sync process"
+                    echo_debug "Path $_source_path is configured for the deletion from sync process"
                     continue
                 fi
                 echo "${_sync_config_entry[@]}" >> "${CP_SYNC_TO_STORAGE_SPEC}.new"
             done <"$CP_SYNC_TO_STORAGE_SPEC"
 
+            # Perform final switch
             mv -f "${CP_SYNC_TO_STORAGE_SPEC}.new" "${CP_SYNC_TO_STORAGE_SPEC}"
-            rm -f "${CP_SYNC_TO_STORAGE_SPEC}.new"
 
-            echo_debug "[DEBUG] Previous number of entries to sync is: $(wc -l < "${CP_SYNC_TO_STORAGE_SPEC}.tmp") now: $(wc -l < "$CP_SYNC_TO_STORAGE_SPEC")"
+            echo_debug "Previous number of entries to sync is: $(wc -l < "${CP_SYNC_TO_STORAGE_SPEC}.tmp") now: $(wc -l < "$CP_SYNC_TO_STORAGE_SPEC")"
         fi
 
-        echo_debug "[DEBUG] Removing temp copy of $CP_SYNC_TO_STORAGE_SPEC, $CP_SYNC_TO_STORAGE_REMOVE_SPEC"
+        echo_debug "Removing temp copy of $CP_SYNC_TO_STORAGE_SPEC, $CP_SYNC_TO_STORAGE_REMOVE_SPEC"
         rm -f "${CP_SYNC_TO_STORAGE_SPEC}.tmp"
         rm -f "${CP_SYNC_TO_STORAGE_REMOVE_SPEC}.tmp"
 
-        echo_debug "[DEBUG] Done iteration of sync_to_storage sync cycle"
+        echo_debug "Done iteration of sync_to_storage sync cycle"
         if [ -z "$CP_SYNC_TO_STORAGE_STOP" ]; then
             sleep "$CP_SYNC_TO_STORAGE_TIMEOUT_SEC"
         fi

--- a/workflows/pipe-common/shell/sync_to_storage
+++ b/workflows/pipe-common/shell/sync_to_storage
@@ -70,6 +70,164 @@ function wait_for_pids() {
     done
 }
 
+function perform_sync() {
+    local _spec_file=$1
+
+    local _sync_pids=()
+    while read -a _sync_config_entry; do
+        echo_debug "Processing entry ${_sync_config_entry[*]}"
+
+        local _source_path=${_sync_config_entry[0]}
+        _source_path_trim=${_source_path#/}
+        _source_path_trim=${_source_path_trim%/}
+
+        local _dest_path
+        if [ -n "${_sync_config_entry[1]}" ]; then
+          _dest_path=${_sync_config_entry[1]}
+        else
+          if [ -z "$CP_SYNC_TO_STORAGE_DESTINATION" ]; then
+            echo "[WARN] CP_SYNC_TO_STORAGE_DESTINATION is not defined and destination is not provided for entry '${_sync_config_entry[*]}', skipping..."
+            continue
+          fi
+          _dest_path="${CP_SYNC_TO_STORAGE_DESTINATION}/${RUN_ID}/$_source_path_trim"
+          echo_debug "Destination path wasn't provided in configuration, will use default one: $_dest_path"
+        fi
+
+        echo_debug "Source path: $_source_path Destination path: $_dest_path"
+
+        if [ ! -d "$_source_path" ] && [ ! -f "$_source_path" ]; then
+            echo_debug "$_source_path not found"
+            continue
+        fi
+
+        local _pipe_extra_args="${CP_SYNC_TO_STORAGE_PIPE_EXTRA_ARGS}"
+        if [ -d "$_source_path" ]; then
+            _pipe_extra_args="$_pipe_extra_args -r"
+        fi
+        if [ "$CP_SYNC_TO_STORAGE_DEBUG" != "true" ]; then
+            _pipe_extra_args="$_pipe_extra_args -q"
+        fi
+        echo_debug "pipe extra args: $_pipe_extra_args"
+
+        echo_debug "destination path: $_dest_path"
+
+        local _pipe_command="pipe storage cp -f \"$_source_path\" \"$_dest_path\" $_pipe_extra_args"
+        echo_debug "pipe command: $_pipe_command"
+
+        if [ "$CP_SYNC_TO_STORAGE_THREADS" -gt 1 ]; then
+            eval "$_pipe_command" &
+            _sync_process_pid=$!
+            echo_debug "Sync $_source_path to $_dest_path has pid $_sync_process_pid"
+
+            _sync_pids[${#_sync_pids[@]}]=$_sync_process_pid
+            if [ "${#_sync_pids[@]}" -eq "$CP_SYNC_TO_STORAGE_THREADS" ]; then
+              wait_for_pids "${_sync_pids[*]}"
+              _sync_pids=()
+            fi
+        else
+            eval "$_pipe_command"
+            if [ $? -ne 0 ]; then
+                echo "[WARN] Sync $_source_path to $_dest_path failed"
+            fi
+        fi
+    done <"$_spec_file"
+
+    if [ "${#_sync_pids[@]}" -gt 0 ]; then
+        wait_for_pids "${_sync_pids[*]}"
+    fi
+}
+
+function sync_spec_allows_batch_mode() {
+    local _spec_file=$1
+
+    _spec_lines=$( wc -l < "$_spec_file")
+
+    if [ "$_spec_lines" -lt "2" ]; then
+        return 1
+    fi
+
+    _all_entries_are_files=1
+    while read -a _sync_config_entry; do
+        _source_path=${_sync_config_entry[0]}
+        if [ -d "$_source_path" ]; then
+            _all_entries_are_files=0
+            break
+        fi
+    done <"$_spec_file"
+
+    if [ "$_all_entries_are_files" -ne "1" ]; then
+        return 1
+    fi
+
+    _spec_lines_with_default_bucket=$(awk '{ print $2 }' < "$_spec_file" | grep -c "^$")
+
+    _sync_common_bucket_path=$(awk '{ print $2 }' < "$_spec_file" | grep -oP -m 1 "^(\w{2}://\w+/)(?=.+)")
+    _spec_lines_with_same_bucket=$(awk '{ print $2 }' < "$_spec_file" | grep -c "$_sync_common_bucket_path")
+
+    _all_entries_for_same_bucket=
+    if [ -n "$_sync_common_bucket_path" ] && [ "$_spec_lines" -ne "$_spec_lines_with_same_bucket" ]; then
+        _all_entries_for_same_bucket="1"
+    fi
+
+
+
+    if [ "$_spec_lines" -ne "$_spec_lines_with_default_bucket" ] && [ "$_all_entries_for_same_bucket" -ne "1" ]; then
+        return 1
+    fi
+
+    return 0
+}
+
+function perform_batch_sync() {
+    local _spec_file=$1
+
+    _sync_common_bucket_path=$(awk '{ print $2 }' < "$_spec_file" | sed -e 'N;s/^\(.*\).*\n\1.*$/\1\n\1/;D')
+
+    if [ -z "$_sync_common_bucket_path" ]; then
+        if [ -z "$CP_SYNC_TO_STORAGE_DESTINATION" ]; then
+          echo "[WARN] CP_SYNC_TO_STORAGE_DESTINATION is not defined and destination is not provided, and CP_SYNC_TO_STORAGE_DESTINATION also is not defined. Exiting."
+          return 1
+        fi
+        _sync_common_bucket_path="${CP_SYNC_TO_STORAGE_DESTINATION}/${RUN_ID}/"
+        echo_debug "Destination bucket wasn't provided in sync configuration, will use default one: $_sync_common_bucket_path"
+    fi
+
+    _file_list="${_spec_file}.file_list"
+    rm -f "$_file_list"
+    while read -a _sync_config_entry; do
+        echo_debug "Processing entry ${_sync_config_entry[*]}"
+
+        local _source_path=${_sync_config_entry[0]}
+        _source_path_trim=${_source_path#/}
+        _source_path_trim=${_source_path_trim%/}
+
+        local _dest_path
+        if [ -n "${_sync_config_entry[1]}" ]; then
+          _dest_path=${_sync_config_entry[1]#$_sync_common_bucket_path}
+        else
+          _dest_path="$_source_path_trim"
+        fi
+
+        echo_debug "Source path: $_source_path Destination path: $_dest_path"
+        printf "%s\t%s\t%s\n" "${_source_path_trim}" "$(stat -c%s "${_source_path}")" "${_dest_path}" >> "${_file_list}"
+    done <"$_spec_file"
+    echo_debug "Prepare file-list file: ${_file_list} with $(wc -l "$_spec_file") lines"
+
+    local _pipe_extra_args="${CP_SYNC_TO_STORAGE_PIPE_EXTRA_ARGS}"
+    if [ "$CP_SYNC_TO_STORAGE_DEBUG" != "true" ]; then
+        _pipe_extra_args="$_pipe_extra_args -q"
+    fi
+    echo_debug "pipe extra args: $_pipe_extra_args"
+
+    local _pipe_command="pipe storage cp -f -r / $_sync_common_bucket_path --file-list ${_file_list} $_pipe_extra_args"
+    echo_debug "pipe command: $_pipe_command"
+    eval "$_pipe_command"
+    if [ $? -ne 0 ]; then
+        echo "[WARN] Sync $_source_path to $_dest_path failed"
+    fi
+    #rm -f "$_file_list"
+}
+
 function start_sync_daemon() {
     while [ -z "$CP_SYNC_TO_STORAGE_STOP" ]; do
 
@@ -86,87 +244,37 @@ function start_sync_daemon() {
             continue
         fi
 
-        local _sync_pids=()
-        while read -a _sync_config_entry; do
-            echo_debug "Processing entry ${_sync_config_entry[*]}"
+        cp -f "$CP_SYNC_TO_STORAGE_SPEC" "${CP_SYNC_TO_STORAGE_SPEC}.tmp"
+        cp -f "$CP_SYNC_TO_STORAGE_REMOVE_SPEC" "${CP_SYNC_TO_STORAGE_REMOVE_SPEC}.tmp"
 
-            local _source_path=${_sync_config_entry[0]}
-            _source_path_trim=${_source_path#/}
-            _source_path_trim=${_source_path_trim%/}
-
-            local _dest_path
-            if [ -n "${_sync_config_entry[1]}" ]; then
-              _dest_path=${_sync_config_entry[1]}
-            else
-              if [ -z "$CP_SYNC_TO_STORAGE_DESTINATION" ]; then
-                echo "[WARN] CP_SYNC_TO_STORAGE_DESTINATION is not defined and destination is not provided for entry '${_sync_config_entry[*]}', skipping..."
-                continue
-              fi
-              _dest_path="${CP_SYNC_TO_STORAGE_DESTINATION}/${RUN_ID}/$_source_path_trim"
-              echo_debug "Destination path wasn't provided in configuration, will use default one: $_dest_path"
-            fi
-
-            echo_debug "Source path: $_source_path Destination path: $_dest_path"
-
-            local _pipe_extra_args="${CP_SYNC_TO_STORAGE_PIPE_EXTRA_ARGS}"
-
-            if [ ! -d "$_source_path" ] && [ ! -f "$_source_path" ]; then
-                echo_debug "$_source_path not found"
-                continue
-            fi
-
-            if [ -d "$_source_path" ]; then
-                _pipe_extra_args="$_pipe_extra_args -r"
-            fi
-            if [ "$CP_SYNC_TO_STORAGE_DEBUG" != "true" ]; then
-                _pipe_extra_args="$_pipe_extra_args -q"
-            fi
-            echo_debug "pipe extra args: $_pipe_extra_args"
-
-            echo_debug "destination path: $_dest_path"
-
-            local _pipe_command="pipe storage cp -f \"$_source_path\" \"$_dest_path\" $_pipe_extra_args"
-            echo_debug "pipe command: $_pipe_command"
-
-            if [ "$CP_SYNC_TO_STORAGE_THREADS" -gt 1 ]; then
-                eval "$_pipe_command" &
-                _sync_process_pid=$!
-                echo_debug "Sync $_source_path to $_dest_path has pid $_sync_process_pid"
-
-                _sync_pids[${#_sync_pids[@]}]=$_sync_process_pid
-                if [ "${#_sync_pids[@]}" -eq "$CP_SYNC_TO_STORAGE_THREADS" ]; then
-                  wait_for_pids "${_sync_pids[*]}"
-                  _sync_pids=()
-                fi
-            else
-                eval "$_pipe_command"
-                if [ $? -ne 0 ]; then
-                    echo "[WARN] Sync $_source_path to $_dest_path failed"
-                fi
-            fi
-        done <"$CP_SYNC_TO_STORAGE_SPEC"
-
-        if [ "${#_sync_pids[@]}" -gt 0 ]; then
-            wait_for_pids "${_sync_pids[*]}"
+        if [ "$CP_SYNC_TO_STORAGE_BATCH_MODE" -eq "0" ] || ! sync_spec_allows_batch_mode "${CP_SYNC_TO_STORAGE_SPEC}.tmp"; then
+            perform_sync "${CP_SYNC_TO_STORAGE_SPEC}.tmp"
+        else
+            perform_batch_sync "${CP_SYNC_TO_STORAGE_SPEC}.tmp"
         fi
 
         # Check if some file from config marked for deletion
-        if [ -f "$CP_SYNC_TO_STORAGE_REMOVE_SPEC" ]; then
+        if [ -f "${CP_SYNC_TO_STORAGE_REMOVE_SPEC}.tmp" ]; then
             echo "Cleaning up $CP_SYNC_TO_STORAGE_SPEC with respect to $CP_SYNC_TO_STORAGE_REMOVE_SPEC"
-            touch "${CP_SYNC_TO_STORAGE_SPEC}.updated"
+
+            touch "${CP_SYNC_TO_STORAGE_SPEC}.new"
             while read -a _sync_config_entry; do
                 local _source_path=${_sync_config_entry[0]}
-                if grep -q -x -F "$_source_path" "$CP_SYNC_TO_STORAGE_REMOVE_SPEC"; then
+                if grep -q -F "$_source_path" "${CP_SYNC_TO_STORAGE_SPEC}.tmp" && grep -q -x -F "$_source_path" "${CP_SYNC_TO_STORAGE_REMOVE_SPEC}.tmp"; then
                     echo_debug "Path $_source_path is configured for the deletion from sync process"
                     continue
                 fi
-                echo "${_sync_config_entry[@]}" >> "${CP_SYNC_TO_STORAGE_SPEC}.updated"
+                echo "${_sync_config_entry[@]}" >> "${CP_SYNC_TO_STORAGE_SPEC}.new"
             done <"$CP_SYNC_TO_STORAGE_SPEC"
-            mv -f "$CP_SYNC_TO_STORAGE_SPEC" "${CP_SYNC_TO_STORAGE_SPEC}.prev"
-            mv -f "${CP_SYNC_TO_STORAGE_SPEC}.updated" "${CP_SYNC_TO_STORAGE_SPEC}"
-            rm -f "${CP_SYNC_TO_STORAGE_SPEC}.updated"
-            echo "Previous number of entries to sync is: $(wc -l < "${CP_SYNC_TO_STORAGE_SPEC}".prev) new number us: $(wc -l < "$CP_SYNC_TO_STORAGE_SPEC")"
+
+            mv -f "${CP_SYNC_TO_STORAGE_SPEC}.new" "${CP_SYNC_TO_STORAGE_SPEC}"
+            rm -f "${CP_SYNC_TO_STORAGE_SPEC}.new"
+
+            echo "Previous number of entries to sync is: $(wc -l < "${CP_SYNC_TO_STORAGE_SPEC}.tmp") now: $(wc -l < "$CP_SYNC_TO_STORAGE_SPEC")"
         fi
+
+        rm -f "${CP_SYNC_TO_STORAGE_SPEC}.tmp"
+        rm -f "${CP_SYNC_TO_STORAGE_REMOVE_SPEC}.tmp"
 
         if [ -z "$CP_SYNC_TO_STORAGE_STOP" ]; then
             sleep "$CP_SYNC_TO_STORAGE_TIMEOUT_SEC"
@@ -174,6 +282,7 @@ function start_sync_daemon() {
     done
 }
 
+export CP_SYNC_TO_STORAGE_BATCH_MODE="${CP_SYNC_TO_STORAGE_BATCH_MODE:-0}"
 export CP_SYNC_TO_STORAGE_SPEC="${CP_SYNC_TO_STORAGE_SPEC:-/etc/sync_to_storage.list}"
 export CP_SYNC_TO_STORAGE_REMOVE_SPEC="${CP_SYNC_TO_STORAGE_REMOVE_SPEC:-/etc/sync_to_storage_remove.list}"
 export CP_SYNC_TO_STORAGE_PID_FILE="${CP_SYNC_TO_STORAGE_PID_FILE:-/var/run/sync_to_storage.pid}"
@@ -216,6 +325,9 @@ elif [ "$_cmd" == "start" ]; then
     export -f start_sync_daemon
     export -f wait_for_pids
     export -f echo_debug
+    export -f sync_spec_allows_batch_mode
+    export -f perform_sync
+    export -f perform_batch_sync
     nohup bash -c start_sync_daemon &> "$CP_SYNC_TO_STORAGE_LOGFILE" &
     echo "$!" > "$CP_SYNC_TO_STORAGE_PID_FILE"
     echo "Sync process has been started, review logs in $CP_SYNC_TO_STORAGE_LOGFILE"


### PR DESCRIPTION
Batch mode for sync_to_storage:

Can be enabled with `CP_SYNC_TO_STORAGE_BATCH_MODE=1`

Limitations:
Would be possible to use only in the next cases:
 - All entries in sync config are files
 - All files configured for the same bucket to sync: either to default sync bucket (with out destination path in spec) of with the same bucket in destination path configured explicitly 