### PR TITLE
Issue #3901: Include run costs into export runs report

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/cluster/NodesManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/NodesManager.java
@@ -22,7 +22,6 @@ import com.epam.pipeline.controller.vo.FilterNodesVO;
 import com.epam.pipeline.dao.cluster.ClusterDao;
 import com.epam.pipeline.entity.cluster.DiskRegistrationRequest;
 import com.epam.pipeline.entity.cluster.FilterPodsRequest;
-import com.epam.pipeline.entity.cluster.InstanceDisk;
 import com.epam.pipeline.entity.cluster.MachineType;
 import com.epam.pipeline.entity.cluster.MasterNode;
 import com.epam.pipeline.entity.cluster.NodeInstance;

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/NodesManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/NodesManager.java
@@ -22,6 +22,7 @@ import com.epam.pipeline.controller.vo.FilterNodesVO;
 import com.epam.pipeline.dao.cluster.ClusterDao;
 import com.epam.pipeline.entity.cluster.DiskRegistrationRequest;
 import com.epam.pipeline.entity.cluster.FilterPodsRequest;
+import com.epam.pipeline.entity.cluster.InstanceDisk;
 import com.epam.pipeline.entity.cluster.MachineType;
 import com.epam.pipeline.entity.cluster.MasterNode;
 import com.epam.pipeline.entity.cluster.NodeInstance;
@@ -443,6 +444,8 @@ public class NodesManager {
                 .orElseGet(regionManager::loadDefaultRegion);
         cloudFacade.attachDisk(region.getId(), run.getId(), request, tags);
         nodeDiskManager.register(nodeId, DiskRegistrationRequest.from(request));
+        pipelineRunManager.adjustRunPricePerHourToDisks(run.getId(),
+                cloudFacade.loadDisks(region.getId(), run.getId()));
     }
 
     private boolean isNodeProtected(NodeInstance nodeInstance) {

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunExporter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunExporter.java
@@ -19,7 +19,10 @@ package com.epam.pipeline.manager.pipeline;
 
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.RunInstance;
+import com.epam.pipeline.entity.pipeline.TaskStatus;
+import com.epam.pipeline.entity.pipeline.run.RunStatus;
 import com.epam.pipeline.entity.utils.DateUtils;
+import com.epam.pipeline.utils.RunDurationUtils;
 import com.opencsv.CSVWriter;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
@@ -27,18 +30,28 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.http.util.TextUtils;
 
 import java.io.StringWriter;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.epam.pipeline.utils.PipelineStringUtils.formatNullable;
 
 public class PipelineRunExporter {
     private static final List<String> HEADER = Arrays.asList("Run ID", "Run Name", "Parent Run ID", "Instance Type",
-            "Tags", "Pipeline", "Docker Image", "Started Date", "Completed Date", "Owner");
+            "Tags", "Pipeline", "Docker Image", "Started Date", "Completed Date", "Owner", "Costs");
     private static final String KEY_VALUE_PATTERN = "%s:%s";
+    private static final int DIVIDE_SCALE = 5;
+    private static final int REPORT_SCALE = 2;
+    private static final int MINUTES_IN_HOUR = 60;
 
     public String export(final Collection<PipelineRun> runs,
                          final String delimiter, final String fieldDelimiter) {
@@ -70,6 +83,7 @@ public class PipelineRunExporter {
                 .map(d -> DateUtils.formatDate(run.getEndDate()))
                 .orElse(StringUtils.EMPTY));
         result.add(formatNullable(run.getOwner()));
+        result.add(formatNullable(getCosts(run)));
         return result.toArray(new String[0]);
     }
 
@@ -77,5 +91,81 @@ public class PipelineRunExporter {
         return TextUtils.isBlank(run.getName()) ?
                 TextUtils.isBlank(run.getPodId()) ? StringUtils.EMPTY : run.getPodId() :
                 run.getName();
+    }
+
+    String getCosts(final PipelineRun run) {
+        final BigDecimal computePricePerHour = getNullableBigDecimal(run.getComputePricePerHour());
+        final BigDecimal computeCosts = getComputeCosts(run, computePricePerHour);
+        final BigDecimal storageCosts = getStorageCosts(run, computePricePerHour);
+
+        return storageCosts.add(computeCosts)
+                .add(getNullableBigDecimal(run.getWorkersPrice()))
+                .setScale(REPORT_SCALE, RoundingMode.HALF_EVEN)
+                .toString();
+    }
+
+    private BigDecimal getComputeCosts(final PipelineRun run, final BigDecimal computePricePerHour) {
+        final BigDecimal runActiveHours = toHours(getRunActiveStateMinutes(run));
+        return runActiveHours.multiply(computePricePerHour);
+    }
+
+    private BigDecimal getStorageCosts(final PipelineRun run, final BigDecimal computePricePerHour) {
+        final BigDecimal totalRunHours = toHours(RunDurationUtils.getBillableDuration(run).toMinutes());
+
+        final BigDecimal runPricePerHour = getNullableBigDecimal(run.getPricePerHour());
+        final BigDecimal diskPricePerHour = runPricePerHour.subtract(computePricePerHour);
+        return totalRunHours.multiply(diskPricePerHour);
+    }
+
+    private BigDecimal getNullableBigDecimal(final BigDecimal value) {
+        return Optional.ofNullable(value).orElse(BigDecimal.ZERO);
+    }
+
+    private BigDecimal toHours(final long minutes) {
+        return BigDecimal.valueOf(minutes)
+                .divide(BigDecimal.valueOf(MINUTES_IN_HOUR), DIVIDE_SCALE, RoundingMode.HALF_EVEN);
+    }
+
+    private long getRunActiveStateMinutes(final PipelineRun run) {
+        final List<RunStatus> statuses = run.getRunStatuses();
+        if (CollectionUtils.isEmpty(statuses)) {
+            return RunDurationUtils.durationBetween(run.getInstanceStartDate(), run.getEndDate()).toMinutes();
+        }
+        final LocalDateTime end = Optional.ofNullable(run.getEndDate())
+                .map(DateUtils::convertDateToLocalDateTime)
+                .orElse(LocalDateTime.now(Clock.systemUTC()));
+        final LocalDateTime start = Optional.ofNullable(run.getInstanceStartDate())
+                .map(DateUtils::convertDateToLocalDateTime)
+                .orElse(end);
+
+        final List<RunStatus> sortedStatuses = prepareStatuses(statuses, start, end);
+
+        final List<Duration> durations = new ArrayList<>();
+        for (int i = 0; i < sortedStatuses.size() - 1; i++) {
+            final RunStatus previous = sortedStatuses.get(i);
+            final RunStatus current = sortedStatuses.get(i + 1);
+            if (isActiveStatus(previous.getStatus())) {
+                durations.add(Duration.between(previous.getTimestamp(), current.getTimestamp()));
+            }
+        }
+        return durations.stream()
+                .mapToLong(Duration::toMinutes)
+                .sum();
+    }
+
+    private List<RunStatus> prepareStatuses(final List<RunStatus> statuses, final LocalDateTime start,
+                                            final LocalDateTime end) {
+        final List<RunStatus> statusesWithArtificialBorders = new ArrayList<>();
+        statusesWithArtificialBorders.add(RunStatus.builder().status(TaskStatus.RUNNING).timestamp(start).build());
+        statusesWithArtificialBorders.add(RunStatus.builder().status(TaskStatus.STOPPED).timestamp(end).build());
+        statusesWithArtificialBorders.addAll(statuses);
+
+        return statusesWithArtificialBorders.stream()
+                .sorted(Comparator.comparing(RunStatus::getTimestamp))
+                .collect(Collectors.toList());
+    }
+
+    private boolean isActiveStatus(final TaskStatus status) {
+        return !TaskStatus.PAUSED.equals(status) && !status.isFinal();
     }
 }

--- a/api/src/main/java/com/epam/pipeline/utils/RunDurationUtils.java
+++ b/api/src/main/java/com/epam/pipeline/utils/RunDurationUtils.java
@@ -20,7 +20,7 @@ public final class RunDurationUtils {
         return durationBetween(run.getInstanceStartDate(), run.getEndDate());
     }
 
-    private static Duration durationBetween(final Date from, final Date to) {
+    public static Duration durationBetween(final Date from, final Date to) {
         final Date end = Optional.ofNullable(to).orElseGet(DateUtils::now);
         final Date start = Optional.ofNullable(from).orElse(end);
         return Duration.ofMillis(end.getTime() - start.getTime()).abs();

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunExporterTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunExporterTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2025 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.epam.pipeline.manager.pipeline;
+
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.pipeline.TaskStatus;
+import com.epam.pipeline.entity.pipeline.run.RunStatus;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+public class PipelineRunExporterTest {
+    private static final double COMPUTE_PRICE = 0.5;
+    private static final double TOTAL_PRICE = 0.7;
+
+    @Test
+    public void shouldCalculateCostsForCompletedRun() {
+        final Date start = DateTime.now(DateTimeZone.UTC).minusDays(1).toDate();
+        final Date end = DateTime.now(DateTimeZone.UTC).minusDays(1).plusHours(7).plusMinutes(7).toDate();
+
+        final LocalDateTime initialDateTime = LocalDateTime.now(Clock.systemUTC()).minusDays(1);
+        final List<RunStatus> runStatuses = Arrays.asList(
+                RunStatus.builder()
+                        .status(TaskStatus.RUNNING)
+                        .timestamp(initialDateTime)
+                        .build(),
+                RunStatus.builder()
+                        .status(TaskStatus.STOPPED)
+                        .timestamp(initialDateTime.plusHours(7).plusMinutes(6))
+                        .build()
+        );
+
+        // total duration: 7 hours 7 minutes; active time: 7 hours 7 minutes
+        final PipelineRun run = run(start, end, runStatuses);
+
+        final String actualCosts = new PipelineRunExporter().getCosts(run);
+        // 0.5 * 7 hours 7 minutes + 0.2 * 7 hours 7 minutes
+        final String expectedCosts = "4.97";
+
+        assertThat(actualCosts).isEqualTo(expectedCosts);
+    }
+
+    @Test
+    public void shouldCalculateCostsForRunningRun() {
+        final Date start = DateTime.now(DateTimeZone.UTC).minusHours(2).toDate();
+
+        final List<RunStatus> runStatuses = Collections.singletonList(
+                RunStatus.builder()
+                        .status(TaskStatus.RUNNING)
+                        .timestamp(LocalDateTime.now(Clock.systemUTC()).minusHours(2))
+                        .build()
+        );
+
+        final PipelineRun run = run(start, null, runStatuses);
+
+        final String actualCosts = new PipelineRunExporter().getCosts(run);
+        // (0.5 + 0.2) * 2 hours
+        final String expectedCosts = "1.40";
+
+        assertThat(actualCosts).isEqualTo(expectedCosts);
+    }
+
+    @Test
+    public void shouldCalculateCostsForCompletedRunWithPauses() {
+        final Date start = DateTime.now(DateTimeZone.UTC).minusDays(1).toDate();
+        final Date end = DateTime.now(DateTimeZone.UTC).minusDays(1).plusHours(7).plusMinutes(7).toDate();
+
+        final LocalDateTime initialDateTime = LocalDateTime.now(Clock.systemUTC()).minusDays(1);
+        final List<RunStatus> runStatuses = generateRunActivity(initialDateTime);
+        runStatuses.add(RunStatus.builder()
+                .status(TaskStatus.STOPPED)
+                .timestamp(initialDateTime.plusHours(7).plusMinutes(6))
+                .build());
+
+        // total duration: 7 hours 7 minutes; active time: 5 hours 6 minutes
+        final PipelineRun run = run(start, end, runStatuses);
+
+        final String actualCosts = new PipelineRunExporter().getCosts(run);
+        // 0.5 * 5 hours 6 minutes + 0.2 * 7 hours 7 minutes = 0.5 * 5.1 hours + 0.2 * 7.11667 hours = 2.55 + 1.423334
+        final String expectedCosts = "3.97";
+
+        assertThat(actualCosts).isEqualTo(expectedCosts);
+    }
+
+    @Test
+    public void shouldCalculateCostsForRunningRunWithPauses() {
+        final Date start = DateTime.now(DateTimeZone.UTC).minusHours(6).minusMinutes(6).toDate();
+
+        final LocalDateTime initialDateTime = LocalDateTime.now(Clock.systemUTC()).minusHours(6).minusMinutes(6);
+        final List<RunStatus> runStatuses = generateRunActivity(initialDateTime);
+
+        // total duration: 6 hours 6 minutes; active time: 4 hours 6 minutes
+        final PipelineRun run = run(start, null, runStatuses);
+
+        final String actualCosts = new PipelineRunExporter().getCosts(run);
+        // 0.5 * 4 hours 6 minutes + 0.2 * 6 hours 6 minutes = 0.5 * 4.1 hours + 0.2 * 6.1 hours = 2.05 + 1.22
+        final String expectedCosts = "3.27";
+
+        assertThat(actualCosts).isEqualTo(expectedCosts);
+    }
+
+    @Test
+    public void shouldCalculateCostsForRunningRunWithEmptyStates() {
+        final Date start = DateTime.now(DateTimeZone.UTC).minusHours(6).minusMinutes(6).toDate();
+
+        // total duration: 6 hours 6 minutes; active time: 6 hours 6 minutes
+        final PipelineRun run = run(start, null, null);
+
+        final String actualCosts = new PipelineRunExporter().getCosts(run);
+        // 6 hours 6 minutes * (0.5 + 0.2) = 6.1 * 0.7
+        final String expectedCosts = "4.27";
+
+        assertThat(actualCosts).isEqualTo(expectedCosts);
+    }
+
+    @Test
+    public void shouldCalculateCostsForClusterCosts() {
+        final Date start = DateTime.now(DateTimeZone.UTC).minusDays(1).toDate();
+        final Date end = DateTime.now(DateTimeZone.UTC).minusDays(1).plusHours(7).plusMinutes(7).toDate();
+
+        // total duration: 7 hours 7 minutes; active time: 7 hours 7 minutes
+        final PipelineRun run = run(start, end, null);
+        run.setWorkersPrice(BigDecimal.TEN);
+
+        final String actualCosts = new PipelineRunExporter().getCosts(run);
+        // 7 hours 7 minutes * (0.5 + 0.2) + 10 = 7.11667 * 0.7 + 10
+        final String expectedCosts = "14.98";
+
+        assertThat(actualCosts).isEqualTo(expectedCosts);
+    }
+
+    @Test
+    public void shouldCalculateCostsForCompletedRunWithEmptyStates() {
+        final Date start = DateTime.now(DateTimeZone.UTC).minusDays(1).toDate();
+        final Date end = DateTime.now(DateTimeZone.UTC).minusDays(1).plusHours(7).plusMinutes(7).toDate();
+
+        // total duration: 7 hours 7 minutes; active time: 7 hours 7 minutes
+        final PipelineRun run = run(start, end, null);
+
+        final String actualCosts = new PipelineRunExporter().getCosts(run);
+        // 7 hours 7 minutes * (0.5 + 0.2) = 7.11667 * 0.7
+        final String expectedCosts = "4.98";
+
+        assertThat(actualCosts).isEqualTo(expectedCosts);
+    }
+
+    private static List<RunStatus> generateRunActivity(final LocalDateTime initialDateTime) {
+        final List<RunStatus> runStatuses = new ArrayList<>();
+
+        LocalDateTime timestamp = initialDateTime.plusMinutes(1);
+        runStatuses.add(RunStatus.builder().status(TaskStatus.RUNNING).timestamp(timestamp).build());
+
+        // active time: 1 hour 1 minute; paused time: -
+        timestamp = timestamp.plusHours(1);
+        runStatuses.add(RunStatus.builder().status(TaskStatus.RUNNING).timestamp(timestamp).build());
+
+        // active time: 2 hours 1 minute; paused time: -
+        timestamp = timestamp.plusHours(1);
+        runStatuses.add(RunStatus.builder().status(TaskStatus.PAUSING).timestamp(timestamp).build());
+
+        // active time: 3 hours 1 minute; paused time: -
+        timestamp = timestamp.plusHours(1);
+        runStatuses.add(RunStatus.builder().status(TaskStatus.PAUSING).timestamp(timestamp).build());
+
+        // active time: 3 hours 2 minutes; paused time: -
+        timestamp = timestamp.plusMinutes(1);
+        runStatuses.add(RunStatus.builder().status(TaskStatus.PAUSED).timestamp(timestamp).build());
+
+        // active time: 3 hours 2 minutes; paused time: 1 hour
+        timestamp = timestamp.plusHours(1);
+        runStatuses.add(RunStatus.builder().status(TaskStatus.RESUMING).timestamp(timestamp).build());
+
+        // active time: 3 hours 3 minutes; paused time: 1 hour
+        timestamp = timestamp.plusMinutes(1);
+        runStatuses.add(RunStatus.builder().status(TaskStatus.RUNNING).timestamp(timestamp).build());
+
+        // active time: 4 hours 3 minutes; paused time: 1 hour
+        timestamp = timestamp.plusHours(1);
+        runStatuses.add(RunStatus.builder().status(TaskStatus.PAUSING).timestamp(timestamp).build());
+
+        // active time: 4 hours 5 minutes; paused time: 1 hour
+        timestamp = timestamp.plusMinutes(1);
+        runStatuses.add(RunStatus.builder().status(TaskStatus.PAUSED).timestamp(timestamp).build());
+
+        // active time: 4 hours 5 minutes; paused time: 2 hours
+        timestamp = timestamp.plusHours(1);
+        runStatuses.add(RunStatus.builder().status(TaskStatus.RESUMING).timestamp(timestamp).build());
+
+        // active time: 4 hours 6 minutes; paused time: 2 hours
+        timestamp = timestamp.plusMinutes(1);
+        runStatuses.add(RunStatus.builder().status(TaskStatus.RUNNING).timestamp(timestamp).build());
+
+        // total time: 6 hours 6 minutes
+        return runStatuses;
+    }
+
+    private static PipelineRun run(final Date start, final Date end, final List<RunStatus> runStatuses) {
+        final PipelineRun run = new PipelineRun();
+        run.setStartDate(start);
+        run.setInstanceStartDate(start);
+        run.setEndDate(end);
+        run.setRunStatuses(runStatuses);
+        run.setPricePerHour(BigDecimal.valueOf(TOTAL_PRICE));
+        run.setComputePricePerHour(BigDecimal.valueOf(COMPUTE_PRICE));
+        return run;
+    }
+}


### PR DESCRIPTION
Relates to #3901 

-  a new column `Costs` added to csv report
- fix: run price shall be re-calculated after disk scaling (`POST /run/<runID>/disk/attach` method)