### PR TITLE
Issue #3925 Google artifactory integration - small updates for correc…

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerClient.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerClient.java
@@ -302,7 +302,7 @@ public class DockerClient {
         String url = String.format(IMAGE_DESCRIPTION_URL, registry.getPath(), imageName, tag);
         try {
             URI uri = new URI(url);
-            HttpEntity httpEntity = GCP == registry.getProvider() ? getV1AuthHeaders() : headers;
+            final HttpEntity httpEntity = GCP == registry.getProvider() ? getV1AuthHeaders() : headers;
             ResponseEntity<RawImageDescription>
                 response = getRestTemplate().exchange(uri, HttpMethod.GET, httpEntity,
                                                       new ParameterizedTypeReference<RawImageDescription>() {});

--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerParsingUtils.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerParsingUtils.java
@@ -88,6 +88,7 @@ public final class DockerParsingUtils {
     public static List<String> getBuildHistory(final RawImageDescription rawImage) {
         final List<String> commandsHistory = getHistoryEntryStream(rawImage)
             .map(HistoryEntryV1::getContainerConfig)
+            .filter(Objects::nonNull)
             .map(ContainerConfig::getCommands)
             .filter(CollectionUtils::isNotEmpty)
             .map(commands -> String.join(SPACE, commands))

--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerRegistryManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerRegistryManager.java
@@ -646,7 +646,7 @@ public class DockerRegistryManager implements SecuredEntityManager {
         String token = null;
         if (registry.isPipelineAuth()) {
             if (GCP == registry.getProvider()) {
-                AbstractCloudRegion gcpRegion = cloudRegionDao
+                final AbstractCloudRegion gcpRegion = cloudRegionDao
                         .loadDefaultRegion()
                         .filter(r -> GCP == r.getProvider())
                         .orElseThrow(() -> new ObjectNotFoundException("No Default Region for GCP"));

--- a/api/src/main/resources/db/migration/v2025.03.07_18.20__issue_3925_alter_version_scan_table_layer_reference_column.sql
+++ b/api/src/main/resources/db/migration/v2025.03.07_18.20__issue_3925_alter_version_scan_table_layer_reference_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pipeline.tool_version_scan ALTER COLUMN layer_reference TYPE VARCHAR(2048);


### PR DESCRIPTION
Resolves #3925 
1. checked that clair and docker component scan are compatible with GCP Artifact Registry
2. add null check for Image descriptions
3. expanded layer_reference column for tool_version_scan table