### PR TITLE
Issue #3919: [pipe storage mount] Allow to grant user/group permissions on storage paths

### DIFF
--- a/pipe-cli/mount/pipe-fuse.py
+++ b/pipe-cli/mount/pipe-fuse.py
@@ -23,6 +23,8 @@ import errno
 import future.utils
 import sys
 from cachetools import TTLCache
+from pipefuse.storage_path_permissions import StoragePathPermissionsFileSystemClient, PermissionsManager, \
+    StoragePathWritePermissionsFilterFS, StoragePathPermissionsRefresherDaemon
 
 
 def is_windows():
@@ -116,12 +118,15 @@ def start(mountpoint, webdav, bucket,
     read_disk_buffer_ttl_delay = int(os.getenv('CP_PIPE_FUSE_READ_DISK_BUFFER_TTL_DELAY', read_disk_buffer_ttl_delay))
     audit_buffer_ttl = int(os.getenv('CP_PIPE_FUSE_AUDIT_BUFFER_TTL', audit_buffer_ttl))
     audit_buffer_size = int(os.getenv('CP_PIPE_FUSE_AUDIT_BUFFER_SIZE', audit_buffer_size))
+    path_permissions_disabled = os.getenv('CP_PIPE_FUSE_PATH_PERMISSIONS_DISABLED', 'false').lower() == 'true'
+    path_permissions_refreshing_delay = int(os.getenv('CP_PIPE_FUSE_PATH_PERMISSIONS_REFRESHING_DELAY', '86400'))
     fs_name = os.getenv('CP_PIPE_FUSE_FS_NAME', 'PIPE_FUSE')
     bucket_type = None
     bucket_path = None
     daemons = []
     if not bearer:
         raise RuntimeError('Cloud Pipeline API_TOKEN should be specified.')
+    permissions_manager = None
     if webdav:
         import urllib3
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -137,7 +142,12 @@ def start(mountpoint, webdav, bucket,
         bucket_type = bucket_object.type
         bucket_name = bucket_object.root
         bucket_path = '/'.join(bucket_object.path.split('/')[1:])
+        user = pipe.whoami()
         if bucket_type == CloudType.S3:
+            if need_to_load_path_permissions(user, bucket_object, path_permissions_disabled):
+                permissions_manager = PermissionsManager(pipe, bucket_object)
+                daemons.append(StoragePathPermissionsRefresherDaemon(permissions_manager,
+                                                                     delay=path_permissions_refreshing_delay))
             client = S3StorageLowLevelClient(bucket_name, bucket_object, pipe=pipe, chunk_size=chunk_size)
             if not show_archived:
                 client = ArchivedFilesFilterFileSystemClient(client, pipe=pipe, bucket=client.bucket_object)
@@ -148,7 +158,7 @@ def start(mountpoint, webdav, bucket,
             raise RuntimeError('Cloud storage type %s is not supported.' % bucket_object.type)
         if audit_buffer_ttl > 0:
             logging.info('Auditing is enabled.')
-            client, daemon = get_audit_client(client, pipe, bucket_object, audit_buffer_ttl, audit_buffer_size)
+            client, daemon = get_audit_client(client, pipe, bucket_object, audit_buffer_ttl, audit_buffer_size, user)
             daemons.append(daemon)
         else:
             logging.info('Auditing is disabled.')
@@ -159,6 +169,8 @@ def start(mountpoint, webdav, bucket,
         client = RecordingFileSystemClient(client)
     if bucket_type in [CloudType.S3, CloudType.GS]:
         client = PathExpandingStorageFileSystemClient(client, root_path=bucket_path)
+    if bucket_type == CloudType.S3 and permissions_manager:
+        client = StoragePathPermissionsFileSystemClient(client, permissions_manager)
     if listing_cache_ttl > 0 and listing_cache_size > 0:
         listing_cache_implementation = TTLCache(maxsize=listing_cache_size, ttl=listing_cache_ttl)
         listing_cache = ListingCache(listing_cache_implementation)
@@ -222,6 +234,8 @@ def start(mountpoint, webdav, bucket,
 
     fs = PipeFS(client=client, lock=get_lock(threads, monitoring_delay=monitoring_delay), mode=int(default_mode, 8))
     if bucket_type == CloudType.S3:
+        if permissions_manager:
+            fs = StoragePathWritePermissionsFilterFS(fs, permissions_manager, client)
         if xattrs_include_prefixes:
             if xattrs_include_prefixes[0] == '*':
                 logging.info('All extended attributes will be processed.')
@@ -256,8 +270,22 @@ def start(mountpoint, webdav, bucket,
     FUSE(fs, mountpoint, nothreads=not threads, foreground=True, ro=ro, fsname=fs_name, **mount_options)
 
 
-def get_audit_client(client, pipe, storage, audit_buffer_ttl, audit_buffer_size):
-    user = pipe.whoami()
+def need_to_load_path_permissions(user, storage, path_permissions_disabled):
+    if path_permissions_disabled:
+        return False
+    if user.get('admin', False):
+        return False
+    if [r for r in user.get('roles', []) if r.get('name', '').upper() == 'ROLE_ADMIN']:
+        return False
+    if [g for g in user.get('groups', []) if g.upper() == 'ROLE_ADMIN']:
+        return False
+    if user.get('userName').upper() == storage.owner.upper():
+        return False
+    logging.info('Storage path permissions processing enabled.')
+    return storage.path_permissions_enabled
+
+
+def get_audit_client(client, pipe, storage, audit_buffer_ttl, audit_buffer_size, user):
     container = SetAuditContainer()
     container = DelayingAuditContainer(container, delay=audit_buffer_ttl)
     consumer = CloudPipelineAuditConsumer(consumer_func=pipe.create_system_logs,

--- a/pipe-cli/mount/pipefuse/api.py
+++ b/pipe-cli/mount/pipefuse/api.py
@@ -84,6 +84,8 @@ class DataStorage:
         self.ro = False
         self.type = None
         self.region_name = None
+        self.owner = None
+        self.path_permissions_enabled = False
 
     @classmethod
     def load(cls, json, region_info=[]):
@@ -94,6 +96,8 @@ class DataStorage:
         instance.mask = json['mask']
         instance.sensitive = json['sensitive']
         instance.type = json['type']
+        instance.owner = json['owner']
+        instance.path_permissions_enabled = json.get('pathPermissionsEnabled', False)
         instance.region_name = cls._find_region_code(json.get('regionId', 0), region_info)
         instance.endpoint = cls._find_endpoint(json.get('regionId', 0), region_info)
         return instance
@@ -196,6 +200,10 @@ class CloudPipelineClient:
 
     def whoami(self):
         return self._retryable_call('GET', 'whoami') or {}
+
+    def get_storage_path_permissions(self, storage_id):
+        request_url = '/datastorage/%s/paths/permissions' % str(storage_id)
+        return self._retryable_call('GET', request_url) or []
 
     def _retryable_call(self, http_method, endpoint, data=None):
         url = '{}/{}'.format(self._api, endpoint)

--- a/pipe-cli/mount/pipefuse/cache.py
+++ b/pipe-cli/mount/pipefuse/cache.py
@@ -194,7 +194,8 @@ class CachingListingFileSystemClient(FileSystemClientDecorator):
                     ctime=None,
                     contenttype=None,
                     is_dir=True,
-                    storage_class=None)
+                    storage_class=None,
+                    mask=None)
 
     def ls(self, path, depth=1):
         return self._ls_as_dict(path, depth).values()

--- a/pipe-cli/mount/pipefuse/fsclient.py
+++ b/pipe-cli/mount/pipefuse/fsclient.py
@@ -17,7 +17,8 @@ from collections import namedtuple
 
 from pipefuse.chain import ChainingService
 
-File = namedtuple('File', ['name', 'size', 'mtime', 'ctime', 'contenttype', 'is_dir', 'storage_class'])
+File = namedtuple('File',
+                  ['name', 'size', 'mtime', 'ctime', 'contenttype', 'is_dir', 'storage_class', 'mask'])
 
 
 class FileSystemOperationException(RuntimeError):

--- a/pipe-cli/mount/pipefuse/gcp.py
+++ b/pipe-cli/mount/pipefuse/gcp.py
@@ -260,7 +260,8 @@ class GoogleStorageLowLevelFileSystemClient(StorageLowLevelFileSystemClient):
                     ctime=None,
                     contenttype='',
                     is_dir=False,
-                    storage_class=None)
+                    storage_class=None,
+                    mask=None)
 
     def _get_folder_object(self, name, prefix, recursive):
         return File(name=self._get_object_name(name, prefix, recursive),
@@ -269,7 +270,8 @@ class GoogleStorageLowLevelFileSystemClient(StorageLowLevelFileSystemClient):
                     ctime=None,
                     contenttype='',
                     is_dir=True,
-                    storage_class=None)
+                    storage_class=None,
+                    mask=None)
 
     def _get_object_name(self, name, prefix, recursive):
         return name if recursive else fuseutils.get_item_name(name, prefix=prefix)

--- a/pipe-cli/mount/pipefuse/s3.py
+++ b/pipe-cli/mount/pipefuse/s3.py
@@ -221,7 +221,8 @@ class S3StorageLowLevelClient(StorageLowLevelFileSystemClient):
                     ctime=None,
                     contenttype='',
                     is_dir=True,
-                    storage_class=None)
+                    storage_class=None,
+                    mask=None)
 
     def get_file_name(self, file, prefix, recursive):
         return file['Key'] if recursive else fuseutils.get_item_name(file['Key'], prefix=prefix)
@@ -233,7 +234,8 @@ class S3StorageLowLevelClient(StorageLowLevelFileSystemClient):
                     ctime=None,
                     contenttype='',
                     is_dir=False,
-                    storage_class=file['StorageClass'])
+                    storage_class=file['StorageClass'],
+                    mask=None)
 
     def upload(self, buf, path):
         with io.BytesIO(bytearray(buf)) as body:

--- a/pipe-cli/mount/pipefuse/storage_path_permissions.py
+++ b/pipe-cli/mount/pipefuse/storage_path_permissions.py
@@ -1,0 +1,373 @@
+#  Copyright 2025 EPAM Systems, Inc. (https://www.epam.com/)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import functools
+import os.path
+import time
+from threading import Thread, RLock
+
+import pygtrie
+import logging
+
+from pipefuse import fuseutils
+from pipefuse.chain import ChainingService
+from pipefuse.fsclient import FileSystemClientDecorator, File, ForbiddenOperationException
+from pipefuse.lock import synchronized
+
+
+class StoragePathPermission:
+
+    def __init__(self, folder_path, file_name, mask):
+        self.folder_path = folder_path
+        self.file_name = file_name
+        self.mask = mask
+
+    @staticmethod
+    def from_dict(data):
+        return StoragePathPermission(data.get("folderPath"), data.get("fileName"), data.get("mask"))
+
+
+class PermissionsManager:
+
+    def __init__(self, pipe, bucket_object, lock=None):
+        self._root = '/'
+        self._delimiter = '/'
+        self._pipe = pipe
+        self._bucket_object = bucket_object
+        self._lock = lock or RLock()
+        self._trie = None
+        self.refresh_trie()
+
+    @synchronized
+    def refresh_trie(self):
+        self._trie = pygtrie.CharTrie(self._permissions_to_dict(self._fetch_permissions()))
+
+    @synchronized
+    def get_trie(self):
+        return self._trie
+
+    def can_write_to_root(self):
+        parent_folder_permissions = [p for p in self.get_closest_parent_permissions(self._root) if not p.file_name]
+        if not parent_folder_permissions:
+            raise ForbiddenOperationException()
+        item = parent_folder_permissions[0]
+        if not self._can_write(item.mask):
+            raise ForbiddenOperationException()
+
+    def can_write_to_path(self, path):
+        path = path if str(path).startswith(self._delimiter) else self._delimiter + path
+        is_folder = path.endswith(self._delimiter)
+        closest_parent = self.get_closest_parent_permissions(path)
+        if not closest_parent:
+            raise ForbiddenOperationException()
+        parent_permissions = [p for p in closest_parent]
+        if not is_folder:
+            file_name = os.path.basename(path)
+            for permission in parent_permissions:
+                if permission.file_name == file_name:
+                    if not self._can_write(permission.mask):
+                        raise ForbiddenOperationException()
+                    return
+        for permission in parent_permissions:
+            if not permission.file_name:
+                if not self._can_write(permission.mask):
+                    raise ForbiddenOperationException()
+                return
+        raise ForbiddenOperationException()
+
+    def check_path_access(self, path, item):
+        path = path if str(path).startswith(self._delimiter) else self._delimiter + path
+        item_mask = item.mask
+        if item_mask is None:
+            permission = self._find_item_permission(path, item)
+            if permission:
+                item_mask = permission.mask
+            else:
+                raise ForbiddenOperationException()
+        if not self._can_write(item_mask):
+            logging.debug("[%s] Item permission denied: %s" % (path, item))
+            raise ForbiddenOperationException()
+
+    def get_parent_permissions(self, path):  # -> int, dict[str: int]
+        parent = self.closest_parent(path)
+        if not parent:
+            return None, {}
+        parent_permissions = self.get_trie().get(parent)
+        folder_mask = self._get_folder_mask(parent_permissions)
+        file_masks = self._get_files_masks_by_name(parent_permissions, path)
+        return folder_mask, file_masks
+
+    @staticmethod
+    def _can_write(mask):
+        return mask & 4 != 0
+
+    def _find_item_permission(self, path, item):
+        closest_parent = self.get_closest_parent_permissions(path)
+        if not closest_parent:
+            return None
+        parent_permissions = [p for p in closest_parent]
+        for permission in parent_permissions:
+            if permission.file_name == item.name:
+                return permission
+        for permission in parent_permissions:
+            if not permission.file_name:
+                return permission
+        return None
+
+    def get_closest_parent_permissions(self, path):  # -> [StoragePathPermission]
+        parent = self.closest_parent(path)
+        if not parent:
+            return None
+        return self.get_trie().get(parent)
+
+    def get_children_with_depth_permissions(self, path, depth=1):  # -> dict[str: StoragePathPermission]
+        """
+        Returns {prepared <folder path>: <folder permission object>}
+        """
+        results = {}
+        children_paths = self.get_children_for_path(path)
+        if not children_paths:
+            return results
+        for child_permission_path in children_paths:
+            key_path = None
+            if child_permission_path.startswith(path):
+                key_path = child_permission_path[len(path):]
+                key_path = key_path.lstrip(self._root)
+            if not key_path:
+                continue
+            parts = key_path.split(self._root)
+            if 0 < depth < len(parts) - 1:
+                key_path = self._root.join(parts[0:depth]) + self._root
+            permissions = self.get_trie().get(child_permission_path)
+            folder_permissions = [p for p in permissions if p.file_name is None]
+            if folder_permissions:
+                results.update({key_path: folder_permissions[0]})
+                continue
+            results.update({key_path: StoragePathPermission(None, None, None)})
+        return results
+
+    def closest_parent(self, prefix):
+        return self.get_trie().longest_prefix(prefix)[0]
+
+    def get_children_for_path(self, path):  # -> [str]
+        try:
+            return self.get_trie().keys(prefix=path, shallow=False)
+        except KeyError:
+            return []
+
+    @staticmethod
+    def _get_folder_mask(permissions):  # -> int | None
+        if not permissions:
+            return None
+        for p in permissions:
+            if not p.file_name:
+                return p.mask
+        return None
+
+    @staticmethod
+    def _get_files_masks_by_name(permissions, path):  # -> dict[str: int]
+        file_masks = {}
+        for p in permissions:
+            if p.file_name and p.folder_path == path:
+                file_masks.update({p.file_name: p.mask})
+        return file_masks
+
+    @staticmethod
+    def _permissions_to_dict(permissions):
+        _dict = {}
+        for p in permissions:
+            if p.folder_path not in _dict:
+                _dict[p.folder_path] = []
+            _dict.get(p.folder_path).append(p)
+        return _dict
+
+    def _fetch_permissions(self):
+        return [StoragePathPermission.from_dict(data)
+                for data in self._pipe.get_storage_path_permissions(self._bucket_object.id)]
+
+
+class StoragePathPermissionsFileSystemClient(FileSystemClientDecorator):
+
+    def __init__(self, inner, permissions_manager):
+        super(StoragePathPermissionsFileSystemClient, self).__init__(inner)
+        self._inner = inner
+        self._manager = permissions_manager
+
+    def mv(self, old, new):
+        logging.debug("[%s] Checking access before creation" % new)
+        self._manager.can_write_to_path(new)
+        logging.debug("[%s] Access to create granted" % new)
+        file_item = self._inner.attrs(old)
+        if file_item:
+            self._can_write(old)
+        else:
+            folder_path = old if str(old).endswith('/') else '/' + old
+            folder_listing = self.ls(folder_path, depth=-1)
+            logging.debug("[%s] Folder listing to move: %s" % (old, folder_listing))
+            for item in folder_listing:
+                item_path = os.path.join(old, item.name)
+                logging.debug("[%s] Checking write permissions..." % item_path)
+                self._manager.check_path_access(item_path, item)
+                logging.debug("[%s] Access to delete granted" % item_path)
+        self._inner.mv(old, new)
+
+    def rmdir(self, path):
+        path = fuseutils.append_delimiter(path)
+        logging.debug("[%s] rmdir permissions checking:" % path)
+        for item in self.ls(fuseutils.append_delimiter(path), depth=-1):
+            self.delete(item.name)
+
+    def delete(self, path):
+        self._can_write(path)
+        logging.debug("[%s] Write permission granted. Deleting file." % path)
+        self._inner.delete(path)
+
+    def ls(self, path, depth=1):
+        listing = self._inner.ls(path, depth)
+        if not listing:
+            return listing
+        folder_mask, files_masks = self._manager.get_parent_permissions(path)
+
+        if folder_mask:
+            logging.debug("[%s] Has permissions to list full folder" % path)
+            return self._add_masks(listing, folder_mask, files_masks)
+
+        children_permissions = self._manager.get_children_with_depth_permissions(path, depth)
+        if not files_masks and not children_permissions:
+            logging.debug("[%s] Has no permissions to list." % path)
+            return []
+
+        logging.debug("[%s] Has permissions on files %s and folders %s"
+                      % (path, files_masks.keys(), children_permissions.keys()))
+        filtered_listing = []
+        for item in listing:
+            folder_permission = children_permissions.get(item.name)
+            if item.is_dir:
+                if folder_permission:
+                    filtered_listing.append(self._item(item, folder_permission.mask))
+                else:
+                    logging.debug("[%s] Filtering out folder '%s' since no permissions found." % (path, item.name))
+                continue
+            if files_masks and item.name in files_masks:
+                filtered_listing.append(self._item(item, files_masks.get(item.name)))
+                continue
+            logging.debug("[%s] Filtering out file '%s' since no permissions found." % (path, item.name))
+        logging.debug("[%s] Result listing: %s" % (path, filtered_listing))
+        return filtered_listing
+
+    def _can_write(self, path):
+        item = self._inner.attrs(path)
+        logging.debug("[%s] Checking write permissions..." % path)
+        self._manager.check_path_access(path, item)
+
+    def _add_masks(self, listing, folder_mask, files_masks):
+        new_listing = []
+        for item in listing:
+            mask = folder_mask
+            if item.name in files_masks:
+                mask = files_masks.get(item.name)
+            new_listing.append(self._item(item, mask))
+        return new_listing
+
+    @staticmethod
+    def _item(item, mask):
+        return File(name=item.name,
+                    size=item.size,
+                    mtime=item.mtime,
+                    ctime=item.ctime,
+                    contenttype=item.contenttype,
+                    is_dir=item.is_dir,
+                    storage_class=item.storage_class,
+                    mask=mask)
+
+
+class StoragePathWritePermissionsFilterFS(ChainingService):
+
+    def __init__(self, inner, permissions_manager, client):
+        self._inner = inner
+        self._root = '/'
+        self._permissions_manager = permissions_manager
+        self._client = client
+
+    def __getattr__(self, name):
+        if not hasattr(self._inner, name):
+            return None
+        attr = getattr(self._inner, name)
+        if not callable(attr):
+            return attr
+        return self._wrap(attr, name=name)
+
+    def __call__(self, name, *args, **kwargs):
+        if not hasattr(self._inner, name):
+            return getattr(self, name)(*args, **kwargs)
+        attr = getattr(self._inner, name)
+        return self._wrap(attr, name=name)(*args, **kwargs)
+
+    def _wrap(self, attr, name=None):
+        @functools.wraps(attr)
+        def _wrapped_attr(*args, **kwargs):
+            method_name = name
+            if method_name == 'access':
+                path = args[0]
+                mode = args[1]
+                self._inner.access(path, mode)
+                if path == self._root:
+                    if self._permissions_manager and mode & os.W_OK:
+                        logging.debug("[%s] Request root write permissions: %s" % (path, mode))
+                        self._permissions_manager.can_write_to_root()
+                    return attr(*args, **kwargs)
+                if self._permissions_manager is None:
+                    logging.debug("[%s] Permissions check not required: %s" % (path, mode))
+                    return attr(*args, **kwargs)
+                item = self._client.attrs(path)
+                logging.debug("[%s] Loading permissions for item: %s" % (path, item))
+                if not item:
+                    return attr(*args, **kwargs)
+                if mode & os.W_OK:
+                    logging.debug("[%s] Request write permissions: %s" % (path, mode))
+                    self._permissions_manager.check_path_access(path, item)
+                return attr(*args, **kwargs)
+            else:
+                return attr(*args, **kwargs)
+
+        return _wrapped_attr
+
+
+class StoragePathPermissionsRefresherDaemon:
+
+    def __init__(self, permissions_manager, delay):
+        self._manager = permissions_manager
+        self._polling_timeout = delay
+        self._thread = Thread(name='StoragePathPermissionsRefresher', target=self.run)
+        self._thread.daemon = True
+
+    def start(self):
+        self._thread.start()
+
+    def join(self, timeout=None):
+        logging.info('Closing storage path permissions refresher daemon...')
+        self._thread.join(timeout=timeout)
+
+    def run(self):
+        logging.info('Initiating storage path permissions refresher daemon...')
+        while True:
+            time.sleep(self._polling_timeout)
+            try:
+                logging.debug('Refreshing storage path permissions...')
+                self._manager.refresh_trie()
+                logging.debug('Storage path permissions refreshed.')
+            except KeyboardInterrupt:
+                logging.warning('Interrupted.')
+                raise
+            except Exception:
+                logging.warning('Disk buffer ttl daemon iteration has failed.', exc_info=True)

--- a/pipe-cli/mount/pipefuse/storage_path_permissions.py
+++ b/pipe-cli/mount/pipefuse/storage_path_permissions.py
@@ -20,6 +20,7 @@ import pygtrie
 import logging
 
 from pipefuse import fuseutils
+from pipefuse.api import CloudPipelineClient, DataStorage
 from pipefuse.chain import ChainingService
 from pipefuse.fsclient import FileSystemClientDecorator, File, ForbiddenOperationException
 from pipefuse.lock import synchronized
@@ -203,6 +204,12 @@ class StoragePathPermissionsFileSystemClient(FileSystemClientDecorator):
         self._inner = inner
         self._manager = permissions_manager
 
+    def mkdir(self, path):
+        logging.debug("[%s] Checking access before folder creation" % path)
+        self._manager.can_write_to_path(path)
+        logging.debug("[%s] Access to create folder granted" % path)
+        self._inner.mkdir(path)
+
     def mv(self, old, new):
         logging.debug("[%s] Checking access before creation" % new)
         self._manager.can_write_to_path(new)
@@ -320,27 +327,41 @@ class StoragePathWritePermissionsFilterFS(ChainingService):
             if method_name == 'access':
                 path = args[0]
                 mode = args[1]
-                self._inner.access(path, mode)
-                if path == self._root:
-                    if self._permissions_manager and mode & os.W_OK:
-                        logging.debug("[%s] Request root write permissions: %s" % (path, mode))
-                        self._permissions_manager.can_write_to_root()
-                    return attr(*args, **kwargs)
-                if self._permissions_manager is None:
-                    logging.debug("[%s] Permissions check not required: %s" % (path, mode))
-                    return attr(*args, **kwargs)
-                item = self._client.attrs(path)
-                logging.debug("[%s] Loading permissions for item: %s" % (path, item))
-                if not item:
-                    return attr(*args, **kwargs)
-                if mode & os.W_OK:
-                    logging.debug("[%s] Request write permissions: %s" % (path, mode))
-                    self._permissions_manager.check_path_access(path, item)
+                self._check_access(path, mode, method_name)
+                return attr(*args, **kwargs)
+            elif method_name == 'create':
+                path = args[0] or kwargs.get('path')
+                self._permissions_manager.can_write_to_path(path)
+                return attr(*args, **kwargs)
+            elif method_name == 'open':
+                path = args[0] or kwargs.get('path')
+                flags = args[1] or kwargs.get('flags')
+                if flags & os.O_CREAT:
+                    self._permissions_manager.can_write_to_path(path)
+                if (flags & os.O_WRONLY) or (flags & os.O_RDWR) or (flags & os.O_APPEND) or (flags & os.O_TRUNC):
+                    self._check_access(path, os.W_OK, method_name)
                 return attr(*args, **kwargs)
             else:
                 return attr(*args, **kwargs)
 
         return _wrapped_attr
+
+    def _check_access(self, path, mode, method):
+        if path == self._root:
+            if self._permissions_manager and mode & os.W_OK:
+                logging.debug("[%s] Request root write permissions to %s: %s" % (path, method, mode))
+                self._permissions_manager.can_write_to_root()
+            return
+        if self._permissions_manager is None:
+            logging.debug("[%s] Permissions check not required to %s: %s" % (path, method, mode))
+            return
+        item = self._client.attrs(path)
+        logging.debug("[%s] Loading permissions for item to %s: %s" % (path, method, item))
+        if not item:
+            return
+        if mode & os.W_OK:
+            logging.debug("[%s] Request write permissions to %s: %s" % (path, method, mode))
+            self._permissions_manager.check_path_access(path, item)
 
 
 class StoragePathPermissionsRefresherDaemon:

--- a/pipe-cli/mount/pipefuse/webdav.py
+++ b/pipe-cli/mount/pipefuse/webdav.py
@@ -237,7 +237,8 @@ class WebDavClient(easywebdav.Client, FileSystemClient):
             self.parse_timestamp(self.prop_value(elem, 'creationdate', ''), self.C_DATE_FORMAT),
             self.prop_value(elem, 'getcontenttype', ''),
             self.prop_exists(elem, 'collection'),
-            storage_class=None
+            storage_class=None,
+            mask=None
         )
 
     def download_range(self, fh, data, remote_path, offset=0, length=0):

--- a/pipe-cli/mount/requirements.txt
+++ b/pipe-cli/mount/requirements.txt
@@ -12,3 +12,4 @@ google-resumable-media==0.3.2
 google-cloud-storage==1.15.0
 python-dateutil==2.6.1
 future==0.18.2
+pygtrie==2.5.0


### PR DESCRIPTION
relates to #3919 

Provides implementation for mount part. 

The following environment variables added to manage permissions aware behaviour:
- `CP_PIPE_FUSE_PATH_PERMISSIONS_DISABLED ` (Default: `false`) - provides ability to disable permissions check for mount command.
- `CP_PIPE_FUSE_PATH_PERMISSIONS_REFRESHING_DELAY` (Default: `86400`) - configures a timeout in **seconds** to fetch permissions form AP.
