### PR TITLE
Issue #3931 GCP Artifact Registry integration, added endpoint for pus…

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -134,7 +134,7 @@ dependencies {
     compile group: 'redis.clients', name: 'jedis', version: '2.9.0'
 
     //GCP
-    compile group: "com.google.auth", name: "google-auth-library-oauth2-http", version: "0.10.0"
+    compile group: "com.google.auth", name: "google-auth-library-oauth2-http", version: "0.27.0"
     compile group: "com.google.api-client", name: "google-api-client", version: "1.34.0"
     compile "com.google.apis:google-api-services-compute:v1-rev20220720-1.32.1"
     compile "com.google.apis:google-api-services-cloudbilling:v1-rev30-1.25.0"

--- a/api/src/main/java/com/epam/pipeline/acl/gcp/GCPRegistryApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/gcp/GCPRegistryApiService.java
@@ -1,0 +1,103 @@
+package com.epam.pipeline.acl.gcp;
+
+import com.epam.pipeline.dao.region.CloudRegionDao;
+import com.epam.pipeline.entity.pipeline.DockerRegistry;
+import com.epam.pipeline.entity.pipeline.DockerRegistryEvent;
+import com.epam.pipeline.entity.pipeline.DockerRegistryEventEnvelope;
+import com.epam.pipeline.entity.pipeline.GcpArtifactRegistryEvent;
+import com.epam.pipeline.entity.pipeline.GcpArtifactRegistryEventBody;
+import com.epam.pipeline.entity.pipeline.Tool;
+import com.epam.pipeline.entity.region.GCPRegion;
+import com.epam.pipeline.entity.security.JwtRawToken;
+import com.epam.pipeline.exception.ObjectNotFoundException;
+import com.epam.pipeline.manager.docker.DockerRegistryAction;
+import com.epam.pipeline.manager.docker.DockerRegistryManager;
+import com.epam.pipeline.manager.gcp.GCPImageDetails;
+import com.epam.pipeline.manager.gcp.GCPParsingUtils;
+import com.epam.pipeline.manager.security.AuthManager;
+import com.epam.pipeline.security.jwt.GCPJwtTokenVerifier;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Objects;
+
+import static com.epam.pipeline.entity.region.CloudProvider.GCP;
+import static com.epam.pipeline.manager.gcp.GCPParsingUtils.MAPPER;
+import static com.epam.pipeline.manager.gcp.GCPRegistryAction.INSERT;
+
+@Service
+@RequiredArgsConstructor
+public class GCPRegistryApiService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GCPRegistryApiService.class);
+    private final CloudRegionDao cloudRegionDao;
+    private final DockerRegistryManager dockerRegistryManager;
+    private final GCPJwtTokenVerifier gcpJwtTokenVerifier;
+    private final AuthManager authManager;
+
+    public Tool notifyGcpRegistryEvent(final String jwtToken, final GcpArtifactRegistryEventBody eventBody) {
+        final JwtRawToken  jwtRawToken = JwtRawToken.fromHeader(jwtToken);
+        gcpJwtTokenVerifier.validateToken(jwtRawToken.getToken());
+        authManager.setAdminContext();
+
+        final GcpArtifactRegistryEventBody.Message message = eventBody.getMessage();
+        final String decodedData = new String(Base64.getDecoder().decode(message.getData()));
+
+        try {
+            final GcpArtifactRegistryEvent event = MAPPER.readValue(decodedData, GcpArtifactRegistryEvent.class);
+            //ignore other actions beside INSERT
+            if (INSERT.getAction().equals(event.getAction()) &&
+                    Objects.nonNull(event.getDigest()) && Objects.nonNull(event.getTag())) {
+
+                final GCPImageDetails imageDetails = GCPParsingUtils.parseGcpEvent(event);
+                final DockerRegistry gcpRegistry = dockerRegistryManager.loadByNameOrId(imageDetails.getRegistry());
+
+                //ignore requests made by different provider
+                if (Objects.nonNull(gcpRegistry) && GCP == gcpRegistry.getProvider()) {
+                    final GCPRegion region = (GCPRegion) cloudRegionDao.loadByRegionName(imageDetails.getRegion())
+                            .filter(r -> GCP == r.getProvider())
+                            .orElseThrow(() -> new ObjectNotFoundException(
+                                    String.format("No GCP Region with region name: %s", imageDetails.getRegion())));
+
+                    //ignore requests made by different project
+                    if (Objects.isNull(region.getProject()) || !region.getProject().equals(imageDetails.getProject())) {
+                        LOGGER.info(String.format("Region - %s: Project missing or mismatched.", region.getName()));
+                        return null;
+                    }
+
+                    final DockerRegistryEvent dockerRegistryEvent = mapGcpEventToDockerRegistryEvent(imageDetails);
+                    final DockerRegistryEventEnvelope events = new DockerRegistryEventEnvelope();
+                    events.setEvents(Collections.singletonList(dockerRegistryEvent));
+                    return dockerRegistryManager.notifyDockerRegistryEvents(gcpRegistry.getPath(), events).get(0);
+                }
+            }
+            LOGGER.info("Event ignored: Action is not INSERT or provider is not GCP.");
+            return null;
+        } catch (IOException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    private DockerRegistryEvent mapGcpEventToDockerRegistryEvent(final GCPImageDetails gcpImageDetails) {
+        final DockerRegistryEvent dockerRegistryEvent = new DockerRegistryEvent();
+        dockerRegistryEvent.setAction(DockerRegistryAction.PUSH.getAction());
+
+        final DockerRegistryEvent.Target target = new DockerRegistryEvent.Target();
+        target.setDigest(gcpImageDetails.getDigest());
+        target.setTag(gcpImageDetails.getTag());
+        target.setRepository(String.format("%s/%s/%s",
+                gcpImageDetails.getProject(), gcpImageDetails.getRepository(), gcpImageDetails.getImage()));
+        dockerRegistryEvent.setTarget(target);
+
+        final DockerRegistryEvent.Actor actor = new DockerRegistryEvent.Actor();
+        actor.setName("PIPE_ADMIN");
+        dockerRegistryEvent.setActor(actor);
+
+        return dockerRegistryEvent;
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/app/JWTSecurityConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/JWTSecurityConfiguration.java
@@ -149,6 +149,7 @@ public class JWTSecurityConfiguration extends WebSecurityConfigurerAdapter {
     protected String[] getUnsecuredResources() {
         final List<String> excludePaths = Arrays.asList(
                 "/restapi/dockerRegistry/oauth",
+                "/restapi/gcpRegistry/notify",
                 "/restapi/proxy/**",
                 "/error",
                 "/error/**");

--- a/api/src/main/java/com/epam/pipeline/controller/ExceptionHandlerAdvice.java
+++ b/api/src/main/java/com/epam/pipeline/controller/ExceptionHandlerAdvice.java
@@ -17,6 +17,7 @@
 package com.epam.pipeline.controller;
 
 import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.exception.GCPAuthorizationException;
 import com.epam.pipeline.exception.ObjectNotFoundException;
 import com.epam.pipeline.exception.StorageForbiddenOperationException;
 import com.epam.pipeline.exception.docker.DockerAuthorizationException;
@@ -73,7 +74,8 @@ public class ExceptionHandlerAdvice {
             } else {
                 message = messageHelper.getMessage("error.sql");
             }
-        } else if (exception instanceof DockerAuthorizationException) {
+        } else if (exception instanceof DockerAuthorizationException ||
+                exception instanceof GCPAuthorizationException) {
             return new ResponseEntity<>(Result.error(exception.getMessage()), HttpStatus.UNAUTHORIZED);
         } else if (exception instanceof StorageForbiddenOperationException) {
             return new ResponseEntity<>(Result.error(exception.getMessage()), HttpStatus.FORBIDDEN);

--- a/api/src/main/java/com/epam/pipeline/controller/gcp/GCPRegistryController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/gcp/GCPRegistryController.java
@@ -1,0 +1,39 @@
+package com.epam.pipeline.controller.gcp;
+
+import com.epam.pipeline.acl.gcp.GCPRegistryApiService;
+import com.epam.pipeline.controller.AbstractRestController;
+import com.epam.pipeline.entity.pipeline.GcpArtifactRegistryEventBody;
+import com.epam.pipeline.entity.pipeline.Tool;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Api(value = "GCP Artifact Registry")
+public class GCPRegistryController extends AbstractRestController {
+
+    @Autowired
+    private GCPRegistryApiService gcpRegistryApiService;
+
+    @RequestMapping(value = "/gcpRegistry/notify", method= RequestMethod.POST)
+    @ResponseBody
+    @ApiOperation(
+            value = "Notify about gcp registry event.",
+            notes = "Notify about gcp registry event.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public ResponseEntity<Tool> notifyGCPRegistryEvent(@RequestHeader(value="Authorization") final String jwtToken,
+                                                       @RequestBody final GcpArtifactRegistryEventBody event) {
+        return ResponseEntity.ok(gcpRegistryApiService.notifyGcpRegistryEvent(jwtToken, event));
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/exception/GCPAuthorizationException.java
+++ b/api/src/main/java/com/epam/pipeline/exception/GCPAuthorizationException.java
@@ -1,0 +1,11 @@
+package com.epam.pipeline.exception;
+
+public class GCPAuthorizationException extends RuntimeException{
+    public GCPAuthorizationException() {
+        super("Authorization failed for GCP Artifact Registry notification");
+    }
+
+    public GCPAuthorizationException(String message) {
+        super(String.format("Authorization failed for GCP Artifact Registry notification. %s", message));
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPClient.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPClient.java
@@ -22,7 +22,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.services.cloudbilling.Cloudbilling;
 import com.google.api.services.compute.Compute;
 import com.google.api.services.iamcredentials.v1.IAMCredentials;
@@ -53,7 +53,7 @@ public class GCPClient {
 
     public GCPClient() throws GeneralSecurityException, IOException {
         this.httpTransport = GoogleNetHttpTransport.newTrustedTransport();
-        this.jsonFactory = JacksonFactory.getDefaultInstance();
+        this.jsonFactory = GsonFactory.getDefaultInstance();
     }
 
     public Compute buildComputeClient(final GCPRegion region) throws IOException {

--- a/api/src/main/java/com/epam/pipeline/manager/docker/DockerRegistryManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/docker/DockerRegistryManager.java
@@ -562,7 +562,11 @@ public class DockerRegistryManager implements SecuredEntityManager {
             toolGroup.setOwner(event.getActor().getName());
             toolGroupManager.create(toolGroup);
         } else {
-            toolGroup = toolGroupManager.loadByNameOrId(registry.getPath() + Constants.PATH_DELIMITER + group);
+            if (registry.getProvider() == GCP) {
+                toolGroup = toolGroupManager.loadByRegistryAndName(registry.getPath(), group);
+            } else {
+                toolGroup = toolGroupManager.loadByNameOrId(registry.getPath() + Constants.PATH_DELIMITER + group);
+            }
         }
         return toolGroup;
     }

--- a/api/src/main/java/com/epam/pipeline/manager/gcp/GCPImageDetails.java
+++ b/api/src/main/java/com/epam/pipeline/manager/gcp/GCPImageDetails.java
@@ -1,0 +1,16 @@
+package com.epam.pipeline.manager.gcp;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class GCPImageDetails {
+    private String registry;
+    private String project;
+    private String repository;
+    private String image;
+    private String digest;
+    private String region;
+    private String tag;
+}

--- a/api/src/main/java/com/epam/pipeline/manager/gcp/GCPParsingUtils.java
+++ b/api/src/main/java/com/epam/pipeline/manager/gcp/GCPParsingUtils.java
@@ -1,0 +1,56 @@
+package com.epam.pipeline.manager.gcp;
+
+import com.epam.pipeline.entity.pipeline.GcpArtifactRegistryEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class GCPParsingUtils {
+    public static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String GCP_IMAGE_DIGEST_FORMAT = "([^/]+\\.pkg\\.dev)/([^/]+)/([^/]+)/([^@]+)@(.+)";
+    private static final String GCP_ARTIFACT_REGISTRY_HOST_FORMAT = "^([a-z0-9]+-[a-z0-9]+)-docker\\.pkg\\.dev$";
+
+    public static GCPImageDetails parseGcpEvent(final GcpArtifactRegistryEvent event) {
+        final Pattern pattern = Pattern.compile(GCP_IMAGE_DIGEST_FORMAT);
+        final Matcher matcher = pattern.matcher(event.getDigest());
+
+        if (matcher.matches()) {
+            return GCPImageDetails.builder()
+                    .registry(matcher.group(1))
+                    .project(matcher.group(2))
+                    .repository(matcher.group(3))
+                    .image(matcher.group(4))
+                    .digest(matcher.group(5))
+                    .region(extractRegionFromRegistry(matcher.group(1)))
+                    .tag(extractTag(event.getTag()))
+                    .build();
+        } else {
+            throw new IllegalArgumentException("Invalid GCP Artifact Registry Digest format: " + event.getDigest());
+        }
+    }
+
+    public static String extractRegionFromRegistry(final String registry) {
+        if (registry == null || registry.isEmpty()) {
+            return null;
+        }
+
+        final Pattern pattern = Pattern.compile(GCP_ARTIFACT_REGISTRY_HOST_FORMAT);
+        final Matcher matcher = pattern.matcher(registry);
+
+        if (matcher.matches()) {
+            return matcher.group(1);
+        }else {
+            throw new IllegalArgumentException("Invalid hostname for GCP Artifact Registry: " + registry);
+        }
+    }
+
+    public static String extractTag(final String input) {
+        if (input == null || !input.contains(":")) {
+            return null;
+        }
+        return input.substring(input.lastIndexOf(':') + 1);
+    }
+
+    private GCPParsingUtils() {}
+}

--- a/api/src/main/java/com/epam/pipeline/manager/gcp/GCPRegistryAction.java
+++ b/api/src/main/java/com/epam/pipeline/manager/gcp/GCPRegistryAction.java
@@ -1,0 +1,12 @@
+package com.epam.pipeline.manager.gcp;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum GCPRegistryAction {
+    INSERT("INSERT"),
+    DELETE("DELETE");
+    private final String action;
+}

--- a/api/src/main/java/com/epam/pipeline/manager/google/GoogleCredentialsManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/google/GoogleCredentialsManager.java
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeFlow;
 import com.google.api.client.googleapis.auth.oauth2.GoogleTokenResponse;
 import com.google.api.client.http.javanet.NetHttpTransport;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.UserCredentials;
 import lombok.AllArgsConstructor;
@@ -105,7 +105,7 @@ public class GoogleCredentialsManager implements CredentialsManager {
 
         GoogleAuthorizationCodeFlow authorizationFlow = new GoogleAuthorizationCodeFlow.Builder(
                 HTTP_TRANSPORT,
-                new JacksonFactory(),
+                GsonFactory.getDefaultInstance(),
                 webClientCredentials.getClientId(),
                 webClientCredentials.getClientSecret(),
                 scopes)

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/ToolGroupManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/ToolGroupManager.java
@@ -269,6 +269,18 @@ public class ToolGroupManager implements SecuredEntityManager {
         }
         return loadResult.orElse(null);
     }
+    public ToolGroup loadByRegistryAndName(final String registry, final String groupName) {
+        final List<ToolGroup> groups = toolGroupDao.loadToolGroupsByNameAndRegistryName(groupName, registry);
+        Assert.isTrue(groups.size() <= 1, messageHelper.getMessage(MessageConstants.ERROR_TOO_MANY_RESULTS,
+                registry + Constants.PATH_DELIMITER + groupName));
+        Assert.isTrue(!groups.isEmpty(), messageHelper.getMessage(MessageConstants.ERROR_TOOL_GROUP_NOT_FOUND,
+                registry + Constants.PATH_DELIMITER + groupName));
+        final ToolGroup result = groups.get(0);
+        result.setTools(toolManager.loadToolsByGroup(result.getId()));
+        result.setPrivateGroup(result.getName().equalsIgnoreCase(makePrivateGroupName()));
+
+        return result;
+    }
 
     /**
      * Splits image into group and image name,

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -1402,6 +1402,10 @@ public class SystemPreferences {
     public static final StringPreference GCP_DEFAULT_GPU_TYPE = new StringPreference(
             "gcp.default.gpu.type", "a100", GCP_GROUP, isNotBlank);
 
+    public static final StringPreference GCP_ARTIFACT_REGISTRY_NOTIFICATION_AUDIENCE = new StringPreference(
+            "gcp.artifact.registry.notification.audience",
+            "/pipeline/restapi/gcpRegistry/notify", GCP_GROUP, isNotBlank);
+
     // Billing Reports
     public static final StringPreference BILLING_USER_NAME_ATTRIBUTE = new StringPreference(
             "billing.reports.user.name.attribute", null, BILLING_GROUP, pass);

--- a/api/src/main/java/com/epam/pipeline/manager/security/AuthManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/AuthManager.java
@@ -213,4 +213,10 @@ public class AuthManager {
         }
         return authentication.getPrincipal();
     }
+
+    public void setAdminContext() {
+        final UserContext userContext = getAdminContext();
+        JwtAuthenticationToken token = new JwtAuthenticationToken(userContext, userContext.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(token);
+    }
 }

--- a/api/src/main/java/com/epam/pipeline/security/jwt/GCPJwtTokenVerifier.java
+++ b/api/src/main/java/com/epam/pipeline/security/jwt/GCPJwtTokenVerifier.java
@@ -1,0 +1,28 @@
+package com.epam.pipeline.security.jwt;
+
+import com.epam.pipeline.exception.GCPAuthorizationException;
+import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.google.auth.oauth2.TokenVerifier;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import static com.epam.pipeline.manager.preference.SystemPreferences.GCP_ARTIFACT_REGISTRY_NOTIFICATION_AUDIENCE;
+
+
+@Component
+@RequiredArgsConstructor
+public class GCPJwtTokenVerifier {
+    private final PreferenceManager preferenceManager;
+    public static final String GOOGLE_ISSUER = "https://accounts.google.com";
+    public void validateToken(final String jwtToken) {
+        try {
+            TokenVerifier tokenVerifier = TokenVerifier.newBuilder()
+                    .setIssuer(GOOGLE_ISSUER)
+                    .setAudience(preferenceManager.getPreference(GCP_ARTIFACT_REGISTRY_NOTIFICATION_AUDIENCE))
+                    .build();
+            tokenVerifier.verify(jwtToken);
+        } catch (TokenVerifier.VerificationException e) {
+            throw new GCPAuthorizationException(e.getMessage());
+        }
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/acl/gcp/GCPRegistryApiServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/acl/gcp/GCPRegistryApiServiceTest.java
@@ -1,0 +1,171 @@
+package com.epam.pipeline.acl.gcp;
+
+import com.epam.pipeline.dao.region.CloudRegionDao;
+import com.epam.pipeline.entity.pipeline.DockerRegistry;
+import com.epam.pipeline.entity.pipeline.DockerRegistryEvent;
+import com.epam.pipeline.entity.pipeline.DockerRegistryEventEnvelope;
+import com.epam.pipeline.entity.pipeline.GcpArtifactRegistryEvent;
+import com.epam.pipeline.entity.pipeline.GcpArtifactRegistryEventBody;
+import com.epam.pipeline.entity.pipeline.Tool;
+import com.epam.pipeline.entity.region.CloudProvider;
+import com.epam.pipeline.entity.region.GCPRegion;
+import com.epam.pipeline.exception.GCPAuthorizationException;
+import com.epam.pipeline.manager.docker.DockerRegistryAction;
+import com.epam.pipeline.manager.docker.DockerRegistryManager;
+import com.epam.pipeline.security.jwt.GCPJwtTokenVerifier;
+import com.epam.pipeline.test.acl.AbstractAclTest;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AuthenticationServiceException;
+
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class GCPRegistryApiServiceTest extends AbstractAclTest {
+
+    private static final String GCP_REGISTRY = "europe-west3-docker.pkg.dev";
+    private static final String GCP_REGION_EUROPE_WEST_3 = "europe-west3";
+    private static final String GCP_PROJECT = "gcp-project";
+    private static final String GCP_REPOSITORY = "gcp-repo";
+    private static final String DOCKER_IMAGE = "docker-image";
+    private static final String DOCKER_IMAGE_DIGEST = "sha256:f6c859b589b72e67c05d";
+    private static final String GCP_JWT_EXPIRED_TOKEN = "eyJhbGciOiJSUzI1NiIsImtpZCI6IjkxNGZiOWIwODcxODBiYzAzMDMyO" +
+            "DQ1MDBjNWY1NDBjNmQ0ZjVlMmYiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJodHRwczovL3B1YnN1Yi10dXRvcmlhbC02MTU2MTE3Njc" +
+            "0MDkuZXVyb3BlLXdlc3QzLnJ1bi5hcHAvIiwiYXpwIjoiMTA5OTkyMTgwODIyMDQ3NDg2Nzc4IiwiZW1haWwiOiJnY2ZhLXBpcGVs" +
+            "aW5lLWduYWkxMC1zYS1kZXZAaGwyLWVwbS1nbmFpMTAtdDFpeWx1LmlhbS5nc2VydmljZWFjY291bnQuY29tIiwiZW1haWxfdmVya" +
+            "WZpZWQiOnRydWUsImV4cCI6MTc0MjM3NjcwMiwiaWF0IjoxNzQyMzczMTAyLCJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS" +
+            "5jb20iLCJzdWIiOiIxMDk5OTIxODA4MjIwNDc0ODY3NzgifQ.iINc0FWK6iXVuujeHWwsCQbHONClZpqS2Ab_YT9fQ65OHg9nkszg" +
+            "tO7-C3Jx6M0QwXCyFKVv7lrzGLjBbs7ioKloeG27DmpYgCzgKtUwkPWxuhoivBfIl9GwhbLH1z73LRGK5fJjZVkfP8P1PN6QA8swO" +
+            "yn9eQg2n7w7OofguwAmb2Qi4Raa4F5OjH-YjdTAGhHl16L-eciofV7wU8i_JRKJOWMSehw3fN4EPv0OYz1FY_5pkafrGQY7XG4DgX" +
+            "u9-UbKLVvUQ-IaglEbvDo-u5utbYpIlGeezn_PRV9rXN93hhYRBW4OLzN5xpnBpNuQAN7kOKkSCPfnNuCtaFQGhg";
+    private static final String GCP_JWT_EXPIRED_TOKEN_BEARER = "Bearer " + GCP_JWT_EXPIRED_TOKEN;
+    @Autowired
+    private GCPRegistryApiService gcpRegistryApiService;
+    @Autowired
+    private GCPJwtTokenVerifier gcpJwtTokenVerifier;
+    @Autowired
+    private DockerRegistryManager dockerRegistryManager;
+    @Autowired
+    private CloudRegionDao cloudRegionDao;
+    @Test(expected = AuthenticationServiceException.class)
+    public void shouldFailOnEmptyAuthHeader() {
+        gcpRegistryApiService.notifyGcpRegistryEvent("", null);
+    }
+
+    @Test(expected = GCPAuthorizationException.class)
+    public void shouldFailOnExpiredToken() {
+        gcpRegistryApiService.notifyGcpRegistryEvent(GCP_JWT_EXPIRED_TOKEN_BEARER, null);
+    }
+
+    @Test
+    public void notifyGcpRegistryEventSuccess() throws JsonProcessingException {
+        doNothing().when(gcpJwtTokenVerifier).validateToken(GCP_JWT_EXPIRED_TOKEN);
+        final DockerRegistry dockerRegistry = buildRegistry(CloudProvider.GCP, GCP_REGISTRY);
+        when(dockerRegistryManager.loadByNameOrId(GCP_REGISTRY)).thenReturn(dockerRegistry);
+        when(cloudRegionDao.loadByRegionName(GCP_REGION_EUROPE_WEST_3))
+                .thenReturn(Optional.of(buildRegion(GCP_REGION_EUROPE_WEST_3)));
+        final Tool expectedTool = buildTool(DOCKER_IMAGE);
+        when(dockerRegistryManager.notifyDockerRegistryEvents(anyString(), any(DockerRegistryEventEnvelope.class)))
+                .thenReturn(Collections.singletonList(expectedTool));
+
+        final Tool actualTool = gcpRegistryApiService
+                .notifyGcpRegistryEvent(GCP_JWT_EXPIRED_TOKEN_BEARER, createTestEventBody("INSERT"));
+
+        verify(gcpJwtTokenVerifier).validateToken(eq(GCP_JWT_EXPIRED_TOKEN));
+        verify(dockerRegistryManager).loadByNameOrId(eq(GCP_REGISTRY));
+        verify(cloudRegionDao).loadByRegionName(eq(GCP_REGION_EUROPE_WEST_3));
+        ArgumentCaptor<DockerRegistryEventEnvelope> captor = ArgumentCaptor.forClass(DockerRegistryEventEnvelope.class);
+
+        verify(dockerRegistryManager).notifyDockerRegistryEvents(eq(GCP_REGISTRY), captor.capture());
+
+
+        assertThat(actualTool.getImage()).isEqualTo(expectedTool.getImage());
+        assertThat(actualTool.getRegistry()).isEqualTo(expectedTool.getRegistry());
+        assertThat(actualTool.getOwner()).isEqualTo(expectedTool.getOwner());
+
+        DockerRegistryEventEnvelope dockerRegistryEventEnvelope = captor.getValue();
+        assertThat(dockerRegistryEventEnvelope.getEvents()).size().isEqualTo(1);
+
+        DockerRegistryEvent dockerRegistryEvent = dockerRegistryEventEnvelope.getEvents().get(0);
+        assertThat(dockerRegistryEvent.getAction()).isEqualTo(DockerRegistryAction.PUSH.getAction());
+        assertThat(dockerRegistryEvent.getTarget()).isNotNull();
+        assertThat(dockerRegistryEvent.getTarget().getDigest()).isEqualTo(DOCKER_IMAGE_DIGEST);
+        assertThat(dockerRegistryEvent.getTarget().getTag()).isEqualTo("latest");
+        assertThat(dockerRegistryEvent.getTarget().getRepository())
+                .isEqualTo(String.format("%s/%s/%s", GCP_PROJECT, GCP_REPOSITORY, DOCKER_IMAGE));
+        assertThat(dockerRegistryEvent.getActor()).isNotNull();
+        assertThat(dockerRegistryEvent.getActor().getName()).isEqualTo("PIPE_ADMIN");
+    }
+
+    @Test
+    public void notifyGcpRegistryEventShouldIgnoreDeleteAction() throws JsonProcessingException {
+        doNothing().when(gcpJwtTokenVerifier).validateToken(GCP_JWT_EXPIRED_TOKEN);
+
+        final Tool actualTool = gcpRegistryApiService
+                .notifyGcpRegistryEvent(GCP_JWT_EXPIRED_TOKEN_BEARER, createTestEventBody("DELETE"));
+
+        verify(gcpJwtTokenVerifier).validateToken(eq(GCP_JWT_EXPIRED_TOKEN));
+        verify(dockerRegistryManager, never()).loadByNameOrId(anyString());
+        verify(dockerRegistryManager, never()).notifyDockerRegistryEvents(anyString(), anyObject());
+        verify(cloudRegionDao, never()).loadByRegionName(anyString());
+
+        assertThat(actualTool).isNull();
+    }
+
+    private GcpArtifactRegistryEventBody createTestEventBody(String action) throws JsonProcessingException {
+        GcpArtifactRegistryEvent gcpEvent = new GcpArtifactRegistryEvent();
+        gcpEvent.setAction(action);
+        gcpEvent.setDigest("europe-west3-docker.pkg.dev/gcp-project/gcp-repo/docker-image@sha256:f6c859b589b72e67c05d");
+        gcpEvent.setTag("gcp-registry/gcp-project/gcp-repo/docker-image:latest");
+
+        GcpArtifactRegistryEventBody.Message message = new GcpArtifactRegistryEventBody.Message();
+        message.setData(Base64.getEncoder().encodeToString(new ObjectMapper().writeValueAsBytes(gcpEvent)));
+        message.setMessageId("12345");
+        message.setPublishTime("2025-03-19T12:00:00Z");
+
+        GcpArtifactRegistryEventBody event = new GcpArtifactRegistryEventBody();
+        event.setMessage(message);
+        return event;
+    }
+
+    private DockerRegistry buildRegistry(CloudProvider provider, String path) {
+        final DockerRegistry registry = new DockerRegistry();
+        registry.setPath(path);
+        registry.setOwner("PIPE_ADMIN");
+        registry.setProvider(provider);
+        return registry;
+    }
+
+    private GCPRegion buildRegion(String region) {
+        final GCPRegion gcpRegion = new GCPRegion();
+        gcpRegion.setName(region);
+        gcpRegion.setRegionCode(region);
+        gcpRegion.setProject(GCP_PROJECT);
+        gcpRegion.setProvider(CloudProvider.GCP);
+        return gcpRegion;
+    }
+
+    private Tool buildTool(String image) {
+        final Tool tool = new Tool();
+        tool.setImage(image);
+        tool.setCpu("0mi");
+        tool.setRam("0Gi");
+        tool.setRegistry(GCP_REGISTRY);
+        tool.setOwner("PIPE_ADMIN");
+        return tool;
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/acl/gcp/GCPRegistryApiServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/acl/gcp/GCPRegistryApiServiceTest.java
@@ -43,15 +43,11 @@ public class GCPRegistryApiServiceTest extends AbstractAclTest {
     private static final String GCP_REPOSITORY = "gcp-repo";
     private static final String DOCKER_IMAGE = "docker-image";
     private static final String DOCKER_IMAGE_DIGEST = "sha256:f6c859b589b72e67c05d";
-    private static final String GCP_JWT_EXPIRED_TOKEN = "eyJhbGciOiJSUzI1NiIsImtpZCI6IjkxNGZiOWIwODcxODBiYzAzMDMyO" +
-            "DQ1MDBjNWY1NDBjNmQ0ZjVlMmYiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJodHRwczovL3B1YnN1Yi10dXRvcmlhbC02MTU2MTE3Njc" +
-            "0MDkuZXVyb3BlLXdlc3QzLnJ1bi5hcHAvIiwiYXpwIjoiMTA5OTkyMTgwODIyMDQ3NDg2Nzc4IiwiZW1haWwiOiJnY2ZhLXBpcGVs" +
-            "aW5lLWduYWkxMC1zYS1kZXZAaGwyLWVwbS1nbmFpMTAtdDFpeWx1LmlhbS5nc2VydmljZWFjY291bnQuY29tIiwiZW1haWxfdmVya" +
-            "WZpZWQiOnRydWUsImV4cCI6MTc0MjM3NjcwMiwiaWF0IjoxNzQyMzczMTAyLCJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS" +
-            "5jb20iLCJzdWIiOiIxMDk5OTIxODA4MjIwNDc0ODY3NzgifQ.iINc0FWK6iXVuujeHWwsCQbHONClZpqS2Ab_YT9fQ65OHg9nkszg" +
-            "tO7-C3Jx6M0QwXCyFKVv7lrzGLjBbs7ioKloeG27DmpYgCzgKtUwkPWxuhoivBfIl9GwhbLH1z73LRGK5fJjZVkfP8P1PN6QA8swO" +
-            "yn9eQg2n7w7OofguwAmb2Qi4Raa4F5OjH-YjdTAGhHl16L-eciofV7wU8i_JRKJOWMSehw3fN4EPv0OYz1FY_5pkafrGQY7XG4DgX" +
-            "u9-UbKLVvUQ-IaglEbvDo-u5utbYpIlGeezn_PRV9rXN93hhYRBW4OLzN5xpnBpNuQAN7kOKkSCPfnNuCtaFQGhg";
+    private static final String GCP_JWT_EXPIRED_TOKEN = "eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0IiwiYX" +
+            "VkIjoidGVzdCIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJleHAiOjE3M" +
+            "TIxNTE2NTgsImlhdCI6MTcxMjA2NTI1OCwianRpIjoiY2IwZWJkNjAtZTBjZi00ODIxLWIxN2EtZjg5YTlkODJlNjIxIiwiZW1haWwi" +
+            "OiJ0ZXN0QHRlc3QuY29tIn0.Kvt-ZFEYgbtgpuvsdn7vY0W-agftCPXpfV_09l88ok-P-dOOnfsq1pp4FmlBQK87QluERCUGE3WSZk_" +
+            "RqithWc6yeWxbEUAaaPPSlUl0XAcskntGDEloOB0_tcg0ZB9RautC2x9LDp5o6sIgCqaeEwnzzpBN9sUejZOjEqH8NBc";
     private static final String GCP_JWT_EXPIRED_TOKEN_BEARER = "Bearer " + GCP_JWT_EXPIRED_TOKEN;
     @Autowired
     private GCPRegistryApiService gcpRegistryApiService;

--- a/api/src/test/java/com/epam/pipeline/controller/gcp/GCPRegistryControllerTest.java
+++ b/api/src/test/java/com/epam/pipeline/controller/gcp/GCPRegistryControllerTest.java
@@ -1,0 +1,62 @@
+package com.epam.pipeline.controller.gcp;
+
+import com.epam.pipeline.acl.gcp.GCPRegistryApiService;
+import com.epam.pipeline.entity.pipeline.GcpArtifactRegistryEvent;
+import com.epam.pipeline.entity.pipeline.GcpArtifactRegistryEventBody;
+import com.epam.pipeline.entity.pipeline.Tool;
+import com.epam.pipeline.test.creator.docker.DockerCreatorUtils;
+import com.epam.pipeline.test.web.AbstractControllerTest;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.Base64;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+@WebMvcTest(controllers = GCPRegistryController.class)
+public class GCPRegistryControllerTest extends AbstractControllerTest {
+    private static final String GCP_REGISTRY_URL = SERVLET_PATH + "/gcpRegistry";
+    private static final String NOTIFY_GCP_REGISTRY_URL = GCP_REGISTRY_URL + "/notify";
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private final Tool tool = DockerCreatorUtils.getTool();
+    @Autowired
+    private GCPRegistryApiService mockGcpRegistryApiService;
+
+    @Test
+    public void shouldNotifyGcpRegistryEvent() throws Exception {
+        final GcpArtifactRegistryEventBody eventBody = createTestEventBody();
+        final String content = getObjectMapper().writeValueAsString(eventBody);
+        doReturn(tool).when(mockGcpRegistryApiService).notifyGcpRegistryEvent(eq(""), eq(eventBody));
+
+        final MvcResult mvcResult = performRequest(
+                post(NOTIFY_GCP_REGISTRY_URL).header(AUTHORIZATION_HEADER, "").content(content));
+
+        verify(mockGcpRegistryApiService).notifyGcpRegistryEvent(eq(""), eq(eventBody));
+        assertResponseEntity(mvcResult, tool);
+        assertEquals(mvcResult.getResponse().getStatus(), HttpStatus.OK.value());
+    }
+
+    private GcpArtifactRegistryEventBody createTestEventBody() throws JsonProcessingException {
+        GcpArtifactRegistryEvent gcpEvent = new GcpArtifactRegistryEvent();
+        gcpEvent.setAction("INSERT");
+        gcpEvent.setDigest("gcp-registry/gcp-project/gcp-repo/docker-image@sha256:f6c859b589b72e67c05db46df6b79ef7dc7");
+        gcpEvent.setTag("gcp-registry/gcp-project/gcp-repo/docker-image:latest");
+
+        GcpArtifactRegistryEventBody.Message message = new GcpArtifactRegistryEventBody.Message();
+        message.setData(Base64.getEncoder().encodeToString(getObjectMapper().writeValueAsBytes(gcpEvent)));
+        message.setMessageId("12345");
+        message.setPublishTime("2025-03-19T12:00:00Z");
+
+        GcpArtifactRegistryEventBody event = new GcpArtifactRegistryEventBody();
+        event.setMessage(message);
+        return event;
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/test/acl/AclTestBeans.java
+++ b/api/src/test/java/com/epam/pipeline/test/acl/AclTestBeans.java
@@ -30,6 +30,7 @@ import com.epam.pipeline.dao.pipeline.RestartRunDao;
 import com.epam.pipeline.dao.pipeline.RunLogDao;
 import com.epam.pipeline.dao.pipeline.RunStatusDao;
 import com.epam.pipeline.dao.pipeline.StopServerlessRunDao;
+import com.epam.pipeline.dao.region.CloudRegionDao;
 import com.epam.pipeline.dao.user.GroupStatusDao;
 import com.epam.pipeline.dao.user.RoleDao;
 import com.epam.pipeline.dao.user.UserDao;
@@ -156,6 +157,7 @@ import com.epam.pipeline.mapper.PermissionGrantVOMapper;
 import com.epam.pipeline.mapper.PipelineWithPermissionsMapper;
 import com.epam.pipeline.repository.notification.UserNotificationRepository;
 import com.epam.pipeline.security.acl.JdbcMutableAclServiceImpl;
+import com.epam.pipeline.security.jwt.GCPJwtTokenVerifier;
 import com.epam.pipeline.security.jwt.JwtTokenGenerator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -622,6 +624,12 @@ public class AclTestBeans {
 
     @MockBean
     protected EngineRunTaskService engineRunTaskService;
+
+    @MockBean
+    protected CloudRegionDao mockCloudRegionDao;
+
+    @SpyBean
+    protected GCPJwtTokenVerifier spyGcpJwtTokenVerifier;
 
     @Bean
     public GrantPermissionManager grantPermissionManager() {

--- a/api/src/test/java/com/epam/pipeline/test/web/AbstractControllerTest.java
+++ b/api/src/test/java/com/epam/pipeline/test/web/AbstractControllerTest.java
@@ -121,6 +121,13 @@ public abstract class AbstractControllerTest {
         assertEquals(expectedResult.getPayload(), actualResult.getPayload());
     }
 
+    @SneakyThrows
+    public <T> void assertResponseEntity(final MvcResult mvcResult, final T payload) {
+        final String actual = mvcResult.getResponse().getContentAsString();
+        assertTrue(StringUtils.isNotBlank(actual));
+        assertThat(actual).isEqualToIgnoringWhitespace(objectMapper.writeValueAsString(payload));
+    }
+
     public void assertResponse(final MvcResult mvcResult) {
         assertResponse(mvcResult, null, new TypeReference<Result<Object>>() {});
     }

--- a/api/src/test/java/com/epam/pipeline/test/web/ControllerTestBeans.java
+++ b/api/src/test/java/com/epam/pipeline/test/web/ControllerTestBeans.java
@@ -23,6 +23,7 @@ import com.epam.pipeline.acl.cluster.NatGatewayApiService;
 import com.epam.pipeline.acl.datastorage.lifecycle.DataStorageLifecycleApiService;
 import com.epam.pipeline.acl.datastorage.lustre.LustreFSApiService;
 import com.epam.pipeline.acl.datastorage.omics.AWSOmicsStoreApiService;
+import com.epam.pipeline.acl.gcp.GCPRegistryApiService;
 import com.epam.pipeline.acl.log.LogApiService;
 import com.epam.pipeline.acl.log.storage.StorageRequestApiService;
 import com.epam.pipeline.acl.notification.UserNotificationApiService;
@@ -294,4 +295,7 @@ public class ControllerTestBeans {
 
     @MockBean
     protected AWSOmicsStoreApiService awsOmicsStoreApiService;
+
+    @MockBean
+    protected GCPRegistryApiService gcpRegistryApiService;
 }

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/GcpArtifactRegistryEvent.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/GcpArtifactRegistryEvent.java
@@ -1,0 +1,10 @@
+package com.epam.pipeline.entity.pipeline;
+
+import lombok.Data;
+
+@Data
+public class GcpArtifactRegistryEvent {
+    private String action;
+    private String digest;
+    private String tag;
+}

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/GcpArtifactRegistryEventBody.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/GcpArtifactRegistryEventBody.java
@@ -1,0 +1,18 @@
+package com.epam.pipeline.entity.pipeline;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GcpArtifactRegistryEventBody {
+    private Message message;
+    private String subscription;
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Message {
+        private String data;
+        private String messageId;
+        private String publishTime;
+    }
+}


### PR DESCRIPTION
Resolves #3931 
     New Controller:
           1. Introduced /gcpRegistry/notification endpoint to handle push events from GCP Artifact Registry.
           2. Parses and processes incoming Pub/Sub event messages.
     Security Enhancement:
           1. Implemented JWT token verification to authenticate incoming requests from GCP Pub/Sub which ensures that only valid requests issued by GCP are processed.