### PR TITLE
Issue #3919: Allow to grant user/group permissions on storage paths

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/datastorage/permissions/StoragePathPermissionsApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/datastorage/permissions/StoragePathPermissionsApiService.java
@@ -16,7 +16,10 @@
 
 package com.epam.pipeline.acl.datastorage.permissions;
 
+import com.epam.pipeline.dto.PermissionVO;
+import com.epam.pipeline.dto.datastorage.permissions.StoragePathPermissionsVO;
 import com.epam.pipeline.dto.datastorage.permissions.StoragePathPermissions;
+import com.epam.pipeline.entity.datastorage.DataStorageItemType;
 import com.epam.pipeline.entity.user.SidImpl;
 import com.epam.pipeline.manager.datastorage.permissions.StoragePathPermissionsService;
 import com.epam.pipeline.security.acl.AclExpressions;
@@ -25,6 +28,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -49,7 +53,16 @@ public class StoragePathPermissionsApiService {
     }
 
     @PreAuthorize(AclExpressions.STORAGE_ID_OWNER)
-    public List<SidImpl> loadStoragePathPermissionsSids(final Long id) {
-        return storagePathPermissionsService.loadSids(id);
+    public List<PermissionVO> loadStoragePathPermissionsSids(final Long id, final String path,
+                                                             final DataStorageItemType type) {
+        return Objects.isNull(path)
+                ? storagePathPermissionsService.loadSids(id)
+                : storagePathPermissionsService.loadSidsByPath(id, path, type);
+    }
+
+    @PreAuthorize(AclExpressions.STORAGE_ID_OWNER)
+    public void updateStoragePathPermissionsForItems(final Long id,
+                                                     final List<StoragePathPermissionsVO> permissions) {
+        storagePathPermissionsService.updateByStorageIdAndPaths(id, permissions);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/acl/datastorage/tag/DataStorageTagBatchApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/datastorage/tag/DataStorageTagBatchApiService.java
@@ -45,7 +45,6 @@ public class DataStorageTagBatchApiService {
     @PreAuthorize(AclExpressions.STORAGE_ID_TAGS_REQUEST_WRITE)
     public List<DataStorageTag> upsert(final Long id, final DataStorageTagUpsertBatchRequest request) {
         return dataStorageTagBatchManager.upsert(id, request);
-
     }
 
     @PreAuthorize(AclExpressions.STORAGE_ID_WRITE)

--- a/api/src/main/java/com/epam/pipeline/controller/datastorage/permissions/StoragePathPermissionsController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/datastorage/permissions/StoragePathPermissionsController.java
@@ -19,7 +19,10 @@ package com.epam.pipeline.controller.datastorage.permissions;
 import com.epam.pipeline.acl.datastorage.permissions.StoragePathPermissionsApiService;
 import com.epam.pipeline.controller.AbstractRestController;
 import com.epam.pipeline.controller.Result;
+import com.epam.pipeline.dto.PermissionVO;
+import com.epam.pipeline.dto.datastorage.permissions.StoragePathPermissionsVO;
 import com.epam.pipeline.dto.datastorage.permissions.StoragePathPermissions;
+import com.epam.pipeline.entity.datastorage.DataStorageItemType;
 import com.epam.pipeline.entity.user.SidImpl;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -27,14 +30,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -44,14 +40,15 @@ import java.util.List;
 public class StoragePathPermissionsController extends AbstractRestController {
 
     private static final String ID = "id";
+    private static final String URL = "/datastorage/{id}/paths/permissions";
 
     private final StoragePathPermissionsApiService storagePathPermissionsApiService;
 
-    @PostMapping("/datastorage/{id}/paths/permissions")
+    @PostMapping(URL)
     @ResponseBody
     @ApiOperation(
-            value = "Updates storage path permissions specified storage and user/group.",
-            notes = "Updates storage path permissions specified storage and user/group.",
+            value = "Rewrites all storage path permissions for storage and user/group.",
+            notes = "Rewrites all storage path permissions for storage and user/group.",
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiResponses(
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
@@ -64,7 +61,7 @@ public class StoragePathPermissionsController extends AbstractRestController {
         return Result.success();
     }
 
-    @GetMapping("/datastorage/{id}/paths/permissions")
+    @GetMapping(URL)
     @ResponseBody
     @ApiOperation(
             value = "Loads storage path permissions for specified storage and current user.",
@@ -77,7 +74,7 @@ public class StoragePathPermissionsController extends AbstractRestController {
         return Result.success(storagePathPermissionsApiService.loadStoragePathPermissions(id));
     }
 
-    @DeleteMapping("/datastorage/{id}/paths/permissions")
+    @DeleteMapping(URL)
     @ResponseBody
     @ApiOperation(
             value = "Deletes storage path permissions for specified storage for specified users and groups.",
@@ -93,7 +90,7 @@ public class StoragePathPermissionsController extends AbstractRestController {
         return Result.success();
     }
 
-    @GetMapping("/datastorage/{id}/paths/permissions/sids")
+    @GetMapping(URL + "/sids")
     @ResponseBody
     @ApiOperation(
             value = "Loads users and groups that have storage path permissions for specified storage.",
@@ -102,7 +99,25 @@ public class StoragePathPermissionsController extends AbstractRestController {
     @ApiResponses(
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
             })
-    public Result<List<SidImpl>> loadStoragePathPermissionsSids(@PathVariable(value = ID) final Long id) {
-        return Result.success(storagePathPermissionsApiService.loadStoragePathPermissionsSids(id));
+    public Result<List<PermissionVO>> loadStoragePathPermissionsSids(
+            @PathVariable(value = ID) final Long id,
+            @RequestParam(required = false) final String path,
+            @RequestParam(required = false) final DataStorageItemType type) {
+        return Result.success(storagePathPermissionsApiService.loadStoragePathPermissionsSids(id, path, type));
+    }
+
+    @PutMapping(URL)
+    @ResponseBody
+    @ApiOperation(
+            value = "Updates storage path permissions for specified storage objects.",
+            notes = "Updates storage path permissions for specified storage objects.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
+            })
+    public Result updateStoragePathPermissionsForItems(
+            @PathVariable(value = ID) final Long id, @RequestBody final List<StoragePathPermissionsVO> permissions) {
+        storagePathPermissionsApiService.updateStoragePathPermissionsForItems(id, permissions);
+        return Result.success();
     }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/datastorage/permissions/StoragePathPermissionsController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/datastorage/permissions/StoragePathPermissionsController.java
@@ -30,7 +30,15 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 

--- a/api/src/main/java/com/epam/pipeline/dao/datastorage/permissions/StoragePathPermissionsDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/datastorage/permissions/StoragePathPermissionsDao.java
@@ -107,7 +107,7 @@ public class StoragePathPermissionsDao extends NamedParameterJdbcDaoSupport {
 
     public List<SidImpl> findSids(final Long storageId) {
         return getJdbcTemplate()
-                .query(findSidsWithStoragePathPermissionsQuery, Parameters.getSidsRowMapper(),  storageId);
+                .query(findSidsWithStoragePathPermissionsQuery, Parameters.getSidsRowMapper(), storageId);
     }
 
     private String buildWhere(final List<SidImpl> sids, final List<String> prefixes, final boolean foldersOnly) {

--- a/api/src/main/java/com/epam/pipeline/dao/datastorage/permissions/StoragePathPermissionsDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/datastorage/permissions/StoragePathPermissionsDao.java
@@ -43,9 +43,9 @@ public class StoragePathPermissionsDao extends NamedParameterJdbcDaoSupport {
     private final String deleteStoragePathPermissionsQuery;
     private final String loadStoragePathPermissionsQuery;
     private final String deleteStoragePathPermissionsByStorageIdQuery;
-    private final String findStoragePathPermissionsByPrefixQuery;
-    private final String countStoragePathPermissionsQuery;
     private final String findSidsWithStoragePathPermissionsQuery;
+    private final String findClosestStorageFolderPermissionQuery;
+    private final String loadClosetsStoragePathPermissionsByPrefixQuery;
 
     @Transactional(propagation = Propagation.MANDATORY)
     public void batchInsert(final List<StoragePathPermissions> entities, final Long storageId,
@@ -74,16 +74,6 @@ public class StoragePathPermissionsDao extends NamedParameterJdbcDaoSupport {
         return getJdbcTemplate().query(query, Parameters.getRowMapper(), storageId);
     }
 
-    public Optional<StoragePathPermissions> findClosestFolderPermission(final Long storageId,
-                                                                        final List<SidImpl> sids,
-                                                                        final List<String> paths) {
-        final String query = limitFirst(
-                WHERE_PATTERN.matcher(loadStoragePathPermissionsQuery)
-                        .replaceFirst(buildWhere(sids, paths, true)));
-        return getJdbcTemplate().query(query, Parameters.getRowMapper(), storageId).stream()
-                .findFirst();
-    }
-
     public Optional<StoragePathPermissions> findClosestFilePermission(final Long storageId,
                                                                       final List<SidImpl> sids,
                                                                       final List<String> tokens,
@@ -95,11 +85,13 @@ public class StoragePathPermissionsDao extends NamedParameterJdbcDaoSupport {
                 .findFirst();
     }
 
-    public int countParentFoldersByStorageAndSids(final Long storageId, final List<SidImpl> sids,
-                                                  final List<String> parentFolders) {
-        final String query = WHERE_PATTERN.matcher(countStoragePathPermissionsQuery)
-                .replaceFirst(buildWhere(sids, parentFolders, true));
-        return getJdbcTemplate().queryForObject(query, Integer.class, storageId);
+    public Optional<StoragePathPermissions> findClosestParentFolderPermission(final Long storageId,
+                                                                              final List<SidImpl> sids,
+                                                                              final List<String> parentFolders) {
+        final String query = limitFirst(WHERE_PATTERN.matcher(findClosestStorageFolderPermissionQuery)
+                .replaceFirst(buildWhere(sids, parentFolders, true)));
+        return getJdbcTemplate().query(query, Parameters.getRowMapper(), storageId).stream()
+                .findFirst();
     }
 
     public List<StoragePathPermissions> findByPrefix(final Long storageId, final List<SidImpl> sids,
@@ -107,7 +99,7 @@ public class StoragePathPermissionsDao extends NamedParameterJdbcDaoSupport {
         final MapSqlParameterSource parameters = new MapSqlParameterSource()
                 .addValue(Parameters.STORAGE_ID.name(), storageId)
                 .addValue(Parameters.FOLDER_PATH.name(), prefix + DaoHelper.POSTGRES_LIKE_CHARACTER);
-        final String query = WHERE_PATTERN.matcher(findStoragePathPermissionsByPrefixQuery)
+        final String query = WHERE_PATTERN.matcher(loadClosetsStoragePathPermissionsByPrefixQuery)
                 .replaceFirst(buildWhere(sids, null, false));
         return getNamedParameterJdbcTemplate()
                 .query(query, parameters, Parameters.getRowMapper());
@@ -201,6 +193,8 @@ public class StoragePathPermissionsDao extends NamedParameterJdbcDaoSupport {
                     .folderPath(rs.getString(FOLDER_PATH.name()))
                     .fileName(rs.getString(FILE_NAME.name()))
                     .mask(rs.getInt(MASK.name()))
+                    .sidName(rs.getString(SID_NAME.name()))
+                    .principal(rs.getBoolean(PRINCIPAL.name()))
                     .build();
         }
 

--- a/api/src/main/java/com/epam/pipeline/dao/datastorage/permissions/StoragePathPermissionsDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/datastorage/permissions/StoragePathPermissionsDao.java
@@ -70,7 +70,7 @@ public class StoragePathPermissionsDao extends NamedParameterJdbcDaoSupport {
     }
 
     @Transactional(propagation = Propagation.MANDATORY)
-    public void batchDelete(final List<StoragePathPermissions> entities, final Long storageId) {
+    public void batchDeleteByPath(final List<StoragePathPermissions> entities, final Long storageId) {
         final MapSqlParameterSource[] filesParams = entities.stream()
                 .filter(entity -> StringUtils.isNotBlank(entity.getFileName()))
                 .map(entity ->  new MapSqlParameterSource()
@@ -233,13 +233,6 @@ public class StoragePathPermissionsDao extends NamedParameterJdbcDaoSupport {
                     .addValue(MASK.name(), entity.getMask());
         }
 
-        static MapSqlParameterSource getPathParameters(final StoragePathPermissions entity, final Long storageId) {
-            return new MapSqlParameterSource()
-                    .addValue(STORAGE_ID.name(), storageId)
-                    .addValue(FOLDER_PATH.name(), entity.getFolderPath())
-                    .addValue(FILE_NAME.name(), entity.getFileName());
-        }
-
         static RowMapper<StoragePathPermissions> getRowMapper() {
             return (rs, rowNum) -> StoragePathPermissions.builder()
                     .folderPath(rs.getString(FOLDER_PATH.name()))
@@ -270,6 +263,6 @@ public class StoragePathPermissionsDao extends NamedParameterJdbcDaoSupport {
 
     private String pathWhere(final String query, final String fileName) {
         return WHERE_PATTERN.matcher(query).replaceFirst(" p.file_name " +
-                (StringUtils.isNotBlank(fileName) ? "= '" + fileName + " '" : "IS NULL "));
+                (StringUtils.isNotBlank(fileName) ? "= '" + fileName + "' " : "IS NULL "));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/dao/datastorage/permissions/StoragePathPermissionsDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/datastorage/permissions/StoragePathPermissionsDao.java
@@ -22,6 +22,8 @@ import com.epam.pipeline.entity.user.SidImpl;
 import joptsimple.internal.Strings;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcDaoSupport;
@@ -46,6 +48,9 @@ public class StoragePathPermissionsDao extends NamedParameterJdbcDaoSupport {
     private final String findSidsWithStoragePathPermissionsQuery;
     private final String findClosestStorageFolderPermissionQuery;
     private final String loadClosetsStoragePathPermissionsByPrefixQuery;
+    private final String deleteStoragePathPermissionsByFilePathQuery;
+    private final String deleteStoragePathPermissionsByFolderPathQuery;
+    private final String loadStoragePathPermissionsByPathQuery;
 
     @Transactional(propagation = Propagation.MANDATORY)
     public void batchInsert(final List<StoragePathPermissions> entities, final Long storageId,
@@ -54,6 +59,37 @@ public class StoragePathPermissionsDao extends NamedParameterJdbcDaoSupport {
                 .map(entity -> Parameters.getParameters(entity, storageId, sidId, principal))
                 .toArray(MapSqlParameterSource[]::new);
         getNamedParameterJdbcTemplate().batchUpdate(insertStoragePathPermissionsQuery, parameters);
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void batchInsert(final List<StoragePathPermissions> entities, final Long storageId) {
+        final MapSqlParameterSource[] parameters = entities.stream()
+                .map(entity -> Parameters.getParameters(entity, storageId, entity.getSidName(), entity.isPrincipal()))
+                .toArray(MapSqlParameterSource[]::new);
+        getNamedParameterJdbcTemplate().batchUpdate(insertStoragePathPermissionsQuery, parameters);
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void batchDelete(final List<StoragePathPermissions> entities, final Long storageId) {
+        final MapSqlParameterSource[] filesParams = entities.stream()
+                .filter(entity -> StringUtils.isNotBlank(entity.getFileName()))
+                .map(entity ->  new MapSqlParameterSource()
+                        .addValue(Parameters.STORAGE_ID.name(), storageId)
+                        .addValue(Parameters.FOLDER_PATH.name(), entity.getFolderPath())
+                        .addValue(Parameters.FILE_NAME.name(), entity.getFileName()))
+                .toArray(MapSqlParameterSource[]::new);
+        if (ArrayUtils.isNotEmpty(filesParams)) {
+            getNamedParameterJdbcTemplate().batchUpdate(deleteStoragePathPermissionsByFilePathQuery, filesParams);
+        }
+        final MapSqlParameterSource[] foldersParams = entities.stream()
+                .filter(entity -> StringUtils.isBlank(entity.getFileName()))
+                .map(entity ->  new MapSqlParameterSource()
+                        .addValue(Parameters.STORAGE_ID.name(), storageId)
+                        .addValue(Parameters.FOLDER_PATH.name(), entity.getFolderPath()))
+                .toArray(MapSqlParameterSource[]::new);
+        if (ArrayUtils.isNotEmpty(foldersParams)) {
+            getNamedParameterJdbcTemplate().batchUpdate(deleteStoragePathPermissionsByFolderPathQuery, foldersParams);
+        }
     }
 
     @Transactional(propagation = Propagation.MANDATORY)
@@ -66,6 +102,15 @@ public class StoragePathPermissionsDao extends NamedParameterJdbcDaoSupport {
     @Transactional(propagation = Propagation.MANDATORY)
     public void deleteForStorageId(final Long storageId) {
         getJdbcTemplate().update(deleteStoragePathPermissionsByStorageIdQuery, storageId);
+    }
+
+    public List<StoragePathPermissions> loadByPath(final Long storageId, final String folderPath,
+                                                   final String fileName) {
+        final MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue(Parameters.STORAGE_ID.name(), storageId)
+                .addValue(Parameters.FOLDER_PATH.name(), folderPath);
+        final String query = pathWhere(loadStoragePathPermissionsByPathQuery, fileName);
+        return getNamedParameterJdbcTemplate().query(query, params, Parameters.getRowMapper());
     }
 
     public List<StoragePathPermissions> findByStorageAndSids(final Long storageId, final List<SidImpl> sids) {
@@ -188,6 +233,13 @@ public class StoragePathPermissionsDao extends NamedParameterJdbcDaoSupport {
                     .addValue(MASK.name(), entity.getMask());
         }
 
+        static MapSqlParameterSource getPathParameters(final StoragePathPermissions entity, final Long storageId) {
+            return new MapSqlParameterSource()
+                    .addValue(STORAGE_ID.name(), storageId)
+                    .addValue(FOLDER_PATH.name(), entity.getFolderPath())
+                    .addValue(FILE_NAME.name(), entity.getFileName());
+        }
+
         static RowMapper<StoragePathPermissions> getRowMapper() {
             return (rs, rowNum) -> StoragePathPermissions.builder()
                     .folderPath(rs.getString(FOLDER_PATH.name()))
@@ -214,5 +266,10 @@ public class StoragePathPermissionsDao extends NamedParameterJdbcDaoSupport {
 
     private String limitFirst(final String query) {
         return LIMIT_PATTERN.matcher(query).replaceFirst(" LIMIT 1");
+    }
+
+    private String pathWhere(final String query, final String fileName) {
+        return WHERE_PATTERN.matcher(query).replaceFirst(" p.file_name " +
+                (StringUtils.isNotBlank(fileName) ? "= '" + fileName + " '" : "IS NULL "));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
@@ -794,7 +794,7 @@ public class DataStorageManager implements SecuredEntityManager {
         final AbstractDataStorage dataStorage = load(id);
         checkDataStorageVersioning(dataStorage, version);
         checkDataStorageObjectExists(dataStorage, path, version);
-        checkReadPermissionsOnFile(dataStorage, path);
+        checkWritePermissionsOnFile(dataStorage, path);
         tagProviderManager.deleteFileTags(dataStorage, path, version, tags);
         return tagProviderManager.loadFileTags(dataStorage, path, version);
     }
@@ -871,7 +871,7 @@ public class DataStorageManager implements SecuredEntityManager {
         final AbstractDataStorage dataStorage = load(id);
         checkDataStorageVersioning(dataStorage, version);
         checkDataStorageObjectExists(dataStorage, path, version);
-        checkReadPermissionsOnFile(dataStorage, path);
+        checkWritePermissionsOnFile(dataStorage, path);
         return tagProviderManager.updateFileTags(dataStorage, path, version, tagsToAdd, rewrite);
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
@@ -101,6 +101,7 @@ import com.epam.pipeline.manager.security.acl.AclSync;
 import com.epam.pipeline.manager.security.storage.StoragePermissionManager;
 import com.epam.pipeline.manager.user.RoleManager;
 import com.epam.pipeline.manager.user.UserManager;
+import com.epam.pipeline.security.acl.AclPermission;
 import com.epam.pipeline.utils.PipelineStringUtils;
 import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.extern.slf4j.Slf4j;
@@ -580,10 +581,12 @@ public class DataStorageManager implements SecuredEntityManager {
         final StorageFolderListPermissionsContainer permissionsContainer = getPermissionsContainer(dataStorage, path);
         if (!showArchived && DataStorageType.S3.equals(dataStorage.getType())) {
             final DataStorageLifecycleRestoredListingContainer restoredListing = loadRestoredPaths(dataStorage, path);
-            return storageProviderManager.getRestoredItems(dataStorage, path, showVersion, pageSize, marker,
-                    restoredListing, permissionsContainer);
+            return addPathsMasks(dataStorage, permissionsContainer, storageProviderManager
+                    .getRestoredItems(dataStorage, path, showVersion, pageSize, marker, restoredListing,
+                            permissionsContainer));
         }
-        return storageProviderManager.getItems(dataStorage, path, showVersion, pageSize, marker, permissionsContainer);
+        return addPathsMasks(dataStorage, permissionsContainer, storageProviderManager
+                .getItems(dataStorage, path, showVersion, pageSize, marker, permissionsContainer));
     }
 
     public DataStorageListing filterDataStorageItems(final Long storageId, final String path,
@@ -1572,5 +1575,22 @@ public class DataStorageManager implements SecuredEntityManager {
     private boolean needToLoadPathPermissions(final AbstractDataStorage storage) {
         return storage.isPathPermissionsEnabled() && DataStorageType.S3.equals(storage.getType())
                 && !authManager.isAdmin() && !authManager.getAuthorizedUser().equalsIgnoreCase(storage.getOwner());
+    }
+
+    private DataStorageListing addPathsMasks(final AbstractDataStorage storage,
+                                             final StorageFolderListPermissionsContainer permissionsContainer,
+                                             final DataStorageListing listing) {
+        if (!DataStorageType.S3.equals(storage.getType()) || !storage.isPathPermissionsEnabled()) {
+            return listing;
+        }
+        if (Objects.isNull(permissionsContainer)) {
+            listing.setParentFolderMask(AbstractSecuredEntity.ALL_PERMISSIONS_MASK);
+            ListUtils.emptyIfNull(listing.getResults())
+                    .forEach(r -> r.setMask(AbstractSecuredEntity.ALL_PERMISSIONS_MASK));
+            return listing;
+        }
+        listing.setParentFolderMask(Optional.ofNullable(permissionsContainer.getFolderMask())
+                .orElse(AclPermission.READ.getMask()));
+        return listing;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/permissions/StoragePathPermissionsService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/permissions/StoragePathPermissionsService.java
@@ -34,6 +34,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
@@ -45,8 +46,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -197,7 +200,7 @@ public class StoragePathPermissionsService {
      * Determines if current user can see folder by given path. To have such access to folder user may have
      * permissions to:
      *  - folder directly
-     *  - one oth parent folders
+     *  - one of the parent folders
      *  - one of the child files or folders
      * That permission does not indicate that user can read folder content.
      * If no permissions provided for user directly or one of user`s group an AccessDeniedException shall be occurred.
@@ -207,7 +210,22 @@ public class StoragePathPermissionsService {
      */
     public void canGetFolder(final Long storageId, final String path) {
         log.debug("Checking current user can get folder '{}' for storage '{}'", path, storageId);
-        getFolderListPermissions(storageId, path);
+        final String folderPath = normalizePath(path);
+        final List<SidImpl> sids = getSids();
+        final List<String> parentFolders = splitPath(folderPath);
+
+        final Optional<StoragePathPermissions> closestFolderPermission = pathPermissionsDao
+                .findClosestParentFolderPermission(storageId, sids, parentFolders);
+        if (closestFolderPermission.isPresent()) {
+            log.debug("Permissions on parent folder found for path '{}' and storage '{}'", path, storageId);
+            return;
+        }
+
+        log.debug("No permissions on parent folders for path '{}' and storage '{}'. Checking children paths..",
+                path, storageId);
+        if (CollectionUtils.isEmpty(pathPermissionsDao.findByPrefix(storageId, sids, folderPath))) {
+            throw new AccessDeniedException("Access is denied");
+        }
     }
 
     /**
@@ -220,20 +238,34 @@ public class StoragePathPermissionsService {
     public StorageFolderListPermissionsContainer getFolderListPermissions(final Long storageId, final String path) {
         final String folderPath = normalizePath(path);
         final List<SidImpl> sids = getSids();
+        final List<String> parentFolders = splitPath(folderPath);
 
-        if (hasPermissionsOnFolder(folderPath, storageId, sids)) {
-            // has permissions on current folder or it's parents
-            log.debug("Current user can list folder '{}' for storage '{}'", path, storageId);
-            return StorageFolderListPermissionsContainer.builder().hasListPermissions(true).build();
-        }
-        log.debug("Current user cannot list folder '{}' for storage '{}'. Checking any permissions on child paths...",
-                path, storageId);
+        final StorageFolderListPermissionsContainer permissionsContainer =
+                StorageFolderListPermissionsContainer.builder().build();
 
-        final List<StoragePathPermissions> childPaths = pathPermissionsDao.findByPrefix(storageId, sids, folderPath);
-        if (CollectionUtils.isEmpty(childPaths)) {
+        final Integer folderMask = pathPermissionsDao.findClosestParentFolderPermission(storageId, sids, parentFolders)
+                .map(StoragePathPermissions::getMask)
+                .orElse(null);
+        permissionsContainer.setFolderMask(folderMask);
+
+        final List<StoragePathPermissions> childPermissions = pathPermissionsDao
+                .findByPrefix(storageId, sids, folderPath);
+        if (Objects.isNull(folderMask) && CollectionUtils.isEmpty(childPermissions)) {
             throw new AccessDeniedException("Access is denied");
         }
-        return buildCurrentFolderPermissionsContainer(childPaths, folderPath);
+        if (CollectionUtils.isEmpty(childPermissions)) {
+            // permissions shall be inherited from folder
+            return permissionsContainer;
+        }
+        final Map<String, Integer> files = getFilesInCurrentFolder(childPermissions, folderPath);
+        if (MapUtils.isNotEmpty(files)) {
+            permissionsContainer.setFiles(files);
+        }
+        final Map<String, Integer> folders = getFoldersInCurrentFolder(childPermissions, folderPath);
+        if (MapUtils.isNotEmpty(folders)) {
+            permissionsContainer.setFolders(folders);
+        }
+        return permissionsContainer;
     }
 
     private Optional<StoragePathPermissions> findFilePermissions(final Long storageId, final String path) {
@@ -251,7 +283,7 @@ public class StoragePathPermissionsService {
         final String folderPath = normalizePath(path);
         final List<String> prefixes = splitPath(folderPath);
         final List<SidImpl> sids = getSids();
-        return pathPermissionsDao.findClosestFolderPermission(storageId, sids, prefixes);
+        return pathPermissionsDao.findClosestParentFolderPermission(storageId, sids, prefixes);
     }
 
     private StoragePathPermissions normalizePermissions(final StoragePathPermissions permissions) {
@@ -323,46 +355,27 @@ public class StoragePathPermissionsService {
         return firstSlashIndex != -1 ? relativePath.substring(0, firstSlashIndex) : relativePath;
     }
 
-    private List<String> getFolderNamesInCurrentFolder(final List<StoragePathPermissions> loadedPaths,
-                                                       final String currentFolder) {
-        return loadedPaths.stream()
-                .map(StoragePathPermissions::getFolderPath)
-                .distinct()
-                .map(folderPath -> extractFolderName(folderPath, currentFolder))
-                .distinct()
-                .filter(StringUtils::isNotBlank)
-                .collect(Collectors.toList());
+    private Map<String, Integer> getFoldersInCurrentFolder(final List<StoragePathPermissions> loadedPaths,
+                                                           final String currentFolder) {
+        final Map<String, Integer> results = new HashMap<>();
+        // Step #1: add permissions that granted on folders directly
+        loadedPaths.stream()
+                .filter(permission -> StringUtils.isBlank(permission.getFileName()))
+                .filter(permission -> !permission.getFolderPath().equals(currentFolder))
+                .forEach(permission -> collectPermissionsInFolder(permission, currentFolder, results));
+        // Step #2: add the rest folders with read-only access level.
+        // If folder already added at Step #1 the lowes permission shall be chosen.
+        loadedPaths
+                .forEach(permission -> collectPermissionsInFolderRecursively(permission, currentFolder, results));
+        return results;
     }
 
-    private List<String> getFileNamesInCurrentFolder(final List<StoragePathPermissions> loadedPaths,
-                                                     final String currentFolder) {
+    private Map<String, Integer> getFilesInCurrentFolder(final List<StoragePathPermissions> loadedPaths,
+                                                         final String currentFolder) {
         return loadedPaths.stream()
                 .filter(permissions -> currentFolder.equals(permissions.getFolderPath()))
-                .map(StoragePathPermissions::getFileName)
-                .filter(StringUtils::isNotBlank)
-                .collect(Collectors.toList());
-    }
-
-    private StorageFolderListPermissionsContainer buildCurrentFolderPermissionsContainer(
-            final List<StoragePathPermissions> loadedPaths, final String currentFolder) {
-        final StorageFolderListPermissionsContainer container = StorageFolderListPermissionsContainer.builder()
-                .hasListPermissions(false)
-                .build();
-        final List<String> fileNames = getFileNamesInCurrentFolder(loadedPaths, currentFolder);
-        if (CollectionUtils.isNotEmpty(fileNames)) {
-            container.setFiles(fileNames);
-        }
-        final List<String> folderNames = getFolderNamesInCurrentFolder(loadedPaths, currentFolder);
-        if (CollectionUtils.isNotEmpty(folderNames)) {
-            container.setFolders(folderNames);
-        }
-        return container;
-    }
-
-    private boolean hasPermissionsOnFolder(final String currentFolder, final Long storageId,
-                                           final List<SidImpl> sids) {
-        final List<String> prefixes = splitPath(currentFolder);
-        return pathPermissionsDao.countParentFoldersByStorageAndSids(storageId, sids, prefixes) > 0;
+                .filter(permissions -> StringUtils.isNotBlank(permissions.getFileName()))
+                .collect(Collectors.toMap(StoragePathPermissions::getFileName, StoragePathPermissions::getMask));
     }
 
     private boolean hasWritePermissions(final StoragePathPermissions permissions) {
@@ -387,5 +400,36 @@ public class StoragePathPermissionsService {
         final AbstractDataStorage storage = findStorage(storageId);
         Assert.state(pathPermissionsAllowed(storage),
                 messageHelper.getMessage(MessageConstants.ERROR_DATASTORAGE_PATH_PERMISSIONS_NOT_ALLOWED));
+    }
+
+    private void collectPermissionsInFolder(final StoragePathPermissions permission,
+                                            final String currentFolder,
+                                            final Map<String, Integer> masksByNames) {
+        final String folderPath = permission.getFolderPath();
+        final String folderName = extractFolderName(folderPath, currentFolder);
+        final int mask = permission.getMask();
+        if (folderPath.endsWith(folderName + ProviderUtils.DELIMITER)) {
+            masksByNames.putIfAbsent(folderName, mask);
+        }
+    }
+
+    private void collectPermissionsInFolderRecursively(final StoragePathPermissions permission,
+                                                       final String currentFolder,
+                                                       final Map<String, Integer> masksByNames) {
+        final String folderName = extractFolderName(permission.getFolderPath(), currentFolder);
+        if (StringUtils.isBlank(folderName)) {
+            return;
+        }
+        if (!masksByNames.containsKey(folderName)) {
+            masksByNames.put(folderName, AclPermission.READ.getMask());
+            return;
+        }
+        final int oldMask = Optional.ofNullable(masksByNames.get(folderName)).orElse(0);
+        final int newMask = permission.getMask();
+        // downgrade permission:
+        // if at least one child path has lower permissions parent folder shall respect it
+        if (newMask < oldMask) {
+            masksByNames.put(folderName, newMask);
+        }
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/permissions/StoragePathPermissionsService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/permissions/StoragePathPermissionsService.java
@@ -145,7 +145,7 @@ public class StoragePathPermissionsService {
         toDelete.addAll(toUpdate);
         if (CollectionUtils.isNotEmpty(toDelete)) {
             log.debug("Deleting '{}' storage path permissions for storage '{}'", toDelete.size(), storageId);
-            pathPermissionsDao.batchDelete(toDelete, storageId);
+            pathPermissionsDao.batchDeleteByPath(toDelete, storageId);
         }
         if (CollectionUtils.isNotEmpty(toUpdate)) {
             log.debug("Inserting '{}' storage path permissions for storage '{}'", toUpdate.size(), storageId);

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/permissions/StoragePathPermissionsService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/permissions/StoragePathPermissionsService.java
@@ -229,6 +229,28 @@ public class StoragePathPermissionsService {
     }
 
     /**
+     * Filters input file paths according to specified permission mask.
+     *
+     * @param storageId storage ID
+     * @param files list of files paths to filter
+     * @param mask target permission mask (1 - read, 4 - write)
+     * @return Filtered files paths
+     */
+    public List<String> filterFiles(final Long storageId, final List<String> files, final int mask) {
+        final List<SidImpl> sids = getSids();
+        final Map<String, Integer> dbMasksByPaths = ListUtils.emptyIfNull(
+                pathPermissionsDao.findByStorageAndSids(storageId, sids)).stream()
+                .collect(Collectors.toMap(permission -> StringUtils.isBlank(permission.getFileName())
+                                ? permission.getFolderPath()
+                                : permission.getFolderPath() + permission.getFileName(),
+                        StoragePathPermissions::getMask));
+
+        return files.stream()
+                .filter(filePath -> isMaskMatch(filePath, mask, dbMasksByPaths))
+                .collect(Collectors.toList());
+    }
+
+    /**
      * Returns container with paths that have read permissions on specified folder.
      *
      * @param storageId storage ID
@@ -431,5 +453,28 @@ public class StoragePathPermissionsService {
         if (newMask < oldMask) {
             masksByNames.put(folderName, newMask);
         }
+    }
+
+    private Optional<Integer> findMatchingMask(final String filePath, final Map<String, Integer> masksByPaths) {
+        String currentPath = ProviderUtils.withLeadingDelimiter(filePath);
+
+        // Traverse the folder hierarchy from the file path back to the root
+        while (currentPath.contains(ProviderUtils.DELIMITER)) {
+            final Integer mask = masksByPaths.get(currentPath);
+            if (Objects.nonNull(mask)) {
+                return Optional.of(mask);
+            }
+            currentPath = normalizePath(currentPath.substring(0, currentPath.lastIndexOf(ProviderUtils.DELIMITER)));
+            if (currentPath.equals(ProviderUtils.DELIMITER)) {
+                break;
+            }
+        }
+        return Optional.empty();
+    }
+
+    private boolean isMaskMatch(final String filePath, final int mask, final Map<String, Integer> masksByPaths) {
+        return findMatchingMask(filePath, masksByPaths)
+                .map(actualMask -> (actualMask & mask) != 0)
+                .orElse(false);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/permissions/StoragePathPermissionsService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/permissions/StoragePathPermissionsService.java
@@ -20,9 +20,12 @@ import com.epam.pipeline.common.MessageConstants;
 import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.dao.datastorage.DataStorageDao;
 import com.epam.pipeline.dao.datastorage.permissions.StoragePathPermissionsDao;
+import com.epam.pipeline.dto.PermissionVO;
+import com.epam.pipeline.dto.datastorage.permissions.StoragePathPermissionsVO;
 import com.epam.pipeline.dto.datastorage.permissions.StoragePathPermissions;
 import com.epam.pipeline.dto.datastorage.permissions.StorageFolderListPermissionsContainer;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
+import com.epam.pipeline.entity.datastorage.DataStorageItemType;
 import com.epam.pipeline.entity.datastorage.DataStorageType;
 import com.epam.pipeline.entity.user.PipelineUser;
 import com.epam.pipeline.entity.user.Role;
@@ -30,6 +33,7 @@ import com.epam.pipeline.entity.user.SidImpl;
 import com.epam.pipeline.manager.datastorage.providers.ProviderUtils;
 import com.epam.pipeline.manager.user.UserManager;
 import com.epam.pipeline.security.acl.AclPermission;
+import joptsimple.internal.Strings;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
@@ -113,6 +117,43 @@ public class StoragePathPermissionsService {
     }
 
     /**
+     * Updated permissions for specified storage and paths.
+     * If no permissions provided all permissions will be deleted for certain path.
+     *
+     * @param storageId storage ID
+     * @param rawPermissions the list of permissions for storage item path.
+     */
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void updateByStorageIdAndPaths(final Long storageId,
+                                          final List<StoragePathPermissionsVO> rawPermissions) {
+        checkStorageExistsAndPathPermissionsAllowed(storageId);
+        if (CollectionUtils.isEmpty(rawPermissions)) {
+            log.debug("No permissions found to update for storage '{}'", storageId);
+            return;
+        }
+        final List<StoragePathPermissions> toUpdate = rawPermissions.stream()
+                .peek(this::verifyRawPermissionsVO)
+                .flatMap(pathPermissions -> ListUtils.emptyIfNull(pathPermissions.getPermissions()).stream()
+                        .map(permissionVO -> toEntity(pathPermissions.getPath(),
+                                pathPermissions.getType(), permissionVO)))
+                .collect(Collectors.toList());
+        // collect permissions to delete if permissions were not provided for path
+        final List<StoragePathPermissions> toDelete = rawPermissions.stream()
+                .filter(vo -> CollectionUtils.isEmpty(vo.getPermissions()))
+                .map(vo -> toEntity(vo.getPath(), vo.getType()))
+                .collect(Collectors.toList());
+        toDelete.addAll(toUpdate);
+        if (CollectionUtils.isNotEmpty(toDelete)) {
+            log.debug("Deleting '{}' storage path permissions for storage '{}'", toDelete.size(), storageId);
+            pathPermissionsDao.batchDelete(toDelete, storageId);
+        }
+        if (CollectionUtils.isNotEmpty(toUpdate)) {
+            log.debug("Inserting '{}' storage path permissions for storage '{}'", toUpdate.size(), storageId);
+            pathPermissionsDao.batchInsert(toUpdate, storageId);
+        }
+    }
+
+    /**
      * Deletes permissions for specified storage. If sids provided permissions shall be
      * deleted for specified users/groups only.
      *
@@ -138,9 +179,39 @@ public class StoragePathPermissionsService {
      * @param storageId storage ID
      * @return users and groups list
      */
-    public List<SidImpl> loadSids(final Long storageId) {
+    public List<PermissionVO> loadSids(final Long storageId) {
         checkStorageExistsAndPathPermissionsAllowed(storageId);
-        return pathPermissionsDao.findSids(storageId);
+        return pathPermissionsDao.findSids(storageId).stream()
+                .map(sid -> PermissionVO.builder()
+                        .name(sid.getName())
+                        .principal(sid.isPrincipal())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns all user/groups with masks for specified storage item.
+     *
+     * @param storageId storage ID
+     * @param path full path from storage root to item
+     * @param type indicated file or folder
+     * @return the list of granted permissions
+     */
+    public List<PermissionVO> loadSidsByPath(final Long storageId, final String path, final DataStorageItemType type) {
+        checkStorageExistsAndPathPermissionsAllowed(storageId);
+        verifyStorageItemType(type);
+        final List<StoragePathPermissions> entities = loadPermissionsForItem(storageId, path, type);
+        if (CollectionUtils.isEmpty(entities)) {
+            log.debug("No permissions found for {} '{}' for storage '{}'", type.name(), path, storageId);
+            return Collections.emptyList();
+        }
+        return entities.stream()
+                .map(entity -> PermissionVO.builder()
+                        .name(entity.getSidName())
+                        .principal(entity.isPrincipal())
+                        .mask(entity.getMask())
+                        .build())
+                .collect(Collectors.toList());
     }
 
     /**
@@ -476,5 +547,60 @@ public class StoragePathPermissionsService {
         return findMatchingMask(filePath, masksByPaths)
                 .map(actualMask -> (actualMask & mask) != 0)
                 .orElse(false);
+    }
+
+    private StoragePathPermissions toEntity(final String path, final DataStorageItemType type,
+                                            final PermissionVO permission) {
+        final StoragePathPermissions entity = toEntity(path, type);
+
+        entity.setMask(permission.getMask());
+        entity.setPrincipal(permission.getPrincipal());
+        entity.setSidName(permission.getName().toUpperCase(Locale.ROOT));
+
+        return entity;
+    }
+
+    private StoragePathPermissions toEntity(final String path, final DataStorageItemType type) {
+        final StoragePathPermissions entity = new StoragePathPermissions();
+        if (DataStorageItemType.Folder.equals(type)) {
+            entity.setFolderPath(normalizePath(path));
+        } else {
+            final int lastSeparatorIndex = path.lastIndexOf(ProviderUtils.DELIMITER);
+            entity.setFolderPath(normalizePath(extractFolderPath(path, lastSeparatorIndex)));
+            entity.setFileName(extractFileName(path, lastSeparatorIndex));
+        }
+        return entity;
+    }
+
+    private List<StoragePathPermissions> loadPermissionsForItem(final Long storageId, final String path,
+                                                                final DataStorageItemType type) {
+        if (DataStorageItemType.Folder.equals(type)) {
+            final String folderPath = normalizePath(path);
+            return pathPermissionsDao.loadByPath(storageId, folderPath, null);
+        } else {
+            final int lastSeparatorIndex = path.lastIndexOf(ProviderUtils.DELIMITER);
+            final String folderPath = normalizePath(extractFolderPath(path, lastSeparatorIndex));
+            final String fileName = extractFileName(path, lastSeparatorIndex);
+            return pathPermissionsDao.loadByPath(storageId, folderPath, fileName);
+        }
+    }
+
+    private void verifyRawPermissionsVO(final StoragePathPermissionsVO vo) {
+        Assert.state(Objects.nonNull(vo), "Permissions shall be specified");
+        Assert.state(StringUtils.isNotBlank(vo.getPath()), "Item path shall be specified");
+        verifyStorageItemType(vo.getType());
+    }
+
+    private void verifyStorageItemType(final DataStorageItemType type) {
+        Assert.state(Objects.nonNull(type), "Item type shall be specified");
+    }
+
+    private String extractFileName(final String path, final int lastSeparatorIndex) {
+        return ProviderUtils.withoutLeadingDelimiter(
+                lastSeparatorIndex == -1 ? path : path.substring(lastSeparatorIndex));
+    }
+
+    private String extractFolderPath(final String path, final int lastSeparatorIndex) {
+        return lastSeparatorIndex == -1 ? Strings.EMPTY : path.substring(0, lastSeparatorIndex + 1);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/permissions/StoragePathPermissionsUtils.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/permissions/StoragePathPermissionsUtils.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.datastorage.permissions;
+
+import com.epam.pipeline.dto.datastorage.permissions.StorageFolderListPermissionsContainer;
+import org.apache.commons.collections4.MapUtils;
+
+import java.util.Objects;
+
+public interface StoragePathPermissionsUtils {
+
+    static Integer getFolderMask(final StorageFolderListPermissionsContainer container, final String folderName) {
+        if (Objects.isNull(container)) {
+            return null;
+        }
+        return MapUtils.emptyIfNull(container.getFolders()).getOrDefault(folderName, container.getFolderMask());
+    }
+
+    static Integer getFileMask(final StorageFolderListPermissionsContainer container, final String fileName) {
+        if (Objects.isNull(container)) {
+            return null;
+        }
+        return MapUtils.emptyIfNull(container.getFiles()).getOrDefault(fileName, container.getFolderMask());
+    }
+
+    static boolean filterNotAllowedFiles(final StorageFolderListPermissionsContainer container,
+                                         final String fileName) {
+        return Objects.nonNull(container)
+                && Objects.isNull(container.getFolderMask())
+                && !MapUtils.emptyIfNull(container.getFiles()).containsKey(fileName);
+    }
+
+    static boolean filterNotAllowedFolders(final StorageFolderListPermissionsContainer container,
+                                           final String folderName) {
+        return Objects.nonNull(container)
+                && Objects.isNull(container.getFolderMask())
+                && !MapUtils.emptyIfNull(container.getFolders()).containsKey(folderName);
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/omics/OmicsReferenceStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/omics/OmicsReferenceStorageProvider.java
@@ -188,7 +188,7 @@ public class OmicsReferenceStorageProvider extends AbstractOmicsStorageProvider<
                 }));
 
         Assert.notEmpty(results, String.format("Path '%s' not found!", path));
-        return new DataStorageListing(null, results);
+        return new DataStorageListing(null, null, results);
     }
 
     @Override
@@ -198,6 +198,7 @@ public class OmicsReferenceStorageProvider extends AbstractOmicsStorageProvider<
                 .listReferences(dataStorage, pageSize, marker);
         return new DataStorageListing(
                 result.getNextToken(),
+                null,
                 Optional.ofNullable(result.getReferences()).orElse(Collections.emptyList()).stream()
                         .map(refItem -> {
                             final DataStorageFolder file = new DataStorageFolder();

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/omics/OmicsSequenceStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/omics/OmicsSequenceStorageProvider.java
@@ -166,7 +166,7 @@ public class OmicsSequenceStorageProvider extends AbstractOmicsStorageProvider<A
                 }));
 
         Assert.notEmpty(results, String.format("Path '%s' not found!", path));
-        return new DataStorageListing(null, results);
+        return new DataStorageListing(null, null, results);
     }
 
     @Override
@@ -175,6 +175,7 @@ public class OmicsSequenceStorageProvider extends AbstractOmicsStorageProvider<A
         final ListReadSetsResult result = getOmicsHelper(dataStorage).listReadSets(dataStorage, pageSize, marker);
         return new DataStorageListing(
                 result.getNextToken(),
+                null,
                 Optional.ofNullable(result.getReadSets()).orElse(Collections.emptyList()).stream()
                         .map(readSet -> {
                             final DataStorageFolder file = new DataStorageFolder();

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3Helper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3Helper.java
@@ -88,6 +88,7 @@ import com.epam.pipeline.exception.ObjectNotFoundException;
 import com.epam.pipeline.entity.datastorage.access.DataAccessType;
 import com.epam.pipeline.entity.datastorage.access.DataAccessEvent;
 import com.epam.pipeline.manager.datastorage.lifecycle.DataStorageLifecycleRestoredListingContainer;
+import com.epam.pipeline.manager.datastorage.permissions.StoragePathPermissionsUtils;
 import com.epam.pipeline.manager.datastorage.providers.StorageEventCollector;
 import com.epam.pipeline.manager.datastorage.providers.ProviderUtils;
 import com.epam.pipeline.utils.FileContentUtils;
@@ -854,12 +855,13 @@ public class S3Helper {
                             continue;
                         }
                     }
-                    if (filterNotAllowedFiles(file.getName(), permissionsContainer)) {
+                    if (StoragePathPermissionsUtils.filterNotAllowedFiles(permissionsContainer, file.getName())) {
                         continue;
                     }
                     if (filterNotRestored(file, fileName, restoredListing)) {
                         continue;
                     }
+                    file.setMask(StoragePathPermissionsUtils.getFileMask(permissionsContainer, file.getName()));
                     previous = getPreviousKey(previous, s3ObjectSummary.getKey());
                     items.add(file);
                 }
@@ -887,12 +889,13 @@ public class S3Helper {
             relativePath = relativePath.substring(0, relativePath.length() - 1);
         }
         String folderName = relativePath.substring(requestPath.length());
-        if (Objects.nonNull(permissionsContainer) && permissionsContainer.folderNotAllowed(folderName)) {
+        if (StoragePathPermissionsUtils.filterNotAllowedFolders(permissionsContainer, folderName)) {
             return null;
         }
         DataStorageFolder folder = new DataStorageFolder();
         folder.setName(folderName);
         folder.setPath(ProviderUtils.removePrefix(relativePath, prefix));
+        folder.setMask(StoragePathPermissionsUtils.getFolderMask(permissionsContainer, folderName));
         return folder;
     }
 
@@ -959,7 +962,7 @@ public class S3Helper {
                 if (file == null) {
                     continue;
                 }
-                if (filterNotAllowedFiles(file.getPath(), permissionsContainer)) {
+                if (StoragePathPermissionsUtils.filterNotAllowedFiles(permissionsContainer, file.getPath())) {
                     continue;
                 }
                 if (filterNotRestored(file, file.getPath(), restoredListing)) {
@@ -976,6 +979,7 @@ public class S3Helper {
                         continue;
                     }
                 }
+                file.setMask(StoragePathPermissionsUtils.getFileMask(permissionsContainer, file.getName()));
                 if (!itemKeys.containsKey(fileName)) {
                     if (checkListingSize(pageSize, items, itemKeys)) {
                         items.addAll(itemKeys.values());
@@ -1379,11 +1383,6 @@ public class S3Helper {
     private boolean filterNotRestored(final DataStorageFile file, final String fileName,
                                       final DataStorageLifecycleRestoredListingContainer restoredListing) {
         return Objects.nonNull(restoredListing) && isArchived(file) && !restoredListing.containsPath(fileName);
-    }
-
-    private boolean filterNotAllowedFiles(final String fileName,
-                                          final StorageFolderListPermissionsContainer permissionsContainer) {
-        return Objects.nonNull(permissionsContainer) && permissionsContainer.fileNotAllowed(fileName);
     }
 
     private boolean isArchived(final DataStorageFile item) {

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3Helper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/aws/s3/S3Helper.java
@@ -811,7 +811,7 @@ public class S3Helper {
             maskingEnabled = true;
             latestMarker = resolveStartAndLastTokens(req.getStartAfter(), resolvedMasks, req::setStartAfter);
             if (latestMarker == null) {
-                return new DataStorageListing(null, Collections.emptyList());
+                return new DataStorageListing(null, null, Collections.emptyList());
             }
         } else {
             maskingEnabled = false;
@@ -872,7 +872,7 @@ public class S3Helper {
             }
         } while(listing.isTruncated() && (pageSize == null || items.size() < pageSize));
         String returnToken = listing.isTruncated() ? previous : null;
-        return new DataStorageListing(returnToken, items);
+        return new DataStorageListing(returnToken, null, items);
     }
 
     private String getPreviousKey(String previous, String key) {
@@ -920,7 +920,7 @@ public class S3Helper {
             maskingEnabled = true;
             latestMarker = resolveStartAndLastTokens(request.getKeyMarker(), resolvedMasks, request::setKeyMarker);
             if (latestMarker == null) {
-                return new DataStorageListing(null, Collections.emptyList());
+                return new DataStorageListing(null, null, Collections.emptyList());
             }
         } else {
             maskingEnabled = false;
@@ -945,7 +945,7 @@ public class S3Helper {
                 }
                 if (checkListingSize(pageSize, items, itemKeys)) {
                     items.addAll(itemKeys.values());
-                    return new DataStorageListing(previous, items);
+                    return new DataStorageListing(previous, null, items);
                 }
                 previous = getPreviousKey(previous, commonPrefix);
                 final DataStorageFolder folder = parseFolder(requestPath, commonPrefix, prefix, permissionsContainer);
@@ -983,7 +983,7 @@ public class S3Helper {
                 if (!itemKeys.containsKey(fileName)) {
                     if (checkListingSize(pageSize, items, itemKeys)) {
                         items.addAll(itemKeys.values());
-                        return new DataStorageListing(previous, items);
+                        return new DataStorageListing(previous, null, items);
                     }
                     previous = getPreviousKey(previous, versionSummary.getKey());
                     Map<String, AbstractDataStorageItem> versions = new LinkedHashMap<>();
@@ -1005,7 +1005,7 @@ public class S3Helper {
         } while (versionListing.isTruncated());
         items.addAll(itemKeys.values());
         String returnToken = versionListing.isTruncated() ? previous : null;
-        return new DataStorageListing(returnToken, items);
+        return new DataStorageListing(returnToken, null, items);
     }
 
     private boolean checkListingSize(Integer pageSize, List<AbstractDataStorageItem> items,

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureStorageHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureStorageHelper.java
@@ -172,7 +172,7 @@ public class AzureStorageHelper {
                 .filter(this::isNotTokenFile)
                 .limit(page)
                 .collect(Collectors.toList());
-        return new DataStorageListing(iterator.getNextMarker(), items);
+        return new DataStorageListing(iterator.getNextMarker(), null, items);
     }
 
     private boolean isNotTokenFile(final AbstractDataStorageItem item) {

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/gcp/GSBucketStorageHelper.java
@@ -155,7 +155,7 @@ public class GSBucketStorageHelper {
         final List<AbstractDataStorageItem> items = showVersion
                 ? listItemsWithVersions(blobs)
                 : listItemsWithoutVersions(blobs);
-        return new DataStorageListing(blobs.getNextPageToken(), items);
+        return new DataStorageListing(blobs.getNextPageToken(), null, items);
     }
 
     public DataStorageItemType getItemType(final GSBucketStorage storage,

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProvider.java
@@ -235,7 +235,7 @@ public class NFSStorageProvider implements StorageProvider<NFSDataStorage> {
         // If we list file - just return it as result
         if (startingPath.isFile()) {
             return new DataStorageListing(
-                    null,
+                    null, null,
                     Collections.singletonList(mapFileToDataStorageFile(dataStorageRoot, startingPath))
             );
         }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/tag/DataStorageTagBatchManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/tag/DataStorageTagBatchManager.java
@@ -19,19 +19,26 @@ package com.epam.pipeline.manager.datastorage.tag;
 import com.epam.pipeline.dao.datastorage.DataStorageDao;
 import com.epam.pipeline.dao.datastorage.tags.DataStorageTagDao;
 import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
+import com.epam.pipeline.entity.datastorage.DataStorageType;
 import com.epam.pipeline.entity.datastorage.tag.DataStorageObject;
 import com.epam.pipeline.entity.datastorage.tag.DataStorageTag;
-import com.epam.pipeline.entity.datastorage.tag.DataStorageTagDeleteAllBatchRequest;
-import com.epam.pipeline.entity.datastorage.tag.DataStorageTagDeleteBatchRequest;
-import com.epam.pipeline.entity.datastorage.tag.DataStorageTagLoadBatchRequest;
 import com.epam.pipeline.entity.datastorage.tag.DataStorageTagCopyBatchRequest;
 import com.epam.pipeline.entity.datastorage.tag.DataStorageTagCopyRequest;
-import com.epam.pipeline.entity.datastorage.tag.DataStorageTagInsertRequest;
+import com.epam.pipeline.entity.datastorage.tag.DataStorageTagDeleteAllBatchRequest;
+import com.epam.pipeline.entity.datastorage.tag.DataStorageTagDeleteAllRequest;
+import com.epam.pipeline.entity.datastorage.tag.DataStorageTagDeleteBatchRequest;
+import com.epam.pipeline.entity.datastorage.tag.DataStorageTagDeleteRequest;
 import com.epam.pipeline.entity.datastorage.tag.DataStorageTagInsertBatchRequest;
+import com.epam.pipeline.entity.datastorage.tag.DataStorageTagInsertRequest;
+import com.epam.pipeline.entity.datastorage.tag.DataStorageTagLoadBatchRequest;
 import com.epam.pipeline.entity.datastorage.tag.DataStorageTagLoadRequest;
 import com.epam.pipeline.entity.datastorage.tag.DataStorageTagUpsertBatchRequest;
 import com.epam.pipeline.entity.datastorage.tag.DataStorageTagUpsertRequest;
+import com.epam.pipeline.manager.datastorage.permissions.StoragePathPermissionsService;
+import com.epam.pipeline.manager.security.AuthManager;
+import com.epam.pipeline.security.acl.AclPermission;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.stereotype.Service;
 
@@ -39,6 +46,7 @@ import javax.transaction.Transactional;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -55,12 +63,15 @@ import java.util.stream.Stream;
  *  TODO: Maybe it is good idea to expand API to allow to specify flag 'relative' on BatchRequest level,
  *  TODO: to be able to automatically performs such resolving of paths on server side rather that client side
  * */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class DataStorageTagBatchManager {
 
     private final DataStorageTagDao tagDao;
     private final DataStorageDao storageDao;
+    private final AuthManager authManager;
+    private final StoragePathPermissionsService storagePathPermissionsService;
 
     @Transactional
     public List<DataStorageTag> insert(final Long storageId, final DataStorageTagInsertBatchRequest request) {
@@ -71,7 +82,14 @@ public class DataStorageTagBatchManager {
         if (!root.isPresent()) {
             return Collections.emptyList();
         }
+        final List<String> allowedPaths = getAllowedPaths(root.get(), request.getRequests(),
+                DataStorageTagInsertRequest::getPath, AclPermission.WRITE.getMask());
+        if (Objects.nonNull(allowedPaths) && CollectionUtils.isEmpty(allowedPaths)) {
+            log.debug("No allowed path found for storage '{}' to insert tags.", storageId);
+            return Collections.emptyList();
+        }
         final List<DataStorageTag> tags = request.getRequests().stream()
+                .filter(insertRequest -> isPathAllowed(insertRequest.getPath(), allowedPaths))
                 .map(this::tagFrom)
                 .collect(Collectors.toList());
         tagDao.batchDelete(root.get(), tags.stream().map(DataStorageTag::getObject));
@@ -92,7 +110,14 @@ public class DataStorageTagBatchManager {
         if (!root.isPresent()) {
             return Collections.emptyList();
         }
+        final List<String> allowedPaths = getAllowedPaths(root.get(), request.getRequests(),
+                DataStorageTagUpsertRequest::getPath, AclPermission.WRITE.getMask());
+        if (Objects.nonNull(allowedPaths) && CollectionUtils.isEmpty(allowedPaths)) {
+            log.debug("No allowed path found for storage '{}' to upsert tags.", storageId);
+            return Collections.emptyList();
+        }
         final List<DataStorageTag> tags = request.getRequests().stream()
+                .filter(upsertRequest -> isPathAllowed(upsertRequest.getPath(), allowedPaths))
                 .map(this::tagFrom)
                 .collect(Collectors.toList());
         return tagDao.batchUpsert(root.get(), tags);
@@ -112,13 +137,29 @@ public class DataStorageTagBatchManager {
         if (!root.isPresent()) {
             return Collections.emptyList();
         }
+        final List<String> readAllowedPaths = getAllowedPaths(root.get(), request.getRequests().stream()
+                        .map(DataStorageTagCopyRequest::getSource).collect(Collectors.toList()),
+                DataStorageTagCopyRequest.DataStorageTagCopyRequestObject::getPath, AclPermission.READ.getMask());
+        if (Objects.nonNull(readAllowedPaths) && CollectionUtils.isEmpty(readAllowedPaths)) {
+            log.debug("No allowed path found for storage '{}' to load tags for copy.", storageId);
+            return Collections.emptyList();
+        }
         final Map<DataStorageTagCopyRequest.DataStorageTagCopyRequestObject, List<DataStorageTag>> sourceTagsMap =
                 request.getRequests().stream()
                         .map(DataStorageTagCopyRequest::getSource)
                         .distinct()
+                        .filter(o -> isPathAllowed(o.getPath(), readAllowedPaths))
                         .collect(Collectors.toMap(Function.identity(),
                             it -> tagDao.load(root.get(), new DataStorageObject(it.getPath(), it.getVersion()))));
+        final List<String> writeAllowedPaths = getAllowedPaths(root.get(), request.getRequests().stream()
+                        .map(DataStorageTagCopyRequest::getDestination).collect(Collectors.toList()),
+                DataStorageTagCopyRequest.DataStorageTagCopyRequestObject::getPath, AclPermission.WRITE.getMask());
+        if (Objects.nonNull(writeAllowedPaths) && CollectionUtils.isEmpty(writeAllowedPaths)) {
+            log.debug("No allowed path found for storage '{}' to copy tags.", storageId);
+            return Collections.emptyList();
+        }
         final List<DataStorageTag> tags = request.getRequests().stream()
+                .filter(r -> isPathAllowed(r.getDestination().getPath(), writeAllowedPaths))
                 .flatMap(r -> Optional.ofNullable(sourceTagsMap.get(r.getSource()))
                         .map(sourceTags -> sourceTags.stream()
                                 .map(it -> it.withObject(new DataStorageObject(r.getDestination().getPath(), 
@@ -138,8 +179,15 @@ public class DataStorageTagBatchManager {
         if (!root.isPresent()) {
             return Collections.emptyList();
         }
+        final List<String> allowedPaths = getAllowedPaths(root.get(), request.getRequests(),
+                DataStorageTagLoadRequest::getPath, AclPermission.READ.getMask());
+        if (Objects.nonNull(allowedPaths) && CollectionUtils.isEmpty(allowedPaths)) {
+            log.debug("No allowed path found for storage '{}' to load tags.", storageId);
+            return Collections.emptyList();
+        }
         return tagDao.batchLoad(root.get(), request.getRequests().stream()
                 .map(DataStorageTagLoadRequest::getPath)
+                .filter(path -> isPathAllowed(path, allowedPaths))
                 .collect(Collectors.toList()));
     }
 
@@ -152,8 +200,15 @@ public class DataStorageTagBatchManager {
         if (!root.isPresent()) {
             return;
         }
+        final List<String> allowedPaths = getAllowedPaths(root.get(), request.getRequests(),
+                DataStorageTagDeleteRequest::getPath, AclPermission.WRITE.getMask());
+        if (Objects.nonNull(allowedPaths) && CollectionUtils.isEmpty(allowedPaths)) {
+            log.debug("No allowed path found for storage '{}' to delete tags.", storageId);
+            return;
+        }
         tagDao.batchDelete(root.get(), request.getRequests().stream()
-            .map(r -> new DataStorageObject(r.getPath(), r.getVersion())));
+                .filter(r -> isPathAllowed(r.getPath(), allowedPaths))
+                .map(r -> new DataStorageObject(r.getPath(), r.getVersion())));
     }
 
     @Transactional
@@ -161,11 +216,18 @@ public class DataStorageTagBatchManager {
         if (CollectionUtils.isEmpty(request.getRequests())) {
             return;
         }
-        final Optional<Long> rootPath = getRoot(storageId);
-        if (!rootPath.isPresent()) {
+        final Optional<Long> root = getRoot(storageId);
+        if (!root.isPresent()) {
             return;
         }
-        tagDao.batchDeleteAll(rootPath.get(), request.getRequests().stream()
+        final List<String> allowedPaths = getAllowedPaths(root.get(), request.getRequests(),
+                DataStorageTagDeleteAllRequest::getPath, AclPermission.WRITE.getMask());
+        if (Objects.nonNull(allowedPaths) && CollectionUtils.isEmpty(allowedPaths)) {
+            log.debug("No allowed path found for storage '{}' to delete all tags.", storageId);
+            return;
+        }
+        tagDao.batchDeleteAll(root.get(), request.getRequests().stream()
+                .filter(r -> isPathAllowed(r.getPath(), allowedPaths))
                 .map(r -> new DataStorageObject(r.getPath()))
                 .map(DataStorageObject::getPath)
                 .collect(Collectors.toList()));
@@ -174,5 +236,23 @@ public class DataStorageTagBatchManager {
     private Optional<Long> getRoot(final Long storageId) {
         return Optional.ofNullable(storageDao.loadDataStorage(storageId))
                 .map(AbstractDataStorage::getRootId);
+    }
+
+    private <T> List<String> getAllowedPaths(final Long storageId, final List<T> requests,
+                                             final Function<T, String> getPathFunction,
+                                             final int mask) {
+        final AbstractDataStorage storage = storageDao.loadDataStorage(storageId);
+        if (!(storage.isPathPermissionsEnabled() && DataStorageType.S3.equals(storage.getType())
+                && !authManager.isAdmin() && !authManager.getAuthorizedUser().equalsIgnoreCase(storage.getOwner()))) {
+            return null;
+        }
+        return storagePathPermissionsService.filterFiles(storageId, requests.stream()
+                .map(getPathFunction)
+                .distinct()
+                .collect(Collectors.toList()), mask);
+    }
+
+    private boolean isPathAllowed(final String targetPath, final List<String> allowedPaths) {
+        return Objects.isNull(allowedPaths) || allowedPaths.contains(targetPath);
     }
 }

--- a/api/src/main/resources/dao/datastorage-path-permissions.xml
+++ b/api/src/main/resources/dao/datastorage-path-permissions.xml
@@ -89,40 +89,6 @@
         </constructor-arg>
         <constructor-arg>
             <value>
-                <!--findStoragePathPermissionsByPrefixQuery-->
-                <![CDATA[
-                    SELECT
-                        p.storage_id,
-                        p.folder_path,
-                        p.file_name,
-                        p.sid_name,
-                        p.principal,
-                        p.mask
-                    FROM
-                        pipeline.datastorage_path_permissions p
-                    WHERE
-                        p.storage_id = :STORAGE_ID AND p.folder_path LIKE :FOLDER_PATH
-                    @WHERE@
-                    ORDER BY LENGTH(p.folder_path) ASC
-                ]]>
-            </value>
-        </constructor-arg>
-        <constructor-arg>
-            <value>
-                <!--countStoragePathPermissionsQuery-->
-                <![CDATA[
-                    SELECT
-                        count(*)
-                    FROM
-                        pipeline.datastorage_path_permissions p
-                    WHERE
-                        p.storage_id = ?
-                    @WHERE@
-                ]]>
-            </value>
-        </constructor-arg>
-        <constructor-arg>
-            <value>
                 <!--findSidsWithStoragePathPermissionsQuery-->
                 <![CDATA[
                     SELECT DISTINCT
@@ -132,6 +98,91 @@
                         pipeline.datastorage_path_permissions p
                     WHERE
                         p.storage_id = ?
+                ]]>
+            </value>
+        </constructor-arg>
+        <constructor-arg>
+            <value>
+                <!--findClosestStorageFolderPermissionQuery-->
+                <![CDATA[
+                    WITH ranked_permissions AS (
+                        SELECT
+                            p.storage_id,
+                            p.folder_path,
+                            p.file_name,
+                            p.sid_name,
+                            p.principal,
+                            p.mask,
+                            ROW_NUMBER() OVER (
+                                PARTITION BY p.storage_id, p.folder_path, p.file_name
+                                ORDER BY
+                                    CASE
+                                        WHEN p.principal = true THEN 0
+                                        ELSE 1
+                                    END,
+                                    p.mask
+                            ) AS rn
+                        FROM
+                            pipeline.datastorage_path_permissions p
+                        WHERE
+                            p.storage_id = ?
+                        @WHERE@
+                    )
+                    SELECT
+                        rp.storage_id,
+                        rp.folder_path,
+                        rp.file_name,
+                        rp.sid_name,
+                        rp.principal,
+                        rp.mask
+                    FROM
+                        ranked_permissions rp
+                    WHERE
+                        rp.rn = 1
+                    ORDER BY LENGTH(rp.folder_path) DESC
+                    @LIMIT@
+                ]]>
+            </value>
+        </constructor-arg>
+        <constructor-arg>
+            <value>
+                <!--loadClosetsStoragePathPermissionsByPrefixQuery-->
+                <![CDATA[
+                    WITH ranked_permissions AS (
+                        SELECT
+                            p.storage_id,
+                            p.folder_path,
+                            p.file_name,
+                            p.sid_name,
+                            p.principal,
+                            p.mask,
+                            ROW_NUMBER() OVER (
+                                PARTITION BY p.storage_id, p.folder_path, p.file_name
+                                ORDER BY
+                                    CASE
+                                        WHEN p.principal = true THEN 0
+                                        ELSE 1
+                                    END,
+                                    p.mask
+                            ) AS rn
+                        FROM
+                            pipeline.datastorage_path_permissions p
+                        WHERE
+                            p.storage_id = :STORAGE_ID AND p.folder_path LIKE :FOLDER_PATH
+                        @WHERE@
+                    )
+                    SELECT
+                        rp.storage_id,
+                        rp.folder_path,
+                        rp.file_name,
+                        rp.sid_name,
+                        rp.principal,
+                        rp.mask
+                    FROM
+                        ranked_permissions rp
+                    WHERE
+                        rp.rn = 1
+                    ORDER BY LENGTH(rp.folder_path) ASC
                 ]]>
             </value>
         </constructor-arg>

--- a/api/src/main/resources/dao/datastorage-path-permissions.xml
+++ b/api/src/main/resources/dao/datastorage-path-permissions.xml
@@ -208,5 +208,45 @@
                 ]]>
             </value>
         </constructor-arg>
+        <constructor-arg>
+            <value>
+                <!--deleteStoragePathPermissionsByFilePathQuery-->
+                <![CDATA[
+                    DELETE FROM
+                        pipeline.datastorage_path_permissions p
+                    WHERE
+                        p.storage_id = :STORAGE_ID AND p.folder_path = :FOLDER_PATH AND p.file_name = :FILE_NAME
+                ]]>
+            </value>
+        </constructor-arg>
+        <constructor-arg>
+            <value>
+                <!--deleteStoragePathPermissionsByFolderPathQuery-->
+                <![CDATA[
+                    DELETE FROM
+                        pipeline.datastorage_path_permissions p
+                    WHERE
+                        p.storage_id = :STORAGE_ID AND p.folder_path = :FOLDER_PATH AND p.file_name IS NULL
+                ]]>
+            </value>
+        </constructor-arg>
+        <constructor-arg>
+            <value>
+                <!--loadStoragePathPermissionsByPathQuery-->
+                <![CDATA[
+                    SELECT
+                        p.storage_id,
+                        p.folder_path,
+                        p.file_name,
+                        p.sid_name,
+                        p.principal,
+                        p.mask
+                    FROM
+                        pipeline.datastorage_path_permissions p
+                    WHERE
+                        p.storage_id = :STORAGE_ID AND p.folder_path = :FOLDER_PATH AND @WHERE@
+                ]]>
+            </value>
+        </constructor-arg>
     </bean>
 </beans>

--- a/api/src/main/resources/dao/datastorage-path-permissions.xml
+++ b/api/src/main/resources/dao/datastorage-path-permissions.xml
@@ -59,19 +59,41 @@
             <value>
                 <!--loadStoragePathPermissionsQuery-->
                 <![CDATA[
+                    WITH ranked_permissions AS (
+                        SELECT
+                            p.storage_id,
+                            p.folder_path,
+                            p.file_name,
+                            p.sid_name,
+                            p.principal,
+                            p.mask,
+                            ROW_NUMBER() OVER (
+                                PARTITION BY p.storage_id, p.folder_path, p.file_name
+                                ORDER BY
+                                    CASE
+                                        WHEN p.principal = true THEN 0
+                                        ELSE 1
+                                    END,
+                                    p.mask
+                            ) AS rn
+                        FROM
+                            pipeline.datastorage_path_permissions p
+                        WHERE
+                            p.storage_id = ?
+                        @WHERE@
+                    )
                     SELECT
-                        p.storage_id,
-                        p.folder_path,
-                        p.file_name,
-                        p.sid_name,
-                        p.principal,
-                        p.mask
+                        rp.storage_id,
+                        rp.folder_path,
+                        rp.file_name,
+                        rp.sid_name,
+                        rp.principal,
+                        rp.mask
                     FROM
-                        pipeline.datastorage_path_permissions p
+                        ranked_permissions rp
                     WHERE
-                        p.storage_id = ?
-                    @WHERE@
-                    ORDER BY LENGTH(p.folder_path) DESC, p.file_name DESC NULLS LAST
+                        rp.rn = 1
+                    ORDER BY LENGTH(rp.folder_path) DESC, rp.file_name DESC NULLS LAST
                     @LIMIT@
                 ]]>
             </value>

--- a/api/src/test/java/com/epam/pipeline/dao/datastorage/permissions/StoragePathPermissionsDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/datastorage/permissions/StoragePathPermissionsDaoTest.java
@@ -48,6 +48,7 @@ public class StoragePathPermissionsDaoTest extends AbstractJdbcTest {
     private static final String PATH3 = "/A/B/C/D/E/F/";
     private static final String FILENAME = "file.txt";
     private static final int READ = 1;
+    private static final int WRITE = 1 << 2;
     private static final String USER = "User";
     private static final String GROUP = "Group";
     private static final List<String> NO_PERMISSIONS_PATHS = Arrays.asList("/", "/Y/", "/Y/X/");
@@ -217,14 +218,14 @@ public class StoragePathPermissionsDaoTest extends AbstractJdbcTest {
         storagePathPermissionsDao.batchInsert(permissions, storageId, GROUP, false);
 
         final Optional<StoragePathPermissions> actual = storagePathPermissionsDao
-                .findClosestFolderPermission(storageId, Collections.singletonList(user),
+                .findClosestParentFolderPermission(storageId, Collections.singletonList(user),
                         PATHS_WITH_PERMISSIONS);
         assertThat(actual.isPresent()).isTrue();
         assertThat(actual.get().getFolderPath()).isEqualTo(PATH1);
         assertThat(actual.get().getFileName()).isNull();
 
         final Optional<StoragePathPermissions> noPermissionsResult = storagePathPermissionsDao
-                .findClosestFolderPermission(storageId, Collections.singletonList(user),
+                .findClosestParentFolderPermission(storageId, Collections.singletonList(user),
                         NO_PERMISSIONS_PATHS);
         assertThat(noPermissionsResult.isPresent()).isFalse();
     }
@@ -232,26 +233,38 @@ public class StoragePathPermissionsDaoTest extends AbstractJdbcTest {
     @Test
     @Transactional
     public void shouldCountPermissions() {
-        final List<StoragePathPermissions> permissions = new ArrayList<>(permissions());
-        permissions.add(StoragePathPermissions.builder()
+        final List<StoragePathPermissions> userPermission = new ArrayList<>(permissions());
+        userPermission.add(StoragePathPermissions.builder()
                 .folderPath(PATH0)
                 .mask(READ)
                 .build());
+        final List<StoragePathPermissions> groupPermission = new ArrayList<>(permissions());
+        groupPermission.add(StoragePathPermissions.builder()
+                .folderPath(PATH0)
+                .mask(WRITE)
+                .build());
         final Long storageId = objectStorage.getId();
         final SidImpl user = userSid();
+        final SidImpl group = groupSid();
 
-        storagePathPermissionsDao.batchInsert(permissions, storageId, USER, true);
-        storagePathPermissionsDao.batchInsert(permissions, storageId, GROUP, false);
+        storagePathPermissionsDao.batchInsert(userPermission, storageId, USER, true);
+        storagePathPermissionsDao.batchInsert(groupPermission, storageId, GROUP, false);
 
-        final int permissionsCountWhenGranted = storagePathPermissionsDao
-                .countParentFoldersByStorageAndSids(storageId, Collections.singletonList(user),
+        final Optional<StoragePathPermissions> actualUserPermission = storagePathPermissionsDao
+                .findClosestParentFolderPermission(storageId, Collections.singletonList(user),
                         PATHS_WITH_PERMISSIONS);
-        assertThat(permissionsCountWhenGranted).isEqualTo(2);
+        assertThat(actualUserPermission.isPresent()).isTrue();
+        assertThat(actualUserPermission.get().getMask()).isEqualTo(READ);
 
-        final int permissionsCountWhenNotGranted = storagePathPermissionsDao
-                .countParentFoldersByStorageAndSids(storageId, Collections.singletonList(user),
-                        NO_PERMISSIONS_PATHS);
-        assertThat(permissionsCountWhenNotGranted).isEqualTo(0);
+        final Optional<StoragePathPermissions> actualPermission = storagePathPermissionsDao
+                .findClosestParentFolderPermission(storageId, Arrays.asList(user, group),
+                        PATHS_WITH_PERMISSIONS);
+        assertThat(actualPermission.isPresent()).isTrue();
+        assertThat(actualPermission.get().getMask()).isEqualTo(READ);
+
+        assertThat(storagePathPermissionsDao
+                .findClosestParentFolderPermission(storageId, Collections.singletonList(user),
+                        NO_PERMISSIONS_PATHS).isPresent()).isFalse();
     }
 
     @Test

--- a/api/src/test/java/com/epam/pipeline/dao/datastorage/permissions/StoragePathPermissionsDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/datastorage/permissions/StoragePathPermissionsDaoTest.java
@@ -34,6 +34,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.epam.pipeline.test.creator.CommonCreatorConstants.TEST_STRING;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -144,6 +145,110 @@ public class StoragePathPermissionsDaoTest extends AbstractJdbcTest {
 
         // do not fail if no records available
         storagePathPermissionsDao.deleteForStorageId(storageId);
+    }
+
+    @Test
+    @Transactional
+    public void shouldLoadAndDeletePathPermissionsByPathForFilesAndFolders() {
+        final List<StoragePathPermissions> permissions = permissions();
+        final Long storageId = objectStorage.getId();
+
+        storagePathPermissionsDao.batchInsert(permissions.stream()
+                .peek(p -> p.setSidName(USER))
+                .peek(p -> p.setPrincipal(true))
+                .collect(Collectors.toList()), storageId);
+        storagePathPermissionsDao.batchInsert(permissions.stream()
+                .peek(p -> p.setSidName(GROUP))
+                .peek(p -> p.setPrincipal(false))
+                .collect(Collectors.toList()), storageId);
+
+        final List<StoragePathPermissions> folderPermissions = storagePathPermissionsDao
+                .loadByPath(storageId, PATH1, null);
+        assertThat(folderPermissions).hasSize(2);
+        assertThat(folderPermissions.stream()
+                .peek(p -> assertThat(p.getFolderPath()).isEqualTo(PATH1))
+                .peek(p -> assertThat(p.getFileName()).isNull())
+                .map(StoragePathPermissions::getSidName)
+                .collect(Collectors.toList())).contains(USER, GROUP);
+
+        final List<StoragePathPermissions> filePermissions = storagePathPermissionsDao
+                .loadByPath(storageId, PATH1, FILENAME);
+        assertThat(filePermissions).hasSize(2);
+        assertThat(filePermissions.stream()
+                .peek(p -> assertThat(p.getFolderPath()).isEqualTo(PATH1))
+                .peek(p -> assertThat(p.getFileName()).isEqualTo(FILENAME))
+                .map(StoragePathPermissions::getSidName)
+                .collect(Collectors.toList())).contains(USER, GROUP);
+
+        final List<StoragePathPermissions> toDelete = Arrays.asList(
+                StoragePathPermissions.builder()
+                        .folderPath(PATH1)
+                        .build(),
+                StoragePathPermissions.builder()
+                        .folderPath(PATH1)
+                        .fileName(FILENAME)
+                        .build()
+        );
+
+        storagePathPermissionsDao.batchDeleteByPath(toDelete, storageId);
+
+        assertThat(storagePathPermissionsDao.loadByPath(storageId, PATH1, null)).isNullOrEmpty();
+        assertThat(storagePathPermissionsDao.loadByPath(storageId, PATH1, FILENAME)).isNullOrEmpty();
+    }
+
+    @Test
+    @Transactional
+    public void shouldDeletePathPermissionsByPathForFiles() {
+        final List<StoragePathPermissions> permissions = permissions();
+        final Long storageId = objectStorage.getId();
+
+        storagePathPermissionsDao.batchInsert(permissions.stream()
+                .peek(p -> p.setSidName(USER))
+                .peek(p -> p.setPrincipal(true))
+                .collect(Collectors.toList()), storageId);
+        storagePathPermissionsDao.batchInsert(permissions.stream()
+                .peek(p -> p.setSidName(GROUP))
+                .peek(p -> p.setPrincipal(false))
+                .collect(Collectors.toList()), storageId);
+
+        final List<StoragePathPermissions> toDelete = Collections.singletonList(
+                StoragePathPermissions.builder()
+                        .folderPath(PATH1)
+                        .fileName(FILENAME)
+                        .build()
+        );
+
+        storagePathPermissionsDao.batchDeleteByPath(toDelete, storageId);
+
+        assertThat(storagePathPermissionsDao.loadByPath(storageId, PATH1, FILENAME)).isNullOrEmpty();
+        assertThat(storagePathPermissionsDao.loadByPath(storageId, PATH1, null)).hasSize(2);
+    }
+
+    @Test
+    @Transactional
+    public void shouldDeletePathPermissionsByPathForFolders() {
+        final List<StoragePathPermissions> permissions = permissions();
+        final Long storageId = objectStorage.getId();
+
+        storagePathPermissionsDao.batchInsert(permissions.stream()
+                .peek(p -> p.setSidName(USER))
+                .peek(p -> p.setPrincipal(true))
+                .collect(Collectors.toList()), storageId);
+        storagePathPermissionsDao.batchInsert(permissions.stream()
+                .peek(p -> p.setSidName(GROUP))
+                .peek(p -> p.setPrincipal(false))
+                .collect(Collectors.toList()), storageId);
+
+        final List<StoragePathPermissions> toDelete = Collections.singletonList(
+                StoragePathPermissions.builder()
+                        .folderPath(PATH1)
+                        .build()
+        );
+
+        storagePathPermissionsDao.batchDeleteByPath(toDelete, storageId);
+
+        assertThat(storagePathPermissionsDao.loadByPath(storageId, PATH1, null)).isNullOrEmpty();
+        assertThat(storagePathPermissionsDao.loadByPath(storageId, PATH1, FILENAME)).hasSize(2);
     }
 
     @Test

--- a/api/src/test/java/com/epam/pipeline/dao/datastorage/permissions/StoragePathPermissionsDaoTest.java
+++ b/api/src/test/java/com/epam/pipeline/dao/datastorage/permissions/StoragePathPermissionsDaoTest.java
@@ -107,7 +107,7 @@ public class StoragePathPermissionsDaoTest extends AbstractJdbcTest {
         storagePathPermissionsDao.batchInsert(permissions, storageId, GROUP, false);
 
         assertThat(storagePathPermissionsDao
-                .findByStorageAndSids(storageId, Arrays.asList(user, group))).hasSize(permissions.size() * 2);
+                .findByStorageAndSids(storageId, Arrays.asList(user, group))).hasSize(permissions.size());
         assertThat(storagePathPermissionsDao
                 .findByStorageAndSids(storageId, Collections.singletonList(user))).hasSize(permissions.size());
         assertThat(storagePathPermissionsDao

--- a/api/src/test/java/com/epam/pipeline/manager/datastorage/permissions/StoragePathPermissionsServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/datastorage/permissions/StoragePathPermissionsServiceTest.java
@@ -93,13 +93,14 @@ public class StoragePathPermissionsServiceTest {
     public void shouldNormalizeFolderPaths() {
         doReturn(pipelineUser()).when(userManager).getCurrentUser();
         doReturn(Optional.of(WRITE_ROOT)).when(pathPermissionsDao)
-                .findClosestFolderPermission(any(), any(), any());
+                .findClosestParentFolderPermission(any(), any(), any());
 
         service.canWriteToFolder(STORAGE_ID, "A/B/C/D");
-        verify(pathPermissionsDao).findClosestFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
+        verify(pathPermissionsDao).findClosestParentFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
 
         service.canWriteToFolder(STORAGE_ID, "");
-        verify(pathPermissionsDao).findClosestFolderPermission(STORAGE_ID, SIDS, Collections.singletonList(ROOT_PATH));
+        verify(pathPermissionsDao)
+                .findClosestParentFolderPermission(STORAGE_ID, SIDS, Collections.singletonList(ROOT_PATH));
     }
 
     @Test
@@ -179,168 +180,170 @@ public class StoragePathPermissionsServiceTest {
     public void shouldNotThrowIfUserCanWriteToFolder() {
         doReturn(pipelineUser()).when(userManager).getCurrentUser();
         doReturn(Optional.of(WRITE_FOLDER_PATH1)).when(pathPermissionsDao)
-                .findClosestFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
+                .findClosestParentFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
 
         service.canWriteToFolder(STORAGE_ID, PATH1);
-        verify(pathPermissionsDao).findClosestFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
+        verify(pathPermissionsDao).findClosestParentFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
     }
 
     @Test
     public void shouldThrowIfUserCanNotWriteToFolder() {
         doReturn(pipelineUser()).when(userManager).getCurrentUser();
         doReturn(Optional.empty()).when(pathPermissionsDao)
-                .findClosestFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
+                .findClosestParentFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
 
         assertThrows(AccessDeniedException.class, () -> service.canWriteToFolder(STORAGE_ID, PATH1));
-        verify(pathPermissionsDao).findClosestFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
+        verify(pathPermissionsDao).findClosestParentFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
     }
 
     @Test
     public void shouldNotThrowIfUserCanReadFolderContent() {
         doReturn(pipelineUser()).when(userManager).getCurrentUser();
         doReturn(Optional.of(READ_FOLDER_PATH1)).when(pathPermissionsDao)
-                .findClosestFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
+                .findClosestParentFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
 
         service.canReadFolder(STORAGE_ID, PATH1);
-        verify(pathPermissionsDao).findClosestFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
+        verify(pathPermissionsDao).findClosestParentFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
     }
 
     @Test
     public void shouldThrowIfUserCanNotReadFolderContent() {
         doReturn(pipelineUser()).when(userManager).getCurrentUser();
         doReturn(Optional.empty()).when(pathPermissionsDao)
-                .findClosestFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
+                .findClosestParentFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
 
         assertThrows(AccessDeniedException.class, () -> service.canReadFolder(STORAGE_ID, PATH1));
-        verify(pathPermissionsDao).findClosestFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
+        verify(pathPermissionsDao).findClosestParentFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
     }
 
     @Test
     public void shouldNotThrowIfUserCanGetFolderWhenPermissionsGrantedOnParentFolder() {
         doReturn(pipelineUser()).when(userManager).getCurrentUser();
-        doReturn(1).when(pathPermissionsDao)
-                .countParentFoldersByStorageAndSids(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
+        doReturn(Optional.of(WRITE_ROOT)).when(pathPermissionsDao)
+                .findClosestParentFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
 
         service.canGetFolder(STORAGE_ID, PATH1);
-        verify(pathPermissionsDao).countParentFoldersByStorageAndSids(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
+        verify(pathPermissionsDao).findClosestParentFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
         CustomAssertions.notInvoked(pathPermissionsDao).findByPrefix(any(), any(), any());
     }
 
     @Test
     public void shouldNotThrowIfUserCanGetFolderWhenPermissionsGrantedOnChildFile() {
         doReturn(pipelineUser()).when(userManager).getCurrentUser();
-        doReturn(0).when(pathPermissionsDao)
-                .countParentFoldersByStorageAndSids(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
+        doReturn(Optional.empty()).when(pathPermissionsDao)
+                .findClosestParentFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
         doReturn(Collections.singletonList(WRITE_FILE_PATH1))
                 .when(pathPermissionsDao).findByPrefix(STORAGE_ID, SIDS, PATH1);
 
         service.canGetFolder(STORAGE_ID, PATH1);
-        verify(pathPermissionsDao).countParentFoldersByStorageAndSids(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
+        verify(pathPermissionsDao).findClosestParentFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
         verify(pathPermissionsDao).findByPrefix(STORAGE_ID, SIDS, PATH1);
     }
 
     @Test
     public void shouldThrowIfUserCanNotGetFolder() {
         doReturn(pipelineUser()).when(userManager).getCurrentUser();
-        doReturn(0).when(pathPermissionsDao)
-                .countParentFoldersByStorageAndSids(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
+        doReturn(Optional.empty()).when(pathPermissionsDao)
+                .findClosestParentFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
         doReturn(Collections.emptyList())
                 .when(pathPermissionsDao).findByPrefix(STORAGE_ID, SIDS, PATH1);
 
         assertThrows(AccessDeniedException.class, () -> service.canGetFolder(STORAGE_ID, PATH1));
-        verify(pathPermissionsDao).countParentFoldersByStorageAndSids(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
+        verify(pathPermissionsDao).findClosestParentFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
         verify(pathPermissionsDao).findByPrefix(STORAGE_ID, SIDS, PATH1);
     }
 
     @Test
     public void shouldGetFolderListPermissionsForUserWhenPermissionsOnRequestedFolderGranted() {
         doReturn(pipelineUser()).when(userManager).getCurrentUser();
-        doReturn(1).when(pathPermissionsDao)
-                .countParentFoldersByStorageAndSids(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
+        doReturn(Optional.of(WRITE_ROOT)).when(pathPermissionsDao)
+                .findClosestParentFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
+        doReturn(Collections.emptyList())
+                .when(pathPermissionsDao).findByPrefix(STORAGE_ID, SIDS, PATH1);
 
         final StorageFolderListPermissionsContainer permissionsContainer = service
                 .getFolderListPermissions(STORAGE_ID, PATH1);
-        assertThat(permissionsContainer.isHasListPermissions()).isEqualTo(true);
-        CustomAssertions.notInvoked(pathPermissionsDao).findByPrefix(any(), any(), any());
+        assertThat(permissionsContainer.getFolderMask()).isEqualTo(WRITE);
+        verify(pathPermissionsDao).findByPrefix(STORAGE_ID, SIDS, PATH1);
     }
 
     @Test
     public void shouldGetFolderListPermissionsForUserWhenPermissionsOnFilesGranted() {
         doReturn(pipelineUser()).when(userManager).getCurrentUser();
-        doReturn(0).when(pathPermissionsDao)
-                .countParentFoldersByStorageAndSids(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
+        doReturn(Optional.empty()).when(pathPermissionsDao)
+                .findClosestParentFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
         doReturn(Arrays.asList(WRITE_FILE_PATH1, WRITE_FILE_PATH12))
                 .when(pathPermissionsDao).findByPrefix(STORAGE_ID, SIDS, PATH1);
 
         final StorageFolderListPermissionsContainer permissionsContainer = service
                 .getFolderListPermissions(STORAGE_ID, PATH1);
-        assertThat(permissionsContainer.isHasListPermissions()).isEqualTo(false);
-        assertThat(permissionsContainer.getFiles()).hasSize(2).contains(FILENAME1, FILENAME2);
+        assertThat(permissionsContainer.getFolderMask()).isNull();
+        assertThat(permissionsContainer.getFiles()).hasSize(2).containsKeys(FILENAME1, FILENAME2);
         assertThat(permissionsContainer.getFolders()).isNull();
-        verify(pathPermissionsDao).countParentFoldersByStorageAndSids(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
+        verify(pathPermissionsDao).findClosestParentFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH1);
         verify(pathPermissionsDao).findByPrefix(STORAGE_ID, SIDS, PATH1);
     }
 
     @Test
     public void shouldGetFolderListPermissionsForUserWhenPermissionsOnFoldersGranted() {
         doReturn(pipelineUser()).when(userManager).getCurrentUser();
-        doReturn(0).when(pathPermissionsDao)
-                .countParentFoldersByStorageAndSids(STORAGE_ID, SIDS, SPLIT_TO_PATH2);
+        doReturn(Optional.empty()).when(pathPermissionsDao)
+                .findClosestParentFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH2);
         doReturn(Arrays.asList(WRITE_FOLDER_PATH1, WRITE_FOLDER_PATH3))
                 .when(pathPermissionsDao).findByPrefix(STORAGE_ID, SIDS, PATH2);
 
         final StorageFolderListPermissionsContainer permissionsContainer = service
                 .getFolderListPermissions(STORAGE_ID, PATH2);
-        assertThat(permissionsContainer.isHasListPermissions()).isEqualTo(false);
-        assertThat(permissionsContainer.getFolders()).hasSize(2).contains("D", "E");
+        assertThat(permissionsContainer.getFolderMask()).isNull();
+        assertThat(permissionsContainer.getFolders()).hasSize(2).containsKeys("D", "E");
         assertThat(permissionsContainer.getFiles()).isNull();
-        verify(pathPermissionsDao).countParentFoldersByStorageAndSids(STORAGE_ID, SIDS, SPLIT_TO_PATH2);
+        verify(pathPermissionsDao).findClosestParentFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH2);
         verify(pathPermissionsDao).findByPrefix(STORAGE_ID, SIDS, PATH2);
     }
 
     @Test
     public void shouldGetFolderListPermissionsForUserWhenPermissionsOnFolderAndFileGranted() {
         doReturn(pipelineUser()).when(userManager).getCurrentUser();
-        doReturn(0).when(pathPermissionsDao)
-                .countParentFoldersByStorageAndSids(STORAGE_ID, SIDS, SPLIT_TO_PATH2);
+        doReturn(Optional.empty()).when(pathPermissionsDao)
+                .findClosestParentFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH2);
         doReturn(Arrays.asList(WRITE_FOLDER_PATH1, READ_FILE_PATH2))
                 .when(pathPermissionsDao).findByPrefix(STORAGE_ID, SIDS, PATH2);
 
         final StorageFolderListPermissionsContainer permissionsContainer = service
                 .getFolderListPermissions(STORAGE_ID, PATH2);
-        assertThat(permissionsContainer.isHasListPermissions()).isEqualTo(false);
-        assertThat(permissionsContainer.getFolders()).hasSize(1).contains("D");
-        assertThat(permissionsContainer.getFiles()).hasSize(1).contains(FILENAME1);
-        verify(pathPermissionsDao).countParentFoldersByStorageAndSids(STORAGE_ID, SIDS, SPLIT_TO_PATH2);
+        assertThat(permissionsContainer.getFolderMask()).isNull();
+        assertThat(permissionsContainer.getFolders()).hasSize(1).containsKeys("D");
+        assertThat(permissionsContainer.getFiles()).hasSize(1).containsKeys(FILENAME1);
+        verify(pathPermissionsDao).findClosestParentFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH2);
         verify(pathPermissionsDao).findByPrefix(STORAGE_ID, SIDS, PATH2);
     }
 
     @Test
     public void shouldGetFolderListPermissionsForUserWhenNestedPermissionsGranted() {
         doReturn(pipelineUser()).when(userManager).getCurrentUser();
-        doReturn(0).when(pathPermissionsDao)
-                .countParentFoldersByStorageAndSids(STORAGE_ID, SIDS, SPLIT_TO_PATH0);
+        doReturn(Optional.empty()).when(pathPermissionsDao)
+                .findClosestParentFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH0);
         doReturn(Arrays.asList(WRITE_FOLDER_PATH1, READ_FILE_PATH2))
                 .when(pathPermissionsDao).findByPrefix(STORAGE_ID, SIDS, PATH0);
 
         final StorageFolderListPermissionsContainer permissionsContainer = service
                 .getFolderListPermissions(STORAGE_ID, PATH0);
-        assertThat(permissionsContainer.isHasListPermissions()).isEqualTo(false);
-        assertThat(permissionsContainer.getFolders()).hasSize(1).contains("B");
+        assertThat(permissionsContainer.getFolderMask()).isNull();
+        assertThat(permissionsContainer.getFolders()).hasSize(1).containsKeys("B");
         assertThat(permissionsContainer.getFiles()).isNull();
-        verify(pathPermissionsDao).countParentFoldersByStorageAndSids(STORAGE_ID, SIDS, SPLIT_TO_PATH0);
+        verify(pathPermissionsDao).findClosestParentFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH0);
         verify(pathPermissionsDao).findByPrefix(STORAGE_ID, SIDS, PATH0);
     }
 
     @Test
     public void shouldThrowWhenGetFolderListPermissionsForUserIfNoPermissionsGranted() {
         doReturn(pipelineUser()).when(userManager).getCurrentUser();
-        doReturn(0).when(pathPermissionsDao)
-                .countParentFoldersByStorageAndSids(STORAGE_ID, SIDS, SPLIT_TO_PATH0);
+        doReturn(Optional.empty()).when(pathPermissionsDao)
+                .findClosestParentFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH0);
         doReturn(Collections.emptyList()).when(pathPermissionsDao).findByPrefix(STORAGE_ID, SIDS, PATH0);
 
         assertThrows(AccessDeniedException.class, () -> service.getFolderListPermissions(STORAGE_ID, PATH0));
-        verify(pathPermissionsDao).countParentFoldersByStorageAndSids(STORAGE_ID, SIDS, SPLIT_TO_PATH0);
+        verify(pathPermissionsDao).findClosestParentFolderPermission(STORAGE_ID, SIDS, SPLIT_TO_PATH0);
         verify(pathPermissionsDao).findByPrefix(STORAGE_ID, SIDS, PATH0);
     }
 

--- a/core/src/main/java/com/epam/pipeline/dto/PermissionVO.java
+++ b/core/src/main/java/com/epam/pipeline/dto/PermissionVO.java
@@ -16,7 +16,11 @@
 
 package com.epam.pipeline.dto;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter

--- a/core/src/main/java/com/epam/pipeline/dto/PermissionVO.java
+++ b/core/src/main/java/com/epam/pipeline/dto/PermissionVO.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PermissionVO {
+    private Boolean principal = true;
+    private String name;
+    private Integer mask;
+}

--- a/core/src/main/java/com/epam/pipeline/dto/datastorage/permissions/StorageFolderListPermissionsContainer.java
+++ b/core/src/main/java/com/epam/pipeline/dto/datastorage/permissions/StorageFolderListPermissionsContainer.java
@@ -19,34 +19,23 @@ package com.epam.pipeline.dto.datastorage.permissions;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import org.apache.commons.collections4.ListUtils;
 
-import java.util.List;
+import java.util.Map;
 
 @Data
 @AllArgsConstructor
 @Builder
 public class StorageFolderListPermissionsContainer {
     /**
-     * Indicates whether list permissions are granted for the requested folder.
-     * If so, files/folders fields will be ignored.
-     * If no permissions are granted, only items that exactly match the names of the files or folders will be listed.
+     * Contains requested folder permission mask. If null no permissions found for parent folders.
      */
-    private boolean hasListPermissions;
+    private Integer folderMask;
     /**
-     * List of file names that folder may contain
+     * Map of file names to permission masks that current folder may contain
      */
-    private List<String> files;
+    private Map<String, Integer> files;
     /**
-     * List of folder names that folder may contain
+     * Map of folder names to permission masks that current folder may contain
      */
-    private List<String> folders;
-
-    public boolean folderNotAllowed(final String folderName) {
-        return !hasListPermissions && !ListUtils.emptyIfNull(folders).contains(folderName);
-    }
-
-    public boolean fileNotAllowed(final String fileName) {
-        return !hasListPermissions && !ListUtils.emptyIfNull(files).contains(fileName);
-    }
+    private Map<String, Integer> folders;
 }

--- a/core/src/main/java/com/epam/pipeline/dto/datastorage/permissions/StoragePathPermissions.java
+++ b/core/src/main/java/com/epam/pipeline/dto/datastorage/permissions/StoragePathPermissions.java
@@ -11,4 +11,6 @@ public class StoragePathPermissions {
     private String folderPath;
     private String fileName;
     private int mask;
+    private String sidName;
+    private boolean principal;
 }

--- a/core/src/main/java/com/epam/pipeline/dto/datastorage/permissions/StoragePathPermissions.java
+++ b/core/src/main/java/com/epam/pipeline/dto/datastorage/permissions/StoragePathPermissions.java
@@ -3,9 +3,11 @@ package com.epam.pipeline.dto.datastorage.permissions;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 @Builder
 public class StoragePathPermissions {
     private String folderPath;

--- a/core/src/main/java/com/epam/pipeline/dto/datastorage/permissions/StoragePathPermissionsVO.java
+++ b/core/src/main/java/com/epam/pipeline/dto/datastorage/permissions/StoragePathPermissionsVO.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.dto.datastorage.permissions;
+
+import com.epam.pipeline.dto.PermissionVO;
+import com.epam.pipeline.entity.datastorage.DataStorageItemType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@Builder
+public class StoragePathPermissionsVO {
+    /**
+     * Full path for storage item from storage root.
+     */
+    private String path;
+    /**
+     * Indicates file or folder.
+     */
+    private DataStorageItemType type;
+    /**
+     * List of permissions for storage item.
+     */
+    private List<PermissionVO> permissions;
+}

--- a/core/src/main/java/com/epam/pipeline/entity/datastorage/AbstractDataStorageItem.java
+++ b/core/src/main/java/com/epam/pipeline/entity/datastorage/AbstractDataStorageItem.java
@@ -33,6 +33,7 @@ public abstract class AbstractDataStorageItem {
     private Map<String, String> tags;
     @Setter(AccessLevel.PACKAGE)
     private DataStorageItemType type;
+    private Integer mask;
 
     @JsonIgnore
     public static Comparator<AbstractDataStorageItem> getStorageItemComparator() {

--- a/core/src/main/java/com/epam/pipeline/entity/datastorage/DataStorageListing.java
+++ b/core/src/main/java/com/epam/pipeline/entity/datastorage/DataStorageListing.java
@@ -31,5 +31,6 @@ import java.util.List;
 @EqualsAndHashCode
 public class DataStorageListing {
     private String nextPageMarker;
+    private Integer parentFolderMask;
     private List<AbstractDataStorageItem> results;
 }


### PR DESCRIPTION
relates to #3919 

implements point 8,9
- a new methods for admins/owners to support path permissions modifications
-  masks in storage listing

Also, provides 
- fixes for permissions merging
- support for storage tags
