### PR TITLE
Issue 3954: Cluster network stats: fix for time based aggregation values 

### DIFF
--- a/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/platform/NetworkEventRequester.java
+++ b/api/src/main/java/com/epam/pipeline/dao/monitoring/metricrequester/platform/NetworkEventRequester.java
@@ -174,8 +174,7 @@ public class NetworkEventRequester extends AbstractPlatformMetricRequester {
                 return AggregationBuilders.dateHistogram(TIME_HISTOGRAM_NAME)
                         .field(TIMESTAMP_FIELD)
                         .order(BucketOrder.key(true))
-                        .interval(interval.toMillis())
-                        .minDocCount(1L);
+                        .interval(interval.toMillis());
         }
     }
 


### PR DESCRIPTION
This PR fix situation when ELK aggregation didn't return zero-count value for time based aggregation