### PR TITLE
Issue #3947- Google Cloud Logging, add save method to GCP Cloud Logging

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -134,7 +134,7 @@ dependencies {
     compile group: 'redis.clients', name: 'jedis', version: '2.9.0'
 
     //GCP
-    compile group: "com.google.auth", name: "google-auth-library-oauth2-http", version: "0.27.0"
+    compile group: "com.google.auth", name: "google-auth-library-oauth2-http", version: "1.31.0"
     compile group: "com.google.api-client", name: "google-api-client", version: "1.34.0"
     compile "com.google.apis:google-api-services-compute:v1-rev20220720-1.32.1"
     compile "com.google.apis:google-api-services-cloudbilling:v1-rev30-1.25.0"
@@ -142,6 +142,7 @@ dependencies {
     compile "com.google.cloud:google-cloud-bigquery:2.49.0"
     compile "com.google.cloud:google-cloud-storage:1.70.0"
     compile "com.google.code.gson:gson:2.10.1"
+    compile "com.google.cloud:google-cloud-logging:3.22.0"
 
     testCompile group: "org.springframework.security", name: "spring-security-test", version: "4.2.2.RELEASE"
     testCompile group: "com.github.tomakehurst", name: "wiremock", version: "2.14.0"

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPClient.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPClient.java
@@ -30,6 +30,8 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.cloud.http.HttpTransportOptions;
+import com.google.cloud.logging.Logging;
+import com.google.cloud.logging.LoggingOptions;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import org.apache.commons.lang3.StringUtils;
@@ -111,6 +113,14 @@ public class GCPClient {
                         .setReadTimeout(readTimeoutMills)
                         .setConnectTimeout(connectTimeout)
                         .build())
+                .build()
+                .getService();
+    }
+
+    public Logging buildCloudLoggingClient(final GCPRegion region) throws IOException {
+        return LoggingOptions.newBuilder()
+                .setProjectId(region.getProject())
+                .setCredentials(createCredentials(region))
                 .build()
                 .getService();
     }

--- a/api/src/main/java/com/epam/pipeline/manager/log/ElasticLogManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/log/ElasticLogManager.java
@@ -95,11 +95,6 @@ public class ElasticLogManager implements LogManager {
             SearchRequest.DEFAULT_INDICES_OPTIONS.expandWildcardsClosed(),
             SearchRequest.DEFAULT_INDICES_OPTIONS);
 
-    private static final DateTimeFormatter DATE_TIME_FORMATTER =
-            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
-    private static final String ID = "event_id";
-    private static final String SERVICE_ACCOUNT = "service_account";
-    private static final String STORAGE_ID = "storage_id";
     private static final String KEYWORD = ".keyword";
     private static final Period FILEBEAT_TRANSITION_PERIOD = Period.ofDays(1);
     private static final String INDEX_TYPE = "_doc";

--- a/api/src/main/java/com/epam/pipeline/manager/log/LogManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/log/LogManager.java
@@ -5,6 +5,7 @@ import com.epam.pipeline.entity.log.LogFilter;
 import com.epam.pipeline.entity.log.LogPagination;
 import com.epam.pipeline.entity.log.LogRequest;
 
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 
@@ -19,6 +20,8 @@ public interface LogManager {
     String SEVERITY = "level";
     String ID = "event_id";
     String DEFAULT_SEVERITY = "INFO";
+    String STORAGE_ID = "storage_id";
+    DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
 
     LogPagination filter(LogFilter logFilter);
 

--- a/api/src/main/java/com/epam/pipeline/manager/log/gcp/GCPLogManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/log/gcp/GCPLogManager.java
@@ -16,13 +16,18 @@ import com.epam.pipeline.manager.cloud.gcp.GCPClient;
 import com.epam.pipeline.manager.log.LogManager;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
+import com.epam.pipeline.manager.security.AuthManager;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.FieldValue;
 import com.google.cloud.bigquery.FieldValueList;
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.TableResult;
+import com.google.cloud.logging.Logging;
+import com.google.cloud.logging.Payload;
+import com.google.cloud.logging.Severity;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections.map.SingletonMap;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -34,9 +39,13 @@ import org.springframework.util.Assert;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -59,9 +68,7 @@ public class GCPLogManager implements LogManager {
     private static final String HOSTNAMES_ALIAS = "hostnames";
     private static final String JSON_PAYLOAD = "json_payload";
     private static final String COUNT_COLUMN = "COUNT(1) as count";
-    private static final DateTimeFormatter LOCAL_DATE_TO_BIGQUERY_FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
-    private static final DateTimeFormatter BIG_QUERY_TO_LOCAL_DATE_FORMATTER =
-            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+    private static final String ZONED_DATE_TIME_TO_BIGQUERY_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
     private static final String SQL_SELECT_TEMPLATE = "SELECT %s FROM `%s._AllLogs` WHERE json_payload IS NOT NULL ";
     private static final String SQL_POSTFIX_TEMPLATE = "%s ORDER BY %s %s, %s %s LIMIT %s";
     private static final String DICTIONARY_QUERY_COLUMNS = String.join(", ",
@@ -90,6 +97,7 @@ public class GCPLogManager implements LogManager {
     private final CloudRegionDao cloudRegionDao;
     private final PreferenceManager preferenceManager;
     private final MessageHelper messageHelper;
+    private final AuthManager authManager;
 
     /**
      * Retrieves available filter values for the log entries.
@@ -176,8 +184,72 @@ public class GCPLogManager implements LogManager {
     }
 
     @Override
-    public void save(List<LogEntry> logEntries) {
-        throw new UnsupportedOperationException("Not supported currently.");
+    public void save(final List<LogEntry> logEntries) {
+        log.debug("Saving log entries to GCP Cloud Logging ({})...", logEntries.size());
+        if (logEntries.isEmpty()) {
+            return;
+        }
+
+        final String logName = preferenceManager.getPreference(SystemPreferences.GCP_LOGGING_LOG_NAME);
+        Map<String, String> labels = new SingletonMap(
+                preferenceManager.getPreference(SystemPreferences.GCP_LOGGING_SINK_LABEL_KEY),
+                preferenceManager.getPreference(SystemPreferences.GCP_LOGGING_SINK_LABEL_VALUE));
+
+        final GCPRegion gcpRegion = (GCPRegion) cloudRegionDao.loadDefaultRegion()
+                .filter(r -> GCP == r.getProvider())
+                .orElseThrow(() -> new ObjectNotFoundException("No Default Region for GCP"));
+
+        try {
+            final Logging logging = gcpClient.buildCloudLoggingClient(gcpRegion);
+            // Convert LogEntry list to GCP LogEntry objects
+            final List<com.google.cloud.logging.LogEntry> gcpLogEntries = logEntries.stream()
+                    .map(e -> toGcpLogEntry(e, labels))
+                    .collect(Collectors.toList());
+
+            // Write logs in bulk
+            logging.write(gcpLogEntries, Logging.WriteOption.logName(logName));
+        } catch (IOException e) {
+            throw new PipelineException(e);
+        }
+    }
+
+    private com.google.cloud.logging.LogEntry toGcpLogEntry(final LogEntry logEntry, final Map<String, String> labels) {
+        final Map<String, Object> payload = new HashMap<>();
+        payload.put(ID, logEntry.getEventId().toString());
+        payload.put(MESSAGE_TIMESTAMP, toUnifiedBigQueryFormat(logEntry.getMessageTimestamp()));
+        payload.put(HOSTNAME, logEntry.getHostname());
+        payload.put(SERVICE_NAME, logEntry.getServiceName());
+        payload.put(TYPE, logEntry.getType());
+        payload.put(USER, logEntry.getUser());
+        payload.put(MESSAGE, logEntry.getMessage());
+        payload.put(SEVERITY, logEntry.getSeverity());
+        payload.put(SERVICE_ACCOUNT, authManager.isServiceUser(logEntry.getUser()));
+        payload.put(STORAGE_ID, logEntry.getStorageId());
+
+        // Build GCP LogEntry
+        return com.google.cloud.logging.LogEntry
+                .newBuilder(Payload.JsonPayload.of(payload))
+                .setLabels(labels)
+                .setSeverity(mapSeverity(logEntry.getSeverity()))
+                .build();
+    }
+
+    private Severity mapSeverity(final String severity) {
+        if (severity == null) {
+            return Severity.DEFAULT;
+        }
+        switch (severity.toUpperCase()) {
+            case "ERROR":
+                return Severity.ERROR;
+            case "WARN":
+                return Severity.WARNING;
+            case "INFO":
+                return Severity.INFO;
+            case "DEBUG":
+                return Severity.DEBUG;
+            default:
+                return Severity.DEFAULT;
+        }
     }
 
     private String constructQueryFilter(final LogFilter logFilter) {
@@ -326,9 +398,18 @@ public class GCPLogManager implements LogManager {
         if (fieldValue.isNull()) {
             return null;
         }
-        String timestampValue = fieldValue.getStringValue();
+        final String timestampValue = fieldValue.getStringValue();
 
-        return timestampValue != null ? LocalDateTime.parse(timestampValue, BIG_QUERY_TO_LOCAL_DATE_FORMATTER) : null;
+        if (StringUtils.isNotBlank(timestampValue)) {
+            try {
+                return LocalDateTime.parse(timestampValue,
+                        DateTimeFormatter.ofPattern(ZONED_DATE_TIME_TO_BIGQUERY_FORMAT));
+            } catch (DateTimeParseException ex) {
+                return LocalDateTime.parse(timestampValue, DATE_TIME_FORMATTER);
+            }
+        }
+
+        return null;
     }
 
     private void applyOrderBasedPagination(final StringBuilder whereClause, final LogFilter logFilter) {
@@ -381,16 +462,14 @@ public class GCPLogManager implements LogManager {
 
         if (timestampFrom != null && timestampTo != null) {
             appendCondition(whereClause,
-                    String.format("%s BETWEEN '%s+0000' AND '%s+0000'",
-                            timestampField,
-                            LOCAL_DATE_TO_BIGQUERY_FORMATTER.format(timestampFrom),
-                            LOCAL_DATE_TO_BIGQUERY_FORMATTER.format(timestampTo)));
+                    String.format("%s BETWEEN '%s' AND '%s'", timestampField,
+                            toUnifiedBigQueryFormat(timestampFrom), toUnifiedBigQueryFormat(timestampTo)));
         } else if (timestampFrom != null) {
-            appendCondition(whereClause, String.format("%s >= '%s+0000'", timestampField,
-                    LOCAL_DATE_TO_BIGQUERY_FORMATTER.format(timestampFrom)));
+            appendCondition(whereClause, String.format("%s >= '%s'", timestampField,
+                    toUnifiedBigQueryFormat(timestampFrom)));
         } else {
-            appendCondition(whereClause, String.format("%s <= '%s+0000'", timestampField,
-                    LOCAL_DATE_TO_BIGQUERY_FORMATTER.format(timestampTo)));
+            appendCondition(whereClause, String.format("%s <= '%s'", timestampField,
+                    toUnifiedBigQueryFormat(timestampTo)));
         }
     }
 
@@ -467,5 +546,10 @@ public class GCPLogManager implements LogManager {
 
     private String getTableName() {
         return preferenceManager.getPreference(SystemPreferences.GCP_LOGGING_BIG_QUERY_TABLE_NAME);
+    }
+
+    public static String toUnifiedBigQueryFormat(final LocalDateTime localDateTime) {
+        final ZonedDateTime zonedDateTime = localDateTime.atZone(ZoneId.of("UTC"));
+        return zonedDateTime.format(DateTimeFormatter.ofPattern(ZONED_DATE_TIME_TO_BIGQUERY_FORMAT));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -1418,6 +1418,15 @@ public class SystemPreferences {
     public static final LongPreference GCP_LOGGING_BIG_QUERY_MAX_BYTES = new LongPreference(
             "gcp.logging.bigquery.max.bytes", 100_000_000L, GCP_GROUP, isNotBlank);
 
+    public static final StringPreference GCP_LOGGING_LOG_NAME = new StringPreference(
+            "gcp.logging.log.name", "security_log", GCP_GROUP, isNotBlank);
+
+    public static final StringPreference GCP_LOGGING_SINK_LABEL_KEY = new StringPreference(
+            "gcp.logging.sink.label.key", "application-label", GCP_GROUP, isNotBlank);
+
+    public static final StringPreference GCP_LOGGING_SINK_LABEL_VALUE = new StringPreference(
+            "gcp.logging.sink.label.value", "pipeline-api", GCP_GROUP, isNotBlank);
+
     // Billing Reports
     public static final StringPreference BILLING_USER_NAME_ATTRIBUTE = new StringPreference(
             "billing.reports.user.name.attribute", null, BILLING_GROUP, pass);

--- a/api/src/test/java/com/epam/pipeline/acl/log/gcp/GCPLogManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/acl/log/gcp/GCPLogManagerTest.java
@@ -10,7 +10,12 @@ import com.epam.pipeline.manager.cloud.gcp.GCPClient;
 import com.epam.pipeline.manager.log.gcp.GCPLogManager;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
+import com.epam.pipeline.manager.security.AuthManager;
 import com.google.cloud.bigquery.*;
+import com.google.cloud.logging.Logging;
+import com.google.cloud.logging.Severity;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
 import org.elasticsearch.search.sort.SortOrder;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,8 +31,16 @@ import java.time.Month;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 
+import static com.epam.pipeline.manager.log.LogManager.HOSTNAME;
+import static com.epam.pipeline.manager.log.LogManager.MESSAGE;
 import static com.epam.pipeline.manager.log.LogManager.MESSAGE_TIMESTAMP;
 import static com.epam.pipeline.manager.log.LogManager.ID;
+import static com.epam.pipeline.manager.log.LogManager.SERVICE_ACCOUNT;
+import static com.epam.pipeline.manager.log.LogManager.SERVICE_NAME;
+import static com.epam.pipeline.manager.log.LogManager.SEVERITY;
+import static com.epam.pipeline.manager.log.LogManager.STORAGE_ID;
+import static com.epam.pipeline.manager.log.LogManager.TYPE;
+import static com.epam.pipeline.manager.log.LogManager.USER;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -56,6 +69,17 @@ public class GCPLogManagerTest {
     public static final String SERVICE_2 = "service2";
     public static final String TYPE_1 = "type1";
     public static final String TYPE_2 = "type2";
+    public static final String SECURITY_LOG = "security_log";
+    public static final String SINK_LABEL = "sink-label";
+    public static final String SINK_LABEL_VALUE = "sink-label-value";
+
+    private static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
+    public static final Long EVENT_ID1 = 1744351501175986176L;
+    public static final Long EVENT_ID2 = 1744351501176002048L;
+    public static final long STORAGE_ID1 = 37943L;
+    public static final long STORAGE_ID2 = 52945L;
+    public static final String INFO = "INFO";
+    public static final String ERROR = "ERROR";
 
     @Mock
     private GCPClient gcpClient;
@@ -73,6 +97,9 @@ public class GCPLogManagerTest {
     private BigQuery bigQuery;
 
     @Mock
+    private Logging logging;
+
+    @Mock
     private TableResult filterTableResult;
 
     @Mock
@@ -83,6 +110,9 @@ public class GCPLogManagerTest {
 
     @Mock
     private TableResult dictionaryTableResult;
+
+    @Mock
+    private AuthManager authManager;
 
     @InjectMocks
     private GCPLogManager gcpLogManager;
@@ -95,6 +125,7 @@ public class GCPLogManagerTest {
         gcpRegion.setProvider(CloudProvider.GCP);
         when(cloudRegionDao.loadDefaultRegion()).thenReturn(Optional.of(gcpRegion));
         when(gcpClient.buildBigQueryClient(eq(gcpRegion), anyInt(), anyInt())).thenReturn(bigQuery);
+        when(gcpClient.buildCloudLoggingClient(eq(gcpRegion))).thenReturn(logging);
         when(preferenceManager.getPreference(SystemPreferences.GCP_LOGGING_BIG_QUERY_TABLE_NAME))
                 .thenReturn(TABLE_NAME);
         when(preferenceManager.getPreference(SystemPreferences.GCP_LOGGING_READ_TIMEOUT_MILLS))
@@ -104,11 +135,16 @@ public class GCPLogManagerTest {
         when(preferenceManager.getPreference(SystemPreferences.GCP_LOGGING_BIG_QUERY_MAX_BYTES))
                 .thenReturn(MAX_BYTES_BILLED);
         when(preferenceManager.getPreference(SystemPreferences.SEARCH_LOGS_AGGS_MAX_COUNT)).thenReturn(AGGS_MAX_COUNT);
+        when(preferenceManager.getPreference(SystemPreferences.GCP_LOGGING_LOG_NAME)).thenReturn(SECURITY_LOG);
+        when(preferenceManager.getPreference(SystemPreferences.GCP_LOGGING_SINK_LABEL_KEY)).thenReturn(SINK_LABEL);
+        when(preferenceManager.getPreference(SystemPreferences.GCP_LOGGING_SINK_LABEL_VALUE))
+                .thenReturn(SINK_LABEL_VALUE);
         when(messageHelper.getMessage(anyString())).thenReturn("Error message");
+        doNothing().when(logging).write(anyList(), anyObject());
     }
 
     @Test
-    public void testFilterSuccess() throws InterruptedException {
+    public void shouldFilterSuccess() throws InterruptedException {
         LogFilter logFilter = createFullLogFilter();
         setupFilterTableResult();
         setupCountTableResult(3L);
@@ -169,7 +205,7 @@ public class GCPLogManagerTest {
         assertThat(entry1.getMessageTimestamp()).isEqualTo(
                 LocalDateTime.parse("2023-01-01T12:00:00.000Z", DateTimeFormatter.ISO_DATE_TIME));
         assertThat(entry1.getUser()).isEqualTo(USER_1);
-        assertThat(entry1.getSeverity()).isEqualTo("INFO");
+        assertThat(entry1.getSeverity()).isEqualTo(INFO);
         assertThat(entry1.getServiceName()).isEqualTo(SERVICE_1);
         assertThat(entry1.getType()).isEqualTo(TYPE_1);
         assertThat(entry1.getHostname()).isEqualTo(HOST_1);
@@ -181,7 +217,7 @@ public class GCPLogManagerTest {
         assertThat(entry2.getMessageTimestamp()).isEqualTo(
                 LocalDateTime.parse("2023-01-02T12:00:00.000Z", DateTimeFormatter.ISO_DATE_TIME));
         assertThat(entry2.getUser()).isEqualTo(USER_2);
-        assertThat(entry2.getSeverity()).isEqualTo("ERROR");
+        assertThat(entry2.getSeverity()).isEqualTo(ERROR);
         assertThat(entry2.getServiceName()).isEqualTo(SERVICE_2);
         assertThat(entry2.getType()).isEqualTo(TYPE_2);
         assertThat(entry2.getHostname()).isEqualTo(HOST_2);
@@ -189,7 +225,7 @@ public class GCPLogManagerTest {
     }
 
     @Test(expected = PipelineException.class)
-    public void testFilterWithIOException() throws IOException {
+    public void shouldFilterWithIOException() throws IOException {
         LogFilter logFilter = createLogFilter();
         when(gcpClient.buildBigQueryClient(any(), anyInt(), anyInt())).thenThrow(new IOException("BigQuery failure"));
 
@@ -197,7 +233,7 @@ public class GCPLogManagerTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testFilterInvalidPagination() {
+    public void shouldFilterInvalidPagination() {
         LogFilter logFilter = new LogFilter();
         logFilter.setPagination(LogPaginationRequest.builder().pageSize(0).token(null).build());
 
@@ -205,7 +241,7 @@ public class GCPLogManagerTest {
     }
 
     @Test
-    public void testGroupSuccess() throws InterruptedException {
+    public void shouldGroupSuccess() throws InterruptedException {
         LogRequest logRequest = new LogRequest();
         logRequest.setGroupBy("user");
         setupGroupTableResult();
@@ -231,7 +267,7 @@ public class GCPLogManagerTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testGroupWithEmptyGroupBy() {
+    public void shouldGroupWithEmptyGroupBy() {
         // Arrange
         LogRequest logRequest = new LogRequest();
         logRequest.setGroupBy("");
@@ -240,7 +276,7 @@ public class GCPLogManagerTest {
     }
 
     @Test
-    public void testGetFiltersSuccess() throws InterruptedException {
+    public void shouldGetFiltersSuccess() throws InterruptedException {
         setupDictionaryTableResult();
         when(bigQuery.query(any(QueryJobConfiguration.class))).thenReturn(dictionaryTableResult);
         ArgumentCaptor<QueryJobConfiguration> queryCaptor = ArgumentCaptor.forClass(QueryJobConfiguration.class);
@@ -267,7 +303,7 @@ public class GCPLogManagerTest {
     }
 
     @Test
-    public void testGetFiltersWithNullValues() throws InterruptedException {
+    public void shouldGetFiltersWithNullValues() throws InterruptedException {
         setupEmptyDictionaryTableResult();
         when(bigQuery.query(any(QueryJobConfiguration.class))).thenReturn(dictionaryTableResult);
 
@@ -279,6 +315,97 @@ public class GCPLogManagerTest {
         assertTrue(result.getServiceNames().isEmpty());
         assertTrue(result.getHostnames().isEmpty());
         verify(bigQuery, times(1)).query(any(QueryJobConfiguration.class));
+    }
+
+    @Test
+    public void shouldReturnOnEmpty() {
+        gcpLogManager.save(Collections.emptyList());
+
+        verifyZeroInteractions(preferenceManager, cloudRegionDao, gcpClient);
+    }
+
+    @Test
+    public void shouldSaveSuccess() throws IOException {
+        when(authManager.isServiceUser(anyString())).thenReturn(true).thenReturn(false);
+
+        final LogEntry logEntry1 = LogEntry.builder()
+                .eventId(EVENT_ID1)
+                .serviceName("pipe-mount1")
+                .user(USER_1)
+                .messageTimestamp(LocalDateTime.parse("2025-04-15 06:05:01.175", TIMESTAMP_FORMATTER))
+                .storageId(STORAGE_ID1)
+                .message("READ s3://e2e-mount-s3-1-11-04-2025-05-58-39/1KB")
+                .hostname("ip-172-31-4-81")
+                .type("audit")
+                .severity(INFO)
+                .build();
+
+        final LogEntry logEntry2 = LogEntry.builder()
+                .eventId(EVENT_ID2)
+                .serviceName("pipe-mount2")
+                .user(USER_2)
+                .messageTimestamp(LocalDateTime.parse("2025-04-15 06:55:01.435", TIMESTAMP_FORMATTER))
+                .storageId(STORAGE_ID2)
+                .message("WRITE s3://e2e-mount-s3-1-11-04-2025-05-58-39/512MB")
+                .hostname("ip-172-31-4-82")
+                .type("log")
+                .severity(ERROR)
+                .build();
+
+        gcpLogManager.save(Arrays.asList(logEntry1, logEntry2));
+
+        //Assert
+        ArgumentCaptor<Logging.WriteOption> optionArgCaptor = ArgumentCaptor.forClass(Logging.WriteOption.class);
+        ArgumentCaptor<List<com.google.cloud.logging.LogEntry>> argCaptor = ArgumentCaptor.forClass((Class) List.class);
+        verify(logging).write(argCaptor.capture(), optionArgCaptor.capture());
+
+        List<com.google.cloud.logging.LogEntry> logEntries = argCaptor.getValue();
+        assertThat(logEntries).hasSize(2);
+
+        final com.google.cloud.logging.LogEntry gcpLogEntry1 = logEntries.get(0);
+        assertEquals(Severity.INFO, gcpLogEntry1.getSeverity());
+        assertEquals(Collections.singletonMap(SINK_LABEL, SINK_LABEL_VALUE), gcpLogEntry1.getLabels());
+
+        Map<String, Value> payload1 = ((Struct) gcpLogEntry1.getPayload().getData()).getFieldsMap();
+        assertThat(payload1.get(HOSTNAME).getStringValue()).isEqualTo("ip-172-31-4-81");
+        assertThat(payload1.get(ID).getStringValue()).isEqualTo(EVENT_ID1.toString());
+        assertThat(payload1.get(SERVICE_NAME).getStringValue()).isEqualTo("pipe-mount1");
+        assertThat(payload1.get(MESSAGE).getStringValue())
+                .isEqualTo("READ s3://e2e-mount-s3-1-11-04-2025-05-58-39/1KB");
+        assertThat(payload1.get(TYPE).getStringValue()).isEqualTo("audit");
+        assertThat(payload1.get(SEVERITY).getStringValue()).isEqualTo(INFO);
+        assertThat(payload1.get(USER).getStringValue()).isEqualTo(USER_1);
+        assertThat(payload1.get(MESSAGE_TIMESTAMP).getStringValue()).isEqualTo("2025-04-15T06:05:01.175+0000");
+        assertThat(payload1.get(SERVICE_ACCOUNT).getBoolValue()).isEqualTo(true);
+        assertThat(payload1.get(STORAGE_ID).getNumberValue()).isEqualTo(STORAGE_ID1);
+        verify(authManager).isServiceUser(USER_1);
+
+        final com.google.cloud.logging.LogEntry gcpLogEntry2 = logEntries.get(1);
+        assertEquals(Severity.ERROR, gcpLogEntry2.getSeverity());
+        assertEquals(Collections.singletonMap(SINK_LABEL, SINK_LABEL_VALUE), gcpLogEntry2.getLabels());
+
+        Map<String, Value> payload2 = ((Struct) gcpLogEntry2.getPayload().getData()).getFieldsMap();
+        assertThat(payload2.get(HOSTNAME).getStringValue()).isEqualTo("ip-172-31-4-82");
+        assertThat(payload2.get(ID).getStringValue()).isEqualTo(EVENT_ID2.toString());
+        assertThat(payload2.get(SERVICE_NAME).getStringValue()).isEqualTo("pipe-mount2");
+        assertThat(payload2.get(MESSAGE).getStringValue())
+                .isEqualTo("WRITE s3://e2e-mount-s3-1-11-04-2025-05-58-39/512MB");
+        assertThat(payload2.get(TYPE).getStringValue()).isEqualTo("log");
+        assertThat(payload2.get(SEVERITY).getStringValue()).isEqualTo(ERROR);
+        assertThat(payload2.get(USER).getStringValue()).isEqualTo(USER_2);
+        assertThat(payload2.get(MESSAGE_TIMESTAMP).getStringValue()).isEqualTo("2025-04-15T06:55:01.435+0000");
+        assertThat(payload2.get(SERVICE_ACCOUNT).getBoolValue()).isEqualTo(false);
+        assertThat(payload2.get(STORAGE_ID).getNumberValue()).isEqualTo(STORAGE_ID2);
+        verify(authManager).isServiceUser(USER_2);
+
+        Logging.WriteOption writeOption = optionArgCaptor.getValue();
+        assertThat(writeOption).isEqualTo(Logging.WriteOption.logName(SECURITY_LOG));
+
+        verify(cloudRegionDao).loadDefaultRegion();
+        verify(gcpClient).buildCloudLoggingClient(gcpRegion);
+        verify(preferenceManager).getPreference(SystemPreferences.GCP_LOGGING_LOG_NAME);
+        verify(preferenceManager).getPreference(SystemPreferences.GCP_LOGGING_SINK_LABEL_KEY);
+        verify(preferenceManager).getPreference(SystemPreferences.GCP_LOGGING_SINK_LABEL_VALUE);
     }
 
     private LogFilter createLogFilter() {
@@ -311,9 +438,9 @@ public class GCPLogManagerTest {
 
     private void setupFilterTableResult() {
         List<FieldValueList> rows = new ArrayList<>();
-        rows.add(createFieldValueList("1", "2023-01-01T12:00:00.000+0000", USER_1, "INFO",
+        rows.add(createFieldValueList("1", "2023-01-01T12:00:00.000+0000", USER_1, INFO,
                 SERVICE_1, TYPE_1, HOST_1, "msg1"));
-        rows.add(createFieldValueList("2", "2023-01-02T12:00:00.000+0000", USER_2, "ERROR",
+        rows.add(createFieldValueList("2", "2023-01-02T12:00:00.000+0000", USER_2, ERROR,
                 SERVICE_2, TYPE_2, HOST_2, "msg2"));
         rows.add(createFieldValueList("3", "2023-01-03T12:00:00.000+0000", "user3", "WARN",
                 "service3", "type3", "host3", "msg3"));


### PR DESCRIPTION
Issue #3947, 
1. Added implementation for save method, which sends logs to GCP Cloud Logging Service.
2. New SystemPreferences: 
2.1. gcp.logging.log.name - logname for GCP Cloud Logging
2.2. gcp.logging.sink.label.key - label key for defining where the log come from, needed for sink which will redirect the log to BigQuery
2.3. gcp.logging.sink.label.value -  label value for defining where the log come from, needed for sink which will redirect the log to BigQuery