### PR TITLE
Issue #3969 - GCP Metrics Integration for Google Compute Engines

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -143,6 +143,8 @@ dependencies {
     compile "com.google.cloud:google-cloud-storage:1.70.0"
     compile "com.google.code.gson:gson:2.10.1"
     compile "com.google.cloud:google-cloud-logging:3.22.0"
+    compile "com.google.cloud:google-cloud-monitoring:3.44.0"
+    compile "com.google.cloud:google-cloud-compute:1.72.0"
 
     testCompile group: "org.springframework.security", name: "spring-security-test", version: "4.2.2.RELEASE"
     testCompile group: "com.github.tomakehurst", name: "wiremock", version: "2.14.0"

--- a/api/src/main/java/com/epam/pipeline/entity/cluster/monitoring/MonitoringStats.java
+++ b/api/src/main/java/com/epam/pipeline/entity/cluster/monitoring/MonitoringStats.java
@@ -103,5 +103,6 @@ public class MonitoringStats {
         private MonitoringMetrics gpuMemoryUtilization;
         private MonitoringMetrics gpuMemoryUsed;
         private MonitoringMetrics activeGpus;
+        private MonitoringMetrics gpuMemoryFree;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPClient.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/GCPClient.java
@@ -18,20 +18,30 @@ package com.epam.pipeline.manager.cloud.gcp;
 
 import com.epam.pipeline.entity.datastorage.DataStorageException;
 import com.epam.pipeline.entity.region.GCPRegion;
+import com.epam.pipeline.manager.cloud.gcp.wrappers.GCPInstancesClientWrapper;
+import com.epam.pipeline.manager.cloud.gcp.wrappers.GCPMachineTypesClientWrapper;
+import com.epam.pipeline.manager.cloud.gcp.wrappers.GCPMetricServiceClientWrapper;
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.api.services.cloudbilling.Cloudbilling;
 import com.google.api.services.compute.Compute;
 import com.google.api.services.iamcredentials.v1.IAMCredentials;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.compute.v1.InstancesClient;
+import com.google.cloud.compute.v1.InstancesSettings;
+import com.google.cloud.compute.v1.MachineTypesClient;
+import com.google.cloud.compute.v1.MachineTypesSettings;
 import com.google.cloud.http.HttpTransportOptions;
 import com.google.cloud.logging.Logging;
 import com.google.cloud.logging.LoggingOptions;
+import com.google.cloud.monitoring.v3.MetricServiceClient;
+import com.google.cloud.monitoring.v3.MetricServiceSettings;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import org.apache.commons.lang3.StringUtils;
@@ -123,6 +133,22 @@ public class GCPClient {
                 .setCredentials(createCredentials(region))
                 .build()
                 .getService();
+    }
+
+    public GCPMetricServiceClientWrapper buildMetricsClient(final  GCPRegion region) throws IOException {
+        return new GCPMetricServiceClientWrapper(MetricServiceClient.create(MetricServiceSettings.newBuilder()
+                .setCredentialsProvider(FixedCredentialsProvider.create(createCredentials(region)))
+                .build()));
+    }
+
+    public GCPInstancesClientWrapper buildInstancesClient(final  GCPRegion region) throws IOException {
+        return new GCPInstancesClientWrapper(InstancesClient.create(InstancesSettings.newBuilder()
+                .setCredentialsProvider(FixedCredentialsProvider.create(createCredentials(region))).build()));
+    }
+
+    public GCPMachineTypesClientWrapper buildMachineTypesClient(final GCPRegion region) throws IOException {
+        return new GCPMachineTypesClientWrapper(MachineTypesClient.create(MachineTypesSettings.newBuilder()
+                .setCredentialsProvider(FixedCredentialsProvider.create(createCredentials(region))).build()));
     }
 
     public String generateToken(final GCPRegion region) throws IOException {

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/wrappers/GCPInstancesClientWrapper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/wrappers/GCPInstancesClientWrapper.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cloud.gcp.wrappers;
+
+import com.google.cloud.compute.v1.Instance;
+import com.google.cloud.compute.v1.InstancesClient;
+
+
+public class GCPInstancesClientWrapper implements AutoCloseable {
+    private final InstancesClient instancesClient;
+    public GCPInstancesClientWrapper(final InstancesClient instancesClient) {
+        this.instancesClient = instancesClient;
+    }
+
+    public Instance get(final String projectId, final String zone, final String instance) {
+        return instancesClient.get(projectId, zone, instance);
+    }
+
+    @Override
+    public void close() {
+        instancesClient.close();
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/wrappers/GCPMachineTypesClientWrapper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/wrappers/GCPMachineTypesClientWrapper.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cloud.gcp.wrappers;
+
+import com.google.cloud.compute.v1.MachineType;
+import com.google.cloud.compute.v1.MachineTypesClient;
+
+public class GCPMachineTypesClientWrapper implements AutoCloseable {
+    private final MachineTypesClient machineTypesClient;
+    public GCPMachineTypesClientWrapper(final MachineTypesClient machineTypesClient) {
+        this.machineTypesClient = machineTypesClient;
+    }
+
+    public MachineType get(final String projectId, final String zone, final String instance) {
+        return machineTypesClient.get(projectId, zone, instance);
+    }
+
+    @Override
+    public void close() {
+        machineTypesClient.close();
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/wrappers/GCPMetricServiceClientWrapper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/gcp/wrappers/GCPMetricServiceClientWrapper.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cloud.gcp.wrappers;
+
+import com.google.cloud.monitoring.v3.MetricServiceClient;
+import com.google.monitoring.v3.ListTimeSeriesRequest;
+
+public class GCPMetricServiceClientWrapper implements AutoCloseable {
+    private final MetricServiceClient metricServiceClient;
+    public GCPMetricServiceClientWrapper(MetricServiceClient metricServiceClient) {
+        this.metricServiceClient = metricServiceClient;
+    }
+
+    public MetricServiceClient.ListTimeSeriesPagedResponse listTimeSeries(ListTimeSeriesRequest request) {
+        return metricServiceClient.listTimeSeries(request);
+    }
+
+    @Override
+    public void close() {
+        metricServiceClient.close();
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/gcp/GCPMonitoringService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/gcp/GCPMonitoringService.java
@@ -1,0 +1,804 @@
+/*
+ * Copyright 2025 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster.performancemonitoring.gcp;
+
+import com.epam.pipeline.common.MessageConstants;
+import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.dao.region.CloudRegionDao;
+import com.epam.pipeline.entity.cluster.NodeInstance;
+import com.epam.pipeline.entity.cluster.monitoring.MonitoringMetrics;
+import com.epam.pipeline.entity.cluster.monitoring.MonitoringStats;
+import com.epam.pipeline.entity.cluster.monitoring.gpu.GpuMetricsGranularity;
+import com.epam.pipeline.entity.cluster.monitoring.gpu.GpuMonitoringStats;
+import com.epam.pipeline.entity.region.CloudProvider;
+import com.epam.pipeline.entity.region.GCPRegion;
+import com.epam.pipeline.entity.utils.DateUtils;
+import com.epam.pipeline.exception.ObjectNotFoundException;
+import com.epam.pipeline.exception.PipelineException;
+import com.epam.pipeline.manager.cloud.gcp.GCPClient;
+import com.epam.pipeline.manager.cloud.gcp.wrappers.GCPInstancesClientWrapper;
+import com.epam.pipeline.manager.cloud.gcp.wrappers.GCPMachineTypesClientWrapper;
+import com.epam.pipeline.manager.cloud.gcp.wrappers.GCPMetricServiceClientWrapper;
+import com.epam.pipeline.manager.cluster.KubernetesConstants;
+import com.epam.pipeline.manager.cluster.MonitoringReportType;
+import com.epam.pipeline.manager.cluster.NodesManager;
+import com.epam.pipeline.manager.cluster.performancemonitoring.UsageMonitoringManager;
+import com.epam.pipeline.manager.cluster.writer.AbstractMonitoringStatsWriter;
+import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.epam.pipeline.manager.preference.SystemPreferences;
+import com.epam.pipeline.utils.CommonUtils;
+import com.google.cloud.compute.v1.Instance;
+import com.google.cloud.compute.v1.MachineType;
+import com.google.cloud.monitoring.v3.MetricServiceClient;
+import com.google.monitoring.v3.Aggregation;
+import com.google.monitoring.v3.ListTimeSeriesRequest;
+import com.google.monitoring.v3.Point;
+import com.google.monitoring.v3.ProjectName;
+import com.google.monitoring.v3.TimeInterval;
+import com.google.monitoring.v3.TimeSeries;
+import com.google.protobuf.util.Timestamps;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.logging.log4j.util.TriConsumer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+
+import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
+import static java.time.format.DateTimeFormatter.ISO_INSTANT;
+
+/**
+ * Service to monitor and retrieve performance metrics for GCP-based nodes.
+ */
+@Service
+@Slf4j
+@ConditionalOnProperty(name = "monitoring.backend", havingValue = "gcp")
+public class GCPMonitoringService implements UsageMonitoringManager {
+
+    private static final int FALLBACK_INTERVALS_NUMBER = 10;
+    private static final Duration FALLBACK_MONITORING_PERIOD = Duration.ofHours(1);
+    private static final Duration FALLBACK_MINIMAL_INTERVAL = Duration.ofMinutes(1);
+    private static final String METRIC_TEMPLATE = "metric.type = \"%s\" AND resource.type = \"gce_instance\" " +
+            "AND resource.labels.instance_id = \"%s\"";
+    private static final String DISK_USED = "agent.googleapis.com/disk/bytes_used";
+    private static final String MEMORY_USED = "agent.googleapis.com/memory/bytes_used";
+    private static final String GPU_UTILIZATION = "agent.googleapis.com/gpu/utilization";
+    private static final String GPU_MEMORY_USED = "agent.googleapis.com/gpu/memory/bytes_used";
+    private static final String CPU_UTILIZATION = "compute.googleapis.com/instance/cpu/utilization";
+    private static final String TRAFFIC_SENT = "compute.googleapis.com/instance/network/sent_bytes_count";
+    private static final String GPU_PROCESSES_UTILIZATION = "agent.googleapis.com/gpu/processes/utilization";
+    private static final String TRAFFIC_RECEIVED = "compute.googleapis.com/instance/network/received_bytes_count";
+    public static final String MODEL = "model";
+    public static final String STATE = "state";
+    public static final String DEVICE = "device";
+    private static final String STATE_USED = "used";
+    private static final String STATE_FREE = "free";
+    public static final String GPU_NUMBER = "gpu_number";
+    private static final String NETWORK_SUMMARY = "summary";
+    public static final String MEMORY_STATE = "memory_state";
+    public static final int MILLS_PER_SEC = 1000;
+    private static final Long BYTES_PER_MB = 1024L * 1024L;
+    public static final double PERCENT_MULTIPLIER = 100.0;
+
+    private final GCPClient gcpClient;
+    private final NodesManager nodesManager;
+    private final MessageHelper messageHelper;
+    private final CloudRegionDao cloudRegionDao;
+    private final PreferenceManager preferenceManager;
+    private final Map<MonitoringReportType, AbstractMonitoringStatsWriter> statsWriters;
+    private final BiFunction<TimeSeries, String, String> keyRetriever = (ts, key) ->
+        ts.getMetric().getLabelsMap().get(key);
+
+    public GCPMonitoringService(final GCPClient gcpClient,
+                                final NodesManager nodesManager,
+                                final MessageHelper messageHelper,
+                                final CloudRegionDao cloudRegionDao,
+                                final PreferenceManager preferenceManager,
+                                final List<AbstractMonitoringStatsWriter> writers) {
+        this.gcpClient = gcpClient;
+        this.nodesManager = nodesManager;
+        this.messageHelper = messageHelper;
+        this.cloudRegionDao = cloudRegionDao;
+        this.preferenceManager = preferenceManager;
+        this.statsWriters = CommonUtils.groupByKey(writers, AbstractMonitoringStatsWriter::getReportType);
+    }
+
+    @Override
+    public List<MonitoringStats> getStatsForNode(final String nodeName,
+                                                 @Nullable final LocalDateTime from,
+                                                 @Nullable final LocalDateTime to) {
+        final LocalDateTime start = Optional.ofNullable(from).orElseGet(() -> creationDate(nodeName));
+        final LocalDateTime end = Optional.ofNullable(to).orElseGet(DateUtils::nowUTC);
+        final Duration duration = calculateInterval(start, end);
+        return end.isAfter(start) ? collectNodeStats(nodeName, start, end, duration) : Collections.emptyList();
+    }
+
+    @Override
+    public InputStream getStatsForNodeAsInputStream(final String nodeName,
+                                                    @Nullable final LocalDateTime from,
+                                                    @Nullable final LocalDateTime to,
+                                                    final Duration interval,
+                                                    final MonitoringReportType type) {
+        final LocalDateTime start = Optional.ofNullable(from).orElseGet(() -> creationDate(nodeName));
+        final LocalDateTime end = Optional.ofNullable(to).orElseGet(DateUtils::nowUTC);
+        final Duration minDuration = minimalDuration();
+        final Duration adjustedDuration = interval.compareTo(minDuration) < 0 ? minDuration : interval;
+        final AbstractMonitoringStatsWriter statsWriter = Optional.ofNullable(statsWriters.get(type))
+                .orElseThrow(() -> new IllegalArgumentException(
+                        messageHelper.getMessage(MessageConstants.ERROR_UNSUPPORTED_STATS_FILE_TYPE)));
+        return statsWriter.convertStatsToFile(collectNodeStats(nodeName, start, end, adjustedDuration));
+    }
+
+    @Override
+    public long getDiskSpaceAvailable(final String nodeName,
+                                      final String podId,
+                                      final String dockerImage) {
+        return 0;
+    }
+
+    @Override
+    public GpuMonitoringStats getGpuStatsForNode(final String nodeName,
+                                                 @Nullable final LocalDateTime from,
+                                                 @Nullable final LocalDateTime to,
+                                                 final List<GpuMetricsGranularity> granularity,
+                                                 final boolean squashCharts) {
+
+        if (nodeName == null || nodeName.isEmpty()) {
+            throw new IllegalArgumentException("Node name cannot be null or empty.");
+        }
+        if (squashCharts) {
+            throw new IllegalArgumentException("Squash charts must be false.");
+        }
+        if (!granularity.equals(Collections.singletonList(GpuMetricsGranularity.ALL))) {
+            throw new IllegalArgumentException("Granularity must be [ALL].");
+        }
+
+        final LocalDateTime start = Optional.ofNullable(from).orElseGet(() -> creationDate(nodeName));
+        final LocalDateTime end = Optional.ofNullable(to).orElseGet(DateUtils::nowUTC);
+
+        if (!end.isAfter(start)) {
+            throw new IllegalArgumentException("End time must be after start time.");
+        }
+
+        final Duration duration = calculateInterval(start, end);
+
+        List<MonitoringStats> charts = getGpuCharts(nodeName, start, end, duration);
+
+        if (!charts.isEmpty()) {
+            final MonitoringStats global = new MonitoringStats();
+            global.setStartTime(ISO_INSTANT.format(start.toInstant(ZoneOffset.UTC)));
+            global.setEndTime(ISO_INSTANT.format(end.toInstant(ZoneOffset.UTC)));
+            global.setMillsInPeriod(Duration.between(start, end).toMillis());
+            global.setGpuDeviceName(charts.get(0).getGpuDeviceName());
+            global.setGpuUsage(calculateGlobalGpuUsage(charts));
+
+            return GpuMonitoringStats.builder()
+                    .charts(charts)
+                    .global(global)
+                    .build();
+        }
+
+        return GpuMonitoringStats.builder().build();
+    }
+    
+    private List<MonitoringStats> getGpuCharts(final String nodeName, final LocalDateTime start,
+                                               final LocalDateTime end, final Duration duration) {
+        final GCPRegion region = getGcpRegion();
+        final VmDetails vmDetails = fetchVmDetails(nodeName, region);
+        final long instanceId = vmDetails.getId();
+
+        try (GCPMetricServiceClientWrapper metricsClient = gcpClient.buildMetricsClient(region)) {
+            final TimeInterval interval = buildTimeInterval(start, end);
+
+            final Aggregation mean = buildAggregation(duration, Aggregation.Aligner.ALIGN_MEAN);
+            final Aggregation max = buildAggregation(duration, Aggregation.Aligner.ALIGN_MAX);
+            final Aggregation min = buildAggregation(duration, Aggregation.Aligner.ALIGN_MIN);
+
+            final Map<Long, MonitoringStats> statsMap = new HashMap<>();
+
+            collectGpuStats(region, metricsClient, instanceId, interval, mean, max, min, statsMap, vmDetails);
+            collectGpuMemoryStats(region, metricsClient, instanceId, interval, mean, max, min, statsMap, vmDetails);
+            collectActiveGpus(region, metricsClient, instanceId, interval, mean, max, min, statsMap, vmDetails);
+            calculateGpuMemoryUtilization(statsMap);
+            calculateCrossGpuUsage(statsMap);
+
+            return statsMap.values().stream()
+                    .sorted(Comparator.comparing(MonitoringStats::getStartTime,
+                            Comparator.comparing(this::parseMonitoringDateTime)))
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            log.error("Failed to collect GPU stats for node {}: {}", nodeName, e.getMessage(), e);
+            throw new PipelineException(e);
+        }
+    }
+
+    private void collectGpuStats(final GCPRegion gcpRegion,
+                                 final GCPMetricServiceClientWrapper client,
+                                 final Long instanceId,
+                                 final TimeInterval interval,
+                                 final Aggregation meanAgg,
+                                 final Aggregation maxAgg,
+                                 final Aggregation minAgg,
+                                 final Map<Long, MonitoringStats> statsMap,
+                                 final VmDetails vmDetails) {
+        final String filter = String.format(METRIC_TEMPLATE, GPU_UTILIZATION, instanceId);
+        processMetric(gcpRegion, client, filter, interval, meanAgg, statsMap, vmDetails,
+            (stats, point, timeSeries) -> {
+                Map<String, MonitoringStats.GPUUsage> gpuDetails = stats.getGpuDetails();
+                if (gpuDetails == null) {
+                    gpuDetails = new HashMap<>();
+                    stats.setGpuDetails(gpuDetails);
+                }
+                gpuDetails.computeIfAbsent(keyRetriever.apply(timeSeries, GPU_NUMBER),
+                    k -> MonitoringStats.GPUUsage.builder()
+                        .gpuMemoryUtilization(initMonitoringMetrics())
+                        .gpuUtilization(initMonitoringMetrics())
+                        .gpuMemoryFree(initMonitoringMetrics())
+                        .gpuMemoryUsed(initMonitoringMetrics())
+                        .activeGpus(initMonitoringMetrics())
+                        .build())
+                    .getGpuUtilization()
+                    .setAverage(point.getValue().getDoubleValue());
+                stats.setGpuDeviceName(keyRetriever.apply(timeSeries, MODEL));
+            });
+        processMetric(gcpRegion, client, filter, interval, maxAgg, statsMap, null,
+            (stats, point, timeSeries) -> stats.getGpuDetails()
+                .get(keyRetriever.apply(timeSeries, GPU_NUMBER))
+                .getGpuUtilization().setMax(point.getValue().getDoubleValue()));
+
+        processMetric(gcpRegion, client, filter, interval, minAgg, statsMap, null,
+            (stats, point, timeSeries) -> stats.getGpuDetails()
+                .get(keyRetriever.apply(timeSeries, GPU_NUMBER))
+                .getGpuUtilization().setMin(point.getValue().getDoubleValue()));
+    }
+
+    private void collectGpuMemoryStats(GCPRegion gcpRegion, GCPMetricServiceClientWrapper client,
+                                       long instanceId, TimeInterval interval,
+                                       Aggregation meanAgg, Aggregation maxAgg, Aggregation minAgg,
+                                       Map<Long, MonitoringStats> statsMap, VmDetails vmDetails) {
+        final String filter = String.format(METRIC_TEMPLATE, GPU_MEMORY_USED, instanceId);
+
+        processMetric(gcpRegion, client, filter, interval, meanAgg, statsMap, vmDetails, (stats, point, timeSeries) -> {
+            final String gpuId = keyRetriever.apply(timeSeries, GPU_NUMBER);
+            final MonitoringStats.GPUUsage gpuUsage = stats.getGpuDetails().get(gpuId);
+            final String memoryState = keyRetriever.apply(timeSeries, MEMORY_STATE);
+            final double value = point.getValue().hasDoubleValue() ?
+                point.getValue().getDoubleValue() : point.getValue().getInt64Value();
+            if (STATE_USED.equals(memoryState)) {
+                gpuUsage.getGpuMemoryUsed().setAverage(value);
+            } else if (STATE_FREE.equals(memoryState)) {
+                gpuUsage.getGpuMemoryFree().setAverage(value);
+            }
+        });
+
+        processMetric(gcpRegion, client, filter, interval, maxAgg, statsMap, null, (stats, point, timeSeries) -> {
+            final String gpuId = keyRetriever.apply(timeSeries, GPU_NUMBER);
+            final String memoryState = keyRetriever.apply(timeSeries, MEMORY_STATE);
+            final double value = point.getValue().hasDoubleValue() ?
+                    point.getValue().getDoubleValue() : point.getValue().getInt64Value();
+            if (STATE_USED.equals(memoryState)) {
+                stats.getGpuDetails().get(gpuId).getGpuMemoryUsed().setMax(value);
+            } else if (STATE_FREE.equals(memoryState)) {
+                stats.getGpuDetails().get(gpuId).getGpuMemoryFree().setMax(value);
+            }
+        });
+
+        processMetric(gcpRegion, client, filter, interval, minAgg, statsMap, null, (stats, point, timeSeries) -> {
+            final String gpuId = keyRetriever.apply(timeSeries, GPU_NUMBER);
+            final String memoryState = keyRetriever.apply(timeSeries, MEMORY_STATE);
+            final double value = point.getValue().hasDoubleValue() ?
+                point.getValue().getDoubleValue() : point.getValue().getInt64Value();
+            if (STATE_USED.equals(memoryState)) {
+                stats.getGpuDetails().get(gpuId).getGpuMemoryUsed().setMin(value);
+            } else if (STATE_FREE.equals(memoryState)) {
+                stats.getGpuDetails().get(gpuId).getGpuMemoryFree().setMin(value);
+            }
+        });
+    }
+
+    private void calculateGpuMemoryUtilization(Map<Long, MonitoringStats> statsMap) {
+        statsMap.forEach((timestamp, stats) -> {
+            final Map<String, MonitoringStats.GPUUsage> gpuDetails = stats.getGpuDetails();
+            if (gpuDetails == null) {
+                return;
+            }
+            gpuDetails.forEach((gpuId, gpuUsage) -> {
+                final MonitoringMetrics used = gpuUsage.getGpuMemoryUsed();
+                final MonitoringMetrics free = gpuUsage.getGpuMemoryFree();
+                final MonitoringMetrics utilization = MonitoringMetrics.builder().build();
+                gpuUsage.setGpuMemoryUtilization(utilization);
+
+                final double minTotal = used.getMin() + free.getMin();
+                utilization.setMin(minTotal > 0 ? (used.getMin() / minTotal) * PERCENT_MULTIPLIER : 0.0);
+                final double maxTotal = used.getMax() + free.getMax();
+                utilization.setMax(maxTotal > 0 ? (used.getMax() / maxTotal) * PERCENT_MULTIPLIER : 0.0);
+                final double avgTotal = used.getAverage() + free.getAverage();
+                utilization.setAverage(avgTotal > 0 ? (used.getAverage() / avgTotal) * PERCENT_MULTIPLIER : 0.0);
+            });
+        });
+    }
+
+    private void collectActiveGpus(final GCPRegion gcpRegion,
+                                   final GCPMetricServiceClientWrapper client,
+                                   final long instanceId,
+                                   final TimeInterval interval,
+                                   final Aggregation meanAgg,
+                                   final Aggregation maxAgg,
+                                   final Aggregation minAgg,
+                                   final Map<Long, MonitoringStats> statsMap,
+                                   final VmDetails vmDetails) {
+        final String filter = String.format(METRIC_TEMPLATE, GPU_PROCESSES_UTILIZATION, instanceId);
+
+        //cumulative avg
+        processMetric(gcpRegion, client, filter, interval, meanAgg, statsMap, vmDetails, (stats, point, timeSeries) -> {
+            String gpuId = keyRetriever.apply(timeSeries, GPU_NUMBER);
+            MonitoringMetrics gpuMetric = stats.getGpuDetails().get(gpuId).getActiveGpus();
+            gpuMetric.setAverage(gpuMetric.getAverage() + point.getValue().getDoubleValue());
+        });
+
+        //cumulative max
+        processMetric(gcpRegion, client, filter, interval, maxAgg, statsMap, null, (stats, point, timeSeries) -> {
+            String gpuId = keyRetriever.apply(timeSeries, GPU_NUMBER);
+            MonitoringMetrics gpuMetric = stats.getGpuDetails().get(gpuId).getActiveGpus();
+            gpuMetric.setMax(gpuMetric.getMax() + point.getValue().getDoubleValue());
+        });
+
+        //cumulative min
+        processMetric(gcpRegion, client, filter, interval, minAgg, statsMap, null, (stats, point, timeSeries) -> {
+            String gpuId = keyRetriever.apply(timeSeries, GPU_NUMBER);
+            MonitoringMetrics gpuMetric = stats.getGpuDetails().get(gpuId).getActiveGpus();
+            gpuMetric.setMin(gpuMetric.getMin() + point.getValue().getDoubleValue());
+        });
+    }
+
+    private MonitoringStats.GPUUsage calculateGlobalGpuUsage(List<MonitoringStats> statsList) {
+        final MonitoringStats.GPUUsage globalUsage = MonitoringStats.GPUUsage.builder()
+                .activeGpus(initMonitoringMetrics())
+                .gpuUtilization(initMonitoringMetrics())
+                .gpuMemoryUtilization(initMonitoringMetrics())
+                .build();
+
+        if (statsList.isEmpty()) {
+            return globalUsage;
+        }
+
+        globalUsage.getGpuUtilization().setAverage(
+                statsList.stream()
+                        .mapToDouble(s -> s.getGpuUsage().getGpuUtilization().getAverage())
+                        .average()
+                        .orElse(0.0));
+        globalUsage.getGpuMemoryUtilization().setAverage(
+                statsList.stream()
+                        .mapToDouble(s -> s.getGpuUsage().getGpuMemoryUtilization().getAverage())
+                        .average()
+                        .orElse(0.0));
+        globalUsage.getActiveGpus().setAverage(
+                statsList.stream()
+                        .mapToDouble(s -> s.getGpuUsage().getActiveGpus().getAverage())
+                        .average()
+                        .orElse(0.0));
+
+        globalUsage.getGpuUtilization().setMin(
+                statsList.stream()
+                        .mapToDouble(s -> s.getGpuUsage().getGpuUtilization().getMin())
+                        .min()
+                        .orElse(0.0));
+        globalUsage.getGpuUtilization().setMax(
+                statsList.stream()
+                        .mapToDouble(s -> s.getGpuUsage().getGpuUtilization().getMax())
+                        .max()
+                        .orElse(0.0));
+
+        globalUsage.getGpuMemoryUtilization().setMin(
+                statsList.stream()
+                        .mapToDouble(s -> s.getGpuUsage().getGpuMemoryUtilization().getMin())
+                        .min()
+                        .orElse(0.0));
+        globalUsage.getGpuMemoryUtilization().setMax(
+                statsList.stream()
+                        .mapToDouble(s -> s.getGpuUsage().getGpuMemoryUtilization().getMax())
+                        .max()
+                        .orElse(0.0));
+
+        globalUsage.getActiveGpus().setMin(
+                statsList.stream()
+                        .mapToDouble(s -> s.getGpuUsage().getActiveGpus().getMin())
+                        .min()
+                        .orElse(0.0));
+        globalUsage.getActiveGpus().setMax(
+                statsList.stream()
+                        .mapToDouble(s -> s.getGpuUsage().getActiveGpus().getMax())
+                        .max()
+                        .orElse(0.0));
+
+        return globalUsage;
+    }
+
+    private void calculateCrossGpuUsage(Map<Long, MonitoringStats> statsMap) {
+        statsMap.forEach((timestamp, stats) -> {
+            final Map<String, MonitoringStats.GPUUsage> gpuDetails = stats.getGpuDetails();
+            if (gpuDetails == null || gpuDetails.isEmpty()) {
+                stats.setGpuUsage(MonitoringStats.GPUUsage.builder()
+                        .gpuUtilization(initMonitoringMetrics())
+                        .gpuMemoryUtilization(initMonitoringMetrics())
+                        .activeGpus(initMonitoringMetrics())
+                        .build());
+                return;
+            }
+
+            final MonitoringStats.GPUUsage crossGpuUsage = MonitoringStats.GPUUsage.builder()
+                    .gpuUtilization(initMonitoringMetrics())
+                    .gpuMemoryUtilization(initMonitoringMetrics())
+                    .activeGpus(initMonitoringMetrics())
+                    .build();
+            stats.setGpuUsage(crossGpuUsage);
+
+            crossGpuUsage.getGpuUtilization().setAverage(
+                    gpuDetails.values().stream()
+                            .mapToDouble(g -> g.getGpuUtilization().getAverage())
+                            .average()
+                            .orElse(0.0));
+            crossGpuUsage.getGpuMemoryUtilization().setAverage(
+                    gpuDetails.values().stream()
+                            .mapToDouble(g -> g.getGpuMemoryUtilization().getAverage())
+                            .average()
+                            .orElse(0.0));
+            crossGpuUsage.getActiveGpus().setAverage(
+                    gpuDetails.values().stream()
+                            .mapToDouble(g -> g.getActiveGpus().getAverage())
+                            .average()
+                            .orElse(0.0));
+
+            crossGpuUsage.getGpuUtilization().setMin(
+                    gpuDetails.values().stream()
+                            .mapToDouble(g -> g.getGpuUtilization().getMin())
+                            .min()
+                            .orElse(0.0));
+            crossGpuUsage.getGpuUtilization().setMax(
+                    gpuDetails.values().stream()
+                            .mapToDouble(g -> g.getGpuUtilization().getMax())
+                            .max()
+                            .orElse(0.0));
+
+            crossGpuUsage.getGpuMemoryUtilization().setMin(
+                    gpuDetails.values().stream()
+                            .mapToDouble(g -> g.getGpuMemoryUtilization().getMin())
+                            .min()
+                            .orElse(0.0));
+            crossGpuUsage.getGpuMemoryUtilization().setMax(
+                    gpuDetails.values().stream()
+                            .mapToDouble(g -> g.getGpuMemoryUtilization().getMax())
+                            .max()
+                            .orElse(0.0));
+
+            crossGpuUsage.getActiveGpus().setMin(
+                    gpuDetails.values().stream()
+                            .mapToDouble(g -> g.getActiveGpus().getMin())
+                            .min()
+                            .orElse(0.0));
+            crossGpuUsage.getActiveGpus().setMax(
+                    gpuDetails.values().stream()
+                            .mapToDouble(g -> g.getActiveGpus().getMax())
+                            .max()
+                            .orElse(0.0));
+        });
+    }
+
+    protected List<MonitoringStats> collectNodeStats(final String nodeName,
+                                                     final LocalDateTime start,
+                                                     final LocalDateTime end,
+                                                     final Duration duration) {
+        final GCPRegion region = getGcpRegion();
+        final VmDetails vmDetails = fetchVmDetails(nodeName, region);
+        final long instanceId = vmDetails.getId();
+
+        try (GCPMetricServiceClientWrapper metricsClient = gcpClient.buildMetricsClient(region)) {
+            final TimeInterval timeInterval = buildTimeInterval(start, end);
+            final Aggregation meanAgg = buildAggregation(duration, Aggregation.Aligner.ALIGN_MEAN);
+            final Aggregation maxAgg = buildAggregation(duration, Aggregation.Aligner.ALIGN_MAX);
+            final Aggregation sumAgg = buildAggregation(duration, Aggregation.Aligner.ALIGN_SUM);
+
+            final Map<Long, MonitoringStats> statsMap = new HashMap<>();
+            collectCpuStats(region, metricsClient, instanceId, timeInterval, meanAgg, maxAgg, statsMap, vmDetails);
+            collectMemoryStats(region, metricsClient, instanceId, timeInterval, meanAgg, maxAgg, statsMap, vmDetails);
+            collectDiskStats(region, metricsClient, instanceId, timeInterval, meanAgg, statsMap);
+            collectNetworkStats(region, metricsClient, instanceId, timeInterval, sumAgg, statsMap);
+
+            return statsMap.values().stream()
+                    .sorted(Comparator.comparing(MonitoringStats::getStartTime,
+                            Comparator.comparing(this::parseMonitoringDateTime)))
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            log.error("Failed to collect stats for node {}: {}", nodeName, e.getMessage(), e);
+            throw new PipelineException(e);
+        }
+    }
+
+    private void collectCpuStats(final GCPRegion gcpRegion,
+                                 final GCPMetricServiceClientWrapper client,
+                                 final Long instanceId,
+                                 final TimeInterval interval,
+                                 final Aggregation meanAgg,
+                                 final Aggregation maxAgg,
+                                 final Map<Long, MonitoringStats> statsMap,
+                                 final VmDetails vmDetails) {
+        final String filter = String.format(METRIC_TEMPLATE, CPU_UTILIZATION, instanceId);
+        processMetric(gcpRegion, client, filter, interval, meanAgg, statsMap, vmDetails,
+            (stats, point, timeSeries) -> {
+                MonitoringStats.CPUUsage cpuUsage = stats.getCpuUsage();
+                if (cpuUsage == null) {
+                    cpuUsage = new MonitoringStats.CPUUsage();
+                    stats.setCpuUsage(cpuUsage);
+                }
+                cpuUsage.setLoad(point.getValue().getDoubleValue());
+            });
+        processMetric(gcpRegion, client, filter, interval, maxAgg, statsMap, null,
+            (stats, point, timeSeries) -> stats.getCpuUsage().setMax(point.getValue().getDoubleValue()));
+    }
+    private MonitoringMetrics initMonitoringMetrics() {
+        return MonitoringMetrics.builder().average(0.0).max(0.0).min(0.0).build();
+    }
+
+    private void collectMemoryStats(final GCPRegion gcpRegion,
+                                    final GCPMetricServiceClientWrapper client,
+                                    final Long instanceId,
+                                    final TimeInterval interval,
+                                    final Aggregation meanAgg,
+                                    final Aggregation maxAgg,
+                                    final Map<Long, MonitoringStats> statsMap,
+                                    final VmDetails vmDetails) {
+        final String filter = String.format(METRIC_TEMPLATE, MEMORY_USED, instanceId);
+        final long capacity = vmDetails.getMemoryMb() * BYTES_PER_MB;
+        processMetric(gcpRegion, client, filter, interval, meanAgg, statsMap, vmDetails,
+            (stats, point, timeSeries) -> {
+                MonitoringStats.MemoryUsage memoryUsage = stats.getMemoryUsage();
+                if (memoryUsage == null) {
+                    memoryUsage = new MonitoringStats.MemoryUsage();
+                    memoryUsage.setCapacity(capacity);
+                    stats.setMemoryUsage(memoryUsage);
+                }
+                if (STATE_USED.equals(keyRetriever.apply(timeSeries, STATE))) {
+                    memoryUsage.setUsage((long) point.getValue().getDoubleValue());
+                }
+            });
+        processMetric(gcpRegion, client, filter, interval, maxAgg, statsMap, vmDetails,
+            (stats, point, timeSeries) -> {
+                if (STATE_USED.equals(keyRetriever.apply(timeSeries, STATE))) {
+                    stats.getMemoryUsage().setMax((long) point.getValue().getDoubleValue());
+                }
+            });
+    }
+
+    private void collectDiskStats(final GCPRegion gcpRegion,
+                                  final GCPMetricServiceClientWrapper client,
+                                  final Long instanceId,
+                                  final TimeInterval interval,
+                                  final Aggregation meanAgg,
+                                  final Map<Long, MonitoringStats> statsMap) {
+        final String filter = String.format(METRIC_TEMPLATE, DISK_USED, instanceId);
+        processMetric(gcpRegion, client, filter, interval, meanAgg, statsMap, null,
+            (stats, point, timeSeries) -> {
+                MonitoringStats.DisksUsage disksUsage = stats.getDisksUsage();
+                if (disksUsage == null) {
+                    disksUsage = new MonitoringStats.DisksUsage();
+                    stats.setDisksUsage(disksUsage);
+                }
+                final String device = keyRetriever.apply(timeSeries, DEVICE);
+                final String state = keyRetriever.apply(timeSeries, STATE);
+                final MonitoringStats.DisksUsage.DiskStats diskStats = disksUsage.getStatsByDevices()
+                        .computeIfAbsent(device, k -> new MonitoringStats.DisksUsage.DiskStats());
+                final long value = (long) point.getValue().getDoubleValue();
+                diskStats.setCapacity(diskStats.getCapacity() + value);
+                if (STATE_FREE.equals(state)) {
+                    diskStats.setUsableSpace(value);
+                }
+            });
+    }
+
+    private void collectNetworkStats(final GCPRegion gcpRegion,
+                                     final GCPMetricServiceClientWrapper client,
+                                     final Long instanceId,
+                                     final TimeInterval interval,
+                                     final Aggregation meanAgg,
+                                     final Map<Long, MonitoringStats> statsMap) {
+        final String receivedFilter = String.format(METRIC_TEMPLATE, TRAFFIC_RECEIVED, instanceId);
+        processMetric(gcpRegion, client, receivedFilter, interval, meanAgg, statsMap, null,
+            (stats, point, timeSeries) -> {
+                MonitoringStats.NetworkUsage networkUsage = stats.getNetworkUsage();
+                if (networkUsage == null) {
+                    networkUsage = new MonitoringStats.NetworkUsage();
+                    stats.setNetworkUsage(networkUsage);
+                }
+                final MonitoringStats.NetworkUsage.NetworkStats networkStats = networkUsage.getStatsByInterface()
+                        .computeIfAbsent(NETWORK_SUMMARY, k -> new MonitoringStats.NetworkUsage.NetworkStats());
+                networkStats.setRxBytes(point.getValue().getInt64Value());
+            });
+
+        final String sentFilter = String.format(METRIC_TEMPLATE, TRAFFIC_SENT, instanceId);
+        processMetric(gcpRegion, client, sentFilter, interval, meanAgg, statsMap, null,
+            (stats, point, timeSeries) -> {
+                MonitoringStats.NetworkUsage networkUsage = stats.getNetworkUsage();
+                if (networkUsage == null) {
+                    networkUsage = new MonitoringStats.NetworkUsage();
+                    stats.setNetworkUsage(networkUsage);
+                }
+                final MonitoringStats.NetworkUsage.NetworkStats networkStats = networkUsage.getStatsByInterface()
+                        .computeIfAbsent(NETWORK_SUMMARY, k -> new MonitoringStats.NetworkUsage.NetworkStats());
+                networkStats.setTxBytes(point.getValue().getInt64Value());
+            });
+    }
+
+    private void processMetric(final GCPRegion gcpRegion,
+                               final GCPMetricServiceClientWrapper client,
+                               final String filter,
+                               final TimeInterval interval,
+                               final Aggregation agg,
+                               final Map<Long, MonitoringStats> statsMap,
+                               final VmDetails vmDetails,
+                               final TriConsumer<MonitoringStats, Point, TimeSeries> updater) {
+        final ListTimeSeriesRequest request = buildTimeSeriesRequest(gcpRegion.getProject(), filter, interval, agg);
+        final MetricServiceClient.ListTimeSeriesPagedResponse response = client.listTimeSeries(request);
+        response.getPage().iterateAll().forEach(timeSeries -> {
+            final TimeSeries finalTimeSeries = timeSeries;
+            timeSeries.getPointsList().forEach(point -> {
+                final long endTimeSec = point.getInterval().getEndTime().getSeconds();
+                final MonitoringStats stat = statsMap.computeIfAbsent(endTimeSec,
+                    k -> buildMonitoringStats(
+                        point, agg.getAlignmentPeriod().getSeconds() * MILLS_PER_SEC, vmDetails));
+                updater.accept(stat, point, finalTimeSeries);
+            });
+        });
+    }
+
+    private MonitoringStats buildMonitoringStats(final Point point,
+                                                 final Long millsInPeriod,
+                                                 final VmDetails vmDetails) {
+        final MonitoringStats stat = new MonitoringStats();
+        final Long endTimeSec = point.getInterval().getEndTime().getSeconds();
+        stat.setMillsInPeriod(millsInPeriod);
+        stat.setStartTime(ISO_INSTANT.format(Instant.ofEpochSecond(endTimeSec - millsInPeriod / MILLS_PER_SEC)));
+        stat.setEndTime(ISO_INSTANT.format(Instant.ofEpochSecond(endTimeSec)));
+        final MonitoringStats.ContainerSpec containerSpec = new MonitoringStats.ContainerSpec();
+        if (vmDetails != null) {
+            containerSpec.setNumberOfCores(vmDetails.getVcpus());
+            containerSpec.setMaxMemory(vmDetails.getMemoryMb() * BYTES_PER_MB);
+        }
+        stat.setContainerSpec(containerSpec);
+        return stat;
+    }
+
+    private VmDetails fetchVmDetails(final String nodeName,
+                                     final GCPRegion gcpRegion) {
+        try {
+            final String zone = nodesManager.getNode(nodeName).getRegion();
+            return getVMDetails(gcpRegion.getProject(), nodeName, zone, gcpRegion);
+        } catch (IOException e) {
+            log.error("Failed to retrieve GCP Compute Instance details for node {}: {}", nodeName, e.getMessage(), e);
+            throw new PipelineException(e);
+        }
+    }
+
+    private VmDetails getVMDetails(final String projectId,
+                                   final String instanceName,
+                                   final String zone,
+                                   final GCPRegion gcpRegion) throws IOException {
+        try (GCPInstancesClientWrapper instancesClient = gcpClient.buildInstancesClient(gcpRegion);
+             GCPMachineTypesClientWrapper machineTypesClient = gcpClient.buildMachineTypesClient(gcpRegion)) {
+            final Instance instance = instancesClient.get(projectId, zone, instanceName);
+            final String machineTypeUrl = instance.getMachineType();
+            final String[] parts = machineTypeUrl.split("/");
+            final String machineTypeName = parts[parts.length - 1];
+            final MachineType machineType = machineTypesClient.get(projectId, zone, machineTypeName);
+            return new VmDetails(instance.getId(), machineType.getGuestCpus(), machineType.getMemoryMb());
+        }
+    }
+
+    private GCPRegion getGcpRegion() {
+        return cloudRegionDao.loadDefaultRegion()
+                .filter(r -> CloudProvider.GCP == r.getProvider())
+                .map(GCPRegion.class::cast)
+                .orElseThrow(() -> new ObjectNotFoundException("No default GCP region configured"));
+    }
+
+    private TimeInterval buildTimeInterval(final LocalDateTime start,
+                                           final LocalDateTime end) {
+        return TimeInterval.newBuilder()
+                .setStartTime(Timestamps.fromSeconds(start.toEpochSecond(ZoneOffset.UTC)))
+                .setEndTime(Timestamps.fromSeconds(end.toEpochSecond(ZoneOffset.UTC)))
+                .build();
+    }
+
+    private Aggregation buildAggregation(final Duration duration,
+                                         final Aggregation.Aligner aligner) {
+        return Aggregation.newBuilder()
+                .setAlignmentPeriod(com.google.protobuf.Duration.newBuilder().setSeconds(duration.getSeconds()).build())
+                .setPerSeriesAligner(aligner)
+                .build();
+    }
+
+    private ListTimeSeriesRequest buildTimeSeriesRequest(final String projectId,
+                                                         final String filter,
+                                                         final TimeInterval interval,
+                                                         final Aggregation agg) {
+        return ListTimeSeriesRequest.newBuilder()
+                .setName(ProjectName.of(projectId).toString())
+                .setFilter(filter)
+                .setInterval(interval)
+                .setView(ListTimeSeriesRequest.TimeSeriesView.FULL)
+                .setAggregation(agg)
+                .build();
+    }
+
+    private Duration calculateInterval(final LocalDateTime start,
+                                       final LocalDateTime end) {
+        final Duration requested = Duration.between(start, end).dividedBy(Math.max(1, numberOfIntervals()));
+        final Duration minimal = minimalDuration();
+        return requested.compareTo(minimal) < 0 ? minimal : requested;
+    }
+
+    private LocalDateTime creationDate(final String nodeName) {
+        return nodesManager.findNode(nodeName)
+                .map(NodeInstance::getCreationTimestamp)
+                .map(it -> LocalDateTime.parse(it, KubernetesConstants.KUBE_DATE_FORMATTER))
+                .orElseGet(this::fallbackMonitoringStart);
+    }
+
+    private LocalDateTime fallbackMonitoringStart() {
+        return DateUtils.nowUTC().minus(FALLBACK_MONITORING_PERIOD);
+    }
+
+    private Duration minimalDuration() {
+        return Optional.of(SystemPreferences.CLUSTER_MONITORING_GCP_MINIMAL_INTERVAL)
+                .map(preferenceManager::getPreference)
+                .map(Duration::ofMillis)
+                .orElse(FALLBACK_MINIMAL_INTERVAL);
+    }
+
+    private int numberOfIntervals() {
+        return Optional.of(SystemPreferences.CLUSTER_MONITORING_GCP_INTERVALS_NUMBER)
+                .map(preferenceManager::getPreference)
+                .orElse(FALLBACK_INTERVALS_NUMBER);
+    }
+
+    private LocalDateTime parseMonitoringDateTime(final String dateTimeString) {
+        return LocalDateTime.parse(dateTimeString, ISO_DATE_TIME);
+    }
+
+    @Data
+    @AllArgsConstructor
+    static class VmDetails {
+        private final Long id;
+        private final Integer vcpus;
+        private final Integer memoryMb;
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -1427,6 +1427,13 @@ public class SystemPreferences {
     public static final StringPreference GCP_LOGGING_SINK_LABEL_VALUE = new StringPreference(
             "gcp.logging.sink.label.value", "pipeline-api", GCP_GROUP, isNotBlank);
 
+    public static final LongPreference CLUSTER_MONITORING_GCP_MINIMAL_INTERVAL = new LongPreference(
+            "cluster.monitoring.gcp.minimal.interval", TimeUnit.MILLISECONDS.convert(1, TimeUnit.MINUTES),
+            CLUSTER_GROUP, isGreaterThan(0L));
+
+    public static final IntPreference CLUSTER_MONITORING_GCP_INTERVALS_NUMBER = new IntPreference(
+            "cluster.monitoring.gcp.intervals.number", 10, CLUSTER_GROUP, isGreaterThan(0));
+
     // Billing Reports
     public static final StringPreference BILLING_USER_NAME_ATTRIBUTE = new StringPreference(
             "billing.reports.user.name.attribute", null, BILLING_GROUP, pass);

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/performancemonitoring/gcp/GCPMonitoringServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/performancemonitoring/gcp/GCPMonitoringServiceTest.java
@@ -1,0 +1,851 @@
+/*
+ * Copyright 2025 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cluster.performancemonitoring.gcp;
+
+import com.epam.pipeline.dao.region.CloudRegionDao;
+import com.epam.pipeline.entity.cluster.NodeInstance;
+import com.epam.pipeline.entity.cluster.monitoring.MonitoringStats;
+import com.epam.pipeline.entity.cluster.monitoring.gpu.GpuMonitoringStats;
+import com.epam.pipeline.entity.region.CloudProvider;
+import com.epam.pipeline.entity.region.GCPRegion;
+import com.epam.pipeline.exception.PipelineException;
+import com.epam.pipeline.manager.cloud.gcp.GCPClient;
+import com.epam.pipeline.manager.cloud.gcp.wrappers.GCPInstancesClientWrapper;
+import com.epam.pipeline.manager.cloud.gcp.wrappers.GCPMachineTypesClientWrapper;
+import com.epam.pipeline.manager.cloud.gcp.wrappers.GCPMetricServiceClientWrapper;
+import com.epam.pipeline.manager.cluster.NodesManager;
+import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.google.api.Metric;
+import com.google.cloud.compute.v1.Instance;
+import com.google.cloud.compute.v1.MachineType;
+import com.google.cloud.monitoring.v3.MetricServiceClient;
+import com.google.monitoring.v3.ListTimeSeriesRequest;
+import com.google.monitoring.v3.Point;
+import com.google.monitoring.v3.TimeInterval;
+import com.google.monitoring.v3.TimeSeries;
+import com.google.monitoring.v3.TypedValue;
+import com.google.protobuf.Timestamp;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.epam.pipeline.entity.cluster.monitoring.gpu.GpuMetricsGranularity.ALL;
+import static com.epam.pipeline.entity.cluster.monitoring.gpu.GpuMetricsGranularity.GLOBAL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GCPMonitoringServiceTest {
+    private static final String NODE_NAME = "test-node";
+    private static final String PROJECT_ID = "test-project";
+    private static final String ZONE = "us-central1-a";
+    private static final String MACHINE_TYPE_URL = "https://www.google.com/machinetypes/e2-micro";
+    private static final Long NODE_ID = 874912437120482L;
+    private static final int CPU_NUMBER = 4;
+    private static final int MEMORY_MB = 2048;
+    private static final long BYTES_PER_MB = 1024L * 1024L;
+    private static final LocalDateTime FROM = LocalDateTime.of(2025, Month.APRIL, 14, 12, 43, 0);
+    private static final LocalDateTime TO = LocalDateTime.of(2025, Month.APRIL, 14, 13, 43, 0);
+    public static final String SDA1 = "/dev/sda1";
+    public static final String SDA15 = "/dev/sda15";
+    public static final String FREE = "free";
+    public static final String USED = "used";
+    public static final String SUMMARY = "summary";
+    private static final String GPU_NUMBER_0 = "0";
+    private static final String GPU_MODEL = "NVIDIA A10G";
+    private static final String MEMORY_STATE_USED = "used";
+    private static final String MEMORY_STATE_FREE = "free";
+    public static final double PERCENT_MULTIPLIER = 100.0;
+    public static final String MAX = "MAX";
+    public static final String MIN = "MIN";
+    public static final String AVG = "AVG";
+    public static final String MEAN = "MEAN";
+    public static final String GPU_NUMBER = "gpu_number";
+    public static final String MEMORY_STATE = "memory_state";
+
+    enum MetricPoint {
+        TIME_1(1744634580L),
+        TIME_2(1744638180L);
+
+        final long timestamp;
+
+        MetricPoint(long timestamp) {
+            this.timestamp = timestamp;
+        }
+    }
+
+    enum CpuMetric {
+        MEAN_1(MetricPoint.TIME_1, 0.38),
+        MEAN_2(MetricPoint.TIME_2, 0.455),
+        MAX_1(MetricPoint.TIME_1, 0.43),
+        MAX_2(MetricPoint.TIME_2, 0.75);
+
+        final MetricPoint point;
+        final double value;
+
+        CpuMetric(MetricPoint point, double value) {
+            this.point = point;
+            this.value = value;
+        }
+    }
+
+    enum MemoryMetric {
+        MEAN_1(MetricPoint.TIME_1, 123124d),
+        MEAN_2(MetricPoint.TIME_2, 425532523d),
+        MAX_1(MetricPoint.TIME_1, 223124d),
+        MAX_2(MetricPoint.TIME_2, 525562523d);
+
+        final MetricPoint point;
+        final double value;
+
+        MemoryMetric(MetricPoint point, double value) {
+            this.point = point;
+            this.value = value;
+        }
+    }
+
+    enum DiskMetric {
+        FREE_SDA1_1(MetricPoint.TIME_1, 36298d, FREE, SDA1),
+        FREE_SDA1_2(MetricPoint.TIME_2, 47320943d, FREE, SDA1),
+        USED_SDA1_1(MetricPoint.TIME_1, 36298d, USED, SDA1),
+        USED_SDA1_2(MetricPoint.TIME_2, 47320943d, USED, SDA1),
+        FREE_SDA15_1(MetricPoint.TIME_1, 7668990d, FREE, SDA15),
+        FREE_SDA15_2(MetricPoint.TIME_2, 47572352d, FREE, SDA15),
+        USED_SDA15_1(MetricPoint.TIME_1, 7668990d, USED, SDA15),
+        USED_SDA15_2(MetricPoint.TIME_2, 47572352d, USED, SDA15);
+
+        final MetricPoint point;
+        final double value;
+        final String state;
+        final String device;
+
+        DiskMetric(MetricPoint point, double value, String state, String device) {
+            this.point = point;
+            this.value = value;
+            this.state = state;
+            this.device = device;
+        }
+    }
+
+    enum NetworkMetric {
+        RX_1(MetricPoint.TIME_1, 1048576L),
+        RX_2(MetricPoint.TIME_2, 2097152L),
+        TX_1(MetricPoint.TIME_1, 524288L),
+        TX_2(MetricPoint.TIME_2, 1572864L);
+
+        final MetricPoint point;
+        final long value;
+
+        NetworkMetric(MetricPoint point, long value) {
+            this.point = point;
+            this.value = value;
+        }
+    }
+
+    enum GpuMetric {
+        AVG_1(MetricPoint.TIME_1, 60.0), // GPU utilization in percent
+        AVG_2(MetricPoint.TIME_2, 80.0),
+        MIN_1(MetricPoint.TIME_1, 50.0),
+        MIN_2(MetricPoint.TIME_2, 70.0),
+        MAX_1(MetricPoint.TIME_1, 65.0),
+        MAX_2(MetricPoint.TIME_2, 85.0);
+
+        final MetricPoint point;
+        final double value;
+
+        GpuMetric(MetricPoint point, double value) {
+            this.point = point;
+            this.value = value;
+        }
+    }
+
+    enum GpuMemoryMetric {
+        AVG_USED_1(MetricPoint.TIME_1, 8000000000L), // 8GB used
+        AVG_USED_2(MetricPoint.TIME_2, 10000000000L), // 10GB used
+        AVG_FREE_1(MetricPoint.TIME_1, 8000000000L), // 8GB free
+        AVG_FREE_2(MetricPoint.TIME_2, 6000000000L), // 6GB free
+        MIN_USED_1(MetricPoint.TIME_1, 7000000000L), // 7GB used
+        MIN_USED_2(MetricPoint.TIME_2, 9000000000L), // 9GB used
+        MIN_FREE_1(MetricPoint.TIME_1, 9000000000L), // 9GB free
+        MIN_FREE_2(MetricPoint.TIME_2, 7000000000L), // 7GB free
+        MAX_USED_1(MetricPoint.TIME_1, 9000000000L), // 9GB used
+        MAX_USED_2(MetricPoint.TIME_2, 11000000000L), // 11GB used
+        MAX_FREE_1(MetricPoint.TIME_1, 7000000000L), // 7GB free
+        MAX_FREE_2(MetricPoint.TIME_2, 5000000000L); // 5GB free
+
+        final MetricPoint point;
+        final double value;
+        final String memoryState;
+
+        GpuMemoryMetric(MetricPoint point, double value) {
+            this.point = point;
+            this.value = value;
+            this.memoryState = name().contains("USED") ? MEMORY_STATE_USED : MEMORY_STATE_FREE;
+        }
+    }
+
+    enum GpuActiveMetric {
+        AVG_1(MetricPoint.TIME_1, 1.0), // 1 active process
+        AVG_2(MetricPoint.TIME_2, 2.0), // 2 active processes
+        MIN_1(MetricPoint.TIME_1, 1.0),
+        MIN_2(MetricPoint.TIME_2, 1.0),
+        MAX_1(MetricPoint.TIME_1, 1.0),
+        MAX_2(MetricPoint.TIME_2, 3.0);
+
+        final MetricPoint point;
+        final double value;
+
+        GpuActiveMetric(MetricPoint point, double value) {
+            this.point = point;
+            this.value = value;
+        }
+    }
+
+    @Mock private GCPClient gcpClient;
+    @Mock private NodesManager nodesManager;
+    @Mock private CloudRegionDao cloudRegionDao;
+    @Mock private PreferenceManager preferenceManager;
+    @Mock private GCPInstancesClientWrapper instancesClient;
+    @Mock private GCPMetricServiceClientWrapper metricsClient;
+    @Mock private GCPMachineTypesClientWrapper machineTypesClient;
+    @Mock private MetricServiceClient.ListTimeSeriesPage timeSeriesPageCpuMax;
+    @Mock private MetricServiceClient.ListTimeSeriesPage timeSeriesPageCpuMean;
+    @Mock private MetricServiceClient.ListTimeSeriesPage timeSeriesPageMemoryMax;
+    @Mock private MetricServiceClient.ListTimeSeriesPage timeSeriesPageMemoryMean;
+    @Mock private MetricServiceClient.ListTimeSeriesPage timeSeriesPageDiskMean;
+    @Mock private MetricServiceClient.ListTimeSeriesPage timeSeriesPageNetworkRx;
+    @Mock private MetricServiceClient.ListTimeSeriesPage timeSeriesPageNetworkTx;
+    @Mock private MetricServiceClient.ListTimeSeriesPage timeSeriesPageGpuAvg;
+    @Mock private MetricServiceClient.ListTimeSeriesPage timeSeriesPageGpuMax;
+    @Mock private MetricServiceClient.ListTimeSeriesPage timeSeriesPageGpuMin;
+    @Mock private MetricServiceClient.ListTimeSeriesPage timeSeriesPageGpuMemoryAvg;
+    @Mock private MetricServiceClient.ListTimeSeriesPage timeSeriesPageGpuMemoryMax;
+    @Mock private MetricServiceClient.ListTimeSeriesPage timeSeriesPageGpuMemoryMin;
+    @Mock private MetricServiceClient.ListTimeSeriesPage timeSeriesPageGpuActiveAvg;
+    @Mock private MetricServiceClient.ListTimeSeriesPage timeSeriesPageGpuActiveMax;
+    @Mock private MetricServiceClient.ListTimeSeriesPage timeSeriesPageGpuActiveMin;
+    @Mock private MetricServiceClient.ListTimeSeriesPagedResponse cpuMeanResponse;
+    @Mock private MetricServiceClient.ListTimeSeriesPagedResponse cpuMaxResponse;
+    @Mock private MetricServiceClient.ListTimeSeriesPagedResponse memoryMeanResponse;
+    @Mock private MetricServiceClient.ListTimeSeriesPagedResponse memoryMaxResponse;
+    @Mock private MetricServiceClient.ListTimeSeriesPagedResponse diskMeanResponse;
+    @Mock private MetricServiceClient.ListTimeSeriesPagedResponse networkRxResponse;
+    @Mock private MetricServiceClient.ListTimeSeriesPagedResponse networkTxResponse;
+    @Mock private MetricServiceClient.ListTimeSeriesPagedResponse gpuAvgResponse;
+    @Mock private MetricServiceClient.ListTimeSeriesPagedResponse gpuMaxResponse;
+    @Mock private MetricServiceClient.ListTimeSeriesPagedResponse gpuMinResponse;
+    @Mock private MetricServiceClient.ListTimeSeriesPagedResponse gpuMemoryAvgResponse;
+    @Mock private MetricServiceClient.ListTimeSeriesPagedResponse gpuMemoryMaxResponse;
+    @Mock private MetricServiceClient.ListTimeSeriesPagedResponse gpuMemoryMinResponse;
+    @Mock private MetricServiceClient.ListTimeSeriesPagedResponse gpuActiveAvgResponse;
+    @Mock private MetricServiceClient.ListTimeSeriesPagedResponse gpuActiveMaxResponse;
+    @Mock private MetricServiceClient.ListTimeSeriesPagedResponse gpuActiveMinResponse;
+
+    @InjectMocks
+    private GCPMonitoringService gcpMonitoringService;
+
+    private final GCPRegion gcpRegion = new GCPRegion();
+    private final NodeInstance nodeInstance = new NodeInstance();
+
+    @Before
+    public void setUp() throws IOException {
+        setupGcpRegion();
+        setupVmDetails();
+        when(gcpClient.buildMetricsClient(gcpRegion)).thenReturn(metricsClient);
+        when(preferenceManager.getPreference(any())).thenReturn(null);
+    }
+
+    @Test
+    public void shouldCollectAllStatsSuccess()  {
+        when(metricsClient.listTimeSeries(any(ListTimeSeriesRequest.class)))
+                .thenReturn(cpuMeanResponse).thenReturn(cpuMaxResponse)
+                .thenReturn(memoryMeanResponse).thenReturn(memoryMaxResponse)
+                .thenReturn(diskMeanResponse)
+                .thenReturn(networkRxResponse)
+                .thenReturn(networkTxResponse);
+
+        setupCpuMetrics();
+        setupMemoryMetrics();
+        setupDiskMetrics();
+        setupNetworkMetrics();
+
+        List<MonitoringStats> stats = gcpMonitoringService.getStatsForNode(NODE_NAME, FROM, TO);
+        assertThat(stats).hasSize(2);
+
+        MonitoringStats stat1 = stats.get(0);
+        assertThat(stat1.getCpuUsage().getLoad()).isEqualTo(CpuMetric.MEAN_1.value);
+        assertThat(stat1.getCpuUsage().getMax()).isEqualTo(CpuMetric.MAX_1.value);
+
+        assertThat(stat1.getMemoryUsage().getUsage()).isEqualTo((long) MemoryMetric.MEAN_1.value);
+        assertThat(stat1.getMemoryUsage().getMax()).isEqualTo((long) MemoryMetric.MAX_1.value);
+        assertThat(stat1.getMemoryUsage().getCapacity()).isEqualTo(MEMORY_MB * BYTES_PER_MB);
+
+        Map<String, MonitoringStats.DisksUsage.DiskStats> devices1 = stat1.getDisksUsage().getStatsByDevices();
+        assertThat(devices1.get("/dev/sda1").getCapacity())
+                .isEqualTo((long) (DiskMetric.FREE_SDA1_1.value + DiskMetric.USED_SDA1_1.value));
+        assertThat(devices1.get("/dev/sda1").getUsableSpace()).isEqualTo((long) DiskMetric.FREE_SDA1_1.value);
+        assertThat(devices1.get(SDA15).getCapacity())
+                .isEqualTo((long) (DiskMetric.FREE_SDA15_1.value + DiskMetric.USED_SDA15_1.value));
+        assertThat(devices1.get(SDA15).getUsableSpace()).isEqualTo((long) DiskMetric.FREE_SDA15_1.value);
+
+        Map<String, MonitoringStats.NetworkUsage.NetworkStats> interfaces1 = stat1.getNetworkUsage()
+                .getStatsByInterface();
+        assertThat(interfaces1.get(SUMMARY).getRxBytes()).isEqualTo(NetworkMetric.RX_1.value);
+        assertThat(interfaces1.get(SUMMARY).getTxBytes()).isEqualTo(NetworkMetric.TX_1.value);
+
+        MonitoringStats stat2 = stats.get(1);
+        assertThat(stat2.getCpuUsage().getLoad()).isEqualTo(CpuMetric.MEAN_2.value);
+        assertThat(stat2.getCpuUsage().getMax()).isEqualTo(CpuMetric.MAX_2.value);
+
+        assertThat(stat2.getMemoryUsage().getUsage()).isEqualTo((long) MemoryMetric.MEAN_2.value);
+        assertThat(stat2.getMemoryUsage().getMax()).isEqualTo((long) MemoryMetric.MAX_2.value);
+        assertThat(stat2.getMemoryUsage().getCapacity()).isEqualTo(MEMORY_MB * BYTES_PER_MB);
+
+        Map<String, MonitoringStats.DisksUsage.DiskStats> devices2 = stat2.getDisksUsage().getStatsByDevices();
+        assertThat(devices2.get(SDA1).getCapacity())
+                .isEqualTo((long) (DiskMetric.FREE_SDA1_2.value + DiskMetric.USED_SDA1_2.value));
+        assertThat(devices2.get(SDA1).getUsableSpace()).isEqualTo((long) DiskMetric.FREE_SDA1_2.value);
+        assertThat(devices2.get(SDA15).getCapacity())
+                .isEqualTo((long) (DiskMetric.FREE_SDA15_2.value + DiskMetric.USED_SDA15_2.value));
+        assertThat(devices2.get(SDA15).getUsableSpace()).isEqualTo((long) DiskMetric.FREE_SDA15_2.value);
+
+        Map<String, MonitoringStats.NetworkUsage.NetworkStats> interfaces2 = stat2.getNetworkUsage()
+                .getStatsByInterface();
+        assertThat(interfaces2.get(SUMMARY).getRxBytes()).isEqualTo(NetworkMetric.RX_2.value);
+        assertThat(interfaces2.get(SUMMARY).getTxBytes()).isEqualTo(NetworkMetric.TX_2.value);
+    }
+
+    @Test(expected = PipelineException.class)
+    public void shouldThrowExceptionOnBuildingMetricsClient() throws IOException {
+        when(gcpClient.buildMetricsClient(gcpRegion)).thenThrow(new IOException());
+        gcpMonitoringService.getStatsForNode(NODE_NAME, FROM, TO);
+    }
+
+    @Test
+    public void shouldCollectContainerSpec()  {
+        when(metricsClient.listTimeSeries(any(ListTimeSeriesRequest.class))).thenReturn(cpuMeanResponse);
+        setupCpuMetrics();
+
+        List<MonitoringStats> stats = gcpMonitoringService.getStatsForNode(NODE_NAME, FROM, TO);
+        assertThat(stats).hasSize(2);
+
+        stats.forEach(stat -> {
+            assertThat(stat.getContainerSpec().getMaxMemory()).isEqualTo(MEMORY_MB * BYTES_PER_MB);
+            assertThat(stat.getContainerSpec().getNumberOfCores()).isEqualTo(CPU_NUMBER);
+        });
+    }
+
+    @Test
+    public void shouldSortStatsInAscendingOrder() {
+        when(metricsClient.listTimeSeries(any(ListTimeSeriesRequest.class))).thenReturn(cpuMeanResponse);
+        setupCpuMetricsReverseOrder();
+
+        List<MonitoringStats> stats = gcpMonitoringService.getStatsForNode(NODE_NAME, FROM, TO);
+        assertThat(stats).hasSize(2);
+
+        for (int i = 0; i < stats.size() - 1; i++) {
+            Instant currentStartTime = Instant.parse(stats.get(i).getStartTime());
+            Instant nextStartTime = Instant.parse(stats.get(i + 1).getStartTime());
+            assertThat(currentStartTime).isLessThanOrEqualTo(nextStartTime);
+        }
+
+        assertThat(stats.get(0).getCpuUsage().getLoad()).isEqualTo(CpuMetric.MEAN_1.value);
+        assertThat(stats.get(1).getCpuUsage().getLoad()).isEqualTo(CpuMetric.MEAN_2.value);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionForNodeNameGetGpuStatsForNode() {
+        gcpMonitoringService.getGpuStatsForNode(null, null, null, null, true);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionForSquashChartsGetGpuStatsForNode() {
+        gcpMonitoringService.getGpuStatsForNode(NODE_NAME, null, null, null, true);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionForGranularityGetGpuStatsForNode() {
+        gcpMonitoringService.getGpuStatsForNode(NODE_NAME, null, null, Collections.singletonList(GLOBAL), false);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionForDatesGetGpuStatsForNode() {
+        gcpMonitoringService.getGpuStatsForNode(NODE_NAME, TO, FROM, Collections.singletonList(ALL), false);
+    }
+
+    @Test
+    public void shouldCollectGpuStatsSuccess() {
+        when(metricsClient.listTimeSeries(any(ListTimeSeriesRequest.class)))
+                .thenReturn(gpuAvgResponse)
+                .thenReturn(gpuMaxResponse)
+                .thenReturn(gpuMinResponse)
+                .thenReturn(gpuMemoryAvgResponse)
+                .thenReturn(gpuMemoryMaxResponse)
+                .thenReturn(gpuMemoryMinResponse)
+                .thenReturn(gpuActiveAvgResponse)
+                .thenReturn(gpuActiveMaxResponse)
+                .thenReturn(gpuActiveMinResponse);
+
+        setupGpuMetrics();
+        setupGpuMemoryMetrics();
+        setupGpuActiveMetrics();
+
+        GpuMonitoringStats stats = gcpMonitoringService.getGpuStatsForNode(NODE_NAME, FROM, TO,
+                Collections.singletonList(ALL), false);
+
+        assertThat(stats).isNotNull();
+        assertThat(stats.getCharts()).hasSize(2);
+
+        MonitoringStats stat1 = stats.getCharts().get(0);
+        MonitoringStats stat2 = stats.getCharts().get(1);
+
+        //1
+        assertThat(stat1.getGpuDeviceName()).isEqualTo(GPU_MODEL);
+        Map<String, MonitoringStats.GPUUsage> details1 = stat1.getGpuDetails();
+        assertThat(details1).hasSize(1);
+        MonitoringStats.GPUUsage gpu1 = details1.get(GPU_NUMBER_0);
+        assertThat(gpu1.getGpuUtilization().getAverage()).isEqualTo(GpuMetric.AVG_1.value);
+        assertThat(gpu1.getGpuUtilization().getMin()).isEqualTo(GpuMetric.MIN_1.value);
+        assertThat(gpu1.getGpuUtilization().getMax()).isEqualTo(GpuMetric.MAX_1.value);
+        assertThat(gpu1.getGpuMemoryUsed().getAverage()).isEqualTo(GpuMemoryMetric.AVG_USED_1.value);
+        assertThat(gpu1.getGpuMemoryUsed().getMin()).isEqualTo(GpuMemoryMetric.MIN_USED_1.value);
+        assertThat(gpu1.getGpuMemoryUsed().getMax()).isEqualTo(GpuMemoryMetric.MAX_USED_1.value);
+        assertThat(gpu1.getGpuMemoryFree().getAverage()).isEqualTo(GpuMemoryMetric.AVG_FREE_1.value);
+        assertThat(gpu1.getGpuMemoryFree().getMin()).isEqualTo(GpuMemoryMetric.MIN_FREE_1.value);
+        assertThat(gpu1.getGpuMemoryFree().getMax()).isEqualTo(GpuMemoryMetric.MAX_FREE_1.value);
+        assertThat(gpu1.getActiveGpus().getAverage()).isEqualTo(GpuActiveMetric.AVG_1.value);
+        assertThat(gpu1.getActiveGpus().getMin()).isEqualTo(GpuActiveMetric.MIN_1.value);
+        assertThat(gpu1.getActiveGpus().getMax()).isEqualTo(GpuActiveMetric.MAX_1.value);
+        // Verify GPU Memory Utilization
+        double totalAvg1 = GpuMemoryMetric.AVG_USED_1.value + GpuMemoryMetric.AVG_FREE_1.value;
+        double totalMin1 = GpuMemoryMetric.MIN_USED_1.value + GpuMemoryMetric.MIN_FREE_1.value;
+        double totalMax1 = GpuMemoryMetric.MAX_USED_1.value + GpuMemoryMetric.MAX_FREE_1.value;
+        assertThat(gpu1.getGpuMemoryUtilization().getAverage())
+                .isEqualTo((GpuMemoryMetric.AVG_USED_1.value / totalAvg1) * PERCENT_MULTIPLIER);
+        assertThat(gpu1.getGpuMemoryUtilization().getMin())
+                .isEqualTo((GpuMemoryMetric.MIN_USED_1.value / totalMin1) * PERCENT_MULTIPLIER);
+        assertThat(gpu1.getGpuMemoryUtilization().getMax())
+                .isEqualTo((GpuMemoryMetric.MAX_USED_1.value / totalMax1) * PERCENT_MULTIPLIER);
+
+        //2
+        assertThat(stat2.getGpuDeviceName()).isEqualTo(GPU_MODEL);
+        Map<String, MonitoringStats.GPUUsage> details2 = stat2.getGpuDetails();
+        assertThat(details2).hasSize(1);
+        MonitoringStats.GPUUsage gpu2 = details2.get(GPU_NUMBER_0);
+        assertThat(gpu2.getGpuUtilization().getAverage()).isEqualTo(GpuMetric.AVG_2.value);
+        assertThat(gpu2.getGpuUtilization().getMin()).isEqualTo(GpuMetric.MIN_2.value);
+        assertThat(gpu2.getGpuUtilization().getMax()).isEqualTo(GpuMetric.MAX_2.value);
+        assertThat(gpu2.getGpuMemoryUsed().getAverage()).isEqualTo(GpuMemoryMetric.AVG_USED_2.value);
+        assertThat(gpu2.getGpuMemoryUsed().getMin()).isEqualTo(GpuMemoryMetric.MIN_USED_2.value);
+        assertThat(gpu2.getGpuMemoryUsed().getMax()).isEqualTo(GpuMemoryMetric.MAX_USED_2.value);
+        assertThat(gpu2.getGpuMemoryFree().getAverage()).isEqualTo(GpuMemoryMetric.AVG_FREE_2.value);
+        assertThat(gpu2.getGpuMemoryFree().getMin()).isEqualTo(GpuMemoryMetric.MIN_FREE_2.value);
+        assertThat(gpu2.getGpuMemoryFree().getMax()).isEqualTo(GpuMemoryMetric.MAX_FREE_2.value);
+        assertThat(gpu2.getActiveGpus().getAverage()).isEqualTo(GpuActiveMetric.AVG_2.value);
+        assertThat(gpu2.getActiveGpus().getMin()).isEqualTo(GpuActiveMetric.MIN_2.value);
+        assertThat(gpu2.getActiveGpus().getMax()).isEqualTo(GpuActiveMetric.MAX_2.value);
+        // Verify GPU Memory Utilization
+        double totalAvg2 = GpuMemoryMetric.AVG_USED_2.value + GpuMemoryMetric.AVG_FREE_2.value;
+        double totalMin2 = GpuMemoryMetric.MIN_USED_2.value + GpuMemoryMetric.MIN_FREE_2.value;
+        double totalMax2 = GpuMemoryMetric.MAX_USED_2.value + GpuMemoryMetric.MAX_FREE_2.value;
+        assertThat(gpu2.getGpuMemoryUtilization().getAverage())
+                .isEqualTo((GpuMemoryMetric.AVG_USED_2.value / totalAvg2) * PERCENT_MULTIPLIER);
+        assertThat(gpu2.getGpuMemoryUtilization().getMin())
+                .isEqualTo((GpuMemoryMetric.MIN_USED_2.value / totalMin2) * PERCENT_MULTIPLIER);
+        assertThat(gpu2.getGpuMemoryUtilization().getMax())
+                .isEqualTo((GpuMemoryMetric.MAX_USED_2.value / totalMax2) * PERCENT_MULTIPLIER);
+
+        // Verify GpuUsage (Cross-GPU)
+        //1
+        MonitoringStats.GPUUsage usage1 = stat1.getGpuUsage();
+        assertThat(usage1.getGpuUtilization().getAverage()).isEqualTo(GpuMetric.AVG_1.value);
+        assertThat(usage1.getGpuUtilization().getMin()).isEqualTo(GpuMetric.MIN_1.value);
+        assertThat(usage1.getGpuUtilization().getMax()).isEqualTo(GpuMetric.MAX_1.value);
+        assertThat(usage1.getGpuMemoryUtilization().getAverage())
+                .isEqualTo((GpuMemoryMetric.AVG_USED_1.value / totalAvg1) * PERCENT_MULTIPLIER);
+        assertThat(usage1.getGpuMemoryUtilization().getMin())
+                .isEqualTo((GpuMemoryMetric.MIN_USED_1.value / totalMin1) * PERCENT_MULTIPLIER);
+        assertThat(usage1.getGpuMemoryUtilization().getMax())
+                .isEqualTo((GpuMemoryMetric.MAX_USED_1.value / totalMax1) * PERCENT_MULTIPLIER);
+        assertThat(usage1.getActiveGpus().getAverage()).isEqualTo(GpuActiveMetric.AVG_1.value);
+        assertThat(usage1.getActiveGpus().getMin()).isEqualTo(GpuActiveMetric.MIN_1.value);
+        assertThat(usage1.getActiveGpus().getMax()).isEqualTo(GpuActiveMetric.MAX_1.value);
+        //2
+        MonitoringStats.GPUUsage usage2 = stat2.getGpuUsage();
+        assertThat(usage2.getGpuUtilization().getAverage()).isEqualTo(GpuMetric.AVG_2.value);
+        assertThat(usage2.getGpuUtilization().getMin()).isEqualTo(GpuMetric.MIN_2.value);
+        assertThat(usage2.getGpuUtilization().getMax()).isEqualTo(GpuMetric.MAX_2.value);
+        assertThat(usage2.getGpuMemoryUtilization().getAverage())
+                .isEqualTo((GpuMemoryMetric.AVG_USED_2.value / totalAvg2) * PERCENT_MULTIPLIER);
+        assertThat(usage2.getGpuMemoryUtilization().getMin())
+                .isEqualTo((GpuMemoryMetric.MIN_USED_2.value / totalMin2) * PERCENT_MULTIPLIER);
+        assertThat(usage2.getGpuMemoryUtilization().getMax())
+                .isEqualTo((GpuMemoryMetric.MAX_USED_2.value / totalMax2) * PERCENT_MULTIPLIER);
+        assertThat(usage2.getActiveGpus().getAverage()).isEqualTo(GpuActiveMetric.AVG_2.value);
+        assertThat(usage2.getActiveGpus().getMin()).isEqualTo(GpuActiveMetric.MIN_2.value);
+        assertThat(usage2.getActiveGpus().getMax()).isEqualTo(GpuActiveMetric.MAX_2.value);
+
+        // Verify Global
+        MonitoringStats global = stats.getGlobal();
+        assertThat(global.getGpuDeviceName()).isEqualTo(GPU_MODEL);
+        MonitoringStats.GPUUsage globalUsage = global.getGpuUsage();
+        assertThat(globalUsage.getGpuUtilization().getAverage())
+                .isEqualTo((GpuMetric.AVG_1.value + GpuMetric.AVG_2.value) / 2.0);
+        assertThat(globalUsage.getGpuUtilization().getMin())
+                .isEqualTo(Math.min(GpuMetric.MIN_1.value, GpuMetric.MIN_2.value));
+        assertThat(globalUsage.getGpuUtilization().getMax())
+                .isEqualTo(Math.max(GpuMetric.MAX_1.value, GpuMetric.MAX_2.value));
+        assertThat(globalUsage.getGpuMemoryUtilization().getAverage())
+                .isEqualTo(((GpuMemoryMetric.AVG_USED_1.value / totalAvg1) * PERCENT_MULTIPLIER +
+                        (GpuMemoryMetric.AVG_USED_2.value / totalAvg2) * PERCENT_MULTIPLIER) / 2.0);
+        assertThat(globalUsage.getGpuMemoryUtilization().getMin())
+                .isEqualTo(Math.min((GpuMemoryMetric.MIN_USED_1.value / totalMin1) * PERCENT_MULTIPLIER,
+                        (GpuMemoryMetric.MIN_USED_2.value / totalMin2) * PERCENT_MULTIPLIER));
+        assertThat(globalUsage.getGpuMemoryUtilization().getMax())
+                .isEqualTo(Math.max((GpuMemoryMetric.MAX_USED_1.value / totalMax1) * PERCENT_MULTIPLIER,
+                        (GpuMemoryMetric.MAX_USED_2.value / totalMax2) * PERCENT_MULTIPLIER));
+        assertThat(globalUsage.getActiveGpus().getAverage())
+                .isEqualTo((GpuActiveMetric.AVG_1.value + GpuActiveMetric.AVG_2.value) / 2.0);
+        assertThat(globalUsage.getActiveGpus().getMin())
+                .isEqualTo(Math.min(GpuActiveMetric.MIN_1.value, GpuActiveMetric.MIN_2.value));
+        assertThat(globalUsage.getActiveGpus().getMax())
+                .isEqualTo(Math.max(GpuActiveMetric.MAX_1.value, GpuActiveMetric.MAX_2.value));
+    }
+
+    private void setupCpuMetricsReverseOrder() {
+        List<Point> meanPoints = Arrays.stream(CpuMetric.values())
+                .filter(m -> m.name().startsWith(MEAN))
+                .sorted((m1, m2) -> Long.compare(m2.point.timestamp, m1.point.timestamp)) // Reverse order
+                .map(m -> createPoint(m.point.timestamp, m.value))
+                .collect(Collectors.toList());
+        TimeSeries cpuMeanSeries = TimeSeries.newBuilder().addAllPoints(meanPoints).build();
+        when(cpuMeanResponse.getPage()).thenReturn(timeSeriesPageCpuMean);
+        when(timeSeriesPageCpuMean.iterateAll()).thenReturn(Collections.singleton(cpuMeanSeries));
+    }
+
+    private void setupGcpRegion() {
+        gcpRegion.setProject(PROJECT_ID);
+        gcpRegion.setProvider(CloudProvider.GCP);
+        when(cloudRegionDao.loadDefaultRegion()).thenReturn(Optional.of(gcpRegion));
+    }
+
+    private void setupVmDetails() throws IOException {
+        nodeInstance.setRegion(ZONE);
+        when(nodesManager.getNode(NODE_NAME)).thenReturn(nodeInstance);
+
+        Instance instance = Instance.newBuilder().setMachineType(MACHINE_TYPE_URL).setId(NODE_ID).build();
+        when(gcpClient.buildInstancesClient(gcpRegion)).thenReturn(instancesClient);
+        when(instancesClient.get(eq(PROJECT_ID), eq(ZONE), eq(NODE_NAME))).thenReturn(instance);
+
+        MachineType machineType = MachineType.newBuilder().setMemoryMb(MEMORY_MB).setGuestCpus(CPU_NUMBER).build();
+        when(gcpClient.buildMachineTypesClient(gcpRegion)).thenReturn(machineTypesClient);
+        when(machineTypesClient.get(PROJECT_ID, ZONE, "e2-micro")).thenReturn(machineType);
+    }
+
+    private void setupCpuMetrics() {
+        List<Point> meanPoints = Arrays.stream(CpuMetric.values())
+                .filter(m -> m.name().startsWith(MEAN))
+                .map(m -> createPoint(m.point.timestamp, m.value))
+                .collect(Collectors.toList());
+        TimeSeries cpuMeanSeries = TimeSeries.newBuilder().addAllPoints(meanPoints).build();
+        when(cpuMeanResponse.getPage()).thenReturn(timeSeriesPageCpuMean);
+        when(timeSeriesPageCpuMean.iterateAll()).thenReturn(Collections.singleton(cpuMeanSeries));
+
+        List<Point> maxPoints = Arrays.stream(CpuMetric.values())
+                .filter(m -> m.name().startsWith(MAX))
+                .map(m -> createPoint(m.point.timestamp, m.value))
+                .collect(Collectors.toList());
+        TimeSeries cpuMaxSeries = TimeSeries.newBuilder().addAllPoints(maxPoints).build();
+        when(cpuMaxResponse.getPage()).thenReturn(timeSeriesPageCpuMax);
+        when(timeSeriesPageCpuMax.iterateAll()).thenReturn(Collections.singleton(cpuMaxSeries));
+    }
+
+    private void setupMemoryMetrics() {
+        List<Point> meanPoints = Arrays.stream(MemoryMetric.values())
+                .filter(m -> m.name().startsWith(MEAN))
+                .map(m -> createPoint(m.point.timestamp, m.value))
+                .collect(Collectors.toList());
+        TimeSeries memoryMeanSeries = TimeSeries.newBuilder()
+                .addAllPoints(meanPoints)
+                .setMetric(Metric.newBuilder().putLabels("state", USED).build())
+                .build();
+        when(memoryMeanResponse.getPage()).thenReturn(timeSeriesPageMemoryMean);
+        when(timeSeriesPageMemoryMean.iterateAll()).thenReturn(Collections.singleton(memoryMeanSeries));
+
+        List<Point> maxPoints = Arrays.stream(MemoryMetric.values())
+                .filter(m -> m.name().startsWith(MAX))
+                .map(m -> createPoint(m.point.timestamp, m.value))
+                .collect(Collectors.toList());
+        TimeSeries memoryMaxSeries = TimeSeries.newBuilder()
+                .addAllPoints(maxPoints)
+                .setMetric(Metric.newBuilder().putLabels("state", USED).build())
+                .build();
+        when(memoryMaxResponse.getPage()).thenReturn(timeSeriesPageMemoryMax);
+        when(timeSeriesPageMemoryMax.iterateAll()).thenReturn(Collections.singleton(memoryMaxSeries));
+    }
+
+    private void setupDiskMetrics() {
+        Map<String, List<Point>> points = new HashMap<>();
+        for (DiskMetric m : DiskMetric.values()) {
+            String key = m.device + ":" + m.state;
+            points.computeIfAbsent(key, k -> new ArrayList<>()).add(createPoint(m.point.timestamp, m.value));
+        }
+
+        List<TimeSeries> series = new ArrayList<>();
+        for (Map.Entry<String, List<Point>> e : points.entrySet()) {
+            String[] parts = e.getKey().split(":");
+            TimeSeries ts = TimeSeries.newBuilder()
+                    .addAllPoints(e.getValue())
+                    .setMetric(Metric.newBuilder()
+                            .putLabels("device", parts[0])
+                            .putLabels("state", parts[1])
+                            .build())
+                    .build();
+            series.add(ts);
+        }
+        when(diskMeanResponse.getPage()).thenReturn(timeSeriesPageDiskMean);
+        when(timeSeriesPageDiskMean.iterateAll()).thenReturn(series);
+    }
+
+    private void setupNetworkMetrics() {
+        List<Point> rxPoints = Arrays.stream(NetworkMetric.values())
+                .filter(m -> m.name().startsWith("RX"))
+                .map(m -> createPoint(m.point.timestamp, m.value))
+                .collect(Collectors.toList());
+        TimeSeries networkRxSeries = TimeSeries.newBuilder().addAllPoints(rxPoints).build();
+        when(networkRxResponse.getPage()).thenReturn(timeSeriesPageNetworkRx);
+        when(timeSeriesPageNetworkRx.iterateAll()).thenReturn(Collections.singleton(networkRxSeries));
+
+        List<Point> txPoints = Arrays.stream(NetworkMetric.values())
+                .filter(m -> m.name().startsWith("TX"))
+                .map(m -> createPoint(m.point.timestamp, m.value))
+                .collect(Collectors.toList());
+        TimeSeries networkTxSeries = TimeSeries.newBuilder().addAllPoints(txPoints).build();
+        when(networkTxResponse.getPage()).thenReturn(timeSeriesPageNetworkTx);
+        when(timeSeriesPageNetworkTx.iterateAll()).thenReturn(Collections.singleton(networkTxSeries));
+    }
+
+    private Point createPoint(long timestamp, double value) {
+        return Point.newBuilder()
+                .setInterval(TimeInterval.newBuilder()
+                        .setEndTime(Timestamp.newBuilder().setSeconds(timestamp).build())
+                        .build())
+                .setValue(TypedValue.newBuilder().setDoubleValue(value).build())
+                .build();
+    }
+
+    private Point createPoint(long timestamp, long value) {
+        return Point.newBuilder()
+                .setInterval(TimeInterval.newBuilder()
+                        .setEndTime(Timestamp.newBuilder().setSeconds(timestamp).build())
+                        .build())
+                .setValue(TypedValue.newBuilder().setInt64Value(value).build())
+                .build();
+    }
+
+    private void setupGpuMetrics() {
+        List<Point> avgPoints = Arrays.stream(GpuMetric.values())
+            .filter(m -> m.name().startsWith(AVG))
+            .map(m -> createPoint(m.point.timestamp, m.value))
+            .collect(Collectors.toList());
+        TimeSeries gpuAvgSeries = TimeSeries.newBuilder()
+            .addAllPoints(avgPoints)
+            .setMetric(Metric.newBuilder()
+                .putLabels(GPU_NUMBER, GPU_NUMBER_0)
+                .putLabels("model", GPU_MODEL)
+                .build())
+            .build();
+        when(gpuAvgResponse.getPage()).thenReturn(timeSeriesPageGpuAvg);
+        when(timeSeriesPageGpuAvg.iterateAll()).thenReturn(Collections.singleton(gpuAvgSeries));
+
+        List<Point> maxPoints = Arrays.stream(GpuMetric.values())
+                .filter(m -> m.name().startsWith(MAX))
+                .map(m -> createPoint(m.point.timestamp, m.value))
+                .collect(Collectors.toList());
+        TimeSeries gpuMaxSeries = TimeSeries.newBuilder()
+            .addAllPoints(maxPoints)
+            .setMetric(Metric.newBuilder()
+                .putLabels(GPU_NUMBER, GPU_NUMBER_0)
+                .putLabels("model", GPU_MODEL)
+                .build())
+            .build();
+        when(gpuMaxResponse.getPage()).thenReturn(timeSeriesPageGpuMax);
+        when(timeSeriesPageGpuMax.iterateAll()).thenReturn(Collections.singleton(gpuMaxSeries));
+
+        List<Point> minPoints = Arrays.stream(GpuMetric.values())
+                .filter(m -> m.name().startsWith(MIN))
+                .map(m -> createPoint(m.point.timestamp, m.value))
+                .collect(Collectors.toList());
+        TimeSeries gpuMinSeries = TimeSeries.newBuilder()
+            .addAllPoints(minPoints)
+            .setMetric(Metric.newBuilder()
+                .putLabels(GPU_NUMBER, GPU_NUMBER_0)
+                .putLabels("model", GPU_MODEL)
+                .build())
+            .build();
+        when(gpuMinResponse.getPage()).thenReturn(timeSeriesPageGpuMin);
+        when(timeSeriesPageGpuMin.iterateAll()).thenReturn(Collections.singleton(gpuMinSeries));
+    }
+
+    private void setupGpuMemoryMetrics() {
+        // Average points
+        List<Point> avgPointsUsed = Arrays.stream(GpuMemoryMetric.values())
+                .filter(m -> m.name().startsWith(AVG) && MEMORY_STATE_USED.equals(m.memoryState))
+                .map(m -> createPoint(m.point.timestamp, m.value))
+                .collect(Collectors.toList());
+        TimeSeries gpuMemoryAvgUsedSeries = TimeSeries.newBuilder()
+                .addAllPoints(avgPointsUsed)
+                .setMetric(Metric.newBuilder()
+                        .putLabels(GPU_NUMBER, GPU_NUMBER_0)
+                        .putLabels(MEMORY_STATE, MEMORY_STATE_USED)
+                        .build())
+                .build();
+
+        List<Point> avgPointsFree = Arrays.stream(GpuMemoryMetric.values())
+                .filter(m -> m.name().startsWith(AVG) && MEMORY_STATE_FREE.equals(m.memoryState))
+                .map(m -> createPoint(m.point.timestamp, m.value))
+                .collect(Collectors.toList());
+        TimeSeries gpuMemoryAvgFreeSeries = TimeSeries.newBuilder()
+                .addAllPoints(avgPointsFree)
+                .setMetric(Metric.newBuilder()
+                        .putLabels(GPU_NUMBER, GPU_NUMBER_0)
+                        .putLabels(MEMORY_STATE, MEMORY_STATE_FREE)
+                        .build())
+                .build();
+
+        // Max points
+        List<Point> maxPointsUsed = Arrays.stream(GpuMemoryMetric.values())
+                .filter(m -> m.name().startsWith(MAX) && MEMORY_STATE_USED.equals(m.memoryState))
+                .map(m -> createPoint(m.point.timestamp, m.value))
+                .collect(Collectors.toList());
+        TimeSeries gpuMemoryMaxUsedSeries = TimeSeries.newBuilder()
+                .addAllPoints(maxPointsUsed)
+                .setMetric(Metric.newBuilder()
+                        .putLabels(GPU_NUMBER, GPU_NUMBER_0)
+                        .putLabels(MEMORY_STATE, MEMORY_STATE_USED)
+                        .build())
+                .build();
+
+        List<Point> maxPointsFree = Arrays.stream(GpuMemoryMetric.values())
+                .filter(m -> m.name().startsWith(MAX) && MEMORY_STATE_FREE.equals(m.memoryState))
+                .map(m -> createPoint(m.point.timestamp, m.value))
+                .collect(Collectors.toList());
+        TimeSeries gpuMemoryMaxFreeSeries = TimeSeries.newBuilder()
+                .addAllPoints(maxPointsFree)
+                .setMetric(Metric.newBuilder()
+                        .putLabels(GPU_NUMBER, GPU_NUMBER_0)
+                        .putLabels(MEMORY_STATE, MEMORY_STATE_FREE)
+                        .build())
+                .build();
+
+        // Min points
+        List<Point> minPointsUsed = Arrays.stream(GpuMemoryMetric.values())
+                .filter(m -> m.name().startsWith(MIN) && MEMORY_STATE_USED.equals(m.memoryState))
+                .map(m -> createPoint(m.point.timestamp, m.value))
+                .collect(Collectors.toList());
+        TimeSeries gpuMemoryMinUsedSeries = TimeSeries.newBuilder()
+                .addAllPoints(minPointsUsed)
+                .setMetric(Metric.newBuilder()
+                        .putLabels(GPU_NUMBER, GPU_NUMBER_0)
+                        .putLabels(MEMORY_STATE, MEMORY_STATE_USED)
+                        .build())
+                .build();
+
+        List<Point> minPointsFree = Arrays.stream(GpuMemoryMetric.values())
+                .filter(m -> m.name().startsWith(MIN) && MEMORY_STATE_FREE.equals(m.memoryState))
+                .map(m -> createPoint(m.point.timestamp, m.value))
+                .collect(Collectors.toList());
+        TimeSeries gpuMemoryMinFreeSeries = TimeSeries.newBuilder()
+                .addAllPoints(minPointsFree)
+                .setMetric(Metric.newBuilder()
+                        .putLabels(GPU_NUMBER, GPU_NUMBER_0)
+                        .putLabels(MEMORY_STATE, MEMORY_STATE_FREE)
+                        .build())
+                .build();
+
+        // Configure mocks
+        when(gpuMemoryAvgResponse.getPage()).thenReturn(timeSeriesPageGpuMemoryAvg);
+        when(timeSeriesPageGpuMemoryAvg.iterateAll())
+                .thenReturn(Arrays.asList(gpuMemoryAvgUsedSeries, gpuMemoryAvgFreeSeries));
+        when(gpuMemoryMaxResponse.getPage()).thenReturn(timeSeriesPageGpuMemoryMax);
+        when(timeSeriesPageGpuMemoryMax.iterateAll())
+                .thenReturn(Arrays.asList(gpuMemoryMaxUsedSeries, gpuMemoryMaxFreeSeries));
+        when(gpuMemoryMinResponse.getPage()).thenReturn(timeSeriesPageGpuMemoryMin);
+        when(timeSeriesPageGpuMemoryMin.iterateAll())
+                .thenReturn(Arrays.asList(gpuMemoryMinUsedSeries, gpuMemoryMinFreeSeries));
+    }
+
+    private void setupGpuActiveMetrics() {
+        List<Point> avgPoints = Arrays.stream(GpuActiveMetric.values())
+                .filter(m -> m.name().startsWith(AVG))
+                .map(m -> createPoint(m.point.timestamp, m.value))
+                .collect(Collectors.toList());
+        TimeSeries gpuActiveAvgSeries = TimeSeries.newBuilder()
+                .addAllPoints(avgPoints)
+                .setMetric(Metric.newBuilder()
+                        .putLabels(GPU_NUMBER, GPU_NUMBER_0)
+                        .build())
+                .build();
+        when(gpuActiveAvgResponse.getPage()).thenReturn(timeSeriesPageGpuActiveAvg);
+        when(timeSeriesPageGpuActiveAvg.iterateAll()).thenReturn(Collections.singleton(gpuActiveAvgSeries));
+
+        List<Point> maxPoints = Arrays.stream(GpuActiveMetric.values())
+                .filter(m -> m.name().startsWith(MAX))
+                .map(m -> createPoint(m.point.timestamp, m.value))
+                .collect(Collectors.toList());
+        TimeSeries gpuActiveMaxSeries = TimeSeries.newBuilder()
+                .addAllPoints(maxPoints)
+                .setMetric(Metric.newBuilder()
+                        .putLabels(GPU_NUMBER, GPU_NUMBER_0)
+                        .build())
+                .build();
+        when(gpuActiveMaxResponse.getPage()).thenReturn(timeSeriesPageGpuActiveMax);
+        when(timeSeriesPageGpuActiveMax.iterateAll()).thenReturn(Collections.singleton(gpuActiveMaxSeries));
+
+        List<Point> minPoints = Arrays.stream(GpuActiveMetric.values())
+                .filter(m -> m.name().startsWith(MIN))
+                .map(m -> createPoint(m.point.timestamp, m.value))
+                .collect(Collectors.toList());
+        TimeSeries gpuActiveMinSeries = TimeSeries.newBuilder()
+                .addAllPoints(minPoints)
+                .setMetric(Metric.newBuilder()
+                        .putLabels(GPU_NUMBER, GPU_NUMBER_0)
+                        .build())
+                .build();
+        when(gpuActiveMinResponse.getPage()).thenReturn(timeSeriesPageGpuActiveMin);
+        when(timeSeriesPageGpuActiveMin.iterateAll()).thenReturn(Collections.singleton(gpuActiveMinSeries));
+    }
+
+}


### PR DESCRIPTION
Addresses Issue #3969 by implementing GCP metrics integration for Google Compute Engine nodes. Adds performance monitoring for CPU, memory, disk, and network metrics, with configurable system preferences.

**Changes:**

Implemented UsageMonitoringManager Methods:
1. getStatsForNode: Collects and sorts node metrics (CPU, memory, disk, network).
2. getStatsForNodeAsInputStream: Converts metrics to a file format (e.g., CSV) via InputStream.
3. getGpuStatsForNode: Collects and sorts node gpu metrics (GPU, gpu memory, active gpu processes).

**Integrated Metrics:**
1. CPU Utilization: Load and max usage.
2. Memory Usage: Used and max memory.
3. Disk Usage: Per-device capacity and free space.
4.  Network Traffic: Sent/received bytes summary.
5. GPU utilization: avg, min, max usages
6. GPU memory usage: avg, min, max
7. GPU processes utilization: avg, min, max.

**New System Preferences:**
cluster.monitoring.gcp.minimal.interval: Minimum interval between metrics.
cluster.monitoring.gcp.intervals.number: Number of intervals in monitoring period.

