### PR TITLE
Issue #4013 Support pipeline cloning for Github and Bitbucket repositories

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineManager.java
@@ -396,24 +396,31 @@ public class PipelineManager implements SecuredEntityManager {
         final String sourceProjectName = GitUtils.convertPipeNameToProject(loadedPipeline.getName());
         final String uuid = PasswordGenerator.generateRandomString(20);
         final String newPipelineName = buildCopyProjectName(sourceProjectName, uuid, newName);
-        final String newProjectName = GitUtils.convertPipeNameToProject(newPipelineName);
-        final String newRepository =
-                GitUtils.replaceGitProjectNameInUrl(loadedPipeline.getRepository(), newProjectName);
-        final String newRepositorySsh =
-                GitUtils.replaceGitProjectNameInUrl(loadedPipeline.getRepositorySsh(), newProjectName);
         final Long sourcePipelineId = loadedPipeline.getId();
 
-        loadedPipeline.setRepository(newRepository);
-        loadedPipeline.setRepositorySsh(newRepositorySsh);
         loadedPipeline.setName(newPipelineName);
         loadedPipeline.setParentFolderId(parentFolderId);
         setFolderIfPresent(loadedPipeline);
         loadedPipeline.setOwner(securityManager.getAuthorizedUser());
-        loadedPipeline.setRepositoryType(null);
         loadedPipeline.setLocked(false);
+
+        final String newProjectName = GitUtils.convertPipeNameToProject(newPipelineName);
+        if (RepositoryType.GITLAB.equals(loadedPipeline.getRepositoryType())) {
+            final String newRepository =
+                    GitUtils.replaceGitProjectNameInUrl(loadedPipeline.getRepository(), newProjectName);
+            final String newRepositorySsh =
+                    GitUtils.replaceGitProjectNameInUrl(loadedPipeline.getRepositorySsh(), newProjectName);
+
+            loadedPipeline.setRepository(newRepository);
+            loadedPipeline.setRepositorySsh(newRepositorySsh);
+        }
+
         final Pipeline newPipeline = crudManager.savePipeline(loadedPipeline);
         copyStorageRules(sourcePipelineId, newPipeline.getId());
-        gitManager.copyRepository(sourceProjectName, newProjectName, uuid);
+
+        if (RepositoryType.GITLAB.equals(loadedPipeline.getRepositoryType())) {
+            gitManager.copyRepository(sourceProjectName, newProjectName, uuid);
+        }
         return newPipeline;
     }
 

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineManagerTest.java
@@ -26,6 +26,7 @@ import com.epam.pipeline.entity.git.GitProject;
 import com.epam.pipeline.entity.pipeline.Pipeline;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.PipelineType;
+import com.epam.pipeline.entity.pipeline.RepositoryType;
 import com.epam.pipeline.entity.utils.DateUtils;
 import com.epam.pipeline.exception.git.GitClientException;
 import com.epam.pipeline.manager.git.GitManager;
@@ -45,8 +46,10 @@ import java.util.Collections;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -244,6 +247,7 @@ public class PipelineManagerTest {
         pipelineVO.setRepository(REPOSITORY_HTTPS);
         pipelineVO.setRepositoryToken(REPOSITORY_TOKEN);
         pipelineVO.setRepositorySsh(REPOSITORY_SSH);
+        pipelineVO.setRepositoryType(RepositoryType.GITLAB);
 
         when(gitManager.copyRepository(any(), any(), any())).thenReturn(null);
         when(metadataManager.hasMetadata(any())).thenReturn(true);
@@ -263,6 +267,33 @@ public class PipelineManagerTest {
         final ArgumentCaptor<DataStorageRule> ruleCaptor = ArgumentCaptor.forClass(DataStorageRule.class);
         verify(dataStorageRuleDao).createDataStorageRule(ruleCaptor.capture());
         Assert.assertEquals(storageRuleMask, ruleCaptor.getValue().getFileMask());
+    }
+
+    @Test
+    public void shouldNotCopyRepositoryWhenForNonGitPipelines() {
+        final String sourceRepositoryName = "repository-clone";
+        final String newName = sourceRepositoryName + "_copy";
+
+        final Pipeline pipeline = new Pipeline();
+        pipeline.setId(ID);
+        pipeline.setName(sourceRepositoryName);
+        pipeline.setRepository(REPOSITORY_HTTPS);
+        pipeline.setRepositoryToken(REPOSITORY_TOKEN);
+        pipeline.setRepositorySsh(REPOSITORY_SSH);
+        pipeline.setRepositoryType(RepositoryType.GITHUB);
+
+        when(pipelineDao.loadPipeline(ID)).thenReturn(pipeline);
+        when(crudManager.savePipeline(any())).thenReturn(pipeline);
+
+        final Pipeline copiedPipeline = pipelineManager.copyPipeline(ID, null, newName);
+
+        assertThat(copiedPipeline.getName(), is(newName));
+        assertThat(copiedPipeline.getRepository(), is(REPOSITORY_HTTPS));
+        assertThat(copiedPipeline.getRepositoryToken(), is(REPOSITORY_TOKEN));
+        assertThat(copiedPipeline.getRepositorySsh(), is(REPOSITORY_SSH));
+        assertThat(copiedPipeline.getRepositoryType(), is(RepositoryType.GITHUB));
+
+        verify(gitManager, never()).copyRepository(anyString(), anyString(), anyString());
     }
 
     @Test


### PR DESCRIPTION
Added logic for supporting cloning for Github & Bitbucket. 
For non Github pipelines cloning by copying only entity without repository. 
Existing repository is used for new entity.