### PR TITLE
Docker Nextflow: nf-weblog-handler improve sync task data process

### DIFF
--- a/deploy/docker/cp-tools/base/nextflow/nf-weblog-handler/app.py
+++ b/deploy/docker/cp-tools/base/nextflow/nf-weblog-handler/app.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import os
 
 from flask import Flask, request
 
@@ -37,6 +38,10 @@ if VERBOSE == 1:
 logger.setLevel(logging_level)
 
 api_client = CloudPipelineApi(API, RUN_ID, logger)
+logger.info(
+    "Configuring NextflowEventHandler with: NF_LOOKUP_FILE - {}, RUN_ID - {}, SYNC_BATCH_SIZE - {}, SYNC_BATCH_TIMEOUT - {}..."
+    .format(NF_TASK_LOOKUP_FILE, RUN_ID, SYNC_BATCH_SIZE, SYNC_BATCH_TIMEOUT)
+)
 event_handler = NextflowEventHandler(logger, api_client, NF_TASK_LOOKUP_FILE, RUN_ID, SYNC_BATCH_SIZE, SYNC_BATCH_TIMEOUT)
 event_handler.enable_sync()
 

--- a/deploy/docker/cp-tools/base/nextflow/nf-weblog-handler/app.py
+++ b/deploy/docker/cp-tools/base/nextflow/nf-weblog-handler/app.py
@@ -25,6 +25,7 @@ logger = app.logger
 
 API = parse.get_required_env("API")
 RUN_ID = parse.get_required_env("RUN_ID")
+NF_TASK_LOOKUP_FILE = os.getenv("CP_NF_TASK_LOOKUP_FILE_PATH", None)
 APP_PORT = int(parse.get_required_env("CP_NF_WEBLOG_HANDLER_PORT", 8080))
 SYNC_BATCH_SIZE = int(parse.get_required_env("CP_NF_WEBLOG_HANDLER_SYNC_BATCH_SIZE", 10))
 SYNC_BATCH_TIMEOUT = int(parse.get_required_env("CP_NF_WEBLOG_HANDLER_SYNC_BATCH_TIMEOUT", 60))
@@ -36,7 +37,7 @@ if VERBOSE == 1:
 logger.setLevel(logging_level)
 
 api_client = CloudPipelineApi(API, RUN_ID, logger)
-event_handler = NextflowEventHandler(logger, api_client, RUN_ID, SYNC_BATCH_SIZE, SYNC_BATCH_TIMEOUT)
+event_handler = NextflowEventHandler(logger, api_client, NF_TASK_LOOKUP_FILE, RUN_ID, SYNC_BATCH_SIZE, SYNC_BATCH_TIMEOUT)
 event_handler.enable_sync()
 
 @app.route('/nextflow/event', methods=['POST'])

--- a/deploy/docker/cp-tools/base/nextflow/nf-weblog-handler/app/nextflow_event_handler.py
+++ b/deploy/docker/cp-tools/base/nextflow/nf-weblog-handler/app/nextflow_event_handler.py
@@ -16,6 +16,7 @@ import json
 import os
 import time
 import threading
+import csv
 
 from app.util import parse
 from engine_task import CloudPipelineRunEngineTask
@@ -169,7 +170,6 @@ class NextflowEventHandler(object):
     def _update_nf_lookup_file_with_events(self, event_list):
 
         def _read_nf_lookup_file(_lookup_file_path):
-            import csv
             _lookup_file_dict = {}
             if os.path.isfile(_lookup_file_path):
                 with open(_lookup_file_path, "rb") as csvfile:
@@ -181,10 +181,9 @@ class NextflowEventHandler(object):
             return _lookup_file_dict
 
         def _write_nf_lookup_file(_lookup_file_path, _lookup_file_dict):
-            import csv
             with open(_lookup_file_path, 'wb') as csvfile:
                 csv_writer = csv.writer(csvfile, delimiter='\t', quoting=csv.QUOTE_MINIMAL)
-                csv_writer.writerow('task_id', 'hash', 'process', 'tag', 'name', 'status')
+                csv_writer.writerow(['task_id', 'hash', 'process', 'tag', 'name', 'status'])
                 for task in _lookup_file_dict.values():
                     csv_writer.writerow(task)
 
@@ -192,6 +191,7 @@ class NextflowEventHandler(object):
             lookup_file_dict = _read_nf_lookup_file(self.nf_task_lookup_file)
             for event in event_list:
                 lookup_file_dict[event.taskId] = [event.taskId, event.taskKey, event.taskGroup, event.taskTag, event.taskName, event.status]
+            self.logger.info("Updating nf task lookup file with {} entries ...".format(len(lookup_file_dict)))
             _write_nf_lookup_file(self.nf_task_lookup_file, lookup_file_dict)
         pass
 

--- a/deploy/docker/cp-tools/base/nextflow/nf-weblog-handler/app/nextflow_event_handler.py
+++ b/deploy/docker/cp-tools/base/nextflow/nf-weblog-handler/app/nextflow_event_handler.py
@@ -43,9 +43,10 @@ class NextflowEventHandler(object):
         "ABORTED": "ABORTED"
     }
 
-    def __init__(self, logger, api_client, run_id, sync_batch_size, sync_batch_timeout):
+    def __init__(self, logger, api_client, nf_task_lookup_file, run_id, sync_batch_size, sync_batch_timeout):
         self.logger = logger
         self.api_client = api_client
+        self.nf_task_lookup_file = nf_task_lookup_file
         self.run_id = run_id
         self.events = SharedObject([])
         self.sync_batch_size = sync_batch_size
@@ -157,12 +158,42 @@ class NextflowEventHandler(object):
 
     def _send_events_batch(self, event_list):
         merged = self._merge_batch(event_list)
+        self._update_nf_lookup_file_with_events(merged)
         if self.api_client.log_pipeline_run_engine_task_events(merged):
             self.events.set([])
             self.sync_timestamp = time.time()
         else:
             self.events.set(merged)
             self.failed_sync_timestamp = time.time()
+
+    def _update_nf_lookup_file_with_events(self, event_list):
+
+        def _read_nf_lookup_file(_lookup_file_path):
+            import csv
+            _lookup_file_dict = {}
+            if os.path.isfile(_lookup_file_path):
+                with open(_lookup_file_path, "rb") as csvfile:
+                    csv_reader = csv.reader(csvfile, delimiter='\t')
+                    # Skip header
+                    csv_reader.next()
+                    for row in csv_reader:
+                        _lookup_file_dict[row[0]] = row
+            return _lookup_file_dict
+
+        def _write_nf_lookup_file(_lookup_file_path, _lookup_file_dict):
+            import csv
+            with open(_lookup_file_path, 'wb') as csvfile:
+                csv_writer = csv.writer(csvfile, delimiter='\t', quoting=csv.QUOTE_MINIMAL)
+                csv_writer.writerow('task_id', 'hash', 'process', 'tag', 'name', 'status')
+                for task in _lookup_file_dict.values():
+                    csv_writer.writerow(task)
+
+        if self.nf_task_lookup_file:
+            lookup_file_dict = _read_nf_lookup_file(self.nf_task_lookup_file)
+            for event in event_list:
+                lookup_file_dict[event.taskId] = [event.taskId, event.taskKey, event.taskGroup, event.taskTag, event.taskName, event.status]
+            _write_nf_lookup_file(self.nf_task_lookup_file, lookup_file_dict)
+        pass
 
     def _merge_batch(self, event_list):
         event_map = {}

--- a/deploy/docker/cp-tools/base/nextflow/nf-weblog-handler/nf-weblog-handler.sh
+++ b/deploy/docker/cp-tools/base/nextflow/nf-weblog-handler/nf-weblog-handler.sh
@@ -119,6 +119,14 @@ function enable_nf_runtime_data_sync() {
     CP_NF_WORKDIR="${CP_NF_WORKDIR:-${ANALYSIS_DIR}/work}"
     CP_NF_TRACE_FILE="${CP_NF_TRACE_FILE_DIR:-$CP_NF_WORKDIR}/trace.txt"
 
+    if [ -n "${CP_NF_TASK_LOOKUP_FILE}" ]; then
+        CP_NF_TASK_LOOKUP_FILE_PATH="${CP_NF_TRACE_FILE_DIR:-$CP_NF_WORKDIR}/${CP_NF_TASK_LOOKUP_FILE}"
+        # Will be used in nf-weblog-handler to populate this path
+        export CP_NF_TASK_LOOKUP_FILE_PATH
+    else
+        CP_NF_TASK_LOOKUP_FILE_PATH="$CP_NF_TRACE_FILE"
+    fi
+
     pipe_log_info "[INFO] Configuring run data sync process..." "$SYNC_RUN_RUNTIME_DATA_TASK"
     run_sync_data_pref_response=$(call_api "$API/preferences/launch.run.sync.runtime.data" "$API_TOKEN")
     if [ $? -ne 0 ]; then
@@ -162,8 +170,8 @@ function enable_nf_runtime_data_sync() {
         while true; do
             sleep "$(( CP_SYNC_TO_STORAGE_TIMEOUT_SEC / 2 ))"
 
-            if [ -f "${CP_NF_TRACE_FILE}" ] ; then
-                tail -n +2 "${CP_NF_TRACE_FILE}" | while read -r task
+            if [ -f "${CP_NF_TASK_LOOKUP_FILE_PATH}" ] ; then
+                tail -n +2 "${CP_NF_TASK_LOOKUP_FILE_PATH}" | while read -r task
                 do
                     task_hash=$(echo "$task" | awk '{ print $2 }')
                     task_workdir=$(realpath "${CP_NF_WORKDIR}/$task_hash*")

--- a/deploy/docker/cp-tools/base/nextflow/nf-weblog-handler/nf-weblog-handler.sh
+++ b/deploy/docker/cp-tools/base/nextflow/nf-weblog-handler/nf-weblog-handler.sh
@@ -119,12 +119,9 @@ function enable_nf_runtime_data_sync() {
     CP_NF_WORKDIR="${CP_NF_WORKDIR:-${ANALYSIS_DIR}/work}"
     CP_NF_TRACE_FILE="${CP_NF_TRACE_FILE_DIR:-$CP_NF_WORKDIR}/trace.txt"
 
-    if [ -n "${CP_NF_TASK_LOOKUP_FILE}" ]; then
-        CP_NF_TASK_LOOKUP_FILE_PATH="${CP_NF_TRACE_FILE_DIR:-$CP_NF_WORKDIR}/${CP_NF_TASK_LOOKUP_FILE}"
-        # Will be used in nf-weblog-handler to populate this path
-        export CP_NF_TASK_LOOKUP_FILE_PATH
-    else
-        CP_NF_TASK_LOOKUP_FILE_PATH="$CP_NF_TRACE_FILE"
+    # If wasn't defined by user, define with default as trace.txt file
+    if [ -z "${CP_NF_TASK_LOOKUP_FILE_PATH}" ]; then
+        export CP_NF_TASK_LOOKUP_FILE_PATH="$CP_NF_TRACE_FILE"
     fi
 
     pipe_log_info "[INFO] Configuring run data sync process..." "$SYNC_RUN_RUNTIME_DATA_TASK"
@@ -174,17 +171,17 @@ function enable_nf_runtime_data_sync() {
                 tail -n +2 "${CP_NF_TASK_LOOKUP_FILE_PATH}" | while read -r task
                 do
                     task_hash=$(echo "$task" | awk '{ print $2 }')
-                    task_workdir=$(realpath "${CP_NF_WORKDIR}/$task_hash*")
-                    if ! grep -q -x -F "$task_hash" $nf_sync_to_storage_processed_task_file ;then
-                        if [ -n "$task_hash" ] && [ -n "$task_workdir" ]; then
-                             sync_to_storage add "$task_workdir/.command.out" "$nf_task_file_sync_path/$task_hash/.command.out"
-                             sync_to_storage add "$task_workdir/.command.err" "$nf_task_file_sync_path/$task_hash/.command.err"
-                             sync_to_storage add "$task_workdir/.command.log" "$nf_task_file_sync_path/$task_hash/.command.log"
-                             sync_to_storage add "$task_workdir/.command.sh" "$nf_task_file_sync_path/$task_hash/.command.sh"
-                             sync_to_storage add "$task_workdir/.command.run" "$nf_task_file_sync_path/$task_hash/.command.run"
-                             sync_to_storage add "$task_workdir/.command.trace" "$nf_task_file_sync_path/$task_hash/.command.trace"
-                             sync_to_storage add "$task_workdir/.command.begin" "$nf_task_file_sync_path/$task_hash/.command.begin"
-                             sync_to_storage add "$task_workdir/.exitcode" "$nf_task_file_sync_path/$task_hash/.exitcode"
+                    if [ -n "$task_hash" ] && ! grep -q -x -F "$task_hash" $nf_sync_to_storage_processed_task_file ; then
+                        task_workdir=$(realpath ${CP_NF_WORKDIR}/$task_hash*)
+                        if [ -d "$task_workdir" ]; then
+                             [ -f "$task_workdir/.command.out" ] && sync_to_storage add "$task_workdir/.command.out" "$nf_task_file_sync_path/$task_hash/.command.out"
+                             [ -f "$task_workdir/.command.err" ] && sync_to_storage add "$task_workdir/.command.err" "$nf_task_file_sync_path/$task_hash/.command.err"
+                             [ -f "$task_workdir/.command.log" ] && sync_to_storage add "$task_workdir/.command.log" "$nf_task_file_sync_path/$task_hash/.command.log"
+                             [ -f "$task_workdir/.command.sh" ] && sync_to_storage add "$task_workdir/.command.sh" "$nf_task_file_sync_path/$task_hash/.command.sh"
+                             [ -f "$task_workdir/.command.run" ] && sync_to_storage add "$task_workdir/.command.run" "$nf_task_file_sync_path/$task_hash/.command.run"
+                             [ -f "$task_workdir/.command.trace" ] && sync_to_storage add "$task_workdir/.command.trace" "$nf_task_file_sync_path/$task_hash/.command.trace"
+                             [ -f "$task_workdir/.command.begin" ] && sync_to_storage add "$task_workdir/.command.begin" "$nf_task_file_sync_path/$task_hash/.command.begin"
+                             [ -f "$task_workdir/.exitcode" ] && sync_to_storage add "$task_workdir/.exitcode" "$nf_task_file_sync_path/$task_hash/.exitcode"
                              if echo "$task" | grep -q -E "COMPLETE|FAILED|CACHED|ABORTED" ; then
                                  sync_to_storage remove "$task_workdir/.command.out"
                                  sync_to_storage remove "$task_workdir/.command.err"
@@ -200,7 +197,7 @@ function enable_nf_runtime_data_sync() {
                     fi
                 done
             else
-                pipe_log_warn "[WARN] There is no ${CP_NF_TRACE_FILE} at the moment, skip runtime data sync iteration." "$SYNC_RUN_RUNTIME_DATA_TASK"
+                pipe_log_warn "[WARN] There is no ${CP_NF_TASK_LOOKUP_FILE_PATH} at the moment, skip runtime data sync iteration." "$SYNC_RUN_RUNTIME_DATA_TASK"
             fi
         done
     else
@@ -232,6 +229,13 @@ fi
 
 if [ "$CP_NF_WEBLOG_HANDLER_START" == 1 ]; then
     echo "Enabling Nextflow weblog handler..."
+
+    if [ -n "${CP_NF_TASK_LOOKUP_FILE}" ]; then
+        CP_NF_TASK_LOOKUP_FILE_PATH="${CP_NF_TRACE_FILE_DIR:-$CP_NF_WORKDIR}/${CP_NF_TASK_LOOKUP_FILE}"
+        echo "Configuring CP_NF_TASK_LOOKUP_FILE_PATH as: $CP_NF_TASK_LOOKUP_FILE_PATH."
+        # Will be used in nf-weblog-handler to populate this path
+        export CP_NF_TASK_LOOKUP_FILE_PATH
+    fi
 
     if [ -f "$CP_NF_WEBLOG_HANDLER_PID_FILE" ]; then
         _process_pid=$(cat "$CP_NF_WEBLOG_HANDLER_PID_FILE")


### PR DESCRIPTION
if configured with `CP_NF_TASK_LOOKUP_FILE` env (name of the file), `nf-weblog-handler` will create it's own lookup task file, during task event processing.
Then `nf-weblog-handler.sh` can utilize this file instead of `trace.txt` file to understand which task file it needs to sync.
This will allow to start sync process of the task file earlier (once task was SUBMITTED), while in `trace.txt` file such task will be available only after it finished.