### PR TITLE
Allow to override default cp/mv templates in DTS

### DIFF
--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/cmd/PipelineCLIImpl.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/cmd/PipelineCLIImpl.java
@@ -51,6 +51,8 @@ public class PipelineCLIImpl implements PipelineCLI {
     public static final Marker PIPE = MarkerFactory.getMarker("PIPE");
 
     private final String pipelineCliExecutable;
+    private final String pipeCpTemplate;
+    private final String pipeMvTemplate;
     private final String pipeCpSuffix;
     private final boolean forceUpload;
     private final int retryCount;
@@ -218,9 +220,12 @@ public class PipelineCLIImpl implements PipelineCLI {
                                             final boolean deleteSource,
                                             final String pipeCmd,
                                             final String pipeCmdSuffix) {
+
+        final String cpTemplate = StringUtils.isBlank(pipeCpTemplate) ? PIPE_CP_TEMPLATE : pipeCpTemplate;
+        final String mvTemplate = StringUtils.isBlank(pipeMvTemplate) ? PIPE_MV_TEMPLATE : pipeMvTemplate;
         return deleteSource
-                ? buildPipeTransferCommand(PIPE_MV_TEMPLATE, source, destination, include, pipeCmd, pipeCmdSuffix)
-                : buildPipeTransferCommand(PIPE_CP_TEMPLATE, source, destination, include, pipeCmd, pipeCmdSuffix);
+                ? buildPipeTransferCommand(mvTemplate, source, destination, include, pipeCmd, pipeCmdSuffix)
+                : buildPipeTransferCommand(cpTemplate, source, destination, include, pipeCmd, pipeCmdSuffix);
     }
 
     private String buildPipeTransferCommand(final String template, final String source, final String destination,

--- a/data-transfer-service/src/main/java/com/epam/pipeline/dts/transfer/TransferConfiguration.java
+++ b/data-transfer-service/src/main/java/com/epam/pipeline/dts/transfer/TransferConfiguration.java
@@ -73,12 +73,16 @@ public class TransferConfiguration {
     public PipelineCliProvider pipelineCliProvider(final CmdExecutorsProvider cmdExecutorsProvider,
                                                    @Value("${dts.transfer.pipe.executable}")
                                                    final String pipelineCliExecutable,
-                                                   @Value("${dts.transfer.pipe.cp.template}") final String pipeCpTemplate,
-                                                   @Value("${dts.transfer.pipe.mv.template}") final String pipeMvTemplate,
-                                                   @Value("${dts.transfer.pipe.cp.suffix:}") final String pipeCpSuffix,
-                                                   @Value("${dts.transfer.grid.template}") final String qsubTemplate,
+                                                   @Value("${dts.transfer.pipe.cp.template}")
+                                                   final String pipeCpTemplate,
+                                                   @Value("${dts.transfer.pipe.mv.template}")
+                                                   final String pipeMvTemplate,
+                                                   @Value("${dts.transfer.pipe.cp.suffix:}")
+                                                   final String pipeCpSuffix,
+                                                   @Value("${dts.transfer.grid.template}")
+                                                   final String qsubTemplate,
                                                    @Value("${dts.transfer.grid.upload}")
-                                                       final boolean isGridUploadEnabled,
+                                                   final boolean isGridUploadEnabled,
                                                    @Value("${dts.transfer.upload.force}") final boolean forceUpload,
                                                    @Value("${dts.transfer.upload.retry}") final int retryCount) {
         return new PipelineCliProviderImpl(cmdExecutorsProvider, pipelineCliExecutable, pipeCpTemplate, pipeMvTemplate,

--- a/data-transfer-service/src/main/java/com/epam/pipeline/dts/transfer/TransferConfiguration.java
+++ b/data-transfer-service/src/main/java/com/epam/pipeline/dts/transfer/TransferConfiguration.java
@@ -73,14 +73,16 @@ public class TransferConfiguration {
     public PipelineCliProvider pipelineCliProvider(final CmdExecutorsProvider cmdExecutorsProvider,
                                                    @Value("${dts.transfer.pipe.executable}")
                                                    final String pipelineCliExecutable,
+                                                   @Value("${dts.transfer.pipe.cp.template}") final String pipeCpTemplate,
+                                                   @Value("${dts.transfer.pipe.mv.template}") final String pipeMvTemplate,
                                                    @Value("${dts.transfer.pipe.cp.suffix:}") final String pipeCpSuffix,
                                                    @Value("${dts.transfer.grid.template}") final String qsubTemplate,
                                                    @Value("${dts.transfer.grid.upload}")
                                                        final boolean isGridUploadEnabled,
                                                    @Value("${dts.transfer.upload.force}") final boolean forceUpload,
                                                    @Value("${dts.transfer.upload.retry}") final int retryCount) {
-        return new PipelineCliProviderImpl(cmdExecutorsProvider, pipelineCliExecutable, pipeCpSuffix, qsubTemplate,
-                isGridUploadEnabled, forceUpload, retryCount);
+        return new PipelineCliProviderImpl(cmdExecutorsProvider, pipelineCliExecutable, pipeCpTemplate, pipeMvTemplate,
+            pipeCpSuffix, qsubTemplate, isGridUploadEnabled, forceUpload, retryCount);
     }
 
     @Bean

--- a/data-transfer-service/src/main/java/com/epam/pipeline/dts/transfer/service/impl/PipelineCliProviderImpl.java
+++ b/data-transfer-service/src/main/java/com/epam/pipeline/dts/transfer/service/impl/PipelineCliProviderImpl.java
@@ -34,6 +34,8 @@ public class PipelineCliProviderImpl implements PipelineCliProvider {
 
     private final CmdExecutorsProvider cmdExecutorsProvider;
     private final String pipelineCliExecutable;
+    private final String pipeCpTemplate;
+    private final String pipeMvTemplate;
     private final String pipeCpSuffix;
     private final String qsubTemplate;
     private final boolean isGridUploadEnabled;
@@ -46,7 +48,8 @@ public class PipelineCliProviderImpl implements PipelineCliProvider {
                 authenticated(api, apiToken,
                         impersonating(
                                 cmdExecutor()));
-        return new PipelineCLIImpl(pipelineCliExecutable, pipeCpSuffix, forceUpload, retryCount, cmdExecutor);
+        return new PipelineCLIImpl(pipelineCliExecutable, pipeCpTemplate, pipeMvTemplate,
+                                    pipeCpSuffix, forceUpload, retryCount, cmdExecutor);
     }
 
     private CmdExecutor authenticated(final String api,

--- a/data-transfer-service/src/main/resources/application.properties
+++ b/data-transfer-service/src/main/resources/application.properties
@@ -36,6 +36,8 @@ task.local.pool.size=${DTS_LOCAL_TRANSFER_POOL_SIZE:3}
 task.scheduled.pool.size=${DTS_SCHEDULED_EXECUTOR_POOL_SIZE:2}
 
 dts.transfer.pipe.executable=${DTS_PIPE_EXECUTABLE:pipe}
+dts.transfer.pipe.cp.template=${DTS_PIPE_CP_TEMPLATE:'%s' storage cp '%s' '%s' %s}
+dts.transfer.pipe.mv.template=${DTS_PIPE_MV_TEMPLATE:'%s' storage mv '%s' '%s' %s}
 dts.transfer.pipe.cp.suffix=-r -f -s -sl=filter
 dts.transfer.grid.upload=false
 dts.transfer.grid.template=qsub -sync y -o %s -e %s %s

--- a/data-transfer-service/src/test/java/com/epam/pipeline/dts/transfer/service/PipelineCliProviderTest.java
+++ b/data-transfer-service/src/test/java/com/epam/pipeline/dts/transfer/service/PipelineCliProviderTest.java
@@ -37,7 +37,7 @@ public class PipelineCliProviderTest {
     private final CmdExecutorsProvider cmdExecutorsProvider = mock(CmdExecutorsProvider.class);
 
     private PipelineCliProvider getPipelineCliProvider(final boolean isGridUploadEnabled) {
-        return new PipelineCliProviderImpl(cmdExecutorsProvider, "pipe", "", QSUB_TEMPLATE,
+        return new PipelineCliProviderImpl(cmdExecutorsProvider, "pipe", "", "", "", QSUB_TEMPLATE,
             isGridUploadEnabled, false, 5);
     }
 


### PR DESCRIPTION
**Background**

DTS had hardcoded copy/move commands templates, i.e. `'%s' storage cp '%s' '%s' %s`. This is incompatible with the other CLI tools which may be required to use.

**Approach**

Two properties can now be used to modify this behavior:
* `dts.transfer.pipe.cp.template=${DTS_PIPE_CP_TEMPLATE:'%s' storage cp '%s' '%s' %s}`
* `dts.transfer.pipe.mv.template=${DTS_PIPE_MV_TEMPLATE:'%s' storage mv '%s' '%s' %s}`
