### PR TITLE
Fix docker login in docker_setup_credentials

### DIFF
--- a/workflows/pipe-common/shell/docker_setup_credentials
+++ b/workflows/pipe-common/shell/docker_setup_credentials
@@ -43,7 +43,8 @@ if [ -z "$_DIND_SKIP_CERTS_SETUP" ]; then
         echo "ca.crt is written to $_DIND_REGISTRY_CERTS_DIR/ca.crt"
 
         # Login to the registry
-        docker login "$_DIND_REGISTRY_NAME" -u "$OWNER" --password-stdin <<< "$API_TOKEN" > /dev/null 2>&1
+        _docker_registry_user="${OWNER_CP_ACCOUNT:-$OWNER}"
+        docker login "$_DIND_REGISTRY_NAME" -u "$_docker_registry_user" --password-stdin <<< "$API_TOKEN" > /dev/null 2>&1
         if [ $? -ne 0 ]; then
             echo "Unable to configure docker credentials for $_DIND_REGISTRY_NAME registry and $OWNER user"
             continue


### PR DESCRIPTION
Fix to login in docker registry: use full user name if present