### PR TITLE
Security logs: use keyword subfield for user in security logs for search

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/log/LogManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/log/LogManager.java
@@ -335,7 +335,7 @@ public class LogManager {
             List<String> formattedUsers = logFilter.getUsers().stream()
                     .flatMap(user -> Stream.of(user.toLowerCase(), user.toUpperCase()))
                     .collect(Collectors.toList());
-            boolQuery.filter(QueryBuilders.termsQuery(USER, formattedUsers));
+            boolQuery.filter(QueryBuilders.termsQuery(USER + KEYWORD, formattedUsers));
         }
         if (CollectionUtils.isNotEmpty(logFilter.getHostnames())) {
             boolQuery.filter(QueryBuilders.termsQuery(HOSTNAME + KEYWORD, logFilter.getHostnames()));


### PR DESCRIPTION
relates to #4076 