### PR TITLE
Issue 4085 - Extend get /datastorage/{id}/paths/permissions to request information by user - fix not required userId

### DIFF
--- a/api/src/main/java/com/epam/pipeline/controller/datastorage/permissions/StoragePathPermissionsController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/datastorage/permissions/StoragePathPermissionsController.java
@@ -80,8 +80,9 @@ public class StoragePathPermissionsController extends AbstractRestController {
     @ApiResponses(
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
             })
-    public Result<List<StoragePathPermissions>> loadStoragePathPermissions(@PathVariable(value = ID) final Long id,
-                                                                           @RequestParam final Long userId) {
+    public Result<List<StoragePathPermissions>> loadStoragePathPermissions(
+            @PathVariable(value = ID) final Long id,
+            @RequestParam(required = false) final Long userId) {
         return Result.success(storagePathPermissionsApiService.loadStoragePathPermissions(id, userId));
     }
 


### PR DESCRIPTION
[Extend get /datastorage/{id}/paths/permissions to request information by user #4085](https://github.com/epam/cloud-pipeline/issues/4085)