### PR TITLE
SLURM: Allow to control the MaxArraySize

### DIFF
--- a/deploy/contents/install/preferences/launch.system.parameters.json
+++ b/deploy/contents/install/preferences/launch.system.parameters.json
@@ -155,6 +155,13 @@
         "passToWorkers": true
     },
     {
+        "name": "CP_CAP_SLURM_MAX_ARRAY_SIZE",
+        "type": "string",
+        "description": "Allow to control the MaxArraySize - a maximum job array size.",
+        "defaultValue": "1001",
+        "passToWorkers": true
+    },
+    {
         "name": "CP_CAP_NFS",
         "type": "boolean",
         "description": "Enables shared filesystem (NFS) for a current run. If a cluster run is scheduled - worker nodes will mount NFS share",

--- a/workflows/pipe-common/shell/slurm_setup_master
+++ b/workflows/pipe-common/shell/slurm_setup_master
@@ -146,6 +146,9 @@ EOL
     if check_cp_cap CP_CAP_GRID_ENGINE_NOTIFICATIONS; then
         echo "MailProg=$COMMON_REPO_DIR_MUTUAL_LOC/shell/pipe_mail" >> ${SLURM_COMMON_CONFIG_DIR}/slurm.conf
     fi
+    if [ "$CP_CAP_SLURM_MAX_ARRAY_SIZE" ]; then
+        echo "MaxArraySize=$CP_CAP_SLURM_MAX_ARRAY_SIZE" >> ${SLURM_COMMON_CONFIG_DIR}/slurm.conf
+    fi
     if check_cp_cap CP_CAP_AUTOSCALE; then
         echo "MaxNodeCount=1000" >> ${SLURM_COMMON_CONFIG_DIR}/slurm.conf
         echo "TreeWidth=65533" >> ${SLURM_COMMON_CONFIG_DIR}/slurm.conf


### PR DESCRIPTION
This PR allows to control the MaxArraySize setting for SLURM cluster, which defines the maximum size of a job array.