### PR TITLE
Checking module permissions before the module launch

### DIFF
--- a/workflows/pipe-common/shell/modules_setup
+++ b/workflows/pipe-common/shell/modules_setup
@@ -174,6 +174,51 @@ elif [ "$CP_CAP_MODULES_TYPE" == "lmod" ]; then
         CP_CAP_MODULES_CONFIG_DIR="${CP_CAP_MODULES_CONFIG_DIR:-$MODULES_FILES_DIR}"
         if [ ! -f "$CP_CAP_MODULES_CONFIG_DIR/SitePackage.lua" ]; then
             mkdir -p "$CP_CAP_MODULES_CONFIG_DIR"
+            cat > "$CP_CAP_MODULES_CONFIG_DIR/CheckPermissions.sh" << 'EOF'
+#!/bin/bash
+
+module_dir=$(dirname "$1")
+permissions_path="$module_dir/permissions.json"
+result="You are not allowed to launch this module. Please contact your administrator."
+
+delimiter="."
+current_user_info_base64=$(echo "$API_TOKEN" | cut -d "$delimiter" -f 2)
+current_user_info=$(echo "$current_user_info_base64" | base64 -d)
+current_user=$(echo "$current_user_info" | jq -r '.sub')
+
+if [[ -z "$current_user" ]]; then
+    result="User ID is undefined. $result"
+elif [[ -f "$permissions_path" ]]; then
+    permissions_mode=$(jq -r '.mode' "$permissions_path")
+    allowed_values=$(jq -r '.values | @sh' "$permissions_path")
+
+    if [[ "$permissions_mode" == 'user' ]]; then
+        if printf "%s\0" "$allowed_values" | grep -w -F -i -- "$current_user" > /dev/null; then
+            result="true"
+        fi
+
+    elif [[ "$permissions_mode" == 'location' ]]; then
+        user_entity=$(curl -s -k -X GET -H "Authorization: Bearer $API_TOKEN" --header "Accept: application/json" \
+                      "${API}metadata/find?entityName=${current_user}&entityClass=PIPELINE_USER" | jq '.payload.entity')
+        user_region=$(curl -s -k -X POST -H "Authorization: Bearer $API_TOKEN" --header "Content-Type: application/json" --header "Accept: application/json" \
+                      -d ["$user_entity"] "${API}metadata/load" | jq '.payload[0].data.user_region.value' | tr -d '" ')
+
+        if [[ -n "$user_region" && "$user_region" != null ]]; then
+            if printf "%s\0" "$allowed_values" | grep -w -F -i -- "$user_region" > /dev/null; then
+                result="true"
+            else
+                result="Region does not match permissions. $result"
+            fi
+        else
+            result="Region is undefined. $result"
+        fi
+    fi
+else
+    result="true"
+fi
+
+printf "$result"
+EOF
             cat > "$CP_CAP_MODULES_CONFIG_DIR/SitePackage.lua" << EOF
 local hook =  require("Hook")
 local uname = require("posix").uname
@@ -181,19 +226,28 @@ local uname = require("posix").uname
 local module_msg = {}
 
 local function load_hook(t)
-   if (mode() ~= "load") then return end
-   local msg = string.format("user=%s module=%s path=%s host=%s time=%f",
-                             os.getenv("USER"), t.modFullName, t.fn, uname("%n"),
-                             epoch())
-   module_msg[t.modFullName] = msg
+    if (mode() ~= "load") then return end
+
+    local cmdCheckPermissions = "bash " .. \"$CP_CAP_MODULES_CONFIG_DIR\" .. "/CheckPermissions.sh " .. t.fn
+    local handle = io.popen(cmdCheckPermissions)
+    local cmdResult = handle:read("*a")
+    handle:close()
+    if (cmdResult ~= "true") then
+        LmodError("[" .. t.modFullName .. "] " .. cmdResult)
+        return end
+
+    local msg = string.format("user=%s module=%s path=%s host=%s time=%f",
+                              os.getenv("USER"), t.modFullName, t.fn, uname("%n"),
+                              epoch())
+    module_msg[t.modFullName] = msg
 end
 
 hook.register("load", load_hook)
 
 local function report_loads()
-   for k,msg in pairs(module_msg) do
-      lmod_system_execute("pipe_log_info \"" .. msg .. "\" \"$CP_CAP_MODULES_USAGE_TASK\" &> /dev/null")
-   end
+    for k,msg in pairs(module_msg) do
+        lmod_system_execute("pipe_log_info \"" .. msg .. "\" \"$CP_CAP_MODULES_USAGE_TASK\" &> /dev/null")
+    end
 end
 
 ExitHookA.register(report_loads)

--- a/workflows/pipe-common/shell/modules_setup
+++ b/workflows/pipe-common/shell/modules_setup
@@ -183,6 +183,8 @@ result="You are not allowed to launch this module. Please contact your administr
 
 delimiter="."
 current_user_info_base64=$(echo "$API_TOKEN" | cut -d "$delimiter" -f 2)
+padding_needed=$(( (4 - ${#current_user_info_base64} % 4) % 4 ))
+current_user_info_base64="${current_user_info_base64}$(printf '%*s' "$padding_needed" | tr ' ' '=')"
 current_user_info=$(echo "$current_user_info_base64" | base64 -d)
 current_user=$(echo "$current_user_info" | jq -r '.sub')
 
@@ -228,7 +230,7 @@ local module_msg = {}
 local function load_hook(t)
     if (mode() ~= "load") then return end
 
-    local cmdCheckPermissions = "bash " .. \"$CP_CAP_MODULES_CONFIG_DIR\" .. "/CheckPermissions.sh " .. t.fn
+    local cmdCheckPermissions = "bash " .. "$CP_CAP_MODULES_CONFIG_DIR" .. "/CheckPermissions.sh " .. t.fn
     local handle = io.popen(cmdCheckPermissions)
     local cmdResult = handle:read("*a")
     handle:close()


### PR DESCRIPTION
This PR adds functionality that checks whether module is permitted to launch for the user.

The approach is the following:
- within the run launched with enabled `Module` capability, via `modules_setup` inner script, a configuration file (`SitePackage.lua`) and auxiliary shell script (`CheckPermissions.sh`) are being created in the `CP_CAP_MODULES_CONFIG_DIR`
- this configuration file contains a hook that is used every time when user loads a module
- this hook checks:
  - if there is a file `permissions.json` in the module directory then:
    - if permissions `mode` in the file is restriction by usernames - then checks whether current user is in the permitted list (in `permissions.json`)
    - if permissions `mode` in the file is restriction by locations - then checks whether location of the current user is in the permitted list (in `permissions.json`)
    - if validation are passed then module is being loaded as usual else launch is being blocked and an error message appears
  - else if no `permissions.json` in the module directory then module is launched without any additional validations

Additional details:
- validations are being performed via `CheckPermissions.sh` shell script that is being launched from module configuration file (`SitePackage.lua`) and located in the same directory (`CP_CAP_MODULES_CONFIG_DIR`)
- name of the current user is obtained from the JWT token (`$API_TOKEN`)
- location of the current user is obtained from the user attribute (`user_region`) 