### PR TITLE
GUI LaunchForm (issue-#4138) enum parameter multiple selection

### DIFF
--- a/client/src/components/pipelines/launch/form/parameters/parameter/inputs/enum-parameter-input.jsx
+++ b/client/src/components/pipelines/launch/form/parameters/parameter/inputs/enum-parameter-input.jsx
@@ -30,6 +30,20 @@ function mapEnumerationItem (eItem) {
   return undefined;
 }
 
+function unMapValue (value, parameter) {
+  if (parameter?.config?.multiple && Array.isArray(value)) {
+    return value.join(',');
+  }
+  return value;
+}
+
+function mapValue (value, parameter) {
+  if (parameter?.config?.multiple) {
+    return (value || '').split(',').filter(Boolean);
+  }
+  return String(value);
+}
+
 function LaunchFormEnumParameterInput (props) {
   const {
     className,
@@ -46,10 +60,10 @@ function LaunchFormEnumParameterInput (props) {
     enumeration: enumerationProps = []
   } = config;
   const enumeration = (enumerationProps || []).map(mapEnumerationItem);
-  const value = valueProps ? String(valueProps) : undefined;
+  const value = mapValue(valueProps, parameter);
   const onInputChange = (e) => {
     if (typeof onChange === 'function') {
-      onChange(e);
+      onChange(unMapValue(e, parameter));
     }
   };
   return (
@@ -60,6 +74,7 @@ function LaunchFormEnumParameterInput (props) {
       onChange={onInputChange}
       disabled={disabled}
       size="large"
+      mode={parameter?.config?.multiple ? 'multiple' : 'default'}
     >
       {enumeration.map((v) => (
         <Select.Option key={v.key} value={v.value}>

--- a/client/src/components/pipelines/launch/form/parameters/parameter/inputs/enum-parameter-input.jsx
+++ b/client/src/components/pipelines/launch/form/parameters/parameter/inputs/enum-parameter-input.jsx
@@ -37,7 +37,7 @@ function unMapValue (value, parameter) {
   return value;
 }
 
-function mapValue (value, parameter) {
+function mapValue (value = '', parameter) {
   if (parameter?.config?.multiple) {
     return (value || '').split(',').filter(Boolean);
   }

--- a/client/src/components/pipelines/launch/form/utilities/parameter-utilities.js
+++ b/client/src/components/pipelines/launch/form/utilities/parameter-utilities.js
@@ -809,6 +809,7 @@ export function getParameterConfig (
         icon,
         'enum': enumerationRaw,
         enumeration = enumerationRaw,
+        multiple,
         resolvedValue,
         visible,
         validation,
@@ -885,6 +886,7 @@ export function getParameterConfig (
         enumeration: enumeration && (Array.isArray(enumeration) || isObservableArray(enumeration))
           ? [...enumeration]
           : undefined,
+        multiple,
         resolvedValue: typedValue(resolvedValue),
         visible,
         validation,
@@ -1201,8 +1203,10 @@ function validateParameter (parameter, parameters, rawEdit = false) {
   try {
     if (actualConfig.visible) {
       if (actualConfig.enumeration && actualConfig.enumeration.length > 0 && !rawEdit) {
-        value = actualConfig.enumeration.find((o) => o === value);
-        if (!value) {
+        if (!actualConfig.multiple) {
+          value = actualConfig.enumeration.find((o) => o === value);
+        }
+        if (!actualConfig.multiple && !value) {
           value = actualConfig.value;
         }
       } else if (configChanged) {
@@ -1640,6 +1644,7 @@ export function parameterConfigToPayloadConfig (parameterConfig) {
     no_override: parameterConfig.noOverride,
     visible: parameterConfig.visible,
     icon: parameterConfig.icon,
+    multiple: parameterConfig.multiple,
     section: parameterConfig.section,
     'enum': parameterConfig.enumeration,
     resolvedValue: parameterConfig.resolvedValue,
@@ -1754,6 +1759,9 @@ function getTypedValue (value, config) {
   }
   if (type === 'object' || typeof value === 'object') {
     return buildSchemeParameterValue(value, scheme);
+  }
+  if (typeof value === 'string' && type === 'enum' && config.multiple) {
+    return value.split(',').sort().join(',');
   }
   return value;
 }


### PR DESCRIPTION
Related to #4138.
To make enum parameter multiple selection enabled - parameter.multiple should be set to "true".

```json
"parameterName" : {
    "enum" : [ "variantA", "variantB", "variantC" ],
    "multiple" : true
},
```