### PR TITLE
Issue 4147 - Schema name for 'cloud_profile_credentials' table creation statement

### DIFF
--- a/api/src/main/resources/db/migration/v2021.01.28_18.00__issue_1713_profiles.sql
+++ b/api/src/main/resources/db/migration/v2021.01.28_18.00__issue_1713_profiles.sql
@@ -1,4 +1,4 @@
-CREATE TABLE cloud_profile_credentials (
+CREATE TABLE pipeline.cloud_profile_credentials (
     id SERIAL PRIMARY KEY,
     cloud_provider varchar,
     policy varchar,


### PR DESCRIPTION
[Schema name is absent for 'cloud_profile_credentials' table creation statement #4147](https://github.com/epam/cloud-pipeline/issues/4147)