### PR TITLE
Issue 4149 - Removed 'if file exists' validation before upload link generation

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureBlobStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureBlobStorageProvider.java
@@ -149,7 +149,7 @@ public class AzureBlobStorageProvider implements StorageProvider<AzureBlobStorag
                 .setReadPermission(true)
                 .setAddPermission(true)
                 .setWritePermission(true);
-        return getAzureStorageHelper(dataStorage).generatePresignedUrl(dataStorage, path, permission.toString(), false);
+        return getAzureStorageHelper(dataStorage).generatePresignedUrl(dataStorage, path, permission.toString());
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureStorageHelper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/azure/AzureStorageHelper.java
@@ -371,6 +371,12 @@ public class AzureStorageHelper {
                                                            final boolean exist) {
         final BlobContainerClient containerClient = getBlobContainerClient(dataStorage);
         validateBlob(containerClient, dataStorage, path, exist);
+        return generatePresignedUrl(dataStorage, path, permission);
+    }
+
+    public DataStorageDownloadFileUrl generatePresignedUrl(final AzureBlobStorage dataStorage,
+                                                           final String path,
+                                                           final String permission) {
         return generateGenericPresignedUrl(dataStorage, path, permission, Duration.ZERO);
     }
 


### PR DESCRIPTION
[Ability to rewrite file for /datastorage/{id}/generateUploadUrl endpoint for Azure datastorage #4149](https://github.com/epam/cloud-pipeline/issues/4149)