### PR TITLE
GUI LaunchForm - add 'metadata-entity' parameters support

### DIFF
--- a/client/src/components/pipelines/launch/LaunchPipeline.js
+++ b/client/src/components/pipelines/launch/LaunchPipeline.js
@@ -562,6 +562,7 @@ class LaunchPipeline extends localization.LocalizedReactComponent {
               });
             }
             if (runInfo) {
+              console.log('runInfo', runInfo)
               return getRunLaunchPayload({
                 run: runInfo,
                 configuration,
@@ -569,6 +570,7 @@ class LaunchPipeline extends localization.LocalizedReactComponent {
               });
             }
             if (configuration) {
+              console.log('configuration', configuration)
               return configuration;
             }
             if (vsPayload) {
@@ -655,6 +657,29 @@ class LaunchPipeline extends localization.LocalizedReactComponent {
     const {
       value: pipeline
     } = this.loadingUtilities.getLoadingState(PIPELINE_STATE_KEY, this.state);
+    // const parametersMock = {
+    //   ...parameters,
+    //   parameters: {
+    //     ...parameters.parameters,
+    //     'GENOME': {
+    //       'type': 'metadata_entity',
+    //       'value': '',
+    //       'multiple': false,
+    //       'metadataConfig': {
+    //         'folderId': '',
+    //         'metadataClass': 'genomes',
+    //         'nameField': 'Name',
+    //         'params': {
+    //           'PARAM_FASTA': 'FASTA',
+    //           'PARAM_GTF': 'GTF',
+    //           'PARAM_GTF2': 'ADDITIONAL_GTF',
+    //           'PARAM_ASDASDADSASD': 'GTF'
+    //         }
+    //       }
+    //     }
+    //   }
+    // };
+    console.log('parameters', parameters)
     const errors = this.getLoadingStateErrors();
     if (payloadPending) {
       return <LoadingView />;

--- a/client/src/components/pipelines/launch/LaunchPipeline.js
+++ b/client/src/components/pipelines/launch/LaunchPipeline.js
@@ -562,7 +562,6 @@ class LaunchPipeline extends localization.LocalizedReactComponent {
               });
             }
             if (runInfo) {
-              console.log('runInfo', runInfo)
               return getRunLaunchPayload({
                 run: runInfo,
                 configuration,
@@ -570,7 +569,6 @@ class LaunchPipeline extends localization.LocalizedReactComponent {
               });
             }
             if (configuration) {
-              console.log('configuration', configuration)
               return configuration;
             }
             if (vsPayload) {
@@ -657,29 +655,6 @@ class LaunchPipeline extends localization.LocalizedReactComponent {
     const {
       value: pipeline
     } = this.loadingUtilities.getLoadingState(PIPELINE_STATE_KEY, this.state);
-    // const parametersMock = {
-    //   ...parameters,
-    //   parameters: {
-    //     ...parameters.parameters,
-    //     'GENOME': {
-    //       'type': 'metadata_entity',
-    //       'value': '',
-    //       'multiple': false,
-    //       'metadataConfig': {
-    //         'folderId': '',
-    //         'metadataClass': 'genomes',
-    //         'nameField': 'Name',
-    //         'params': {
-    //           'PARAM_FASTA': 'FASTA',
-    //           'PARAM_GTF': 'GTF',
-    //           'PARAM_GTF2': 'ADDITIONAL_GTF',
-    //           'PARAM_ASDASDADSASD': 'GTF'
-    //         }
-    //       }
-    //     }
-    //   }
-    // };
-    console.log('parameters', parameters)
     const errors = this.getLoadingStateErrors();
     if (payloadPending) {
       return <LoadingView />;

--- a/client/src/components/pipelines/launch/form/LaunchPipelineForm.js
+++ b/client/src/components/pipelines/launch/form/LaunchPipelineForm.js
@@ -324,6 +324,7 @@ class LaunchPipelineForm extends localization.LocalizedReactComponent {
     bucketPathParameterKey: null,
     bucketPathParameterSection: null,
     currentMetadataEntity: [],
+    parametersMetadata: {},
     rootEntityId: null,
     filteredEntityFields: [],
     activeAutoCompleteParameterKey: null,
@@ -1653,6 +1654,12 @@ class LaunchPipelineForm extends localization.LocalizedReactComponent {
       payload.params
     );
     payload.params = appliedReservationParameters;
+    payload.params = parameterUtilities
+      .resolveMetadataEntityParameters(
+        payload.params,
+        this.getParameters(parametersPayloadId),
+        this.state.parametersMetadata
+      );
     payload.podAssignPolicy = podAssignPolicy;
     if (!payload.isSpot &&
       !this.state.launchCluster &&
@@ -2696,6 +2703,7 @@ class LaunchPipelineForm extends localization.LocalizedReactComponent {
         detached={detached}
         pipeline={pipelineSelected}
         description={description ? (<Markdown md={description} />) : undefined}
+        parametersMetadata={this.state.parametersMetadata}
       />,
       <div
         key={`add-${system ? 'system' : 'default'}-parameter`}
@@ -5480,19 +5488,27 @@ class LaunchPipelineForm extends localization.LocalizedReactComponent {
     } = this.state;
     this.wrapLoading('parameters', async (commitState) => {
       let params = [];
+      let parametersMetadata = {};
       try {
         params = await parameterUtilities.readParametersFromConfiguration(
           payload,
           {
             detached,
-            pipeline: pipeline !== undefined && pipeline !== null
+            pipeline: pipeline !== undefined && pipeline !== null,
+            pipelineObject: pipeline
           }
         );
+        parametersMetadata = await parameterUtilities
+          .getMetadataForParameters(params, this.state.pipeline);
       } catch (error) {
         console.log(`error initializing parameters: ${error.message}`);
       }
+      this.setState({parametersMetadata});
       await this.registerParametersPayloads(
-        [{parameters: params, id: 'default'}],
+        [{
+          parameters: params,
+          id: 'default'
+        }],
         commitState
       );
     });

--- a/client/src/components/pipelines/launch/form/parameters/parameter/index.js
+++ b/client/src/components/pipelines/launch/form/parameters/parameter/index.js
@@ -24,7 +24,8 @@ function LaunchFormParameter (props) {
     rootEntityId,
     metadataAutoComplete,
     detached = false,
-    pipeline = false
+    pipeline = false,
+    parametersMetadata
   } = props;
   if (!parameter) {
     return null;
@@ -81,6 +82,7 @@ function LaunchFormParameter (props) {
             currentMetadataEntity={currentMetadataEntity}
             rootEntityId={rootEntityId}
             metadataAutoComplete={metadataAutoComplete}
+            parametersMetadata={parametersMetadata}
           />
         </Form.Item>
         {removeAllowed && typeof onRemoveParameter === 'function' ? (

--- a/client/src/components/pipelines/launch/form/parameters/parameter/inputs/index.jsx
+++ b/client/src/components/pipelines/launch/form/parameters/parameter/inputs/index.jsx
@@ -6,6 +6,7 @@ import LaunchFormEnumParameterInput from './enum-parameter-input';
 import LaunchFormMetadataParameterInput from './metadata-parameter-input';
 import LaunchFormSchemeParameterInput from './scheme-parameter-input/scheme-parameter-input';
 import {registerRenderer, renderParameter} from './renderers';
+import LaunchFormMetadataEntityParameter from './metadata-entity-parameter';
 
 registerRenderer('string', LaunchFormStringParameterInput, true);
 registerRenderer('enum', LaunchFormEnumParameterInput);
@@ -19,6 +20,7 @@ registerRenderer('path', LaunchFormPathParameterInput);
 registerRenderer('common', LaunchFormPathParameterInput);
 registerRenderer('input', LaunchFormPathParameterInput);
 registerRenderer('output', LaunchFormPathParameterInput);
+registerRenderer('metadata_entity', LaunchFormMetadataEntityParameter);
 
 function LaunchFormParameterInput (props) {
   return renderParameter(props);

--- a/client/src/components/pipelines/launch/form/parameters/parameter/inputs/input-selector.jsx
+++ b/client/src/components/pipelines/launch/form/parameters/parameter/inputs/input-selector.jsx
@@ -7,6 +7,7 @@ import {isObservableArray} from 'mobx';
 import LaunchFormEnumParameterInput from './enum-parameter-input';
 import LaunchFormMetadataParameterInput from './metadata-parameter-input';
 import LaunchFormSchemeParameterInput from './scheme-parameter-input/scheme-parameter-input';
+import LaunchFormMetadataEntityParameter from './metadata-entity-parameter';
 
 function DefaultInputSelector (props) {
   const {
@@ -131,6 +132,22 @@ function DefaultInputSelector (props) {
     case 'metadata':
       return (
         <LaunchFormMetadataParameterInput
+          className={className}
+          style={style}
+          value={value}
+          onChange={onParameterValueChange}
+          disabled={readOnly || disabled}
+          required={required}
+          currentProjectId={currentProjectId}
+          currentProjectMetadata={currentProjectMetadata}
+          currentMetadataEntity={currentMetadataEntity}
+          rootEntityId={rootEntityId}
+          metadataAutoComplete={metadataAutoComplete}
+        />
+      );
+    case 'metadata_entity':
+      return (
+        <LaunchFormMetadataEntityParameter
           className={className}
           style={style}
           value={value}

--- a/client/src/components/pipelines/launch/form/parameters/parameter/inputs/metadata-entity-parameter.jsx
+++ b/client/src/components/pipelines/launch/form/parameters/parameter/inputs/metadata-entity-parameter.jsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import classNames from 'classnames';
+import {Select} from 'antd';
+import styles from './launch-form-parameter-input.css';
+
+function unMapValue (value, parameter) {
+  if (parameter?.config?.multiple && Array.isArray(value)) {
+    return value.join(',');
+  }
+  return value;
+}
+
+function mapValue (value = '', parameter) {
+  if (parameter?.config?.multiple) {
+    return (value || '').split(',').filter(Boolean);
+  }
+  return String(value);
+}
+
+class LaunchFormMetadataEntityParameter extends React.PureComponent {
+  get metadata () {
+    const {parameter, parametersMetadata = {}} = this.props;
+    return parametersMetadata[parameter.name]?.elements || [];
+  }
+
+  get enum () {
+    return this.metadata.map(entry => ({
+      key: entry.id,
+      value: entry.externalId
+    }));
+  }
+
+  getDisplayLabel = (externalId) => {
+    const {parameter} = this.props;
+    const metadataConfig = parameter?.config?.metadata_config || {};
+    const entry = this.metadata.find(m => m.externalId === externalId);
+    if (entry?.data && metadataConfig.nameField) {
+      return entry.data[metadataConfig.nameField]?.value || externalId;
+    }
+    return externalId;
+  };
+
+  filterOption = (input, option) => {
+    const label = option.props.label || '';
+    return label.toLowerCase().includes(input.toLowerCase());
+  };
+
+  render () {
+    const {
+      className,
+      style,
+      value: valueProps,
+      parameter,
+      onChange,
+      disabled
+    } = this.props;
+    const onInputChange = (e) => {
+      if (typeof onChange === 'function') {
+        onChange(unMapValue(e, parameter));
+      }
+    };
+    return (
+      <Select
+        className={classNames(className, styles.launchParameterInput)}
+        style={style}
+        value={mapValue(valueProps, parameter)}
+        onChange={onInputChange}
+        disabled={disabled}
+        size="large"
+        mode={parameter?.config?.multiple ? 'multiple' : 'default'}
+        filterOption={this.filterOption}
+        optionLabelProp="label"
+        showSearch
+      >
+        {this.enum.map((v) => (
+          <Select.Option key={v.key} value={v.value} label={this.getDisplayLabel(v.value)}>
+            {this.getDisplayLabel(v.value)}
+          </Select.Option>
+        ))}
+      </Select>
+    );
+  }
+}
+
+export default LaunchFormMetadataEntityParameter;

--- a/client/src/components/pipelines/launch/form/parameters/parameters.jsx
+++ b/client/src/components/pipelines/launch/form/parameters/parameters.jsx
@@ -148,7 +148,8 @@ class Parameters extends Component {
       detached,
       pipeline,
       parameterRowClassName,
-      description
+      description,
+      parametersMetadata
     } = this.props;
     if (!preferences.loaded || !runDefaultParameters.loaded) {
       return (<LoadingView />);
@@ -291,6 +292,7 @@ class Parameters extends Component {
                       currentCloudRegionId={currentCloudRegionId}
                       currentProjectId={currentProjectId}
                       currentProjectMetadata={currentProjectMetadata}
+                      parametersMetadata={parametersMetadata}
                       currentMetadataEntity={currentMetadataEntity}
                       rootEntityId={rootEntityId}
                       metadataAutoComplete={metadataAutoComplete}

--- a/client/src/components/pipelines/launch/form/utilities/parameter-utilities.js
+++ b/client/src/components/pipelines/launch/form/utilities/parameter-utilities.js
@@ -542,7 +542,6 @@ const metadataCache = {};
  * @param {Object} [pipeline]
  **/
 async function getMetadataForParameters (parameters = [], pipeline) {
-  console.log('123', parameters);
   const metadataEntityParams = parameters
     .filter(p => p.type === 'metadata_entity' &&
       p.config?.metadata_config?.metadataClass

--- a/client/src/components/pipelines/launch/form/utilities/parameter-utilities.js
+++ b/client/src/components/pipelines/launch/form/utilities/parameter-utilities.js
@@ -24,6 +24,7 @@ import {
 import {getSkippedParameters as getGPUScalingSkippedParameters} from './enable-gpu-scaling';
 import whoAmI from '../../../../../models/user/WhoAmI';
 import {base64toString, stringToBase64} from '../../../../../utils/base64';
+import MetadataEntityFilter from '../../../../../models/folderMetadata/MetadataEntityFilter';
 
 function normalizeParameters (parameters) {
   const {keys = [], params = {}} = parameters || {};
@@ -353,6 +354,7 @@ window.launchFormVerbose = function (vb = true) {
  * @property [resolvedValue]
  * @property {boolean} [system]
  * @property {boolean} [userParameter]
+ * @property {object} [metadata_config]
  * @property {object} [restConfig]
  * @property {boolean} [fallbackConfig]
  * @property {ObjectParameterScheme} [scheme]
@@ -467,6 +469,147 @@ export function buildSchemeParameterValue (value, scheme) {
     result.push(e);
   }
   return stringToBase64(JSON.stringify(result));
+}
+
+/**
+ * Resolves metadata_entity parameter and update payload parameters from metadata_entity parameters
+ * @param {Object} [payload={}]
+ * @param {Parameter[]} [parameters=[]]
+ * @param {Object} [metadata={}]
+ **/
+function resolveMetadataEntityParameters (payload = {}, parameters = [], metadata = {}) {
+  const result = {...payload};
+  const metadataEntityParams = parameters.filter(
+    p => p.type === 'metadata_entity' && p.config?.metadata_config?.params
+  );
+  if (metadataEntityParams.length === 0) {
+    return result;
+  }
+  for (const param of metadataEntityParams) {
+    const {value, config} = param;
+    const {metadata_config: metadataConfig} = config;
+    const {params: paramsMapping} = metadataConfig;
+    if (!value || !paramsMapping) {
+      continue;
+    }
+    const metadataEntries = metadata[param.name];
+    if (!metadataEntries || !metadataEntries.elements) {
+      continue;
+    }
+    const externalIds = config.multiple
+      ? (typeof value === 'string' ? value.split(',').map(v => v.trim()) : [value])
+      : [value];
+    const matchingElements = metadataEntries.elements.filter(
+      element => externalIds.includes(element.externalId)
+    );
+    if (matchingElements.length === 0) {
+      continue;
+    }
+    for (const [paramName, metadataField] of Object.entries(paramsMapping)) {
+      const values = matchingElements
+        .map(element => {
+          const fieldData = element.data?.[metadataField];
+          return fieldData?.value;
+        })
+        .filter(v => v !== undefined && v !== null);
+      if (values.length === 0) {
+        continue;
+      }
+      const resolvedValue = config.multiple
+        ? values.join(',')
+        : values[0];
+      if (result[paramName]) {
+        result[paramName] = {
+          ...result[paramName],
+          value: resolvedValue
+        };
+      } else {
+        result[paramName] = {
+          type: 'string',
+          value: resolvedValue
+        };
+      }
+    }
+  }
+  return result;
+}
+
+const metadataCache = {};
+
+/**
+ * Fetch metadata for all metadata_entity type parameters.
+ * @param {Parameter[]} [parameters=[]]
+ * @param {Object} [pipeline]
+ **/
+async function getMetadataForParameters (parameters = [], pipeline) {
+  console.log('123', parameters);
+  const metadataEntityParams = parameters
+    .filter(p => p.type === 'metadata_entity' &&
+      p.config?.metadata_config?.metadataClass
+    );
+  if (metadataEntityParams.length === 0) {
+    return {};
+  }
+  const folderIdFallback = pipeline?.parentFolderId;
+  const getKey = ({config}) => {
+    const {folderId, metadataClass = ''} = config?.metadata_config || {};
+    return `${folderId || folderIdFallback}_${metadataClass}`;
+  };
+  const requestsTemp = {};
+  for (const param of metadataEntityParams) {
+    const {folderId, metadataClass} = param.config.metadata_config;
+    const key = getKey(param);
+    if (metadataCache[key]) {
+      continue;
+    }
+    if (!requestsTemp[key]) {
+      requestsTemp[key] = {
+        folderId: folderId || folderIdFallback,
+        metadataClass,
+        name: param.name
+      };
+    }
+  }
+  const requests = Object.entries(requestsTemp).map(
+    ([key, {name, folderId, metadataClass}]) => {
+      return new Promise((resolve) => {
+        const filter = new MetadataEntityFilter();
+        const payload = {
+          folderId,
+          metadataClass,
+          page: 1,
+          pageSize: 999
+        };
+        filter
+          .send(payload)
+          .then(() => {
+            if (filter.error || !filter.loaded) {
+              console.error(
+                `Error fetching metadata for ${name} parameter:`,
+                filter.error
+              );
+              metadataCache[key] = {error: filter.error};
+            } else {
+              metadataCache[key] = filter.value || {};
+            }
+            resolve();
+          })
+          .catch((error) => {
+            console.error(`Error fetching metadata for ${name} parameter: ${error.message}`);
+            metadataCache[key] = {error: error.message};
+            resolve();
+          });
+      });
+    }
+  );
+  await Promise.all(requests);
+  const result = {};
+  for (const param of metadataEntityParams) {
+    const {name} = param;
+    const key = getKey(param);
+    result[name] = metadataCache[key];
+  }
+  return result;
 }
 
 /**
@@ -817,6 +960,8 @@ export function getParameterConfig (
         fallbackConfig = false,
         // eslint-disable-next-line camelcase
         pretty_name,
+        // eslint-disable-next-line camelcase
+        metadata_config,
         prettyName = pretty_name,
         scheme: parameterScheme,
         ...rest
@@ -892,6 +1037,7 @@ export function getParameterConfig (
         validation,
         condition,
         system,
+        metadata_config,
         restConfig: rest,
         fallbackConfig,
         scheme
@@ -1651,7 +1797,8 @@ export function parameterConfigToPayloadConfig (parameterConfig) {
     validation: parameterConfig.validation,
     description: parameterConfig.description,
     scheme: objectParameterSchemeToPayload(parameterConfig.scheme),
-    pretty_name: parameterConfig.prettyName
+    pretty_name: parameterConfig.prettyName,
+    metadata_config: parameterConfig.metadata_config
   };
 }
 
@@ -1907,5 +2054,7 @@ export {
   addSystemParameters,
   hasResolvedValues,
   toggleResolvedValues,
-  downloadParametersTemplate
+  downloadParametersTemplate,
+  getMetadataForParameters,
+  resolveMetadataEntityParameters
 };


### PR DESCRIPTION
related to #4189.
# Add Metadata Entity Parameter Type


```json
"<parameter-name>": {
  "type": "metadata_entity",
  "value": "",
  "multiple": true,
  "metadata_config": {
    "folderId": "11624",
    "metadataClass": "genomes",
    "nameField": "Name",
    "params": {
      "PARAMETER_NAME": "METADATA_COLUMN"
    }
  }
}
```

Configuration Options:
`value`: String or comma-separated string of metadata entry external IDs
`multiple`:  Enables multi-select dropdown
`folderId`: Specific folder ID to search for metadata. If empty, searches for metadata in the parent folder
`nameField`: Metadata entry column name to use as display label. If empty, shows the external ID
`params`: Object mapping parameter names to metadata column names. When a metadata entity is selected (externalId), the specified parameters will be automatically populated (or created) with values from the corresponding metadata entry columns before launch.