### PR TITLE
Issue #4192: `AbstractCloudRegion` returns `null` when `getProvider` method called

### DIFF
--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/region/AbstractCloudRegion.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/region/AbstractCloudRegion.java
@@ -36,6 +36,7 @@ import java.util.List;
         use = JsonTypeInfo.Id.NAME,
         include = JsonTypeInfo.As.PROPERTY,
         property = "provider",
+        visible = true,
         defaultImpl = AwsRegion.class)
 @JsonSubTypes({
         @JsonSubTypes.Type(value = AwsRegion.class, name = "AWS"),


### PR DESCRIPTION
resolves #4192 
The issue is that Jackson handles and removes the type identifier (the `provider` field) from JSON content that is passed to JsonDeserializer. To fix is `visible=true` can be used.