### PR TITLE
[Nextflow] Handle `integer/float` parameter types

### DIFF
--- a/deploy/docker/cp-tools/base/nextflow/nextflow
+++ b/deploy/docker/cp-tools/base/nextflow/nextflow
@@ -23,7 +23,7 @@ function generate_params_file() {
         [[ "$cp_param" =~ CP_* ]]  && continue
         cp_param_clean=$(echo "$cp_param" | sed 's/_PARAM_TYPE//')
         cp_param_type="${!cp_param}"
-        if [ "$cp_param_type" == "boolean" ]; then
+        if [ "$cp_param_type" == "boolean" ] || [ "$cp_param_type" == "integer" ] || [ "$cp_param_type" == "float" ]; then
             all_cp_params_json="${all_cp_params_json},\"$cp_param_clean\": ${!cp_param_clean}"
         else
             # Escaping special characters for JSON


### PR DESCRIPTION
This PR updates `generate_params_file to handle` method to handle `integer/float` types without quotes