### PR TITLE
Fix docker login for non-root user

### DIFF
--- a/workflows/pipe-common/shell/docker_setup_credentials
+++ b/workflows/pipe-common/shell/docker_setup_credentials
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2017-2023 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2025 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ if [ -z "$_DIND_SKIP_CERTS_SETUP" ]; then
     fi
 
     _DIND_REGISTRIES_LIST=$(echo "$_DIND_REGISTRIES_JSON" | jq -r '.payload | keys[]')
+    _DOCKER_REGISTRY_USER="${OWNER_CP_ACCOUNT:-$OWNER}"
     _DIND_REGISTRY_NAME_EXAMPLE=
     while read _DIND_REGISTRY_NAME; do
         echo "Configuring certificates and credentials for $_DIND_REGISTRY_NAME registry"
@@ -43,19 +44,34 @@ if [ -z "$_DIND_SKIP_CERTS_SETUP" ]; then
         echo "ca.crt is written to $_DIND_REGISTRY_CERTS_DIR/ca.crt"
 
         # Login to the registry
-        _docker_registry_user="${OWNER_CP_ACCOUNT:-$OWNER}"
-        docker login "$_DIND_REGISTRY_NAME" -u "$_docker_registry_user" --password-stdin <<< "$API_TOKEN" > /dev/null 2>&1
+
+        _default_docker_user="root"
+        export DOCKER_CONFIG="/${_default_docker_user}/.docker"
+        # By default, configuration file is stored in ~/.docker/config.json.
+        # See: https://docs.docker.com/reference/cli/docker/#docker-cli-configuration-file-configjson-properties
+        docker login "$_DIND_REGISTRY_NAME" -u "$_DOCKER_REGISTRY_USER" --password-stdin <<< "$API_TOKEN" > /dev/null 2>&1
         if [ $? -ne 0 ]; then
-            echo "Unable to configure docker credentials for $_DIND_REGISTRY_NAME registry and $OWNER user"
+            echo "Unable to configure docker credentials for $_DIND_REGISTRY_NAME registry and ${_default_docker_user} user"
             continue
         else
-            echo "Docker credentials are configured for $_DIND_REGISTRY_NAME registry and $OWNER user"
+            echo "Docker credentials are configured for $_DIND_REGISTRY_NAME registry and ${_default_docker_user} user"
+        fi
+        if [ "$OWNER" != "root" ] && [ -d "$OWNER_HOME" ]; then
+            mkdir -p "$OWNER_HOME/.docker"
+            cp "$DOCKER_CONFIG/config.json" "$OWNER_HOME/.docker/config.json"
+            chown -R ${OWNER} "$OWNER_HOME/.docker"
+            if [ $? -ne 0 ]; then
+                echo "Unable to configure docker credentials for $_DIND_REGISTRY_NAME registry and $OWNER user"
+                continue
+            else
+                echo "Docker credentials are configured for $_DIND_REGISTRY_NAME registry and $OWNER user"
+            fi
         fi
     done <<<$_DIND_REGISTRIES_LIST
     
     echo "Registry certificates and credentials are configured"
 
-_DIND_PRIVATE_REPO_NAME=$(echo $OWNER | tr '[:upper:]' '[:lower:]')
+_DIND_PRIVATE_REPO_NAME=$(echo "$_DOCKER_REGISTRY_USER" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]\+/-/g')
 motd_setup add "This job was launched with 'Docker-IN-Docker' enabled
 The following registries are available and authenticated:
 $_DIND_REGISTRIES_LIST


### PR DESCRIPTION
This PR:
* explicitly configures docker login for root and $OWNER when they differ
* updates motd setup