### PR TITLE
GUI Search and FacetedSearch: add support to search.prompt.template

### DIFF
--- a/client/src/components/search/FacetedSearch.js
+++ b/client/src/components/search/FacetedSearch.js
@@ -65,6 +65,7 @@ import {
 } from './utilities/get-storage-file-display-name-templates';
 import getUserSearchColumnsOrder from './utilities/get-user-search-columns-order';
 import roleModel from '../../utils/roleModel';
+import {getSearchPrompt} from './utilities/search-utilities';
 
 function getDomainKey (domain) {
   return `domain-${domain || ''}`;
@@ -540,6 +541,7 @@ class FacetedSearch extends React.Component {
             storageFileDisplayNameTemplates = [],
             disableCounts
           } = this.state;
+          const {preferences} = this.props;
           if (facets.length === 0) {
             // eslint-disable-next-line
             console.warn('No facets configured. Please, check "faceted.filter.dictionaries" preference and system dictionaries');
@@ -548,9 +550,8 @@ class FacetedSearch extends React.Component {
             });
             return;
           }
-          const query = !advancedSearchMode && currentQuery
-            ? `*${currentQuery}*`
-            : currentQuery;
+          const template = preferences.searchPromptTemplate;
+          const query = getSearchPrompt(currentQuery, template, advancedSearchMode);
           const userDocumentTypesFilter = userDocumentTypes.length > 0
             ? {[DocumentTypeFilterName]: userDocumentTypes}
             : {};

--- a/client/src/components/search/SearchDialog.js
+++ b/client/src/components/search/SearchDialog.js
@@ -36,6 +36,7 @@ import getStyle from '../../utils/browserDependentStyle';
 import {facetedQueryString} from './faceted-search/utilities';
 import {DocumentTypeFilterName} from './faceted-search/filter';
 import getItemUrl from './faceted-search/utilities/get-item-url';
+import {getSearchPrompt} from './utilities/search-utilities';
 import '../../staticStyles/Search.css';
 
 const PAGE_SIZE = 50;
@@ -171,6 +172,17 @@ export default class SearchDialog extends localization.LocalizedReactComponent {
     return aggregates;
   };
 
+  getSearchQuery = (searchCriteria) => {
+    const {preferences} = this.props;
+    const template = preferences.searchPromptTemplate;
+    return getSearchPrompt(
+      searchCriteria,
+      template,
+      false,
+      true
+    );
+  };
+
   performSearch = (force = false) => {
     this.delayedSearch && clearTimeout(this.delayedSearch);
     if (!force &&
@@ -192,11 +204,12 @@ export default class SearchDialog extends localization.LocalizedReactComponent {
       return;
     }
     const searchCriteria = this.state.searchString;
+    const query = this.getSearchQuery(searchCriteria);
     this.setState({
       searching: true
     }, async () => {
       await this.props.searchEngine.send(
-        searchCriteria,
+        query,
         undefined,
         PAGE_SIZE,
         this.generateSearchTypes()
@@ -234,11 +247,12 @@ export default class SearchDialog extends localization.LocalizedReactComponent {
       return;
     }
     const searchCriteria = this.state.searchString;
+    const query = this.getSearchQuery(searchCriteria);
     this.setState({
       searching: true
     }, async () => {
       await this.props.searchEngine.send(
-        searchCriteria,
+        query,
         undefined,
         PAGE_SIZE,
         this.generateSearchTypes()
@@ -468,6 +482,7 @@ export default class SearchDialog extends localization.LocalizedReactComponent {
         return;
       }
       const searchCriteria = this.state.searchString;
+      const query = this.getSearchQuery(searchCriteria);
       this.setState({
         searching: true
       }, async () => {
@@ -477,7 +492,7 @@ export default class SearchDialog extends localization.LocalizedReactComponent {
           ? searchResults[searchResults.length - 1]
           : undefined;
         await this.props.searchEngine.send(
-          searchCriteria,
+          query,
           lastResult
             ? {docId: lastResult.elasticId, docScore: lastResult.score, scrollingBackward: false}
             : undefined,

--- a/client/src/components/search/utilities/search-utilities.js
+++ b/client/src/components/search/utilities/search-utilities.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2025 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const PROMPT_PLACEHOLDER = '{user_prompt}';
+
+function resolvePromptTemplate (query, template) {
+  return template.replace(PROMPT_PLACEHOLDER, query);
+}
+
+export function getSearchPrompt (
+  query = '',
+  template = '',
+  isAdvanced = false,
+  omitWildcardWrapper = false
+) {
+  let result = query;
+  const hasTemplate = template?.length > 0 && template.includes(PROMPT_PLACEHOLDER);
+  if (!isAdvanced && hasTemplate) {
+    result = resolvePromptTemplate(query, template);
+  } else if (!isAdvanced && !hasTemplate) {
+    result = query && !omitWildcardWrapper
+      ? `*${query}*`
+      : query;
+  } else {
+    result = query || '';
+  }
+  return result;
+}

--- a/client/src/models/preferences/PreferencesLoad.js
+++ b/client/src/models/preferences/PreferencesLoad.js
@@ -119,6 +119,11 @@ class PreferencesLoad extends Remote {
   }
 
   @computed
+  get searchPromptTemplate () {
+    return this.getPreferenceValue('search.prompt.template');
+  }
+
+  @computed
   get billingEnabled () {
     const value = this.getPreferenceValue('billing.reports.enabled');
     return value && `${value}`.toLowerCase() === 'true';


### PR DESCRIPTION
Add support to `search.prompt.template` settings.
- If template is provided and contains `{user_prompt}` placeholder → user query is wrapped with the template.
- If template is NOT provided (or doesn't contain placeholder) AND not in advanced mode → user query is wrapped with wildcards (`*query*`, for FacetedSearch).
- If in advanced mode → user query is used as-is (no modification).

Example:
Preference: search.prompt.template = "Template {user_prompt} wrapper"
User prompt: "some text"
Search query: "Template some text wrapper"