### PR TITLE
issue 4237: extend email notification about run status changed with run performance metrics if run status is final

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/notification/NotificationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/notification/NotificationManager.java
@@ -94,6 +94,10 @@ public class NotificationManager implements NotificationService { // TODO: rewri
     private static final Pattern MENTION_PATTERN = Pattern.compile("@([^ ]*\\b)");
     public static final String TRUE = "true";
     public static final String METRICS_PREFIX = "metrics_";
+    public static final String TAGS_POSTFIX = "tags";
+    public static final String AVG_POSTFIX = "_avg";
+    public static final String MAX_POSTFIX = "_max";
+    public static final String CAPACITY_POSTFIX = "_capacity";
 
     @Autowired
     private UserManager userManager;
@@ -292,14 +296,14 @@ public class NotificationManager implements NotificationService { // TODO: rewri
                 .filter(tag -> tag.getValue().equalsIgnoreCase(TRUE))
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toList());
-        runPerformanceMetrics.put(METRICS_PREFIX + "tags", runFlags);
+        runPerformanceMetrics.put(METRICS_PREFIX + TAGS_POSTFIX, runFlags);
         Optional.ofNullable(pipelineRunManager.loadPipelineRunPerformanceMetrics(run.getId()))
                 .map(PipelineRunPerformanceMetrics::getMetrics).orElse(Collections.emptyList())
                 .forEach(metric -> {
                     final String metricName = metric.getType().name();
-                    runPerformanceMetrics.put(METRICS_PREFIX + metricName + "_avg", metric.getAvg());
-                    runPerformanceMetrics.put(METRICS_PREFIX + metricName + "_max", metric.getMax());
-                    runPerformanceMetrics.put(METRICS_PREFIX + metricName + "_capacity", metric.getCapacity());
+                    runPerformanceMetrics.put(METRICS_PREFIX + metricName + AVG_POSTFIX, metric.getAvg());
+                    runPerformanceMetrics.put(METRICS_PREFIX + metricName + MAX_POSTFIX, metric.getMax());
+                    runPerformanceMetrics.put(METRICS_PREFIX + metricName + CAPACITY_POSTFIX, metric.getCapacity());
                 });
         return runPerformanceMetrics;
     }

--- a/api/src/main/java/com/epam/pipeline/manager/notification/NotificationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/notification/NotificationManager.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -52,10 +53,13 @@ import com.epam.pipeline.entity.notification.filter.NotificationFilter;
 import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.epam.pipeline.entity.pipeline.run.RunStatus;
+import com.epam.pipeline.entity.run.PipelineRunPerformanceMetrics;
 import com.epam.pipeline.entity.user.Sid;
 import com.epam.pipeline.entity.utils.DateUtils;
 import com.epam.pipeline.manager.datastorage.DataStorageManager;
+import com.epam.pipeline.manager.pipeline.PipelineRunManager;
 import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import lombok.extern.slf4j.Slf4j;
@@ -88,6 +92,8 @@ import com.epam.pipeline.controller.vo.notification.NotificationMessageVO;
 public class NotificationManager implements NotificationService { // TODO: rewrite with Strategy pattern?
 
     private static final Pattern MENTION_PATTERN = Pattern.compile("@([^ ]*\\b)");
+    public static final String TRUE = "true";
+    public static final String METRICS_PREFIX = "metrics_";
 
     @Autowired
     private UserManager userManager;
@@ -118,6 +124,9 @@ public class NotificationManager implements NotificationService { // TODO: rewri
 
     @Autowired
     private DataStorageManager dataStorageManager;
+
+    @Autowired
+    private PipelineRunManager pipelineRunManager;
 
     private final AntPathMatcher matcher = new AntPathMatcher();
 
@@ -259,8 +268,14 @@ public class NotificationManager implements NotificationService { // TODO: rewri
 
         final NotificationMessage message = new NotificationMessage();
         message.setTemplate(new NotificationTemplate(settings.getTemplateId()));
-        message.setTemplateParameters(parameterManager.build(type, run));
 
+        final Map<String, Object> runParameters = parameterManager.build(type, run);
+
+        if (run.getStatus().isFinal()) {
+            runParameters.putAll(getRunPerformanceMetricParameters(run));
+        }
+
+        message.setTemplateParameters(runParameters);
         message.setCopyUserIds(getCCUsers(settings));
 
         if (settings.isKeepInformedOwner()) {
@@ -269,6 +284,24 @@ public class NotificationManager implements NotificationService { // TODO: rewri
         }
 
         saveNotification(message);
+    }
+
+    private Map<String, Object> getRunPerformanceMetricParameters(final PipelineRun run) {
+        final Map<String, Object> runPerformanceMetrics = new HashMap<>();
+        final List<String> runFlags = MapUtils.emptyIfNull(run.getTags()).entrySet().stream()
+                .filter(tag -> tag.getValue().equalsIgnoreCase(TRUE))
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
+        runPerformanceMetrics.put(METRICS_PREFIX + "tags", runFlags);
+        Optional.ofNullable(pipelineRunManager.loadPipelineRunPerformanceMetrics(run.getId()))
+                .map(PipelineRunPerformanceMetrics::getMetrics).orElse(Collections.emptyList())
+                .forEach(metric -> {
+                    final String metricName = metric.getType().name();
+                    runPerformanceMetrics.put(METRICS_PREFIX + metricName + "_avg", metric.getAvg());
+                    runPerformanceMetrics.put(METRICS_PREFIX + metricName + "_max", metric.getMax());
+                    runPerformanceMetrics.put(METRICS_PREFIX + metricName + "_capacity", metric.getCapacity());
+                });
+        return runPerformanceMetrics;
     }
 
     /**

--- a/api/src/test/java/com/epam/pipeline/app/TestApplication.java
+++ b/api/src/test/java/com/epam/pipeline/app/TestApplication.java
@@ -40,6 +40,7 @@ import com.epam.pipeline.manager.quota.QuotaService;
 import com.epam.pipeline.manager.scheduling.AutowiringSpringBeanJobFactory;
 import com.epam.pipeline.manager.user.OnlineUsersService;
 import com.epam.pipeline.manager.user.UserRunnersManager;
+import com.epam.pipeline.manager.utils.GlobalSearchElasticHelper;
 import com.epam.pipeline.repository.access.AccessCodeRepository;
 import com.epam.pipeline.repository.datastorage.lifecycle.DataStorageLifecycleRuleExecutionRepository;
 import com.epam.pipeline.repository.datastorage.lifecycle.DataStorageLifecycleRuleRepository;
@@ -193,13 +194,18 @@ public class TestApplication {
 
     @MockBean
     protected UIPluginRepository pluginRepository;
+
     @MockBean
     protected UIPluginAssignmentRepository assignmentRepository;
 
     @MockBean
     public AccessCodeRepository accessCodeRepository;
+
     @MockBean
     public AccessCodeCleaner accessCodeCleaner;
+
+    @MockBean
+    public GlobalSearchElasticHelper elasticHelper;
 
     @Bean
     public EmbeddedServletContainerCustomizer containerCustomizer() throws FileNotFoundException {

--- a/api/src/test/java/com/epam/pipeline/manager/notification/NotificationManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/notification/NotificationManagerTest.java
@@ -16,40 +16,27 @@
 
 package com.epam.pipeline.manager.notification;
 
-import static com.epam.pipeline.entity.notification.NotificationType.HIGH_CONSUMED_RESOURCES;
-import static com.epam.pipeline.entity.notification.NotificationType.IDLE_RUN;
-import static com.epam.pipeline.entity.notification.NotificationType.LONG_PAUSED;
-import static com.epam.pipeline.entity.notification.NotificationType.LONG_PAUSED_STOPPED;
-import static com.epam.pipeline.entity.notification.NotificationType.LONG_RUNNING;
-import static com.epam.pipeline.entity.notification.NotificationType.LONG_STATUS;
-import static com.epam.pipeline.entity.notification.NotificationType.NEW_ISSUE;
-import static com.epam.pipeline.entity.notification.NotificationType.NEW_ISSUE_COMMENT;
-import static com.epam.pipeline.util.CustomAssertions.assertThrows;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
+import com.epam.pipeline.app.TestApplication;
+import com.epam.pipeline.controller.vo.EntityVO;
 import com.epam.pipeline.controller.vo.notification.NotificationMessageVO;
+import com.epam.pipeline.dao.issue.IssueDao;
+import com.epam.pipeline.dao.notification.MonitoringNotificationDao;
+import com.epam.pipeline.dao.notification.NotificationSettingsDao;
+import com.epam.pipeline.dao.notification.NotificationTemplateDao;
+import com.epam.pipeline.dao.pipeline.PipelineDao;
 import com.epam.pipeline.dao.pipeline.PipelineRunDao;
+import com.epam.pipeline.dao.user.UserDao;
+import com.epam.pipeline.entity.AbstractSecuredEntity;
 import com.epam.pipeline.entity.cluster.monitoring.ELKUsageMetric;
 import com.epam.pipeline.entity.configuration.PipelineConfiguration;
+import com.epam.pipeline.entity.issue.Issue;
+import com.epam.pipeline.entity.issue.IssueComment;
 import com.epam.pipeline.entity.notification.NotificationMessage;
-import com.epam.pipeline.entity.notification.filter.NotificationFilter;
-import com.epam.pipeline.entity.notification.filter.NotificationFilterOperator;
 import com.epam.pipeline.entity.notification.NotificationSettings;
 import com.epam.pipeline.entity.notification.NotificationTemplate;
 import com.epam.pipeline.entity.notification.NotificationType;
+import com.epam.pipeline.entity.notification.filter.NotificationFilter;
+import com.epam.pipeline.entity.notification.filter.NotificationFilterOperator;
 import com.epam.pipeline.entity.pipeline.CommitStatus;
 import com.epam.pipeline.entity.pipeline.Pipeline;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
@@ -58,19 +45,38 @@ import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.epam.pipeline.entity.pipeline.run.RunStatus;
 import com.epam.pipeline.entity.pipeline.run.parameter.PipelineRunParameter;
 import com.epam.pipeline.entity.region.CloudProvider;
+import com.epam.pipeline.entity.run.PipelineRunPerformanceMetric;
+import com.epam.pipeline.entity.run.PipelineRunPerformanceMetrics;
+import com.epam.pipeline.entity.user.DefaultRoles;
+import com.epam.pipeline.entity.user.ExtendedRole;
+import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.entity.utils.DateUtils;
+import com.epam.pipeline.manager.AbstractManagerTest;
+import com.epam.pipeline.manager.cluster.KubernetesManager;
+import com.epam.pipeline.manager.cluster.PodMonitor;
 import com.epam.pipeline.manager.execution.EnvVarsBuilder;
 import com.epam.pipeline.manager.execution.EnvVarsBuilderTest;
 import com.epam.pipeline.manager.execution.SystemParams;
+import com.epam.pipeline.manager.pipeline.PipelineRunManager;
 import com.epam.pipeline.manager.pipeline.RunStatusManager;
 import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.test.creator.user.UserCreatorUtils;
+import com.epam.pipeline.util.KubernetesTestUtils;
+import io.fabric8.kubernetes.api.model.DoneablePod;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.PodStatus;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.PodResource;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.hamcrest.Matchers;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -83,35 +89,36 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.epam.pipeline.app.TestApplication;
-import com.epam.pipeline.controller.vo.EntityVO;
-import com.epam.pipeline.dao.issue.IssueDao;
-import com.epam.pipeline.dao.notification.MonitoringNotificationDao;
-import com.epam.pipeline.dao.notification.NotificationSettingsDao;
-import com.epam.pipeline.dao.notification.NotificationTemplateDao;
-import com.epam.pipeline.dao.pipeline.PipelineDao;
-import com.epam.pipeline.dao.user.UserDao;
-import com.epam.pipeline.entity.AbstractSecuredEntity;
-import com.epam.pipeline.entity.issue.Issue;
-import com.epam.pipeline.entity.issue.IssueComment;
-import com.epam.pipeline.entity.user.DefaultRoles;
-import com.epam.pipeline.entity.user.ExtendedRole;
-import com.epam.pipeline.entity.user.PipelineUser;
-import com.epam.pipeline.entity.utils.DateUtils;
-import com.epam.pipeline.manager.AbstractManagerTest;
-import com.epam.pipeline.manager.cluster.KubernetesManager;
-import com.epam.pipeline.manager.cluster.PodMonitor;
-import com.epam.pipeline.manager.pipeline.PipelineRunManager;
-import com.epam.pipeline.manager.preference.SystemPreferences;
-import com.epam.pipeline.util.KubernetesTestUtils;
-import io.fabric8.kubernetes.api.model.DoneablePod;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.PodList;
-import io.fabric8.kubernetes.api.model.PodStatus;
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.dsl.MixedOperation;
-import io.fabric8.kubernetes.client.dsl.PodResource;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.epam.pipeline.entity.notification.NotificationType.HIGH_CONSUMED_RESOURCES;
+import static com.epam.pipeline.entity.notification.NotificationType.IDLE_RUN;
+import static com.epam.pipeline.entity.notification.NotificationType.LONG_PAUSED;
+import static com.epam.pipeline.entity.notification.NotificationType.LONG_PAUSED_STOPPED;
+import static com.epam.pipeline.entity.notification.NotificationType.LONG_RUNNING;
+import static com.epam.pipeline.entity.notification.NotificationType.LONG_STATUS;
+import static com.epam.pipeline.entity.notification.NotificationType.NEW_ISSUE;
+import static com.epam.pipeline.entity.notification.NotificationType.NEW_ISSUE_COMMENT;
+import static com.epam.pipeline.entity.notification.NotificationType.PIPELINE_RUN_STATUS;
+import static com.epam.pipeline.entity.run.PipelineRunPerformanceMetricsType.CPU;
+import static com.epam.pipeline.entity.run.PipelineRunPerformanceMetricsType.MEMORY;
+import static com.epam.pipeline.util.CustomAssertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ContextConfiguration(classes = TestApplication.class)
 @Transactional
@@ -135,6 +142,13 @@ public class NotificationManagerTest extends AbstractManagerTest {
     private static final String INCLUDE_PARAM_VALUE = "includeParamValue";
     private static final String INCLUDE_PARAM_NAME = "includeParamName";
     private static final long LONG_THRESHOLD = 2000L;
+    public static final String LONG_RUNNING_TAG = "LONG_RUNNING";
+    public static final double CPU_AVG = 0.5d;
+    public static final double CPU_MAX = 1d;
+    public static final double CPU_CAP = 2d;
+    public static final double MEM_AVG = 50d;
+    public static final double MEM_MAX = 100d;
+    public static final double MEM_CAP = 1024d;
 
     @Autowired
     private NotificationManager notificationManager;
@@ -227,6 +241,10 @@ public class NotificationManagerTest extends AbstractManagerTest {
         highConsuming = createSettings(HIGH_CONSUMED_RESOURCES, HIGH_CONSUMED_RESOURCES.getId(),
                 HIGH_CONSUMED_RESOURCES.getDefaultThreshold(), HIGH_CONSUMED_RESOURCES.getDefaultResendDelay());
 
+        createTemplate(PIPELINE_RUN_STATUS.getId(), "runStatusChangedTemplate");
+        createSettings(PIPELINE_RUN_STATUS, PIPELINE_RUN_STATUS.getId(),
+                PIPELINE_RUN_STATUS.getDefaultThreshold(), PIPELINE_RUN_STATUS.getDefaultResendDelay());
+
         longRunnging = new PipelineRun();
         DateTime date = DateTime.now(DateTimeZone.UTC).minus(LONG_RUNNING_DURATION);
         longRunnging.setId(1L);
@@ -267,16 +285,16 @@ public class NotificationManagerTest extends AbstractManagerTest {
     public void testNotifyLongRunning() {
         podMonitor.updateStatus();
         List<NotificationMessage> messages = monitoringNotificationDao.loadAllNotifications();
-        Assert.assertEquals(1, messages.size());
-        Assert.assertEquals(admin.getId(), messages.get(0).getToUserId());
-        Assert.assertTrue(messages.get(0).getCopyUserIds().contains(admin.getId()));
-        Assert.assertEquals(longRunningTemplate.getId(), messages.get(0).getTemplate().getId());
+        assertEquals(1, messages.size());
+        assertEquals(admin.getId(), messages.get(0).getToUserId());
+        assertTrue(messages.get(0).getCopyUserIds().contains(admin.getId()));
+        assertEquals(longRunningTemplate.getId(), messages.get(0).getTemplate().getId());
 
         ArgumentCaptor<PipelineRun> runCaptor = ArgumentCaptor.forClass(PipelineRun.class);
         verify(pipelineRunManager).updatePipelineRunLastNotification(runCaptor.capture());
 
         PipelineRun capturedRun = runCaptor.getValue();
-        Assert.assertNotNull(capturedRun.getLastNotificationTime());
+        assertNotNull(capturedRun.getLastNotificationTime());
     }
 
     @Test
@@ -285,7 +303,7 @@ public class NotificationManagerTest extends AbstractManagerTest {
         notificationTemplateDao.deleteNotificationTemplate(longRunningTemplate.getId());
         podMonitor.updateStatus();
         List<NotificationMessage> messages = monitoringNotificationDao.loadAllNotifications();
-        Assert.assertEquals(0, messages.size());
+        assertEquals(0, messages.size());
     }
 
     @Test
@@ -320,7 +338,7 @@ public class NotificationManagerTest extends AbstractManagerTest {
         pipelineRunManager.updatePipelineStatus(longRunnging);
         podMonitor.updateStatus();
         final List<NotificationMessage> messages = monitoringNotificationDao.loadAllNotifications();
-        Assert.assertEquals(0, messages.size());
+        assertEquals(0, messages.size());
     }
 
     @Test
@@ -329,8 +347,8 @@ public class NotificationManagerTest extends AbstractManagerTest {
 
         podMonitor.updateStatus();
         List<NotificationMessage> messages = monitoringNotificationDao.loadAllNotifications();
-        Assert.assertEquals(1, messages.size());
-        Assert.assertNull(messages.get(0).getToUserId());
+        assertEquals(1, messages.size());
+        assertNull(messages.get(0).getToUserId());
     }
 
     @Test
@@ -340,10 +358,10 @@ public class NotificationManagerTest extends AbstractManagerTest {
 
         podMonitor.updateStatus();
         List<NotificationMessage> messages = monitoringNotificationDao.loadAllNotifications();
-        Assert.assertEquals(1, messages.size());
-        Assert.assertEquals(admin.getId(), messages.get(0).getToUserId());
-        Assert.assertTrue(messages.get(0).getCopyUserIds().contains(admin.getId()));
-        Assert.assertEquals(longRunningTemplate.getId(), messages.get(0).getTemplate().getId());
+        assertEquals(1, messages.size());
+        assertEquals(admin.getId(), messages.get(0).getToUserId());
+        assertTrue(messages.get(0).getCopyUserIds().contains(admin.getId()));
+        assertEquals(longRunningTemplate.getId(), messages.get(0).getTemplate().getId());
     }
 
     @Test
@@ -352,7 +370,7 @@ public class NotificationManagerTest extends AbstractManagerTest {
         podMonitor.updateStatus();
 
         List<NotificationMessage> messages = monitoringNotificationDao.loadAllNotifications();
-        Assert.assertTrue(messages.isEmpty());
+        assertTrue(messages.isEmpty());
     }
 
     @Test
@@ -364,10 +382,10 @@ public class NotificationManagerTest extends AbstractManagerTest {
                 LONG_RUNNING, settings);
 
         List<NotificationMessage> messages = monitoringNotificationDao.loadAllNotifications();
-        Assert.assertEquals(1, messages.size());
-        Assert.assertEquals(admin.getId(), messages.get(0).getToUserId());
-        Assert.assertTrue(messages.get(0).getCopyUserIds().isEmpty());
-        Assert.assertEquals(longRunningTemplate.getId(), messages.get(0).getTemplate().getId());
+        assertEquals(1, messages.size());
+        assertEquals(admin.getId(), messages.get(0).getToUserId());
+        assertTrue(messages.get(0).getCopyUserIds().isEmpty());
+        assertEquals(longRunningTemplate.getId(), messages.get(0).getTemplate().getId());
 
         settings.setKeepInformedAdmins(false);
         settings.setInformedUserIds(Collections.singletonList(userDao.loadUserByName("admin").getId()));
@@ -375,7 +393,7 @@ public class NotificationManagerTest extends AbstractManagerTest {
         notificationManager.notifyLongRunningTask(longRunnging, LONG_RUNNING_DURATION.getStandardSeconds(),
                 LONG_RUNNING, settings);
         messages = monitoringNotificationDao.loadAllNotifications();
-        Assert.assertTrue(messages.get(messages.size() - 1).getCopyUserIds().contains(admin.getId()));
+        assertTrue(messages.get(messages.size() - 1).getCopyUserIds().contains(admin.getId()));
     }
 
     @Test
@@ -386,19 +404,19 @@ public class NotificationManagerTest extends AbstractManagerTest {
         notificationManager.notifyIssue(issue, pipeline, issue.getText());
 
         List<NotificationMessage> messages = monitoringNotificationDao.loadAllNotifications();
-        Assert.assertEquals(1, messages.size());
+        assertEquals(1, messages.size());
         NotificationMessage message = messages.get(0);
 
-        Assert.assertEquals(testOwner.getId(), message.getToUserId());
-        Assert.assertTrue(message.getCopyUserIds().stream().anyMatch(id -> id.equals(testUser1.getId())));
-        Assert.assertTrue(message.getCopyUserIds().stream().anyMatch(id -> id.equals(testUser2.getId())));
-        Assert.assertTrue(message.getCopyUserIds().stream().anyMatch(id -> id.equals(admin.getId())));
+        assertEquals(testOwner.getId(), message.getToUserId());
+        assertTrue(message.getCopyUserIds().stream().anyMatch(id -> id.equals(testUser1.getId())));
+        assertTrue(message.getCopyUserIds().stream().anyMatch(id -> id.equals(testUser2.getId())));
+        assertTrue(message.getCopyUserIds().stream().anyMatch(id -> id.equals(admin.getId())));
 
         updateKeepInformedOwner(issueSettings, false);
         notificationManager.notifyIssue(issue, pipeline, issue.getText());
         messages = monitoringNotificationDao.loadAllNotifications();
-        Assert.assertEquals(2, messages.size());
-        Assert.assertNull(messages.get(1).getToUserId());
+        assertEquals(2, messages.size());
+        assertNull(messages.get(1).getToUserId());
     }
 
     @Test
@@ -432,9 +450,79 @@ public class NotificationManagerTest extends AbstractManagerTest {
 
         notificationManager.notifyStuckInStatusRuns(Arrays.asList(notified, skipped));
         final List<NotificationMessage> messages = monitoringNotificationDao.loadAllNotifications();
-        Assert.assertEquals(1, messages.size());
-        Assert.assertEquals(testUser1.getId(), messages.get(0).getToUserId());
+        assertEquals(1, messages.size());
+        assertEquals(testUser1.getId(), messages.get(0).getToUserId());
 
+    }
+
+    @Test
+    public void testRunStatusChangedNotificationCollectsPerfMetricsForRun() {
+        final PipelineRun notified = new PipelineRun();
+        notified.setId(1L);
+        notified.setStatus(TaskStatus.STOPPED);
+        notified.setOwner(testUser1.getUserName());
+        notified.setStartDate(new Date());
+        notified.setTags(Collections.singletonMap(LONG_RUNNING_TAG, "true"));
+        notified.setRunStatuses(Collections.singletonList(
+                RunStatus.builder()
+                        .runId(notified.getId())
+                        .status(TaskStatus.STOPPED)
+                        .timestamp(DateUtils.nowUTC())
+                        .build()));
+
+        final PipelineRunPerformanceMetrics runPerformanceMetrics =
+                new PipelineRunPerformanceMetrics(
+                        notified.getId(),
+                        Arrays.asList(
+                                PipelineRunPerformanceMetric.builder()
+                                        .type(CPU)
+                                        .max(CPU_MAX)
+                                        .avg(CPU_AVG)
+                                        .capacity(CPU_CAP)
+                                        .build(),
+                                PipelineRunPerformanceMetric.builder()
+                                        .type(MEMORY)
+                                        .max(MEM_MAX)
+                                        .avg(MEM_AVG)
+                                        .capacity(MEM_CAP)
+                                        .build()
+                        )
+                );
+
+        when(pipelineRunManager.loadPipelineRunPerformanceMetrics(notified.getId()))
+                .thenReturn(runPerformanceMetrics);
+
+        notificationManager.notifyRunStatusChanged(notified);
+        final List<NotificationMessage> messages = monitoringNotificationDao.loadAllNotifications();
+        assertEquals(1, messages.size());
+        final NotificationMessage message = messages.get(0);
+        assertEquals(testUser1.getId(), message.getToUserId());
+        Map<String, Object> parameters = message.getTemplateParameters();
+
+        assertTrue(parameters.get(
+            NotificationManager.METRICS_PREFIX + CPU + NotificationManager.AVG_POSTFIX).equals(CPU_AVG)
+        );
+        assertTrue(parameters.get(
+            NotificationManager.METRICS_PREFIX + CPU + NotificationManager.MAX_POSTFIX).equals(CPU_MAX)
+        );
+        assertTrue(parameters.get(
+            NotificationManager.METRICS_PREFIX + CPU + NotificationManager.CAPACITY_POSTFIX).equals(CPU_CAP)
+        );
+
+        assertTrue(parameters.get(
+            NotificationManager.METRICS_PREFIX + MEMORY + NotificationManager.AVG_POSTFIX).equals(MEM_AVG)
+        );
+        assertTrue(parameters.get(
+            NotificationManager.METRICS_PREFIX + MEMORY + NotificationManager.MAX_POSTFIX).equals(MEM_MAX)
+        );
+        assertTrue(parameters.get(
+            NotificationManager.METRICS_PREFIX + MEMORY + NotificationManager.CAPACITY_POSTFIX).equals(MEM_CAP)
+        );
+
+        assertTrue(
+            parameters.get(NotificationManager.METRICS_PREFIX + NotificationManager.TAGS_POSTFIX)
+                    .equals(Collections.singletonList(LONG_RUNNING_TAG))
+        );
     }
 
     @Test
@@ -451,19 +539,19 @@ public class NotificationManagerTest extends AbstractManagerTest {
         notificationManager.notifyIssueComment(comment, issue, comment.getText());
 
         List<NotificationMessage> messages = monitoringNotificationDao.loadAllNotifications();
-        Assert.assertEquals(1, messages.size());
+        assertEquals(1, messages.size());
         NotificationMessage message = messages.get(0);
 
-        Assert.assertEquals(testUser2.getId(), message.getToUserId());
-        Assert.assertEquals(issueCommentTemplate.getId(), message.getTemplate().getId());
-        Assert.assertTrue(message.getCopyUserIds().stream().anyMatch(id -> id.equals(testUser1.getId())));
-        Assert.assertTrue(message.getCopyUserIds().stream().anyMatch(id -> id.equals(testOwner.getId())));
+        assertEquals(testUser2.getId(), message.getToUserId());
+        assertEquals(issueCommentTemplate.getId(), message.getTemplate().getId());
+        assertTrue(message.getCopyUserIds().stream().anyMatch(id -> id.equals(testUser1.getId())));
+        assertTrue(message.getCopyUserIds().stream().anyMatch(id -> id.equals(testOwner.getId())));
 
         updateKeepInformedOwner(issueCommentSettings, false);
         notificationManager.notifyIssueComment(comment, issue, comment.getText());
         messages = monitoringNotificationDao.loadAllNotifications();
-        Assert.assertEquals(2, messages.size());
-        Assert.assertNull(messages.get(1).getToUserId());
+        assertEquals(2, messages.size());
+        assertNull(messages.get(1).getToUserId());
     }
 
     @Test
@@ -480,8 +568,8 @@ public class NotificationManagerTest extends AbstractManagerTest {
             new ImmutablePair<>(run2, TEST_CPU_RATE2)), IDLE_RUN);
 
         List<NotificationMessage> messages = monitoringNotificationDao.loadAllNotifications();
-        Assert.assertEquals(2, messages.size());
-        messages.forEach(m -> Assert.assertEquals(
+        assertEquals(2, messages.size());
+        messages.forEach(m -> assertEquals(
             SystemPreferences.SYSTEM_IDLE_CPU_THRESHOLD_PERCENT.getDefaultValue().doubleValue(),
             m.getTemplateParameters().get("idleCpuLevel")));
 
@@ -489,15 +577,15 @@ public class NotificationManagerTest extends AbstractManagerTest {
             .filter(m -> m.getToUserId().equals(testUser1.getId()))
             .findFirst().get();
 
-        Assert.assertEquals(TEST_CPU_RATE1 * PERCENT, run1Message.getTemplateParameters().get("cpuRate"));
-        Assert.assertEquals(run1.getId().intValue(), run1Message.getTemplateParameters().get("id"));
+        assertEquals(TEST_CPU_RATE1 * PERCENT, run1Message.getTemplateParameters().get("cpuRate"));
+        assertEquals(run1.getId().intValue(), run1Message.getTemplateParameters().get("id"));
 
         NotificationMessage run2Message = messages.stream()
             .filter(m -> m.getToUserId().equals(testUser2.getId()))
             .findFirst().get();
 
-        Assert.assertEquals(TEST_CPU_RATE2 * PERCENT, run2Message.getTemplateParameters().get("cpuRate"));
-        Assert.assertEquals(run2.getId().intValue(), run2Message.getTemplateParameters().get("id"));
+        assertEquals(TEST_CPU_RATE2 * PERCENT, run2Message.getTemplateParameters().get("cpuRate"));
+        assertEquals(run2.getId().intValue(), run2Message.getTemplateParameters().get("id"));
     }
 
     @Test
@@ -512,24 +600,24 @@ public class NotificationManagerTest extends AbstractManagerTest {
         notificationManager.notifyHighResourceConsumingRuns(pipelinesMetrics, HIGH_CONSUMED_RESOURCES);
 
         List<NotificationMessage> messages = monitoringNotificationDao.loadAllNotifications();
-        Assert.assertEquals(2, messages.size());
+        assertEquals(2, messages.size());
 
-        Assert.assertEquals(TEST_MEMORY_RATE * PERCENT, messages.get(0).getTemplateParameters().get("memoryRate"));
-        Assert.assertEquals(0.0, messages.get(0).getTemplateParameters().get("diskRate"));
+        assertEquals(TEST_MEMORY_RATE * PERCENT, messages.get(0).getTemplateParameters().get("memoryRate"));
+        assertEquals(0.0, messages.get(0).getTemplateParameters().get("diskRate"));
 
-        Assert.assertEquals(0.0, messages.get(1).getTemplateParameters().get("memoryRate"));
-        Assert.assertEquals(TEST_DISK_RATE * PERCENT, messages.get(1).getTemplateParameters().get("diskRate"));
+        assertEquals(0.0, messages.get(1).getTemplateParameters().get("memoryRate"));
+        assertEquals(TEST_DISK_RATE * PERCENT, messages.get(1).getTemplateParameters().get("diskRate"));
 
-        Assert.assertNotNull(
+        assertNotNull(
                 monitoringNotificationDao.loadNotificationTimestamp(run1.getId(), HIGH_CONSUMED_RESOURCES));
-        Assert.assertNotNull(
+        assertNotNull(
                 monitoringNotificationDao.loadNotificationTimestamp(run2.getId(), HIGH_CONSUMED_RESOURCES));
 
         monitoringNotificationDao.deleteNotificationsByTemplateId(HIGH_CONSUMED_RESOURCES.getId());
         notificationManager.notifyHighResourceConsumingRuns(pipelinesMetrics, HIGH_CONSUMED_RESOURCES);
 
         messages = monitoringNotificationDao.loadAllNotifications();
-        Assert.assertEquals(0, messages.size());
+        assertEquals(0, messages.size());
     }
 
     @Test
@@ -544,14 +632,14 @@ public class NotificationManagerTest extends AbstractManagerTest {
         notificationManager.notifyHighResourceConsumingRuns(pipelinesMetrics, HIGH_CONSUMED_RESOURCES);
 
         List<NotificationMessage> messages = monitoringNotificationDao.loadAllNotifications();
-        Assert.assertEquals(1, messages.size());
+        assertEquals(1, messages.size());
 
         monitoringNotificationDao.deleteNotificationsByTemplateId(HIGH_CONSUMED_RESOURCES.getId());
 
         notificationManager.notifyHighResourceConsumingRuns(pipelinesMetrics, HIGH_CONSUMED_RESOURCES);
 
         messages = monitoringNotificationDao.loadAllNotifications();
-        Assert.assertEquals(0, messages.size());
+        assertEquals(0, messages.size());
     }
 
     @Test
@@ -621,10 +709,10 @@ public class NotificationManagerTest extends AbstractManagerTest {
 
         final NotificationMessage loadedMessage =
                 monitoringNotificationDao.loadMonitoringNotification(savedMessage.getId());
-        Assert.assertEquals(BODY, loadedMessage.getBody());
-        Assert.assertEquals(SUBJECT, loadedMessage.getSubject());
-        Assert.assertEquals(PARAMETERS, loadedMessage.getTemplateParameters());
-        Assert.assertEquals(testUser1.getId(), loadedMessage.getToUserId());
+        assertEquals(BODY, loadedMessage.getBody());
+        assertEquals(SUBJECT, loadedMessage.getSubject());
+        assertEquals(PARAMETERS, loadedMessage.getTemplateParameters());
+        assertEquals(testUser1.getId(), loadedMessage.getToUserId());
     }
 
     @Test
@@ -640,11 +728,11 @@ public class NotificationManagerTest extends AbstractManagerTest {
 
         final NotificationMessage loadedMessage =
                 monitoringNotificationDao.loadMonitoringNotification(savedMessage.getId());
-        Assert.assertEquals(BODY, loadedMessage.getBody());
-        Assert.assertEquals(SUBJECT, loadedMessage.getSubject());
-        Assert.assertEquals(PARAMETERS, loadedMessage.getTemplateParameters());
-        Assert.assertEquals(testUser1.getId(), loadedMessage.getToUserId());
-        Assert.assertEquals(Collections.singletonList(testUser2.getId()), loadedMessage.getCopyUserIds());
+        assertEquals(BODY, loadedMessage.getBody());
+        assertEquals(SUBJECT, loadedMessage.getSubject());
+        assertEquals(PARAMETERS, loadedMessage.getTemplateParameters());
+        assertEquals(testUser1.getId(), loadedMessage.getToUserId());
+        assertEquals(Collections.singletonList(testUser2.getId()), loadedMessage.getCopyUserIds());
     }
 
     @Test
@@ -655,10 +743,10 @@ public class NotificationManagerTest extends AbstractManagerTest {
         notificationManager.notifyLongPausedRuns(Arrays.asList(runningRun, pausedRun));
 
         final List<NotificationMessage> messages = monitoringNotificationDao.loadAllNotifications();
-        Assert.assertEquals(1, messages.size());
-        Assert.assertEquals(messages.get(0).getTemplate().getId(), longPausedTemplate.getId());
+        assertEquals(1, messages.size());
+        assertEquals(messages.get(0).getTemplate().getId(), longPausedTemplate.getId());
 
-        Assert.assertTrue(notificationManager.loadLastNotificationTimestamp(pausedRun.getId(), LONG_PAUSED)
+        assertTrue(notificationManager.loadLastNotificationTimestamp(pausedRun.getId(), LONG_PAUSED)
                 .isPresent());
     }
 
@@ -669,7 +757,7 @@ public class NotificationManagerTest extends AbstractManagerTest {
         notificationManager.notifyLongPausedRuns(Collections.singletonList(pausedRun));
 
         final List<NotificationMessage> messages = monitoringNotificationDao.loadAllNotifications();
-        Assert.assertEquals(0, messages.size());
+        assertEquals(0, messages.size());
     }
 
     @Test
@@ -680,8 +768,8 @@ public class NotificationManagerTest extends AbstractManagerTest {
         notificationManager.notifyLongPausedRunsBeforeStop(Arrays.asList(runningRun, pausedRun));
 
         final List<NotificationMessage> messages = monitoringNotificationDao.loadAllNotifications();
-        Assert.assertEquals(1, messages.size());
-        Assert.assertEquals(messages.get(0).getTemplate().getId(), stopLongPausedTemplate.getId());
+        assertEquals(1, messages.size());
+        assertEquals(messages.get(0).getTemplate().getId(), stopLongPausedTemplate.getId());
     }
 
     @Test
@@ -691,7 +779,7 @@ public class NotificationManagerTest extends AbstractManagerTest {
         notificationManager.notifyLongPausedRunsBeforeStop(Collections.singletonList(pausedRun));
 
         final List<NotificationMessage> messages = monitoringNotificationDao.loadAllNotifications();
-        Assert.assertEquals(0, messages.size());
+        assertEquals(0, messages.size());
     }
 
     @Test
@@ -709,8 +797,8 @@ public class NotificationManagerTest extends AbstractManagerTest {
                 pausedRunToExclude2,
                 pausedRunToInclude));
 
-        Assert.assertEquals(1, filtered.size());
-        Assert.assertEquals(pausedRunToInclude.getId(), filtered.get(0).getId());
+        assertEquals(1, filtered.size());
+        assertEquals(pausedRunToInclude.getId(), filtered.get(0).getId());
     }
 
     @Test


### PR DESCRIPTION
#4237 
additional functionality for #4226 