### PR TITLE
issue 4226: move logic for update of run perf metrics from PodMonitor to NotificationAspect

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/cluster/PodMonitor.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/PodMonitor.java
@@ -29,10 +29,8 @@ import com.epam.pipeline.entity.pipeline.RunLog;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.epam.pipeline.entity.pipeline.run.RunStatus;
 import com.epam.pipeline.entity.utils.DateUtils;
-import com.epam.pipeline.exception.PipelineException;
 import com.epam.pipeline.manager.cloud.CloudFacade;
 import com.epam.pipeline.manager.cluster.cleaner.RunCleaner;
-import com.epam.pipeline.manager.cluster.performancemonitoring.UsageMonitoringManager;
 import com.epam.pipeline.manager.notification.NotificationManager;
 import com.epam.pipeline.manager.notification.NotificationSettingsManager;
 import com.epam.pipeline.manager.pipeline.PipelineRunManager;
@@ -115,7 +113,6 @@ public class PodMonitor extends AbstractSchedulingManager {
         private static final int POD_RELEASE_TIMEOUT = 3000;
 
         private final BlockingQueue<PipelineRun> queueToKill = new LinkedBlockingQueue<>();
-        private final BlockingQueue<PipelineRun> queueToSavePerformanceMetrics = new LinkedBlockingQueue<>();
         private final Map<String, LocalDateTime> hangingPods = new ConcurrentHashMap<>();
 
         private final String kubeNamespace;
@@ -130,7 +127,6 @@ public class PodMonitor extends AbstractSchedulingManager {
         private final RestartRunManager restartRunManager;
         private final CloudFacade cloudFacade;
         private final PreferenceManager preferenceManager;
-        private final UsageMonitoringManager usageMonitoringManager;
         private final List<RunCleaner> cleaners;
 
         @Autowired
@@ -145,7 +141,6 @@ public class PodMonitor extends AbstractSchedulingManager {
                        final RestartRunManager restartRunManager,
                        final CloudFacade cloudFacade,
                        final PreferenceManager preferenceManager,
-                       final UsageMonitoringManager usageMonitoringManager,
                        final List<RunCleaner> cleaners,
                        final @Value("${kube.namespace:default}") String kubeNamespace) {
             this.runLogManager = runLogManager;
@@ -159,7 +154,6 @@ public class PodMonitor extends AbstractSchedulingManager {
             this.restartRunManager = restartRunManager;
             this.cloudFacade = cloudFacade;
             this.preferenceManager = preferenceManager;
-            this.usageMonitoringManager = usageMonitoringManager;
             this.kubeNamespace = kubeNamespace;
             this.cleaners = ListUtils.emptyIfNull(cleaners);
         }
@@ -218,7 +212,6 @@ public class PodMonitor extends AbstractSchedulingManager {
                                 run.setTerminating(true);
                                 hangingPods.putIfAbsent(run.getPodId(), LocalDateTime.now());
                             }
-                            saveMetricsAsync(run);
                         } else if (status.getPhase().equals(KubernetesConstants.POD_FAILED_PHASE) ||
                                 (status.getReason() != null &&
                                         status.getReason().equals(KubernetesConstants.NODE_LOST))) {
@@ -264,21 +257,6 @@ public class PodMonitor extends AbstractSchedulingManager {
             }
         }
 
-        @Scheduled(fixedDelay = POD_RELEASE_TIMEOUT)
-        public void savePerformanceMetricsForFinishedRuns() {
-            while (!queueToSavePerformanceMetrics.isEmpty()) {
-                try {
-                    final PipelineRun run = queueToSavePerformanceMetrics.take();
-                    LOGGER.debug("Save performance metrics for run: {}", run.getId());
-                    storeRunPerformanceMetrics(run);
-                } catch (Exception e) {
-                    LOGGER.error(messageHelper
-                            .getMessage(MessageConstants.ERROR_SAVE_RUN_METRICS, e));
-                    LOGGER.error(e.getMessage(), e);
-                }
-            }
-        }
-
         /**
          * Put tasks from specified {@link PipelineRun} to a queue for killing
          *
@@ -286,15 +264,6 @@ public class PodMonitor extends AbstractSchedulingManager {
          */
         private void killAsync(PipelineRun run) {
             queueToKill.add(run);
-        }
-
-        /**
-         * Put tasks from specified {@link PipelineRun} to a queue for updating performance metrics
-         *
-         * @param run a {@link PipelineRun} which metrics to update
-         */
-        private void saveMetricsAsync(PipelineRun run) {
-            queueToSavePerformanceMetrics.add(run);
         }
 
         private void notifyIfExceedsThreshold(PipelineRun run, Pod pod, NotificationType type) {
@@ -521,38 +490,7 @@ public class PodMonitor extends AbstractSchedulingManager {
             run.setTerminating(true);
             run.setEndDate(DateUtils.now());
             notificationManager.removeNotificationTimestamps(run.getId());
-            saveMetricsAsync(run);
             killAsync(run);
-        }
-
-        private void storeRunPerformanceMetrics(final PipelineRun run) {
-            final long runId = run.getId();
-            final String nodeName = Optional.ofNullable(run.getInstance())
-                    .map(RunInstance::getNodeName).orElse(StringUtils.EMPTY);
-
-            if (StringUtils.isBlank(nodeName)) {
-                LOGGER.warn("Can't find nodeName for run: {}", runId);
-                return;
-            }
-
-            if (usageMonitoringManager != null) {
-                try {
-                    final LocalDateTime from = DateUtils.convertDateToLocalDateTime(run.getStartDate());
-                    final LocalDateTime to = Optional.ofNullable(run.getEndDate())
-                            .map(DateUtils::convertDateToLocalDateTime).orElse(DateUtils.nowUTC());
-
-                    Optional.ofNullable(
-                            usageMonitoringManager.getMeanPerformanceMetricsForRun(nodeName, runId, from, to)
-                    ).ifPresent(pipelineRunManager::savePipelineRunPerformanceMetrics);
-                } catch (PipelineException e) {
-                    LOGGER.warn("Can't request pipeline run performance metrics, it won't be saved for run: {}", runId);
-                }
-            } else {
-                LOGGER.debug(
-                        "UsageMonitoringManager is not initialized! Performance metrics won't be saved for run: {}",
-                        runId
-                );
-            }
         }
 
         private void cleanRunResources(final PipelineRun run) {

--- a/api/src/main/java/com/epam/pipeline/manager/notification/NotificationAspect.java
+++ b/api/src/main/java/com/epam/pipeline/manager/notification/NotificationAspect.java
@@ -17,16 +17,24 @@
 package com.epam.pipeline.manager.notification;
 
 import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.run.RunStatus;
 import com.epam.pipeline.entity.utils.DateUtils;
+import com.epam.pipeline.exception.PipelineException;
+import com.epam.pipeline.manager.cluster.performancemonitoring.UsageMonitoringManager;
+import com.epam.pipeline.manager.pipeline.PipelineRunManager;
 import com.epam.pipeline.manager.pipeline.RunStatusManager;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 
 /**
@@ -36,13 +44,19 @@ import org.springframework.stereotype.Component;
 @Component
 @Slf4j
 public class NotificationAspect {
-    public static final String RESUME_RUN_FAILED = "Resume run failed.";
 
     @Autowired
     private NotificationManager notificationManager;
 
     @Autowired
     private RunStatusManager runStatusManager;
+
+    @Autowired
+    private UsageMonitoringManager usageMonitoringManager;
+
+    @Autowired
+    private PipelineRunManager pipelineRunManager;
+
 
     /**
      * Generates system notifications for PipelineRun status changes
@@ -74,9 +88,43 @@ public class NotificationAspect {
                     run.getId(), run.getStatus());
             return;
         }
+
+        if (newStatus.getStatus().isFinal()) {
+            storeRunPerformanceMetrics(run);
+        }
+
         log.debug("Notify all about pipelineRun status changed {} {} {}: {}",
-                     run.getPodId(), run.getPipelineName(), run.getVersion(), run.getStatus());
+                run.getPodId(), run.getPipelineName(), run.getVersion(), run.getStatus());
         notificationManager.notifyRunStatusChanged(run);
+    }
+
+    private void storeRunPerformanceMetrics(final PipelineRun run) {
+        final long runId = run.getId();
+        final String nodeName = Optional.ofNullable(run.getInstance())
+                .map(RunInstance::getNodeName).orElse(StringUtils.EMPTY);
+
+        if (StringUtils.isBlank(nodeName)) {
+            log.warn("Can't find nodeName for run: {}", runId);
+            return;
+        }
+
+        if (usageMonitoringManager != null) {
+            try {
+                final LocalDateTime from = DateUtils.convertDateToLocalDateTime(run.getStartDate());
+                final LocalDateTime to = Optional.ofNullable(run.getEndDate())
+                        .map(DateUtils::convertDateToLocalDateTime).orElse(DateUtils.nowUTC());
+                Optional.ofNullable(
+                        usageMonitoringManager.getMeanPerformanceMetricsForRun(nodeName, runId, from, to)
+                ).ifPresent(pipelineRunManager::savePipelineRunPerformanceMetrics);
+            } catch (PipelineException e) {
+                log.warn("Can't request pipeline run performance metrics, it won't be saved for run: {}", runId);
+            }
+        } else {
+            log.debug(
+                    "UsageMonitoringManager is not initialized! Performance metrics won't be saved for run: {}",
+                    runId
+            );
+        }
     }
 }
 


### PR DESCRIPTION
related to #4226 and #4237 
To be sure, data is available when notification is about to send we need to move logic for run performance metric calculation to notification aspect. 