### PR TITLE
Use SystemPreferences.SYSTEM_LONG_PAUSED_ACTION_TIMEOUT_MINUTES as threshold for LONG_PAUSED_STOPPED notification

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/notification/NotificationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/notification/NotificationManager.java
@@ -862,6 +862,13 @@ public class NotificationManager implements NotificationService { // TODO: rewri
             return Collections.emptyList();
         }
 
+        if (type == NotificationType.LONG_PAUSED_STOPPED) {
+            final long longPausedActionThreshold = Optional.ofNullable(
+                    preferenceManager.getPreference(SystemPreferences.SYSTEM_LONG_PAUSED_ACTION_TIMEOUT_MINUTES)
+            ).map(Integer::longValue).orElse(-1L);
+            settings.setThreshold(longPausedActionThreshold);
+        }
+
         final LocalDateTime now = DateUtils.nowUTC();
         final Long threshold = settings.getThreshold();
         if (threshold == null || threshold <= 0) {


### PR DESCRIPTION
Previously we used threshold field from LONG_PAUSED_STOPPED notification to check if we need to send notification while to perform an action we use SystemPreferences.SYSTEM_LONG_PAUSED_ACTION_TIMEOUT_MINUTES.

To make it consistent this PR changes the logic to use only  SystemPreferences.SYSTEM_LONG_PAUSED_ACTION_TIMEOUT_MINUTES in all cases