### PR TITLE
Implement pipe-cli binaries signing for MacOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,13 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - run: bash deploy/github_actions/gha_build_macos_arm.sh
+        env:
+          MAC_SIGN_IDENTITY: ${{ secrets.MAC_SIGN_IDENTITY }}
+          MAC_SIGN_KEYCHAIN: ${{ secrets.MAC_SIGN_KEYCHAIN }}
+          MAC_SIGN_KEYCHAIN_PASSWORD: ${{ secrets.MAC_SIGN_KEYCHAIN_PASSWORD }}
+          MAC_SIGN_P12: ${{ secrets.MAC_SIGN_P12 }}
+          MAC_SIGN_P12_PASSWORD: ${{ secrets.MAC_SIGN_P12_PASSWORD }}
+          PIPE_CLI_REQUIRES_SIGNING: ${{ secrets.PIPE_CLI_REQUIRES_SIGNING }}
   Publish_Docs:
     runs-on: ubuntu-22.04
     steps:

--- a/api/profiles/dev/application.properties
+++ b/api/profiles/dev/application.properties
@@ -21,7 +21,7 @@ elasticsearch.client.auth=
 api.security.anonymous.urls=${CP_API_SRV_ANONYMOUS_URLS:/restapi/route,/restapi/whoami,/restapi/static-resources/**}
 api.security.redirected.urls=${CP_API_SRV_REDIRECTED_URLS:/restapi/route,/restapi/access/auth,/restapi/**/prolong**,/restapi/static-resources/**}
 api.security.impersonation.operations.root.url=${CP_API_SECURITY_IMPERSONATION_ROOT_URL:/restapi/user/impersonation}
-api.security.public.urls=${CP_API_SECURITY_PUBLIC_URLS:/init.sh,/launch.sh,/launch.py,/PipelineCLI.tar.gz,/pipe-common.tar.gz,/commit-run-scripts/**,/pipe,/fsbrowser.tar.gz,/gpustat.tar.gz,/pipe.zip,/pipe.tar.gz,/pipe-el6,/pipe-el6.tar.gz,/pipe-osx-arm,/pipe-osx-arm.tar.gz,/cloud-data-linux.tar.gz,/cloud-data-win64.zip,/fsautoscale.sh,/data-transfer-service.jar,/data-transfer-service-windows.zip,/data-transfer-service-linux.zip,/DeployDts.ps1,/deploy_dts.sh}
+api.security.public.urls=${CP_API_SECURITY_PUBLIC_URLS:/init.sh,/launch.sh,/launch.py,/PipelineCLI.tar.gz,/pipe-common.tar.gz,/commit-run-scripts/**,/pipe,/fsbrowser.tar.gz,/gpustat.tar.gz,/pipe.zip,/pipe.tar.gz,/pipe-el6,/pipe-el6.tar.gz,/pipe-osx-arm.tar.gz,/cloud-data-linux.tar.gz,/cloud-data-win64.zip,/fsautoscale.sh,/data-transfer-service.jar,/data-transfer-service-windows.zip,/data-transfer-service-linux.zip,/DeployDts.ps1,/deploy_dts.sh}
 api.security.swagger.access.roles=${CP_API_SECURITY_SWAGGER_ACCESS_ROLES:ROLE_ADMIN,ROLE_USER}
 
 #db configuration

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -24,7 +24,7 @@ task buildUI(type: NpmTask) {
       exclude ('launch.sh', 'config.json', '*.tar.gz', 'pipe', 'pipe-el6',
         'pipe-el6.tar.gz','pipe.zip', 'pipe.tar.gz', 'fsbrowser.tar.gz',
         'cloud-data-linux.tar.gz', 'cloud-data-win64.zip', 'fsautoscale.sh',
-        'pipe-osx-arm', 'pipe-osx-arm.tar.gz', 'gpustat.tar.gz')
+        'pipe-osx-arm.tar.gz', 'gpustat.tar.gz')
     }
   }
   args = ['run', 'build']

--- a/deploy/docker/cp-api-srv/config/application.properties
+++ b/deploy/docker/cp-api-srv/config/application.properties
@@ -16,7 +16,7 @@ spring.resources.static-locations=file:${CP_API_SRV_STATIC_DIR}/,classpath:/META
 api.security.redirected.urls=${CP_API_SRV_REDIRECTED_URLS:/restapi/route,/restapi/access/auth,/restapi/**/prolong**,/restapi/static-resources/**}
 api.security.anonymous.urls=${CP_API_SRV_ANONYMOUS_URLS:/restapi/route,/restapi/static-resources/**}
 api.security.impersonation.operations.root.url=${CP_API_SECURITY_IMPERSONATION_ROOT_URL:/restapi/user/impersonation}
-api.security.public.urls=${CP_API_SECURITY_PUBLIC_URLS:/init.sh,/launch.sh,/launch.py,/PipelineCLI.tar.gz,/pipe-common.tar.gz,/commit-run-scripts/**,/pipe,/fsbrowser.tar.gz,/gpustat.tar.gz,/pipe.zip,/pipe.tar.gz,/pipe-el6,/pipe-el6.tar.gz,/pipe-osx-arm,/pipe-osx-arm.tar.gz,/cloud-data-linux.tar.gz,/cloud-data-win64.zip,/cloud-data-cli-linux,/cloud-data-cli-macos,/cloud-data-cli-win.exe,/fsautoscale.sh,/emergency_node_terminator.sh,/data-transfer-service.jar,/data-transfer-service-windows.zip,/data-transfer-service-linux.zip,/DeployDts.ps1,/deploy_dts.sh}
+api.security.public.urls=${CP_API_SECURITY_PUBLIC_URLS:/init.sh,/launch.sh,/launch.py,/PipelineCLI.tar.gz,/pipe-common.tar.gz,/commit-run-scripts/**,/pipe,/fsbrowser.tar.gz,/gpustat.tar.gz,/pipe.zip,/pipe.tar.gz,/pipe-el6,/pipe-el6.tar.gz,/pipe-osx-arm.tar.gz,/cloud-data-linux.tar.gz,/cloud-data-win64.zip,/cloud-data-cli-linux,/cloud-data-cli-macos,/cloud-data-cli-win.exe,/fsautoscale.sh,/emergency_node_terminator.sh,/data-transfer-service.jar,/data-transfer-service-windows.zip,/data-transfer-service-linux.zip,/DeployDts.ps1,/deploy_dts.sh}
 api.security.swagger.access.roles=${CP_API_SECURITY_SWAGGER_ACCESS_ROLES:ROLE_ADMIN,ROLE_USER}
 api.security.disable.logging=${CP_API_SECURITY_DISABLE_LOGGING:false}
 # supported values - jdbc, HASH_MAP

--- a/deploy/github_actions/gha_pack_dist.sh
+++ b/deploy/github_actions/gha_pack_dist.sh
@@ -50,7 +50,6 @@ function get_pipe_binaries() {
   aws s3 cp --no-progress s3://cloud-pipeline-oss-builds/temp/${_OSX_CLI_TAR_NAME} ${_OSX_CLI_PATH}/
   tar -zxf $_OSX_CLI_PATH/$_OSX_CLI_TAR_NAME -C $_OSX_CLI_PATH
 
-  mv $_OSX_CLI_PATH/dist/dist-file/pipe-osx* ${API_STATIC_PATH}/
   mv $_OSX_CLI_PATH/dist/dist-folder/pipe-osx*.tar.gz ${API_STATIC_PATH}/
 }
 

--- a/pipe-cli/build.gradle
+++ b/pipe-cli/build.gradle
@@ -83,15 +83,17 @@ task buildMacArm(type: Exec) {
     environment "PIPE_CLI_LINUX_DIST_DIR": "$project.rootDir/pipe-cli"
     environment "PIPE_MOUNT_SOURCES_DIR": "$project.rootDir/pipe-cli/mount"
     environment "PYINSTALLER_PATH": "/tmp/pyinstaller"
+    // Code signing options
+    environment "MAC_SIGN_IDENTITY": System.getenv("MAC_SIGN_IDENTITY")
+    environment "MAC_SIGN_KEYCHAIN": System.getenv("MAC_SIGN_KEYCHAIN")
+    environment "MAC_SIGN_KEYCHAIN_PASSWORD": System.getenv("MAC_SIGN_KEYCHAIN_PASSWORD")
+    environment "MAC_SIGN_P12": System.getenv("MAC_SIGN_P12")
+    environment "MAC_SIGN_P12_PASSWORD": System.getenv("MAC_SIGN_P12_PASSWORD")
+    environment "PIPE_CLI_REQUIRES_SIGNING": System.getenv("PIPE_CLI_REQUIRES_SIGNING")
 
     commandLine "bash", "$project.rootDir/pipe-cli/build_mac_arm.sh"
     doLast {
         cleanCLIVersion()
-        delete("$project.rootDir/api/src/main/resources/static/pipe_osx_arm")
-        copy {
-            from("$project.rootDir/pipe-cli/dist/dist-file/pipe_osx_arm")
-            into("$project.rootDir/api/src/main/resources/static/")
-        }
         copy {
             from("$project.rootDir/pipe-cli/dist/dist-folder/pipe_osx_arm.tar.gz")
             into("$project.rootDir/api/src/main/resources/static/")

--- a/pipe-cli/build_mac_arm.sh
+++ b/pipe-cli/build_mac_arm.sh
@@ -115,10 +115,11 @@ function build_pipe {
                                     --add-data "$PIPE_CLI_SOURCES_DIR/res/effective_tld_names.dat.txt:tld/res/" \
                                     ${PIPE_CLI_SOURCES_DIR}/pipe.py $onefile
 }
-build_pipe $PIPE_CLI_LINUX_DIST_DIR/dist/dist-file --onefile
-mv $PIPE_CLI_LINUX_DIST_DIR/dist/dist-file/pipe $PIPE_CLI_LINUX_DIST_DIR/dist/dist-file/pipe-osx-arm
 
 build_pipe $PIPE_CLI_LINUX_DIST_DIR/dist/dist-folder
+if [ "$PIPE_CLI_REQUIRES_SIGNING" == "true" ]; then
+  bash sign_mac.sh $PIPE_CLI_LINUX_DIST_DIR/dist/dist-folder/pipe
+fi
 tar -zcf $PIPE_CLI_LINUX_DIST_DIR/dist/dist-folder/pipe-osx-arm.tar.gz \
         -C $PIPE_CLI_LINUX_DIST_DIR/dist/dist-folder \
         pipe

--- a/pipe-cli/sign_mac.sh
+++ b/pipe-cli/sign_mac.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -e
+
+PIPE_CLI_PATH="$1"
+if [ -z "$PIPE_CLI_PATH" ]; then
+  echo "[ERROR] Path to pipe cli is not defined"
+  exit 1
+fi
+
+if [ ! -d "$PIPE_CLI_PATH" ] && [ ! -f "$PIPE_CLI_PATH" ]; then
+  echo "[ERROR] CLI path is not a directory nor a file, might be does not exist"
+  exit 1
+fi
+
+echo "Starting pipe-cli signing for MacOS"
+
+echo "Creating keychain..."
+security create-keychain -p "$MAC_SIGN_KEYCHAIN_PASSWORD" "$MAC_SIGN_KEYCHAIN"
+security default-keychain -s "$MAC_SIGN_KEYCHAIN"
+security unlock-keychain -p "$MAC_SIGN_KEYCHAIN_PASSWORD" "$MAC_SIGN_KEYCHAIN"
+security set-keychain-settings -t 3600 -u "$MAC_SIGN_KEYCHAIN"
+
+echo "Importing certificate..."
+echo "$MAC_SIGN_P12" | base64 --decode > cert.p12
+security import cert.p12 -k "$MAC_SIGN_KEYCHAIN" -P "$MAC_SIGN_P12_PASSWORD" -T /usr/bin/codesign
+security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MAC_SIGN_KEYCHAIN_PASSWORD" "$MAC_SIGN_KEYCHAIN"
+
+echo "Writing entitlements..."
+cat > entitlements.plist <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+ "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>
+EOF
+
+if [ -d "$PIPE_CLI_PATH" ]; then
+  echo "Signing all binaries in directory $PIPE_CLI_PATH"
+  find "$PIPE_CLI_PATH" -type f \( -perm +111 -o -name "*.dylib" \) -exec \
+    codesign --force --options runtime \
+    --entitlements entitlements.plist \
+    --sign "$MAC_SIGN_IDENTITY" {} \;
+else
+  echo "Signing single binary $PIPE_CLI_PATH"
+  codesign --force --options runtime \
+    --entitlements entitlements.plist \
+    --sign "$MAC_SIGN_IDENTITY" "$PIPE_CLI_PATH"
+fi
+
+echo "Verifying signature..."
+codesign --verify --deep --strict --verbose=2 "$PIPE_CLI_PATH/pipe"
+
+echo "Cleanup..."
+security delete-keychain "$MAC_SIGN_KEYCHAIN"
+rm -f entitlements.plist
+rm -f cert.p12
+
+echo "Signing for pipe-cli completed"


### PR DESCRIPTION
## Summary

These days macOS security policies have become significantly stricter, which caused pipe-cli to stop working for the majority of users.

## + Changes

This pull request introduces proper binary signing for both single-file and folder-based distributions to comply with updated macOS security requirements.

## Motivation

Without signed binaries, macOS blocks execution by default, leading to a broken user experience. Signing the binaries restores usability and ensures smoother installation and execution for end users.