### PR TITLE
issue 4130: fix cp-search-elk-curator deployment labels

### DIFF
--- a/deploy/contents/k8s/cp-search/cp-search-elk-curator-dpl-awsn.yaml
+++ b/deploy/contents/k8s/cp-search/cp-search-elk-curator-dpl-awsn.yaml
@@ -6,13 +6,13 @@ metadata:
 spec:
   selector:
     matchLabels:
-      cloud-pipeline/cp-search-elk: "true"
+      cloud-pipeline/cp-search-elk-curator: "true"
   replicas: 1
   template:
     metadata:
       namespace: default
       labels:
-        cloud-pipeline/cp-search-elk: "true"
+        cloud-pipeline/cp-search-elk-curator: "true"
         cloud-pipeline/core-component: "Deployment"
     spec:
       nodeSelector:

--- a/deploy/contents/k8s/cp-search/cp-search-elk-curator-dpl.yaml
+++ b/deploy/contents/k8s/cp-search/cp-search-elk-curator-dpl.yaml
@@ -6,13 +6,13 @@ metadata:
 spec:
   selector:
     matchLabels:
-      cloud-pipeline/cp-search-elk: "true"
+      cloud-pipeline/cp-search-elk-curator: "true"
   replicas: 1
   template:
     metadata:
       namespace: default
       labels:
-        cloud-pipeline/cp-search-elk: "true"
+        cloud-pipeline/cp-search-elk-curator: "true"
         cloud-pipeline/core-component: "Deployment"
     spec:
       nodeSelector:


### PR DESCRIPTION
#4130 
There was a bug when kube service could route request for elk to a wrong pod, because of labels.
Labels for curator deployment changed from  cloud-pipeline/cp-search-elk to cloud-pipeline/cp-search-elk-curator