### PR TITLE
Issue 4263 ability to get run info by engine task

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
@@ -472,6 +472,6 @@ public class RunApiService {
     @PreAuthorize(ADMIN_ONLY + OR + RUN_ADMIN_ONLY)
     public List<PipelineRunWithEngineTasks> getPipelineRunInfoByEngineTask(final EngineType engineType,
                                                                            final EngineRunTaskKeys keys) {
-        return engineRunTaskService.loadRunInfoByTasks(engineType, keys.getTaskKeys());
+        return engineRunTaskService.loadRunInfoByTasks(engineType, keys.getEngineTaskKeys());
     }
 }

--- a/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/run/RunApiService.java
@@ -45,9 +45,11 @@ import com.epam.pipeline.entity.pipeline.RunLog;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.epam.pipeline.entity.pipeline.run.EngineRunTask;
 import com.epam.pipeline.entity.pipeline.run.EngineRunTaskFilter;
+import com.epam.pipeline.entity.pipeline.run.EngineRunTaskKeys;
 import com.epam.pipeline.entity.pipeline.run.EngineType;
 import com.epam.pipeline.entity.pipeline.run.PipeRunCmdStartVO;
 import com.epam.pipeline.entity.pipeline.run.PipelineRunResult;
+import com.epam.pipeline.entity.pipeline.run.PipelineRunWithEngineTasks;
 import com.epam.pipeline.entity.pipeline.run.PipelineStart;
 import com.epam.pipeline.entity.pipeline.run.RunChartInfo;
 import com.epam.pipeline.entity.pipeline.run.RunInfo;
@@ -465,5 +467,11 @@ public class RunApiService {
     @PreAuthorize(RUN_ID_READ)
     public PipelineRunPerformanceMetrics loadPipelineRunPerformanceMetrics(final Long runId) {
         return runManager.loadPipelineRunPerformanceMetrics(runId);
+    }
+
+    @PreAuthorize(ADMIN_ONLY + OR + RUN_ADMIN_ONLY)
+    public List<PipelineRunWithEngineTasks> getPipelineRunInfoByEngineTask(final EngineType engineType,
+                                                                           final EngineRunTaskKeys keys) {
+        return engineRunTaskService.loadRunInfoByTasks(engineType, keys.getTaskKeys());
     }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
@@ -726,8 +726,8 @@ public class PipelineRunController extends AbstractRestController {
 
     @PostMapping("run/engine/{engineType}/tasks/runInfo")
     @ApiOperation(
-            value = "Loads engine task for run with applied filters",
-            notes = "Loads engine task for run with applied filters",
+            value = "Loads pipeline runs for provided engine task keys, response is grouped by pipeline run.",
+            notes = "Loads pipeline runs for provided engine task keys, response is grouped by pipeline run.",
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
     public Result<List<PipelineRunWithEngineTasks>> getPipelineRunInfoByEngineTask(

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineRunController.java
@@ -45,9 +45,11 @@ import com.epam.pipeline.entity.pipeline.RunInstance;
 import com.epam.pipeline.entity.pipeline.RunLog;
 import com.epam.pipeline.entity.pipeline.run.EngineRunTask;
 import com.epam.pipeline.entity.pipeline.run.EngineRunTaskFilter;
+import com.epam.pipeline.entity.pipeline.run.EngineRunTaskKeys;
 import com.epam.pipeline.entity.pipeline.run.EngineType;
 import com.epam.pipeline.entity.pipeline.run.PipeRunCmdStartVO;
 import com.epam.pipeline.entity.pipeline.run.PipelineRunResult;
+import com.epam.pipeline.entity.pipeline.run.PipelineRunWithEngineTasks;
 import com.epam.pipeline.entity.pipeline.run.PipelineStart;
 import com.epam.pipeline.entity.pipeline.run.RunChartInfo;
 import com.epam.pipeline.entity.pipeline.run.RunInfo;
@@ -720,6 +722,18 @@ public class PipelineRunController extends AbstractRestController {
             @PathVariable(value = ENGINE_TYPE) final EngineType engineType,
             @RequestBody final EngineRunTaskFilter filter) {
         return Result.success(runApiService.filterEngineRunTasks(runId, engineType, filter));
+    }
+
+    @PostMapping("run/engine/{engineType}/tasks/runInfo")
+    @ApiOperation(
+            value = "Loads engine task for run with applied filters",
+            notes = "Loads engine task for run with applied filters",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<List<PipelineRunWithEngineTasks>> getPipelineRunInfoByEngineTask(
+            @PathVariable(value = ENGINE_TYPE) final EngineType engineType,
+            @RequestBody final EngineRunTaskKeys keys) {
+        return Result.success(runApiService.getPipelineRunInfoByEngineTask(engineType, keys));
     }
 
     @PostMapping("/run/{runId}/result")

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/EngineRunTaskDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/EngineRunTaskDao.java
@@ -54,6 +54,7 @@ public class EngineRunTaskDao extends DryRunJdbcDaoSupport {
     private String loadEngineRunTasksStatsByRunIdAndTypeQuery;
     private String findEngineRunTaskByRunIdAndTypeQuery;
     private String countEngineRunTaskByRunIdAndTypeQuery;
+    private String loadEngineRunTasksByKeysQuery;
 
     @Transactional(propagation = Propagation.MANDATORY)
     public List<EngineRunTask> batchUpsert(final List<EngineRunTask> tasks) {
@@ -141,6 +142,15 @@ public class EngineRunTaskDao extends DryRunJdbcDaoSupport {
 
     private String buildDbSorting(final EngineRunTaskSortVO sorting) {
         return "r." + sorting.getColumn().getDbColumn() + " " + (sorting.isDescending() ? "DESC" : "ASC");
+    }
+
+    public List<EngineRunTask> loadEngineTasksByTaskKeys(final EngineType engineType, final List<String> taskKeys) {
+        final MapSqlParameterSource parameters = new MapSqlParameterSource()
+                .addValue(Parameters.ENGINE_TYPE.name(), engineType)
+                .addValue(Parameters.TASK_ID.name(), taskKeys);
+
+        return getNamedParameterJdbcTemplate().query(loadEngineRunTasksByKeysQuery, parameters, Parameters.getRowMapper());
+
     }
 
     enum Parameters {
@@ -239,6 +249,11 @@ public class EngineRunTaskDao extends DryRunJdbcDaoSupport {
     @Required
     public void setDeleteEngineRunTaskByRunIdsQuery(final String deleteEngineRunTaskByRunIdsQuery) {
         this.deleteEngineRunTaskByRunIdsQuery = deleteEngineRunTaskByRunIdsQuery;
+    }
+
+    @Required
+    public void setLoadEngineRunTasksByKeysQuery(final String loadEngineRunTasksByKeysQuery) {
+        this.loadEngineRunTasksByKeysQuery = loadEngineRunTasksByKeysQuery;
     }
 
     @Required

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/EngineRunTaskDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/EngineRunTaskDao.java
@@ -146,8 +146,8 @@ public class EngineRunTaskDao extends DryRunJdbcDaoSupport {
 
     public List<EngineRunTask> loadEngineTasksByTaskKeys(final EngineType engineType, final List<String> taskKeys) {
         final MapSqlParameterSource parameters = new MapSqlParameterSource()
-                .addValue(Parameters.ENGINE_TYPE.name(), engineType)
-                .addValue(Parameters.TASK_ID.name(), taskKeys);
+                .addValue(Parameters.ENGINE_TYPE.name(), engineType.name())
+                .addValue(Parameters.TASK_KEY.name(), taskKeys);
 
         return getNamedParameterJdbcTemplate().query(loadEngineRunTasksByKeysQuery, parameters, Parameters.getRowMapper());
 

--- a/api/src/main/java/com/epam/pipeline/dao/pipeline/EngineRunTaskDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/pipeline/EngineRunTaskDao.java
@@ -149,7 +149,8 @@ public class EngineRunTaskDao extends DryRunJdbcDaoSupport {
                 .addValue(Parameters.ENGINE_TYPE.name(), engineType.name())
                 .addValue(Parameters.TASK_KEY.name(), taskKeys);
 
-        return getNamedParameterJdbcTemplate().query(loadEngineRunTasksByKeysQuery, parameters, Parameters.getRowMapper());
+        return getNamedParameterJdbcTemplate().query(loadEngineRunTasksByKeysQuery,
+                parameters, Parameters.getRowMapper());
 
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/EngineRunTaskService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/EngineRunTaskService.java
@@ -20,23 +20,22 @@ import com.epam.pipeline.common.MessageConstants;
 import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.controller.PagedResult;
 import com.epam.pipeline.dao.pipeline.EngineRunTaskDao;
+import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.run.EngineRunTask;
 import com.epam.pipeline.entity.pipeline.run.EngineRunTaskFilter;
+import com.epam.pipeline.entity.pipeline.run.EngineType;
+import com.epam.pipeline.entity.pipeline.run.PipelineRunWithEngineTasks;
 import com.epam.pipeline.entity.run.EngineRunTaskGroupStatsEntity;
 import com.epam.pipeline.entity.run.EngineRunTaskStatsEntity;
-import com.epam.pipeline.entity.pipeline.run.EngineType;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.math3.util.Pair;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -79,6 +78,34 @@ public class EngineRunTaskService {
         runCRUDService.loadRunById(runId);
         return new PagedResult<>(engineRunTaskDao.filterTasksByRunIdAndTypeAndFilter(runId, engineType, filter),
                 engineRunTaskDao.countTasksByRunIdAndTypeAndFilter(runId, engineType, filter));
+    }
+
+    public List<EngineRunTask> loadTasks(final EngineType engineType, final List<String> taskKeys) {
+        Assert.notEmpty(taskKeys, "List of task keys should be provided!");
+        return engineRunTaskDao.loadEngineTasksByTaskKeys(engineType, taskKeys);
+    }
+
+    public List<PipelineRunWithEngineTasks> loadRunInfoByTasks(final EngineType engineType,
+                                                               final List<String> taskKeys) {
+        final List<EngineRunTask> engineRunTasks = loadTasks(engineType, taskKeys);
+        final Map<Long, List<EngineRunTask>> tasksGroupedByRun =
+                engineRunTasks.stream().collect(Collectors.groupingBy(EngineRunTask::getRunId));
+        final List<PipelineRun> pipelineRuns = runCRUDService.loadRunsByIds(
+                new ArrayList<>(tasksGroupedByRun.keySet())
+        );
+        return pipelineRuns.stream()
+                .map(pipelineRun ->
+                    Pair.create(
+                        pipelineRun,
+                        tasksGroupedByRun.getOrDefault(pipelineRun.getId(), Collections.emptyList())
+                    )
+                ).map(p ->
+                    PipelineRunWithEngineTasks.builder()
+                        .run(p.getKey())
+                        .engineTaskKeys(
+                                p.getValue().stream().map(EngineRunTask::getTaskKey).collect(Collectors.toList())
+                        ).build()
+                ).collect(Collectors.toList());
     }
 
     protected static Map<String, EngineRunTaskGroupStatsEntity> calculateTaskGroupStatistic(

--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/EngineRunTaskService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/EngineRunTaskService.java
@@ -87,9 +87,9 @@ public class EngineRunTaskService {
 
     public List<PipelineRunWithEngineTasks> loadRunInfoByTasks(final EngineType engineType,
                                                                final List<String> taskKeys) {
-        final List<EngineRunTask> engineRunTasks = loadTasks(engineType, taskKeys);
-        final Map<Long, List<EngineRunTask>> tasksGroupedByRun =
-                engineRunTasks.stream().collect(Collectors.groupingBy(EngineRunTask::getRunId));
+        final Map<Long, List<EngineRunTask>> tasksGroupedByRun = loadTasks(engineType, taskKeys)
+                .stream()
+                .collect(Collectors.groupingBy(EngineRunTask::getRunId));
         final List<PipelineRun> pipelineRuns = runCRUDService.loadRunsByIds(
                 new ArrayList<>(tasksGroupedByRun.keySet())
         );

--- a/api/src/main/resources/dao/engine-run-tasks.xml
+++ b/api/src/main/resources/dao/engine-run-tasks.xml
@@ -88,7 +88,7 @@
                 ]]>
             </value>
         </property>
-        <property name="loadEngineRunTasksByIdsQuery">
+        <property name="loadEngineRunTasksByKeysQuery">
             <value>
                 <![CDATA[
                     SELECT
@@ -104,7 +104,7 @@
                         r.end_date,
                         r.run_id,
                         r.duration,
-                        null as r.data
+                        null as data
                     FROM
                         pipeline.engine_run_task r
                     WHERE r.engine_type = :ENGINE_TYPE AND r.task_key IN (:TASK_KEY)

--- a/api/src/main/resources/dao/engine-run-tasks.xml
+++ b/api/src/main/resources/dao/engine-run-tasks.xml
@@ -88,6 +88,30 @@
                 ]]>
             </value>
         </property>
+        <property name="loadEngineRunTasksByIdsQuery">
+            <value>
+                <![CDATA[
+                    SELECT
+                        r.task_id,
+                        r.task_name,
+                        r.task_key,
+                        r.task_tag,
+                        r.task_group,
+                        r.parent_id,
+                        r.engine_type,
+                        r.status,
+                        r.start_date,
+                        r.end_date,
+                        r.run_id,
+                        r.duration,
+                        null as r.data
+                    FROM
+                        pipeline.engine_run_task r
+                    WHERE r.engine_type = :ENGINE_TYPE AND r.task_key IN (:TASK_KEY)
+                    ORDER BY r.run_id
+                ]]>
+            </value>
+        </property>
         <property name="findEngineRunTaskByRunIdAndTypeQuery">
             <value>
                 <![CDATA[

--- a/api/src/main/resources/db/migration/v2026.02.10_17.00__pipeline_run_engine_task_indeces.sql
+++ b/api/src/main/resources/db/migration/v2026.02.10_17.00__pipeline_run_engine_task_indeces.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS engine_run_task_run_id_index ON pipeline.engine_run_task (run_id);
+CREATE INDEX IF NOT EXISTS engine_run_task_task_key_index ON pipeline.engine_run_task (task_key);

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/run/EngineRunTaskKeys.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/run/EngineRunTaskKeys.java
@@ -26,5 +26,5 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class EngineRunTaskKeys {
-   private final List<String> engineTaskKeys;
+    private final List<String> engineTaskKeys;
 }

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/run/EngineRunTaskKeys.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/run/EngineRunTaskKeys.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.pipeline.run;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@Builder
+public class EngineRunTaskKeys {
+   private final List<String> taskKeys;
+}

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/run/EngineRunTaskKeys.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/run/EngineRunTaskKeys.java
@@ -26,5 +26,5 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class EngineRunTaskKeys {
-   private final List<String> taskKeys;
+   private final List<String> engineTaskKeys;
 }

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/run/EngineRunTaskKeys.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/run/EngineRunTaskKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 EPAM Systems, Inc. (https://www.epam.com/)
+ * Copyright 2026 EPAM Systems, Inc. (https://www.epam.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/run/PipelineRunWithEngineTasks.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/run/PipelineRunWithEngineTasks.java
@@ -1,0 +1,14 @@
+package com.epam.pipeline.entity.pipeline.run;
+
+import com.epam.pipeline.entity.pipeline.PipelineRun;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class PipelineRunWithEngineTasks {
+    private final PipelineRun run;
+    private final List<String> engineTaskKeys;
+}

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/run/PipelineRunWithEngineTasks.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/run/PipelineRunWithEngineTasks.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.epam.pipeline.entity.pipeline.run;
 
 import com.epam.pipeline.entity.pipeline.PipelineRun;


### PR DESCRIPTION
#4263 
This PR implements new method in PipelineRun API to return information about runs by provided engine task keys:

`POST` /run/engine/{engineType}/tasks/runInfo
Body:
```
{
  "engineTaskKeys": [
    "<engine-task-key>"
  ]
}
```

Response:
Response is a list of objects contained information about a pipeline and engine task that were run as a part of this pipeline.
If `engine-task-key` doesn't belong to any of existing pipeline run (f.e. because of typo), it will be filtered out from a response.
```
{
  "message": "string",
  "payload": [
    {
      "engineTaskKeys": [
        "<engine-task-key>"
      ],
      "run": { <pipeline-run-object-fields> }
   }
  ],
  "status": "OK"
}
```