### PR TITLE
Issue #4265: [pipe cli] Fix for STREAM transfers for large files

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -308,6 +308,11 @@ def cli():
       CP_CLI_API_CALL_RETRY_TIMEOUT          The time interval in seconds between API call attempts (Default: 5)
       CP_AWS_MAX_ATTEMPTS                    The number of maximum retries to call AWS API. If not specifies the
                                              default boto3 provided values will be used.
+      CP_AWS_MULTIPART_CHUNKSIZE_MB          The partition size of each part for a multipart transfer. If not specified
+                                             the default boto3 provided values will be used (8 MB). AWS S3 enforces
+                                             a maximum of 10,000 parts per object. Configuring part size is important
+                                             for large STREAM transfers, as the final size of the stream cannot
+                                             be predicted.
     """
     pass
 

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -308,7 +308,7 @@ def cli():
       CP_CLI_API_CALL_RETRY_TIMEOUT          The time interval in seconds between API call attempts (Default: 5)
       CP_AWS_MAX_ATTEMPTS                    The number of maximum retries to call AWS API. If not specifies the
                                              default boto3 provided values will be used.
-      CP_AWS_MULTIPART_CHUNKSIZE_MB          The partition size of each part for a multipart transfer. If not specified
+      CP_AWS_STREAM_MULTIPART_CHUNKSIZE_MB   The partition size of each part for a multipart transfer. If not specified
                                              the default boto3 provided values will be used (8 MB). AWS S3 enforces
                                              a maximum of 10,000 parts per object. Configuring part size is important
                                              for large STREAM transfers, as the final size of the stream cannot

--- a/pipe-cli/src/utilities/storage/s3.py
+++ b/pipe-cli/src/utilities/storage/s3.py
@@ -206,12 +206,11 @@ class StorageItemManager(object):
     def get_local_modification_datetime(path):
         return StorageOperations.get_local_file_modification_datetime(path)
 
-    def get_transfer_config(self, io_threads):
+    def get_transfer_config(self, io_threads, multipart_chunksize=None):
         transfer_config = TransferConfig()
         if io_threads is not None:
             transfer_config.max_concurrency = max(io_threads, 1)
             transfer_config.use_threads = transfer_config.max_concurrency > 1
-        multipart_chunksize = os.getenv('CP_AWS_MULTIPART_CHUNKSIZE_MB')
         if multipart_chunksize:
             transfer_config.multipart_chunksize = int(multipart_chunksize) * 1024 * 1024
         return transfer_config
@@ -282,7 +281,8 @@ class DownloadStreamManager(StorageItemManager, AbstractTransferManager):
         source_key = self.get_source_key(source_wrapper, path)
         destination_key = self.get_destination_key(destination_wrapper, relative_path)
 
-        transfer_config = self.get_transfer_config(io_threads)
+        multipart_chunksize = os.getenv('CP_AWS_STREAM_MULTIPART_CHUNKSIZE_MB')
+        transfer_config = self.get_transfer_config(io_threads, multipart_chunksize)
         if StorageItemManager.show_progress(quiet, size, lock):
             progress_callback = ProgressPercentage(relative_path, size)
         else:
@@ -377,7 +377,8 @@ class UploadStreamManager(StorageItemManager, AbstractTransferManager):
             'ACL': 'bucket-owner-full-control'
         }
         TransferManager.ALLOWED_UPLOAD_ARGS.append('Tagging')
-        transfer_config = self.get_transfer_config(io_threads)
+        multipart_chunksize = os.getenv('CP_AWS_STREAM_MULTIPART_CHUNKSIZE_MB')
+        transfer_config = self.get_transfer_config(io_threads, multipart_chunksize)
         if StorageItemManager.show_progress(quiet, size, lock):
             progress_callback = ProgressPercentage(relative_path, size)
         else:

--- a/pipe-cli/src/utilities/storage/s3.py
+++ b/pipe-cli/src/utilities/storage/s3.py
@@ -211,6 +211,9 @@ class StorageItemManager(object):
         if io_threads is not None:
             transfer_config.max_concurrency = max(io_threads, 1)
             transfer_config.use_threads = transfer_config.max_concurrency > 1
+        multipart_chunksize = os.getenv('CP_AWS_MULTIPART_CHUNKSIZE_MB')
+        if multipart_chunksize:
+            transfer_config.multipart_chunksize = int(multipart_chunksize) * 1024 * 1024
         return transfer_config
 
 


### PR DESCRIPTION
relates to #4265 

A new environment variable `CP_AWS_STREAM_MULTIPART_CHUNKSIZE_MB` introduced.
- if not specified the default chunk size (8 MB) will be used.
- if specifies each chunk will have size `CP_AWS_STREAM_MULTIPART_CHUNKSIZE_MB` MB during multipart upload.

This option shall be used for stream transfers and when it is known in advance that the content size exceeds 80 GB or exception below has occurred.
```
An error occurred (InvalidArgument) when calling the UploadPart operation: Part number must be an integer between 1 and 10000, inclusive
```