### PR TITLE
Issue #4008: [API] cache migration 

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -133,14 +133,13 @@ dependencies {
     implementation 'com.auth0:java-jwt:3.1.0'
     implementation 'org.springframework.security:spring-security-acl'
     implementation 'com.jcraft:jsch:0.1.55'
-//    implementation 'com.coveo:saml-client:1.4.0'
     implementation 'org.bouncycastle:bcprov-jdk15on:1.68'
     implementation 'com.nimbusds:oauth2-oidc-sdk:11.29.2'
 
     // Cache
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-    implementation 'redis.clients:jedis'
+    implementation 'redis.clients:jedis:5.0.2'
 
     // GCP
     implementation 'com.google.auth:google-auth-library-oauth2-http:0.10.0'

--- a/api/src/main/java/com/epam/pipeline/app/CacheConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/CacheConfiguration.java
@@ -44,7 +44,6 @@ import org.springframework.security.acls.domain.AclImpl;
 import redis.clients.jedis.JedisPoolConfig;
 
 import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;

--- a/api/src/main/java/com/epam/pipeline/app/CacheConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/CacheConfiguration.java
@@ -19,8 +19,8 @@ import com.epam.pipeline.config.JsonMapper;
 import com.epam.pipeline.security.acl.redis.AclImplDeserializer;
 import com.epam.pipeline.security.acl.redis.AclImplSerializer;
 import com.epam.pipeline.security.acl.redis.JsonRedisSerializer;
-import com.epam.pipeline.entity.preference.Preference;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -34,16 +34,20 @@ import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.cache.RedisCacheWriter;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.jedis.JedisClientConfiguration;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.security.acls.domain.AclImpl;
 import redis.clients.jedis.JedisPoolConfig;
 
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.Set;
 
 @EnableCaching
 public class CacheConfiguration {
@@ -77,71 +81,37 @@ public class CacheConfiguration {
     @Value("${redis.use.optimized.parsing:false}")
     private boolean useOptimizedParsing;
 
-    @Value("${redis.expose.connection:false}")
-    private boolean exposeConnection;
-
     @Bean
     @Primary
-    public CacheManager cacheManager(final Optional<RedisCacheManager> redisCacheManagerPref) {
-        switch (cacheType) {
-            case MEMORY:
-                return new ConcurrentMapCacheManager(PREFERENCE_CACHE);
-            case REDIS:
-                return redisCacheManagerPref
-                        .orElseThrow(IllegalArgumentException::new);
-            default:
-                return new NoOpCacheManager();
-        }
+    public CacheManager cacheManager(@Qualifier("redisCacheManagerPref")
+                                         final Optional<RedisCacheManager> redisCacheManagerPref) {
+        return switch (cacheType) {
+            case MEMORY -> new ConcurrentMapCacheManager(PREFERENCE_CACHE);
+            case REDIS -> redisCacheManagerPref.orElseThrow(IllegalArgumentException::new);
+            default -> new NoOpCacheManager();
+        };
     }
 
     @Bean
-    public CacheManager aclCacheManager(final Optional<RedisCacheManager> redisCacheManagerAcl) {
-        switch (cacheTypeAcl) {
-            case MEMORY:
-                return new ConcurrentMapCacheManager(ACL_CACHE);
-            case REDIS:
-                return redisCacheManagerAcl
-                        .orElseThrow(IllegalArgumentException::new);
-            default:
-                return new NoOpCacheManager();
-        }
+    public CacheManager aclCacheManager(@Qualifier("redisCacheManagerAcl")
+                                            final Optional<RedisCacheManager> redisCacheManagerAcl) {
+        return switch (cacheTypeAcl) {
+            case MEMORY -> new ConcurrentMapCacheManager(ACL_CACHE);
+            case REDIS -> redisCacheManagerAcl.orElseThrow(IllegalArgumentException::new);
+            default -> new NoOpCacheManager();
+        };
     }
 
-    @Bean
+    @Bean("redisCacheManagerPref")
     @ConditionalOnProperty(value = CACHE_TYPE, havingValue = REDIS)
     public RedisCacheManager redisCacheManagerPref(final RedisConnectionFactory connectionFactory) {
-        //TODO this code could be not working properly, updated it for compilation purpose
-        RedisCacheConfiguration cacheConfiguration = RedisCacheConfiguration
-            .defaultCacheConfig()
-            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
-            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
-                    new GenericJackson2JsonRedisSerializer()));
-
-        RedisCacheWriter cacheWriter = RedisCacheWriter.nonLockingRedisCacheWriter(connectionFactory);
-
-        return RedisCacheManager.builder(cacheWriter)
-                .cacheDefaults(cacheConfiguration)
-                .initialCacheNames(Collections.singleton(PREFERENCE_CACHE))
-                .build();
-        //return new RedisCacheManager(templatePreference, Collections.singleton(PREFERENCE_CACHE));
+        return buildRedisCacheManager(connectionFactory, Collections.singleton(ACL_CACHE), false);
     }
 
-    @Bean
+    @Bean("redisCacheManagerAcl")
     @ConditionalOnProperty(value = ACL_CACHE_TYPE, havingValue = REDIS)
     public RedisCacheManager redisCacheManagerAcl(final RedisConnectionFactory connectionFactory) {
-        //TODO this code could be not working properly, updated it for compilation purpose
-        RedisCacheConfiguration cacheConfiguration = RedisCacheConfiguration
-            .defaultCacheConfig()
-            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
-            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
-                    new GenericJackson2JsonRedisSerializer())); // or new Jackson2JsonRedisSerializer(Preference.class)
-
-        RedisCacheWriter cacheWriter = RedisCacheWriter.nonLockingRedisCacheWriter(connectionFactory);
-
-        return RedisCacheManager.builder(cacheWriter)
-                .cacheDefaults(cacheConfiguration)
-                .initialCacheNames(Collections.singleton(ACL_CACHE))
-                .build();
+        return buildRedisCacheManager(connectionFactory, Collections.singleton(ACL_CACHE), useOptimizedParsing);
     }
 
     @Bean("redisConnectionFactory")
@@ -159,39 +129,50 @@ public class CacheConfiguration {
     }
 
     private JedisConnectionFactory redisConnectionFactory() {
-        final JedisConnectionFactory jedisConnectionFactory = new JedisConnectionFactory();
-        jedisConnectionFactory.setHostName(redisHost);
-        jedisConnectionFactory.setPort(redisPort);
-        jedisConnectionFactory.setTimeout(poolTimeout);
-        final JedisPoolConfig poolConfig = new JedisPoolConfig();
+        final var poolConfig = new JedisPoolConfig();
         poolConfig.setMaxTotal(redisPoolConnections);
         poolConfig.setMaxIdle(redisPoolConnections);
-        jedisConnectionFactory.setPoolConfig(poolConfig);
-        return jedisConnectionFactory;
+        final var clientConfig = JedisClientConfiguration.builder()
+                .connectTimeout(Duration.ofMillis(poolTimeout))
+                .usePooling().poolConfig(poolConfig)
+                .build();
+        final var redisConfig = new RedisStandaloneConfiguration(redisHost, redisPort);
+        return new JedisConnectionFactory(redisConfig, clientConfig);
     }
 
-    @Bean
-    @ConditionalOnProperty(value = CACHE_TYPE, havingValue = REDIS)
-    public RedisTemplate<String, Preference> templatePreference(final RedisConnectionFactory redisConnectionFactory) {
-        final RedisTemplate<String, Preference> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory);
-        return redisTemplate;
+    private RedisCacheManager buildRedisCacheManager(final RedisConnectionFactory connectionFactory,
+                                                     final Set<String> cacheNames,
+                                                     final boolean useOptimizedParsing) {
+        final var cacheConfiguration = buildRedisCacheConfiguration(useOptimizedParsing);
+        final var cacheWriter = RedisCacheWriter.nonLockingRedisCacheWriter(connectionFactory);
+        return RedisCacheManager.builder(cacheWriter)
+                .cacheDefaults(cacheConfiguration)
+                .initialCacheNames(cacheNames)
+                .build();
     }
 
-    @Bean
-    @ConditionalOnProperty(value = ACL_CACHE_TYPE, havingValue = REDIS)
-    public RedisTemplate<Object, AclImpl> templateACl(final RedisConnectionFactory redisConnectionFactory) {
-        final RedisTemplate<Object, AclImpl> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory);
-        if (useOptimizedParsing) {
-            final JsonMapper jsonMapper = new JsonMapper();
-            final SimpleModule module = new SimpleModule();
-            module.addDeserializer(AclImpl.class, new AclImplDeserializer());
-            module.addSerializer(AclImpl.class, new AclImplSerializer());
-            jsonMapper.registerModule(module);
-            redisTemplate.setDefaultSerializer(new JsonRedisSerializer(jsonMapper));
+    private RedisCacheConfiguration buildRedisCacheConfiguration(final boolean useOptimizedParsing) {
+        if (!useOptimizedParsing) {
+            return RedisCacheConfiguration.defaultCacheConfig()
+                    .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(
+                            new StringRedisSerializer()))
+                    .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
+                            new JdkSerializationRedisSerializer()));
         }
-        redisTemplate.setExposeConnection(exposeConnection);
-        return redisTemplate;
+        final var jsonMapper = new JsonMapper();
+        final var module = new SimpleModule();
+        module.addDeserializer(AclImpl.class, new AclImplDeserializer());
+        module.addSerializer(AclImpl.class, new AclImplSerializer());
+        jsonMapper.registerModule(module);
+
+        return RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(getSerializer(jsonMapper, String.class))
+                .serializeValuesWith(getSerializer(jsonMapper, AclImpl.class));
+    }
+
+    private <T> RedisSerializationContext.SerializationPair<T> getSerializer(final JsonMapper jsonMapper,
+                                                                             final Class<T> type) {
+        return RedisSerializationContext.SerializationPair
+                .fromSerializer(new JsonRedisSerializer<>(jsonMapper, type));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/security/acl/redis/JsonRedisSerializer.java
+++ b/api/src/main/java/com/epam/pipeline/security/acl/redis/JsonRedisSerializer.java
@@ -22,16 +22,18 @@ import org.springframework.data.redis.serializer.SerializationException;
 import org.springframework.security.acls.domain.AclImpl;
 
 @SuppressWarnings("PMD.AvoidCatchingGenericException")
-public class JsonRedisSerializer implements RedisSerializer<Object> {
+public class JsonRedisSerializer<T> implements RedisSerializer<T> {
 
     private final ObjectMapper om;
+    private final Class<T> type;
 
-    public JsonRedisSerializer(final ObjectMapper om) {
+    public JsonRedisSerializer(final ObjectMapper om, final Class<T> type) {
         this.om = om;
+        this.type = type;
     }
 
     @Override
-    public byte[] serialize(final Object t) throws SerializationException {
+    public byte[] serialize(final T t) throws SerializationException {
         try {
             return om.writeValueAsBytes(t);
         } catch (JsonProcessingException e) {
@@ -40,12 +42,12 @@ public class JsonRedisSerializer implements RedisSerializer<Object> {
     }
 
     @Override
-    public Object deserialize(final byte[] bytes) throws SerializationException {
+    public T deserialize(final byte[] bytes) throws SerializationException {
         if (bytes == null) {
             return null;
         }
         try {
-            return om.readValue(bytes, AclImpl.class);
+            return om.readValue(bytes, type);
         } catch (Exception e) {
             throw new SerializationException(e.getMessage(), e);
         }

--- a/deploy/docker/cp-api-srv/config/application.properties
+++ b/deploy/docker/cp-api-srv/config/application.properties
@@ -209,7 +209,6 @@ redis.port=${CP_REDIS_INTERNAL_PORT:}
 redis.pool.timeout=${CP_REDIS_POOL_TIMEOUT:20000}
 redis.max.connections=${CP_REDIS_MAX_CONNECTIONS:20}
 redis.use.optimized.parsing=${CP_REDIS_OPTIMIZED_PARSING:false}
-redis.expose.connection=${CP_REDIS_EXPOSE_CONNECTION:false}
 
 #Event sourcing
 event.sourcing.enabled=${CP_EVENT_SOURCING_ENABLED:false}


### PR DESCRIPTION
relates to #4008

Key changes:
- `RedisTemplate` class is not used by `RedisCacheManager` any more
- `redis.expose.connection` property has been removed