### PR TITLE
Issue #4264 Introduce application property to configure nfs storage mount timeout in api-srv

### DIFF
--- a/api/profiles/dev/application.properties
+++ b/api/profiles/dev/application.properties
@@ -189,6 +189,7 @@ data.storage.nfs.root.mount.point=
 # Mount options for NFS
 data.storage.nfs.options.rsize=1048576
 data.storage.nfs.options.wsize=1048576
+data.storage.nfs.mount.timeout.mills=60000
 
 data.storage.nfs.quota.poll=60000
 data.storage.nfs.quota.metadata.key=fs_notifications

--- a/api/profiles/release/application.properties
+++ b/api/profiles/release/application.properties
@@ -118,6 +118,7 @@ data.storage.nfs.root.mount.point=
 # Mount options for NFS
 data.storage.nfs.options.rsize=1048576
 data.storage.nfs.options.wsize=1048576
+data.storage.nfs.mount.timeout.mills=60000
 
 data.storage.nfs.quota.poll=${CP_API_NFS_QUOTA_POLL:60000}
 data.storage.nfs.quota.metadata.key=${CP_API_NFS_QUOTA_METADATA_KEY:fs_notifications}

--- a/api/src/main/java/com/epam/pipeline/manager/CmdExecutor.java
+++ b/api/src/main/java/com/epam/pipeline/manager/CmdExecutor.java
@@ -27,17 +27,27 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 public class CmdExecutor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CmdExecutor.class);
+    public static final int TIMEOUT_EXITCODE = 124;
 
     public String executeCommand(String command) {
         return executeCommand(command, false);
     }
 
+    public String executeCommand(String command, long timeout) {
+        return executeCommand(command, false, timeout);
+    }
+
     public String executeCommand(String command, boolean silent) {
-        return executeCommand(command, null, null, silent);
+        return executeCommand(command,  silent, 0);
+    }
+
+    public String executeCommand(String command, boolean silent, long timeout) {
+        return executeCommand(command, null, null, silent, timeout);
     }
 
     public String executeCommandWithEnvVars(String command, Map<String, String> envVars) {
@@ -56,6 +66,10 @@ public class CmdExecutor {
     }
 
     public String executeCommand(String command, String[] envVars, File context, boolean silent) {
+        return executeCommand(command, envVars, context, silent, 0);
+    }
+
+    public String executeCommand(String command, String[] envVars, File context, boolean silent, long timeoutMills) {
         StringBuilder output = new StringBuilder();
         StringBuilder errors = new StringBuilder();
         Process p;
@@ -67,7 +81,8 @@ public class CmdExecutor {
                     new InputStreamReader(p.getErrorStream())));
             stdReader.start();
             errReader.start();
-            int exitCode = p.waitFor();
+
+            int exitCode = waitForProcessToExit(p, command, timeoutMills);
             stdReader.join();
             errReader.join();
             if (exitCode != 0) {
@@ -83,6 +98,27 @@ public class CmdExecutor {
             throw new CmdExecutionException(command, e);
         }
         return output.toString();
+    }
+
+    private int waitForProcessToExit(final Process p, final String command,
+                                            final long timeoutMills) throws InterruptedException {
+        if (timeoutMills > 0) {
+            boolean finished = p.waitFor(timeoutMills, TimeUnit.MILLISECONDS);
+            if (finished) {
+                return p.exitValue();
+            } else {
+                p.destroyForcibly();
+                throw new CmdExecutionException(
+                        command, TIMEOUT_EXITCODE,
+                        String.format(
+                                "Command was not able to finish in configured timeout: %d mills",
+                                timeoutMills
+                        )
+                );
+            }
+        } else {
+            return p.waitFor();
+        }
     }
 
     private void readOutputStream(String command, StringBuilder content, InputStreamReader in) {

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageMounter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageMounter.java
@@ -54,18 +54,22 @@ public class NFSStorageMounter {
     private final CloudRegionManager regionManager;
     private final FileShareMountManager shareMountManager;
     private final String rootMountPoint;
+    private final long timeoutMills;
 
     public NFSStorageMounter(final MessageHelper messageHelper,
                              final DataStorageDao dataStorageDao,
                              final CloudRegionManager regionManager,
                              final FileShareMountManager shareMountManager,
                              @Value("${data.storage.nfs.root.mount.point}")
-                             final String rootMountPoint) {
+                             final String rootMountPoint,
+                             @Value("${data.storage.nfs.mount.timeout.mills:0}")
+                             final long timeoutMills) {
         this.messageHelper = messageHelper;
         this.dataStorageDao = dataStorageDao;
         this.regionManager = regionManager;
         this.shareMountManager = shareMountManager;
         this.rootMountPoint = rootMountPoint;
+        this.timeoutMills = timeoutMills;
     }
 
     public synchronized File mount(final NFSDataStorage dataStorage) {
@@ -95,7 +99,7 @@ public class NFSStorageMounter {
                 final String mountCmd = String.format(NFS_MOUNT_CMD_PATTERN, protocol, mountOptions,
                         rootNfsPath, rootMount.getAbsolutePath());
                 try {
-                    cmdExecutor.executeCommand(mountCmd);
+                    cmdExecutor.executeCommand(mountCmd, timeoutMills);
                 } catch (CmdExecutionException e) {
                     NFSHelper.deleteFolderIfEmpty(rootMount);
                     LOGGER.error(messageHelper.getMessage(

--- a/api/src/test/java/com/epam/pipeline/manager/CmdExecutorTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/CmdExecutorTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager;
+
+import com.epam.pipeline.exception.CmdExecutionException;
+import org.junit.Test;
+
+public class CmdExecutorTest {
+
+    public static final String COMMAND_WITH_SLEEP = "sleep %f";
+    public static final int TIMEOUT = 100;
+    public static final double MILLS_100 = 0.1;
+    public static final double MILLS_300 = 0.3;
+    public static final int MILLS_IN_SEC = 1000;
+
+    @Test
+    public void executeCommandWithOutTimeoutFinishes() {
+        CmdExecutor cmdExecutor = new CmdExecutor();
+
+        double timeToSleep = MILLS_100;
+        cmdExecutor.executeCommand(String.format(COMMAND_WITH_SLEEP, timeToSleep));
+
+        timeToSleep = MILLS_300;
+        cmdExecutor.executeCommand(String.format(COMMAND_WITH_SLEEP, timeToSleep));
+    }
+
+    @Test
+    public void executeCommandWithTimeoutShouldFinishIfNotReachedTimeout() {
+        CmdExecutor cmdExecutor = new CmdExecutor();
+
+        // bash sleep measured in sec but timeout in mills
+        double timeToSleep = TIMEOUT / 2 / MILLS_IN_SEC;
+        cmdExecutor.executeCommand(String.format(COMMAND_WITH_SLEEP, timeToSleep), TIMEOUT);
+
+    }
+
+    @Test(expected = CmdExecutionException.class)
+    public void executeCommandWithTimeoutShouldBeInterruptedIfReachedTimeout() {
+        CmdExecutor cmdExecutor = new CmdExecutor();
+
+        // bash sleep measured in sec but timeout in mills
+        double timeToSleep = (TIMEOUT + TIMEOUT) / MILLS_IN_SEC;
+        cmdExecutor.executeCommand(String.format(COMMAND_WITH_SLEEP, timeToSleep), TIMEOUT);
+    }
+}

--- a/deploy/docker/cp-api-srv/config/application.properties
+++ b/deploy/docker/cp-api-srv/config/application.properties
@@ -188,6 +188,7 @@ luigi.graph.script=/usr/lib/python2.7/site-packages/scripts/deps_graph.py
 # File storages
 data.storage.nfs.root.mount.point=/opt/api/file-systems
 data.storage.nfs.default.umask=${CP_FILE_SHARE_STORAGE_DEFAULT_UMASK:0002}
+data.storage.nfs.mount.timeout.mills=${CP_STORAGE_NFS_TIMEOUT_MILLS:60000}
 
 #Billing API
 billing.index.common.prefix=cp-billing


### PR DESCRIPTION
#4264 
Now it is possible to configure  `CP_STORAGE_NFS_TIMEOUT_MILLS` value in config map to change application property of cp-api-srv `data.storage.nfs.mount.timeout.mills` to enable this timeout (default 60000 - one minute)

NOTE: If value is =< 0 - it means no timeout 