### PR TITLE
GUI Issue #2079: LaunchForm - add 'show optional parameters' filter, parameters Markdown description

### DIFF
--- a/client/src/components/pipelines/launch/form/LaunchPipelineForm.js
+++ b/client/src/components/pipelines/launch/form/LaunchPipelineForm.js
@@ -884,6 +884,22 @@ class LaunchPipelineForm extends localization.LocalizedReactComponent {
     return tools;
   }
 
+  get showOptionalParametersFilter () {
+    const {uiNavigation} = this.props;
+    const parameters = this.getParameters();
+    const hasOptional = parameters
+      .some(({config}) => config.visible && !config.system && !config.required);
+    if (!hasOptional || this.state.isRawEditEnabled || this.props.editConfigurationMode) {
+      return false;
+    }
+    const {pipeline} = this.state;
+    const {tools, pipelines} = uiNavigation.utils.showOptionalParametersFilter();
+    if (pipeline) {
+      return pipelines;
+    }
+    return tools;
+  }
+
   get currentDetachedConfiguration () {
     const {detachedConfigurations = []} = this.state;
     const {currentConfigurationName} = this.props;
@@ -2719,6 +2735,7 @@ class LaunchPipelineForm extends localization.LocalizedReactComponent {
         pipeline={pipelineSelected}
         description={description ? (<Markdown md={description} />) : undefined}
         parametersMetadata={this.state.parametersMetadata}
+        swowOptionalParametersFilter={this.showOptionalParametersFilter}
       />,
       <div
         key={`add-${system ? 'system' : 'default'}-parameter`}

--- a/client/src/components/pipelines/launch/form/parameters/parameter/index.js
+++ b/client/src/components/pipelines/launch/form/parameters/parameter/index.js
@@ -120,7 +120,10 @@ function LaunchFormParameter (props) {
       {
         description && (
           <div className="cp-text-not-important">
-            <Markdown md={description} />
+            <Markdown
+              md={description}
+              className={styles.parameterDescription}
+            />
           </div>
         )
       }

--- a/client/src/components/pipelines/launch/form/parameters/parameter/index.js
+++ b/client/src/components/pipelines/launch/form/parameters/parameter/index.js
@@ -6,6 +6,7 @@ import LaunchFormParameterInput from './inputs';
 import styles from './launch-form-parameter.css';
 import ParameterNameInput from './name-input';
 import {getParameterKeyClassName} from '../utilities';
+import Markdown from '../../../../../special/markdown';
 
 function LaunchFormParameter (props) {
   const {
@@ -119,7 +120,7 @@ function LaunchFormParameter (props) {
       {
         description && (
           <div className="cp-text-not-important">
-            {description}
+            <Markdown md={description} />
           </div>
         )
       }

--- a/client/src/components/pipelines/launch/form/parameters/parameter/launch-form-parameter.css
+++ b/client/src/components/pipelines/launch/form/parameters/parameter/launch-form-parameter.css
@@ -5,3 +5,20 @@
 .launch-form-parameter > *:not(:last-child) {
   margin-bottom: 2px;
 }
+
+.parameter-description {
+  overflow-wrap: break-word;
+}
+
+.parameter-description table {
+  display: block;
+  overflow-x: auto;
+  white-space: nowrap;
+  max-width: 100%;
+}
+
+.parameter-description table tbody,
+.parameter-description table thead {
+  display: table;
+  width: 100%;
+}

--- a/client/src/components/pipelines/launch/form/parameters/parameter/launch-form-parameter.css
+++ b/client/src/components/pipelines/launch/form/parameters/parameter/launch-form-parameter.css
@@ -16,9 +16,3 @@
   white-space: nowrap;
   max-width: 100%;
 }
-
-.parameter-description table tbody,
-.parameter-description table thead {
-  display: table;
-  width: 100%;
-}

--- a/client/src/components/pipelines/launch/form/parameters/parameters.jsx
+++ b/client/src/components/pipelines/launch/form/parameters/parameters.jsx
@@ -52,7 +52,8 @@ function filterParameterBySection (parameter, section) {
 class Parameters extends Component {
   state = {
     useResolvedValues: false,
-    highlightedSection: undefined
+    highlightedSection: undefined,
+    showOptional: false
   };
 
   sectionDivs = {};
@@ -77,6 +78,14 @@ class Parameters extends Component {
       return undefined;
     }
     return this.props.authenticatedUserInfo.value;
+  }
+
+  get optionalIsVisible () {
+    const {swowOptionalParametersFilter, system} = this.props;
+    if (!swowOptionalParametersFilter || system) {
+      return true;
+    }
+    return this.state.showOptional;
   }
 
   checkResolvedValues = () => {
@@ -122,6 +131,10 @@ class Parameters extends Component {
     }), 1000);
   }
 
+  onChangeShowOptional = (e) => {
+    this.setState({showOptional: e.target.checked});
+  };
+
   render () {
     const {
       className,
@@ -149,12 +162,19 @@ class Parameters extends Component {
       pipeline,
       parameterRowClassName,
       description,
-      parametersMetadata
+      parametersMetadata,
+      swowOptionalParametersFilter
     } = this.props;
     if (!preferences.loaded || !runDefaultParameters.loaded) {
       return (<LoadingView />);
     }
-    const filtered = getVisibleParameters(parameters, system, rawEdit, this.userInfo);
+    const filtered = getVisibleParameters(
+      parameters,
+      system,
+      rawEdit,
+      this.userInfo,
+      this.optionalIsVisible
+    );
     const sections = getSections(filtered);
     const grouped = sections.map((section) => ({
       section,
@@ -262,6 +282,16 @@ class Parameters extends Component {
               </div>
             )
           }
+          {!system && swowOptionalParametersFilter ? (
+            <div className={styles.parametersGroupContainer}>
+              <Checkbox
+                checked={this.state.showOptional}
+                onChange={this.onChangeShowOptional}
+              >
+                Show optional parameters
+              </Checkbox>
+            </div>
+          ) : null}
           {
             grouped.map(({section, parameters: sectionParameters}) => {
               return (

--- a/client/src/components/pipelines/launch/form/utilities/parameter-utilities.js
+++ b/client/src/components/pipelines/launch/form/utilities/parameter-utilities.js
@@ -1999,11 +1999,15 @@ export function parametersModified (parameters, initialParameters) {
 
 /**
  * @param {Parameter} parameter
+ * @param {boolean} showOptional
  */
-function parameterIsVisible (parameter = {}) {
+function parameterIsVisible (parameter = {}, showOptional = true) {
   const {config = {}} = parameter;
-  const {visible = true} = config;
-  return visible;
+  const {visible = true, required} = config;
+  if (showOptional) {
+    return visible;
+  }
+  return visible && required;
 }
 
 /**
@@ -2011,15 +2015,17 @@ function parameterIsVisible (parameter = {}) {
  * @param {boolean} isSystem
  * @param {boolean} rawEdit
  * @param {object} userInfo
+ * @param {boolean} showOptional
  */
 function getVisibleParameters (
   parameters = [],
   isSystem = false,
   rawEdit = false,
-  userInfo
+  userInfo,
+  showOptional = true
 ) {
   return parameters
-    .filter((parameter) => rawEdit || parameterIsVisible(parameter))
+    .filter((parameter) => rawEdit || parameterIsVisible(parameter, showOptional))
     .filter((parameter) => isSystem
       ? parameter.system &&
       !isReservedParameter(parameter.name) &&

--- a/client/src/utils/ui-navigation/index.js
+++ b/client/src/utils/ui-navigation/index.js
@@ -18,7 +18,7 @@ import {action, computed, observable} from 'mobx';
 import Pages from './pages';
 import NavigationItems from './navigation-items';
 import MetadataMultiLoad from '../../models/metadata/MetadataMultiLoad';
-import {estimatedPriceVisible} from './utils';
+import {estimatedPriceVisible, showOptionalParametersFilter} from './utils';
 
 const USER_CLASS = 'PIPELINE_USER';
 const ROLE_CLASS = 'ROLE';
@@ -434,7 +434,8 @@ class UINavigation {
   @computed
   get utils () {
     return {
-      estimatedPriceVisible: () => estimatedPriceVisible(this.launchForm)
+      estimatedPriceVisible: () => estimatedPriceVisible(this.launchForm),
+      showOptionalParametersFilter: () => showOptionalParametersFilter(this.launchForm)
     };
   }
 

--- a/client/src/utils/ui-navigation/utils.js
+++ b/client/src/utils/ui-navigation/utils.js
@@ -35,3 +35,17 @@ export function estimatedPriceVisible (launchFormSettings) {
     tools: getSectionVisibility(SECTIONS.tools)
   };
 }
+
+export function showOptionalParametersFilter (launchFormSettings) {
+  const getSectionVisibility = (section) => {
+    const config = launchFormSettings?.[section] || {};
+    const {
+      'show-optional-parameters-filter': showOptional
+    } = config;
+    return `${showOptional}`.toLowerCase() === 'true';
+  };
+  return {
+    pipelines: getSectionVisibility(SECTIONS.pipelines),
+    tools: getSectionVisibility(SECTIONS.tools)
+  };
+}

--- a/client/src/utils/ui-navigation/utils.js
+++ b/client/src/utils/ui-navigation/utils.js
@@ -40,7 +40,7 @@ export function showOptionalParametersFilter (launchFormSettings) {
   const getSectionVisibility = (section) => {
     const config = launchFormSettings?.[section] || {};
     const {
-      'show-optional-parameters-filter': showOptional
+      'optional-parameters-filter': showOptional
     } = config;
     return `${showOptional}`.toLowerCase() === 'true';
   };


### PR DESCRIPTION
Add optional parameters filter ('show-optional-parameters-filter' flag) for launchForm.
Add Markdown support for parameter's description.
Related to #2079 