### PR TITLE
Update the check of the role metadata for external linux IDs

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/user/ExternalUIDManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/ExternalUIDManager.java
@@ -66,11 +66,13 @@ public class ExternalUIDManager {
         }
         final String externalGidFieldName = preferenceManager.getPreference(
                 SystemPreferences.LAUNCH_EXTERNAL_GID_FIELD_NAME);
+        final String externalUidFieldName = preferenceManager.getPreference(
+                SystemPreferences.LAUNCH_EXTERNAL_UID_FIELD_NAME);
         if (StringUtils.isBlank(externalGidFieldName)) {
             return Optional.empty();
         }
         return resolveExternalId(user, externalGidFieldName)
-                .filter(gid -> userHasRoleWithGid(user, externalGidFieldName, gid));
+                .filter(gid -> userHasRoleWithGid(user, externalUidFieldName, gid));
     }
 
     private boolean userHasRoleWithGid(final PipelineUser user, final String metadataKey, final Long gid) {

--- a/api/src/test/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProviderTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProviderTest.java
@@ -587,9 +587,9 @@ public class NFSStorageProviderTest extends AbstractSpringTest {
         final MetadataEntry entry = new MetadataEntry();
         entry.setEntity(roleEntity);
         final Map<String, PipeConfValue> data = new HashMap<>();
-        data.put(NFSStorageProviderTest.GID_FIELD, new PipeConfValue("string", value));
+        data.put(NFSStorageProviderTest.UID_FIELD, new PipeConfValue("string", value));
         entry.setData(data);
-        when(mockMetadataManager.listMetadataItemsByKey(eq(NFSStorageProviderTest.GID_FIELD),
+        when(mockMetadataManager.listMetadataItemsByKey(eq(NFSStorageProviderTest.UID_FIELD),
                 eq(Collections.singletonList(roleEntity)))).thenReturn(Collections.singletonList(entry));
     }
 


### PR DESCRIPTION
#4299 Update the check of the role metadata for external linux IDs - use LAUNCH_EXTERNAL_UID_FIELD_NAME field name