### PR TITLE
GUI issue(#4284) run capabilities restricted by securityContext.prive…

### DIFF
--- a/client/src/components/pipelines/launch/dialogs/configuration-browser/configuration-payload.js
+++ b/client/src/components/pipelines/launch/dialogs/configuration-browser/configuration-payload.js
@@ -904,7 +904,8 @@ class ConfigurationPayload extends React.Component {
       return null;
     }
     const {
-      docker_image: dockerImage
+      docker_image: dockerImage,
+      instance_size: instanceType
     } = payload;
     return (
       <div
@@ -920,6 +921,7 @@ class ConfigurationPayload extends React.Component {
           tool={tool}
           provider={this.currentProvider}
           region={this.currentCloudRegion}
+          instanceType={instanceType}
         />
       </div>
     );

--- a/client/src/components/pipelines/launch/dialogs/configuration-browser/parameters/capabilities.js
+++ b/client/src/components/pipelines/launch/dialogs/configuration-browser/parameters/capabilities.js
@@ -29,7 +29,8 @@ function ParametersRunCapabilities (props) {
     disabled,
     tool,
     provider,
-    region
+    region,
+    instanceType
   } = props;
   if (!parametersStore) {
     return null;
@@ -46,6 +47,7 @@ function ParametersRunCapabilities (props) {
       region={region}
       values={parametersStore.capabilities}
       mode={RUN_CAPABILITIES_MODE.launch}
+      instanceType={instanceType}
     />
   );
 }
@@ -57,7 +59,8 @@ ParametersRunCapabilities.propTypes = {
   dockerImage: PropTypes.string,
   tool: PropTypes.object,
   provider: PropTypes.string,
-  region: PropTypes.object
+  region: PropTypes.object,
+  instanceType: PropTypes.string
 };
 
 export default injectParametersStore(observer(ParametersRunCapabilities));

--- a/client/src/components/pipelines/launch/form/LaunchPipelineForm.js
+++ b/client/src/components/pipelines/launch/form/LaunchPipelineForm.js
@@ -599,6 +599,7 @@ class LaunchPipelineForm extends localization.LocalizedReactComponent {
 
   renderAdditionalRunCapabilities = () => {
     if (hasPlatformSpecificCapabilities(this.toolPlatform, this.props.preferences)) {
+      const instanceTypeValue = this.getSectionFieldValue(EXEC_ENVIRONMENT)('type');
       return (
         <FormItem
           className={getFormItemClassName(styles.formItem, 'runCapabilities')}
@@ -615,6 +616,7 @@ class LaunchPipelineForm extends localization.LocalizedReactComponent {
             provider={this.currentCloudRegionProvider}
             region={this.currentCloudRegion}
             mode={RUN_CAPABILITIES_MODE.launch}
+            instanceType={instanceTypeValue}
           />
         </FormItem>
       );

--- a/client/src/components/pipelines/launch/form/LaunchPipelineForm.js
+++ b/client/src/components/pipelines/launch/form/LaunchPipelineForm.js
@@ -107,7 +107,6 @@ import RunCapabilities, {
   getEnabledCapabilities,
   getUserCapabilities,
   hasPlatformSpecificCapabilities,
-  RUN_CAPABILITIES,
   RUN_CAPABILITIES_MODE
 } from './utilities/run-capabilities';
 import {
@@ -122,7 +121,8 @@ import {
   CP_CAP_AUTOSCALE_WORKERS,
   CP_CAP_AUTOSCALE_HYBRID,
   CP_CAP_AUTOSCALE_PRICE_TYPE,
-  CP_CAP_RESCHEDULE_RUN
+  CP_CAP_RESCHEDULE_RUN,
+  RUN_CAPABILITIES,
 } from './utilities/parameters';
 import OOMCheck from './utilities/oom-check';
 import AllowedInstancesCountWarning from

--- a/client/src/components/pipelines/launch/form/utilities/capability.js
+++ b/client/src/components/pipelines/launch/form/utilities/capability.js
@@ -45,6 +45,8 @@ function renderCloudRestriction (cloudSetting, awsRegions) {
   return null;
 }
 
+const DISABLED_BY_RESERVATION_MESSAGE = 'Disabled by instance type security policy';
+
 const Capability = ({capability, selected, style, nested = [], awsRegions}) => {
   if (!capability) {
     return null;
@@ -54,9 +56,12 @@ const Capability = ({capability, selected, style, nested = [], awsRegions}) => {
     disabled,
     os = [],
     cloud = [],
-    description
+    description,
+    disabledByReservationConfig = false
   } = capability;
-  if (disabled && (os.length > 0 || cloud.length > 0)) {
+  const hasOSOrCloudRestriction = os.length > 0 || cloud.length > 0;
+  const showDisabledTooltip = disabled && (hasOSOrCloudRestriction || disabledByReservationConfig);
+  if (showDisabledTooltip) {
     return (
       <Tooltip
         title={(
@@ -66,6 +71,13 @@ const Capability = ({capability, selected, style, nested = [], awsRegions}) => {
             >
               <b>This capability is not allowed</b>
             </div>
+            {
+              disabledByReservationConfig && (
+                <div style={{marginBottom: hasOSOrCloudRestriction ? 10 : 0}}>
+                  {DISABLED_BY_RESERVATION_MESSAGE}
+                </div>
+              )
+            }
             {
               os.length > 0 && (
                 <div>

--- a/client/src/components/pipelines/launch/form/utilities/capability.js
+++ b/client/src/components/pipelines/launch/form/utilities/capability.js
@@ -45,7 +45,7 @@ function renderCloudRestriction (cloudSetting, awsRegions) {
   return null;
 }
 
-const DISABLED_BY_RESERVATION_MESSAGE = 'Disabled by instance type security policy';
+const DISABLED_BY_RESERVATION_MESSAGE = 'Disabled by instance type security context';
 
 const Capability = ({capability, selected, style, nested = [], awsRegions}) => {
   if (!capability) {

--- a/client/src/components/pipelines/launch/form/utilities/parameters.js
+++ b/client/src/components/pipelines/launch/form/utilities/parameters.js
@@ -71,3 +71,23 @@ export const reservedParameters = [
   CP_CAP_REQUESTS_GPU,
   CP_CAP_REQUESTS_RAM
 ];
+
+export const RUN_CAPABILITIES = {
+  dinD: 'DinD',
+  singularity: 'Singularity',
+  systemD: 'SystemD',
+  noMachine: 'NoMachine',
+  module: 'Module',
+  disableHyperThreading: 'Disable Hyper-Threading',
+  dcv: 'NICE DCV'
+};
+
+export const RUN_CAPABILITIES_PARAMETERS = {
+  [RUN_CAPABILITIES.dinD]: CP_CAP_DIND_CONTAINER,
+  [RUN_CAPABILITIES.singularity]: CP_CAP_SINGULARITY,
+  [RUN_CAPABILITIES.systemD]: CP_CAP_SYSTEMD_CONTAINER,
+  [RUN_CAPABILITIES.noMachine]: CP_CAP_DESKTOP_NM,
+  [RUN_CAPABILITIES.module]: CP_CAP_MODULES,
+  [RUN_CAPABILITIES.disableHyperThreading]: CP_DISABLE_HYPER_THREADING,
+  [RUN_CAPABILITIES.dcv]: CP_CAP_DCV
+};

--- a/client/src/components/pipelines/launch/form/utilities/run-capabilities.js
+++ b/client/src/components/pipelines/launch/form/utilities/run-capabilities.js
@@ -136,7 +136,7 @@ function getAllPlatformCapabilities (preferences, platformInfo = {}) {
     } = capability;
     const enabledByOS = filterByOS(capability);
     const enabledByCloudProvider = filterByCloudProvider(capability);
-    const enabledByReservationConfig = !isDisabledByReservationConfig(
+    const enabledByReservationConfig = isEnabledByReservationConfig(
       capability,
       reservationConfig
     );
@@ -194,21 +194,31 @@ function getPlatformSpecificCapabilities (preferences, platformInfo = {}) {
   );
 }
 
-export function isDisabledByReservationConfig (capability, reservationConfig) {
-  if (!reservationConfig || !capability.checkPrivileged) {
-    return false;
+export function isEnabledByReservationConfig (capability, reservationConfig) {
+  // If capability does not specify "check privileged" flag, allow
+  if (!capability.privileged) {
+    return true;
+  }
+  // If reservation config is not specified, allow
+  if (!reservationConfig) {
+    return true;
   }
   const {
     kube_assign_policy: _kubeAssignPolicy = {},
     kubeAssignPolicy = _kubeAssignPolicy
   } = reservationConfig || {};
+  // If kube assign policy is not overridden, allow
   if (!kubeAssignPolicy) {
-    return false;
+    return true;
   }
   const {securityContext} = kubeAssignPolicy;
-  return securityContext
-    ? securityContext.privileged !== true
-    : false;
+  // If kube assign policy is overridden, but the security context is not overridden, allow
+  if (!securityContext) {
+    return true;
+  }
+  const {privileged} = securityContext;
+  // Allow only if the privileged flag is specified
+  return privileged === true;
 }
 
 @inject('preferences', 'dockerRegistries')

--- a/client/src/components/pipelines/launch/form/utilities/run-capabilities.js
+++ b/client/src/components/pipelines/launch/form/utilities/run-capabilities.js
@@ -7,38 +7,23 @@ import {inject, observer} from 'mobx-react';
 import classNames from 'classnames';
 import {booleanParameterIsSetToValue} from './parameter-utilities';
 import {
-  CP_CAP_DIND_CONTAINER,
   CP_CAP_SYSTEMD_CONTAINER,
-  CP_CAP_SINGULARITY,
-  CP_CAP_DESKTOP_NM,
-  CP_CAP_MODULES,
-  CP_DISABLE_HYPER_THREADING,
-  CP_CAP_DCV,
   CP_CAP_DCV_WEB,
   CP_CAP_DCV_DESKTOP,
-  CP_CAP_RUN_CAPABILITIES
+  CP_CAP_RUN_CAPABILITIES,
+  RUN_CAPABILITIES,
+  RUN_CAPABILITIES_PARAMETERS
 } from './parameters';
 import fetchToolOS from './fetch-tool-os';
 import Capability from './capability';
 import {mergeUserRoleAttributes} from '../../../../../utils/attributes/merge-user-role-attributes';
 import fetchToolDefaultParameters from './fetch-tool-default-parameters';
 import {getReservationParametersConfig} from '../components/reservation-parameters/utilities';
-import {RUN_CAPABILITIES} from '../../../../../models/preferences/PreferencesLoad';
 import styles from './run-capabilities.css';
 import parseCapabilityCloudSetting from './capabilities-utilities/parse-cloud-setting';
 import {defaultSorter} from '../../../../../utils/sorting';
 
 export {RUN_CAPABILITIES};
-
-export const RUN_CAPABILITIES_PARAMETERS = {
-  [RUN_CAPABILITIES.dinD]: CP_CAP_DIND_CONTAINER,
-  [RUN_CAPABILITIES.singularity]: CP_CAP_SINGULARITY,
-  [RUN_CAPABILITIES.systemD]: CP_CAP_SYSTEMD_CONTAINER,
-  [RUN_CAPABILITIES.noMachine]: CP_CAP_DESKTOP_NM,
-  [RUN_CAPABILITIES.module]: CP_CAP_MODULES,
-  [RUN_CAPABILITIES.disableHyperThreading]: CP_DISABLE_HYPER_THREADING,
-  [RUN_CAPABILITIES.dcv]: CP_CAP_DCV
-};
 
 export const RUN_CAPABILITIES_MODE = {
   launch: 'launch',

--- a/client/src/components/pipelines/launch/form/utilities/run-capabilities.js
+++ b/client/src/components/pipelines/launch/form/utilities/run-capabilities.js
@@ -22,6 +22,7 @@ import fetchToolOS from './fetch-tool-os';
 import Capability from './capability';
 import {mergeUserRoleAttributes} from '../../../../../utils/attributes/merge-user-role-attributes';
 import fetchToolDefaultParameters from './fetch-tool-default-parameters';
+import {getReservationParametersConfig} from '../components/reservation-parameters/utilities';
 import {RUN_CAPABILITIES} from '../../../../../models/preferences/PreferencesLoad';
 import styles from './run-capabilities.css';
 import parseCapabilityCloudSetting from './capabilities-utilities/parse-cloud-setting';
@@ -102,12 +103,15 @@ function getAllPlatformCapabilities (preferences, platformInfo = {}) {
     platform,
     os,
     provider,
-    region
+    region,
+    reservationConfig
   } = platformInfo;
   const capabilities = platform && PLATFORM_SPECIFIC_CAPABILITIES.hasOwnProperty(platform)
     ? PLATFORM_SPECIFIC_CAPABILITIES[platform]
     : PLATFORM_SPECIFIC_CAPABILITIES.default;
-  const custom = preferences ? preferences.launchCapabilities : [];
+  const launchCapabilities = preferences ? preferences.launchCapabilities : [];
+  const systemOverrides = (launchCapabilities || []).filter(c => c.custom === false);
+  const custom = (launchCapabilities || []).filter(c => c.custom !== false);
   const filterCustomCapability = capability => (capability.platforms || []).length === 0 ||
     platform === undefined ||
     !capability.platforms ||
@@ -147,19 +151,38 @@ function getAllPlatformCapabilities (preferences, platformInfo = {}) {
     } = capability;
     const enabledByOS = filterByOS(capability);
     const enabledByCloudProvider = filterByCloudProvider(capability);
+    const enabledByReservationConfig = !isDisabledByReservationConfig(
+      capability,
+      reservationConfig
+    );
     return {
       ...capabilityInfo,
       capabilities: capabilities.map(c => mapCapability(c, capability)),
-      disabled: !enabledByOS || !enabledByCloudProvider,
+      disabled: !enabledByOS || !enabledByCloudProvider || !enabledByReservationConfig,
+      disabledByReservationConfig: !enabledByReservationConfig,
       parentValue: parent?.value
     };
   };
-  return capabilities.map(o => ({
-    value: o,
-    name: o,
-    os: CAPABILITIES_OS_FILTERS[o],
-    cloud: CAPABILITIES_CLOUD_FILTERS[o]
-  }))
+  const systemCapabilities = capabilities.map(o => {
+    const override = systemOverrides.find(ov => ov.value === o);
+    const base = {
+      value: o,
+      name: o,
+      os: CAPABILITIES_OS_FILTERS[o],
+      cloud: CAPABILITIES_CLOUD_FILTERS[o]
+    };
+    if (!override) {
+      return base;
+    }
+    const {value: _v, custom: _c, ...overrideFields} = override;
+    return {
+      ...base,
+      ...overrideFields,
+      value: o,
+      custom: false
+    };
+  });
+  return systemCapabilities
     .concat((custom || []).filter(filterCustomCapability))
     .map(capability => mapCapability(capability));
 }
@@ -186,6 +209,23 @@ function getPlatformSpecificCapabilities (preferences, platformInfo = {}) {
   );
 }
 
+export function isDisabledByReservationConfig (capability, reservationConfig) {
+  if (!reservationConfig || !capability.checkPrivileged) {
+    return false;
+  }
+  const {
+    kube_assign_policy: _kubeAssignPolicy = {},
+    kubeAssignPolicy = _kubeAssignPolicy
+  } = reservationConfig || {};
+  if (!kubeAssignPolicy) {
+    return false;
+  }
+  const {securityContext} = kubeAssignPolicy;
+  return securityContext
+    ? securityContext.privileged !== true
+    : false;
+}
+
 @inject('preferences', 'dockerRegistries')
 @observer
 class RunCapabilities extends React.Component {
@@ -203,7 +243,8 @@ class RunCapabilities extends React.Component {
     region: PropTypes.object,
     mode: PropTypes.string,
     showError: PropTypes.bool,
-    getPopupContainer: PropTypes.func
+    getPopupContainer: PropTypes.func,
+    instanceType: PropTypes.string
   };
 
   static defaultProps = {
@@ -213,12 +254,14 @@ class RunCapabilities extends React.Component {
   };
 
   state = {
-    os: undefined
+    os: undefined,
+    reservationConfig: undefined
   };
 
   componentDidMount () {
     this.fetchDockerImageOS();
     this.setInitialRequiredCapabilities();
+    this.setReservationConfig();
   }
 
   componentDidUpdate (prevProps, prevState, snapshot) {
@@ -233,6 +276,12 @@ class RunCapabilities extends React.Component {
     }
     if (this.props.values && !prevProps.values) {
       this.setInitialRequiredCapabilities();
+    }
+    if (prevProps.instanceType !== this.props.instanceType) {
+      this.setReservationConfig();
+    }
+    if (prevState.reservationConfig !== this.state.reservationConfig) {
+      this.correctCapabilitiesSelection();
     }
   }
 
@@ -258,6 +307,21 @@ class RunCapabilities extends React.Component {
       });
   };
 
+  setReservationConfig = async () => {
+    const {instanceType} = this.props;
+    if (!instanceType || typeof instanceType !== 'string') {
+      this.setState({reservationConfig: undefined});
+      return;
+    }
+    try {
+      const config = await getReservationParametersConfig(instanceType);
+      this.setState({reservationConfig: config});
+    } catch (error) {
+      console.error('Error retrieving reservation config:', error);
+      this.setState({reservationConfig: undefined});
+    }
+  };
+
   get allCapabilities () {
     const {
       platform,
@@ -266,7 +330,8 @@ class RunCapabilities extends React.Component {
       preferences
     } = this.props;
     const {
-      os
+      os,
+      reservationConfig
     } = this.state;
     return getAllPlatformCapabilities(
       preferences,
@@ -274,7 +339,8 @@ class RunCapabilities extends React.Component {
         platform,
         os,
         provider,
-        region
+        region,
+        reservationConfig
       }
     );
   }
@@ -288,7 +354,8 @@ class RunCapabilities extends React.Component {
       values
     } = this.props;
     const {
-      os
+      os,
+      reservationConfig
     } = this.state;
     const capabilities = getPlatformSpecificCapabilities(
       preferences,
@@ -296,7 +363,8 @@ class RunCapabilities extends React.Component {
         platform,
         os,
         provider,
-        region
+        region,
+        reservationConfig
       }
     );
     return (values || [])
@@ -347,14 +415,15 @@ class RunCapabilities extends React.Component {
       preferences,
       onChange
     } = this.props;
-    const {os} = this.state;
+    const {os, reservationConfig} = this.state;
     const capabilities = getPlatformSpecificCapabilities(
       preferences,
       {
         platform,
         os,
         provider,
-        region
+        region,
+        reservationConfig
       }
     );
     const filtered = (values || [])
@@ -501,13 +570,14 @@ class RunCapabilities extends React.Component {
       ) {
         return null;
       }
+      const isDisabled = capability.disabled;
       if (capabilities.length === 0) {
         return (
           <MenuItem
             key={capability.value}
             value={capability.value}
             title={capability.description || capability.name}
-            disabled={capability.disabled}
+            disabled={isDisabled}
           >
             <Capability
               capability={capability}
@@ -536,7 +606,7 @@ class RunCapabilities extends React.Component {
               }
             />
           )}
-          disabled={capability.disabled}
+          disabled={isDisabled}
           onTitleClick={onCapabilityClick}
         >
           {

--- a/client/src/components/runs/actions/run.js
+++ b/client/src/components/runs/actions/run.js
@@ -1316,6 +1316,7 @@ export class RunConfirmation extends React.Component {
                     style={{padding: '2px'}}
                     showError={false}
                     getPopupContainer={node => node}
+                    instanceType={this.state.instanceType?.name}
                   />
                 </Provider>
               </div>

--- a/client/src/components/tools/forms/EditToolForm.js
+++ b/client/src/components/tools/forms/EditToolForm.js
@@ -72,11 +72,11 @@ import {
   CP_CAP_AUTOSCALE_WORKERS,
   CP_CAP_AUTOSCALE_HYBRID,
   CP_CAP_AUTOSCALE_PRICE_TYPE,
-  CP_CAP_RESCHEDULE_RUN
+  CP_CAP_RESCHEDULE_RUN,
+  RUN_CAPABILITIES
 } from '../../pipelines/launch/form/utilities/parameters';
 import AWSRegionTag from '../../special/AWSRegionTag';
 import RunCapabilities, {
-  RUN_CAPABILITIES,
   RUN_CAPABILITIES_MODE,
   getEnabledCapabilities,
   applyCapabilities,

--- a/client/src/components/tools/forms/EditToolForm.js
+++ b/client/src/components/tools/forms/EditToolForm.js
@@ -1396,6 +1396,7 @@ export default class EditToolForm extends React.Component {
         allowSensitive = this.getAllowSensitiveInitialValue();
       }
       const limitMountsValue = getFieldValue('limitMounts');
+      const instanceTypeValue = this.getInstanceTypeValue();
       return (
         <div>
           {this.renderSeparator('Execution defaults')}
@@ -1801,6 +1802,7 @@ export default class EditToolForm extends React.Component {
                       provider={this.getCloudProvider()}
                       region={this.getCloudRegion()}
                       mode={RUN_CAPABILITIES_MODE.edit}
+                      instanceType={instanceTypeValue?.name}
                     />
                   </Form.Item>
                 )

--- a/client/src/models/preferences/PreferencesLoad.js
+++ b/client/src/models/preferences/PreferencesLoad.js
@@ -20,39 +20,20 @@ import escapeRegExp, {ESCAPE_CHARACTERS} from '../../utils/escape-reg-exp';
 import {parsePermissionsRestrictionsConfig} from './utilities/parse-permissions-restrictions';
 import {parseRunActionCriteria} from '../../components/runs/actions/actions-availability/utilities';
 import {
-  CP_CAP_DIND_CONTAINER,
-  CP_CAP_SINGULARITY,
-  CP_CAP_SYSTEMD_CONTAINER,
-  CP_CAP_DESKTOP_NM,
-  CP_CAP_MODULES,
-  CP_DISABLE_HYPER_THREADING,
-  CP_CAP_DCV,
-  systemCapabilitiesParameters
+  systemCapabilitiesParameters,
+  RUN_CAPABILITIES,
+  RUN_CAPABILITIES_PARAMETERS
 } from '../../components/pipelines/launch/form/utilities/parameters';
 
 const FETCH_ID_SYMBOL = Symbol('Fetch id');
 // eslint-disable-next-line max-len
 const MAINTENANCE_MODE_DISCLAIMER = 'Platform is in a maintenance mode, operation is temporary unavailable';
 
-export const RUN_CAPABILITIES = {
-  dinD: 'DinD',
-  singularity: 'Singularity',
-  systemD: 'SystemD',
-  noMachine: 'NoMachine',
-  module: 'Module',
-  disableHyperThreading: 'Disable Hyper-Threading',
-  dcv: 'NICE DCV'
-};
-
-const SYSTEM_CAPABILITY_PARAMETER_TO_DISPLAY = {
-  [CP_CAP_DIND_CONTAINER]: RUN_CAPABILITIES.dinD,
-  [CP_CAP_SINGULARITY]: RUN_CAPABILITIES.singularity,
-  [CP_CAP_SYSTEMD_CONTAINER]: RUN_CAPABILITIES.systemD,
-  [CP_CAP_DESKTOP_NM]: RUN_CAPABILITIES.noMachine,
-  [CP_CAP_MODULES]: RUN_CAPABILITIES.module,
-  [CP_DISABLE_HYPER_THREADING]: RUN_CAPABILITIES.disableHyperThreading,
-  [CP_CAP_DCV]: RUN_CAPABILITIES.dcv
-};
+const SYSTEM_CAPABILITY_PARAMETER_TO_DISPLAY = Object.entries(RUN_CAPABILITIES_PARAMETERS)
+  .reduce((acc, [name, parameter]) => ({
+    ...acc,
+    [parameter]: name
+  }), {});
 
 class PreferencesLoad extends Remote {
   constructor () {

--- a/client/src/models/preferences/PreferencesLoad.js
+++ b/client/src/models/preferences/PreferencesLoad.js
@@ -19,6 +19,16 @@ import {computed, isObservableArray} from 'mobx';
 import escapeRegExp, {ESCAPE_CHARACTERS} from '../../utils/escape-reg-exp';
 import {parsePermissionsRestrictionsConfig} from './utilities/parse-permissions-restrictions';
 import {parseRunActionCriteria} from '../../components/runs/actions/actions-availability/utilities';
+import {
+  CP_CAP_DIND_CONTAINER,
+  CP_CAP_SINGULARITY,
+  CP_CAP_SYSTEMD_CONTAINER,
+  CP_CAP_DESKTOP_NM,
+  CP_CAP_MODULES,
+  CP_DISABLE_HYPER_THREADING,
+  CP_CAP_DCV,
+  systemCapabilitiesParameters
+} from '../../components/pipelines/launch/form/utilities/parameters';
 
 const FETCH_ID_SYMBOL = Symbol('Fetch id');
 // eslint-disable-next-line max-len
@@ -32,6 +42,16 @@ export const RUN_CAPABILITIES = {
   module: 'Module',
   disableHyperThreading: 'Disable Hyper-Threading',
   dcv: 'NICE DCV'
+};
+
+const SYSTEM_CAPABILITY_PARAMETER_TO_DISPLAY = {
+  [CP_CAP_DIND_CONTAINER]: RUN_CAPABILITIES.dinD,
+  [CP_CAP_SINGULARITY]: RUN_CAPABILITIES.singularity,
+  [CP_CAP_SYSTEMD_CONTAINER]: RUN_CAPABILITIES.systemD,
+  [CP_CAP_DESKTOP_NM]: RUN_CAPABILITIES.noMachine,
+  [CP_CAP_MODULES]: RUN_CAPABILITIES.module,
+  [CP_DISABLE_HYPER_THREADING]: RUN_CAPABILITIES.disableHyperThreading,
+  [CP_CAP_DCV]: RUN_CAPABILITIES.dcv
 };
 
 class PreferencesLoad extends Remote {
@@ -401,12 +421,38 @@ class PreferencesLoad extends Remote {
             .filter(o => o.length);
         };
         const mapCapability = ([key, entry]) => {
-          if (
-            typeof entry === 'boolean' ||
-            entry.visible === false ||
-            Object.keys(RUN_CAPABILITIES).includes(key)
-          ) {
+          if (typeof entry === 'boolean' || entry.visible === false) {
             return undefined;
+          }
+          const isSystemCapability = systemCapabilitiesParameters.includes(key);
+          if (isSystemCapability) {
+            const displayName = SYSTEM_CAPABILITY_PARAMETER_TO_DISPLAY[key];
+            if (!displayName) {
+              return undefined;
+            }
+            return {
+              value: displayName,
+              name: entry?.name || displayName,
+              custom: false,
+              ...(entry?.description !== undefined
+                ? {description: entry.description}
+                : {}),
+              ...(entry?.platforms !== undefined
+                ? {platforms: parsePlatforms(entry.platforms)}
+                : {}),
+              ...(entry?.cloud !== undefined
+                ? {cloud: parseCloudProviders(entry.cloud)}
+                : {}),
+              ...(entry?.os !== undefined
+                ? {os: parseOS(entry.os)}
+                : {}),
+              ...(entry?.disclaimer !== undefined
+                ? {disclaimer: entry.disclaimer}
+                : {}),
+              ...(entry?.checkPrivileged !== undefined
+                ? {checkPrivileged: entry.checkPrivileged}
+                : {})
+            };
           }
           const {
             capabilities: childCapabilities = {}
@@ -423,7 +469,8 @@ class PreferencesLoad extends Remote {
             disclaimer: entry?.disclaimer || '',
             capabilities: Object.entries(childCapabilities)
               .map(mapCapability),
-            multiple: Boolean(entry?.multiple)
+            multiple: Boolean(entry?.multiple),
+            checkPrivileged: entry?.checkPrivileged
           };
         };
         return Object
@@ -606,6 +653,9 @@ class PreferencesLoad extends Remote {
       try {
         const capabilities = JSON.parse(value);
         const getCapabilityByKey = (key) => {
+          if (systemCapabilitiesParameters.includes(key)) {
+            return SYSTEM_CAPABILITY_PARAMETER_TO_DISPLAY[key];
+          }
           const capabilityKey = Object
             .keys(RUN_CAPABILITIES)
             .find((aKey) => aKey.toLowerCase() === (key || '').toLowerCase());
@@ -617,7 +667,7 @@ class PreferencesLoad extends Remote {
         return Object
           .entries(capabilities || {})
           .filter(([, value]) => (typeof value === 'boolean' && !value) ||
-            (typeof value === 'object' && !value.visible)
+            (typeof value === 'object' && value.visible === false)
           )
           .map(([key]) => getCapabilityByKey(key))
           .filter(Boolean);

--- a/client/src/models/preferences/PreferencesLoad.js
+++ b/client/src/models/preferences/PreferencesLoad.js
@@ -430,8 +430,8 @@ class PreferencesLoad extends Remote {
               ...(entry?.disclaimer !== undefined
                 ? {disclaimer: entry.disclaimer}
                 : {}),
-              ...(entry?.checkPrivileged !== undefined
-                ? {checkPrivileged: entry.checkPrivileged}
+              ...(entry?.privileged !== undefined
+                ? {privileged: entry.privileged}
                 : {})
             };
           }
@@ -451,7 +451,7 @@ class PreferencesLoad extends Remote {
             capabilities: Object.entries(childCapabilities)
               .map(mapCapability),
             multiple: Boolean(entry?.multiple),
-            checkPrivileged: entry?.checkPrivileged
+            privileged: entry?.privileged
           };
         };
         return Object


### PR DESCRIPTION
…leged

Related to #4284

# Restrict run capabilities by reservation config (securityContext.privileged)

## Summary

Disables run capabilities that require privileged containers when the selected instance type’s reservation config does not allow them. The UI now respects `kube_assign_policy.securityContext.privileged` from the reservation config and disables capabilities that need privilege when the policy does not set `privileged: true`.

## Behavior

1. User selects an **instance type** (e.g. in Launch form, Edit Tool form, or Run confirmation).
2. Reservation config for that instance type is loaded (including `kube_assign_policy.securityContext.privileged`).
3. Capabilities marked with **`privileged: true`** in preferences are:
   - **Enabled** when `kubeAssignPolicy` is undefined (no restriction applied).
   - **Enabled** when `kubeAssignPolicy.securityContext.privileged === true` for that instance type.
   - **Disabled** when `kubeAssignPolicy` is present and `securityContext.privileged !== true`, with tooltip *"Disabled by instance type security policy"*.
4. Other capabilities (without `privileged` or with `privileged: false`) are not affected by reservation config.

## Configuration: enabling `privileged` for capabilities

To make a capability subject to the instance type’s security policy, set **`privileged: true`** for that capability in the **`launch.capabilities`** preference.

Example `launch.capabilities` configuration:

```json
{
  "CP_CAP_DIND_CONTAINER": {
    "privileged": true
  },
  "CP_CAP_SYSTEMD_CONTAINER": {
    "privileged": true
  },
  "CP_CAP_DCV": {
    "privileged": true
  }
}
```