### PR TITLE
#4292: Chown the user's default NFS storage

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProvider.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageProvider.java
@@ -54,6 +54,7 @@ import com.epam.pipeline.utils.PosixPermissionUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.slf4j.Logger;
@@ -399,17 +400,7 @@ public class NFSStorageProvider implements StorageProvider<NFSDataStorage> {
     }
 
     private void initFile(final File file, final Set<PosixFilePermission> permissions) throws IOException {
-        if (!SystemUtils.IS_OS_WINDOWS) {
-            Files.setPosixFilePermissions(file.toPath(), permissions);
-            if (!preferenceManager.getPreference(SystemPreferences.SYSTEM_SSH_DEFAULT_ROOT_USER_ENABLED)) {
-                Optional.ofNullable(authManager.getCurrentUser())
-                        .ifPresent(user -> {
-                            final Long userUID = resolveUid(user);
-                            final Long userGID = resolveGid(user, userUID);
-                            nfsStorageMounter.chown(file, userUID, userGID);
-                        });
-            }
-        }
+        setPermissionsAndOwnership(file, permissions, authManager.getCurrentUser(), false);
     }
 
     private Long resolveUid(final PipelineUser user) {
@@ -420,6 +411,49 @@ public class NFSStorageProvider implements StorageProvider<NFSDataStorage> {
     private Long resolveGid(final PipelineUser user, final Long uid) {
         final Long defaultGID = Optional.ofNullable(groupUID).map(Integer::longValue).orElse(uid);
         return externalUIDManager.resolveExternalGid(user).orElse(defaultGID);
+    }
+
+    private boolean shouldApplyUserOwnership() {
+        return !BooleanUtils.toBoolean(
+                preferenceManager.getPreference(SystemPreferences.SYSTEM_SSH_DEFAULT_ROOT_USER_ENABLED));
+    }
+
+    /**
+     * Sets posix permissions on the file, then if user ownership is enabled
+     * chowns the file to userUID:userGID.
+     *
+     * @param file          target file or directory
+     * @param permissions   posix permissions to set
+     * @param user          user for ownership; if null, only permissions are set
+     * @param useUidAsGid   if true, use UID as GID (user:user); otherwise use {@link #resolveGid}
+     */
+    private void setPermissionsAndOwnership(final File file, final Set<PosixFilePermission> permissions,
+                                            final PipelineUser user, final boolean useUidAsGid) {
+        if (SystemUtils.IS_OS_WINDOWS) {
+            return;
+        }
+        try {
+            Files.setPosixFilePermissions(file.toPath(), permissions);
+        } catch (IOException e) {
+            LOGGER.warn("Failed to set posix permissions on {}: {}", file.getAbsolutePath(), e.getMessage());
+        }
+        if (shouldApplyUserOwnership() && user != null) {
+            final Long uid = resolveUid(user);
+            final Long gid = useUidAsGid ? uid : resolveGid(user, uid);
+            nfsStorageMounter.chown(file, uid, gid);
+        }
+    }
+
+    /**
+     * Sets posix permissions and chowns the NFS storage mount root folder to userUID:userUID, using
+     * the same UID resolution as {@link #resolveUid(PipelineUser)} and the same folder permissions
+     * as in {@link #initFile}. Ownership is applied only when not Windows and root user is disabled
+     * (same as {@link #initFile} via {@link #setPermissionsAndOwnership}). Used when user's default
+     * storage is set so the mount root has correct ownership and permissions.
+     */
+    public void chownUserStorageRoot(final PipelineUser user, final NFSDataStorage dataStorage) {
+        final File mountRoot = nfsStorageMounter.mount(dataStorage);
+        setPermissionsAndOwnership(mountRoot, folderPermissions, user, true);
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/manager/user/UserAspect.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/UserAspect.java
@@ -1,27 +1,35 @@
 /*
+ * Copyright 2017-2026 EPAM Systems, Inc. (https://www.epam.com/)
  *
- *  * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
- *  *
- *  * Licensed under the Apache License, Version 2.0 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.epam.pipeline.manager.user;
 
+import com.epam.pipeline.controller.vo.PipelineUserVO;
 import com.epam.pipeline.dao.notification.MonitoringNotificationDao;
+import com.epam.pipeline.entity.datastorage.AbstractDataStorage;
+import com.epam.pipeline.entity.datastorage.DataStorageType;
+import com.epam.pipeline.entity.datastorage.nfs.NFSDataStorage;
+import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.manager.datastorage.DataStorageManager;
+import com.epam.pipeline.manager.datastorage.providers.nfs.NFSStorageProvider;
 import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.After;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
@@ -29,10 +37,22 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Aspect
 @Component
+@SuppressWarnings("PMD.AvoidCatchingGenericException")
 public class UserAspect {
+
+    private static final Logger LOG = LoggerFactory.getLogger(UserAspect.class);
 
     @Autowired
     private MonitoringNotificationDao monitoringNotificationDao;
+
+    @Autowired
+    private UserManager userManager;
+
+    @Autowired
+    private DataStorageManager dataStorageManager;
+
+    @Autowired
+    private NFSStorageProvider nfsStorageProvider;
 
     /**
      * Deletes all notification to specific user. This Aspect is used when user is being deleted
@@ -43,5 +63,29 @@ public class UserAspect {
     @Transactional(propagation = Propagation.REQUIRED)
     public void deleteAllUserNotification(final JoinPoint joinPoint, final Long userId) {
         monitoringNotificationDao.deleteNotificationsForUser(userId);
+    }
+
+    /**
+     * After user default storage is updated via updateUser(id, userVO), chown the NFS mount root folder
+     * to userUID:userUID so the user owns their default storage.
+     */
+    @After("execution(* com.epam.pipeline.manager.user.UserManager.updateUser(..)) && args(id, userVO)")
+    public void updateDefaultUserStorage(final JoinPoint joinPoint, final Long id, final PipelineUserVO userVO) {
+        if (userVO == null || userVO.getDefaultStorageId() == null) {
+            return;
+        }
+        try {
+            final PipelineUser user = userManager.load(id);
+            if (user.getDefaultStorageId() == null) {
+                return;
+            }
+            final AbstractDataStorage storage = dataStorageManager.load(user.getDefaultStorageId());
+            if (!DataStorageType.NFS.equals(storage.getType())) {
+                return;
+            }
+            nfsStorageProvider.chownUserStorageRoot(user, (NFSDataStorage) storage);
+        } catch (Exception e) {
+            LOG.warn("Failed to chown NFS default storage root for user id {}: {}", id, e.getMessage());
+        }
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/user/UserAspect.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/UserAspect.java
@@ -77,10 +77,12 @@ public class UserAspect {
         try {
             final PipelineUser user = userManager.load(id);
             if (user.getDefaultStorageId() == null) {
+                LOG.debug("Default NFS storage for user {} not found", user.getUserName());
                 return;
             }
             final AbstractDataStorage storage = dataStorageManager.load(user.getDefaultStorageId());
             if (!DataStorageType.NFS.equals(storage.getType())) {
+                LOG.debug("Default storage for user {} is not NFS", user.getUserName());
                 return;
             }
             nfsStorageProvider.chownUserStorageRoot(user, (NFSDataStorage) storage);

--- a/api/src/test/java/com/epam/pipeline/manager/user/UserAspectTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/user/UserAspectTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.user;
+
+import com.epam.pipeline.controller.vo.PipelineUserVO;
+import com.epam.pipeline.entity.datastorage.aws.S3bucketDataStorage;
+import com.epam.pipeline.entity.datastorage.nfs.NFSDataStorage;
+import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.manager.datastorage.DataStorageManager;
+import com.epam.pipeline.manager.datastorage.providers.nfs.NFSStorageProvider;
+import org.aspectj.lang.JoinPoint;
+import org.junit.Test;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.internal.util.reflection.Whitebox.setInternalState;
+
+public class UserAspectTest {
+
+    private static final Long USER_ID = 1L;
+    private static final Long STORAGE_ID = 1L;
+
+    private final UserManager userManager = mock(UserManager.class);
+    private final DataStorageManager dataStorageManager = mock(DataStorageManager.class);
+    private final NFSStorageProvider nfsStorageProvider = mock(NFSStorageProvider.class);
+    private final JoinPoint joinPoint = mock(JoinPoint.class);
+
+    private final UserAspect userAspect = createUserAspect();
+
+    @Test
+    public void shouldChownWhenStorageIsNFS() {
+        final PipelineUserVO userVO = userVO();
+        final PipelineUser user = PipelineUser.builder().id(USER_ID).defaultStorageId(STORAGE_ID).build();
+        when(userManager.load(USER_ID)).thenReturn(user);
+
+        final NFSDataStorage nfsStorage = new NFSDataStorage(STORAGE_ID, "username", "server:/home/username");
+        when(dataStorageManager.load(STORAGE_ID)).thenReturn(nfsStorage);
+
+        userAspect.updateDefaultUserStorage(joinPoint, USER_ID, userVO);
+
+        verify(nfsStorageProvider).chownUserStorageRoot(eq(user), eq(nfsStorage));
+    }
+
+    @Test
+    public void shouldSkipWhenStorageIsNotNFS() {
+        final PipelineUserVO userVO = userVO();
+        final PipelineUser user = PipelineUser.builder().id(USER_ID).defaultStorageId(STORAGE_ID).build();
+        when(userManager.load(USER_ID)).thenReturn(user);
+
+        final S3bucketDataStorage s3Storage = new S3bucketDataStorage();
+        s3Storage.setId(STORAGE_ID);
+        when(dataStorageManager.load(STORAGE_ID)).thenReturn(s3Storage);
+
+        userAspect.updateDefaultUserStorage(joinPoint, USER_ID, userVO);
+
+        verify(nfsStorageProvider, never()).chownUserStorageRoot(any(), any());
+    }
+
+    @Test
+    public void shouldSkipWhenUserVOHasNoDefaultStorageId() {
+        final PipelineUserVO userVO = new PipelineUserVO();
+
+        userAspect.updateDefaultUserStorage(joinPoint, USER_ID, userVO);
+
+        verify(userManager, never()).load(any());
+        verify(nfsStorageProvider, never()).chownUserStorageRoot(any(), any());
+    }
+
+    @Test
+    public void shouldSkipWhenLoadedUserHasNoDefaultStorageId() {
+        final PipelineUserVO userVO = userVO();
+        final PipelineUser user = PipelineUser.builder().id(USER_ID).build();
+        when(userManager.load(USER_ID)).thenReturn(user);
+
+        userAspect.updateDefaultUserStorage(joinPoint, USER_ID, userVO);
+
+        verify(dataStorageManager, never()).load(any(Long.class));
+        verify(nfsStorageProvider, never()).chownUserStorageRoot(any(), any());
+    }
+
+    private static PipelineUserVO userVO() {
+        final PipelineUserVO vo = new PipelineUserVO();
+        vo.setDefaultStorageId(STORAGE_ID);
+        return vo;
+    }
+
+    private UserAspect createUserAspect() {
+        final UserAspect aspect = new UserAspect();
+        setInternalState(aspect, "userManager", userManager);
+        setInternalState(aspect, "dataStorageManager", dataStorageManager);
+        setInternalState(aspect, "nfsStorageProvider", nfsStorageProvider);
+        return aspect;
+    }
+}


### PR DESCRIPTION
This PR updates API related to #4292: set posix permissions and chown the NFS storage mount root folder for user's default storage.