### PR TITLE
Try improve mount performance for buffered files

### DIFF
--- a/pipe-cli/mount/pipe-fuse.py
+++ b/pipe-cli/mount/pipe-fuse.py
@@ -90,6 +90,7 @@ _xattrs_include_prefix = 'user'
 def start(mountpoint, webdav, bucket,
           read_buffer_size, read_ahead_min_size, read_ahead_max_size, read_ahead_size_multiplier,
           read_disk_buffer_path, read_disk_buffer_read_ahead_size, read_disk_buffer_ttl, read_disk_buffer_ttl_delay,
+          read_disk_buffer_download_workers,
           write_buffer_size, trunc_buffer_size, chunk_size,
           listing_cache_ttl, listing_cache_size,
           xattrs_include_prefixes, xattrs_exclude_prefixes,
@@ -112,10 +113,13 @@ def start(mountpoint, webdav, bucket,
     read_ahead_size_multiplier = int(os.getenv('CP_PIPE_FUSE_READ_AHEAD_SIZE_MULTIPLIER',
                                                read_ahead_size_multiplier))
     read_disk_buffer_path = os.getenv('CP_PIPE_FUSE_READ_DISK_BUFFER_PATH', read_disk_buffer_path)
-    read_disk_buffer_read_ahead_size = int(os.getenv('CP_PIPE_FUSE_READ_DISK_BUFFER_READ_AHEAD_SIZE',
-                                                     read_disk_buffer_read_ahead_size))
+    _env_read_ahead = os.getenv('CP_PIPE_FUSE_READ_DISK_BUFFER_READ_AHEAD_SIZE')
+    if _env_read_ahead not in (None, ''):
+        read_disk_buffer_read_ahead_size = int(_env_read_ahead)
     read_disk_buffer_ttl = int(os.getenv('CP_PIPE_FUSE_READ_DISK_BUFFER_TTL', read_disk_buffer_ttl))
     read_disk_buffer_ttl_delay = int(os.getenv('CP_PIPE_FUSE_READ_DISK_BUFFER_TTL_DELAY', read_disk_buffer_ttl_delay))
+    read_disk_buffer_download_workers = int(os.getenv('CP_PIPE_FUSE_READ_DISK_BUFFER_DOWNLOAD_WORKERS',
+                                                       read_disk_buffer_download_workers))
     audit_buffer_ttl = int(os.getenv('CP_PIPE_FUSE_AUDIT_BUFFER_TTL', audit_buffer_ttl))
     audit_buffer_size = int(os.getenv('CP_PIPE_FUSE_AUDIT_BUFFER_SIZE', audit_buffer_size))
     path_permissions_disabled = os.getenv('CP_PIPE_FUSE_PATH_PERMISSIONS_DISABLED', 'false').lower() == 'true'
@@ -189,10 +193,18 @@ def start(mountpoint, webdav, bucket,
         else:
             logging.info('Extended attributes caching is disabled.')
     if read_disk_buffer_path:
+        # Auto chunk size when not set and workers > 1: split each file into download_workers equal chunks
+        if read_disk_buffer_read_ahead_size is None and read_disk_buffer_download_workers > 1:
+            _effective_read_ahead = 0  # auto
+        elif read_disk_buffer_read_ahead_size is not None:
+            _effective_read_ahead = read_disk_buffer_read_ahead_size
+        else:
+            _effective_read_ahead = 512 * MB  # default when workers == 1 and not set
         logging.info('Disk buffering read is enabled.')
         client = DiskBufferingReadAllFileSystemClient(client,
-                                                      read_ahead_size=read_disk_buffer_read_ahead_size,
-                                                      path=read_disk_buffer_path)
+                                                      read_ahead_size=_effective_read_ahead,
+                                                      path=read_disk_buffer_path,
+                                                      download_workers=read_disk_buffer_download_workers)
         if read_disk_buffer_ttl > 0:
             logging.info('Disk buffering read ttl is enabled.')
             daemons.append(DiskBufferTTLDaemon(path=read_disk_buffer_path,
@@ -401,12 +413,17 @@ if __name__ == '__main__':
                              "Can be configured via CP_PIPE_FUSE_READ_AHEAD_SIZE_MULTIPLIER environment variable.")
     parser.add_argument("--read-disk-buffer-path", required=False, default='',
                         help="Read disk buffer path")
-    parser.add_argument("--read-disk-buffer-read-ahead-size", type=int, required=False, default=512 * MB,
-                        help="Read disk buffer read size")
+    parser.add_argument("--read-disk-buffer-read-ahead-size", type=int, required=False, default=None,
+                        help="Read disk buffer chunk size in bytes. If not set and download-workers > 1, "
+                             "chunk size is auto-calculated per file (equal chunks). "
+                             "Can be set via CP_PIPE_FUSE_READ_DISK_BUFFER_READ_AHEAD_SIZE.")
     parser.add_argument("--read-disk-buffer-ttl", type=int, required=False, default=1 * HOUR,
                         help="Read disk buffer time to live, seconds")
     parser.add_argument("--read-disk-buffer-ttl-delay", type=int, required=False, default=2 * HOUR,
                         help="Read disk buffer time to live polling delay, seconds")
+    parser.add_argument("--read-disk-buffer-download-workers", type=int, required=False, default=8,
+                        help="Number of parallel workers for disk buffer full-file download (1=sequential). "
+                             "Can be configured via CP_PIPE_FUSE_READ_DISK_BUFFER_DOWNLOAD_WORKERS.")
     parser.add_argument("-wb", "--write-buffer-size", type=int, required=False, default=512 * MB,
                         help="Write buffer size for a single file")
     parser.add_argument("-r", "--trunc-buffer-size", type=int, required=False, default=512 * MB,
@@ -491,6 +508,7 @@ if __name__ == '__main__':
               read_disk_buffer_read_ahead_size=args.read_disk_buffer_read_ahead_size,
               read_disk_buffer_ttl=args.read_disk_buffer_ttl,
               read_disk_buffer_ttl_delay=args.read_disk_buffer_ttl_delay,
+              read_disk_buffer_download_workers=args.read_disk_buffer_download_workers,
               write_buffer_size=args.write_buffer_size, trunc_buffer_size=args.trunc_buffer_size,
               chunk_size=args.chunk_size,
               listing_cache_ttl=args.listing_cache_ttl, listing_cache_size=args.listing_cache_size,

--- a/pipe-cli/mount/pipefuse/diskread.py
+++ b/pipe-cli/mount/pipefuse/diskread.py
@@ -120,12 +120,8 @@ class DiskBufferingReadAllFileSystemClient(FileSystemClientDecorator):
                             # Collect results in offset order for sequential write
                             results_by_offset = {}
                             for future in as_completed(future_to_chunk):
-                                co, cl = future_to_chunk[future]
-                                try:
-                                    range_offset, data = future.result()
-                                    results_by_offset[range_offset] = data
-                                except Exception:
-                                    raise
+                                range_offset, data = future.result()
+                                results_by_offset[range_offset] = data
                             for range_offset, range_length in chunks:
                                 data = results_by_offset[range_offset]
                                 logging.info('Persisting buffer range %d-%d for %d:%s'

--- a/pipe-cli/mount/pipefuse/diskread.py
+++ b/pipe-cli/mount/pipefuse/diskread.py
@@ -15,6 +15,7 @@
 import io
 import logging
 import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from threading import Thread
 
 import errno
@@ -37,7 +38,7 @@ def mkdir(path):
 
 class DiskBufferingReadAllFileSystemClient(FileSystemClientDecorator):
 
-    def __init__(self, inner, read_ahead_size, path):
+    def __init__(self, inner, read_ahead_size, path, download_workers=1):
         """
         Disk buffering read all file system client decorator.
 
@@ -46,12 +47,25 @@ class DiskBufferingReadAllFileSystemClient(FileSystemClientDecorator):
 
         :param inner: Decorating file system client.
         :param read_ahead_size: Amount of bytes that will be read ahead from an inner file system client at once.
+                               Use 0 or None for auto: when download_workers > 1, split each file into
+                               download_workers equal chunks; when download_workers == 1, one chunk per file.
         :param path: Local file system path to persist files.
+        :param download_workers: Number of parallel workers for full-file download (1 = sequential).
         """
         super(DiskBufferingReadAllFileSystemClient, self).__init__(inner)
         self._inner = inner
         self._path = path
         self._read_ahead_size = read_ahead_size
+        self._download_workers = max(1, int(download_workers))
+        self._auto_chunk = read_ahead_size is None or read_ahead_size == 0
+
+    def _download_one_range(self, fh, path, range_offset, range_length):
+        """Download a single range from the inner client. Returns (range_offset, bytes)."""
+        with io.BytesIO() as current_buf:
+            logging.info('Downloading buffer range %d-%d for %d:%s'
+                         % (range_offset, range_offset + range_length, fh, path))
+            self._inner.download_range(fh, current_buf, path, range_offset, length=range_length)
+            return (range_offset, current_buf.getvalue())
 
     def download_range(self, fh, buf, path, offset=0, length=0):
         try:
@@ -61,20 +75,64 @@ class DiskBufferingReadAllFileSystemClient(FileSystemClientDecorator):
                 if not file_size or offset >= file_size:
                     return
                 mkdir(os.path.dirname(file_buf_path))
-                with open(file_buf_path, 'wb') as f:
-                    remaining_size = file_size
+
+                # Build list of (offset, length) chunks for the whole file
+                if self._auto_chunk and self._download_workers > 1:
+                    # Auto: split file into equal chunks according to download_workers
+                    desired_chunks = max(1, min(self._download_workers, file_size))
+                    chunks = []
+                    for i in range(desired_chunks):
+                        chunk_start = (i * file_size) // desired_chunks
+                        chunk_end = ((i + 1) * file_size) // desired_chunks
+                        chunk_len = chunk_end - chunk_start
+                        if chunk_len > 0:
+                            chunks.append((chunk_start, chunk_len))
+                elif self._auto_chunk and self._download_workers == 1:
+                    # Auto with one worker: single chunk (whole file)
+                    chunks = [(0, file_size)]
+                else:
+                    # User-defined read_ahead_size: fixed-size chunks
+                    chunks = []
                     current_offset = 0
+                    remaining_size = file_size
                     while remaining_size:
-                        current_length = min(remaining_size, self._read_ahead_size)
-                        with io.BytesIO() as current_buf:
-                            logging.info('Downloading buffer range %d-%d for %d:%s'
-                                         % (current_offset, current_offset + current_length, fh, path))
-                            self._inner.download_range(fh, current_buf, path, current_offset, length=current_length)
+                        chunk_length = min(remaining_size, self._read_ahead_size)
+                        chunks.append((current_offset, chunk_length))
+                        remaining_size -= chunk_length
+                        current_offset += chunk_length
+
+                with open(file_buf_path, 'wb') as f:
+                    if self._download_workers <= 1 or len(chunks) <= 1:
+                        # Sequential download
+                        for range_offset, range_length in chunks:
+                            _, data = self._download_one_range(fh, path, range_offset, range_length)
                             logging.info('Persisting buffer range %d-%d for %d:%s'
-                                         % (current_offset, current_offset + current_length, fh, path))
-                            f.write(current_buf.getvalue())
-                        remaining_size -= current_length
-                        current_offset += current_length
+                                         % (range_offset, range_offset + len(data), fh, path))
+                            f.write(data)
+                    else:
+                        # Parallel download: submit all ranges, then write in offset order
+                        workers = min(self._download_workers, len(chunks))
+                        with ThreadPoolExecutor(max_workers=workers) as executor:
+                            future_to_chunk = {
+                                executor.submit(self._download_one_range, fh, path, co, cl): (co, cl)
+                                for co, cl in chunks
+                            }
+                            # Collect results in offset order for sequential write
+                            results_by_offset = {}
+                            for future in as_completed(future_to_chunk):
+                                co, cl = future_to_chunk[future]
+                                try:
+                                    range_offset, data = future.result()
+                                    results_by_offset[range_offset] = data
+                                except Exception:
+                                    raise
+                            for range_offset, range_length in chunks:
+                                data = results_by_offset[range_offset]
+                                logging.info('Persisting buffer range %d-%d for %d:%s'
+                                             % (range_offset, range_offset + len(data), fh, path))
+                                f.seek(range_offset)
+                                f.write(data)
+
             file_size = os.path.getsize(file_buf_path)
             if not file_size or offset >= file_size:
                 return

--- a/pipe-cli/mount/pipefuse/s3.py
+++ b/pipe-cli/mount/pipefuse/s3.py
@@ -146,7 +146,9 @@ class S3StorageLowLevelClient(StorageLowLevelFileSystemClient):
     def _generate_s3_client(self, pipe):
         session = self._generate_aws_session(pipe, self.bucket_object)
         custom_endpoint = self.bucket_object.endpoint
-        return session.client('s3', config=Config(), region_name=self.bucket_object.region_name,
+        # Allow enough connections for parallel disk-buffer downloads (default 10 may limit throughput)
+        config = Config(max_pool_connections=50)
+        return session.client('s3', config=config, region_name=self.bucket_object.region_name,
                               endpoint_url=custom_endpoint, verify=False if custom_endpoint else None)
 
     def _generate_aws_session(self, pipe, bucket_object):


### PR DESCRIPTION
## Improve mount performance for buffered reads

### Summary
Previously, when disk buffering was enabled, files were downloaded sequentially in fixed-size chunks
(default 512 MB each) using a single thread before being served from local disk. This caused a delay
proportional to file size before any read could be served from the buffer.

With this change, files are downloaded in parallel using multiple workers (default 8). Each file is
split into equal chunks that are fetched concurrently via a thread pool, then written to the buffer
file in order. This reduces the time-to-first-read for large files significantly.

### Changes

**1. Parallel disk-buffer download (`pipefuse/diskread.py`)**
- Introduced a `download_workers` parameter (default 8 when invoked from pipe-fuse) for parallel full-file download.
- When `download_workers > 1`, file download is split into chunks and fetched in parallel via `ThreadPoolExecutor`; results are written to the buffer file in offset order.
- **Auto chunk size:**
  - If read-ahead/chunk size is not set and `download_workers > 1`, the file is split into `download_workers` equal chunks.
  - If `download_workers == 1`, a single chunk (whole file) is used.
- Added `_download_one_range()` to download a single byte range; sequential behavior is unchanged when `download_workers <= 1` or there is only one chunk.

**2. CLI and configuration (`pipe-fuse.py`)**
- New option: `--read-disk-buffer-download-workers` (default: 8).
  Env: `CP_PIPE_FUSE_READ_DISK_BUFFER_DOWNLOAD_WORKERS`.
- `--read-disk-buffer-read-ahead-size` is now optional (default: `None`). When unset and `download-workers > 1`, chunk size is derived automatically (equal chunks per file).
  Env: `CP_PIPE_FUSE_READ_DISK_BUFFER_READ_AHEAD_SIZE`.
- Safer env parsing for read-ahead size: only convert to int when the env value is non-empty.
- `DiskBufferingReadAllFileSystemClient` is instantiated with `download_workers=read_disk_buffer_download_workers`.

**3. S3 connection pool (`pipefuse/s3.py`)**
- S3 client `max_pool_connections` increased from default (10) to 50 so parallel disk-buffer downloads are not limited by the connection pool.

### Configuration

| CLI flag | Env variable | Default | Description |
|---|---|---|---|
| `--read-disk-buffer-download-workers` | `CP_PIPE_FUSE_READ_DISK_BUFFER_DOWNLOAD_WORKERS` | `8` | Number of parallel workers for full-file disk-buffer download (1 = sequential). |
| `--read-disk-buffer-read-ahead-size` | `CP_PIPE_FUSE_READ_DISK_BUFFER_READ_AHEAD_SIZE` | auto | Chunk size in bytes. If not set and `download-workers > 1`, chunks are auto-sized equally per file. If not set and `download-workers == 1`, the whole file is one chunk. |