### PR TITLE
Fix permissions for ROLE_STORAGE_ADMIN

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/cloud/TemporaryCredentialsManagerImpl.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/TemporaryCredentialsManagerImpl.java
@@ -27,6 +27,7 @@ import com.epam.pipeline.manager.datastorage.DataStorageManager;
 import com.epam.pipeline.manager.datastorage.leakagepolicy.SensitiveStorageOperation;
 import com.epam.pipeline.manager.datastorage.permissions.StoragePathPermissionsService;
 import com.epam.pipeline.manager.security.AuthManager;
+import com.epam.pipeline.manager.security.storage.StoragePermissionManager;
 import com.epam.pipeline.utils.CommonUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
@@ -51,18 +52,21 @@ public class TemporaryCredentialsManagerImpl implements TemporaryCredentialsMana
     private final MessageHelper messageHelper;
     private final DataStorageManager dataStorageManager;
     private final StoragePathPermissionsService storagePathPermissionsService;
+    private final StoragePermissionManager storagePermissionManager;
     private final AuthManager authManager;
 
     public TemporaryCredentialsManagerImpl(final List<TemporaryCredentialsGenerator> credentialsGenerators,
                                            final MessageHelper messageHelper,
                                            final DataStorageManager dataStorageManager,
                                            final StoragePathPermissionsService storagePathPermissionsService,
+                                           final StoragePermissionManager storagePermissionManager,
                                            final AuthManager authManager) {
         this.credentialsGenerators = CommonUtils.groupByKey(credentialsGenerators,
                 TemporaryCredentialsGenerator::getStorageType);
         this.messageHelper = messageHelper;
         this.dataStorageManager = dataStorageManager;
         this.storagePathPermissionsService = storagePathPermissionsService;
+        this.storagePermissionManager = storagePermissionManager;
         this.authManager = authManager;
     }
 
@@ -139,7 +143,8 @@ public class TemporaryCredentialsManagerImpl implements TemporaryCredentialsMana
             action.setItemType(null);
             return true;
         }
-        if (authManager.isAdmin() || storage.getOwner().equalsIgnoreCase(authManager.getAuthorizedUser())) {
+        if (storagePermissionManager.isStorageAdmin()
+                || storage.getOwner().equalsIgnoreCase(authManager.getAuthorizedUser())) {
             return true;
         }
         return DataStorageItemType.File.equals(action.getItemType())

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/DataStorageManager.java
@@ -1576,7 +1576,8 @@ public class DataStorageManager implements SecuredEntityManager {
 
     private boolean needToLoadPathPermissions(final AbstractDataStorage storage) {
         return storage.isPathPermissionsEnabled() && DataStorageType.S3.equals(storage.getType())
-                && !authManager.isAdmin() && !authManager.getAuthorizedUser().equalsIgnoreCase(storage.getOwner());
+                && !storagePermissionManager.isStorageAdmin()
+                && !authManager.getAuthorizedUser().equalsIgnoreCase(storage.getOwner());
     }
 
     private DataStorageListing addPathsMasks(final AbstractDataStorage storage,

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/tag/DataStorageTagBatchManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/tag/DataStorageTagBatchManager.java
@@ -36,6 +36,7 @@ import com.epam.pipeline.entity.datastorage.tag.DataStorageTagUpsertBatchRequest
 import com.epam.pipeline.entity.datastorage.tag.DataStorageTagUpsertRequest;
 import com.epam.pipeline.manager.datastorage.permissions.StoragePathPermissionsService;
 import com.epam.pipeline.manager.security.AuthManager;
+import com.epam.pipeline.manager.security.storage.StoragePermissionManager;
 import com.epam.pipeline.security.acl.AclPermission;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -71,6 +72,7 @@ public class DataStorageTagBatchManager {
     private final DataStorageTagDao tagDao;
     private final DataStorageDao storageDao;
     private final AuthManager authManager;
+    private final StoragePermissionManager storagePermissionManager;
     private final StoragePathPermissionsService storagePathPermissionsService;
 
     @Transactional
@@ -249,7 +251,8 @@ public class DataStorageTagBatchManager {
             log.debug("Storage '{}' was not found.", storageId);
             return Collections.emptyList();
         }
-        if (!(storage.isPathPermissionsEnabled() && DataStorageType.S3.equals(storage.getType())
+        if (storagePermissionManager.isStorageAdmin()
+                || !(storage.isPathPermissionsEnabled() && DataStorageType.S3.equals(storage.getType())
                 && !authManager.getAuthorizedUser().equalsIgnoreCase(storage.getOwner()))) {
             return null;
         }

--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/tag/DataStorageTagBatchManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/tag/DataStorageTagBatchManager.java
@@ -243,7 +243,7 @@ public class DataStorageTagBatchManager {
     private <T> List<String> getAllowedPaths(final Long storageId, final List<T> requests,
                                              final Function<T, String> getPathFunction,
                                              final int mask) {
-        if (authManager.isAdmin()) {
+        if (storagePermissionManager.isStorageAdmin()) {
             return null;
         }
         final AbstractDataStorage storage = storageDao.loadDataStorage(storageId);
@@ -251,8 +251,7 @@ public class DataStorageTagBatchManager {
             log.debug("Storage '{}' was not found.", storageId);
             return Collections.emptyList();
         }
-        if (storagePermissionManager.isStorageAdmin()
-                || !(storage.isPathPermissionsEnabled() && DataStorageType.S3.equals(storage.getType())
+        if (!(storage.isPathPermissionsEnabled() && DataStorageType.S3.equals(storage.getType())
                 && !authManager.getAuthorizedUser().equalsIgnoreCase(storage.getOwner()))) {
             return null;
         }

--- a/api/src/main/java/com/epam/pipeline/manager/security/storage/StoragePermissionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/storage/StoragePermissionManager.java
@@ -83,7 +83,7 @@ public class StoragePermissionManager {
 
     public boolean isStorageAdmin() {
         return authManager.isAdmin()
-            && permissionHelper.isScopedAdmin(AclClass.DATA_STORAGE);
+            || permissionHelper.isScopedAdmin(AclClass.DATA_STORAGE);
     }
 
     public boolean storagePermission(final AbstractDataStorage storage,

--- a/api/src/main/java/com/epam/pipeline/manager/security/storage/StoragePermissionManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/security/storage/StoragePermissionManager.java
@@ -81,6 +81,11 @@ public class StoragePermissionManager {
     private final PreferenceManager preferenceManager;
     private final ContextualPreferenceManager contextualPreferenceManager;
 
+    public boolean isStorageAdmin() {
+        return authManager.isAdmin()
+            && permissionHelper.isScopedAdmin(AclClass.DATA_STORAGE);
+    }
+
     public boolean storagePermission(final AbstractDataStorage storage,
                                      final String permissionName) {
         return grantPermissionManager.storagePermission(storage, permissionName);

--- a/api/src/test/java/com/epam/pipeline/manager/cloud/TemporaryCredentialsManagerImplTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cloud/TemporaryCredentialsManagerImplTest.java
@@ -25,6 +25,7 @@ import com.epam.pipeline.entity.datastorage.azure.AzureBlobStorage;
 import com.epam.pipeline.manager.datastorage.DataStorageManager;
 import com.epam.pipeline.manager.datastorage.permissions.StoragePathPermissionsService;
 import com.epam.pipeline.manager.security.AuthManager;
+import com.epam.pipeline.manager.security.storage.StoragePermissionManager;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Before;
@@ -54,10 +55,11 @@ public class TemporaryCredentialsManagerImplTest {
     private final MessageHelper messageHelper = mock(MessageHelper.class);
     private final DataStorageManager dataStorageManager = mock(DataStorageManager.class);
     private final StoragePathPermissionsService pathPermissionsService = mock(StoragePathPermissionsService.class);
+    private final StoragePermissionManager storagePermissionManager = mock(StoragePermissionManager.class);
     private final AuthManager authManager = mock(AuthManager.class);
 
     private final TemporaryCredentialsManagerImpl manager = new TemporaryCredentialsManagerImpl(credentialsGenerators,
-            messageHelper, dataStorageManager, pathPermissionsService, authManager);
+            messageHelper, dataStorageManager, pathPermissionsService, storagePermissionManager, authManager);
 
     @Before
     public void setUp() {


### PR DESCRIPTION
### Problem
Users with `ROLE_STORAGE_ADMIN` received "Access is denied" on path-permission–enabled S3 storages when listing items, using tag batch APIs, or requesting temporary credentials. Path checks were only bypassed for full ADMIN and storage owner.

### Approach
Reuse the existing scoped-admin concept: storage scoped admin (`ROLE_STORAGE_ADMIN`) is now treated like ADMIN and storage owner wherever path permissions are bypassed.

### Changes
- **StoragePermissionManager** — Added `isStorageAdmin()` (no args), delegating to `permissionHelper.isScopedAdmin(AclClass.DATA_STORAGE)`.
- **DataStorageManager** — `needToLoadPathPermissions()` returns false when `storagePermissionManager.isStorageAdmin()` is true, so listing/filtering and path permission checks are skipped for storage admins.
- **DataStorageTagBatchManager** — `getAllowedPaths()` returns null (all paths allowed) when `storagePermissionManager.isStorageAdmin()` is true, so tag batch operations are not restricted by path permissions for storage admins.
- **TemporaryCredentialsManagerImpl** — `filterNotAllowedAction()` bypasses path checks when `storagePermissionManager.isStorageAdmin()` is true, so temporary credentials are generated without path restrictions for storage admins.
- **TemporaryCredentialsManagerImplTest** — Constructor updated to pass the new `StoragePermissionManager` dependency.

### Result
`ROLE_STORAGE_ADMIN` can list storage contents, run tag batch operations, and obtain temporary credentials on path-permission–enabled S3 storages without needing explicit path-level grants.
