### PR TITLE
Allow ROLE_STORAGE_ADMIN to perform nfs storage mounts

### DIFF
--- a/workflows/pipe-common/shell/mount_restrictor
+++ b/workflows/pipe-common/shell/mount_restrictor
@@ -27,7 +27,7 @@ if [ -z "$API_TOKEN" ]; then
 fi
 
 _roles_info=$(curl -sk -H "Authorization: Bearer $API_TOKEN" $API/whoami | jq -r '.payload.roles[]')
-_admin_role=$(echo "$_roles_info" | jq -r 'select(.name == "ROLE_ADMIN")')
+_admin_role=$(echo "$_roles_info" | jq -r 'select(.name == "ROLE_ADMIN" or .name == "ROLE_STORAGE_ADMIN")')
 
 _custom_mount_role="false"
 if [ "$CP_MOUNT_ALLOWED_ROLES" ]; then
@@ -42,7 +42,7 @@ if [ "$CP_MOUNT_ALLOWED_ROLES" ]; then
 fi
 
 if [ -z "$_admin_role" ] && [ "$_custom_mount_role" == "false" ]; then
-    echo "[ERROR] mount: only ROLE_ADMIN can do that"
+    echo "[ERROR] mount: only ROLE_ADMIN or ROLE_STORAGE_ADMIN can do that"
     exit 1
 fi
 


### PR DESCRIPTION
#4329

### Summary
Extended `mount_restrictor` so that users with **ROLE_STORAGE_ADMIN** can perform data storage mounts in addition to **ROLE_ADMIN**. Custom roles via `CP_MOUNT_ALLOWED_ROLES` are unchanged.

### Changes
- **`workflows/pipe-common/shell/mount_restrictor`**
  - Role check now allows both `ROLE_ADMIN` and `ROLE_STORAGE_ADMIN` via a single jq call: `select(.name == "ROLE_ADMIN" or .name == "ROLE_STORAGE_ADMIN")`
  - Error message updated to: `"mount: only ROLE_ADMIN or ROLE_STORAGE_ADMIN can do that"`