### PR TITLE
issue 4334 Independent sync flow for each NFS in NFSStorageMounter

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageMounter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageMounter.java
@@ -43,6 +43,8 @@ import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
 import static com.epam.pipeline.manager.datastorage.providers.nfs.NFSHelper.formatNfsPath;
@@ -62,6 +64,7 @@ public class NFSStorageMounter {
      */
     private static final String NFS_UNMOUNT_CMD_PATTERN = "sudo umount -l -f %s";
 
+
     private final CmdExecutor cmdExecutor = new CmdExecutor();
     private final MessageHelper messageHelper;
     private final DataStorageDao dataStorageDao;
@@ -69,6 +72,7 @@ public class NFSStorageMounter {
     private final FileShareMountManager shareMountManager;
     private final String rootMountPoint;
     private final long timeoutMills;
+    private final ConcurrentHashMap<String, ReentrantLock> rootMountPointLocks;
 
     public NFSStorageMounter(final MessageHelper messageHelper,
                              final DataStorageDao dataStorageDao,
@@ -84,12 +88,15 @@ public class NFSStorageMounter {
         this.shareMountManager = shareMountManager;
         this.rootMountPoint = rootMountPoint;
         this.timeoutMills = timeoutMills;
+        this.rootMountPointLocks = new ConcurrentHashMap<>();
     }
 
-    public synchronized File mount(final NFSDataStorage dataStorage) {
+    public File mount(final NFSDataStorage dataStorage) {
+        final FileShareMount fileShareMount = shareMountManager.load(dataStorage.getFileShareMountId());
+        final File rootMount = getShareRootMount(dataStorage, fileShareMount);
+        final ReentrantLock lock = getMountPointLock(rootMount);
+        lock.lock();
         try {
-            final FileShareMount fileShareMount = shareMountManager.load(dataStorage.getFileShareMountId());
-            final File rootMount = getShareRootMount(dataStorage, fileShareMount);
             if (!rootMount.exists()) {
                 Assert.isTrue(rootMount.mkdirs(), messageHelper.getMessage(
                         MessageConstants.ERROR_DATASTORAGE_NFS_MOUNT_DIRECTORY_NOT_CREATED));
@@ -128,27 +135,35 @@ public class NFSStorageMounter {
             throw new DataStorageException(messageHelper.getMessage(
                     messageHelper.getMessage(MessageConstants.ERROR_DATASTORAGE_NFS_MOUNT, dataStorage.getName(),
                             dataStorage.getPath())), e);
+        } finally {
+            lock.unlock();
         }
     }
 
-    public synchronized void unmountNFSIfEmpty(NFSDataStorage storage) {
+    public void unmountNFSIfEmpty(final NFSDataStorage storage) {
         final FileShareMount fileShareMount = shareMountManager.load(storage.getFileShareMountId());
         final File rootMount = getShareRootMount(storage, fileShareMount);
-        // if mount exact path, storage will be mounted to the unique dir
-        final List<AbstractDataStorage> remaining = storage.isMountExactPath()
-                ? Collections.singletonList(storage)
-                : dataStorageDao.loadDataStoragesByFileShareMountID(storage.getFileShareMountId());
-        LOGGER.debug("Remaining NFS: " + remaining.stream().map(AbstractDataStorage::getPath)
-                .collect(Collectors.joining(";")) + " related with current file share mount");
+        final ReentrantLock lock = getMountPointLock(rootMount);
+        lock.lock();
+        try {
+            // if mount exact path, storage will be mounted to the unique dir
+            final List<AbstractDataStorage> remaining = storage.isMountExactPath()
+                    ? Collections.singletonList(storage)
+                    : dataStorageDao.loadDataStoragesByFileShareMountID(storage.getFileShareMountId());
+            LOGGER.debug("Remaining NFS: " + remaining.stream().map(AbstractDataStorage::getPath)
+                    .collect(Collectors.joining(";")) + " related with current file share mount");
 
-        if (rootMount.exists() && isStorageOnlyOnNFS(storage, remaining)) {
-            try {
-                final String umountCmd = String.format(NFS_UNMOUNT_CMD_PATTERN, rootMount.getAbsolutePath());
-                cmdExecutor.executeCommand(umountCmd);
-                FileUtils.deleteDirectory(rootMount);
-            } catch (IOException e) {
-                throw new DataStorageException(e);
+            if (rootMount.exists() && isStorageOnlyOnNFS(storage, remaining)) {
+                try {
+                    final String umountCmd = String.format(NFS_UNMOUNT_CMD_PATTERN, rootMount.getAbsolutePath());
+                    cmdExecutor.executeCommand(umountCmd);
+                    FileUtils.deleteDirectory(rootMount);
+                } catch (IOException e) {
+                    throw new DataStorageException(e);
+                }
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -162,6 +177,10 @@ public class NFSStorageMounter {
             LOGGER.error("Failed to change owner for path {}:", path);
             LOGGER.error(e.getMessage(), e);
         }
+    }
+
+    private ReentrantLock getMountPointLock(final File rootMount) {
+        return rootMountPointLocks.computeIfAbsent(rootMount.getAbsolutePath(), k -> new ReentrantLock());
     }
 
     private File getStorageMountPath(final NFSDataStorage storage, final FileShareMount fileShareMount) {

--- a/api/src/test/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageMounterTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/datastorage/providers/nfs/NFSStorageMounterTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.epam.pipeline.manager.datastorage.providers.nfs;
+
+import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.dao.datastorage.DataStorageDao;
+import com.epam.pipeline.entity.datastorage.FileShareMount;
+import com.epam.pipeline.entity.datastorage.MountType;
+import com.epam.pipeline.entity.datastorage.nfs.NFSDataStorage;
+import com.epam.pipeline.entity.region.AwsRegion;
+import com.epam.pipeline.entity.region.CloudProvider;
+import com.epam.pipeline.manager.CmdExecutor;
+import com.epam.pipeline.manager.datastorage.FileShareMountManager;
+import com.epam.pipeline.manager.region.CloudRegionManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.internal.util.reflection.Whitebox;
+
+import java.util.Collections;
+import java.util.concurrent.*;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+
+public class NFSStorageMounterTest {
+
+    private static final long SHARE_MOUNT_ID_A = 1L;
+    private static final long SHARE_MOUNT_ID_B = 2L;
+    private static final long REGION_ID = 10L;
+    private static final String MOUNT_ROOT_A = "server-a";
+    private static final String MOUNT_ROOT_B = "server-b";
+    private static final long TIMEOUT_SEC = 1L;
+    private static final long LOCK_WAIT_MS = 100L;
+    private static final String ROOT_DIR_1 = ":root/dir1";
+    private static final String ROOT_DIR_2 = ":root/dir2";
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Mock
+    private MessageHelper messageHelper;
+    @Mock
+    private DataStorageDao dataStorageDao;
+    @Mock
+    private CloudRegionManager regionManager;
+    @Mock
+    private FileShareMountManager shareMountManager;
+    @Mock
+    private CmdExecutor mockCmdExecutor;
+
+    private NFSStorageMounter mounter;
+    private ExecutorService executor;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        mounter = new NFSStorageMounter(
+                messageHelper, dataStorageDao, regionManager, shareMountManager,
+                tempFolder.getRoot().getAbsolutePath(), 0L);
+        Whitebox.setInternalState(mounter, "cmdExecutor", mockCmdExecutor);
+
+        final AwsRegion region = new AwsRegion();
+        region.setId(REGION_ID);
+        region.setProvider(CloudProvider.AWS);
+        when(regionManager.load(REGION_ID)).thenReturn(region);
+
+        when(shareMountManager.load(SHARE_MOUNT_ID_A))
+                .thenReturn(createFileShareMount(SHARE_MOUNT_ID_A, MOUNT_ROOT_A));
+        when(shareMountManager.load(SHARE_MOUNT_ID_B))
+                .thenReturn(createFileShareMount(SHARE_MOUNT_ID_B, MOUNT_ROOT_B));
+
+        executor = Executors.newFixedThreadPool(2);
+    }
+
+    @After
+    public void tearDown() {
+        executor.shutdownNow();
+    }
+
+    @Test
+    public void mountShouldSerializeOperationsOnSameShareRoot() throws Exception {
+        final CountDownLatch firstMountEntered = new CountDownLatch(1);
+        final CountDownLatch firstMountCanProceed = new CountDownLatch(1);
+
+        when(mockCmdExecutor.executeCommand(anyString(), anyLong()))
+                .thenAnswer(invocation -> {
+                    firstMountEntered.countDown();
+                    firstMountCanProceed.await(TIMEOUT_SEC, TimeUnit.SECONDS);
+                    return "";
+                });
+
+        final NFSDataStorage storage1 = createStorage(1L, MOUNT_ROOT_A + ROOT_DIR_1, SHARE_MOUNT_ID_A);
+        final NFSDataStorage storage2 = createStorage(2L, MOUNT_ROOT_A + ROOT_DIR_2, SHARE_MOUNT_ID_A);
+
+        final Future<?> future1 = executor.submit(() -> mounter.mount(storage1));
+
+        assertTrue("First mount should enter executeCommand",
+                firstMountEntered.await(TIMEOUT_SEC, TimeUnit.SECONDS));
+
+        final Future<?> future2 = executor.submit(() -> mounter.mount(storage2));
+
+        Thread.sleep(LOCK_WAIT_MS);
+        assertFalse("Second mount should be blocked while first holds the lock",
+                future2.isDone());
+
+        firstMountCanProceed.countDown();
+
+        future1.get(TIMEOUT_SEC, TimeUnit.SECONDS);
+        future2.get(TIMEOUT_SEC, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void mountShouldAllowParallelOperationsOnDifferentShareRoots() throws Exception {
+        final CountDownLatch bothMountsEntered = new CountDownLatch(2);
+        final CountDownLatch canProceed = new CountDownLatch(1);
+
+        when(mockCmdExecutor.executeCommand(anyString(), anyLong()))
+                .thenAnswer(invocation -> {
+                    bothMountsEntered.countDown();
+                    canProceed.await(TIMEOUT_SEC, TimeUnit.SECONDS);
+                    return "";
+                });
+
+        final NFSDataStorage storageA = createStorage(1L, MOUNT_ROOT_A + ROOT_DIR_1, SHARE_MOUNT_ID_A);
+        final NFSDataStorage storageB = createStorage(2L, MOUNT_ROOT_B + ROOT_DIR_1, SHARE_MOUNT_ID_B);
+
+        final Future<?> futureA = executor.submit(() -> mounter.mount(storageA));
+        final Future<?> futureB = executor.submit(() -> mounter.mount(storageB));
+
+        assertTrue("Both mounts should enter executeCommand concurrently",
+                bothMountsEntered.await(TIMEOUT_SEC, TimeUnit.SECONDS));
+
+        canProceed.countDown();
+
+        futureA.get(TIMEOUT_SEC, TimeUnit.SECONDS);
+        futureB.get(TIMEOUT_SEC, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void mountAndUnmountShouldShareLockForSameShareRoot() throws Exception {
+        final CountDownLatch mountEntered = new CountDownLatch(1);
+        final CountDownLatch mountCanProceed = new CountDownLatch(1);
+
+        when(mockCmdExecutor.executeCommand(anyString(), anyLong()))
+                .thenAnswer(invocation -> {
+                    mountEntered.countDown();
+                    mountCanProceed.await(TIMEOUT_SEC, TimeUnit.SECONDS);
+                    return "";
+                });
+        when(mockCmdExecutor.executeCommand(anyString()))
+                .thenReturn("");
+
+        final NFSDataStorage storage = createStorage(1L, MOUNT_ROOT_A + ROOT_DIR_1, SHARE_MOUNT_ID_A);
+        when(dataStorageDao.loadDataStoragesByFileShareMountID(SHARE_MOUNT_ID_A))
+                .thenReturn(Collections.singletonList(storage));
+
+        final Future<?> mountFuture = executor.submit(() -> mounter.mount(storage));
+
+        assertTrue("Mount should enter executeCommand",
+                mountEntered.await(TIMEOUT_SEC, TimeUnit.SECONDS));
+
+        final Future<?> unmountFuture = executor.submit(() -> mounter.unmountNFSIfEmpty(storage));
+
+        Thread.sleep(LOCK_WAIT_MS);
+        assertFalse("Unmount should be blocked while mount holds the lock",
+                unmountFuture.isDone());
+
+        mountCanProceed.countDown();
+
+        mountFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS);
+        unmountFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS);
+    }
+
+    private NFSDataStorage createStorage(final long id, final String path, final long fileShareMountId) {
+        final NFSDataStorage storage = new NFSDataStorage(id, "storage-" + id, path);
+        storage.setFileShareMountId(fileShareMountId);
+        return storage;
+    }
+
+    private FileShareMount createFileShareMount(final long id, final String mountRoot) {
+        final FileShareMount mount = new FileShareMount();
+        mount.setId(id);
+        mount.setMountRoot(mountRoot);
+        mount.setMountType(MountType.NFS);
+        mount.setRegionId(REGION_ID);
+        return mount;
+    }
+}


### PR DESCRIPTION
Relates to #4334 Solves #4336
First fix out of 2

New approach to synchronize in NFSStorageMounter, instead of having same lock for each mount operation (even if we mount two different NFS), now we will have its own lock for each NFS (using ConcurrentHashMap of locks inside NFSStorageMounter)