### PR TITLE
Issue #4349 - Pipe CLI: Support json output option to pipe commands - run

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -536,7 +536,7 @@ def view_pipe(pipeline, versions, parameters, storage_rules, permissions):
 @click.option('-td', '--tasks-details', help='Display tasks of a specific run', is_flag=True)
 @click.option('-uf', '--user-filter', help='Display tasks of a specific users. Format: Comma separated list.')
 @click.option('--tags-details', help='Display detailed tags information of a specific run', is_flag=True, default=False)
-@click.option('-o', '--output', type=click.Choice(['json']), default=None,
+@click.option('-of', '--output-format', type=click.Choice(['json']), default=None,
               help='Output format. Default is a text table.')
 @common_options
 def view_runs(run_id,
@@ -552,15 +552,15 @@ def view_runs(run_id,
               tasks_details,
               user_filter,
               tags_details,
-              output):
+              output_format):
     """Displays details of a run or list of pipeline runs
     """
     # If a run id is specified - list details of a run
     if run_id:
-        view_run(run_id, node_details, parameters_details, tasks_details, tags_details, output=output)
+        view_run(run_id, node_details, parameters_details, tasks_details, tags_details, output=output_format)
     # If no argument is specified - list runs according to options
     else:
-        view_all_runs(status, date_from, date_to, pipeline, parent_id, find, top, user_filter, output=output)
+        view_all_runs(status, date_from, date_to, pipeline, parent_id, find, top, user_filter, output=output_format)
 
 
 def view_all_runs(status, date_from, date_to, pipeline, parent_id, find, top, user_filter, output=None):

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -772,6 +772,8 @@ def view_cluster_for_node(node_name):
 @click.option('-t', '--timeout', type=int,
               help='Specifies run timeout in minutes. '
                    'If a run doesn\'t finish within this period of time, than it is marked as failed and stopped.')
+@click.option('-of', '--output-format', type=click.Choice(['json']), default=None,
+              help='Structured output format. When set, quiet mode is enabled automatically.')
 @click.option('-q', '--quiet', help='Quiet mode', is_flag=True)
 @click.option('-ic', '--instance-count', help='Number of worker instances to launch in a cluster',
               type=click.IntRange(0, MAX_INSTANCE_COUNT, clamp=True), required=False)
@@ -830,6 +832,7 @@ def run(pipeline,
         docker_image,
         cmd_template,
         timeout,
+        output_format,
         quiet,
         instance_count,
         cores,
@@ -888,7 +891,7 @@ def run(pipeline,
                               status_notifications,
                               status_notifications_status, status_notifications_recipient,
                               status_notifications_subject, status_notifications_body,
-                              user)
+                              user, output_format)
 
 
 @cli.command(name='stop')

--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -536,7 +536,7 @@ def view_pipe(pipeline, versions, parameters, storage_rules, permissions):
 @click.option('-td', '--tasks-details', help='Display tasks of a specific run', is_flag=True)
 @click.option('-uf', '--user-filter', help='Display tasks of a specific users. Format: Comma separated list.')
 @click.option('--tags-details', help='Display detailed tags information of a specific run', is_flag=True, default=False)
-@click.option('-of', '--output-format', type=click.Choice(['json']), default=None,
+@click.option('-o', '--output', type=click.Choice(['json']), default=None,
               help='Output format. Default is a text table.')
 @common_options
 def view_runs(run_id,
@@ -552,15 +552,15 @@ def view_runs(run_id,
               tasks_details,
               user_filter,
               tags_details,
-              output_format):
+              output):
     """Displays details of a run or list of pipeline runs
     """
     # If a run id is specified - list details of a run
     if run_id:
-        view_run(run_id, node_details, parameters_details, tasks_details, tags_details, output=output_format)
+        view_run(run_id, node_details, parameters_details, tasks_details, tags_details, output=output)
     # If no argument is specified - list runs according to options
     else:
-        view_all_runs(status, date_from, date_to, pipeline, parent_id, find, top, user_filter, output=output_format)
+        view_all_runs(status, date_from, date_to, pipeline, parent_id, find, top, user_filter, output=output)
 
 
 def view_all_runs(status, date_from, date_to, pipeline, parent_id, find, top, user_filter, output=None):

--- a/pipe-cli/src/utilities/capacity_block_processor.py
+++ b/pipe-cli/src/utilities/capacity_block_processor.py
@@ -22,7 +22,7 @@ from src.api.preferenceapi import PreferenceAPI
 class CapacityBlockProcessor:
     CONFIG_PREFERENCE = 'launch.reservation.parameters'
 
-    def __init__(self, instance_type):
+    def __init__(self, instance_type, print_service):
         self._config = None
         if not instance_type:
             # instance type is None, we can not to check further
@@ -30,6 +30,7 @@ class CapacityBlockProcessor:
         self._instance_type = instance_type
         config = self._find_capacity_block_config()
         self._config = config.get(self._instance_type)
+        self._print_service = print_service
 
     def verify(self, parameters):
         if not self._config:
@@ -64,7 +65,8 @@ class CapacityBlockProcessor:
         try:
             return json.loads(preference_value)
         except json.JSONDecodeError:
-            click.echo('Cannot parse preference %s, not a valid json.' % self.CONFIG_PREFERENCE, err=True)
+            self._print_service.error('Cannot parse preference %s, not a valid json.' % self.CONFIG_PREFERENCE,
+                                      err=True, buf=True)
             return {}
 
     def _validate_parameter(self, config_marker_name, parameters, parameter_name):
@@ -72,6 +74,6 @@ class CapacityBlockProcessor:
             return
         if parameters.get(parameter_name):
             return
-        click.echo('Parameter %s shall be specified for instance type %s.' % (parameter_name, self._instance_type),
-                   err=True)
+        self._print_service.error(
+            'Parameter %s shall be specified for instance type %s.' % (parameter_name, self._instance_type), err=True)
         sys.exit(1)

--- a/pipe-cli/src/utilities/pipeline_run_operations.py
+++ b/pipe-cli/src/utilities/pipeline_run_operations.py
@@ -30,6 +30,7 @@ from src.utilities.user_operations_manager import UserOperationsManager
 from src.utilities.user_token_operations import UserTokenOperations
 
 from src.api.pipeline import Pipeline
+from src.utilities.printing.print_service import create_print_service
 
 ROLE_ADMIN = 'ROLE_ADMIN'
 DELAY = 30
@@ -55,8 +56,15 @@ class PipelineRunOperations(object):
             status_notifications=False,
             status_notifications_status=None, status_notifications_recipient=None,
             status_notifications_subject=None, status_notifications_body=None,
-            run_as_user=None):
+            run_as_user=None, output_format=None):
+        if output_format and not yes:
+            click.echo('Output in json format supported with -y (--yes) option only.', err=True)
+            sys.exit(1)
+        if output_format:
+            # force enable quite mode to support valid json output
+            quiet = True
 
+        print_service = create_print_service(output_format)
         all_user_roles = UserOperationsManager().get_all_user_roles()
         # Preserving old style impersonation for admin users. Specified user token is generated and used
         # for impersonation rather than run as capability which is used for non-admin users.
@@ -70,13 +78,14 @@ class PipelineRunOperations(object):
         # This approach is used because we do not know parameters list beforehand
 
         run_params_dict = dict([(k.strip('-'), v) for k, v in zip(run_params[::2], run_params[1::2])])
-        cls._validate_run_params(run_params_dict, all_user_roles)
+        cls._validate_run_params(run_params_dict, all_user_roles, print_service)
 
         if instance_count == 0:
             instance_count = None
 
         if non_pause and not price_type == PriceType.ON_DEMAND:
-            click.echo("--non-pause option supported for on-demand runs only and will be ignored")
+            if output_format is None:
+                click.echo("--non-pause option supported for on-demand runs only and will be ignored")
             non_pause = None
         if price_type == PriceType.ON_DEMAND and non_pause is None:
             non_pause = False
@@ -92,13 +101,14 @@ class PipelineRunOperations(object):
             instance_type = nodes_spec["name"]
 
         if friendly_url:
-            friendly_url = cls._build_pretty_url(friendly_url)
+            friendly_url = cls._build_pretty_url(friendly_url, print_service)
 
         try:
             if not pipeline and docker_image and cls.required_args_missing(parent_node, instance_type, instance_disk,
                                                                            cmd_template):
                 instance_disk, instance_type, cmd_template = cls.load_missing_args(docker_image, instance_disk,
-                                                                                   instance_type, cmd_template)
+                                                                                   instance_type, cmd_template,
+                                                                                   print_service)
             if pipeline:
                 parts = pipeline.split('@')
                 pipeline_name = parts[0]
@@ -121,7 +131,8 @@ class PipelineRunOperations(object):
                     if not quiet:
                         click.echo('done.', nl=True)
                 if parameters:
-                    cls.print_pipeline_parameters_info(pipeline_model, pipeline_run_parameters)
+                    cls.print_pipeline_parameters_info(pipeline_model, pipeline_run_parameters, print_service,
+                                                       output_format)
                 else:
                     if not quiet:
                         click.echo('Evaluating estimated price...', nl=False)
@@ -170,14 +181,15 @@ class PipelineRunOperations(object):
                             if not quiet:
                                 click.echo('"{}" parameter is required'.format(parameter.name), err=True)
                             else:
-                                click.echo(parameter.name)
+                                print_service.error(parameter.name)
                                 sys.exit(1)
                             wrong_parameters = True
                         elif run_params_dict.get(parameter.name) is not None:
                             parameter.value = run_params_dict.get(parameter.name)
 
                     run_params_dict, pod_assign_policy = cls._apply_capacity_block_config_if_required(instance_type,
-                                                                                                      run_params_dict)
+                                                                                                      run_params_dict,
+                                                                                                      print_service)
 
                     for user_parameter in run_params_dict.keys():
                         custom_parameter = True
@@ -228,12 +240,14 @@ class PipelineRunOperations(object):
                                 if pipeline_processed_status != 'SUCCESS':
                                     sys.exit(1)
                         else:
-                            click.echo(pipeline_run_id)
+                            print_service.launch_run_id(pipeline_run_id)
                             if sync:
                                 pipeline_processed_status = cls.get_pipeline_processed_status(pipeline_run_id)
-                                click.echo(pipeline_processed_status)
+                                print_service.launch_run_status(pipeline_processed_status)
                                 if pipeline_processed_status != 'SUCCESS':
+                                    print_service.flush()
                                     sys.exit(1)
+                            print_service.flush()
             elif parameters:
                 if not quiet:
                     click.echo('You must specify pipeline for listing parameters', err=True)
@@ -252,14 +266,15 @@ class PipelineRunOperations(object):
                         required_parameters.append('instance_disk')
                     if cmd_template is None:
                         required_parameters.append('cmd_template')
-                    click.echo(', '.join(required_parameters))
+                    print_service.error(', '.join(required_parameters))
                     sys.exit(1)
             else:
                 if not quiet:
                     cls._check_gpu_and_cuda_compatibility(instance_type, docker_image=docker_image)
 
                 run_params_dict, pod_assign_policy = cls._apply_capacity_block_config_if_required(instance_type,
-                                                                                                  run_params_dict)
+                                                                                                  run_params_dict,
+                                                                                                  print_service)
 
                 if not yes:
                     click.confirm('Are you sure you want to schedule a run?', abort=True)
@@ -293,14 +308,17 @@ class PipelineRunOperations(object):
                         if pipeline_processed_status != 'SUCCESS':
                             sys.exit(1)
                 else:
-                    click.echo(pipeline_run_id)
+                    print_service.launch_run_id(pipeline_run_id)
                     if sync:
                         pipeline_processed_status = cls.get_pipeline_processed_status(pipeline_run_id)
-                        click.echo(pipeline_processed_status)
+                        print_service.launch_run_status(pipeline_processed_status)
                         if pipeline_processed_status != 'SUCCESS':
+                            print_service.flush()
                             sys.exit(1)
+                    print_service.flush()
 
         except click.exceptions.Abort:
+            print_service.flush()
             sys.exit(0)
 
     @classmethod
@@ -339,20 +357,14 @@ class PipelineRunOperations(object):
         return PipelineRun.get(identifier)
 
     @staticmethod
-    def print_pipeline_parameters_info(pipeline_model, pipeline_run_parameters):
-        click.echo('"{}" pipeline arguments:'.format(
-            PipelineRunOperations.build_image_name(pipeline_model.name, pipeline_run_parameters.version)))
+    def print_pipeline_parameters_info(pipeline_model, pipeline_run_parameters, print_service, output_format=None):
+        if not output_format:
+            click.echo('"{}" pipeline arguments:'.format(
+                PipelineRunOperations.build_image_name(pipeline_model.name, pipeline_run_parameters.version)))
         if len(pipeline_run_parameters.parameters) > 0:
-            for parameter in pipeline_run_parameters.parameters:
-                if parameter.required:
-                    click.echo('* --{}'.format(parameter.name))
-                else:
-                    click.echo('  --{} ({})'.format(parameter.name, parameter.parameter_type))
-                if parameter.value is not None:
-                    click.echo('    Default: {}'.format(parameter.value))
-                click.echo()
+            print_service.launch_run_parameters(pipeline_run_parameters.parameters)
         else:
-            click.echo('No parameters are configured')
+            print_service.error('No parameters are configured')
 
     @classmethod
     def get_pipeline_processed_status(cls, identifier):
@@ -382,14 +394,14 @@ class PipelineRunOperations(object):
         return image_name, image_tag
 
     @classmethod
-    def load_missing_args(cls, docker_image, instance_disk, instance_type, cmd_template):
+    def load_missing_args(cls, docker_image, instance_disk, instance_type, cmd_template, print_service=None):
         image_name, image_tag = cls.parse_image(docker_image)
 
         tool = Tool().find_tool_by_name(docker_image)
         if tool and 'id' in tool:
             tool_id = tool['id']
         else:
-            click.echo("Failed to find tool by name %s" % docker_image, err=True)
+            print_service.error("Failed to find tool by name %s" % docker_image, err=True)
             sys.exit(1)
 
         tool_settings = Tool().load_settings(tool_id, image_tag)
@@ -425,7 +437,7 @@ class PipelineRunOperations(object):
             return '{}@{}'.format(name, version)
 
     @classmethod
-    def _build_pretty_url(cls, pretty_url):
+    def _build_pretty_url(cls, pretty_url, print_service=None):
         path = str(pretty_url).strip('/')
         try:
             json.loads(path)
@@ -435,7 +447,8 @@ class PipelineRunOperations(object):
 
         parts = path.split('/')
         if len(parts) > 2:
-            click.echo("Pretty URL has an incorrect format. Expected formats: <domain>/<path> or <path>.", err=True)
+            print_service.error("Pretty URL has an incorrect format. Expected formats: <domain>/<path> or <path>.",
+                                err=True)
             sys.exit(1)
         if len(parts) == 1:
             return '{"path":"%s"}' % parts[0]
@@ -454,7 +467,7 @@ class PipelineRunOperations(object):
         return pipeline_name
 
     @classmethod
-    def _validate_run_params(cls, run_params_dict, all_user_roles):
+    def _validate_run_params(cls, run_params_dict, all_user_roles, print_service=None):
         if ROLE_ADMIN in all_user_roles:
             return
         default_system_parameters_dict = {param.name: param for param in Pipeline.get_default_run_parameters()}
@@ -464,7 +477,7 @@ class PipelineRunOperations(object):
                 if default_system_parameter.value != run_param_value:
                     allowed_roles = default_system_parameter.roles
                     if allowed_roles and len(allowed_roles.intersection(all_user_roles)) == 0:
-                        click.echo('An error has occurred while starting a job: "{}" parameter'
+                        print_service.error('An error has occurred while starting a job: "{}" parameter'
                                    ' is not permitted for overriding'.format(run_param_name), err=True)
                         sys.exit(1)
 
@@ -503,7 +516,7 @@ class PipelineRunOperations(object):
             click.echo(CPU_WITH_CUDA_WARN_MSG)
 
     @classmethod
-    def _apply_capacity_block_config_if_required(cls, instance_type, run_params_dict):
-        capacity_block_processor = CapacityBlockProcessor(instance_type)
+    def _apply_capacity_block_config_if_required(cls, instance_type, run_params_dict, print_service):
+        capacity_block_processor = CapacityBlockProcessor(instance_type, print_service)
         capacity_block_processor.verify(run_params_dict)
         return capacity_block_processor.apply_config(run_params_dict)

--- a/pipe-cli/src/utilities/printing/print_service.py
+++ b/pipe-cli/src/utilities/printing/print_service.py
@@ -38,7 +38,7 @@ class PrintService(object):
         pass
 
     @abstractmethod
-    def error(self, message):
+    def error(self, message, err=False, buf=False):
         pass
 
     @abstractmethod
@@ -69,6 +69,18 @@ class PrintService(object):
     def run_tags(self, run_model):
         pass
 
+    @abstractmethod
+    def launch_run_id(self, run_id):
+        pass
+
+    @abstractmethod
+    def launch_run_status(self, run_status):
+        pass
+
+    @abstractmethod
+    def launch_run_parameters(self, parameters):
+        pass
+
 
 class PrettyTablePrintService(PrintService):
 
@@ -84,8 +96,8 @@ class PrettyTablePrintService(PrintService):
         # not supported for text table
         pass
 
-    def error(self, message):
-        click.echo(message)
+    def error(self, message, err=False, buf=False):
+        click.echo(message, err=err)
 
     def empty_runs(self, run_filter=None):
         click.echo('No data is available for the request')
@@ -207,22 +219,62 @@ class PrettyTablePrintService(PrintService):
             click.echo('No tags are configured')
         click.echo()
 
+    def launch_run_id(self, run_id):
+        click.echo(run_id)
+
+    def launch_run_status(self, run_status):
+        click.echo(run_status)
+
+    def launch_run_parameters(self, parameters):
+        for parameter in parameters:
+            if parameter.required:
+                click.echo('* --{}'.format(parameter.name))
+            else:
+                click.echo('  --{} ({})'.format(parameter.name, parameter.parameter_type))
+            if parameter.value is not None:
+                click.echo('    Default: {}'.format(parameter.value))
+            click.echo()
+
 
 class JsonPrintService(PrintService):
 
     def __init__(self):
-        self.__buffer = None
+        self.__buffer = {}
 
     @staticmethod
     def _to_json(obj):
         return json.dumps(obj, default=str, indent=2, ensure_ascii=False)
 
     def flush(self):
-        if self.__buffer is not None:
+        if self.__buffer:
             click.echo(self._to_json(self.__buffer))
 
-    def error(self, message):
-        click.echo(self._to_json({'error': message}))
+    def launch_run_id(self, run_id):
+        self.__buffer['runId'] = _to_int_value(run_id)
+
+    def launch_run_status(self, status):
+        self.__buffer['status'] = status
+
+    def launch_run_parameters(self, parameters):
+        run_params = []
+        for parameter in parameters:
+            run_param = {
+                'name': parameter.name,
+                'type': parameter.parameter_type,
+                'required': parameter.required
+            }
+            if parameter.value is not None:
+                run_param['value'] = parameter.value
+            run_params.append(run_param)
+        click.echo(self._to_json(run_params))
+
+    def error(self, message, err=False, buf=False):
+        if buf:
+            if not 'error' in self.__buffer:
+                self.__buffer['error'] = [message]
+            else:
+                self.__buffer['error'].append(message)
+        click.echo(self._to_json({'error': message}), err=err)
 
     def empty_runs(self, run_filter=None):
         payload = {


### PR DESCRIPTION
relates to #4349

The current PR provides implementation of `--output-format` option for `pipe run` command.

- `--output-format` works in combination with `--yes` only
- `--output-format` force enables `--quite` mode  