### PR TITLE
Issue #4198: Support Azure Data Lake folders removal with CLI

### DIFF
--- a/pipe-cli/src/model/data_storage_wrapper.py
+++ b/pipe-cli/src/model/data_storage_wrapper.py
@@ -431,7 +431,8 @@ class AzureBucketWrapper(CloudDataStorageWrapper):
     def get_delete_manager(self, events, versioning):
         if versioning:
             raise RuntimeError('Versioning is not supported by AZURE cloud provider')
-        return AzureDeleteManager(self._blob_service(read=True, write=True), events, self.bucket, self.is_hns_enabled)
+        return AzureDeleteManager(self._blob_service(read=True, write=True), events, self.bucket, self.is_file(),
+                                  self.is_hns_enabled)
 
     def _blob_service(self, read, write):
         if write or not self.service:

--- a/pipe-cli/src/model/data_storage_wrapper.py
+++ b/pipe-cli/src/model/data_storage_wrapper.py
@@ -30,6 +30,7 @@ from urllib.parse import urlparse
 import click
 import requests
 import sys
+from ..api.cloud_region import CloudRegion
 from ..api.data_storage import DataStorage
 from ..config import ConfigNotFoundError
 from ..utilities.storage.s3 import S3BucketOperations
@@ -392,6 +393,7 @@ class AzureBucketWrapper(CloudDataStorageWrapper):
     def __init__(self, bucket, path):
         super(AzureBucketWrapper, self).__init__(bucket, path)
         self.service = None
+        self.is_hns_enabled = False
 
     @classmethod
     def build_wrapper(cls, root_bucket, relative_path, versioning=False, init=True):
@@ -400,7 +402,20 @@ class AzureBucketWrapper(CloudDataStorageWrapper):
         wrapper = AzureBucketWrapper(root_bucket, relative_path)
         if init:
             StorageOperations.init_wrapper(wrapper, versioning=versioning)
+            if not wrapper.is_file_flag:
+                wrapper.is_hns_enabled = cls._is_hns_enabled(root_bucket)
         return wrapper
+
+    @staticmethod
+    def _is_hns_enabled(bucket):
+        region_code = bucket.region
+        if not region_code:
+            return False
+        for region in CloudRegion.get_cloud_regions('azure'):
+            rid = region.get('regionId')
+            if rid and rid.lower() == region_code.lower():
+                return bool(region.get('hierarchicalStorageNamespace', False))
+        return False
 
     def get_type(self):
         return WrapperType.AZURE
@@ -416,7 +431,7 @@ class AzureBucketWrapper(CloudDataStorageWrapper):
     def get_delete_manager(self, events, versioning):
         if versioning:
             raise RuntimeError('Versioning is not supported by AZURE cloud provider')
-        return AzureDeleteManager(self._blob_service(read=True, write=True), events, self.bucket)
+        return AzureDeleteManager(self._blob_service(read=True, write=True), events, self.bucket, self.is_hns_enabled)
 
     def _blob_service(self, read, write):
         if write or not self.service:

--- a/pipe-cli/src/utilities/storage/azure.py
+++ b/pipe-cli/src/utilities/storage/azure.py
@@ -175,17 +175,23 @@ class AzureDeleteManager(AzureManager, AbstractDeleteManager):
             blob_names_for_deletion = []
             for item in self.listing_manager.list_items(prefix, recursive=True, show_all=True):
                 if item.name == prefix and check_file:
-                    # case: only file to delete
+                    # Typically, this branch is used only for files. However, in ADLS Gen2 storage,
+                    # there is no distinction between files and folders. If a path does not end with '/',
+                    # and, consequently, the check_file flag is set to True, this branch will be executed.
+                    # This way, if the item is not a file, an error will occur.
                     blob_names_for_deletion = [item.name]
                     break
                 if self.__file_under_folder(item.name, prefix):
                     blob_names_for_deletion.append(item.name)
+                elif self.is_hns_enabled and item.name == prefix:
+                    # root folder itself
+                    blob_names_for_deletion.append(item.name)
             deleted_blob_names = []
             # For ADLS Gen2 storage, folders must be deleted as well as files. Non-empty folders cannot be deleted,
             # so all files within a folder should be deleted before deleting the folder itself.
-            blob_names = blob_names_for_deletion.sort(key=len, reverse=True) if self.is_hns_enabled \
-                else blob_names_for_deletion
-            for blob_name in blob_names:
+            if self.is_hns_enabled:
+                blob_names_for_deletion.sort(key=len, reverse=True)
+            for blob_name in blob_names_for_deletion:
                 deleted = self.__delete_blob(blob_name, exclude, include, prefix=prefix)
                 if deleted:
                     deleted_blob_names.append(blob_name)

--- a/pipe-cli/src/utilities/storage/azure.py
+++ b/pipe-cli/src/utilities/storage/azure.py
@@ -151,11 +151,12 @@ class AzureListingManager(AzureManager, AbstractListingManager):
 
 class AzureDeleteManager(AzureManager, AbstractDeleteManager):
 
-    def __init__(self, blob_service, events, bucket):
+    def __init__(self, blob_service, events, bucket, is_hns_enabled=False):
         super(AzureDeleteManager, self).__init__(blob_service, events)
         self.bucket = bucket
         self.delimiter = StorageOperations.PATH_SEPARATOR
         self.listing_manager = AzureListingManager(self.service, self.bucket)
+        self.is_hns_enabled = is_hns_enabled
 
     def delete_items(self, relative_path, recursive=False, exclude=[], include=[], version=None, hard_delete=False,
                      page_size=None):
@@ -174,12 +175,17 @@ class AzureDeleteManager(AzureManager, AbstractDeleteManager):
             blob_names_for_deletion = []
             for item in self.listing_manager.list_items(prefix, recursive=True, show_all=True):
                 if item.name == prefix and check_file:
+                    # case: only file to delete
                     blob_names_for_deletion = [item.name]
                     break
                 if self.__file_under_folder(item.name, prefix):
                     blob_names_for_deletion.append(item.name)
             deleted_blob_names = []
-            for blob_name in blob_names_for_deletion:
+            # For ADLS Gen2 storage, folders must be deleted as well as files. Non-empty folders cannot be deleted,
+            # so all files within a folder should be deleted before deleting the folder itself.
+            blob_names = blob_names_for_deletion.sort(key=len, reverse=True) if self.is_hns_enabled \
+                else blob_names_for_deletion
+            for blob_name in blob_names:
                 deleted = self.__delete_blob(blob_name, exclude, include, prefix=prefix)
                 if deleted:
                     deleted_blob_names.append(blob_name)

--- a/pipe-cli/src/utilities/storage/azure.py
+++ b/pipe-cli/src/utilities/storage/azure.py
@@ -151,11 +151,12 @@ class AzureListingManager(AzureManager, AbstractListingManager):
 
 class AzureDeleteManager(AzureManager, AbstractDeleteManager):
 
-    def __init__(self, blob_service, events, bucket, is_hns_enabled=False):
+    def __init__(self, blob_service, events, bucket, is_file, is_hns_enabled=False):
         super(AzureDeleteManager, self).__init__(blob_service, events)
         self.bucket = bucket
         self.delimiter = StorageOperations.PATH_SEPARATOR
         self.listing_manager = AzureListingManager(self.service, self.bucket)
+        self.is_file = is_file
         self.is_hns_enabled = is_hns_enabled
 
     def delete_items(self, relative_path, recursive=False, exclude=[], include=[], version=None, hard_delete=False,
@@ -167,6 +168,8 @@ class AzureDeleteManager(AzureManager, AbstractDeleteManager):
         if prefix.endswith(self.delimiter):
             prefix = prefix[:-1]
             check_file = False
+        elif self.is_hns_enabled and not self.is_file:
+            check_file = False
         if not recursive:
             deleted = self.__delete_blob(prefix, exclude, include)
             if deleted:
@@ -175,10 +178,7 @@ class AzureDeleteManager(AzureManager, AbstractDeleteManager):
             blob_names_for_deletion = []
             for item in self.listing_manager.list_items(prefix, recursive=True, show_all=True):
                 if item.name == prefix and check_file:
-                    # Typically, this branch is used only for files. However, in ADLS Gen2 storage,
-                    # there is no distinction between files and folders. If a path does not end with '/',
-                    # and, consequently, the check_file flag is set to True, this branch will be executed.
-                    # This way, if the item is not a file, an error will occur.
+                    # Typically, this branch is used only for files.
                     blob_names_for_deletion = [item.name]
                     break
                 if self.__file_under_folder(item.name, prefix):

--- a/pipe-cli/src/utilities/storage/azure.py
+++ b/pipe-cli/src/utilities/storage/azure.py
@@ -89,6 +89,9 @@ class AzureListingManager(AzureManager, AbstractListingManager):
                                                   prefix=prefix if relative_path else None,
                                                   num_results=page_size if not show_all else None,
                                                   delimiter=StorageOperations.PATH_SEPARATOR if not recursive else None)
+        # TODO: When using ADLS Gen2 storage with the recursive flag enabled, the list_blobs function
+        #  treats both files and folders as Blob class objects. As a result, it cannot accurately identify
+        #  whether an item is a file or a folder, and all items are classified as files.
         absolute_items = [self._to_storage_item(blob) for blob in blobs_generator]
         return absolute_items if recursive else [self._to_local_item(item, prefix) for item in absolute_items]
 


### PR DESCRIPTION
relates to #4198

Provides implementation for ADLS Gen2 folders removal with `pipe storage rm` command.