### PR TITLE
issue_4368_launch_reservation

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -824,9 +824,9 @@ public class SystemPreferences {
                     new TypeReference<Map<String, ResourcesParameter>>() {},
                     LAUNCH_GROUP, isNullOrValidJson(new TypeReference<Map<String, ResourcesParameter>>() {}));
     public static final ObjectPreference<Map<String, Object>> LAUNCH_RESERVATION_PARAMS =
-            new ObjectPreference<>("launch.reservation.parameters", null,
+            new ObjectPreference<>("launch.reservation.parameters", Collections.emptyMap(),
                     new TypeReference<Map<String, Object>>() {},
-                    LAUNCH_GROUP, isNullOrValidJson(new TypeReference<Map<String, Object>>() {}));
+                    LAUNCH_GROUP, isNullOrValidJson(new TypeReference<Map<String, Object>>() {}), true);
     public static final IntPreference LAUNCH_CONTAINER_MEMORY_RESOURCE_REQUEST = new IntPreference(
             "launch.container.memory.resource.request", 1, LAUNCH_GROUP, isGreaterThan(0));
     public static final IntPreference LAUNCH_SERVERLESS_WAIT_COUNT = new IntPreference(

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/ArchiveRunServiceSpringTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/ArchiveRunServiceSpringTest.java
@@ -579,7 +579,7 @@ public class ArchiveRunServiceSpringTest extends AbstractManagerTest {
                 Arrays.asList(run1.getId(), run2.getId(), run3.getId(), runAfterTestDate.getId())))
                 .hasSize(4);
 
-        verifyDryRunInvoked(7, 7 * 2);
+        verifyDryRunInvoked(7, 8 * 2);
     }
 
     private PipelineRun run() {


### PR DESCRIPTION
Issue #4368, making preference - launch.reservation.parameter visible and not null.