### PR TITLE
Issue #4361: Microsoft Graph API notifications implementation

### DIFF
--- a/deploy/docker/cp-notifier/config/application.properties
+++ b/deploy/docker/cp-notifier/config/application.properties
@@ -10,6 +10,7 @@ spring.datasource.hikari.maximumPoolSize=${CP_NOTIFIER_DB_POOL_SIZE:1}
 notification.scheduler.delay=30000
 notification.enable.smtp=${CP_NOTIFIER_SMTP_ENABLE:true}
 notification.enable.ui=${CP_NOTIFIER_UI_ENABLE:false}
+notification.enable.azure=${CP_NOTIFIER_AZ_ENABLE:false}
 
 submit.threads=2
 
@@ -26,3 +27,11 @@ email.notification.retry.count=3
 email.notification.retry.delay=1000
 #in ms
 email.notification.letter.delay=1000
+
+# azure api
+notification.azure.tenant.id=${CP_NOTIFIER_AZ_TENANT_ID:}
+notification.azure.client.id=${CP_NOTIFIER_AZ_CLIENT_ID:}
+notification.azure.client.secret=${CP_NOTIFIER_AZ_CLIENT_SECRET:}
+notification.azure.scopes=${CP_NOTIFIER_AZ_SCOPES:https://graph.microsoft.com/.default}
+notification.azure.sender=${CP_NOTIFIER_AZ_SENDER:}
+notification.azure.dry-run=${CP_NOTIFIER_AZ_DRY_RUN:false}

--- a/notifier/smtp/build.gradle
+++ b/notifier/smtp/build.gradle
@@ -47,6 +47,12 @@ dependencies {
     compile group: 'org.apache.velocity', name: 'velocity', version: '1.7'
     compile group: 'org.apache.velocity', name: 'velocity-tools', version: '2.0'
 
+    // Azure
+    // azure-identity uses Reactor at runtime; keep explicit so it is not dropped from the classpath
+    compile group: 'io.projectreactor', name: 'reactor-core', version: '3.4.34'
+    compile group: 'com.azure', name: 'azure-identity', version: '1.18.2'
+    compile group: 'com.microsoft.graph', name: 'microsoft-graph', version: '6.62.0'
+
     //Tests
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'com.h2database', name: 'h2', version: '1.4.197'

--- a/notifier/smtp/build.gradle
+++ b/notifier/smtp/build.gradle
@@ -19,6 +19,28 @@ repositories {
 
 ext { springBootVersion = '1.5.2.RELEASE' }
 
+// Azure SDK (azure-core 1.5x+) requires Jackson 2.10+ (e.g. com.fasterxml.jackson.databind.cfg.MapperBuilder).
+// :core and Spring Boot 1.5 still pull Jackson 2.8.x; force a single aligned stack for this module only.
+ext.jacksonVersionForAzure = '2.10.5'
+
+// Microsoft Kiota JSON (microsoft-graph) calls JsonParser.parseReader(Reader); that API exists from Gson 2.8.6+.
+// Spring Boot 1.5 BOM still resolves an older Gson; pin a current 2.x line for this module.
+ext.gsonVersionForGraph = '2.10.1'
+
+// This part resolves transitive dependencies:
+configurations.all {
+    resolutionStrategy.eachDependency { details ->
+        if (details.requested.group?.startsWith('com.fasterxml.jackson')) {
+            details.useVersion jacksonVersionForAzure
+            details.because('Azure SDK / Graph require Jackson 2.10+; align on 2.10.5 minimum; :core still references 2.8.x')
+        }
+        if (details.requested.group == 'com.google.code.gson' && details.requested.name == 'gson') {
+            details.useVersion gsonVersionForGraph
+            details.because('Microsoft Kiota / Graph require Gson with JsonParser.parseReader(Reader)')
+        }
+    }
+}
+
 dependencies {
     // Spring Boot
     configurations {
@@ -37,7 +59,10 @@ dependencies {
 
     //DB
     compile group: 'org.postgresql', name: 'postgresql', version: '42.7.3'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.8.7'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: jacksonVersionForAzure
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersionForAzure
+    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: jacksonVersionForAzure
+    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-xml', version: jacksonVersionForAzure
     compile('org.springframework.boot:spring-boot-starter-data-jpa')
     compile group: 'com.zaxxer', name: 'HikariCP', version: '3.2.0'
     compile group: 'org.hibernate', name: 'hibernate-java8', version: '5.0.12.Final'
@@ -48,6 +73,7 @@ dependencies {
     compile group: 'org.apache.velocity', name: 'velocity-tools', version: '2.0'
 
     // Azure
+    compile group: 'com.google.code.gson', name: 'gson', version: gsonVersionForGraph
     // azure-identity uses Reactor at runtime; keep explicit so it is not dropped from the classpath
     compile group: 'io.projectreactor', name: 'reactor-core', version: '3.4.34'
     compile group: 'com.azure', name: 'azure-identity', version: '1.18.2'

--- a/notifier/smtp/src/main/java/com/epam/pipeline/notifier/service/task/MicrosoftGraphAPINotificationManager.java
+++ b/notifier/smtp/src/main/java/com/epam/pipeline/notifier/service/task/MicrosoftGraphAPINotificationManager.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.notifier.service.task;
+
+import com.azure.identity.ClientSecretCredential;
+import com.azure.identity.ClientSecretCredentialBuilder;
+import com.epam.pipeline.entity.notification.NotificationMessage;
+import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.notifier.entity.message.MessageText;
+import com.epam.pipeline.notifier.repository.UserRepository;
+import com.epam.pipeline.notifier.service.TemplateService;
+import com.microsoft.graph.models.BodyType;
+import com.microsoft.graph.models.EmailAddress;
+import com.microsoft.graph.models.ItemBody;
+import com.microsoft.graph.models.Message;
+import com.microsoft.graph.models.Recipient;
+import com.microsoft.graph.serviceclient.GraphServiceClient;
+import com.microsoft.graph.users.item.sendmail.SendMailPostRequestBody;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.validator.EmailValidator;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Sends pipeline notifications through Microsoft Graph using the
+ * <a href="https://learn.microsoft.com/en-us/graph/api/user-sendmail">sendMail</a> API.
+ * <p>
+ * The delegated mailbox is {@code notification.azure.sender}. Authentication uses an Azure AD
+ * application (client credentials): {@code notification.azure.tenant.id},
+ * {@code notification.azure.client.id}, and {@code notification.azure.client.secret}.
+ * Scopes default to Graph application permissions (for example {@code https://graph.microsoft.com/.default}).
+ * </p>
+ * <p>
+ * When {@code notification.azure.dry-run} is {@code true}, the Graph {@code sendMail} request is not executed;
+ * instead, recipients, subject, and resolved body are written to the application log.
+ * </p>
+ *
+ * @see NotificationManager
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(name = "notification.enable.azure", havingValue = "true")
+public class MicrosoftGraphAPINotificationManager implements NotificationManager {
+
+    private final String tenantId;
+    private final String clientId;
+    private final String clientSecret;
+    private final String[] scopes;
+    private final String sender;
+    private final boolean dryRun;
+    private final UserRepository userRepository;
+    private final TemplateService templateService;
+
+    /**
+     * @param tenantId        Azure AD tenant (directory) ID
+     * @param clientId        application (client) ID of the registered app used for Graph
+     * @param clientSecret    client secret for the application
+     * @param scopes          OAuth scopes (typically {@code https://graph.microsoft.com/.default})
+     * @param sender          email of the mailbox that sends mail
+     * @param dryRun          when {@code true}, skip {@code sendMail} and only log the composed message
+     * @param userRepository  a {@link UserRepository} object
+     * @param templateService builds subject and body (Velocity) from the notification message
+     */
+    public MicrosoftGraphAPINotificationManager(@Value("${notification.azure.tenant.id}") final String tenantId,
+                                                @Value("${notification.azure.client.id}") final String clientId,
+                                                @Value("${notification.azure.client.secret}") final String clientSecret,
+                                                @Value("${notification.azure.scopes}") final String[] scopes,
+                                                @Value("${notification.azure.sender}") final String sender,
+                                                @Value("${notification.azure.dry-run}") final boolean dryRun,
+                                                final UserRepository userRepository,
+                                                final TemplateService templateService) {
+        this.tenantId = tenantId;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.scopes = scopes;
+        this.sender = sender;
+        this.dryRun = dryRun;
+        this.userRepository = userRepository;
+        this.templateService = templateService;
+    }
+
+    /**
+     * Builds a Graph {@link Message}, authenticates with client credentials, and posts {@code sendMail}
+     * for {@link #sender}, unless there are no valid recipients or dry-run is enabled.
+     *
+     * @param message notification row
+     */
+    @Override
+    public void notifySubscribers(final NotificationMessage message) {
+        log.info("Trying to send message #{} over Microsoft Graph API", message.getId());
+        final Message emailMessage = toEmailMessage(message);
+        if (CollectionUtils.isEmpty(emailMessage.getToRecipients())
+                && CollectionUtils.isEmpty(emailMessage.getCcRecipients())) {
+            log.info("Microsoft Graph mail for message #{} skipped: no valid recipients", message.getId());
+            return;
+        }
+
+        final ClientSecretCredential credential = new ClientSecretCredentialBuilder()
+                .tenantId(tenantId)
+                .clientId(clientId)
+                .clientSecret(clientSecret)
+                .build();
+        final GraphServiceClient graphClient = new GraphServiceClient(credential, scopes);
+
+        final SendMailPostRequestBody requestBody = new SendMailPostRequestBody();
+        requestBody.setMessage(emailMessage);
+        requestBody.setSaveToSentItems(false);
+
+        if (dryRun) {
+            logDryRunMailPreview(message.getId(), emailMessage);
+            return;
+        }
+
+        graphClient
+                .users()
+                .byUserId(sender)
+                .sendMail()
+                .post(requestBody);
+    }
+
+    private Message toEmailMessage(final NotificationMessage message) {
+        final MessageText messageText = templateService.buildMessageText(message);
+
+        final Message emailMessage = new Message();
+        emailMessage.setSubject(messageText.getSubject());
+
+        final ItemBody body = new ItemBody();
+        body.setContent(messageText.getBody());
+        body.setContentType(BodyType.Html);
+        emailMessage.setBody(body);
+
+        emailMessage.setToRecipients(buildToRecipients(message));
+        emailMessage.setCcRecipients(buildCcRecipients(message));
+
+        return emailMessage;
+    }
+
+    private List<Recipient> buildToRecipients(final NotificationMessage message) {
+        if (message.getToUserId() == null) {
+            return Collections.emptyList();
+        }
+        final PipelineUser targetUser = userRepository.findOne(message.getToUserId());
+        if (targetUser == null) {
+            log.info("Cannot find user with id {} for message {}", message.getToUserId(), message.getId());
+            return Collections.emptyList();
+        }
+        final String address = targetUser.getEmail();
+        if (!isValidEmail(address)) {
+            return Collections.emptyList();
+        }
+        return Collections.singletonList(toRecipient(address));
+    }
+
+    private List<Recipient> buildCcRecipients(final NotificationMessage message) {
+        if (CollectionUtils.isEmpty(message.getCopyUserIds())) {
+            return Collections.emptyList();
+        }
+        return userRepository.findByIdIn(message.getCopyUserIds()).stream()
+                .map(PipelineUser::getEmail)
+                .filter(this::isValidEmail)
+                .map(this::toRecipient)
+                .collect(Collectors.toList());
+    }
+
+    private Recipient toRecipient(final String emailAddress) {
+        final Recipient recipient = new Recipient();
+        final EmailAddress email = new EmailAddress();
+        email.setAddress(emailAddress);
+        recipient.setEmailAddress(email);
+        return recipient;
+    }
+
+    private boolean isValidEmail(final String email) {
+        return EmailValidator.getInstance().isValid(email);
+    }
+
+    private void logDryRunMailPreview(final Long messageId, final Message emailMessage) {
+        log.info("[DRY-RUN #{}] — To recipients: {}", messageId,
+                formatRecipientAddresses(emailMessage.getToRecipients()));
+        log.info("[DRY-RUN #{}] — CC recipients: {}", messageId,
+                formatRecipientAddresses(emailMessage.getCcRecipients()));
+        log.info("[DRY-RUN #{}] — Subject: {}", messageId, emailMessage.getSubject());
+        final String resolvedBody = Optional.ofNullable(emailMessage.getBody())
+                .map(ItemBody::getContent)
+                .orElse("");
+        log.info("[DRY-RUN #{}] — Body:\n{}", messageId, resolvedBody);
+    }
+
+    private String formatRecipientAddresses(final List<Recipient> recipients) {
+        if (CollectionUtils.isEmpty(recipients)) {
+            return "(none)";
+        }
+        return recipients.stream()
+                .map(r -> Optional.ofNullable(r.getEmailAddress()).map(EmailAddress::getAddress).orElse("?"))
+                .collect(Collectors.joining(", "));
+    }
+}

--- a/notifier/smtp/src/main/resources/application.properties
+++ b/notifier/smtp/src/main/resources/application.properties
@@ -10,6 +10,7 @@ notification.scheduler.delay=30000
 
 notification.enable.smtp=true
 notification.enable.ui=false
+notification.enable.azure=false
 
 submit.threads=2
 
@@ -26,3 +27,12 @@ email.notification.retry.count=3
 email.notification.retry.delay=100
 #in ms
 email.notification.letter.delay=100
+
+# azure api
+notification.azure.tenant.id=${CP_NOTIFIER_AZ_TENANT_ID:}
+notification.azure.client.id=${CP_NOTIFIER_AZ_CLIENT_ID:}
+notification.azure.client.secret=${CP_NOTIFIER_AZ_CLIENT_SECRET:}
+# comma separated values:
+notification.azure.scopes=${CP_NOTIFIER_AZ_SCOPES:https://graph.microsoft.com/.default}
+notification.azure.sender=${CP_NOTIFIER_AZ_SENDER:}
+notification.azure.dry-run=${CP_NOTIFIER_AZ_DRY_RUN:false}


### PR DESCRIPTION
relates to #4361

Introduced a new application properties:
-  `notification.enable.azure` (`$CP_NOTIFIER_AZ_ENABLE`) - enables Azure API based notifications
- `notification.azure.tenant.id` (`$CP_NOTIFIER_AZ_TENANT_ID`) - Azure AD tenant (directory) ID
- `notification.azure.client.id` (`$CP_NOTIFIER_AZ_CLIENT_ID`) - application (client) ID of the registered app used for Microsoft Graph API
- `notification.azure.client.secret` (`$CP_NOTIFIER_AZ_CLIENT_SECRET`) - client secret for the application
- `notification.azure.scopes` (`$CP_NOTIFIER_AZ_SCOPES`) - comma separated list with OAuth scopes, default `https://graph.microsoft.com/.default`
- `notification.azure.sender` (`$CP_NOTIFIER_AZ_SENDER`) - email of the mailbox that sends mails
- `notification.azure.dry-run` (`$CP_NOTIFIER_AZ_DRY_RUN`) - when `true` only log the composed message (default: `false`)