### PR TITLE
Issue #4360: Support file system autoscaling for capacity blocks

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/cluster/ClusterApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/cluster/ClusterApiService.java
@@ -39,6 +39,7 @@ import com.epam.pipeline.entity.cluster.monitoring.gpu.GpuMonitoringStats;
 import com.epam.pipeline.entity.cluster.monitoring.platform.network.NetworkEventFilter;
 import com.epam.pipeline.entity.cluster.monitoring.platform.histogram.HistogramBin;
 import com.epam.pipeline.entity.cluster.monitoring.platform.histogram.HistogramType;
+import com.epam.pipeline.entity.pipeline.DiskAttachRequest;
 import com.epam.pipeline.entity.pipeline.run.RunInfo;
 import com.epam.pipeline.manager.cluster.EdgeServiceManager;
 import com.epam.pipeline.manager.cluster.InstanceOfferManager;
@@ -154,6 +155,12 @@ public class ClusterApiService {
     @PreAuthorize(NODE_READ)
     public List<NodeDisk> loadNodeDisks(final String name) {
         return nodeDiskManager.loadByNodeId(name);
+    }
+
+    @PreAuthorize(ADMIN_ONLY)
+    public NodeInstance attachDiskToNode(final String name, final DiskAttachRequest request) {
+        nodesManager.attachDiskToNode(name, request);
+        return nodesManager.getKubeOrCloudNode(name, MachineType.KUBE, null);
     }
 
     public String buildEdgeExternalUrl(final String region) {

--- a/api/src/main/java/com/epam/pipeline/acl/cluster/ClusterApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/cluster/ClusterApiService.java
@@ -159,8 +159,7 @@ public class ClusterApiService {
 
     @PreAuthorize(ADMIN_ONLY)
     public NodeInstance attachDiskToNode(final String name, final DiskAttachRequest request) {
-        nodesManager.attachDiskToNode(name, request);
-        return nodesManager.getKubeOrCloudNode(name, MachineType.KUBE, null);
+        return nodesManager.attachDiskToNode(name, request);
     }
 
     public String buildEdgeExternalUrl(final String region) {

--- a/api/src/main/java/com/epam/pipeline/controller/cluster/ClusterController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/cluster/ClusterController.java
@@ -38,6 +38,7 @@ import com.epam.pipeline.entity.cluster.monitoring.gpu.GpuMonitoringStats;
 import com.epam.pipeline.entity.cluster.monitoring.platform.network.NetworkEventFilter;
 import com.epam.pipeline.entity.cluster.monitoring.platform.histogram.HistogramBin;
 import com.epam.pipeline.entity.cluster.monitoring.platform.histogram.HistogramType;
+import com.epam.pipeline.entity.pipeline.DiskAttachRequest;
 import com.epam.pipeline.entity.pipeline.run.RunInfo;
 import com.epam.pipeline.manager.cluster.MonitoringReportType;
 import io.swagger.annotations.Api;
@@ -316,6 +317,19 @@ public class ClusterController extends AbstractRestController {
     @ApiResponses(@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION))
     public Result<List<NodeDisk>> loadNodeDisks(@PathVariable(value = NAME) final String name) {
         return Result.success(clusterApiService.loadNodeDisks(name));
+    }
+
+    @PostMapping(value = "/cluster/node/{name}/disk/attach")
+    @ApiOperation(
+            value = "Creates and attaches a new disk to the node's cloud instance.",
+            notes = "Creates and attaches a new disk by node name (on AWS, the EC2 instance id). "
+                    + "Disk size is specified in GB. Intended for Capacity Blocks and other cases "
+                    + "where the instance is not tagged by pipeline run id.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<NodeInstance> attachDiskToNode(@PathVariable(value = NAME) final String name,
+                                                 @RequestBody final DiskAttachRequest request) {
+        return Result.success(clusterApiService.attachDiskToNode(name, request));
     }
 
     @PostMapping("/cluster/dnsrecord")

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacade.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacade.java
@@ -97,6 +97,11 @@ public interface CloudFacade {
     void attachDisk(Long regionId, Long runId, DiskAttachRequest request, Map<String, String> tags);
 
     /**
+     * Creates and attaches a new disk to the cloud instance identified by node name.
+     */
+    void attachDiskToNode(Long regionId, String nodeName, DiskAttachRequest request, Map<String, String> tags);
+
+    /**
      * Loads all disks attached to an instance associated with run including os, data and swap disks.
      */
     List<InstanceDisk> loadDisks(Long regionId, Long runId);

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacadeImpl.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/CloudFacadeImpl.java
@@ -276,6 +276,13 @@ public class CloudFacadeImpl implements CloudFacade {
     }
 
     @Override
+    public void attachDiskToNode(final Long regionId, final String nodeName, final DiskAttachRequest request,
+                                 final Map<String, String> tags) {
+        final AbstractCloudRegion region = regionManager.loadOrDefault(regionId);
+        getInstanceService(region).attachDiskToInstance(region, nodeName, request, tags);
+    }
+
+    @Override
     public List<InstanceDisk> loadDisks(final Long regionId, final Long runId) {
         final AbstractCloudRegion region = regionManager.loadOrDefault(regionId);
         return getInstanceService(region).loadDisks(region, runId);

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/CloudInstanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/CloudInstanceService.java
@@ -202,6 +202,15 @@ public interface CloudInstanceService<T extends AbstractCloudRegion>
     void attachDisk(T region, Long runId, DiskAttachRequest request, Map<String, String> tags);
 
     /**
+     * Creates and attaches a new disk to the cloud instance identified by node name.
+     */
+    default void attachDiskToInstance(T region, String nodeName, DiskAttachRequest request,
+                                      Map<String, String> tags) {
+        throw new UnsupportedOperationException(String.format(
+                "Attaching disk to instance by node name is not supported for cloud provider %s", getProvider()));
+    }
+
+    /**
      * Loads all disks attached to cloud instance.
      * @param region
      * @param runId

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSInstanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/aws/AWSInstanceService.java
@@ -281,6 +281,13 @@ public class AWSInstanceService implements CloudInstanceService<AwsRegion> {
     }
 
     @Override
+    public void attachDiskToInstance(final AwsRegion region, final String nodeName, final DiskAttachRequest request,
+                                     final Map<String, String> tags) {
+        ec2Helper.createAndAttachVolumeToInstance(nodeName, request.getSize(), region,
+                region.getKmsKeyArn(), tags);
+    }
+
+    @Override
     public List<InstanceDisk> loadDisks(final AwsRegion region, final Long runId) {
         return ec2Helper.loadAttachedVolumes(String.valueOf(runId), region);
     }

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/aws/EC2Helper.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/aws/EC2Helper.java
@@ -312,6 +312,20 @@ public class EC2Helper implements EC2GpuHelper {
                         STOPPING_STATE, STOPPED_STATE));
     }
 
+    /**
+     * Retrieves running or paused instance by instance ID.
+     * @param instanceId Instance id.
+     * @param awsRegion Instance aws region.
+     * @return Required instance.
+     */
+    public Instance getAliveInstanceById(final String instanceId, final AwsRegion awsRegion) {
+        return findInstance(instanceId, awsRegion)
+                .orElseThrow(() -> new AwsEc2Exception(String.format(
+                        "No alive instance with id '%s' found in %s region "
+                                + "(expected instance states: running, pending, stopping, or stopped)",
+                        instanceId, awsRegion)));
+    }
+
     private Instance getInstance(final String runId, final AwsRegion awsRegion, final Filter... filters) {
         final AmazonEC2 client = getEC2Client(awsRegion);
         final List<Reservation> reservations = client.describeInstances(new DescribeInstancesRequest()
@@ -376,14 +390,29 @@ public class EC2Helper implements EC2GpuHelper {
     public void createAndAttachVolume(final String runId, final Long size,
                                       final AwsRegion awsRegion, final String kmsKeyArn,
                                       final Map<String, String> tags) {
-        final AmazonEC2 client = getEC2Client(awsRegion);
         final Instance instance = getAliveInstance(runId, awsRegion);
+        createAndAttachVolumeToInstance(instance, size, awsRegion, kmsKeyArn, tags);
+    }
+
+    public void createAndAttachVolumeToInstance(final String ec2InstanceId, final Long size,
+                                                final AwsRegion awsRegion, final String kmsKeyArn,
+                                                final Map<String, String> tags) {
+        final Instance instance = getAliveInstanceById(ec2InstanceId, awsRegion);
+        createAndAttachVolumeToInstance(instance, size, awsRegion, kmsKeyArn, tags);
+    }
+
+    private void createAndAttachVolumeToInstance(final Instance instance, final Long size,
+                                                 final AwsRegion awsRegion, final String kmsKeyArn,
+                                                 final Map<String, String> tags) {
+        final AmazonEC2 client = getEC2Client(awsRegion);
         final String device = getVacantDeviceName(instance);
         final String zone = getAvailabilityZone(instance);
         final Volume volume = createVolume(client, size, zone, kmsKeyArn);
         tryAttachVolume(client, instance, volume, device);
         enableVolumeDeletionOnInstanceTermination(client, instance.getInstanceId(), device);
-        createTags(client, tags, Collections.singletonList(volume.getVolumeId()));
+        if (MapUtils.isNotEmpty(tags)) {
+            createTags(client, tags, Collections.singletonList(volume.getVolumeId()));
+        }
     }
 
     public void deleteInstanceTags(final AwsRegion awsRegion, final String runId, final Set<String> tags) {

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/NodesManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/NodesManager.java
@@ -466,6 +466,21 @@ public class NodesManager {
                 cloudFacade.loadDisks(region.getId(), run.getId()));
     }
 
+    /**
+     * Attaches a new disk to the node's cloud instance (region is taken from the node's cloud labels).
+     * Intended for workloads such as AWS Capacity Blocks where the instance is not tagged by run id.
+     */
+    public void attachDiskToNode(final String nodeId, final DiskAttachRequest request) {
+        Assert.notNull(request.getSize(),
+                messageHelper.getMessage(MessageConstants.ERROR_RUN_DISK_SIZE_NOT_FOUND));
+        Assert.isTrue(request.getSize() > 0,
+                messageHelper.getMessage(MessageConstants.ERROR_INSTANCE_DISK_IS_INVALID, request.getSize()));
+        final NodeInstance nodeInstance = getNode(nodeId);
+        final AbstractCloudRegion region = loadRegionFromLabels(nodeInstance);
+        cloudFacade.attachDiskToNode(region.getId(), nodeId, request, Collections.emptyMap());
+        nodeDiskManager.register(nodeId, DiskRegistrationRequest.from(request));
+    }
+
     private boolean isNodeProtected(NodeInstance nodeInstance) {
         Map<String, String> labels = nodeInstance.getLabels();
         if (MapUtils.isEmpty(labels)) {

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/NodesManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/NodesManager.java
@@ -470,7 +470,7 @@ public class NodesManager {
      * Attaches a new disk to the node's cloud instance (region is taken from the node's cloud labels).
      * Intended for workloads such as AWS Capacity Blocks where the instance is not tagged by run id.
      */
-    public void attachDiskToNode(final String nodeId, final DiskAttachRequest request) {
+    public NodeInstance attachDiskToNode(final String nodeId, final DiskAttachRequest request) {
         Assert.notNull(request.getSize(),
                 messageHelper.getMessage(MessageConstants.ERROR_RUN_DISK_SIZE_NOT_FOUND));
         Assert.isTrue(request.getSize() > 0,
@@ -479,6 +479,7 @@ public class NodesManager {
         final AbstractCloudRegion region = loadRegionFromLabels(nodeInstance);
         cloudFacade.attachDiskToNode(region.getId(), nodeId, request, Collections.emptyMap());
         nodeDiskManager.register(nodeId, DiskRegistrationRequest.from(request));
+        return nodeInstance;
     }
 
     private boolean isNodeProtected(NodeInstance nodeInstance) {

--- a/scripts/autoscaling/fsautoscale.sh
+++ b/scripts/autoscaling/fsautoscale.sh
@@ -164,7 +164,6 @@ function is_capacity_block_context() {
   _RESERVATION_PARAMS=$(resolve_system_preference "$_PREFERENCES" "launch.reservation.parameters" "{}")
   if echo "$_RESERVATION_PARAMS" | jq -e --arg t "$_INSTANCE_TYPE" 'type == "object" and has($t)' >/dev/null 2>&1
   then
-    pipe_log_debug "Capacity block context detected for instance type ${_INSTANCE_TYPE}; attaching disk by node name."
     return 0
   fi
   return 1
@@ -345,6 +344,15 @@ then
 fi
 
 pipe_log_debug "Starting filesystem $MOUNT_POINT autoscaling process for node $NODE..."
+
+if is_capacity_block_context "$(get_system_preferences "$API" "$API_TOKEN")" "$INSTANCE_TYPE"
+then
+  pipe_log_debug "Capacity block context detected for instance type ${_INSTANCE_TYPE}; attaching disk by node name."
+  CAPACITY_BLOCK_CONTEXT=0
+else
+  CAPACITY_BLOCK_CONTEXT=1
+fi
+
 while true
 do
   sleep "$MONITORING_DELAY"
@@ -386,7 +394,7 @@ do
       ADDITIONAL_DISK_SIZE=$(get_additional_disk_size "$TOTAL_SIZE" "$REQUIRED_SIZE" "$MIN_DISK_SIZE" "$MAX_DISK_SIZE")
       RESULTING_SIZE=$((TOTAL_SIZE + ADDITIONAL_DISK_SIZE))
       pipe_log_debug "Scaling filesystem $MOUNT_POINT ${TOTAL_SIZE}G + ${ADDITIONAL_DISK_SIZE}G = ${RESULTING_SIZE}G..."
-      if is_capacity_block_context "$PREFERENCES" "$INSTANCE_TYPE"
+      if [[ "$CAPACITY_BLOCK_CONTEXT" -eq 0 ]]
       then
         if attach_new_disk_to_node "$API" "$API_TOKEN" "$NODE" "$ADDITIONAL_DISK_SIZE"
         then

--- a/scripts/autoscaling/fsautoscale.sh
+++ b/scripts/autoscaling/fsautoscale.sh
@@ -146,6 +146,30 @@ function attach_new_disk() {
   call_api "$_API" "$_API_TOKEN" "run/$_RUN_ID/disk/attach" "POST" '{"size": "'"$_SIZE"'"}'
 }
 
+function attach_new_disk_to_node() {
+  _API="$1"
+  _API_TOKEN="$2"
+  _NODE="$3"
+  _SIZE="$4"
+  call_api "$_API" "$_API_TOKEN" "cluster/node/$_NODE/disk/attach" "POST" '{"size": "'"$_SIZE"'"}'
+}
+
+function is_capacity_block_context() {
+  _PREFERENCES="$1"
+  _INSTANCE_TYPE="$2"
+  if [[ -z "$_INSTANCE_TYPE" ]]
+  then
+    return 1
+  fi
+  _RESERVATION_PARAMS=$(resolve_system_preference "$_PREFERENCES" "launch.reservation.parameters" "{}")
+  if echo "$_RESERVATION_PARAMS" | jq -e --arg t "$_INSTANCE_TYPE" 'type == "object" and has($t)' >/dev/null 2>&1
+  then
+    pipe_log_debug "Capacity block context detected for instance type ${_INSTANCE_TYPE}; attaching disk by node name."
+    return 0
+  fi
+  return 1
+}
+
 function get_matching_devices() {
   _SIZE="$1"
   lsblk -sdrpnb -o NAME,TYPE,SIZE,MOUNTPOINT | awk '$2 == "disk" && $3 / (1024 ^ 3) == "'"$_SIZE"'" && $4 == "" { print $1 }'
@@ -270,6 +294,11 @@ do
     shift
     shift
     ;;
+  -i | --instance-type)
+    INSTANCE_TYPE="$2"
+    shift
+    shift
+    ;;
   -e | --debug)
     DEBUG="true"
     shift
@@ -357,18 +386,29 @@ do
       ADDITIONAL_DISK_SIZE=$(get_additional_disk_size "$TOTAL_SIZE" "$REQUIRED_SIZE" "$MIN_DISK_SIZE" "$MAX_DISK_SIZE")
       RESULTING_SIZE=$((TOTAL_SIZE + ADDITIONAL_DISK_SIZE))
       pipe_log_debug "Scaling filesystem $MOUNT_POINT ${TOTAL_SIZE}G + ${ADDITIONAL_DISK_SIZE}G = ${RESULTING_SIZE}G..."
-      RUN_ID=$(get_current_run_id "$API" "$API_TOKEN" "$NODE")
-      if [[ -z "$RUN_ID" ]]
+      if is_capacity_block_context "$PREFERENCES" "$INSTANCE_TYPE"
       then
-        pipe_log_debug "No run is assigned to the node. Filesystem won't be autoscaled."
-        continue
-      fi
-      if attach_new_disk "$API" "$API_TOKEN" "$RUN_ID" "$ADDITIONAL_DISK_SIZE"
-      then
-        pipe_log_debug "New disk ${ADDITIONAL_DISK_SIZE}G was attached to the node."
+        if attach_new_disk_to_node "$API" "$API_TOKEN" "$NODE" "$ADDITIONAL_DISK_SIZE"
+        then
+          pipe_log_debug "New disk ${ADDITIONAL_DISK_SIZE}G was attached to the node."
+        else
+          pipe_log_error "New disk ${ADDITIONAL_DISK_SIZE}G wasn't attached to the node because of the underlying error."
+          continue
+        fi
       else
-        pipe_log_error "New disk ${ADDITIONAL_DISK_SIZE}G wasn't attached to the node because of the underlying error."
-        continue
+        RUN_ID=$(get_current_run_id "$API" "$API_TOKEN" "$NODE")
+        if [[ -z "$RUN_ID" ]]
+        then
+          pipe_log_debug "No run is assigned to the node. Filesystem won't be autoscaled."
+          continue
+        fi
+        if attach_new_disk "$API" "$API_TOKEN" "$RUN_ID" "$ADDITIONAL_DISK_SIZE"
+        then
+          pipe_log_debug "New disk ${ADDITIONAL_DISK_SIZE}G was attached to the node."
+        else
+          pipe_log_error "New disk ${ADDITIONAL_DISK_SIZE}G wasn't attached to the node because of the underlying error."
+          continue
+        fi
       fi
       pipe_log_debug "Waiting for the new disk ${ADDITIONAL_DISK_SIZE}G to be available."
       NEW_DEVICE=$(get_new_device "$MOUNT_POINT" "$ADDITIONAL_DISK_SIZE" "$DISK_AVAILABILITY_TIMEOUT")

--- a/scripts/autoscaling/fsautoscale.sh
+++ b/scripts/autoscaling/fsautoscale.sh
@@ -347,7 +347,7 @@ pipe_log_debug "Starting filesystem $MOUNT_POINT autoscaling process for node $N
 
 if is_capacity_block_context "$(get_system_preferences "$API" "$API_TOKEN")" "$INSTANCE_TYPE"
 then
-  pipe_log_debug "Capacity block context detected for instance type ${_INSTANCE_TYPE}; attaching disk by node name."
+  pipe_log_debug "Capacity block context detected for instance type $INSTANCE_TYPE; attaching disk by node name."
   CAPACITY_BLOCK_CONTEXT=0
 else
   CAPACITY_BLOCK_CONTEXT=1

--- a/scripts/autoscaling/init_aws_native.sh
+++ b/scripts/autoscaling/init_aws_native.sh
@@ -348,7 +348,8 @@ RestartSec=10
 Environment="API_ARGS=--api-url $_API_URL --api-token $_API_TOKEN"
 Environment="NODE_ARGS=--node-name $_KUBE_NODE_NAME"
 Environment="MOUNT_POINT_ARGS=--mount-point $_MOUNT_POINT"
-ExecStart=/usr/bin/fsautoscale \$API_ARGS \$NODE_ARGS \$MOUNT_POINT_ARGS
+Environment="INSTANCE_TYPE_ARGS=--instance-type $_CLOUD_INSTANCE_TYPE"
+ExecStart=/usr/bin/fsautoscale \$API_ARGS \$NODE_ARGS \$MOUNT_POINT_ARGS \$INSTANCE_TYPE_ARGS
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/autoscaling/init_aws_native.sh
+++ b/scripts/autoscaling/init_aws_native.sh
@@ -346,10 +346,9 @@ Restart=always
 StartLimitInterval=0
 RestartSec=10
 Environment="API_ARGS=--api-url $_API_URL --api-token $_API_TOKEN"
-Environment="NODE_ARGS=--node-name $_KUBE_NODE_NAME"
+Environment="NODE_ARGS=--node-name $_KUBE_NODE_NAME --instance-type $_CLOUD_INSTANCE_TYPE"
 Environment="MOUNT_POINT_ARGS=--mount-point $_MOUNT_POINT"
-Environment="INSTANCE_TYPE_ARGS=--instance-type $_CLOUD_INSTANCE_TYPE"
-ExecStart=/usr/bin/fsautoscale \$API_ARGS \$NODE_ARGS \$MOUNT_POINT_ARGS \$INSTANCE_TYPE_ARGS
+ExecStart=/usr/bin/fsautoscale \$API_ARGS \$NODE_ARGS \$MOUNT_POINT_ARGS
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/autoscaling/init_multicloud.sh
+++ b/scripts/autoscaling/init_multicloud.sh
@@ -351,7 +351,7 @@ RestartSec=10
 Environment="API_ARGS=--api-url $_API_URL --api-token $_API_TOKEN"
 Environment="NODE_ARGS=--node-name $_KUBE_NODE_NAME"
 Environment="MOUNT_POINT_ARGS=--mount-point $_MOUNT_POINT"
-Environment="INSTANCE_TYPE_ARGS=--instance-type $_CLOUD_INSTANCE_TYPE"
+Environment="INSTANCE_TYPE_ARGS=$( [[ $cloud == *"EC2"* ]] && echo "--instance-type $_CLOUD_INSTANCE_TYPE" )"
 ExecStart=/usr/bin/fsautoscale \$API_ARGS \$NODE_ARGS \$MOUNT_POINT_ARGS \$INSTANCE_TYPE_ARGS
 
 [Install]

--- a/scripts/autoscaling/init_multicloud.sh
+++ b/scripts/autoscaling/init_multicloud.sh
@@ -350,10 +350,9 @@ Restart=always
 StartLimitInterval=0
 RestartSec=10
 Environment="API_ARGS=--api-url $_API_URL --api-token $_API_TOKEN"
-Environment="NODE_ARGS=--node-name $_KUBE_NODE_NAME"
+Environment="NODE_ARGS=--node-name $_KUBE_NODE_NAME $_FS_INSTANCE_TYPE_ARGS"
 Environment="MOUNT_POINT_ARGS=--mount-point $_MOUNT_POINT"
-Environment="INSTANCE_TYPE_ARGS=$_FS_INSTANCE_TYPE_ARGS"
-ExecStart=/usr/bin/fsautoscale \$API_ARGS \$NODE_ARGS \$MOUNT_POINT_ARGS \$INSTANCE_TYPE_ARGS
+ExecStart=/usr/bin/fsautoscale \$API_ARGS \$NODE_ARGS \$MOUNT_POINT_ARGS
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/autoscaling/init_multicloud.sh
+++ b/scripts/autoscaling/init_multicloud.sh
@@ -339,6 +339,7 @@ if [[ $FS_TYPE == "btrfs" ]]; then
   fi
   if [ $_FS_AUTOSCALE_PRESENT -eq 1 ]; then
     chmod +x /usr/bin/fsautoscale
+    _FS_INSTANCE_TYPE_ARGS=$( [[ $cloud == *"EC2"* ]] && echo "--instance-type $_CLOUD_INSTANCE_TYPE" )
 cat >/etc/systemd/system/fsautoscale.service <<EOL
 [Unit]
 Description=Cloud Pipeline Filesystem Autoscaling Daemon
@@ -351,7 +352,7 @@ RestartSec=10
 Environment="API_ARGS=--api-url $_API_URL --api-token $_API_TOKEN"
 Environment="NODE_ARGS=--node-name $_KUBE_NODE_NAME"
 Environment="MOUNT_POINT_ARGS=--mount-point $_MOUNT_POINT"
-Environment="INSTANCE_TYPE_ARGS=$( [[ $cloud == *"EC2"* ]] && echo "--instance-type $_CLOUD_INSTANCE_TYPE" )"
+Environment="INSTANCE_TYPE_ARGS=$_FS_INSTANCE_TYPE_ARGS"
 ExecStart=/usr/bin/fsautoscale \$API_ARGS \$NODE_ARGS \$MOUNT_POINT_ARGS \$INSTANCE_TYPE_ARGS
 
 [Install]

--- a/scripts/autoscaling/init_multicloud.sh
+++ b/scripts/autoscaling/init_multicloud.sh
@@ -351,7 +351,8 @@ RestartSec=10
 Environment="API_ARGS=--api-url $_API_URL --api-token $_API_TOKEN"
 Environment="NODE_ARGS=--node-name $_KUBE_NODE_NAME"
 Environment="MOUNT_POINT_ARGS=--mount-point $_MOUNT_POINT"
-ExecStart=/usr/bin/fsautoscale \$API_ARGS \$NODE_ARGS \$MOUNT_POINT_ARGS
+Environment="INSTANCE_TYPE_ARGS=--instance-type $_CLOUD_INSTANCE_TYPE"
+ExecStart=/usr/bin/fsautoscale \$API_ARGS \$NODE_ARGS \$MOUNT_POINT_ARGS \$INSTANCE_TYPE_ARGS
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/autoscaling/init_multicloud_v1.15.4.sh
+++ b/scripts/autoscaling/init_multicloud_v1.15.4.sh
@@ -534,7 +534,8 @@ RestartSec=10
 Environment="API_ARGS=--api-url $_API_URL --api-token $_API_TOKEN"
 Environment="NODE_ARGS=--node-name $_KUBE_NODE_NAME"
 Environment="MOUNT_POINT_ARGS=--mount-point $_MOUNT_POINT"
-ExecStart=/usr/bin/fsautoscale \$API_ARGS \$NODE_ARGS \$MOUNT_POINT_ARGS
+Environment="INSTANCE_TYPE_ARGS=--instance-type $_CLOUD_INSTANCE_TYPE"
+ExecStart=/usr/bin/fsautoscale \$API_ARGS \$NODE_ARGS \$MOUNT_POINT_ARGS \$INSTANCE_TYPE_ARGS
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/autoscaling/init_multicloud_v1.15.4.sh
+++ b/scripts/autoscaling/init_multicloud_v1.15.4.sh
@@ -522,6 +522,7 @@ if [[ $FS_TYPE == "btrfs" ]]; then
   fi
   if [ $_FS_AUTOSCALE_PRESENT -eq 1 ]; then
     chmod +x /usr/bin/fsautoscale
+    _FS_INSTANCE_TYPE_ARGS=$( [[ $cloud == *"EC2"* ]] && echo "--instance-type $_CLOUD_INSTANCE_TYPE" )
 cat >/etc/systemd/system/fsautoscale.service <<EOL
 [Unit]
 Description=Cloud Pipeline Filesystem Autoscaling Daemon
@@ -534,7 +535,7 @@ RestartSec=10
 Environment="API_ARGS=--api-url $_API_URL --api-token $_API_TOKEN"
 Environment="NODE_ARGS=--node-name $_KUBE_NODE_NAME"
 Environment="MOUNT_POINT_ARGS=--mount-point $_MOUNT_POINT"
-Environment="INSTANCE_TYPE_ARGS=$( [[ $cloud == *"EC2"* ]] && echo "--instance-type $_CLOUD_INSTANCE_TYPE" )"
+Environment="INSTANCE_TYPE_ARGS=$_FS_INSTANCE_TYPE_ARGS"
 ExecStart=/usr/bin/fsautoscale \$API_ARGS \$NODE_ARGS \$MOUNT_POINT_ARGS \$INSTANCE_TYPE_ARGS
 
 [Install]

--- a/scripts/autoscaling/init_multicloud_v1.15.4.sh
+++ b/scripts/autoscaling/init_multicloud_v1.15.4.sh
@@ -533,10 +533,9 @@ Restart=always
 StartLimitInterval=0
 RestartSec=10
 Environment="API_ARGS=--api-url $_API_URL --api-token $_API_TOKEN"
-Environment="NODE_ARGS=--node-name $_KUBE_NODE_NAME"
+Environment="NODE_ARGS=--node-name $_KUBE_NODE_NAME $_FS_INSTANCE_TYPE_ARGS"
 Environment="MOUNT_POINT_ARGS=--mount-point $_MOUNT_POINT"
-Environment="INSTANCE_TYPE_ARGS=$_FS_INSTANCE_TYPE_ARGS"
-ExecStart=/usr/bin/fsautoscale \$API_ARGS \$NODE_ARGS \$MOUNT_POINT_ARGS \$INSTANCE_TYPE_ARGS
+ExecStart=/usr/bin/fsautoscale \$API_ARGS \$NODE_ARGS \$MOUNT_POINT_ARGS
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/autoscaling/init_multicloud_v1.15.4.sh
+++ b/scripts/autoscaling/init_multicloud_v1.15.4.sh
@@ -534,7 +534,7 @@ RestartSec=10
 Environment="API_ARGS=--api-url $_API_URL --api-token $_API_TOKEN"
 Environment="NODE_ARGS=--node-name $_KUBE_NODE_NAME"
 Environment="MOUNT_POINT_ARGS=--mount-point $_MOUNT_POINT"
-Environment="INSTANCE_TYPE_ARGS=--instance-type $_CLOUD_INSTANCE_TYPE"
+Environment="INSTANCE_TYPE_ARGS=$( [[ $cloud == *"EC2"* ]] && echo "--instance-type $_CLOUD_INSTANCE_TYPE" )"
 ExecStart=/usr/bin/fsautoscale \$API_ARGS \$NODE_ARGS \$MOUNT_POINT_ARGS \$INSTANCE_TYPE_ARGS
 
 [Install]


### PR DESCRIPTION
relates to #4360 

### Background
Currently, Cloud Pipeline is not properly handles disk autoscaling for Capacity Blocks. The main reason is that `fsautoscale.sh` script queries Cloud Pipeline API `POST run/$_RUN_ID/disk/attach` method that is not compatible with Capacity Blocks:
- pricing is not applicaple
- compute resources cannot be found by Run ID tag
### API
Implemented a new API method `POST cluster/node/{name}/disk/attach` that creates a volume for specified instance. Currently, supported for AWS provider only. This method developed for capacity blocks disk autoscaling. 
### autoscaling
Implemented a new option `-i | --instance-type` for `fsautoscale` script that required to determine capacity block context. If so, a new API method shall be used to attach disk to node.  