### PR TITLE
Issue #4375: [API] Show detailed capacity blocks usage

### DIFF
--- a/api/src/main/java/com/epam/pipeline/entity/cluster/PodInstance.java
+++ b/api/src/main/java/com/epam/pipeline/entity/cluster/PodInstance.java
@@ -25,7 +25,9 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -43,18 +45,27 @@ public class PodInstance {
     private String parentName;
     private PodInstanceStatus status;
     private List<ContainerInstance> containers;
+    private Map<String, String> labels;
 
     public PodInstance() {
         containers = new ArrayList<>();
+        labels = Collections.emptyMap();
     }
 
-    public PodInstance(Pod pod) {
+    public PodInstance(final Pod pod) {
+        this(pod, false);
+    }
+
+    public PodInstance(final Pod pod, final boolean showLabes) {
         this();
         ObjectMeta metadata = pod.getMetadata();
         if (metadata != null) {
             this.setUid(UUID.fromString(metadata.getUid()));
             this.setName(metadata.getName());
             this.setNamespace(metadata.getNamespace());
+            if (showLabes) {
+                this.setLabels(metadata.getLabels());
+            }
         }
         PodStatus podStatus = pod.getStatus();
         if (podStatus != null) {

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesConstants.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/KubernetesConstants.java
@@ -49,6 +49,7 @@ public final class KubernetesConstants {
     public static final String POD_WORKER_NODE_LABEL = "cluster_id";
     public static final String PAUSED_NODE_LABEL = "Paused";
     public static final String UNAVAILABLE_NODE_LABEL = "Unavailable";
+    public static final String OWNER_LABEL = "owner";
 
     public static final String CP_CAP_DIND_NATIVE = "CP_CAP_DIND_NATIVE";
     public static final String CP_CAP_SYSTEMD_CONTAINER = "CP_CAP_SYSTEMD_CONTAINER";

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/NodeAvailableResourcesParser.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/NodeAvailableResourcesParser.java
@@ -148,7 +148,7 @@ public final class NodeAvailableResourcesParser {
             return null;
         }
         return NodeResources.RunDetails.builder()
-                .quantities(collectContainersResources(ListUtils.emptyIfNull(pod.getContainers()).stream()))
+                .allocated(collectContainersResources(ListUtils.emptyIfNull(pod.getContainers()).stream()))
                 .runId(Long.parseLong(runIdValue))
                 // if owner label was not provided will try to fetch from DB later
                 .owner(pod.getLabels().getOrDefault(KubernetesConstants.OWNER_LABEL, null))

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/NodeAvailableResourcesParser.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/NodeAvailableResourcesParser.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Slf4j
 public final class NodeAvailableResourcesParser {
@@ -43,29 +45,33 @@ public final class NodeAvailableResourcesParser {
     private NodeAvailableResourcesParser() {
     }
 
-    public static NodeResources parse(final NodeInstance node, final List<PodInstance> pods) {
+    public static NodeResources parse(final NodeInstance node, final List<PodInstance> pods,
+                                      final boolean showDetails) {
         final NodeResources resources = NodeResources.builder()
                 .nodeName(node.getName())
                 .total(toQuantities(node.getAllocatable(), false))
                 .build();
-        resources.setUsed(CollectionUtils.isEmpty(pods)
-                ? NodeResources.Quantities.empty()  // empty node
-                : collectAllocatedResources(pods));
+        if (CollectionUtils.isEmpty(pods)) {
+            resources.setUsed(NodeResources.Quantities.empty()); // empty node
+            return resources;
+        }
+        resources.setUsed(collectAllocatedResources(pods));
+        if (showDetails) {
+            resources.setDetails(collectDetailsForRuns(pods));
+        }
         return resources;
     }
 
     private static NodeResources.Quantities collectAllocatedResources(final List<PodInstance> pods) {
+        return collectContainersResources(ListUtils.emptyIfNull(pods).stream()
+                .flatMap(pod -> ListUtils.emptyIfNull(pod.getContainers()).stream()));
+    }
+
+    private static List<NodeResources.RunDetails> collectDetailsForRuns(final List<PodInstance> pods) {
         return ListUtils.emptyIfNull(pods).stream()
-                .flatMap(pod -> ListUtils.emptyIfNull(pod.getContainers()).stream())
-                .map(ContainerInstance::getRequests)
-                .filter(MapUtils::isNotEmpty)
-                .map(quantities -> toQuantities(quantities, true))
-                .reduce(NodeResources.Quantities.builder().build(), (q1, q2) ->
-                        NodeResources.Quantities.builder()
-                                .cpu(nullSafeSum(q1.getCpu(), q2.getCpu()))
-                                .gpu(nullSafeSum(q1.getGpu(), q2.getGpu()))
-                                .memory(nullSafeSum(q1.getMemory(), q2.getMemory()))
-                                .build());
+                .map(NodeAvailableResourcesParser::podToNodeDetails)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     private static Long parseMemory(final String memoryValue) {
@@ -129,5 +135,37 @@ public final class NodeAvailableResourcesParser {
 
     private static Long zeroIfNull(final Long value) {
         return Optional.ofNullable(value).orElse(0L);
+    }
+
+    private static NodeResources.RunDetails podToNodeDetails(final PodInstance pod) {
+        if (!MapUtils.emptyIfNull(pod.getLabels()).containsKey(KubernetesConstants.RUN_ID_LABEL)) {
+            // skip if pod has not 'runid' label
+            return null;
+        }
+        final String runIdValue = pod.getLabels().get(KubernetesConstants.RUN_ID_LABEL);
+        if (StringUtils.isBlank(runIdValue) || !NumberUtils.isDigits(runIdValue)) {
+            // skip if run is not assigned to pod
+            return null;
+        }
+        return NodeResources.RunDetails.builder()
+                .quantities(collectContainersResources(ListUtils.emptyIfNull(pod.getContainers()).stream()))
+                .runId(Long.parseLong(runIdValue))
+                // if owner label was not provided will try to fetch from DB later
+                .owner(pod.getLabels().getOrDefault(KubernetesConstants.OWNER_LABEL, null))
+                .build();
+    }
+
+    private static NodeResources.Quantities collectContainersResources(
+            final Stream<ContainerInstance> containersStream) {
+        return containersStream
+                .map(ContainerInstance::getRequests)
+                .filter(MapUtils::isNotEmpty)
+                .map(quantities -> toQuantities(quantities, true))
+                .reduce(NodeResources.Quantities.builder().build(), (q1, q2) ->
+                        NodeResources.Quantities.builder()
+                                .cpu(nullSafeSum(q1.getCpu(), q2.getCpu()))
+                                .gpu(nullSafeSum(q1.getGpu(), q2.getGpu()))
+                                .memory(nullSafeSum(q1.getMemory(), q2.getMemory()))
+                                .build());
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/NodesManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/NodesManager.java
@@ -177,12 +177,14 @@ public class NodesManager {
             return Collections.emptyList();
         }
         log.debug("Found {} nodes matching labels {}", nodes.size(), labels);
-        final List<PodInstance> pods = findActivePodsByLabelsAndNodes(labels, nodes);
+        final boolean showDetails = preferenceManager.getPreference(
+                SystemPreferences.CLUSTER_NODE_RESOURCES_SHOW_DETAILS);
+        final List<PodInstance> pods = findActivePodsByLabelsAndNodes(labels, nodes, showDetails);
         log.debug("Found {} active pods matching labels {}", pods.size(), labels);
         final Map<String, List<PodInstance>> podsByNodes = pods.stream()
                 .collect(Collectors.groupingBy(PodInstance::getNodeName));
         return ListUtils.emptyIfNull(nodes).stream()
-                .map(node -> NodeAvailableResourcesParser.parse(node, podsByNodes.get(node.getName())))
+                .map(node -> parseNodeResources(node, podsByNodes.get(node.getName()), showDetails))
                 .collect(Collectors.toList());
     }
 
@@ -641,14 +643,29 @@ public class NodesManager {
     }
 
     private List<PodInstance> findActivePodsByLabelsAndNodes(final Map<String, String> labels,
-                                                             final List<NodeInstance> nodes) {
+                                                             final List<NodeInstance> nodes,
+                                                             final boolean showLabels) {
         final Set<String> nodeNames = ListUtils.emptyIfNull(nodes).stream()
                 .map(NodeInstance::getName)
                 .collect(Collectors.toSet());
         return ListUtils.emptyIfNull(kubernetesManager.getPodsByLabels(labels)).stream()
-                .map(PodInstance::new)
+                .map(pod -> new PodInstance(pod, showLabels))
                 .filter(pod -> isPodOnNodeIn(pod, nodeNames))
                 .filter(this::isActivePod)
                 .collect(Collectors.toList());
+    }
+
+    private NodeResources parseNodeResources(final NodeInstance node, final List<PodInstance> pods,
+                                             final boolean showDetails) {
+        final NodeResources resources = NodeAvailableResourcesParser.parse(node, pods, showDetails);
+        ListUtils.emptyIfNull(resources.getDetails())
+                .forEach(details -> {
+                    if (Objects.isNull(details.getOwner())) {
+                        details.setOwner(runCRUDService.findRunByRunId(details.getRunId())
+                                .map(PipelineRun::getOwner)
+                                .orElse(null));
+                    }
+                });
+        return resources;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -724,6 +724,14 @@ public class SystemPreferences {
             "cluster.kube.core.component.label", "cloud-pipeline/core-component", CLUSTER_GROUP, pass);
     public static final IntPreference CLUSTER_INSTANCE_LOAD_TIMEOUT = new IntPreference(
             "cluster.instance.load.timeout.seconds", 15, CLUSTER_GROUP, isGreaterThan(0));
+    /**
+     * When {@code true}, responses that report Kubernetes node available resources include a per-run
+     * {@link com.epam.pipeline.entity.cluster.NodeResources#getDetails() details} list on each node
+     * (run id, owner label when set, and requested CPU/GPU/memory for that pod's containers).
+     * Default is {@code false} to keep payloads smaller and omit run-level breakdown unless needed.
+     */
+    public static final BooleanPreference CLUSTER_NODE_RESOURCES_SHOW_DETAILS = new BooleanPreference(
+            "cluster.node.resources.show.details", false, CLUSTER_GROUP, pass);
 
     //LAUNCH_GROUP
     public static final StringPreference LAUNCH_CMD_TEMPLATE = new StringPreference("launch.cmd.template",

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/NodeAvailableResourcesParserTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/NodeAvailableResourcesParserTest.java
@@ -20,6 +20,7 @@ import com.epam.pipeline.entity.cluster.ContainerInstance;
 import com.epam.pipeline.entity.cluster.NodeInstance;
 import com.epam.pipeline.entity.cluster.NodeResources;
 import com.epam.pipeline.entity.cluster.PodInstance;
+import joptsimple.internal.Strings;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -28,8 +29,14 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
+import static com.epam.pipeline.manager.cluster.KubernetesConstants.RUN_ID_LABEL;
+import static com.epam.pipeline.manager.cluster.KubernetesConstants.OWNER_LABEL;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isIn;
+import static org.hamcrest.Matchers.nullValue;
 
 public class NodeAvailableResourcesParserTest {
     private static final String NODE_NAME = "testNode";
@@ -42,41 +49,28 @@ public class NodeAvailableResourcesParserTest {
     private static final String FOUR_GB = "4096Mi";
     private static final String ONE_GPU = "1";
     private static final String TEST_CPU = "7400m";
+    private static final long ONE_GB_IN_BYTES = 1073741824L;
     private static final long TWO_GB_IN_BYTES = 2147483648L;
     private static final long FOUR_GB_IN_BYTES = 4294967296L;
+    private static final String RUN_ID_LABEL_VALUE = "123";
+    private static final String RUN_ID_LABEL_VALUE_2 = "321";
+    private static final String POOL_ID_LABEL_VALUE = "p-123";
+    private static final long RUN_ID = 123L;
+    private static final long RUN_ID_2 = 321L;
+    private static final String OWNER = "USER";
 
     @Test
     public void shouldCollectAllocatedPods() {
-        final Map<String, String> wholeContainer = new HashMap<>();
-        wholeContainer.put(CPU, TWO_CPUS);
-        wholeContainer.put(MEMORY, ONE_GB);
-        wholeContainer.put(GPU, ONE_GPU);
+        final NodeInstance node = node();
 
-        final Map<String, String> noGpuContainer = new HashMap<>();
-        noGpuContainer.put(CPU, TWO_CPUS_IN_MILLICORES);
-        noGpuContainer.put(MEMORY, ONE_GB);
+        final ContainerInstance wholeContainer = container(TWO_CPUS, ONE_GB, ONE_GPU);
+        final ContainerInstance noGpuContainer = container(TWO_CPUS_IN_MILLICORES, ONE_GB, null);
 
-        final Map<String, String> allocatable = new HashMap<>();
-        allocatable.put(CPU, TEST_CPU);
-        allocatable.put(MEMORY, FOUR_GB);
-        allocatable.put(GPU, ONE_GPU);
-
-        final NodeInstance node = new NodeInstance();
-        node.setName(NODE_NAME);
-        node.setAllocatable(allocatable);
-
-        final ContainerInstance container1 = new ContainerInstance();
-        container1.setRequests(wholeContainer);
-        final ContainerInstance container2 = new ContainerInstance();
-        container2.setRequests(noGpuContainer);
-
-        final PodInstance pod1 = new PodInstance();
-        pod1.setContainers(Collections.singletonList(container1));
-        final PodInstance pod2 = new PodInstance();
-        pod2.setContainers(Collections.singletonList(container2));
+        final PodInstance pod1 = pod(Collections.singletonList(wholeContainer));
+        final PodInstance pod2 = pod(Collections.singletonList(noGpuContainer));
         final List<PodInstance> pods = Arrays.asList(pod1, pod2, new PodInstance());
 
-        final NodeResources actual = NodeAvailableResourcesParser.parse(node, pods);
+        final NodeResources actual = NodeAvailableResourcesParser.parse(node, pods, false);
         Assert.assertThat(actual.getNodeName(), is(NODE_NAME));
         Assert.assertThat(actual.getUsed().getCpu(), is(4L));
         Assert.assertThat(actual.getUsed().getGpu(), is(1L));
@@ -84,10 +78,174 @@ public class NodeAvailableResourcesParserTest {
         Assert.assertThat(actual.getTotal().getCpu(), is(7L));
         Assert.assertThat(actual.getTotal().getGpu(), is(1L));
         Assert.assertThat(actual.getTotal().getMemory(), is(FOUR_GB_IN_BYTES));
+        Assert.assertThat(actual.getDetails(), is(nullValue()));
     }
 
     @Test
     public void shouldProceedIfNoPodsAllocated() {
+        final NodeResources actual = NodeAvailableResourcesParser.parse(node(), null, false);
+
+        Assert.assertThat(actual.getNodeName(), is(NODE_NAME));
+        Assert.assertThat(actual.getUsed().getCpu(), is(0L));
+        Assert.assertThat(actual.getUsed().getGpu(), is(0L));
+        Assert.assertThat(actual.getUsed().getMemory(), is(0L));
+        Assert.assertThat(actual.getTotal().getCpu(), is(7L));
+        Assert.assertThat(actual.getTotal().getGpu(), is(1L));
+        Assert.assertThat(actual.getTotal().getMemory(), is(FOUR_GB_IN_BYTES));
+        Assert.assertThat(actual.getDetails(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldPopulateRunDetailsWhenSingleRunIdLabelProvided() {
+        final NodeInstance node = node();
+
+        final ContainerInstance container = container(TWO_CPUS, ONE_GB, ONE_GPU);
+        final Map<String, String> labels = new HashMap<>();
+        labels.put(RUN_ID_LABEL, RUN_ID_LABEL_VALUE);
+        final PodInstance runPod = pod(Collections.singletonList(container), labels);
+        final PodInstance noRunPod = pod(Collections.singletonList(container));
+        final List<PodInstance> pods = Arrays.asList(runPod, noRunPod, new PodInstance());
+
+        final NodeResources actual = NodeAvailableResourcesParser.parse(node, pods, true);
+
+        Assert.assertThat(actual.getDetails().size(), is(1));
+        final NodeResources.RunDetails runDetails = actual.getDetails().get(0);
+        Assert.assertThat(runDetails.getRunId(), is(RUN_ID));
+        Assert.assertThat(runDetails.getOwner(), is(nullValue()));
+        Assert.assertThat(runDetails.getQuantities().getCpu(), is(2L));
+        Assert.assertThat(runDetails.getQuantities().getGpu(), is(1L));
+        Assert.assertThat(runDetails.getQuantities().getMemory(), is(ONE_GB_IN_BYTES));
+    }
+
+    @Test
+    public void shouldPopulateRunDetailsWhenRunIdAndOwnerLabelsProvided() {
+        final NodeInstance node = node();
+
+        final ContainerInstance container = container(TWO_CPUS, ONE_GB, ONE_GPU);
+        final Map<String, String> labels = new HashMap<>();
+        labels.put(RUN_ID_LABEL, RUN_ID_LABEL_VALUE);
+        labels.put(OWNER_LABEL, OWNER);
+        final PodInstance runPod = pod(Collections.singletonList(container), labels);
+        final PodInstance noRunPod = pod(Collections.singletonList(container));
+        final List<PodInstance> pods = Arrays.asList(runPod, noRunPod, new PodInstance());
+
+        final NodeResources actual = NodeAvailableResourcesParser.parse(node, pods, true);
+
+        Assert.assertThat(actual.getDetails().size(), is(1));
+        final NodeResources.RunDetails runDetails = actual.getDetails().get(0);
+        Assert.assertThat(runDetails.getRunId(), is(RUN_ID));
+        Assert.assertThat(runDetails.getOwner(), is(OWNER));
+        Assert.assertThat(runDetails.getQuantities().getCpu(), is(2L));
+        Assert.assertThat(runDetails.getQuantities().getGpu(), is(1L));
+        Assert.assertThat(runDetails.getQuantities().getMemory(), is(ONE_GB_IN_BYTES));
+    }
+
+    @Test
+    public void shouldPopulateRunDetailsWhenMultipleRunIdLabelProvided() {
+        final NodeInstance node = node();
+
+        final ContainerInstance container = container(TWO_CPUS, ONE_GB, ONE_GPU);
+
+        final Map<String, String> labels1 = new HashMap<>();
+        labels1.put(RUN_ID_LABEL, RUN_ID_LABEL_VALUE);
+        final PodInstance runPod1 = pod(Collections.singletonList(container), labels1);
+
+        final Map<String, String> labels2 = new HashMap<>();
+        labels2.put(RUN_ID_LABEL, RUN_ID_LABEL_VALUE_2);
+        final PodInstance runPod2 = pod(Collections.singletonList(container), labels2);
+
+        final PodInstance noRunPod = pod(Collections.singletonList(container));
+
+        final List<PodInstance> pods = Arrays.asList(runPod1, runPod2, noRunPod, new PodInstance());
+
+        final NodeResources actual = NodeAvailableResourcesParser.parse(node, pods, true);
+
+        Assert.assertThat(actual.getDetails().size(), is(2));
+        actual.getDetails().forEach(runDetails -> {
+            Assert.assertThat(runDetails.getRunId(), isIn(Arrays.asList(RUN_ID, RUN_ID_2).toArray()));
+            Assert.assertThat(runDetails.getOwner(), is(nullValue()));
+            Assert.assertThat(runDetails.getQuantities().getCpu(), is(2L));
+            Assert.assertThat(runDetails.getQuantities().getGpu(), is(1L));
+            Assert.assertThat(runDetails.getQuantities().getMemory(), is(ONE_GB_IN_BYTES));
+        });
+    }
+
+    @Test
+    public void shouldOmitRunDetailsWhenRunIdLabelNotProvided() {
+        final NodeInstance node = node();
+
+        final ContainerInstance container = container(TWO_CPUS, ONE_GB, ONE_GPU);
+        final PodInstance noRunPod = pod(Collections.singletonList(container));
+        final List<PodInstance> pods = Arrays.asList(noRunPod, new PodInstance());
+
+        final NodeResources actual = NodeAvailableResourcesParser.parse(node, pods, true);
+
+        Assert.assertThat(actual.getDetails(), is(empty()));
+    }
+
+    @Test
+    public void shouldOmitRunDetailsWhenRunIdLabelIsNotNumeric() {
+        final NodeInstance node = node();
+
+        final ContainerInstance container = container(TWO_CPUS, ONE_GB, ONE_GPU);
+        final Map<String, String> labels = new HashMap<>();
+        labels.put(RUN_ID_LABEL, POOL_ID_LABEL_VALUE);
+        final PodInstance noRunPod = pod(Collections.singletonList(container), labels);
+        final List<PodInstance> pods = Arrays.asList(noRunPod, new PodInstance());
+
+        final NodeResources actual = NodeAvailableResourcesParser.parse(node, pods, true);
+
+        Assert.assertThat(actual.getDetails(), is(empty()));
+    }
+
+    @Test
+    public void shouldOmitRunDetailsWhenRunIdLabelIsBlank() {
+        final NodeInstance node = node();
+
+        final ContainerInstance container = container(TWO_CPUS, ONE_GB, ONE_GPU);
+        final Map<String, String> labels = new HashMap<>();
+        labels.put(RUN_ID_LABEL, Strings.EMPTY);
+        final PodInstance noRunPod = pod(Collections.singletonList(container), labels);
+        final List<PodInstance> pods = Arrays.asList(noRunPod, new PodInstance());
+
+        final NodeResources actual = NodeAvailableResourcesParser.parse(node, pods, true);
+
+        Assert.assertThat(actual.getDetails(), is(empty()));
+    }
+
+    private static PodInstance pod(final List<ContainerInstance> containers) {
+        return pod(containers, Collections.emptyMap());
+    }
+
+    private static PodInstance pod(final List<ContainerInstance> containers,
+                                   final Map<String, String> labels) {
+        final PodInstance pod = new PodInstance();
+        pod.setLabels(labels);
+        pod.setContainers(containers);
+        return pod;
+    }
+
+    private static ContainerInstance container(final String cpuValue,
+                                               final String memoryValue,
+                                               final String gpuValue) {
+        final Map<String, String> requests = new HashMap<>();
+        if (Objects.nonNull(cpuValue)) {
+            requests.put(CPU, cpuValue);
+        }
+        if (Objects.nonNull(memoryValue)) {
+            requests.put(MEMORY, memoryValue);
+        }
+        if (Objects.nonNull(gpuValue)) {
+            requests.put(GPU, ONE_GPU);
+        }
+
+        final ContainerInstance container = new ContainerInstance();
+        container.setRequests(requests);
+
+        return container;
+    }
+
+    private static NodeInstance node() {
         final Map<String, String> allocatable = new HashMap<>();
         allocatable.put(CPU, TEST_CPU);
         allocatable.put(MEMORY, FOUR_GB);
@@ -97,13 +255,6 @@ public class NodeAvailableResourcesParserTest {
         node.setName(NODE_NAME);
         node.setAllocatable(allocatable);
 
-        final NodeResources actual = NodeAvailableResourcesParser.parse(node, null);
-        Assert.assertThat(actual.getNodeName(), is(NODE_NAME));
-        Assert.assertThat(actual.getUsed().getCpu(), is(0L));
-        Assert.assertThat(actual.getUsed().getGpu(), is(0L));
-        Assert.assertThat(actual.getUsed().getMemory(), is(0L));
-        Assert.assertThat(actual.getTotal().getCpu(), is(7L));
-        Assert.assertThat(actual.getTotal().getGpu(), is(1L));
-        Assert.assertThat(actual.getTotal().getMemory(), is(FOUR_GB_IN_BYTES));
+        return node;
     }
 }

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/NodeAvailableResourcesParserTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/NodeAvailableResourcesParserTest.java
@@ -112,9 +112,9 @@ public class NodeAvailableResourcesParserTest {
         final NodeResources.RunDetails runDetails = actual.getDetails().get(0);
         Assert.assertThat(runDetails.getRunId(), is(RUN_ID));
         Assert.assertThat(runDetails.getOwner(), is(nullValue()));
-        Assert.assertThat(runDetails.getQuantities().getCpu(), is(2L));
-        Assert.assertThat(runDetails.getQuantities().getGpu(), is(1L));
-        Assert.assertThat(runDetails.getQuantities().getMemory(), is(ONE_GB_IN_BYTES));
+        Assert.assertThat(runDetails.getAllocated().getCpu(), is(2L));
+        Assert.assertThat(runDetails.getAllocated().getGpu(), is(1L));
+        Assert.assertThat(runDetails.getAllocated().getMemory(), is(ONE_GB_IN_BYTES));
     }
 
     @Test
@@ -135,9 +135,9 @@ public class NodeAvailableResourcesParserTest {
         final NodeResources.RunDetails runDetails = actual.getDetails().get(0);
         Assert.assertThat(runDetails.getRunId(), is(RUN_ID));
         Assert.assertThat(runDetails.getOwner(), is(OWNER));
-        Assert.assertThat(runDetails.getQuantities().getCpu(), is(2L));
-        Assert.assertThat(runDetails.getQuantities().getGpu(), is(1L));
-        Assert.assertThat(runDetails.getQuantities().getMemory(), is(ONE_GB_IN_BYTES));
+        Assert.assertThat(runDetails.getAllocated().getCpu(), is(2L));
+        Assert.assertThat(runDetails.getAllocated().getGpu(), is(1L));
+        Assert.assertThat(runDetails.getAllocated().getMemory(), is(ONE_GB_IN_BYTES));
     }
 
     @Test
@@ -164,9 +164,9 @@ public class NodeAvailableResourcesParserTest {
         actual.getDetails().forEach(runDetails -> {
             Assert.assertThat(runDetails.getRunId(), isIn(Arrays.asList(RUN_ID, RUN_ID_2).toArray()));
             Assert.assertThat(runDetails.getOwner(), is(nullValue()));
-            Assert.assertThat(runDetails.getQuantities().getCpu(), is(2L));
-            Assert.assertThat(runDetails.getQuantities().getGpu(), is(1L));
-            Assert.assertThat(runDetails.getQuantities().getMemory(), is(ONE_GB_IN_BYTES));
+            Assert.assertThat(runDetails.getAllocated().getCpu(), is(2L));
+            Assert.assertThat(runDetails.getAllocated().getGpu(), is(1L));
+            Assert.assertThat(runDetails.getAllocated().getMemory(), is(ONE_GB_IN_BYTES));
         });
     }
 

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/NodeResources.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/NodeResources.java
@@ -21,6 +21,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -38,6 +40,15 @@ public class NodeResources {
      * (cpu/memory/nvidia.com/gpu).
      */
     private Quantities used;
+    /**
+     * Per-run breakdown of resource requests allocated on this node (one entry per qualifying pod).
+     * Each {@link RunDetails} row aggregates container {@code requests} for CPU, memory, and
+     * GPU for pods that carry a run id label.
+     * <p>
+     * This list is only populated when the {@code cluster.node.resources.show.details} system preference
+     * is enabled; otherwise the field shall be {@code null}.
+     */
+    private List<RunDetails> details;
 
     @Data
     @NoArgsConstructor
@@ -55,5 +66,15 @@ public class NodeResources {
                     .memory(0L)
                     .build();
         }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class RunDetails {
+        private Long runId;
+        private String owner;
+        private Quantities quantities;
     }
 }

--- a/core/src/main/java/com/epam/pipeline/entity/cluster/NodeResources.java
+++ b/core/src/main/java/com/epam/pipeline/entity/cluster/NodeResources.java
@@ -75,6 +75,6 @@ public class NodeResources {
     public static class RunDetails {
         private Long runId;
         private String owner;
-        private Quantities quantities;
+        private Quantities allocated;
     }
 }


### PR DESCRIPTION
retales to #4375

A new system preference `cluster.node.resources.show.details` (default: `false`) introduced. Once, the value is `true` the following new field `details` will be collected for `POST /cluster/node/resources` API query:
```
{
    "used": <>,
    "total": <>, 
    "details": [
        { 
            "runId": <>,  # the `runid` pod label value
            "owner": "<>",  # the `owner` pod label value
            "allocated": {  # contains resources allocated for pod (format the same as for node `used`/`total` fields)
                "cpu": <>,
                "gpu": <>,
                "memory": <>
            }
        }
    ]
}
```