### PR TITLE
GUI DataStorage: add support to 'Storage operations' attribute

### DIFF
--- a/client/src/components/pipelines/browser/data-storage/index.js
+++ b/client/src/components/pipelines/browser/data-storage/index.js
@@ -117,6 +117,7 @@ import {
 } from './components/storage-item-permissions';
 import {getDataStorageItemFullPath} from '../../launch/dialogs/BucketBrowser';
 import copyTextToClipboard from '../../../special/copy-text-to-clipboard';
+import {checkStorageOperationsEnabled} from './utils';
 
 const STORAGE_CLASSES = {
   standard: 'STANDARD',
@@ -206,6 +207,14 @@ export default class DataStorage extends React.Component {
 
   @observable generateDownloadUrls;
   @observable filterDropdownVisible;
+
+  get storageActionsEnabled () {
+    if (!this.storage.loaded) {
+      return false;
+    }
+    const metadata = this.storage?.metadata;
+    return metadata ? checkStorageOperationsEnabled(metadata) : true;
+  }
 
   get showMetadata () {
     if (this.state.metadata === undefined && this.storage.info) {
@@ -1285,7 +1294,7 @@ export default class DataStorage extends React.Component {
   };
 
   canRestoreVersion = (item) => {
-    if (!this.showVersions) {
+    if (!this.showVersions || !this.storageOperationsEnabled) {
       return false;
     }
     if (
@@ -2337,14 +2346,16 @@ export default class DataStorage extends React.Component {
     const restoreAction = {
       key: Keys.restore,
       title: `Restore transferred item${this.restorableItems.length > 1 ? 's' : ''}`,
-      available: this.userLifeCyclePermissions.write &&
+      available: this.storageActionsEnabled &&
+        this.userLifeCyclePermissions.write &&
         this.restorableItems.length > 0 && !this.isOmicsStore,
       icon: 'reload'
     };
     const restoreOmicsAction = {
       key: Keys.restoreOmics,
       title: `Restore transferred item${this.restorableItems.length > 1 ? 's' : ''}`,
-      available: this.userLifeCyclePermissions.write &&
+      available: this.storageActionsEnabled &&
+        this.userLifeCyclePermissions.write &&
         this.restorableItems.length > 0 && this.isSequenceStorage && this.isOmicsFolder,
       icon: 'reload'
     };
@@ -3090,10 +3101,10 @@ export default class DataStorage extends React.Component {
               }
               fileIsEmpty={this.isFileSelectedEmpty}
               extraKeys={[
-                (/^nfs$/i.test(type) && !this.isOmicsStore)
+                (this.storageActionsEnabled && /^nfs$/i.test(type) && !this.isOmicsStore)
                   ? FS_MOUNTS_NOTIFICATIONS_ATTRIBUTE
                   : false,
-                ((!/^nfs$/i.test(type) && !this.state.selectedFile) && !this.isOmicsStore)
+                (this.storageActionsEnabled && !/^nfs$/i.test(type) && !this.state.selectedFile && !this.isOmicsStore)
                   ? REQUEST_DAV_ACCESS_ATTRIBUTE
                   : false
               ].filter(Boolean)}
@@ -3118,12 +3129,19 @@ export default class DataStorage extends React.Component {
                   onClickRestore={() => this.openRestoreFilesDialog('folder')}
                   restoreInfo={this.lifeCycleRestoreInfo}
                   restoreEnabled={this.userLifeCyclePermissions.write}
-                  visible={!this.state.selectedFile && (
-                    this.userLifeCyclePermissions.read ||
-                    this.userLifeCyclePermissions.write
-                  )}
+                  visible={
+                    !this.state.selectedFile &&
+                    this.storageActionsEnabled &&
+                    (
+                      this.userLifeCyclePermissions.read ||
+                      this.userLifeCyclePermissions.write
+                    )
+                  }
                 />,
-                <StorageSize storage={this.storage.info} />
+                <StorageSize
+                  storage={this.storage.info}
+                  storageOperationsEnabled={this.storageActionsEnabled}
+                />
               ].filter(Boolean) : []}
               specialTagsProperties={{
                 storageType: this.fileShareMount ? this.fileShareMount.mountType : undefined,

--- a/client/src/components/pipelines/browser/data-storage/index.js
+++ b/client/src/components/pipelines/browser/data-storage/index.js
@@ -208,7 +208,7 @@ export default class DataStorage extends React.Component {
   @observable generateDownloadUrls;
   @observable filterDropdownVisible;
 
-  get storageActionsEnabled () {
+  get storageOperationsEnabled () {
     if (!this.storage.loaded) {
       return false;
     }
@@ -2346,7 +2346,7 @@ export default class DataStorage extends React.Component {
     const restoreAction = {
       key: Keys.restore,
       title: `Restore transferred item${this.restorableItems.length > 1 ? 's' : ''}`,
-      available: this.storageActionsEnabled &&
+      available: this.storageOperationsEnabled &&
         this.userLifeCyclePermissions.write &&
         this.restorableItems.length > 0 && !this.isOmicsStore,
       icon: 'reload'
@@ -2354,7 +2354,7 @@ export default class DataStorage extends React.Component {
     const restoreOmicsAction = {
       key: Keys.restoreOmics,
       title: `Restore transferred item${this.restorableItems.length > 1 ? 's' : ''}`,
-      available: this.storageActionsEnabled &&
+      available: this.storageOperationsEnabled &&
         this.userLifeCyclePermissions.write &&
         this.restorableItems.length > 0 && this.isSequenceStorage && this.isOmicsFolder,
       icon: 'reload'
@@ -3101,10 +3101,10 @@ export default class DataStorage extends React.Component {
               }
               fileIsEmpty={this.isFileSelectedEmpty}
               extraKeys={[
-                (this.storageActionsEnabled && /^nfs$/i.test(type) && !this.isOmicsStore)
+                (/^nfs$/i.test(type) && !this.isOmicsStore)
                   ? FS_MOUNTS_NOTIFICATIONS_ATTRIBUTE
                   : false,
-                (this.storageActionsEnabled && !/^nfs$/i.test(type) && !this.state.selectedFile && !this.isOmicsStore)
+                (this.storageOperationsEnabled && !/^nfs$/i.test(type) && !this.state.selectedFile && !this.isOmicsStore)
                   ? REQUEST_DAV_ACCESS_ATTRIBUTE
                   : false
               ].filter(Boolean)}
@@ -3131,7 +3131,7 @@ export default class DataStorage extends React.Component {
                   restoreEnabled={this.userLifeCyclePermissions.write}
                   visible={
                     !this.state.selectedFile &&
-                    this.storageActionsEnabled &&
+                    this.storageOperationsEnabled &&
                     (
                       this.userLifeCyclePermissions.read ||
                       this.userLifeCyclePermissions.write
@@ -3140,7 +3140,7 @@ export default class DataStorage extends React.Component {
                 />,
                 <StorageSize
                   storage={this.storage.info}
-                  storageOperationsEnabled={this.storageActionsEnabled}
+                  storageOperationsEnabled={this.storageOperationsEnabled}
                 />
               ].filter(Boolean) : []}
               specialTagsProperties={{
@@ -3163,6 +3163,7 @@ export default class DataStorage extends React.Component {
         <DataStorageEditDialog
           visible={this.state.editDialogVisible}
           dataStorage={this.storage.info}
+          storageOperationsEnabled={this.storageOperationsEnabled}
           pending={this.storage.infoPending}
           policySupported={policySupported}
           onDelete={this.deleteStorage}

--- a/client/src/components/pipelines/browser/data-storage/utils.js
+++ b/client/src/components/pipelines/browser/data-storage/utils.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const STORAGE_OPERATIONS_METADATA_KEYS = [
+  'Storage operations',
+  'StorageOperations',
+  'storage_operations'
+];
+
+const FALSY_STORAGE_OPERATION_VALUES = new Set(['none', 'false']);
+
+function getMetadataEntryValueString (entry) {
+  if (entry == null) {
+    return undefined;
+  }
+  const raw = typeof entry === 'object' && entry !== null && 'value' in entry
+    ? entry.value
+    : entry;
+  if (!raw) {
+    return undefined;
+  }
+  return String(raw).trim().toLowerCase();
+}
+
+export function checkStorageOperationsEnabled (metadata = {}) {
+  if (!metadata?.data) {
+    return true;
+  }
+  const {data} = metadata;
+  for (const key of STORAGE_OPERATIONS_METADATA_KEYS) {
+    if (!Object.prototype.hasOwnProperty.call(data, key)) {
+      continue;
+    }
+    const value = getMetadataEntryValueString(data[key]);
+    if (!value) {
+      continue;
+    }
+    if (FALSY_STORAGE_OPERATION_VALUES.has(value)) {
+      return false;
+    }
+    return true;
+  }
+  return true;
+}

--- a/client/src/components/pipelines/browser/data-storage/utils.js
+++ b/client/src/components/pipelines/browser/data-storage/utils.js
@@ -20,7 +20,14 @@ const STORAGE_OPERATIONS_METADATA_KEYS = [
   'storage_operations'
 ];
 
-const FALSY_STORAGE_OPERATION_VALUES = new Set(['none', 'false']);
+const FALSY_STORAGE_OPERATION_VALUES = new Set([
+  'none',
+  "'none'",
+  '"none"',
+  'false',
+  "'false'",
+  '"false"'
+]);
 
 function getMetadataEntryValueString (entry) {
   if (entry == null) {

--- a/client/src/components/pipelines/browser/forms/DataStorageEditDialog.js
+++ b/client/src/components/pipelines/browser/forms/DataStorageEditDialog.js
@@ -70,7 +70,8 @@ export class DataStorageEditDialog extends React.Component {
     addExistingStorageFlag: PropTypes.bool,
     omicsStore: PropTypes.bool,
     isNfsMount: PropTypes.bool,
-    policySupported: PropTypes.bool
+    policySupported: PropTypes.bool,
+    storageOperationsEnabled: PropTypes.bool
   };
 
   state = {
@@ -289,12 +290,14 @@ export class DataStorageEditDialog extends React.Component {
   @computed
   get transitionRulesAvailable () {
     const {
-      dataStorage
+      dataStorage,
+      storageOperationsEnabled = true
     } = this.props;
     return (this.userPermissions.read || this.userPermissions.write) &&
       dataStorage &&
       dataStorage.id &&
-      /^s3$/i.test(dataStorage.storageType || dataStorage.type);
+      /^s3$/i.test(dataStorage.storageType || dataStorage.type) &&
+      storageOperationsEnabled;
   }
 
   get transitionRulesReadOnly () {

--- a/client/src/components/special/storage-size/index.js
+++ b/client/src/components/special/storage-size/index.js
@@ -369,9 +369,15 @@ class StorageSize extends React.PureComponent {
   };
 
   renderControls = () => {
+    const {storageOperationsEnabled = true} = this.props;
+    const showReindex = storageOperationsEnabled;
+    const showDetails = this.hasArchivedData && this.usageInfo?.details?.length > 0;
+    if (!showDetails && !showReindex) {
+      return null;
+    }
     return (
       <div>
-        {this.hasArchivedData && this.usageInfo?.details?.length > 0 ? (
+        {showDetails ? (
           <a
             className={styles.controlsButton}
             onClick={this.showDetailedInfo}
@@ -379,18 +385,20 @@ class StorageSize extends React.PureComponent {
             Show details
           </a>
         ) : null}
-        <a
-          className={styles.controlsButton}
-          onClick={this.refreshSize}
-        >
-          Re-index
-        </a>
+        {showReindex ? (
+          <a
+            className={styles.controlsButton}
+            onClick={this.refreshSize}
+          >
+            Re-index
+          </a>
+        ) : null}
       </div>
     );
   };
 
   render () {
-    const {className, style} = this.props;
+    const {className, style, storageOperationsEnabled = true} = this.props;
     if (
       this.usageInfo &&
       (this.usageInfo.size || this.usageInfo.archiveSizeTotal)
@@ -410,6 +418,9 @@ class StorageSize extends React.PureComponent {
           {this.renderDetailedInfoModal()}
         </div>
       );
+    }
+    if (!storageOperationsEnabled) {
+      return null;
     }
     return (
       <div
@@ -436,6 +447,7 @@ StorageSize.propTypes = {
   className: PropTypes.string,
   storage: PropTypes.object,
   storageId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  storageOperationsEnabled: PropTypes.bool,
   style: PropTypes.object
 };
 


### PR DESCRIPTION
Storage metadata can disable object-storage actions via several aliases (`Storage operations`, `StorageOperations`, `storage_operations`). Values `none` and `false` disable operations; matching is case-insensitive.