### PR TITLE
issue 4397 introduce deployment specific image version with fallback to default CP_VERSION

### DIFF
--- a/deploy/contents/install/app/install-utils.sh
+++ b/deploy/contents/install/app/install-utils.sh
@@ -633,6 +633,43 @@ function import_users_from_point_in_time_configuration {
   fi
 }
 
+function init_service_versions {
+    # Initialize per-service image version variables.
+    # Each variable falls back to CP_VERSION if not explicitly set,
+    # preserving the default behaviour while allowing individual services
+    # to be pinned to a different version via -env or the install-config file.
+    # leader-elector shares CP_API_SRV_VERSION because it is always
+    # deployed together with api-srv and released as the same image build.
+    export CP_LEADER_ELECTOR_VERSION="${CP_LEADER_ELECTOR_VERSION:-$CP_VERSION}"
+    export CP_API_SRV_VERSION="${CP_API_SRV_VERSION:-$CP_VERSION}"
+    export CP_BILLING_SRV_VERSION="${CP_BILLING_SRV_VERSION:-$CP_VERSION}"
+    export CP_BKP_WORKER_VERSION="${CP_BKP_WORKER_VERSION:-$CP_VERSION}"
+    export CP_CLAIR_VERSION="${CP_CLAIR_VERSION:-$CP_VERSION}"
+    export CP_DAV_VERSION="${CP_DAV_VERSION:-$CP_VERSION}"
+    export CP_DEPLOYMENT_AUTOSCALER_VERSION="${CP_DEPLOYMENT_AUTOSCALER_VERSION:-$CP_VERSION}"
+    export CP_DOCKER_COMP_VERSION="${CP_DOCKER_COMP_VERSION:-$CP_VERSION}"
+    export CP_DOCKER_REGISTRY_VERSION="${CP_DOCKER_REGISTRY_VERSION:-$CP_VERSION}"
+    export CP_EDGE_VERSION="${CP_EDGE_VERSION:-$CP_VERSION}"
+    export CP_GIT_VERSION="${CP_GIT_VERSION:-$CP_VERSION}"
+    export CP_GITLAB_READER_VERSION="${CP_GITLAB_READER_VERSION:-$CP_VERSION}"
+    export CP_HEAPSTER_VERSION="${CP_HEAPSTER_VERSION:-$CP_VERSION}"
+    export CP_IDP_VERSION="${CP_IDP_VERSION:-$CP_VERSION}"
+    export CP_MLFLOW_VERSION="${CP_MLFLOW_VERSION:-$CP_VERSION}"
+    export CP_MONITORING_SRV_VERSION="${CP_MONITORING_SRV_VERSION:-$CP_VERSION}"
+    export CP_NODE_LOGGER_VERSION="${CP_NODE_LOGGER_VERSION:-$CP_VERSION}"
+    export CP_NODE_REPORTER_VERSION="${CP_NODE_REPORTER_VERSION:-$CP_VERSION}"
+    export CP_NOTIFIER_VERSION="${CP_NOTIFIER_VERSION:-$CP_VERSION}"
+    export CP_RUN_CLEANUP_JOB_VERSION="${CP_RUN_CLEANUP_JOB_VERSION:-$CP_VERSION}"
+    export CP_RUN_POLICY_MANAGER_VERSION="${CP_RUN_POLICY_MANAGER_VERSION:-$CP_VERSION}"
+    export CP_SEARCH_SRV_VERSION="${CP_SEARCH_SRV_VERSION:-$CP_VERSION}"
+    export CP_SEARCH_ELK_VERSION="${CP_SEARCH_ELK_VERSION:-$CP_VERSION}"
+    export CP_SEARCH_ELK_CURATOR_VERSION="${CP_SEARCH_ELK_CURATOR_VERSION:-$CP_VERSION}"
+    export CP_SHARE_SRV_VERSION="${CP_SHARE_SRV_VERSION:-$CP_VERSION}"
+    export CP_STATPING_MONITOR_VERSION="${CP_STATPING_MONITOR_VERSION:-$CP_VERSION}"
+    export CP_TINYPROXY_VERSION="${CP_TINYPROXY_VERSION:-$CP_VERSION}"
+    export CP_VM_MONITOR_VERSION="${CP_VM_MONITOR_VERSION:-$CP_VERSION}"
+}
+
 function parse_options {
     local services_count=0
     export CP_SERVICES_ENABLED=

--- a/deploy/contents/install/app/install.sh
+++ b/deploy/contents/install/app/install.sh
@@ -44,6 +44,8 @@ if [ $? -ne 0 ]; then
     print_err "Unable to setup installation configuration, exiting"
     exit 1
 fi
+
+init_service_versions
 echo
 
 ##########

--- a/deploy/contents/k8s/cp-api-srv/cp-api-srv-dpl-awsn.yaml
+++ b/deploy/contents/k8s/cp-api-srv/cp-api-srv-dpl-awsn.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: cp-main-service
       containers:
         - name: cp-api-srv-leader-elector
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:leader-elector-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:leader-elector-${CP_LEADER_ELECTOR_VERSION}
           imagePullPolicy: "Always"
           securityContext:
             privileged: true
@@ -49,7 +49,7 @@ spec:
                 name: cp-config-global
           
         - name: cp-api-srv
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:api-srv-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:api-srv-${CP_API_SRV_VERSION}
           imagePullPolicy: "Always"
           securityContext:
             privileged: true

--- a/deploy/contents/k8s/cp-api-srv/cp-api-srv-dpl.yaml
+++ b/deploy/contents/k8s/cp-api-srv/cp-api-srv-dpl.yaml
@@ -27,7 +27,7 @@ spec:
       terminationGracePeriodSeconds: 50
       containers:
         - name: cp-api-srv-leader-elector
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:leader-elector-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:leader-elector-${CP_LEADER_ELECTOR_VERSION}
           imagePullPolicy: "Always"
           securityContext:
             privileged: true
@@ -46,7 +46,7 @@ spec:
                 name: cp-config-global
           
         - name: cp-api-srv
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:api-srv-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:api-srv-${CP_API_SRV_VERSION}
           imagePullPolicy: "Always"
           securityContext:
             privileged: true

--- a/deploy/contents/k8s/cp-billing-srv/cp-billing-srv-dpl-awsn.yaml
+++ b/deploy/contents/k8s/cp-billing-srv/cp-billing-srv-dpl-awsn.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: cp-main-service
       containers:
         - name: cp-billing-srv
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:billing-srv-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:billing-srv-${CP_BILLING_SRV_VERSION}
           imagePullPolicy: "Always"
           command: ["/init"]
           envFrom:

--- a/deploy/contents/k8s/cp-billing-srv/cp-billing-srv-dpl.yaml
+++ b/deploy/contents/k8s/cp-billing-srv/cp-billing-srv-dpl.yaml
@@ -23,7 +23,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: cp-billing-srv
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:billing-srv-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:billing-srv-${CP_BILLING_SRV_VERSION}
           imagePullPolicy: "Always"
           command: ["/init"]
           envFrom:

--- a/deploy/contents/k8s/cp-bkp-worker/cp-bkp-worker-dpl.yaml
+++ b/deploy/contents/k8s/cp-bkp-worker/cp-bkp-worker-dpl.yaml
@@ -22,7 +22,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-bkp-worker-$CP_BKP_SERVICE_NAME
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:cp-bkp-worker-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:cp-bkp-worker-${CP_BKP_WORKER_VERSION}
           imagePullPolicy: "Always"
           envFrom:
             - configMapRef:

--- a/deploy/contents/k8s/cp-clair/cp-clair-dpl-awsn.yaml
+++ b/deploy/contents/k8s/cp-clair/cp-clair-dpl-awsn.yaml
@@ -21,7 +21,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-clair
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:clair-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:clair-${CP_CLAIR_VERSION}
           imagePullPolicy: "Always"
           ports:
             - containerPort: 8080

--- a/deploy/contents/k8s/cp-clair/cp-clair-dpl.yaml
+++ b/deploy/contents/k8s/cp-clair/cp-clair-dpl.yaml
@@ -22,7 +22,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: cp-clair
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:${CP_CLAIR_DOCKER_NAME}-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:${CP_CLAIR_DOCKER_NAME}-${CP_CLAIR_VERSION}
           imagePullPolicy: "Always"
           ports:
             - containerPort: 8080

--- a/deploy/contents/k8s/cp-dav/cp-dav-dpl-awsn.yaml
+++ b/deploy/contents/k8s/cp-dav/cp-dav-dpl-awsn.yaml
@@ -21,7 +21,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-dav
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:dav-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:dav-${CP_DAV_VERSION}
           imagePullPolicy: "Always"
           securityContext:
             privileged: true

--- a/deploy/contents/k8s/cp-dav/cp-dav-dpl.yaml
+++ b/deploy/contents/k8s/cp-dav/cp-dav-dpl.yaml
@@ -22,7 +22,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-dav
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:dav-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:dav-${CP_DAV_VERSION}
           imagePullPolicy: "Always"
           securityContext:
             privileged: true

--- a/deploy/contents/k8s/cp-deployment-autoscaler/cp-deployment-autoscaler-dpl-awsn.yaml
+++ b/deploy/contents/k8s/cp-deployment-autoscaler/cp-deployment-autoscaler-dpl-awsn.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: cp-main-service
       containers:
         - name: cp-deployment-autoscaler
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:deployment-autoscaler-${CP_VERSION}
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:deployment-autoscaler-${CP_DEPLOYMENT_AUTOSCALER_VERSION}
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:

--- a/deploy/contents/k8s/cp-deployment-autoscaler/cp-deployment-autoscaler-dpl.yaml
+++ b/deploy/contents/k8s/cp-deployment-autoscaler/cp-deployment-autoscaler-dpl.yaml
@@ -23,7 +23,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: cp-deployment-autoscaler
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:deployment-autoscaler-${CP_VERSION}
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:deployment-autoscaler-${CP_DEPLOYMENT_AUTOSCALER_VERSION}
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:

--- a/deploy/contents/k8s/cp-docker-comp/cp-docker-comp-dpl-awsn.yaml
+++ b/deploy/contents/k8s/cp-docker-comp/cp-docker-comp-dpl-awsn.yaml
@@ -21,7 +21,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-docker-comp
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:docker-comp-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:docker-comp-${CP_DOCKER_COMP_VERSION}
           imagePullPolicy: "Always"
           command: ["/init"]
           ports:

--- a/deploy/contents/k8s/cp-docker-comp/cp-docker-comp-dpl.yaml
+++ b/deploy/contents/k8s/cp-docker-comp/cp-docker-comp-dpl.yaml
@@ -22,7 +22,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-docker-comp
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:docker-comp-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:docker-comp-${CP_DOCKER_COMP_VERSION}
           imagePullPolicy: "Always"
           command: ["/init"]
           ports:

--- a/deploy/contents/k8s/cp-docker-registry/cp-docker-registry-dpl-awsn.yaml
+++ b/deploy/contents/k8s/cp-docker-registry/cp-docker-registry-dpl-awsn.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: cp-main-service
       containers:
         - name: cp-docker-registry
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:registry-${CP_VERSION}-${CP_DOCKER_REGISTRY_TYPE}
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:registry-${CP_DOCKER_REGISTRY_VERSION}-${CP_DOCKER_REGISTRY_TYPE}
           imagePullPolicy: "Always"
           ports:
             - containerPort: 443

--- a/deploy/contents/k8s/cp-docker-registry/cp-docker-registry-dpl.yaml
+++ b/deploy/contents/k8s/cp-docker-registry/cp-docker-registry-dpl.yaml
@@ -22,7 +22,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-docker-registry
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:registry-${CP_VERSION}-${CP_DOCKER_REGISTRY_TYPE}
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:registry-${CP_DOCKER_REGISTRY_VERSION}-${CP_DOCKER_REGISTRY_TYPE}
           imagePullPolicy: "Always"
           ports:
             - containerPort: 443

--- a/deploy/contents/k8s/cp-edge/cp-edge-dpl-additional-region.yaml
+++ b/deploy/contents/k8s/cp-edge/cp-edge-dpl-additional-region.yaml
@@ -27,7 +27,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-edge
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:edge-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:edge-${CP_EDGE_VERSION}
           imagePullPolicy: "Always"
           command: ["/init"]
           env:

--- a/deploy/contents/k8s/cp-edge/cp-edge-dpl-awsn.yaml
+++ b/deploy/contents/k8s/cp-edge/cp-edge-dpl-awsn.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: cp-main-service
       containers:
         - name: cp-edge
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:edge-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:edge-${CP_EDGE_VERSION}
           imagePullPolicy: "Always"
           command: ["/init"]
           env:

--- a/deploy/contents/k8s/cp-edge/cp-edge-dpl.yaml
+++ b/deploy/contents/k8s/cp-edge/cp-edge-dpl.yaml
@@ -27,7 +27,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-edge
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:edge-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:edge-${CP_EDGE_VERSION}
           imagePullPolicy: "Always"
           command: ["/init"]
           env:

--- a/deploy/contents/k8s/cp-git-sync/cp-git-sync-dpl-awsn.yaml
+++ b/deploy/contents/k8s/cp-git-sync/cp-git-sync-dpl-awsn.yaml
@@ -22,7 +22,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-git-sync
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:api-srv-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:api-srv-${CP_API_SRV_VERSION}
           imagePullPolicy: "Always"
           command: ["/init-git-sync", "https://$(CP_API_SRV_INTERNAL_HOST):$(CP_API_SRV_INTERNAL_PORT)/pipeline/restapi/", "$(CP_API_JWT_ADMIN)"]
           envFrom:

--- a/deploy/contents/k8s/cp-git-sync/cp-git-sync-dpl.yaml
+++ b/deploy/contents/k8s/cp-git-sync/cp-git-sync-dpl.yaml
@@ -23,7 +23,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-git-sync
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:api-srv-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:api-srv-${CP_API_SRV_VERSION}
           imagePullPolicy: "Always"
           command: ["/init-git-sync", "https://$(CP_API_SRV_INTERNAL_HOST):$(CP_API_SRV_INTERNAL_PORT)/pipeline/restapi/", "$(CP_API_JWT_ADMIN)"]
           envFrom:

--- a/deploy/contents/k8s/cp-git/cp-git-dpl-awsn.yaml
+++ b/deploy/contents/k8s/cp-git/cp-git-dpl-awsn.yaml
@@ -21,7 +21,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-git
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:git-$CP_GITLAB_VERSION-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:git-$CP_GITLAB_VERSION-${CP_GIT_VERSION}
           imagePullPolicy: "Always"
           ports:
             - containerPort: ${CP_GITLAB_INTERNAL_PORT}

--- a/deploy/contents/k8s/cp-git/cp-git-dpl.yaml
+++ b/deploy/contents/k8s/cp-git/cp-git-dpl.yaml
@@ -22,7 +22,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-git
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:git-$CP_GITLAB_VERSION-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:git-$CP_GITLAB_VERSION-${CP_GIT_VERSION}
           imagePullPolicy: "Always"
           ports:
             - containerPort: ${CP_GITLAB_INTERNAL_PORT}

--- a/deploy/contents/k8s/cp-gitlab-reader/cp-gitlab-reader-dpl-awsn.yaml
+++ b/deploy/contents/k8s/cp-gitlab-reader/cp-gitlab-reader-dpl-awsn.yaml
@@ -22,7 +22,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-gitlab-reader
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:gitlab-reader-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:gitlab-reader-${CP_GITLAB_READER_VERSION}
           imagePullPolicy: "Always"
           command: ["/init.sh"]
           envFrom:

--- a/deploy/contents/k8s/cp-gitlab-reader/cp-gitlab-reader-dpl.yaml
+++ b/deploy/contents/k8s/cp-gitlab-reader/cp-gitlab-reader-dpl.yaml
@@ -23,7 +23,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-gitlab-reader
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:gitlab-reader-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:gitlab-reader-${CP_GITLAB_READER_VERSION}
           imagePullPolicy: "Always"
           command: ["/init.sh"]
           envFrom:

--- a/deploy/contents/k8s/cp-heapster/cp-heapster-elk-dpl.yaml
+++ b/deploy/contents/k8s/cp-heapster/cp-heapster-elk-dpl.yaml
@@ -24,7 +24,7 @@ spec:
         - name: cp-heapster-elk
           command: 
           - /init
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:heapster-elk-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:heapster-elk-${CP_HEAPSTER_VERSION}
           imagePullPolicy: "IfNotPresent"
           envFrom:
           - configMapRef:

--- a/deploy/contents/k8s/cp-idp/cp-idp-dpl-awsn.yaml
+++ b/deploy/contents/k8s/cp-idp/cp-idp-dpl-awsn.yaml
@@ -21,7 +21,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-idp
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:idp-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:idp-${CP_IDP_VERSION}
           imagePullPolicy: "Always"
           command: ["/init"]
           ports:

--- a/deploy/contents/k8s/cp-idp/cp-idp-dpl.yaml
+++ b/deploy/contents/k8s/cp-idp/cp-idp-dpl.yaml
@@ -22,7 +22,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-idp
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:idp-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:idp-${CP_IDP_VERSION}
           imagePullPolicy: "Always"
           command: ["/init"]
           ports:

--- a/deploy/contents/k8s/cp-mlflow/cp-mlflow-dpl.yaml
+++ b/deploy/contents/k8s/cp-mlflow/cp-mlflow-dpl.yaml
@@ -26,7 +26,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: cp-mlflow
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:mlflow-server-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:mlflow-server-${CP_MLFLOW_VERSION}
           imagePullPolicy: "Always"
           securityContext:
             privileged: true

--- a/deploy/contents/k8s/cp-monitoring-srv/cp-monitoring-srv-dpl-awsn.yaml
+++ b/deploy/contents/k8s/cp-monitoring-srv/cp-monitoring-srv-dpl-awsn.yaml
@@ -21,7 +21,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-monitoring-srv
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:monitoring-service-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:monitoring-service-${CP_MONITORING_SRV_VERSION}
           imagePullPolicy: "Always"
           command: ["/init"]
           envFrom:

--- a/deploy/contents/k8s/cp-monitoring-srv/cp-monitoring-srv-dpl.yaml
+++ b/deploy/contents/k8s/cp-monitoring-srv/cp-monitoring-srv-dpl.yaml
@@ -22,7 +22,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-monitoring-srv
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:monitoring-service-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:monitoring-service-${CP_MONITORING_SRV_VERSION}
           imagePullPolicy: "Always"
           command: ["/init"]
           envFrom:

--- a/deploy/contents/k8s/cp-node-logger/cp-node-logger-ds.yaml
+++ b/deploy/contents/k8s/cp-node-logger/cp-node-logger-ds.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: cp-node-logger
-        image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:node-logger-$CP_VERSION
+        image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:node-logger-${CP_NODE_LOGGER_VERSION}
         imagePullPolicy: "IfNotPresent"
         securityContext:
           privileged: true

--- a/deploy/contents/k8s/cp-node-reporter/cp-node-reporter.yaml
+++ b/deploy/contents/k8s/cp-node-reporter/cp-node-reporter.yaml
@@ -22,7 +22,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cp-node-reporter
-        image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:node-reporter-$CP_VERSION
+        image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:node-reporter-${CP_NODE_REPORTER_VERSION}
         imagePullPolicy: "IfNotPresent"
         resources:
           limits:

--- a/deploy/contents/k8s/cp-notifier/cp-notifier-dpl-awsn.yaml
+++ b/deploy/contents/k8s/cp-notifier/cp-notifier-dpl-awsn.yaml
@@ -22,7 +22,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-notifier
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:notifier-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:notifier-${CP_NOTIFIER_VERSION}
           imagePullPolicy: "Always"
           command: ["/init"]
           envFrom:

--- a/deploy/contents/k8s/cp-notifier/cp-notifier-dpl.yaml
+++ b/deploy/contents/k8s/cp-notifier/cp-notifier-dpl.yaml
@@ -23,7 +23,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-notifier
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:notifier-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:notifier-${CP_NOTIFIER_VERSION}
           imagePullPolicy: "Always"
           command: ["/init"]
           envFrom:

--- a/deploy/contents/k8s/cp-run-cleanup-job/cp-run-cleanup-job-cron.yaml
+++ b/deploy/contents/k8s/cp-run-cleanup-job/cp-run-cleanup-job-cron.yaml
@@ -25,7 +25,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: cp-run-cleanup-job
-            image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:run-cleanup-job-${CP_VERSION}
+            image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:run-cleanup-job-${CP_RUN_CLEANUP_JOB_VERSION}
             imagePullPolicy: Always
             command: ["/init"]
             envFrom:

--- a/deploy/contents/k8s/cp-run-policy-manager/cp-run-policy-manager-dpl-awsn.yaml
+++ b/deploy/contents/k8s/cp-run-policy-manager/cp-run-policy-manager-dpl-awsn.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: cp-main-service
       containers:
         - name: cp-run-policy-manager
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:run-policy-manager-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:run-policy-manager-${CP_RUN_POLICY_MANAGER_VERSION}
           imagePullPolicy: "Always"
           securityContext:
             privileged: true

--- a/deploy/contents/k8s/cp-run-policy-manager/cp-run-policy-manager-dpl.yaml
+++ b/deploy/contents/k8s/cp-run-policy-manager/cp-run-policy-manager-dpl.yaml
@@ -22,7 +22,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-run-policy-manager
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:run-policy-manager-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:run-policy-manager-${CP_RUN_POLICY_MANAGER_VERSION}
           imagePullPolicy: "Always"
           securityContext:
             privileged: true

--- a/deploy/contents/k8s/cp-search/cp-search-elk-curator-dpl-awsn.yaml
+++ b/deploy/contents/k8s/cp-search/cp-search-elk-curator-dpl-awsn.yaml
@@ -22,7 +22,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-search-elk
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:search-elk-curator-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:search-elk-curator-${CP_SEARCH_ELK_CURATOR_VERSION}
           securityContext:
             privileged: true
           imagePullPolicy: "Always"

--- a/deploy/contents/k8s/cp-search/cp-search-elk-curator-dpl.yaml
+++ b/deploy/contents/k8s/cp-search/cp-search-elk-curator-dpl.yaml
@@ -22,7 +22,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-search-elk-curator
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:search-elk-curator-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:search-elk-curator-${CP_SEARCH_ELK_CURATOR_VERSION}
           securityContext:
             privileged: true
           imagePullPolicy: "Always"

--- a/deploy/contents/k8s/cp-search/cp-search-elk-dpl-awsn.yaml
+++ b/deploy/contents/k8s/cp-search/cp-search-elk-dpl-awsn.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: cp-main-service
       containers:
         - name: cp-search-elk
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:search-elk-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:search-elk-${CP_SEARCH_ELK_VERSION}
           securityContext:
             privileged: true
           imagePullPolicy: "IfNotPresent"

--- a/deploy/contents/k8s/cp-search/cp-search-elk-dpl.yaml
+++ b/deploy/contents/k8s/cp-search/cp-search-elk-dpl.yaml
@@ -22,7 +22,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-search-elk
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:search-elk-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:search-elk-${CP_SEARCH_ELK_VERSION}
           securityContext:
             privileged: true
           imagePullPolicy: "IfNotPresent"

--- a/deploy/contents/k8s/cp-search/cp-search-elk-set.yaml
+++ b/deploy/contents/k8s/cp-search/cp-search-elk-set.yaml
@@ -22,7 +22,7 @@ spec:
         - name: cp-search-elk
           securityContext:
             privileged: true
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:search-elk-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:search-elk-${CP_SEARCH_ELK_VERSION}
           imagePullPolicy: IfNotPresent
           command: [ "bash" ]
           args: [ "-c", "/init.sh" ]

--- a/deploy/contents/k8s/cp-search/cp-search-srv-dpl-awsn.yaml
+++ b/deploy/contents/k8s/cp-search/cp-search-srv-dpl-awsn.yaml
@@ -22,7 +22,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-search-srv
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:search-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:search-${CP_SEARCH_SRV_VERSION}
           imagePullPolicy: "Always"
           securityContext:
             privileged: true

--- a/deploy/contents/k8s/cp-search/cp-search-srv-dpl.yaml
+++ b/deploy/contents/k8s/cp-search/cp-search-srv-dpl.yaml
@@ -23,7 +23,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-search-srv
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:search-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:search-${CP_SEARCH_SRV_VERSION}
           imagePullPolicy: "Always"
           securityContext:
             privileged: true

--- a/deploy/contents/k8s/cp-search/cp-search-srv-nfs-events-dpl-awsn.yaml
+++ b/deploy/contents/k8s/cp-search/cp-search-srv-nfs-events-dpl-awsn.yaml
@@ -22,7 +22,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: cp-search-srv
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:search-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:search-${CP_SEARCH_SRV_VERSION}
           imagePullPolicy: "Always"
           securityContext:
             privileged: true

--- a/deploy/contents/k8s/cp-search/cp-search-srv-nfs-events-dpl.yaml
+++ b/deploy/contents/k8s/cp-search/cp-search-srv-nfs-events-dpl.yaml
@@ -23,7 +23,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: cp-search-srv
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:search-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:search-${CP_SEARCH_SRV_VERSION}
           imagePullPolicy: "Always"
           securityContext:
             privileged: true

--- a/deploy/contents/k8s/cp-search/cp-search-srv-nfs-only-dpl-awsn.yaml
+++ b/deploy/contents/k8s/cp-search/cp-search-srv-nfs-only-dpl-awsn.yaml
@@ -22,7 +22,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: cp-search-srv
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:search-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:search-${CP_SEARCH_SRV_VERSION}
           imagePullPolicy: "Always"
           securityContext:
             privileged: true

--- a/deploy/contents/k8s/cp-search/cp-search-srv-nfs-only-dpl.yaml
+++ b/deploy/contents/k8s/cp-search/cp-search-srv-nfs-only-dpl.yaml
@@ -23,7 +23,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: cp-search-srv
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:search-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:search-${CP_SEARCH_SRV_VERSION}
           imagePullPolicy: "Always"
           securityContext:
             privileged: true

--- a/deploy/contents/k8s/cp-sensitive-proxy/cp-sensitive-proxy-dpl-awsn.yaml
+++ b/deploy/contents/k8s/cp-sensitive-proxy/cp-sensitive-proxy-dpl-awsn.yaml
@@ -21,7 +21,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-sensitive-proxy
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:tinyproxy-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:tinyproxy-${CP_TINYPROXY_VERSION}
           imagePullPolicy: "IfNotPresent"
           command: ["/init"]
           env:

--- a/deploy/contents/k8s/cp-sensitive-proxy/cp-sensitive-proxy-dpl.yaml
+++ b/deploy/contents/k8s/cp-sensitive-proxy/cp-sensitive-proxy-dpl.yaml
@@ -22,7 +22,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-sensitive-proxy
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:tinyproxy-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:tinyproxy-${CP_TINYPROXY_VERSION}
           imagePullPolicy: "IfNotPresent"
           command: ["/init"]
           env:

--- a/deploy/contents/k8s/cp-share-srv/cp-share-srv-dpl-awsn.yaml
+++ b/deploy/contents/k8s/cp-share-srv/cp-share-srv-dpl-awsn.yaml
@@ -21,7 +21,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-share-srv
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:share-srv-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:share-srv-${CP_SHARE_SRV_VERSION}
           imagePullPolicy: "Always"
           securityContext:
             privileged: true

--- a/deploy/contents/k8s/cp-share-srv/cp-share-srv-dpl.yaml
+++ b/deploy/contents/k8s/cp-share-srv/cp-share-srv-dpl.yaml
@@ -22,7 +22,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-share-srv
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:share-srv-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:share-srv-${CP_SHARE_SRV_VERSION}
           imagePullPolicy: "Always"
           securityContext:
             privileged: true

--- a/deploy/contents/k8s/cp-statping-monitor/cp-statping-monitor-dpl-awsn.yaml
+++ b/deploy/contents/k8s/cp-statping-monitor/cp-statping-monitor-dpl-awsn.yaml
@@ -21,7 +21,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-health
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:statping-monitor-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:statping-monitor-${CP_STATPING_MONITOR_VERSION}
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 8080

--- a/deploy/contents/k8s/cp-statping-monitor/cp-statping-monitor-dpl.yaml
+++ b/deploy/contents/k8s/cp-statping-monitor/cp-statping-monitor-dpl.yaml
@@ -22,7 +22,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-health
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:statping-monitor-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:statping-monitor-${CP_STATPING_MONITOR_VERSION}
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 8080

--- a/deploy/contents/k8s/cp-tinyproxy/cp-tinyproxy-dpl-awsn.yaml
+++ b/deploy/contents/k8s/cp-tinyproxy/cp-tinyproxy-dpl-awsn.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: cp-main-service
       containers:
         - name: cp-tinyproxy
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:tinyproxy-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:tinyproxy-${CP_TINYPROXY_VERSION}
           imagePullPolicy: "IfNotPresent"
           command: ["/init"]
           env:

--- a/deploy/contents/k8s/cp-tinyproxy/cp-tinyproxy-dpl.yaml
+++ b/deploy/contents/k8s/cp-tinyproxy/cp-tinyproxy-dpl.yaml
@@ -22,7 +22,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-tinyproxy
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:tinyproxy-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:tinyproxy-${CP_TINYPROXY_VERSION}
           imagePullPolicy: "IfNotPresent"
           command: ["/init"]
           env:

--- a/deploy/contents/k8s/cp-vm-monitor/cp-vm-monitor-dpl-awsn.yaml
+++ b/deploy/contents/k8s/cp-vm-monitor/cp-vm-monitor-dpl-awsn.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: cp-main-service
       containers:
         - name: cp-vm-monitor
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:vm-monitor-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:vm-monitor-${CP_VM_MONITOR_VERSION}
           imagePullPolicy: "Always"
           securityContext:
             privileged: true

--- a/deploy/contents/k8s/cp-vm-monitor/cp-vm-monitor-dpl.yaml
+++ b/deploy/contents/k8s/cp-vm-monitor/cp-vm-monitor-dpl.yaml
@@ -22,7 +22,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cp-vm-monitor
-          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:vm-monitor-$CP_VERSION
+          image: ${CP_DOCKER_DIST_SRV}lifescience/cloud-pipeline:vm-monitor-${CP_VM_MONITOR_VERSION}
           imagePullPolicy: "Always"
           securityContext:
             privileged: true


### PR DESCRIPTION
related #4397 
Changes:

  Each service image tag now uses a dedicated version variable (e.g. CP_API_SRV_VERSION, CP_EDGE_VERSION, CP_NOTIFIER_VERSION, etc.). All per-service variables fall back to CP_VERSION when not set, so the existing behaviour
   is fully preserved.

  To override a specific service, pass the variable via -env or set it in the install-config file:

```  
# All services use 0.17, except api-srv which uses a release candidate
pipectl install \
  .... \  
  -env CP_API_SRV_VERSION=0.17.99-rc1
```