### PR TITLE
[API]: Support global github credentials

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -122,6 +122,7 @@ dependencies {
     //security
     compile("org.springframework.boot:spring-boot-starter-security")
     compile "com.auth0:java-jwt:3.1.0"
+    compile "org.bouncycastle:bcpkix-jdk18on:1.78.1"
     compile "org.springframework.security.extensions:spring-security-saml2-core:1.0.2.RELEASE"
     compile group: "org.springframework.security", name: "spring-security-acl", version: "4.2.2.RELEASE"
     compile group: "net.sf.ehcache", name: "ehcache", version: "2.10.4"

--- a/api/profiles/dev/application.properties
+++ b/api/profiles/dev/application.properties
@@ -239,3 +239,6 @@ edge.internal.port=${CP_EDGE_INTERNAL_PORT:31081}
 #Misc
 app.component.version.name=${CP_API_VERSION_PRETTY_NAME:}
 app.component.version.file=${CP_API_COMPONENT_VERSION_FILE:classpath:static/components_versions.json}
+
+#GitHub
+github.app.private.key.pem=${CP_GITHUB_APP_PRIVATE_KEY:}

--- a/api/profiles/release/application.properties
+++ b/api/profiles/release/application.properties
@@ -132,3 +132,6 @@ data.storage.nfs.events.dump.timeout=${CP_API_STORAGE_EVENTS_DUMPING_TIMEOUT:300
 #Firecloud
 firecloud.auth.client.id=
 firecloud.auth.client.secret=
+
+#GitHub
+github.app.private.key.pem=${CP_GITHUB_APP_PRIVATE_KEY:}

--- a/api/src/main/java/com/epam/pipeline/acl/pipeline/PipelineApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/pipeline/PipelineApiService.java
@@ -31,6 +31,8 @@ import com.epam.pipeline.entity.cluster.InstancePrice;
 import com.epam.pipeline.entity.git.GitCommitEntry;
 import com.epam.pipeline.entity.git.GitCommitsFilter;
 import com.epam.pipeline.entity.git.GitCredentials;
+import com.epam.pipeline.entity.git.GitNamespace;
+import com.epam.pipeline.entity.git.GitProject;
 import com.epam.pipeline.entity.git.GitRepositoryEntry;
 import com.epam.pipeline.entity.git.GitTagEntry;
 import com.epam.pipeline.entity.git.report.GitDiffReportFilter;
@@ -47,6 +49,7 @@ import com.epam.pipeline.entity.pipeline.DocumentGenerationProperty;
 import com.epam.pipeline.entity.pipeline.Pipeline;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.PipelineWithMetadata;
+import com.epam.pipeline.entity.pipeline.RepositoryType;
 import com.epam.pipeline.entity.pipeline.Revision;
 import com.epam.pipeline.exception.git.GitClientException;
 import com.epam.pipeline.manager.cluster.InstanceOfferManager;
@@ -387,5 +390,15 @@ public class PipelineApiService {
     public VersionStorageReportFile generateReportForVersionedStorage(final Long id,
                                                                       final GitDiffReportFilter reportFilters) {
         return fileGenerationManager.generateVersionStorageReport(id, reportFilters);
+    }
+
+    @PreAuthorize(ADMIN_OR_GENERAL_USER)
+    public List<GitNamespace> getAllowedNamespaces(final RepositoryType type) {
+        return pipelineRepositoryService.getAllowedNamespaces(type);
+    }
+    
+    @PreAuthorize(ADMIN_OR_GENERAL_USER)
+    public List<GitProject> getNamespaceRepositories(final String namespaceId, final RepositoryType type) {
+        return pipelineRepositoryService.getNamespaceRepositories(namespaceId, type);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/acl/pipeline/PipelineApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/pipeline/PipelineApiService.java
@@ -27,12 +27,12 @@ import com.epam.pipeline.controller.vo.RegisterPipelineVersionVO;
 import com.epam.pipeline.controller.vo.TaskGraphVO;
 import com.epam.pipeline.controller.vo.UploadFileMetadata;
 import com.epam.pipeline.controller.vo.EntityFilterVO;
+import com.epam.pipeline.dto.git.GitRepositoryDTO;
 import com.epam.pipeline.entity.cluster.InstancePrice;
 import com.epam.pipeline.entity.git.GitCommitEntry;
 import com.epam.pipeline.entity.git.GitCommitsFilter;
 import com.epam.pipeline.entity.git.GitCredentials;
 import com.epam.pipeline.entity.git.GitNamespace;
-import com.epam.pipeline.entity.git.GitProject;
 import com.epam.pipeline.entity.git.GitRepositoryEntry;
 import com.epam.pipeline.entity.git.GitTagEntry;
 import com.epam.pipeline.entity.git.report.GitDiffReportFilter;
@@ -396,9 +396,9 @@ public class PipelineApiService {
     public List<GitNamespace> getAllowedNamespaces(final RepositoryType type) {
         return pipelineRepositoryService.getAllowedNamespaces(type);
     }
-    
+
     @PreAuthorize(ADMIN_OR_GENERAL_USER)
-    public List<GitProject> getNamespaceRepositories(final String namespaceId, final RepositoryType type) {
+    public List<GitRepositoryDTO> getNamespaceRepositories(final String namespaceId, final RepositoryType type) {
         return pipelineRepositoryService.getNamespaceRepositories(namespaceId, type);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineController.java
@@ -30,12 +30,12 @@ import com.epam.pipeline.controller.vo.RegisterPipelineVersionVO;
 import com.epam.pipeline.controller.vo.TaskGraphVO;
 import com.epam.pipeline.controller.vo.UploadFileMetadata;
 import com.epam.pipeline.controller.vo.EntityFilterVO;
+import com.epam.pipeline.dto.git.GitRepositoryDTO;
 import com.epam.pipeline.entity.cluster.InstancePrice;
 import com.epam.pipeline.entity.git.GitCommitEntry;
 import com.epam.pipeline.entity.git.GitCommitsFilter;
 import com.epam.pipeline.entity.git.GitCredentials;
 import com.epam.pipeline.entity.git.GitNamespace;
-import com.epam.pipeline.entity.git.GitProject;
 import com.epam.pipeline.entity.git.GitRepositoryEntry;
 import com.epam.pipeline.entity.git.GitTagEntry;
 import com.epam.pipeline.entity.git.report.GitDiffReportFilter;
@@ -891,7 +891,7 @@ public class PipelineController extends AbstractRestController {
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiResponses(
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
-    public Result<List<GitProject>> getNamespaceRepositories(
+    public Result<List<GitRepositoryDTO>> getNamespaceRepositories(
             @PathVariable(value = "namespaceId") final String namespaceId,
             @RequestParam(value = TYPE) final RepositoryType type) {
         return Result.success(pipelineApiService.getNamespaceRepositories(namespaceId, type));

--- a/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/pipeline/PipelineController.java
@@ -34,6 +34,8 @@ import com.epam.pipeline.entity.cluster.InstancePrice;
 import com.epam.pipeline.entity.git.GitCommitEntry;
 import com.epam.pipeline.entity.git.GitCommitsFilter;
 import com.epam.pipeline.entity.git.GitCredentials;
+import com.epam.pipeline.entity.git.GitNamespace;
+import com.epam.pipeline.entity.git.GitProject;
 import com.epam.pipeline.entity.git.GitRepositoryEntry;
 import com.epam.pipeline.entity.git.GitTagEntry;
 import com.epam.pipeline.entity.git.report.GitDiffReportFilter;
@@ -50,6 +52,7 @@ import com.epam.pipeline.entity.pipeline.DocumentGenerationProperty;
 import com.epam.pipeline.entity.pipeline.Pipeline;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.PipelineWithMetadata;
+import com.epam.pipeline.entity.pipeline.RepositoryType;
 import com.epam.pipeline.entity.pipeline.Revision;
 import com.epam.pipeline.exception.git.GitClientException;
 import com.epam.pipeline.acl.pipeline.PipelineApiService;
@@ -97,6 +100,7 @@ public class PipelineController extends AbstractRestController {
     private static final String PAGE_SIZE = "page_size";
     private static final String KEEP_REPOSITORY = "keep_repository";
     private static final String RECURSIVE = "recursive";
+    private static final String TYPE = "type";
     private static final Logger LOGGER = LoggerFactory.getLogger(PipelineController.class);
     @Autowired
     private PipelineApiService pipelineApiService;
@@ -864,5 +868,32 @@ public class PipelineController extends AbstractRestController {
             final HttpServletResponse response) throws IOException {
         final VersionStorageReportFile report = pipelineApiService.generateReportForVersionedStorage(id, filter);
         writeFileToResponse(response, report.getContent(), report.getName());
+    }
+
+    @GetMapping("/pipeline/git/namespaces")
+    @ResponseBody
+    @ApiOperation(
+            value = "Returns all allowed Git namespaces. For now only GitHub provider supported.",
+            notes = "Returns all allowed Git namespaces (organizations/users) for the specified repository type.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<List<GitNamespace>> getAllowedNamespaces(
+            @RequestParam(value = TYPE) final RepositoryType type) {
+        return Result.success(pipelineApiService.getAllowedNamespaces(type));
+    }
+
+    @GetMapping("/pipeline/git/{namespaceId}/repositories")
+    @ResponseBody
+    @ApiOperation(
+            value = "Returns all repositories for a specific Git namespace. For now only GitHub provider supported.",
+            notes = "Returns all repositories accessible within the specified Git namespace.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(
+            value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<List<GitProject>> getNamespaceRepositories(
+            @PathVariable(value = "namespaceId") final String namespaceId,
+            @RequestParam(value = TYPE) final RepositoryType type) {
+        return Result.success(pipelineApiService.getNamespaceRepositories(namespaceId, type));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/entity/git/GitNamespace.java
+++ b/api/src/main/java/com/epam/pipeline/entity/git/GitNamespace.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.epam.pipeline.entity.git;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class GitNamespace {
+    private String name;
+    private String id;
+    private String type;
+}

--- a/api/src/main/java/com/epam/pipeline/entity/git/github/GitHubAccessToken.java
+++ b/api/src/main/java/com/epam/pipeline/entity/git/github/GitHubAccessToken.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.git.github;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class GitHubAccessToken {
+    private String token;
+}

--- a/api/src/main/java/com/epam/pipeline/entity/git/github/GitHubInstallation.java
+++ b/api/src/main/java/com/epam/pipeline/entity/git/github/GitHubInstallation.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.git.github;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class GitHubInstallation {
+    private Long id;
+    private GitHubInstallationAccount account;
+}

--- a/api/src/main/java/com/epam/pipeline/entity/git/github/GitHubInstallationAccount.java
+++ b/api/src/main/java/com/epam/pipeline/entity/git/github/GitHubInstallationAccount.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.epam.pipeline.entity.git.github;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class GitHubInstallationAccount {
+    private String login;
+    private String type;
+}

--- a/api/src/main/java/com/epam/pipeline/entity/git/github/GitHubInstallationRepositories.java
+++ b/api/src/main/java/com/epam/pipeline/entity/git/github/GitHubInstallationRepositories.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.git.github;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class GitHubInstallationRepositories {
+    @JsonProperty("total_count")
+    private int totalCount;
+    private List<GitHubRepository> repositories;
+}

--- a/api/src/main/java/com/epam/pipeline/manager/git/ApiBuilder.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/ApiBuilder.java
@@ -19,11 +19,11 @@ package com.epam.pipeline.manager.git;
 import com.epam.pipeline.config.JsonMapper;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import lombok.AllArgsConstructor;
-import lombok.RequiredArgsConstructor;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.util.Assert;
 import retrofit2.Retrofit;
@@ -36,10 +36,11 @@ import javax.net.ssl.X509TrustManager;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.text.SimpleDateFormat;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-@RequiredArgsConstructor
 public class ApiBuilder<T> {
 
     private static final int TIMEOUT = 30;
@@ -51,9 +52,16 @@ public class ApiBuilder<T> {
     private Class<T> apiClientClass;
     private String authHeaderName;
     private String dateFormat;
+    private final Map<String, String> extraHeaders;
 
     public ApiBuilder(final Class<T> apiClientClass, final String apiHost,
                       final String authHeaderName, final String token, final String dateFormat) {
+        this(apiClientClass, apiHost, authHeaderName, token, dateFormat, Collections.emptyMap());
+    }
+
+    public ApiBuilder(final Class<T> apiClientClass, final String apiHost,
+                      final String authHeaderName, final String token, final String dateFormat,
+                      final Map<String, String> extraHeaders) {
         this.apiClientClass = apiClientClass;
         this.authHeaderName = authHeaderName;
         this.dateFormat = dateFormat;
@@ -61,6 +69,7 @@ public class ApiBuilder<T> {
         this.readTimeout = TIMEOUT;
         this.apiHost = apiHost;
         this.token = token;
+        this.extraHeaders = MapUtils.emptyIfNull(extraHeaders);
     }
 
     public T build() {
@@ -105,6 +114,13 @@ public class ApiBuilder<T> {
         builder.readTimeout(readTimeout, TimeUnit.SECONDS)
                 .connectTimeout(connectTimeout, TimeUnit.SECONDS)
                 .hostnameVerifier((s, sslSession) -> true);
+        if (MapUtils.isNotEmpty(extraHeaders)) {
+            builder.addInterceptor(chain -> {
+                final Request.Builder requestBuilder = chain.request().newBuilder();
+                extraHeaders.forEach(requestBuilder::header);
+                return chain.proceed(requestBuilder.build());
+            });
+        }
         if (StringUtils.isNotBlank(token)) {
             builder.addInterceptor(new TokenInterceptor(authHeaderName, token));
         }

--- a/api/src/main/java/com/epam/pipeline/manager/git/GitClientService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/GitClientService.java
@@ -20,6 +20,7 @@ import com.epam.pipeline.controller.vo.PipelineSourceItemsVO;
 import com.epam.pipeline.controller.vo.UploadFileMetadata;
 import com.epam.pipeline.entity.git.GitCommitEntry;
 import com.epam.pipeline.entity.git.GitCredentials;
+import com.epam.pipeline.entity.git.GitNamespace;
 import com.epam.pipeline.entity.git.GitProject;
 import com.epam.pipeline.entity.git.GitRepositoryEntry;
 import com.epam.pipeline.entity.git.GitTagEntry;
@@ -98,4 +99,14 @@ public interface GitClientService {
     GitCommitEntry uploadFiles(Pipeline pipeline, List<UploadFileMetadata> files, String message);
 
     boolean fileExists(Pipeline pipeline, String filePath);
+
+    default List<GitNamespace> getAllowedNamespaces() {
+        throw new UnsupportedOperationException(
+                String.format("Getting allowed namespaces is not supported for %s repository", getType()));
+    }
+
+    default List<GitProject> getNamespaceRepositories(String namespaceId) {
+        throw new UnsupportedOperationException(
+                String.format("Getting namespace repositories is not supported for %s repository", getType()));
+    }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/git/GitClientService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/GitClientService.java
@@ -18,6 +18,7 @@ package com.epam.pipeline.manager.git;
 
 import com.epam.pipeline.controller.vo.PipelineSourceItemsVO;
 import com.epam.pipeline.controller.vo.UploadFileMetadata;
+import com.epam.pipeline.dto.git.GitRepositoryDTO;
 import com.epam.pipeline.entity.git.GitCommitEntry;
 import com.epam.pipeline.entity.git.GitCredentials;
 import com.epam.pipeline.entity.git.GitNamespace;
@@ -105,7 +106,7 @@ public interface GitClientService {
                 String.format("Getting allowed namespaces is not supported for %s repository", getType()));
     }
 
-    default List<GitProject> getNamespaceRepositories(String namespaceId) {
+    default List<GitRepositoryDTO> getNamespaceRepositories(String namespaceId) {
         throw new UnsupportedOperationException(
                 String.format("Getting namespace repositories is not supported for %s repository", getType()));
     }

--- a/api/src/main/java/com/epam/pipeline/manager/git/PipelineRepositoryProviderService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/PipelineRepositoryProviderService.java
@@ -20,6 +20,7 @@ import com.epam.pipeline.controller.vo.PipelineSourceItemsVO;
 import com.epam.pipeline.controller.vo.UploadFileMetadata;
 import com.epam.pipeline.entity.git.GitCommitEntry;
 import com.epam.pipeline.entity.git.GitCredentials;
+import com.epam.pipeline.entity.git.GitNamespace;
 import com.epam.pipeline.entity.git.GitProject;
 import com.epam.pipeline.entity.git.GitRepositoryEntry;
 import com.epam.pipeline.entity.git.GitTagEntry;
@@ -177,5 +178,13 @@ public class PipelineRepositoryProviderService {
 
     public boolean fileExists(final Pipeline pipeline, final String filePath) {
         return getProvider(pipeline.getRepositoryType()).fileExists(pipeline, filePath);
+    }
+
+    public List<GitNamespace> getAllowedNamespaces(final RepositoryType repositoryType) {
+        return getProvider(repositoryType).getAllowedNamespaces();
+    }
+
+    public List<GitProject> getNamespaceRepositories(final String namespaceId, final RepositoryType repositoryType) {
+        return getProvider(repositoryType).getNamespaceRepositories(namespaceId);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/git/PipelineRepositoryProviderService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/PipelineRepositoryProviderService.java
@@ -18,6 +18,7 @@ package com.epam.pipeline.manager.git;
 
 import com.epam.pipeline.controller.vo.PipelineSourceItemsVO;
 import com.epam.pipeline.controller.vo.UploadFileMetadata;
+import com.epam.pipeline.dto.git.GitRepositoryDTO;
 import com.epam.pipeline.entity.git.GitCommitEntry;
 import com.epam.pipeline.entity.git.GitCredentials;
 import com.epam.pipeline.entity.git.GitNamespace;
@@ -184,7 +185,8 @@ public class PipelineRepositoryProviderService {
         return getProvider(repositoryType).getAllowedNamespaces();
     }
 
-    public List<GitProject> getNamespaceRepositories(final String namespaceId, final RepositoryType repositoryType) {
+    public List<GitRepositoryDTO> getNamespaceRepositories(final String namespaceId,
+                                                           final RepositoryType repositoryType) {
         return getProvider(repositoryType).getNamespaceRepositories(namespaceId);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/git/PipelineRepositoryService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/PipelineRepositoryService.java
@@ -23,6 +23,7 @@ import com.epam.pipeline.controller.vo.PipelineSourceItemVO;
 import com.epam.pipeline.controller.vo.PipelineSourceItemsVO;
 import com.epam.pipeline.controller.vo.PipelineVO;
 import com.epam.pipeline.controller.vo.UploadFileMetadata;
+import com.epam.pipeline.dto.git.GitRepositoryDTO;
 import com.epam.pipeline.entity.git.GitCommitEntry;
 import com.epam.pipeline.entity.git.GitCredentials;
 import com.epam.pipeline.entity.git.GitNamespace;
@@ -562,7 +563,7 @@ public class PipelineRepositoryService {
         return providerService.getAllowedNamespaces(type);
     }
 
-    public List<GitProject> getNamespaceRepositories(final String namespaceId, final RepositoryType type) {
+    public List<GitRepositoryDTO> getNamespaceRepositories(final String namespaceId, final RepositoryType type) {
         return providerService.getNamespaceRepositories(namespaceId, type);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/git/PipelineRepositoryService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/PipelineRepositoryService.java
@@ -25,6 +25,7 @@ import com.epam.pipeline.controller.vo.PipelineVO;
 import com.epam.pipeline.controller.vo.UploadFileMetadata;
 import com.epam.pipeline.entity.git.GitCommitEntry;
 import com.epam.pipeline.entity.git.GitCredentials;
+import com.epam.pipeline.entity.git.GitNamespace;
 import com.epam.pipeline.entity.git.GitProject;
 import com.epam.pipeline.entity.git.GitRepositoryEntry;
 import com.epam.pipeline.entity.git.GitTagEntry;
@@ -555,5 +556,13 @@ public class PipelineRepositoryService {
                 (RepositoryType.GITHUB.equals(repositoryType) ? commit.getCommitId().substring(0, 7) :
                         commit.getName());
         return GitUtils.DRAFT_PREFIX + commitId;
+    }
+
+    public List<GitNamespace> getAllowedNamespaces(final RepositoryType type) {
+        return providerService.getAllowedNamespaces(type);
+    }
+
+    public List<GitProject> getNamespaceRepositories(final String namespaceId, final RepositoryType type) {
+        return providerService.getNamespaceRepositories(namespaceId, type);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubApi.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubApi.java
@@ -16,8 +16,11 @@
 
 package com.epam.pipeline.manager.git.github;
 
+import com.epam.pipeline.entity.git.github.GitHubAccessToken;
 import com.epam.pipeline.entity.git.github.GitHubCommitNode;
+import com.epam.pipeline.entity.git.github.GitHubInstallationRepositories;
 import com.epam.pipeline.entity.git.github.GitHubContent;
+import com.epam.pipeline.entity.git.github.GitHubInstallation;
 import com.epam.pipeline.entity.git.github.GitHubRef;
 import com.epam.pipeline.entity.git.github.GitHubRelease;
 import com.epam.pipeline.entity.git.github.GitHubRepository;
@@ -50,6 +53,7 @@ public interface GitHubApi {
     String SHA = "sha";
     String PAGE_LENGTH = "per_page";
     String REF = "ref";
+    String INSTALLATION_ID = "installation_id";
 
     @GET("repos/{workspace}/{repository}")
     Call<GitHubRepository> getRepository(@Path(WORKSPACE) String workspace,
@@ -142,4 +146,59 @@ public interface GitHubApi {
                                       @Path(REPOSITORY) String repository,
                                       @Query(PAGE) Integer page,
                                       @Query(PAGE_LENGTH) Integer pageLength);
+
+    //CHECKSTYLE:OFF: Line is longer than 120 characters
+    /**
+     * List installations for the authenticated app. For more information, see
+     * <a href="https://docs.github.com/en/rest/apps/apps?apiVersion=2026-03-10#list-installations-for-the-authenticated-app">API Docs</a>
+     * <p>A JWT must be used to access this endpoint.</p>
+     * @param page The page number of the results to fetch.
+     * @param pageLength The number of results per page (max 100).
+     * @return Allowed installations.
+     */
+    //CHECKSTYLE:ON
+    @GET("app/installations")
+    Call<List<GitHubInstallation>> getAppInstallations(@Query(PAGE) Integer page,
+                                                       @Query(PAGE_LENGTH) Integer pageLength);
+
+    //CHECKSTYLE:OFF: Line is longer than 120 characters
+    /**
+     * Get a repository installation for the authenticated app. For more information, see
+     * <a href="https://docs.github.com/en/rest/apps/apps?apiVersion=2026-03-10#get-a-repository-installation-for-the-authenticated-app">API Docs</a>
+     * <p>A JWT must be used to access this endpoint.</p>
+     * @param workspace The account owner of the repository. The name is not case-sensitive.
+     * @param repository The name of the repository without the .git extension. The name is not case-sensitive.
+     * @return Repository.
+     */
+    //CHECKSTYLE:ON
+    @GET("repos/{workspace}/{repository}/installation")
+    Call<GitHubInstallation> getRepositoryInstallation(@Path(WORKSPACE) String workspace,
+                                                       @Path(REPOSITORY) String repository);
+
+    //CHECKSTYLE:OFF: Line is longer than 120 characters
+    /**
+     * Create an installation access token for an app. For more information, see
+     * <a href="https://docs.github.com/en/rest/apps/apps?apiVersion=2026-03-10#create-an-installation-access-token-for-an-app">API Docs</a>
+     * <p>A JWT must be used to access this endpoint.</p>
+     * @param installationId The unique identifier of the installation.
+     * @return Access token.
+     */
+    //CHECKSTYLE:ON
+    @POST("app/installations/{installation_id}/access_tokens")
+    Call<GitHubAccessToken> createInstallationAccessToken(@Path(INSTALLATION_ID) Long installationId);
+
+    //CHECKSTYLE:OFF: Line is longer than 120 characters
+    /**
+     * List repositories that an app installation can access. For more information, see
+     * <a href="https://docs.github.com/en/rest/apps/installations?apiVersion=2026-03-10#list-repositories-accessible-to-the-app-installation">API Docs</a>
+     * <p>An access token from {@link GitHubApi#createInstallationAccessToken(Long)} must be used to access this
+     * endpoint.</p>
+     * @param page The page number of the results to fetch.
+     * @param pageLength The number of results per page (max 100).
+     * @return List of allowed repositories.
+     */
+    //CHECKSTYLE:ON
+    @GET("installation/repositories")
+    Call<GitHubInstallationRepositories> getInstallationRepositories(@Query(PAGE) Integer page,
+                                                                     @Query(PAGE_LENGTH) Integer pageLength);
 }

--- a/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubApi.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubApi.java
@@ -152,7 +152,8 @@ public interface GitHubApi {
      * List installations for the authenticated app. For more information, see
      * <a href="https://docs.github.com/en/rest/apps/apps?apiVersion=2026-03-10#list-installations-for-the-authenticated-app">API Docs</a>
      * <p>A JWT must be used to access this endpoint.</p>
-     * @param page The page number of the results to fetch.
+     *
+     * @param page       The page number of the results to fetch.
      * @param pageLength The number of results per page (max 100).
      * @return Allowed installations.
      */
@@ -166,7 +167,8 @@ public interface GitHubApi {
      * Get a repository installation for the authenticated app. For more information, see
      * <a href="https://docs.github.com/en/rest/apps/apps?apiVersion=2026-03-10#get-a-repository-installation-for-the-authenticated-app">API Docs</a>
      * <p>A JWT must be used to access this endpoint.</p>
-     * @param workspace The account owner of the repository. The name is not case-sensitive.
+     *
+     * @param workspace  The account owner of the repository. The name is not case-sensitive.
      * @param repository The name of the repository without the .git extension. The name is not case-sensitive.
      * @return Repository.
      */
@@ -177,9 +179,23 @@ public interface GitHubApi {
 
     //CHECKSTYLE:OFF: Line is longer than 120 characters
     /**
+     * Get an installation for the authenticated app. For more information, see
+     * <a href="https://docs.github.com/en/rest/apps/apps?apiVersion=2026-03-10#get-an-installation-for-the-authenticated-app">API Docs</a>
+     * <p>A JWT must be used to access this endpoint.</p>
+     *
+     * @param installationId The unique identifier of the installation.
+     * @return Installation.
+     */
+    //CHECKSTYLE:ON
+    @GET("app/installations/{installation_id}")
+    Call<GitHubInstallation> getAppInstallation(@Path(INSTALLATION_ID) Long installationId);
+
+    //CHECKSTYLE:OFF: Line is longer than 120 characters
+    /**
      * Create an installation access token for an app. For more information, see
      * <a href="https://docs.github.com/en/rest/apps/apps?apiVersion=2026-03-10#create-an-installation-access-token-for-an-app">API Docs</a>
      * <p>A JWT must be used to access this endpoint.</p>
+     *
      * @param installationId The unique identifier of the installation.
      * @return Access token.
      */
@@ -193,7 +209,8 @@ public interface GitHubApi {
      * <a href="https://docs.github.com/en/rest/apps/installations?apiVersion=2026-03-10#list-repositories-accessible-to-the-app-installation">API Docs</a>
      * <p>An access token from {@link GitHubApi#createInstallationAccessToken(Long)} must be used to access this
      * endpoint.</p>
-     * @param page The page number of the results to fetch.
+     *
+     * @param page       The page number of the results to fetch.
      * @param pageLength The number of results per page (max 100).
      * @return List of allowed repositories.
      */

--- a/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubAppClient.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubAppClient.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.git.github;
+
+import com.epam.pipeline.entity.git.github.GitHubAccessToken;
+import com.epam.pipeline.entity.git.github.GitHubInstallation;
+import com.epam.pipeline.entity.git.github.GitHubInstallationRepositories;
+import com.epam.pipeline.manager.git.ApiBuilder;
+import com.epam.pipeline.manager.git.RestApiUtils;
+import retrofit2.Response;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.epam.pipeline.manager.git.github.GitHubUtils.AUTHORIZATION;
+import static com.epam.pipeline.manager.git.github.GitHubUtils.LIMIT;
+
+/**
+ * GitHub client for App-level operations (installations, access tokens).
+ * This client does NOT have repository context and cannot call repository-scoped methods.
+ */
+public class GitHubAppClient {
+
+    private final GitHubApi serverApi;
+
+    public GitHubAppClient(final String baseUrl, final String credentials, final String dateFormat,
+                           final Map<String, String> headers) {
+        this.serverApi = buildClient(baseUrl, credentials, dateFormat, headers);
+    }
+
+    public Response<List<GitHubInstallation>> getAppInstallations(final Integer page) {
+        return RestApiUtils.getResponse(serverApi.getAppInstallations(page, LIMIT));
+    }
+
+    public GitHubInstallation getRepositoryInstallation(final String owner, final String repository) {
+        return RestApiUtils.execute(serverApi.getRepositoryInstallation(owner, repository));
+    }
+
+    public GitHubInstallation getAppInstallation(final Long installationId) {
+        return RestApiUtils.execute(serverApi.getAppInstallation(installationId));
+    }
+
+    public GitHubAccessToken createInstallationAccessToken(final Long installationId) {
+        return RestApiUtils.execute(serverApi.createInstallationAccessToken(installationId));
+    }
+
+    public Response<GitHubInstallationRepositories> getInstallationRepositories(final Integer page) {
+        return RestApiUtils.getResponse(serverApi.getInstallationRepositories(page, LIMIT));
+    }
+
+    private static GitHubApi buildClient(final String baseUrl, final String bearerCredentials, final String dataFormat,
+                                         final Map<String, String> headers) {
+        return new ApiBuilder<>(GitHubApi.class, baseUrl, AUTHORIZATION, bearerCredentials, dataFormat, headers)
+                .build();
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubAppService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubAppService.java
@@ -22,6 +22,7 @@ import com.epam.pipeline.entity.git.github.GitHubInstallationAccount;
 import com.epam.pipeline.entity.git.github.GitHubInstallationRepositories;
 import com.epam.pipeline.entity.git.github.GitHubRepository;
 import com.epam.pipeline.exception.git.GitClientException;
+import com.epam.pipeline.exception.git.UnexpectedResponseStatusException;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.utils.AuthorizationUtils;
@@ -31,6 +32,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
@@ -170,15 +172,16 @@ public class GitHubAppService {
         final String jwt = generateJWT();
         final GitHubAppClient appClient = buildAppClient(jwt);
 
-        final GitHubInstallation installation = appClient.getAppInstallation(installationIdLong);
-        Assert.notNull(installation, String.format("Installation with ID %s does not exist.", installationId));
+        final GitHubInstallation installation = findAppInstallation(appClient, installationIdLong)
+                .orElseThrow(() -> new GitClientException(String.format(
+                        "Installation with ID %s does not exist.", installationId)));
 
         assertInstallationAllowed(installation);
 
         final String accessToken = generateAccessToken(jwt, installationIdLong);
         final GitHubAppClient client = buildAppClient(accessToken);
 
-        return GitHubUtils.pagination(client::getInstallationRepositories,
+        return GitHubUtils.fetchAllPages(client::getInstallationRepositories,
             responseBody -> Optional.ofNullable(responseBody)
                     .map(GitHubInstallationRepositories::getRepositories)
                     .orElse(Collections.emptyList()));
@@ -240,7 +243,7 @@ public class GitHubAppService {
 
     private List<GitHubInstallation> findInstallations(final String jwt) {
         final GitHubAppClient appClient = buildAppClient(jwt);
-        return GitHubUtils.pagination(appClient::getAppInstallations);
+        return GitHubUtils.fetchAllPages(appClient::getAppInstallations);
     }
 
     private String generateAccessToken(final String jwt, final Long installationId) {
@@ -263,5 +266,17 @@ public class GitHubAppService {
         headers.put(ACCEPT_HEADER, ACCEPT_GITHUB_JSON);
         headers.put(API_VERSION_HEADER, X_GITHUB_API_VERSION);
         return new GitHubAppClient(apiUrl, AuthorizationUtils.buildBearerTokenAuth(token), null, headers);
+    }
+
+    private Optional<GitHubInstallation> findAppInstallation(final GitHubAppClient appClient,
+                                                             final Long installationId) {
+        try {
+            return Optional.ofNullable(appClient.getAppInstallation(installationId));
+        } catch (UnexpectedResponseStatusException e) {
+            if (e.getStatus() == HttpStatus.NOT_FOUND) {
+                return Optional.empty();
+            }
+            throw e;
+        }
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubAppService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubAppService.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.git.github;
+
+import com.epam.pipeline.entity.git.github.GitHubAccessToken;
+import com.epam.pipeline.entity.git.github.GitHubInstallation;
+import com.epam.pipeline.entity.git.github.GitHubInstallationAccount;
+import com.epam.pipeline.entity.git.github.GitHubInstallationRepositories;
+import com.epam.pipeline.entity.git.github.GitHubRepository;
+import com.epam.pipeline.exception.git.GitClientException;
+import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.epam.pipeline.manager.preference.SystemPreferences;
+import com.epam.pipeline.utils.AuthorizationUtils;
+import com.epam.pipeline.utils.JwtUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Service class for managing GitHub App authentication and installation operations.
+ * <p>
+ * This service provides functionality to interact with GitHub Apps API.
+ * </p>
+ * <p>
+ * The service enforces security through installation allowlists configured via system preferences.
+ * Only installations explicitly listed in {@code GITHUB_ALLOWED_INSTALLATIONS} can be accessed.
+ * </p>
+ *
+ * <h2>GitHub App Authentication Flow:</h2>
+ * <ol>
+ *   <li>Generate a JWT using the App's private key and App ID</li>
+ *   <li>Locate the installation for a specific repository or organization</li>
+ *   <li>Verify the installation is in the allowlist</li>
+ *   <li>Generate an installation access token for API operations</li>
+ * </ol>
+ *
+ * <h2>Configuration Requirements:</h2>
+ * <ul>
+ *   <li>{@code github.app.id}: GitHub App identifier</li>
+ *   <li>{@code github.app.private.key.pem}: RSA private key in PEM format</li>
+ *   <li>{@code github.allowed.installations}: Allowlist of installation IDs or account names</li>
+ *   <li>{@code github.api.root.url}: GitHub API base URL</li>
+ * </ul>
+ */
+@Service
+@Slf4j
+public class GitHubAppService {
+    private static final int GITHUB_APP_JWT_MAX_TTL_SECONDS = 600;
+    private static final String ACCEPT_HEADER = "Accept";
+    private static final String ACCEPT_GITHUB_JSON = "application/vnd.github+json";
+    private static final String X_GITHUB_API_VERSION = "2026-03-10";
+    private static final String API_VERSION_HEADER = "X-GitHub-Api-Version";
+
+    private final PreferenceManager preferenceManager;
+    private final String privateKeyPem;
+
+    public GitHubAppService(final PreferenceManager preferenceManager,
+                            @Value("${github.app.private.key.pem:}") final String privateKeyPem) {
+        this.preferenceManager = preferenceManager;
+        this.privateKeyPem = privateKeyPem;
+    }
+
+    /**
+     * Generates a GitHub App installation access token for a specific repository.
+     * <p>
+     * This method performs the following steps:
+     * </p>
+     * <ol>
+     *   <li>Generates a JWT for GitHub App authentication</li>
+     *   <li>Locates the installation associated with the repository</li>
+     *   <li>Validates that the installation is in the allowlist
+     *   ({@link com.epam.pipeline.manager.preference.SystemPreferences#GITHUB_ALLOWED_INSTALLATIONS})</li>
+     *   <li>Generates and returns an installation access token</li>
+     * </ol>
+     * <p>
+     * The returned token can be used to authenticate API requests for the specified repository
+     * with the permissions granted to the GitHub App installation.
+     * </p>
+     *
+     * @param projectName    the GitHub organization or username that owns the repository.
+     *                       Must not be null or empty.
+     * @param repositoryName the name of the repository within the project.
+     *                       Must not be null or empty.
+     * @return a GitHub installation access token that can be used for API authentication.
+     * The token has a limited lifetime as determined by GitHub's API.
+     */
+    public String getGithubAppToken(final String projectName, final String repositoryName) {
+        final String jwt = generateJWT();
+        final GitHubInstallation installation = findInstallationId(projectName, repositoryName, jwt);
+        assertInstallationAllowed(installation);
+        return generateAccessToken(jwt, installation.getId());
+    }
+
+    /**
+     * Retrieves all GitHub App installations that are permitted by the allowlist configuration.
+     * <p>
+     * This method fetches all installations where the GitHub App is installed and filters them
+     * against the allowlist defined in {@code GITHUB_ALLOWED_INSTALLATIONS}. Installations can
+     * be allowed by either their installation ID or account name (organization/user login).
+     * </p>
+     * <p>
+     * The allowlist matching is case-insensitive for account names.
+     * </p>
+     *
+     * @return a list of {@link GitHubInstallation} objects representing allowed installations.
+     * Returns an empty list if no installations match the allowlist.
+     */
+    public List<GitHubInstallation> findAllowedInstallations() {
+        final List<String> allowed = getAllowedInstallations();
+
+        final String jwt = generateJWT();
+        final List<GitHubInstallation> installations = findInstallations(jwt);
+        return installations.stream()
+                .filter(Objects::nonNull)
+                .filter(installation -> isInstallationAllowed(installation, allowed))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Retrieves all repositories accessible through a specific GitHub App installation.
+     *
+     * <p>
+     * Only installations explicitly listed in
+     * {@link com.epam.pipeline.manager.preference.SystemPreferences#GITHUB_ALLOWED_INSTALLATIONS}
+     * can be accessed.
+     * </p>
+     *
+     * @param installationId the GitHub App installation ID as a string.
+     *                       Must not be null, empty, or blank.
+     *                       Must contain only digits.
+     *                       Must represent an existing installation.
+     * @return a list of {@link GitHubRepository} objects accessible through the installation.
+     * Returns an empty list if the installation has no accessible repositories.
+     */
+    public List<GitHubRepository> findRepositoriesByInstallation(final String installationId) {
+        Assert.hasText(installationId, "Installation ID must not be null or empty.");
+        Assert.state(NumberUtils.isDigits(installationId),
+                String.format("Installation ID must contain only digits, but got: %s", installationId));
+
+        final Long installationIdLong = Long.valueOf(installationId);
+        final String jwt = generateJWT();
+        final GitHubAppClient appClient = buildAppClient(jwt);
+
+        final GitHubInstallation installation = appClient.getAppInstallation(installationIdLong);
+        Assert.notNull(installation, String.format("Installation with ID %s does not exist.", installationId));
+
+        assertInstallationAllowed(installation);
+
+        final String accessToken = generateAccessToken(jwt, installationIdLong);
+        final GitHubAppClient client = buildAppClient(accessToken);
+
+        return GitHubUtils.pagination(client::getInstallationRepositories,
+            responseBody -> Optional.ofNullable(responseBody)
+                    .map(GitHubInstallationRepositories::getRepositories)
+                    .orElse(Collections.emptyList()));
+    }
+
+    private String generateJWT() {
+        final String appId = preferenceManager.getPreference(SystemPreferences.GITHUB_APP_ID);
+        Assert.hasText(appId, "GitHub App ID shall be configured.");
+        try {
+            return JwtUtils.generateRsa256Jwt(privateKeyPem, appId, GITHUB_APP_JWT_MAX_TTL_SECONDS);
+        } catch (IOException e) {
+            log.error(e.getMessage(), e);
+            throw new GitClientException("Failed to read GitHub App private key: " + e.getMessage());
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+            log.error(e.getMessage(), e);
+            throw new GitClientException("Failed to parse GitHub App private key: " + e.getMessage());
+        }
+    }
+
+    private void assertInstallationAllowed(final GitHubInstallation installation) {
+        final List<String> allowed = getAllowedInstallations();
+        if (isInstallationAllowed(installation, allowed)) {
+            return;
+        }
+        throw new GitClientException(String.format(
+                "GitHub App installation %s is not allowed by github.allowed.installations.", installation.getId()));
+    }
+
+    private List<String> getAllowedInstallations() {
+        final List<String> allowed = preferenceManager.getPreference(SystemPreferences.GITHUB_ALLOWED_INSTALLATIONS);
+        if (CollectionUtils.isEmpty(allowed)) {
+            throw new GitClientException("GitHub App installation access token generation is not allowed.");
+        }
+        return allowed;
+    }
+
+    private boolean isInstallationAllowed(final GitHubInstallation installation, final List<String> allowed) {
+        // check by installation ID:
+        final Long installationId = installation.getId();
+        if (Objects.nonNull(installationId) && allowed.stream()
+                .anyMatch(entry -> Objects.equals(entry, String.valueOf(installationId)))) {
+            return true;
+        }
+
+        // check by installation account name (org or username):
+        final String installationName = Optional.ofNullable(installation.getAccount())
+                .map(GitHubInstallationAccount::getLogin)
+                .filter(StringUtils::isNotBlank)
+                .orElse(null);
+        return StringUtils.isNotBlank(installationName) && allowed.stream()
+                .anyMatch(installationName::equalsIgnoreCase);
+    }
+
+    private GitHubInstallation findInstallationId(final String projectName, final String repositoryName,
+                                                  final String jwt) {
+        final GitHubAppClient appClient = buildAppClient(jwt);
+        return appClient.getRepositoryInstallation(projectName, repositoryName);
+    }
+
+    private List<GitHubInstallation> findInstallations(final String jwt) {
+        final GitHubAppClient appClient = buildAppClient(jwt);
+        return GitHubUtils.pagination(appClient::getAppInstallations);
+    }
+
+    private String generateAccessToken(final String jwt, final Long installationId) {
+        final GitHubAppClient appClient = buildAppClient(jwt);
+        final GitHubAccessToken tokenResponse = appClient.createInstallationAccessToken(installationId);
+        return Optional.ofNullable(tokenResponse)
+                .map(GitHubAccessToken::getToken)
+                .filter(StringUtils::isNotBlank)
+                .orElseThrow(() -> new GitClientException(
+                        "GitHub installation access token response did not contain a token."));
+    }
+
+    private GitHubAppClient buildAppClient(final String token) {
+        final String apiUrl = preferenceManager.getPreference(SystemPreferences.GITHUB_API_ROOT_URL);
+        return buildAppClient(apiUrl, token);
+    }
+
+    private GitHubAppClient buildAppClient(final String apiUrl, final String token) {
+        final Map<String, String> headers = new HashMap<>();
+        headers.put(ACCEPT_HEADER, ACCEPT_GITHUB_JSON);
+        headers.put(API_VERSION_HEADER, X_GITHUB_API_VERSION);
+        return new GitHubAppClient(apiUrl, AuthorizationUtils.buildBearerTokenAuth(token), null, headers);
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubClient.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubClient.java
@@ -16,11 +16,8 @@
 
 package com.epam.pipeline.manager.git.github;
 
-import com.epam.pipeline.entity.git.github.GitHubAccessToken;
 import com.epam.pipeline.entity.git.github.GitHubCommitNode;
 import com.epam.pipeline.entity.git.github.GitHubContent;
-import com.epam.pipeline.entity.git.github.GitHubInstallation;
-import com.epam.pipeline.entity.git.github.GitHubInstallationRepositories;
 import com.epam.pipeline.entity.git.github.GitHubRef;
 import com.epam.pipeline.entity.git.github.GitHubRelease;
 import com.epam.pipeline.entity.git.github.GitHubRepository;
@@ -38,12 +35,16 @@ import retrofit2.Response;
 import java.io.IOException;
 import java.util.Base64;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
+import static com.epam.pipeline.manager.git.github.GitHubUtils.AUTHORIZATION;
+import static com.epam.pipeline.manager.git.github.GitHubUtils.LIMIT;
+
+/**
+ * GitHub client for repository-scoped operations.
+ * This client requires project name and repository name and can only call repository-scoped methods.
+ */
 public class GitHubClient {
-    private static final String AUTHORIZATION = "Authorization";
-    private static final Integer LIMIT = 100;
     private static final String DUMMY_CONTENT = "# Put your content here";
 
     private final GitHubApi serverApi;
@@ -53,13 +54,6 @@ public class GitHubClient {
     public GitHubClient(final String baseUrl, final String credentials, final String dateFormat,
                         final String projectName, final String repositoryName) {
         this.serverApi = buildClient(baseUrl, credentials, dateFormat);
-        this.projectName = projectName;
-        this.repositoryName = repositoryName;
-    }
-
-    public GitHubClient(final String baseUrl, final String credentials, final String dateFormat,
-                        final String projectName, final String repositoryName, final Map<String, String> headers) {
-        this.serverApi = buildClient(baseUrl, credentials, dateFormat, headers);
         this.projectName = projectName;
         this.repositoryName = repositoryName;
     }
@@ -178,31 +172,9 @@ public class GitHubClient {
     public Response<List<GitHubRef>> getBranches(final Integer page) {
         return RestApiUtils.getResponse(serverApi.getBranches(projectName, repositoryName, page, LIMIT));
     }
-
-    public Response<List<GitHubInstallation>> getAppInstallations(final Integer page) {
-        return RestApiUtils.getResponse(serverApi.getAppInstallations(page, LIMIT));
-    }
-
-    public GitHubInstallation getRepositoryInstallation(final String owner, final String repository) {
-        return RestApiUtils.execute(serverApi.getRepositoryInstallation(owner, repository));
-    }
-
-    public GitHubAccessToken createInstallationAccessToken(final Long installationId) {
-        return RestApiUtils.execute(serverApi.createInstallationAccessToken(installationId));
-    }
-
-    public Response<GitHubInstallationRepositories> getInstallationRepositories(final Integer page) {
-        return RestApiUtils.getResponse(serverApi.getInstallationRepositories(page, LIMIT));
-    }
-
+    
     private GitHubApi buildClient(final String baseUrl, final String credentials, final String dataFormat) {
         return new ApiBuilder<>(GitHubApi.class, baseUrl, AUTHORIZATION, credentials, dataFormat).build();
-    }
-
-    private static GitHubApi buildClient(final String baseUrl, final String bearerCredentials, final String dataFormat,
-                                         final Map<String, String> headers) {
-        return new ApiBuilder<>(GitHubApi.class, baseUrl, AUTHORIZATION, bearerCredentials, dataFormat, headers)
-                .build();
     }
 
     private GitHubSource createFile(final String path, final GitHubContent request) {

--- a/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubClient.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubClient.java
@@ -16,8 +16,11 @@
 
 package com.epam.pipeline.manager.git.github;
 
+import com.epam.pipeline.entity.git.github.GitHubAccessToken;
 import com.epam.pipeline.entity.git.github.GitHubCommitNode;
 import com.epam.pipeline.entity.git.github.GitHubContent;
+import com.epam.pipeline.entity.git.github.GitHubInstallation;
+import com.epam.pipeline.entity.git.github.GitHubInstallationRepositories;
 import com.epam.pipeline.entity.git.github.GitHubRef;
 import com.epam.pipeline.entity.git.github.GitHubRelease;
 import com.epam.pipeline.entity.git.github.GitHubRepository;
@@ -35,6 +38,7 @@ import retrofit2.Response;
 import java.io.IOException;
 import java.util.Base64;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class GitHubClient {
@@ -49,6 +53,13 @@ public class GitHubClient {
     public GitHubClient(final String baseUrl, final String credentials, final String dateFormat,
                         final String projectName, final String repositoryName) {
         this.serverApi = buildClient(baseUrl, credentials, dateFormat);
+        this.projectName = projectName;
+        this.repositoryName = repositoryName;
+    }
+
+    public GitHubClient(final String baseUrl, final String credentials, final String dateFormat,
+                        final String projectName, final String repositoryName, final Map<String, String> headers) {
+        this.serverApi = buildClient(baseUrl, credentials, dateFormat, headers);
         this.projectName = projectName;
         this.repositoryName = repositoryName;
     }
@@ -168,8 +179,30 @@ public class GitHubClient {
         return RestApiUtils.getResponse(serverApi.getBranches(projectName, repositoryName, page, LIMIT));
     }
 
+    public Response<List<GitHubInstallation>> getAppInstallations(final Integer page) {
+        return RestApiUtils.getResponse(serverApi.getAppInstallations(page, LIMIT));
+    }
+
+    public GitHubInstallation getRepositoryInstallation(final String owner, final String repository) {
+        return RestApiUtils.execute(serverApi.getRepositoryInstallation(owner, repository));
+    }
+
+    public GitHubAccessToken createInstallationAccessToken(final Long installationId) {
+        return RestApiUtils.execute(serverApi.createInstallationAccessToken(installationId));
+    }
+
+    public Response<GitHubInstallationRepositories> getInstallationRepositories(final Integer page) {
+        return RestApiUtils.getResponse(serverApi.getInstallationRepositories(page, LIMIT));
+    }
+
     private GitHubApi buildClient(final String baseUrl, final String credentials, final String dataFormat) {
         return new ApiBuilder<>(GitHubApi.class, baseUrl, AUTHORIZATION, credentials, dataFormat).build();
+    }
+
+    private static GitHubApi buildClient(final String baseUrl, final String bearerCredentials, final String dataFormat,
+                                         final Map<String, String> headers) {
+        return new ApiBuilder<>(GitHubApi.class, baseUrl, AUTHORIZATION, bearerCredentials, dataFormat, headers)
+                .build();
     }
 
     private GitHubSource createFile(final String path, final GitHubContent request) {

--- a/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubService.java
@@ -30,10 +30,6 @@ import com.epam.pipeline.entity.git.GitRepositoryUrl;
 import com.epam.pipeline.entity.git.GitTagEntry;
 import com.epam.pipeline.entity.git.github.GitHubCommitNode;
 import com.epam.pipeline.entity.git.github.GitHubContent;
-import com.epam.pipeline.entity.git.github.GitHubAccessToken;
-import com.epam.pipeline.entity.git.github.GitHubInstallation;
-import com.epam.pipeline.entity.git.github.GitHubInstallationAccount;
-import com.epam.pipeline.entity.git.github.GitHubInstallationRepositories;
 import com.epam.pipeline.entity.git.github.GitHubRef;
 import com.epam.pipeline.entity.git.github.GitHubRelease;
 import com.epam.pipeline.entity.git.github.GitHubRepository;
@@ -51,34 +47,25 @@ import com.epam.pipeline.manager.git.GitClientService;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.mapper.git.GitHubMapper;
-import com.epam.pipeline.utils.JwtUtils;
 import com.epam.pipeline.utils.AuthorizationUtils;
 import com.epam.pipeline.utils.GitUtils;
 import joptsimple.internal.Strings;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.util.TextUtils;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 import retrofit2.Response;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Paths;
-import java.security.NoSuchAlgorithmException;
-import java.security.spec.InvalidKeySpecException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -86,35 +73,19 @@ import static com.epam.pipeline.manager.git.PipelineRepositoryService.NOT_SUPPOR
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class GitHubService implements GitClientService {
     private static final String REPOSITORY_NAME = "repository name";
     private static final String PROJECT_NAME = "project name";
     private static final String GITHUB_FOLDER_MARKER = "tree";
     private static final String GITHUB_FILE_MARKER = "blob";
-    private static final String LINK = "link";
-    private static final String REL_NEXT = "rel=\"next\"";
     private static final String COMMIT = "commit";
     private static final String REFS_TAGS_PREFIX = "refs/tags/%s";
-    private static final int GITHUB_APP_JWT_MAX_TTL_SECONDS = 600;
-    private static final String ACCEPT_HEADER = "Accept";
-    private static final String ACCEPT_GITHUB_JSON = "application/vnd.github+json";
-    private static final String X_GITHUB_API_VERSION = "2026-03-10";
-    private static final String API_VERSION_HEADER = "X-GitHub-Api-Version";
 
     private final GitHubMapper mapper;
     private final MessageHelper messageHelper;
     private final PreferenceManager preferenceManager;
-    private final String privateKeyPem;
-
-    public GitHubService(final GitHubMapper mapper,
-                         final MessageHelper messageHelper,
-                         final PreferenceManager preferenceManager,
-                         @Value("${github.app.private.key.pem:}") final String privateKeyPem) {
-        this.mapper = mapper;
-        this.messageHelper = messageHelper;
-        this.preferenceManager = preferenceManager;
-        this.privateKeyPem = privateKeyPem;
-    }
+    private final GitHubAppService gitHubAppService;
 
     @Override
     public RepositoryType getType() {
@@ -152,7 +123,7 @@ public class GitHubService implements GitClientService {
     @Override
     public List<String> getBranches(final String repositoryPath, final String token) {
         final GitHubClient client = getClient(repositoryPath, token);
-        return pagination(client::getBranches).stream()
+        return GitHubUtils.pagination(client::getBranches).stream()
                 .map(GitHubRef::getName)
                 .collect(Collectors.toList());
     }
@@ -184,7 +155,7 @@ public class GitHubService implements GitClientService {
     @Override
     public List<Revision> getTags(final Pipeline pipeline) {
         final GitHubClient client = getClient(pipeline);
-        return pagination(client::getTags).stream()
+        return GitHubUtils.pagination(client::getTags).stream()
                 .map(tag -> fillCommitInfo(tag, client))
                 .map(mapper::refToRevision)
                 .collect(Collectors.toList());
@@ -361,26 +332,14 @@ public class GitHubService implements GitClientService {
 
     @Override
     public List<GitNamespace> getAllowedNamespaces() {
-        final List<String> allowed = getAllowedInstallations();
-
-        final String jwt = generateJWT();
-        final List<GitHubInstallation> installations = findInstallations(jwt);
-        return installations.stream()
-                .filter(Objects::nonNull)
-                .filter(installation -> isInstallationAllowed(installation, allowed))
+        return gitHubAppService.findAllowedInstallations().stream()
                 .map(mapper::installationToNamespace)
                 .collect(Collectors.toList());
     }
 
     @Override
     public List<GitProject> getNamespaceRepositories(final String installationId) {
-        final String jwt = generateJWT();
-        final String accessToken = generateAccessToken(jwt, Long.valueOf(installationId));
-        final GitHubClient client = buildAppClient(accessToken);
-        return pagination(client::getInstallationRepositories,
-            responseBody -> Optional.ofNullable(responseBody)
-                    .map(GitHubInstallationRepositories::getRepositories)
-                    .orElse(Collections.emptyList())).stream()
+        return gitHubAppService.findRepositoriesByInstallation(installationId).stream()
                 .map(mapper::toGitRepository)
                 .collect(Collectors.toList());
     }
@@ -419,28 +378,11 @@ public class GitHubService implements GitClientService {
         final String host = repositoryUrl.getHost();
         final String gitHubHost = protocol + "api." + host;
 
-        final String credentials = buildAuthHeader(token);
-
-        return new GitHubClient(gitHubHost, credentials, null, projectName, repositoryName);
-    }
-
-    private GitHubClient buildAppClient(final String token) {
-        final String apiUrl = preferenceManager.getPreference(SystemPreferences.GITHUB_API_ROOT_URL);
-        return buildAppClient(apiUrl, token);
-    }
-
-    private GitHubClient buildAppClient(final String apiUrl, final String token) {
-        final Map<String, String> headers = new HashMap<>();
-        headers.put(ACCEPT_HEADER, ACCEPT_GITHUB_JSON);
-        headers.put(API_VERSION_HEADER, X_GITHUB_API_VERSION);
-        return new GitHubClient(apiUrl, buildAuthHeader(token),
-                null, null, null, headers);
-    }
-
-    private String buildAuthHeader(final String token) {
         Assert.isTrue(StringUtils.isNotBlank(token), messageHelper
                 .getMessage(MessageConstants.ERROR_REPOSITORY_TOKEN_NOT_FOUND, getType()));
-        return AuthorizationUtils.buildBearerTokenAuth(token);
+        final String credentials = AuthorizationUtils.buildBearerTokenAuth(token);
+
+        return new GitHubClient(gitHubHost, credentials, null, projectName, repositoryName);
     }
 
     private GitClientException buildUrlParseError(final String urlPart) {
@@ -480,101 +422,10 @@ public class GitHubService implements GitClientService {
         return client.fileExists(ref, path);
     }
 
-    private String generateJWT() {
-        final String appId = preferenceManager.getPreference(SystemPreferences.GITHUB_APP_ID);
-        Assert.hasText(appId, "GitHub App ID shall be configured.");
-        try {
-            return JwtUtils.generateRsa256Jwt(privateKeyPem, appId, GITHUB_APP_JWT_MAX_TTL_SECONDS);
-        } catch (IOException e) {
-            log.error(e.getMessage(), e);
-            throw new GitClientException("Failed to read GitHub App private key: " + e.getMessage());
-        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
-            log.error(e.getMessage(), e);
-            throw new GitClientException("Failed to parse GitHub App private key: " + e.getMessage());
-        }
-    }
-
     private String getGithubAppToken(final String repositoryPath) {
         final GitRepositoryUrl repositoryUrl = GitRepositoryUrl.from(repositoryPath);
         final String projectName = repositoryUrl.getNamespace().orElseThrow(() -> buildUrlParseError(PROJECT_NAME));
         final String repositoryName = repositoryUrl.getProject().orElseThrow(() -> buildUrlParseError(REPOSITORY_NAME));
-        final String jwt = generateJWT();
-        final GitHubInstallation installation = findInstallationId(projectName, repositoryName, jwt);
-        assertInstallationAllowed(installation);
-        return generateAccessToken(jwt, installation.getId());
-    }
-
-    private void assertInstallationAllowed(final GitHubInstallation installation) {
-        final List<String> allowed = getAllowedInstallations();
-        if (isInstallationAllowed(installation, allowed)) {
-            return;
-        }
-        throw new GitClientException(String.format(
-                "GitHub App installation %s is not allowed by github.allowed.installations.", installation.getId()));
-    }
-
-    private List<String> getAllowedInstallations() {
-        final List<String> allowed = preferenceManager.getPreference(SystemPreferences.GITHUB_ALLOWED_INSTALLATIONS);
-        if (CollectionUtils.isEmpty(allowed)) {
-            throw new GitClientException("GitHub App installation access token generation is not allowed.");
-        }
-        return allowed;
-    }
-
-    private boolean isInstallationAllowed(final GitHubInstallation installation, final List<String> allowed) {
-        // check by installation ID:
-        final Long installationId = installation.getId();
-        if (Objects.nonNull(installationId) && allowed.stream()
-                .anyMatch(entry -> Objects.equals(entry, String.valueOf(installationId)))) {
-            return true;
-        }
-
-        // check by installation account name (org or username):
-        final String installationName = Optional.ofNullable(installation.getAccount())
-                .map(GitHubInstallationAccount::getLogin)
-                .filter(StringUtils::isNotBlank)
-                .orElse(null);
-        return StringUtils.isNotBlank(installationName) && allowed.stream()
-                .anyMatch(installationName::equalsIgnoreCase);
-    }
-
-    private GitHubInstallation findInstallationId(final String projectName, final String repositoryName,
-                                                  final String jwt) {
-        final GitHubClient appClient = buildAppClient(jwt);
-        return appClient.getRepositoryInstallation(projectName, repositoryName);
-    }
-
-    private List<GitHubInstallation> findInstallations(final String jwt) {
-        final GitHubClient appClient = buildAppClient(jwt);
-        return pagination(appClient::getAppInstallations);
-    }
-
-    private String generateAccessToken(final String jwt, final Long installationId) {
-        final GitHubClient appClient = buildAppClient(jwt);
-        final GitHubAccessToken tokenResponse = appClient.createInstallationAccessToken(installationId);
-        return Optional.ofNullable(tokenResponse)
-                .map(GitHubAccessToken::getToken)
-                .filter(StringUtils::isNotBlank)
-                .orElseThrow(() -> new GitClientException(
-                        "GitHub installation access token response did not contain a token."));
-    }
-
-    private <T> List<T> pagination(final Function<Integer, Response<List<T>>> apiCall) {
-        return pagination(apiCall, Function.identity());
-    }
-
-    private <T, R> List<T> pagination(final Function<Integer, Response<R>> apiCall,
-                                      final Function<R, List<T>> responseConverter) {
-        int page = 1;
-        Response<R> response = apiCall.apply(page);
-        final List<T> values = new ArrayList<>(ListUtils.emptyIfNull(responseConverter.apply(response.body())));
-        String link = response.headers().get(LINK);
-        while (link != null && link.contains(REL_NEXT)) {
-            page++;
-            response = apiCall.apply(page);
-            values.addAll(ListUtils.emptyIfNull(responseConverter.apply(response.body())));
-            link = response.headers().get(LINK);
-        }
-        return values;
+        return gitHubAppService.getGithubAppToken(projectName, repositoryName);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubService.java
@@ -23,12 +23,17 @@ import com.epam.pipeline.controller.vo.PipelineSourceItemsVO;
 import com.epam.pipeline.controller.vo.UploadFileMetadata;
 import com.epam.pipeline.entity.git.GitCommitEntry;
 import com.epam.pipeline.entity.git.GitCredentials;
+import com.epam.pipeline.entity.git.GitNamespace;
 import com.epam.pipeline.entity.git.GitProject;
 import com.epam.pipeline.entity.git.GitRepositoryEntry;
 import com.epam.pipeline.entity.git.GitRepositoryUrl;
 import com.epam.pipeline.entity.git.GitTagEntry;
 import com.epam.pipeline.entity.git.github.GitHubCommitNode;
 import com.epam.pipeline.entity.git.github.GitHubContent;
+import com.epam.pipeline.entity.git.github.GitHubAccessToken;
+import com.epam.pipeline.entity.git.github.GitHubInstallation;
+import com.epam.pipeline.entity.git.github.GitHubInstallationAccount;
+import com.epam.pipeline.entity.git.github.GitHubInstallationRepositories;
 import com.epam.pipeline.entity.git.github.GitHubRef;
 import com.epam.pipeline.entity.git.github.GitHubRelease;
 import com.epam.pipeline.entity.git.github.GitHubRepository;
@@ -46,32 +51,41 @@ import com.epam.pipeline.manager.git.GitClientService;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.mapper.git.GitHubMapper;
+import com.epam.pipeline.utils.JwtUtils;
 import com.epam.pipeline.utils.AuthorizationUtils;
 import com.epam.pipeline.utils.GitUtils;
 import joptsimple.internal.Strings;
-import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.util.TextUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 import retrofit2.Response;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Paths;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.epam.pipeline.manager.git.PipelineRepositoryService.NOT_SUPPORTED_PATTERN;
 
 @Service
-@RequiredArgsConstructor
+@Slf4j
 public class GitHubService implements GitClientService {
     private static final String REPOSITORY_NAME = "repository name";
     private static final String PROJECT_NAME = "project name";
@@ -81,10 +95,26 @@ public class GitHubService implements GitClientService {
     private static final String REL_NEXT = "rel=\"next\"";
     private static final String COMMIT = "commit";
     private static final String REFS_TAGS_PREFIX = "refs/tags/%s";
+    private static final int GITHUB_APP_JWT_MAX_TTL_SECONDS = 600;
+    private static final String ACCEPT_HEADER = "Accept";
+    private static final String ACCEPT_GITHUB_JSON = "application/vnd.github+json";
+    private static final String X_GITHUB_API_VERSION = "2026-03-10";
+    private static final String API_VERSION_HEADER = "X-GitHub-Api-Version";
+
     private final GitHubMapper mapper;
     private final MessageHelper messageHelper;
     private final PreferenceManager preferenceManager;
+    private final String privateKeyPem;
 
+    public GitHubService(final GitHubMapper mapper,
+                         final MessageHelper messageHelper,
+                         final PreferenceManager preferenceManager,
+                         @Value("${github.app.private.key.pem:}") final String privateKeyPem) {
+        this.mapper = mapper;
+        this.messageHelper = messageHelper;
+        this.preferenceManager = preferenceManager;
+        this.privateKeyPem = privateKeyPem;
+    }
 
     @Override
     public RepositoryType getType() {
@@ -122,18 +152,7 @@ public class GitHubService implements GitClientService {
     @Override
     public List<String> getBranches(final String repositoryPath, final String token) {
         final GitHubClient client = getClient(repositoryPath, token);
-        int page = 1;
-        Response<List<GitHubRef>> response = client.getBranches(page);
-        final List<GitHubRef> values = new ArrayList<>(Optional.ofNullable(response.body())
-                .orElse(Collections.emptyList()));
-        String link = response.headers().get(LINK);
-        while (link != null && link.contains(REL_NEXT)) {
-            page++;
-            response = client.getBranches(page);
-            values.addAll(Optional.ofNullable(response.body()).orElse(Collections.emptyList()));
-            link = response.headers().get(LINK);
-        }
-        return values.stream()
+        return pagination(client::getBranches).stream()
                 .map(GitHubRef::getName)
                 .collect(Collectors.toList());
     }
@@ -165,18 +184,7 @@ public class GitHubService implements GitClientService {
     @Override
     public List<Revision> getTags(final Pipeline pipeline) {
         final GitHubClient client = getClient(pipeline);
-        int page = 1;
-        Response<List<GitHubRelease>> response = client.getTags(page);
-        final List<GitHubRelease> values = new ArrayList<>(Optional.ofNullable(response.body())
-                .orElse(Collections.emptyList()));
-        String link = response.headers().get(LINK);
-        while (link != null && link.contains(REL_NEXT)) {
-            page++;
-            response = client.getTags(page);
-            values.addAll(Optional.ofNullable(response.body()).orElse(Collections.emptyList()));
-            link = response.headers().get(LINK);
-        }
-        return values.stream()
+        return pagination(client::getTags).stream()
                 .map(tag -> fillCommitInfo(tag, client))
                 .map(mapper::refToRevision)
                 .collect(Collectors.toList());
@@ -223,7 +231,9 @@ public class GitHubService implements GitClientService {
     public GitCredentials getCloneCredentials(final Pipeline pipeline, final boolean useEnvVars,
                                               final boolean issueToken, final Long duration) {
         final GitRepositoryUrl repositoryUrl = GitRepositoryUrl.from(pipeline.getRepository());
-        final String token = pipeline.getRepositoryToken();
+        final String token = StringUtils.isBlank(pipeline.getRepositoryToken())
+                ? getGithubAppToken(pipeline.getRepository())
+                : pipeline.getRepositoryToken();
         final String username = preferenceManager.getPreference(SystemPreferences.GITHUB_USER_NAME);
         final String host = repositoryUrl.getHost();
         return GitCredentials.builder()
@@ -349,6 +359,32 @@ public class GitHubService implements GitClientService {
         return fileExists(getClient(pipeline), pipeline.getBranch(), filePath);
     }
 
+    @Override
+    public List<GitNamespace> getAllowedNamespaces() {
+        final List<String> allowed = getAllowedInstallations();
+
+        final String jwt = generateJWT();
+        final List<GitHubInstallation> installations = findInstallations(jwt);
+        return installations.stream()
+                .filter(Objects::nonNull)
+                .filter(installation -> isInstallationAllowed(installation, allowed))
+                .map(mapper::installationToNamespace)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<GitProject> getNamespaceRepositories(final String installationId) {
+        final String jwt = generateJWT();
+        final String accessToken = generateAccessToken(jwt, Long.valueOf(installationId));
+        final GitHubClient client = buildAppClient(accessToken);
+        return pagination(client::getInstallationRepositories,
+            responseBody -> Optional.ofNullable(responseBody)
+                    .map(GitHubInstallationRepositories::getRepositories)
+                    .orElse(Collections.emptyList())).stream()
+                .map(mapper::toGitRepository)
+                .collect(Collectors.toList());
+    }
+
     private static String getContentSha(final String rawPath, final String version, final GitHubClient client) {
         final File folder = new File(rawPath);
         final String parentDirectory = Optional.ofNullable(folder.getParent()).orElse(Strings.EMPTY);
@@ -365,10 +401,17 @@ public class GitHubService implements GitClientService {
     }
 
     private GitHubClient getClient(final String repositoryPath, final String token) {
-        return buildClient(repositoryPath, token);
+        return StringUtils.isBlank(token) ? buildGithubAppClient(repositoryPath) : buildClient(repositoryPath, token);
+    }
+
+    private GitHubClient buildGithubAppClient(final String repositoryPath) {
+        log.debug("Token was not provided. Building Github App installation token for repository {}.", repositoryPath);
+        final String accessToken = getGithubAppToken(repositoryPath);
+        return buildClient(repositoryPath, accessToken);
     }
 
     private GitHubClient buildClient(final String repositoryPath, final String token) {
+        log.debug("Token has been provided. Building plain client for repository {}.", repositoryPath);
         final GitRepositoryUrl repositoryUrl = GitRepositoryUrl.from(repositoryPath);
         final String projectName = repositoryUrl.getNamespace().orElseThrow(() -> buildUrlParseError(PROJECT_NAME));
         final String repositoryName = repositoryUrl.getProject().orElseThrow(() -> buildUrlParseError(REPOSITORY_NAME));
@@ -376,11 +419,28 @@ public class GitHubService implements GitClientService {
         final String host = repositoryUrl.getHost();
         final String gitHubHost = protocol + "api." + host;
 
-        Assert.isTrue(StringUtils.isNotBlank(token), messageHelper
-                .getMessage(MessageConstants.ERROR_REPOSITORY_TOKEN_NOT_FOUND, getType()));
-        final String credentials = AuthorizationUtils.BEARER_AUTH + token;
+        final String credentials = buildAuthHeader(token);
 
         return new GitHubClient(gitHubHost, credentials, null, projectName, repositoryName);
+    }
+
+    private GitHubClient buildAppClient(final String token) {
+        final String apiUrl = preferenceManager.getPreference(SystemPreferences.GITHUB_API_ROOT_URL);
+        return buildAppClient(apiUrl, token);
+    }
+
+    private GitHubClient buildAppClient(final String apiUrl, final String token) {
+        final Map<String, String> headers = new HashMap<>();
+        headers.put(ACCEPT_HEADER, ACCEPT_GITHUB_JSON);
+        headers.put(API_VERSION_HEADER, X_GITHUB_API_VERSION);
+        return new GitHubClient(apiUrl, buildAuthHeader(token),
+                null, null, null, headers);
+    }
+
+    private String buildAuthHeader(final String token) {
+        Assert.isTrue(StringUtils.isNotBlank(token), messageHelper
+                .getMessage(MessageConstants.ERROR_REPOSITORY_TOKEN_NOT_FOUND, getType()));
+        return AuthorizationUtils.buildBearerTokenAuth(token);
     }
 
     private GitClientException buildUrlParseError(final String urlPart) {
@@ -418,5 +478,103 @@ public class GitHubService implements GitClientService {
 
     private boolean fileExists(final GitHubClient client, final String ref, final String path) {
         return client.fileExists(ref, path);
+    }
+
+    private String generateJWT() {
+        final String appId = preferenceManager.getPreference(SystemPreferences.GITHUB_APP_ID);
+        Assert.hasText(appId, "GitHub App ID shall be configured.");
+        try {
+            return JwtUtils.generateRsa256Jwt(privateKeyPem, appId, GITHUB_APP_JWT_MAX_TTL_SECONDS);
+        } catch (IOException e) {
+            log.error(e.getMessage(), e);
+            throw new GitClientException("Failed to read GitHub App private key: " + e.getMessage());
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+            log.error(e.getMessage(), e);
+            throw new GitClientException("Failed to parse GitHub App private key: " + e.getMessage());
+        }
+    }
+
+    private String getGithubAppToken(final String repositoryPath) {
+        final GitRepositoryUrl repositoryUrl = GitRepositoryUrl.from(repositoryPath);
+        final String projectName = repositoryUrl.getNamespace().orElseThrow(() -> buildUrlParseError(PROJECT_NAME));
+        final String repositoryName = repositoryUrl.getProject().orElseThrow(() -> buildUrlParseError(REPOSITORY_NAME));
+        final String jwt = generateJWT();
+        final GitHubInstallation installation = findInstallationId(projectName, repositoryName, jwt);
+        assertInstallationAllowed(installation);
+        return generateAccessToken(jwt, installation.getId());
+    }
+
+    private void assertInstallationAllowed(final GitHubInstallation installation) {
+        final List<String> allowed = getAllowedInstallations();
+        if (isInstallationAllowed(installation, allowed)) {
+            return;
+        }
+        throw new GitClientException(String.format(
+                "GitHub App installation %s is not allowed by github.allowed.installations.", installation.getId()));
+    }
+
+    private List<String> getAllowedInstallations() {
+        final List<String> allowed = preferenceManager.getPreference(SystemPreferences.GITHUB_ALLOWED_INSTALLATIONS);
+        if (CollectionUtils.isEmpty(allowed)) {
+            throw new GitClientException("GitHub App installation access token generation is not allowed.");
+        }
+        return allowed;
+    }
+
+    private boolean isInstallationAllowed(final GitHubInstallation installation, final List<String> allowed) {
+        // check by installation ID:
+        final Long installationId = installation.getId();
+        if (Objects.nonNull(installationId) && allowed.stream()
+                .anyMatch(entry -> Objects.equals(entry, String.valueOf(installationId)))) {
+            return true;
+        }
+
+        // check by installation account name (org or username):
+        final String installationName = Optional.ofNullable(installation.getAccount())
+                .map(GitHubInstallationAccount::getLogin)
+                .filter(StringUtils::isNotBlank)
+                .orElse(null);
+        return StringUtils.isNotBlank(installationName) && allowed.stream()
+                .anyMatch(installationName::equalsIgnoreCase);
+    }
+
+    private GitHubInstallation findInstallationId(final String projectName, final String repositoryName,
+                                                  final String jwt) {
+        final GitHubClient appClient = buildAppClient(jwt);
+        return appClient.getRepositoryInstallation(projectName, repositoryName);
+    }
+
+    private List<GitHubInstallation> findInstallations(final String jwt) {
+        final GitHubClient appClient = buildAppClient(jwt);
+        return pagination(appClient::getAppInstallations);
+    }
+
+    private String generateAccessToken(final String jwt, final Long installationId) {
+        final GitHubClient appClient = buildAppClient(jwt);
+        final GitHubAccessToken tokenResponse = appClient.createInstallationAccessToken(installationId);
+        return Optional.ofNullable(tokenResponse)
+                .map(GitHubAccessToken::getToken)
+                .filter(StringUtils::isNotBlank)
+                .orElseThrow(() -> new GitClientException(
+                        "GitHub installation access token response did not contain a token."));
+    }
+
+    private <T> List<T> pagination(final Function<Integer, Response<List<T>>> apiCall) {
+        return pagination(apiCall, Function.identity());
+    }
+
+    private <T, R> List<T> pagination(final Function<Integer, Response<R>> apiCall,
+                                      final Function<R, List<T>> responseConverter) {
+        int page = 1;
+        Response<R> response = apiCall.apply(page);
+        final List<T> values = new ArrayList<>(ListUtils.emptyIfNull(responseConverter.apply(response.body())));
+        String link = response.headers().get(LINK);
+        while (link != null && link.contains(REL_NEXT)) {
+            page++;
+            response = apiCall.apply(page);
+            values.addAll(ListUtils.emptyIfNull(responseConverter.apply(response.body())));
+            link = response.headers().get(LINK);
+        }
+        return values;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubService.java
@@ -21,6 +21,7 @@ import com.epam.pipeline.common.MessageHelper;
 import com.epam.pipeline.controller.vo.PipelineSourceItemVO;
 import com.epam.pipeline.controller.vo.PipelineSourceItemsVO;
 import com.epam.pipeline.controller.vo.UploadFileMetadata;
+import com.epam.pipeline.dto.git.GitRepositoryDTO;
 import com.epam.pipeline.entity.git.GitCommitEntry;
 import com.epam.pipeline.entity.git.GitCredentials;
 import com.epam.pipeline.entity.git.GitNamespace;
@@ -123,7 +124,7 @@ public class GitHubService implements GitClientService {
     @Override
     public List<String> getBranches(final String repositoryPath, final String token) {
         final GitHubClient client = getClient(repositoryPath, token);
-        return GitHubUtils.pagination(client::getBranches).stream()
+        return GitHubUtils.fetchAllPages(client::getBranches).stream()
                 .map(GitHubRef::getName)
                 .collect(Collectors.toList());
     }
@@ -155,7 +156,7 @@ public class GitHubService implements GitClientService {
     @Override
     public List<Revision> getTags(final Pipeline pipeline) {
         final GitHubClient client = getClient(pipeline);
-        return GitHubUtils.pagination(client::getTags).stream()
+        return GitHubUtils.fetchAllPages(client::getTags).stream()
                 .map(tag -> fillCommitInfo(tag, client))
                 .map(mapper::refToRevision)
                 .collect(Collectors.toList());
@@ -338,9 +339,9 @@ public class GitHubService implements GitClientService {
     }
 
     @Override
-    public List<GitProject> getNamespaceRepositories(final String installationId) {
+    public List<GitRepositoryDTO> getNamespaceRepositories(final String installationId) {
         return gitHubAppService.findRepositoriesByInstallation(installationId).stream()
-                .map(mapper::toGitRepository)
+                .map(mapper::toGitRepositoryDTO)
                 .collect(Collectors.toList());
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubUtils.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubUtils.java
@@ -36,12 +36,12 @@ public final class GitHubUtils {
         // no-op
     }
 
-    public static <T> List<T> pagination(final Function<Integer, Response<List<T>>> apiCall) {
-        return pagination(apiCall, Function.identity());
+    public static <T> List<T> fetchAllPages(final Function<Integer, Response<List<T>>> apiCall) {
+        return fetchAllPages(apiCall, Function.identity());
     }
 
-    public static <T, R> List<T> pagination(final Function<Integer, Response<R>> apiCall,
-                                            final Function<R, List<T>> responseConverter) {
+    public static <T, R> List<T> fetchAllPages(final Function<Integer, Response<R>> apiCall,
+                                               final Function<R, List<T>> responseConverter) {
         int page = 1;
         Response<R> response = apiCall.apply(page);
         final List<T> values = new ArrayList<>(ListUtils.emptyIfNull(responseConverter.apply(response.body())));

--- a/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubUtils.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubUtils.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.git.github;
+
+import org.apache.commons.collections4.ListUtils;
+import retrofit2.Response;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Common utils for GitHub.
+ */
+public final class GitHubUtils {
+    public static final String AUTHORIZATION = "Authorization";
+    public static final Integer LIMIT = 100;
+    private static final String LINK = "link";
+    private static final String REL_NEXT = "rel=\"next\"";
+
+    private GitHubUtils() {
+        // no-op
+    }
+
+    public static <T> List<T> pagination(final Function<Integer, Response<List<T>>> apiCall) {
+        return pagination(apiCall, Function.identity());
+    }
+
+    public static <T, R> List<T> pagination(final Function<Integer, Response<R>> apiCall,
+                                            final Function<R, List<T>> responseConverter) {
+        int page = 1;
+        Response<R> response = apiCall.apply(page);
+        final List<T> values = new ArrayList<>(ListUtils.emptyIfNull(responseConverter.apply(response.body())));
+        String link = response.headers().get(LINK);
+        while (link != null && link.contains(REL_NEXT)) {
+            page++;
+            response = apiCall.apply(page);
+            values.addAll(ListUtils.emptyIfNull(responseConverter.apply(response.body())));
+            link = response.headers().get(LINK);
+        }
+        return values;
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -381,6 +381,21 @@ public class SystemPreferences {
 
     public static final StringPreference GITHUB_USER_NAME = new StringPreference(
             "github.user.name", "x-token-auth", GIT_GROUP, pass);
+    /**
+     * GitHub App numeric identifier ({@code iss} claim for app JWT).
+     */
+    public static final StringPreference GITHUB_APP_ID = new StringPreference(
+            "github.app.id", null, GIT_GROUP, pass);
+    public static final StringPreference GITHUB_API_ROOT_URL = new StringPreference(
+            "github.api.root.url", "https://api.github.com", GIT_GROUP, pass);
+    /** A list acts as a whitelist: access is allowed if any entry equals the installation id
+     * or the installation account login (organization or username).
+     * If empty access over GitHub App is denied.
+     **/
+    public static final ObjectPreference<List<String>> GITHUB_ALLOWED_INSTALLATIONS = new ObjectPreference<>(
+            "github.allowed.installations", null, new TypeReference<List<String>>() {}, GIT_GROUP,
+            isNullOrValidJson(new TypeReference<List<String>>() {}), true);
+
 
     public static final EnumPreference<AuthType> BITBUCKET_CLOUD_AUTH_TYPE = new EnumPreference<>(
             "bitbucket.cloud.auth.type", AuthType.BASIC, GIT_GROUP, pass);

--- a/api/src/main/java/com/epam/pipeline/mapper/git/GitHubMapper.java
+++ b/api/src/main/java/com/epam/pipeline/mapper/git/GitHubMapper.java
@@ -17,8 +17,10 @@
 package com.epam.pipeline.mapper.git;
 
 import com.epam.pipeline.entity.git.GitCommitEntry;
+import com.epam.pipeline.entity.git.GitNamespace;
 import com.epam.pipeline.entity.git.GitProject;
 import com.epam.pipeline.entity.git.GitTagEntry;
+import com.epam.pipeline.entity.git.github.GitHubInstallation;
 import com.epam.pipeline.entity.git.github.GitHubAuthor;
 import com.epam.pipeline.entity.git.github.GitHubCommit;
 import com.epam.pipeline.entity.git.github.GitHubCommitNode;
@@ -107,6 +109,11 @@ public interface GitHubMapper {
 
     @Mapping(target = "message", ignore = true)
     GitTagEntry tagToTagEntry(GitHubRelease tag);
+
+    @Mapping(target = "name", source = "account.login")
+    @Mapping(target = "type", source = "account.type")
+    @Mapping(target = "id", expression = "java(String.valueOf(installation.getId()))")
+    GitNamespace installationToNamespace(GitHubInstallation installation);
 
     @SneakyThrows
     default Date fillDate(final String date) {

--- a/api/src/main/java/com/epam/pipeline/mapper/git/GitHubMapper.java
+++ b/api/src/main/java/com/epam/pipeline/mapper/git/GitHubMapper.java
@@ -16,6 +16,7 @@
 
 package com.epam.pipeline.mapper.git;
 
+import com.epam.pipeline.dto.git.GitRepositoryDTO;
 import com.epam.pipeline.entity.git.GitCommitEntry;
 import com.epam.pipeline.entity.git.GitNamespace;
 import com.epam.pipeline.entity.git.GitProject;
@@ -114,6 +115,12 @@ public interface GitHubMapper {
     @Mapping(target = "type", source = "account.type")
     @Mapping(target = "id", expression = "java(String.valueOf(installation.getId()))")
     GitNamespace installationToNamespace(GitHubInstallation installation);
+
+    @Mapping(target = "id", expression = "java(String.valueOf(repository.getId()))")
+    @Mapping(target = "httpUrl", source = "cloneUrl")
+    @Mapping(target = "sshUrl", source = "sshUrl")
+    @Mapping(target = "path", source = "htmlUrl")
+    GitRepositoryDTO toGitRepositoryDTO(GitHubRepository repository);
 
     @SneakyThrows
     default Date fillDate(final String date) {

--- a/api/src/main/java/com/epam/pipeline/utils/JwtUtils.java
+++ b/api/src/main/java/com/epam/pipeline/utils/JwtUtils.java
@@ -37,6 +37,20 @@ import java.time.Instant;
 import java.util.Base64;
 import java.util.Date;
 
+/**
+ * Utility class for JWT generation.
+ * <p>
+ * This class provides functionality to generate RSA-256 signed JWT tokens using private keys
+ * in either PKCS#8 or PKCS#1 PEM format. It supports reading private keys from the file system
+ * and creating JWT tokens with configurable issuer and time-to-live settings.
+ * </p>
+ *
+ * <h2>Supported Key Formats:</h2>
+ * <ul>
+ *   <li>PKCS#8 format: {@code -----BEGIN PRIVATE KEY-----}</li>
+ *   <li>PKCS#1 format: {@code -----BEGIN RSA PRIVATE KEY-----}</li>
+ * </ul>
+ */
 public final class JwtUtils {
 
     private static final String PEM_PKCS8_HEADER = "-----BEGIN PRIVATE KEY-----";
@@ -48,6 +62,35 @@ public final class JwtUtils {
     private JwtUtils() {
     }
 
+    /**
+     * Generates a JWT token signed with RSA-256 algorithm using a private key from a PEM file.
+     * <p>
+     * This method creates a JWT with the following claims:
+     * </p>
+     * <ul>
+     *   <li><strong>iss</strong> (Issuer): The entity that issued the token</li>
+     *   <li><strong>iat</strong> (Issued At): The timestamp when the token was created</li>
+     *   <li><strong>exp</strong> (Expiration Time): The timestamp when the token expires</li>
+     * </ul>
+     * <p>
+     * The private key file must be in PEM format and can be either PKCS#8 or PKCS#1 encoded.
+     * The method automatically detects the format based on the PEM header.
+     * </p>
+     *
+     * @param privateKeyPath the file system path to the RSA private key in PEM format.
+     *                       Must not be null or empty, and the file must exist.
+     * @param issuer         the issuer claim (iss) to include in the JWT.
+     *                       Typically identifies the principal that issued the token.
+     * @param ttlSeconds     the time-to-live in seconds. The token will expire
+     *                       this many seconds after the current time.
+     *                       Must be a positive value.
+     * @return a signed JWT token as a compact, URL-safe string in the format:
+     * {@code header.payload.signature}
+     * @throws IOException              if the private key file cannot be read or does not exist
+     * @throws NoSuchAlgorithmException if the RSA algorithm is not available in the JVM
+     * @throws InvalidKeySpecException  if the private key format is invalid or cannot be parsed
+     * @throws IllegalArgumentException if privateKeyPath is null/empty or the file doesn't exist
+     */
     public static String generateRsa256Jwt(final String privateKeyPath,
                                            final String issuer,
                                            final long ttlSeconds)

--- a/api/src/main/java/com/epam/pipeline/utils/JwtUtils.java
+++ b/api/src/main/java/com/epam/pipeline/utils/JwtUtils.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.utils;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import joptsimple.internal.Strings;
+import org.bouncycastle.asn1.ASN1Sequence;
+import org.springframework.util.Assert;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.RSAPrivateCrtKeySpec;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Date;
+
+public final class JwtUtils {
+
+    private static final String PEM_PKCS8_HEADER = "-----BEGIN PRIVATE KEY-----";
+    private static final String PEM_PKCS8_FOOTER = "-----END PRIVATE KEY-----";
+    private static final String PEM_PKCS1_HEADER = "-----BEGIN RSA PRIVATE KEY-----";
+    private static final String PEM_PKCS1_FOOTER = "-----END RSA PRIVATE KEY-----";
+    private static final String RSA = "RSA";
+
+    private JwtUtils() {
+    }
+
+    public static String generateRsa256Jwt(final String privateKeyPath,
+                                           final String issuer,
+                                           final long ttlSeconds)
+            throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+        final String pem = readPrivateKeyPem(privateKeyPath);
+        final RSAPrivateKey rsa = parseRsaPrivateKey(pem);
+
+        final long nowSeconds = Instant.now().getEpochSecond();
+        final Date issuedAt = Date.from(Instant.ofEpochSecond(nowSeconds));
+        final Date expiresAt = Date.from(Instant.ofEpochSecond(nowSeconds + ttlSeconds));
+
+        return JWT.create()
+                .withIssuer(issuer)
+                .withIssuedAt(issuedAt)
+                .withExpiresAt(expiresAt)
+                .sign(Algorithm.RSA256(rsa));
+    }
+
+    private static String readPrivateKeyPem(final String pathToPem) throws IOException {
+        Assert.isTrue(!Strings.isNullOrEmpty(pathToPem),
+                "Private key file path must be provided to generate JWT.");
+        final File file = new File(pathToPem);
+        Assert.isTrue(file.isFile() && file.exists(),
+                "Private key file must be provided to generate JWT.");
+        return new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+    }
+
+    private static byte[] normalizeKey(final String rawKey, final String header, final String footer) {
+        final String normalized = rawKey.replace(header, Strings.EMPTY)
+                .replace(footer, Strings.EMPTY)
+                .replaceAll("\\s", Strings.EMPTY);
+        return Base64.getDecoder().decode(normalized);
+    }
+
+    private static KeySpec getPKCS8KeySpec(final String rawKey) {
+        final byte[] normalized = normalizeKey(rawKey, PEM_PKCS8_HEADER, PEM_PKCS8_FOOTER);
+        return new PKCS8EncodedKeySpec(normalized);
+    }
+
+    private static KeySpec getPKCS1KeySpec(final String rawKey) {
+        final byte[] normalized = normalizeKey(rawKey, PEM_PKCS1_HEADER, PEM_PKCS1_FOOTER);
+
+        final ASN1Sequence asn1Sequence = ASN1Sequence.getInstance(normalized);
+        final org.bouncycastle.asn1.pkcs.RSAPrivateKey rsaPrivateKey =
+                org.bouncycastle.asn1.pkcs.RSAPrivateKey.getInstance(asn1Sequence);
+
+        return new RSAPrivateCrtKeySpec(
+                rsaPrivateKey.getModulus(),
+                rsaPrivateKey.getPublicExponent(),
+                rsaPrivateKey.getPrivateExponent(),
+                rsaPrivateKey.getPrime1(),
+                rsaPrivateKey.getPrime2(),
+                rsaPrivateKey.getExponent1(),
+                rsaPrivateKey.getExponent2(),
+                rsaPrivateKey.getCoefficient()
+        );
+    }
+
+    private static RSAPrivateKey parseRsaPrivateKey(final String pem)
+            throws NoSuchAlgorithmException, InvalidKeySpecException {
+        final KeySpec spec = pem.startsWith(PEM_PKCS8_HEADER) ? getPKCS8KeySpec(pem) : getPKCS1KeySpec(pem);
+        final KeyFactory keyFactory = KeyFactory.getInstance(RSA);
+        return (RSAPrivateKey) keyFactory.generatePrivate(spec);
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/acl/pipeline/PipelineApiServiceGitTest.java
+++ b/api/src/test/java/com/epam/pipeline/acl/pipeline/PipelineApiServiceGitTest.java
@@ -23,9 +23,12 @@ import com.epam.pipeline.controller.vo.TaskGraphVO;
 import com.epam.pipeline.controller.vo.UploadFileMetadata;
 import com.epam.pipeline.entity.git.GitCommitEntry;
 import com.epam.pipeline.entity.git.GitCredentials;
+import com.epam.pipeline.entity.git.GitNamespace;
+import com.epam.pipeline.entity.git.GitProject;
 import com.epam.pipeline.entity.git.GitRepositoryEntry;
 import com.epam.pipeline.entity.git.GitTagEntry;
 import com.epam.pipeline.entity.pipeline.Pipeline;
+import com.epam.pipeline.entity.pipeline.RepositoryType;
 import com.epam.pipeline.entity.pipeline.Revision;
 import com.epam.pipeline.exception.git.GitClientException;
 import com.epam.pipeline.manager.git.GitManager;
@@ -69,6 +72,10 @@ public class PipelineApiServiceGitTest extends AbstractAclTest {
     private final TaskGraphVO taskGraphVO = PipelineCreatorUtils.getTaskGraphVO();
     private final RegisterPipelineVersionVO pipelineVersionVO = PipelineCreatorUtils.getRegisterPipelineVersionVO();
     private final List<Revision> revisionList = Collections.singletonList(revision);
+    private final GitNamespace gitNamespace = GitCreatorUtils.getGitNamespace();
+    private final GitProject gitProject = GitCreatorUtils.getGitProject();
+    private final List<GitNamespace> gitNamespaceList = Collections.singletonList(gitNamespace);
+    private final List<GitProject> gitProjectList = Collections.singletonList(gitProject);
 
     @Autowired
     private PipelineApiService pipelineApiService;
@@ -568,5 +575,23 @@ public class PipelineApiServiceGitTest extends AbstractAclTest {
 
         assertThrowsChecked(AccessDeniedException.class, () ->
                 pipelineApiService.registerPipelineVersion(pipelineVersionVO));
+    }
+
+    @Test
+    @WithMockUser
+    public void shouldGetAllowedNamespacesForUser() {
+        doReturn(gitNamespaceList).when(mockPipelineRepositoryService).getAllowedNamespaces(RepositoryType.GITHUB);
+
+        assertThat(pipelineApiService.getAllowedNamespaces(RepositoryType.GITHUB)).isEqualTo(gitNamespaceList);
+    }
+
+    @Test
+    @WithMockUser
+    public void shouldGetNamespaceRepositoriesForUser() {
+        doReturn(gitProjectList).when(mockPipelineRepositoryService)
+                .getNamespaceRepositories(TEST_STRING, RepositoryType.GITHUB);
+
+        assertThat(pipelineApiService.getNamespaceRepositories(TEST_STRING, RepositoryType.GITHUB))
+                .isEqualTo(gitProjectList);
     }
 }

--- a/api/src/test/java/com/epam/pipeline/acl/pipeline/PipelineApiServiceGitTest.java
+++ b/api/src/test/java/com/epam/pipeline/acl/pipeline/PipelineApiServiceGitTest.java
@@ -21,10 +21,10 @@ import com.epam.pipeline.controller.vo.PipelineSourceItemsVO;
 import com.epam.pipeline.controller.vo.RegisterPipelineVersionVO;
 import com.epam.pipeline.controller.vo.TaskGraphVO;
 import com.epam.pipeline.controller.vo.UploadFileMetadata;
+import com.epam.pipeline.dto.git.GitRepositoryDTO;
 import com.epam.pipeline.entity.git.GitCommitEntry;
 import com.epam.pipeline.entity.git.GitCredentials;
 import com.epam.pipeline.entity.git.GitNamespace;
-import com.epam.pipeline.entity.git.GitProject;
 import com.epam.pipeline.entity.git.GitRepositoryEntry;
 import com.epam.pipeline.entity.git.GitTagEntry;
 import com.epam.pipeline.entity.pipeline.Pipeline;
@@ -73,9 +73,9 @@ public class PipelineApiServiceGitTest extends AbstractAclTest {
     private final RegisterPipelineVersionVO pipelineVersionVO = PipelineCreatorUtils.getRegisterPipelineVersionVO();
     private final List<Revision> revisionList = Collections.singletonList(revision);
     private final GitNamespace gitNamespace = GitCreatorUtils.getGitNamespace();
-    private final GitProject gitProject = GitCreatorUtils.getGitProject();
+    private final GitRepositoryDTO gitRepositoryDTO = GitCreatorUtils.getGitRepositoryDTO();
     private final List<GitNamespace> gitNamespaceList = Collections.singletonList(gitNamespace);
-    private final List<GitProject> gitProjectList = Collections.singletonList(gitProject);
+    private final List<GitRepositoryDTO> gitRepositoryDTOList = Collections.singletonList(gitRepositoryDTO);
 
     @Autowired
     private PipelineApiService pipelineApiService;
@@ -588,10 +588,10 @@ public class PipelineApiServiceGitTest extends AbstractAclTest {
     @Test
     @WithMockUser
     public void shouldGetNamespaceRepositoriesForUser() {
-        doReturn(gitProjectList).when(mockPipelineRepositoryService)
+        doReturn(gitRepositoryDTOList).when(mockPipelineRepositoryService)
                 .getNamespaceRepositories(TEST_STRING, RepositoryType.GITHUB);
 
         assertThat(pipelineApiService.getNamespaceRepositories(TEST_STRING, RepositoryType.GITHUB))
-                .isEqualTo(gitProjectList);
+                .isEqualTo(gitRepositoryDTOList);
     }
 }

--- a/api/src/test/java/com/epam/pipeline/controller/pipeline/PipelineControllerTest.java
+++ b/api/src/test/java/com/epam/pipeline/controller/pipeline/PipelineControllerTest.java
@@ -27,11 +27,11 @@ import com.epam.pipeline.controller.vo.PipelinesWithPermissionsVO;
 import com.epam.pipeline.controller.vo.RegisterPipelineVersionVO;
 import com.epam.pipeline.controller.vo.TaskGraphVO;
 import com.epam.pipeline.controller.vo.UploadFileMetadata;
+import com.epam.pipeline.dto.git.GitRepositoryDTO;
 import com.epam.pipeline.entity.cluster.InstancePrice;
 import com.epam.pipeline.entity.git.GitCommitEntry;
 import com.epam.pipeline.entity.git.GitCredentials;
 import com.epam.pipeline.entity.git.GitNamespace;
-import com.epam.pipeline.entity.git.GitProject;
 import com.epam.pipeline.entity.git.GitRepositoryEntry;
 import com.epam.pipeline.entity.git.GitTagEntry;
 import com.epam.pipeline.entity.pipeline.DocumentGenerationProperty;
@@ -160,8 +160,8 @@ public class PipelineControllerTest extends AbstractControllerTest {
             Collections.singletonList(documentGenerationProperty);
     private final GitNamespace gitNamespace = GitCreatorUtils.getGitNamespace();
     private final List<GitNamespace> gitNamespaceList = Collections.singletonList(gitNamespace);
-    private final List<GitProject> gitProjectList = Collections.singletonList(
-            GitCreatorUtils.getGitProject());
+    private final GitRepositoryDTO gitRepositoryDTO = GitCreatorUtils.getGitRepositoryDTO();
+    private final List<GitRepositoryDTO> gitRepositoryDTOList = Collections.singletonList(gitRepositoryDTO);
 
     @Autowired
     private PipelineApiService mockPipelineApiService;
@@ -853,7 +853,7 @@ public class PipelineControllerTest extends AbstractControllerTest {
     @Test
     @WithMockUser
     public void shouldGetNamespaceRepositories() {
-        doReturn(gitProjectList).when(mockPipelineApiService)
+        doReturn(gitRepositoryDTOList).when(mockPipelineApiService)
                 .getNamespaceRepositories(NAMESPACE_ID, RepositoryType.GITHUB);
     
         final MvcResult mvcResult = performRequest(
@@ -861,7 +861,7 @@ public class PipelineControllerTest extends AbstractControllerTest {
                         .params(multiValueMapOf(TYPE, RepositoryType.GITHUB)));
     
         verify(mockPipelineApiService).getNamespaceRepositories(NAMESPACE_ID, RepositoryType.GITHUB);
-        assertResponse(mvcResult, gitProjectList, GitCreatorUtils.GIT_PROJECT_LIST_TYPE);
+        assertResponse(mvcResult, gitRepositoryDTOList, GitCreatorUtils.GIT_REPOSITORY_DTO_LIST_TYPE);
     }
 
     private void assertResponseAsBytes(final MvcResult mvcResult, final byte[] bytes) throws Exception {

--- a/api/src/test/java/com/epam/pipeline/controller/pipeline/PipelineControllerTest.java
+++ b/api/src/test/java/com/epam/pipeline/controller/pipeline/PipelineControllerTest.java
@@ -30,11 +30,14 @@ import com.epam.pipeline.controller.vo.UploadFileMetadata;
 import com.epam.pipeline.entity.cluster.InstancePrice;
 import com.epam.pipeline.entity.git.GitCommitEntry;
 import com.epam.pipeline.entity.git.GitCredentials;
+import com.epam.pipeline.entity.git.GitNamespace;
+import com.epam.pipeline.entity.git.GitProject;
 import com.epam.pipeline.entity.git.GitRepositoryEntry;
 import com.epam.pipeline.entity.git.GitTagEntry;
 import com.epam.pipeline.entity.pipeline.DocumentGenerationProperty;
 import com.epam.pipeline.entity.pipeline.Pipeline;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
+import com.epam.pipeline.entity.pipeline.RepositoryType;
 import com.epam.pipeline.entity.pipeline.Revision;
 import com.epam.pipeline.exception.git.GitClientException;
 import com.epam.pipeline.test.creator.CommonCreatorConstants;
@@ -103,6 +106,8 @@ public class PipelineControllerTest extends AbstractControllerTest {
     private static final String PIPELINE_ID_ADD_HOOK_URL = PIPELINE_ID_URL + "/addHook";
     private static final String PIPELINE_ID_REPOSITORY_URL = PIPELINE_ID_URL + "/repository";
     private static final String PIPELINE_ID_COPY_URL = PIPELINE_ID_URL + "/copy";
+    private static final String PIPELINE_GIT_NAMESPACES_URL = PIPELINE_GIT_URL + "/namespaces";
+    private static final String PIPELINE_GIT_NAMESPACE_REPOSITORIES_URL = PIPELINE_GIT_URL + "/%s/repositories";
 
     private static final String LOAD_VERSION = "loadVersion";
     private static final String PAGE_NUM = "pageNum";
@@ -119,6 +124,8 @@ public class PipelineControllerTest extends AbstractControllerTest {
     private static final String NAME = "name";
     private static final String BYTE_LIMIT = "byteLimit";
     private static final String FILE_SIZE = "0 Kb";
+    private static final String TYPE = "type";
+    private static final String NAMESPACE_ID = "test-namespace";
 
     private final Pipeline pipeline = PipelineCreatorUtils.getPipeline();
     private final PipelineVO pipelineVO = PipelineCreatorUtils.getPipelineVO();
@@ -151,6 +158,10 @@ public class PipelineControllerTest extends AbstractControllerTest {
     private final List<UploadFileMetadata> fileMetadataList = Collections.singletonList(fileMetadata);
     private final List<DocumentGenerationProperty> generationProperties =
             Collections.singletonList(documentGenerationProperty);
+    private final GitNamespace gitNamespace = GitCreatorUtils.getGitNamespace();
+    private final List<GitNamespace> gitNamespaceList = Collections.singletonList(gitNamespace);
+    private final List<GitProject> gitProjectList = Collections.singletonList(
+            GitCreatorUtils.getGitProject());
 
     @Autowired
     private PipelineApiService mockPipelineApiService;
@@ -803,18 +814,54 @@ public class PipelineControllerTest extends AbstractControllerTest {
     @WithMockUser
     public void shouldCopyPipeline() {
         doReturn(pipeline).when(mockPipelineApiService).copyPipeline(ID, ID, TEST_STRING);
-
+    
         final MvcResult mvcResult = performRequest(post(String.format(PIPELINE_ID_COPY_URL, ID))
                 .params(multiValueMapOf(PARENT_ID, ID,
                                         NAME, TEST_STRING)));
-
+    
         verify(mockPipelineApiService).copyPipeline(ID, ID, TEST_STRING);
         assertResponse(mvcResult, pipeline, PipelineCreatorUtils.PIPELINE_INSTANCE_TYPE);
     }
-
+    
     @Test
     public void shouldFailCopyPipelineForUnauthorizedUser() {
         performUnauthorizedRequest(post(String.format(PIPELINE_ID_COPY_URL, ID)));
+    }
+    
+    @Test
+    public void shouldFailGetAllowedNamespacesForUnauthorizedUser() {
+        performUnauthorizedRequest(get(PIPELINE_GIT_NAMESPACES_URL));
+    }
+    
+    @Test
+    @WithMockUser
+    public void shouldGetAllowedNamespaces() {
+        doReturn(gitNamespaceList).when(mockPipelineApiService).getAllowedNamespaces(RepositoryType.GITHUB);
+    
+        final MvcResult mvcResult = performRequest(get(PIPELINE_GIT_NAMESPACES_URL)
+                .params(multiValueMapOf(TYPE, RepositoryType.GITHUB)));
+    
+        verify(mockPipelineApiService).getAllowedNamespaces(RepositoryType.GITHUB);
+        assertResponse(mvcResult, gitNamespaceList, GitCreatorUtils.GIT_NAMESPACE_LIST_TYPE);
+    }
+    
+    @Test
+    public void shouldFailGetNamespaceRepositoriesForUnauthorizedUser() {
+        performUnauthorizedRequest(get(String.format(PIPELINE_GIT_NAMESPACE_REPOSITORIES_URL, NAMESPACE_ID)));
+    }
+    
+    @Test
+    @WithMockUser
+    public void shouldGetNamespaceRepositories() {
+        doReturn(gitProjectList).when(mockPipelineApiService)
+                .getNamespaceRepositories(NAMESPACE_ID, RepositoryType.GITHUB);
+    
+        final MvcResult mvcResult = performRequest(
+                get(String.format(PIPELINE_GIT_NAMESPACE_REPOSITORIES_URL, NAMESPACE_ID))
+                        .params(multiValueMapOf(TYPE, RepositoryType.GITHUB)));
+    
+        verify(mockPipelineApiService).getNamespaceRepositories(NAMESPACE_ID, RepositoryType.GITHUB);
+        assertResponse(mvcResult, gitProjectList, GitCreatorUtils.GIT_PROJECT_LIST_TYPE);
     }
 
     private void assertResponseAsBytes(final MvcResult mvcResult, final byte[] bytes) throws Exception {

--- a/api/src/test/java/com/epam/pipeline/test/creator/git/GitCreatorUtils.java
+++ b/api/src/test/java/com/epam/pipeline/test/creator/git/GitCreatorUtils.java
@@ -17,10 +17,10 @@
 package com.epam.pipeline.test.creator.git;
 
 import com.epam.pipeline.controller.Result;
+import com.epam.pipeline.dto.git.GitRepositoryDTO;
 import com.epam.pipeline.entity.git.GitCommitEntry;
 import com.epam.pipeline.entity.git.GitCredentials;
 import com.epam.pipeline.entity.git.GitNamespace;
-import com.epam.pipeline.entity.git.GitProject;
 import com.epam.pipeline.entity.git.GitRepositoryEntry;
 import com.epam.pipeline.entity.git.GitTagEntry;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -43,8 +43,8 @@ public final class GitCreatorUtils {
             new TypeReference<Result<List<GitRepositoryEntry>>>() {};
     public static final TypeReference<Result<List<GitNamespace>>> GIT_NAMESPACE_LIST_TYPE =
             new TypeReference<Result<List<GitNamespace>>>() {};
-    public static final TypeReference<Result<List<GitProject>>> GIT_PROJECT_LIST_TYPE =
-            new TypeReference<Result<List<GitProject>>>() {};
+    public static final TypeReference<Result<List<GitRepositoryDTO>>> GIT_REPOSITORY_DTO_LIST_TYPE =
+            new TypeReference<Result<List<GitRepositoryDTO>>>() {};
 
     private GitCreatorUtils() {
 
@@ -74,12 +74,15 @@ public final class GitCreatorUtils {
         return namespace;
     }
 
-    public static GitProject getGitProject() {
-        final GitProject project = new GitProject();
-        project.setName("test-repo");
-        project.setProjectId(1L);
-        project.setRepoUrl("https://github.com/test-org/test-repo");
-        project.setPath("test-org/test-repo");
-        return project;
+    public static GitRepositoryDTO getGitRepositoryDTO() {
+        return GitRepositoryDTO.builder()
+                .id("123456")
+                .name("test-repo")
+                .description("Test repository")
+                .defaultBranch("main")
+                .httpUrl("https://github.com/test-org/test-repo.git")
+                .sshUrl("git@github.com:test-org/test-repo.git")
+                .path("https://github.com/test-org/test-repo")
+                .build();
     }
 }

--- a/api/src/test/java/com/epam/pipeline/test/creator/git/GitCreatorUtils.java
+++ b/api/src/test/java/com/epam/pipeline/test/creator/git/GitCreatorUtils.java
@@ -19,6 +19,8 @@ package com.epam.pipeline.test.creator.git;
 import com.epam.pipeline.controller.Result;
 import com.epam.pipeline.entity.git.GitCommitEntry;
 import com.epam.pipeline.entity.git.GitCredentials;
+import com.epam.pipeline.entity.git.GitNamespace;
+import com.epam.pipeline.entity.git.GitProject;
 import com.epam.pipeline.entity.git.GitRepositoryEntry;
 import com.epam.pipeline.entity.git.GitTagEntry;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -39,6 +41,10 @@ public final class GitCreatorUtils {
             new TypeReference<Result<GitRepositoryEntry>>() {};
     public static final TypeReference<Result<List<GitRepositoryEntry>>> GIT_REPOSITORY_ENTRY_LIST_TYPE =
             new TypeReference<Result<List<GitRepositoryEntry>>>() {};
+    public static final TypeReference<Result<List<GitNamespace>>> GIT_NAMESPACE_LIST_TYPE =
+            new TypeReference<Result<List<GitNamespace>>>() {};
+    public static final TypeReference<Result<List<GitProject>>> GIT_PROJECT_LIST_TYPE =
+            new TypeReference<Result<List<GitProject>>>() {};
 
     private GitCreatorUtils() {
 
@@ -58,5 +64,22 @@ public final class GitCreatorUtils {
 
     public static GitCredentials getGitCredentials() {
         return new GitCredentials(TEST_STRING, TEST_STRING, TEST_STRING, TEST_STRING);
+    }
+
+    public static GitNamespace getGitNamespace() {
+        final GitNamespace namespace = new GitNamespace();
+        namespace.setName("test-org");
+        namespace.setId("123456");
+        namespace.setType("Organization");
+        return namespace;
+    }
+
+    public static GitProject getGitProject() {
+        final GitProject project = new GitProject();
+        project.setName("test-repo");
+        project.setProjectId(1L);
+        project.setRepoUrl("https://github.com/test-org/test-repo");
+        project.setPath("test-org/test-repo");
+        return project;
     }
 }

--- a/core/src/main/java/com/epam/pipeline/dto/git/GitRepositoryDTO.java
+++ b/core/src/main/java/com/epam/pipeline/dto/git/GitRepositoryDTO.java
@@ -13,26 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.epam.pipeline.entity.git;
+
+package com.epam.pipeline.dto.git;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class GitNamespace {
-    /**
-     * For GitHub provider: organization name or presonal accont name
-     */
-    private String name;
-    /**
-     * For GitHub provider: installation ID associated with this organization / account
-     */
+public class GitRepositoryDTO {
     private String id;
-    /**
-     * For GitHub provider: User (for personal accounts) or Organization
-     */
-    private String type;
+    private String name;
+    private String description;
+    private String defaultBranch;
+    private String httpUrl;
+    private String sshUrl;
+    private String path;
 }

--- a/deploy/docker/cp-api-srv/config/application.properties
+++ b/deploy/docker/cp-api-srv/config/application.properties
@@ -242,3 +242,6 @@ billing.quota.monitor.cron=${CP_API_BILLING_QUOTA_CRON:0 0 9 ? * *}
 #Misc
 app.component.version.name=${CP_API_VERSION_PRETTY_NAME:}
 app.component.version.file=${CP_API_COMPONENT_VERSION_FILE:classpath:static/components_versions.json}
+
+#GitHub
+github.app.private.key.pem=${CP_GITHUB_APP_PRIVATE_KEY:}


### PR DESCRIPTION
relates to #4374 

The current PR enables pipeline repository registration without the need to explicitly specify a GitHub token.
