### PR TITLE
Issue #4374: [API]: Support global github credentials - GITHUB_APP repository type

### DIFF
--- a/api/src/main/java/com/epam/pipeline/app/GitHubClientConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/GitHubClientConfiguration.java
@@ -27,11 +27,14 @@ import com.epam.pipeline.mapper.git.GitHubMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * This configuration implemented to distinguish GITHUB and GITHUB_APP repository types.
+ */
 @Configuration
 public class GitHubClientConfiguration {
 
     @Bean
-    public GitClientService gitHubGitClientService(
+    public GitClientService gitHubClientService(
             final GitHubTokenAuthService gitHubTokenAuthService,
             final GitHubMapper mapper,
             final MessageHelper messageHelper,
@@ -45,7 +48,7 @@ public class GitHubClientConfiguration {
     }
 
     @Bean
-    public GitClientService gitHubAppGitClientService(
+    public GitClientService gitHubAppClientService(
             final GitHubAppAuthService gitHubAppAuthService,
             final GitHubMapper mapper,
             final MessageHelper messageHelper,

--- a/api/src/main/java/com/epam/pipeline/app/GitHubClientConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/GitHubClientConfiguration.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.app;
+
+import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.entity.pipeline.RepositoryType;
+import com.epam.pipeline.manager.git.GitClientService;
+import com.epam.pipeline.manager.git.github.GitHubAppAuthService;
+import com.epam.pipeline.manager.git.github.GitHubTokenAuthService;
+import com.epam.pipeline.manager.git.github.GitHubService;
+import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.epam.pipeline.mapper.git.GitHubMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GitHubClientConfiguration {
+
+    @Bean
+    public GitClientService gitHubGitClientService(
+            final GitHubTokenAuthService gitHubTokenAuthService,
+            final GitHubMapper mapper,
+            final MessageHelper messageHelper,
+            final PreferenceManager preferenceManager) {
+        return new GitHubService(
+                RepositoryType.GITHUB,
+                gitHubTokenAuthService,
+                mapper,
+                messageHelper,
+                preferenceManager);
+    }
+
+    @Bean
+    public GitClientService gitHubAppGitClientService(
+            final GitHubAppAuthService gitHubAppAuthService,
+            final GitHubMapper mapper,
+            final MessageHelper messageHelper,
+            final PreferenceManager preferenceManager) {
+        return new GitHubService(
+                RepositoryType.GITHUB_APP,
+                gitHubAppAuthService,
+                mapper,
+                messageHelper,
+                preferenceManager);
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/git/PipelineRepositoryService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/PipelineRepositoryService.java
@@ -276,7 +276,8 @@ public class PipelineRepositoryService {
                                        final String lastCommitId,
                                        final String commitMessage) throws GitClientException {
         if (pipeline.getRepositoryType() == RepositoryType.BITBUCKET_CLOUD ||
-                pipeline.getRepositoryType() == RepositoryType.GITHUB) {
+                pipeline.getRepositoryType() == RepositoryType.GITHUB ||
+                pipeline.getRepositoryType() == RepositoryType.GITHUB_APP) {
             throw new UnsupportedOperationException(String.format(NOT_SUPPORTED_PATTERN, "Folder creation",
                     pipeline.getRepositoryType()));
         }
@@ -311,7 +312,8 @@ public class PipelineRepositoryService {
                                        final String lastCommitId,
                                        final String commitMessage) throws GitClientException {
         if (pipeline.getRepositoryType() == RepositoryType.BITBUCKET_CLOUD ||
-                pipeline.getRepositoryType() == RepositoryType.GITHUB) {
+                pipeline.getRepositoryType() == RepositoryType.GITHUB ||
+                pipeline.getRepositoryType() == RepositoryType.GITHUB_APP) {
             throw new UnsupportedOperationException(String.format(NOT_SUPPORTED_PATTERN, "Folder renaming",
                     pipeline.getRepositoryType()));
         }
@@ -554,7 +556,8 @@ public class PipelineRepositoryService {
     private static String getCommitName(final Revision commit, final RepositoryType repositoryType) {
         final String commitId = RepositoryType.BITBUCKET_CLOUD.equals(repositoryType) ?
                 commit.getCommitId().substring(0, 6) :
-                (RepositoryType.GITHUB.equals(repositoryType) ? commit.getCommitId().substring(0, 7) :
+                (RepositoryType.GITHUB.equals(repositoryType) || RepositoryType.GITHUB_APP.equals(repositoryType)
+                        ? commit.getCommitId().substring(0, 7) :
                         commit.getName());
         return GitUtils.DRAFT_PREFIX + commitId;
     }

--- a/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubAppAuthService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubAppAuthService.java
@@ -16,11 +16,16 @@
 
 package com.epam.pipeline.manager.git.github;
 
+import com.epam.pipeline.common.MessageConstants;
+import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.entity.git.GitRepositoryUrl;
 import com.epam.pipeline.entity.git.github.GitHubAccessToken;
 import com.epam.pipeline.entity.git.github.GitHubInstallation;
 import com.epam.pipeline.entity.git.github.GitHubInstallationAccount;
 import com.epam.pipeline.entity.git.github.GitHubInstallationRepositories;
 import com.epam.pipeline.entity.git.github.GitHubRepository;
+import com.epam.pipeline.entity.pipeline.Pipeline;
+import com.epam.pipeline.entity.pipeline.RepositoryType;
 import com.epam.pipeline.exception.git.GitClientException;
 import com.epam.pipeline.exception.git.UnexpectedResponseStatusException;
 import com.epam.pipeline.manager.preference.PreferenceManager;
@@ -75,18 +80,23 @@ import java.util.stream.Collectors;
  */
 @Service
 @Slf4j
-public class GitHubAppService {
+public class GitHubAppAuthService implements GitHubAuthInnerService {
     private static final int GITHUB_APP_JWT_MAX_TTL_SECONDS = 600;
     private static final String ACCEPT_HEADER = "Accept";
     private static final String ACCEPT_GITHUB_JSON = "application/vnd.github+json";
     private static final String X_GITHUB_API_VERSION = "2026-03-10";
     private static final String API_VERSION_HEADER = "X-GitHub-Api-Version";
+    private static final String REPOSITORY_NAME = "repository name";
+    private static final String PROJECT_NAME = "project name";
 
+    private final MessageHelper messageHelper;
     private final PreferenceManager preferenceManager;
     private final String privateKeyPem;
 
-    public GitHubAppService(final PreferenceManager preferenceManager,
-                            @Value("${github.app.private.key.pem:}") final String privateKeyPem) {
+    public GitHubAppAuthService(final MessageHelper messageHelper,
+                                final PreferenceManager preferenceManager,
+                                @Value("${github.app.private.key.pem:}") final String privateKeyPem) {
+        this.messageHelper = messageHelper;
         this.preferenceManager = preferenceManager;
         this.privateKeyPem = privateKeyPem;
     }
@@ -108,18 +118,19 @@ public class GitHubAppService {
      * with the permissions granted to the GitHub App installation.
      * </p>
      *
-     * @param projectName    the GitHub organization or username that owns the repository.
-     *                       Must not be null or empty.
-     * @param repositoryName the name of the repository within the project.
-     *                       Must not be null or empty.
+     * @param repositoryPath    the GitHub path to the repository. Must not be null or empty.
+     * @param explicitToken     ignored.
      * @return a GitHub installation access token that can be used for API authentication.
      * The token has a limited lifetime as determined by GitHub's API.
      */
-    public String getGithubAppToken(final String projectName, final String repositoryName) {
-        final String jwt = generateJWT();
-        final GitHubInstallation installation = findInstallationId(projectName, repositoryName, jwt);
-        assertInstallationAllowed(installation);
-        return generateAccessToken(jwt, installation.getId());
+    @Override
+    public String resolveToken(final String repositoryPath, @SuppressWarnings("unused") final String explicitToken) {
+        return installationTokenForRepository(repositoryPath);
+    }
+
+    @Override
+    public String resolveCloneToken(final Pipeline pipeline) {
+        return installationTokenForRepository(pipeline.getRepository());
     }
 
     /**
@@ -136,7 +147,8 @@ public class GitHubAppService {
      * @return a list of {@link GitHubInstallation} objects representing allowed installations.
      * Returns an empty list if no installations match the allowlist.
      */
-    public List<GitHubInstallation> findAllowedInstallations() {
+    @Override
+    public List<GitHubInstallation> getAllowedNamespaces() {
         final List<String> allowed = getAllowedInstallations();
 
         final String jwt = generateJWT();
@@ -163,7 +175,8 @@ public class GitHubAppService {
      * @return a list of {@link GitHubRepository} objects accessible through the installation.
      * Returns an empty list if the installation has no accessible repositories.
      */
-    public List<GitHubRepository> findRepositoriesByInstallation(final String installationId) {
+    @Override
+    public List<GitHubRepository> getNamespaceRepositories(final String installationId) {
         Assert.hasText(installationId, "Installation ID must not be null or empty.");
         Assert.state(NumberUtils.isDigits(installationId),
                 String.format("Installation ID must contain only digits, but got: %s", installationId));
@@ -181,10 +194,31 @@ public class GitHubAppService {
         final String accessToken = generateAccessToken(jwt, installationIdLong);
         final GitHubAppClient client = buildAppClient(accessToken);
 
-        return GitHubUtils.fetchAllPages(client::getInstallationRepositories,
-            responseBody -> Optional.ofNullable(responseBody)
-                    .map(GitHubInstallationRepositories::getRepositories)
-                    .orElse(Collections.emptyList()));
+        return GitHubUtils.fetchAllPages(client::getInstallationRepositories, responseBody ->
+                Optional.ofNullable(responseBody)
+                        .map(GitHubInstallationRepositories::getRepositories)
+                        .orElse(Collections.emptyList()));
+    }
+
+    private String installationTokenForRepository(final String repositoryPath) {
+        final GitRepositoryUrl repositoryUrl = GitRepositoryUrl.from(repositoryPath);
+        final String projectName = repositoryUrl.getNamespace()
+                .orElseThrow(() -> buildUrlParseError(PROJECT_NAME));
+        final String repoName = repositoryUrl.getProject()
+                .orElseThrow(() -> buildUrlParseError(REPOSITORY_NAME));
+        return getGithubAppToken(projectName, repoName);
+    }
+
+    private GitClientException buildUrlParseError(final String urlPart) {
+        return new GitClientException(messageHelper.getMessage(
+                MessageConstants.ERROR_REPOSITORY_PATH_PARSE, urlPart, RepositoryType.GITHUB_APP));
+    }
+
+    private String getGithubAppToken(final String projectName, final String repositoryName) {
+        final String jwt = generateJWT();
+        final GitHubInstallation installation = findInstallationId(projectName, repositoryName, jwt);
+        assertInstallationAllowed(installation);
+        return generateAccessToken(jwt, installation.getId());
     }
 
     private String generateJWT() {

--- a/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubAuthInnerService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubAuthInnerService.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.git.github;
+
+import com.epam.pipeline.entity.git.github.GitHubInstallation;
+import com.epam.pipeline.entity.git.github.GitHubRepository;
+import com.epam.pipeline.entity.pipeline.Pipeline;
+import com.epam.pipeline.entity.pipeline.RepositoryType;
+
+import java.util.List;
+
+/**
+ * Authentication and optional GitHub App installation discovery for {@link GitHubService}.
+ * Implementations align with {@link com.epam.pipeline.entity.pipeline.RepositoryType} (PAT vs GitHub App).
+ */
+public interface GitHubAuthInnerService {
+
+    /**
+     * @param repositoryPath repository URL
+     * @param explicitToken  token supplied by the caller (e.g. pipeline stored token); may be ignored
+     */
+    String resolveToken(String repositoryPath, String explicitToken);
+
+    String resolveCloneToken(Pipeline pipeline);
+
+    /**
+     * GitHub App installations exposed as namespaces. Not used for PAT-only {@link RepositoryType#GITHUB}
+     * (implementations return an empty list).
+     */
+    List<GitHubInstallation> getAllowedNamespaces();
+
+    /**
+     * Repositories for a GitHub App installation id. Not used for PAT-only {@link RepositoryType#GITHUB}
+     * (implementations return an empty list).
+     */
+    List<GitHubRepository> getNamespaceRepositories(String installationId);
+}

--- a/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubService.java
@@ -26,8 +26,8 @@ import com.epam.pipeline.entity.git.GitCommitEntry;
 import com.epam.pipeline.entity.git.GitCredentials;
 import com.epam.pipeline.entity.git.GitNamespace;
 import com.epam.pipeline.entity.git.GitProject;
-import com.epam.pipeline.entity.git.GitRepositoryEntry;
 import com.epam.pipeline.entity.git.GitRepositoryUrl;
+import com.epam.pipeline.entity.git.GitRepositoryEntry;
 import com.epam.pipeline.entity.git.GitTagEntry;
 import com.epam.pipeline.entity.git.github.GitHubCommitNode;
 import com.epam.pipeline.entity.git.github.GitHubContent;
@@ -56,7 +56,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.util.TextUtils;
-import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 import retrofit2.Response;
 
@@ -72,7 +71,6 @@ import java.util.stream.Stream;
 
 import static com.epam.pipeline.manager.git.PipelineRepositoryService.NOT_SUPPORTED_PATTERN;
 
-@Service
 @Slf4j
 @RequiredArgsConstructor
 public class GitHubService implements GitClientService {
@@ -83,14 +81,15 @@ public class GitHubService implements GitClientService {
     private static final String COMMIT = "commit";
     private static final String REFS_TAGS_PREFIX = "refs/tags/%s";
 
+    private final RepositoryType repositoryType;
+    private final GitHubAuthInnerService innerService;
     private final GitHubMapper mapper;
     private final MessageHelper messageHelper;
     private final PreferenceManager preferenceManager;
-    private final GitHubAppService gitHubAppService;
 
     @Override
     public RepositoryType getType() {
-        return RepositoryType.GITHUB;
+        return repositoryType;
     }
 
     @Override
@@ -203,9 +202,7 @@ public class GitHubService implements GitClientService {
     public GitCredentials getCloneCredentials(final Pipeline pipeline, final boolean useEnvVars,
                                               final boolean issueToken, final Long duration) {
         final GitRepositoryUrl repositoryUrl = GitRepositoryUrl.from(pipeline.getRepository());
-        final String token = StringUtils.isBlank(pipeline.getRepositoryToken())
-                ? getGithubAppToken(pipeline.getRepository())
-                : pipeline.getRepositoryToken();
+        final String token = innerService.resolveCloneToken(pipeline);
         final String username = preferenceManager.getPreference(SystemPreferences.GITHUB_USER_NAME);
         final String host = repositoryUrl.getHost();
         return GitCredentials.builder()
@@ -260,7 +257,7 @@ public class GitHubService implements GitClientService {
     @Override
     public GitCommitEntry updateFile(final Pipeline pipeline, final String path, final String content,
                                      final String message, final boolean fileExists) {
-        final GitHubClient client = getClient(pipeline.getRepository(), pipeline.getRepositoryToken());
+        final GitHubClient client = getClient(pipeline);
         final GitHubSource gitHubSource = fileExists ?
                 client.updateFile(path, content, message, pipeline.getBranch()) :
                 client.createFile(path, content, message, pipeline.getBranch());
@@ -275,7 +272,7 @@ public class GitHubService implements GitClientService {
 
     @Override
     public GitCommitEntry deleteFile(final Pipeline pipeline, final String filePath, final String commitMessage) {
-        final GitHubSource gitHubSource = getClient(pipeline.getRepository(), pipeline.getRepositoryToken())
+        final GitHubSource gitHubSource = getClient(pipeline)
                 .deleteFile(filePath, commitMessage, pipeline.getBranch());
         return mapper.gitHubSourceToCommitEntry(gitHubSource);
     }
@@ -333,14 +330,14 @@ public class GitHubService implements GitClientService {
 
     @Override
     public List<GitNamespace> getAllowedNamespaces() {
-        return gitHubAppService.findAllowedInstallations().stream()
+        return ListUtils.emptyIfNull(innerService.getAllowedNamespaces()).stream()
                 .map(mapper::installationToNamespace)
                 .collect(Collectors.toList());
     }
 
     @Override
     public List<GitRepositoryDTO> getNamespaceRepositories(final String installationId) {
-        return gitHubAppService.findRepositoriesByInstallation(installationId).stream()
+        return ListUtils.emptyIfNull(innerService.getNamespaceRepositories(installationId)).stream()
                 .map(mapper::toGitRepositoryDTO)
                 .collect(Collectors.toList());
     }
@@ -360,18 +357,13 @@ public class GitHubService implements GitClientService {
         return getClient(pipeline.getRepository(), pipeline.getRepositoryToken());
     }
 
-    private GitHubClient getClient(final String repositoryPath, final String token) {
-        return StringUtils.isBlank(token) ? buildGithubAppClient(repositoryPath) : buildClient(repositoryPath, token);
-    }
-
-    private GitHubClient buildGithubAppClient(final String repositoryPath) {
-        log.debug("Token was not provided. Building Github App installation token for repository {}.", repositoryPath);
-        final String accessToken = getGithubAppToken(repositoryPath);
-        return buildClient(repositoryPath, accessToken);
+    private GitHubClient getClient(final String repositoryPath, final String explicitToken) {
+        final String token = innerService.resolveToken(repositoryPath, explicitToken);
+        return buildClient(repositoryPath, token);
     }
 
     private GitHubClient buildClient(final String repositoryPath, final String token) {
-        log.debug("Token has been provided. Building plain client for repository {}.", repositoryPath);
+        log.debug("Building GitHub REST client for repository {} (type {}).", repositoryPath, repositoryType);
         final GitRepositoryUrl repositoryUrl = GitRepositoryUrl.from(repositoryPath);
         final String projectName = repositoryUrl.getNamespace().orElseThrow(() -> buildUrlParseError(PROJECT_NAME));
         final String repositoryName = repositoryUrl.getProject().orElseThrow(() -> buildUrlParseError(REPOSITORY_NAME));
@@ -421,12 +413,5 @@ public class GitHubService implements GitClientService {
 
     private boolean fileExists(final GitHubClient client, final String ref, final String path) {
         return client.fileExists(ref, path);
-    }
-
-    private String getGithubAppToken(final String repositoryPath) {
-        final GitRepositoryUrl repositoryUrl = GitRepositoryUrl.from(repositoryPath);
-        final String projectName = repositoryUrl.getNamespace().orElseThrow(() -> buildUrlParseError(PROJECT_NAME));
-        final String repositoryName = repositoryUrl.getProject().orElseThrow(() -> buildUrlParseError(REPOSITORY_NAME));
-        return gitHubAppService.getGithubAppToken(projectName, repositoryName);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubTokenAuthService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/github/GitHubTokenAuthService.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.git.github;
+
+import com.epam.pipeline.common.MessageConstants;
+import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.entity.git.github.GitHubInstallation;
+import com.epam.pipeline.entity.git.github.GitHubRepository;
+import com.epam.pipeline.entity.pipeline.Pipeline;
+import com.epam.pipeline.entity.pipeline.RepositoryType;
+import com.epam.pipeline.exception.git.GitClientException;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * {@link RepositoryType#GITHUB}: use only the stored repository token (PAT). Installation tokens are not used.
+ */
+@Component
+@RequiredArgsConstructor
+public class GitHubTokenAuthService implements GitHubAuthInnerService {
+
+    private final MessageHelper messageHelper;
+
+    @Override
+    public String resolveToken(final String repositoryPath, final String explicitToken) {
+        return requireRepositoryToken(explicitToken);
+    }
+
+    @Override
+    public String resolveCloneToken(final Pipeline pipeline) {
+        return requireRepositoryToken(pipeline.getRepositoryToken());
+    }
+
+    @Override
+    public List<GitHubInstallation> getAllowedNamespaces() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<GitHubRepository> getNamespaceRepositories(final String installationId) {
+        return Collections.emptyList();
+    }
+
+    private String requireRepositoryToken(final String token) {
+        if (StringUtils.isBlank(token)) {
+            throw new GitClientException(messageHelper.getMessage(
+                    MessageConstants.ERROR_REPOSITORY_TOKEN_NOT_FOUND, RepositoryType.GITHUB));
+        }
+        return token;
+    }
+}

--- a/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/pipeline/RepositoryType.java
+++ b/cloud-pipeline-common/model/src/main/java/com/epam/pipeline/entity/pipeline/RepositoryType.java
@@ -20,7 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public enum RepositoryType {
-    GITLAB(0), GITHUB(1), BITBUCKET(2), BITBUCKET_CLOUD(3), AZURE_DEVOPS(4);
+    GITLAB(0), GITHUB(1), BITBUCKET(2), BITBUCKET_CLOUD(3), AZURE_DEVOPS(4), GITHUB_APP(5);
 
     private long id;
     private static Map<Long, RepositoryType> idMap = new HashMap<>();
@@ -30,6 +30,7 @@ public enum RepositoryType {
         idMap.put(BITBUCKET.id, BITBUCKET);
         idMap.put(BITBUCKET_CLOUD.id, BITBUCKET_CLOUD);
         idMap.put(AZURE_DEVOPS.id, AZURE_DEVOPS);
+        idMap.put(GITHUB_APP.id, GITHUB_APP);
     }
     private static Map<String, RepositoryType> namesMap = new HashMap<>();
     static {
@@ -38,6 +39,7 @@ public enum RepositoryType {
         namesMap.put(BITBUCKET.name(), BITBUCKET);
         namesMap.put(BITBUCKET_CLOUD.name(), BITBUCKET_CLOUD);
         namesMap.put(AZURE_DEVOPS.name(), AZURE_DEVOPS);
+        namesMap.put(GITHUB_APP.name(), GITHUB_APP);
     }
 
     RepositoryType(long id) {

--- a/core/src/main/java/com/epam/pipeline/entity/pipeline/RepositoryType.java
+++ b/core/src/main/java/com/epam/pipeline/entity/pipeline/RepositoryType.java
@@ -20,7 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public enum RepositoryType {
-    GITLAB(0), GITHUB(1), BITBUCKET(2), BITBUCKET_CLOUD(3), AZURE_DEVOPS(4);
+    GITLAB(0), GITHUB(1), BITBUCKET(2), BITBUCKET_CLOUD(3), AZURE_DEVOPS(4), GITHUB_APP(5);
 
     private long id;
     private static Map<Long, RepositoryType> idMap = new HashMap<>();
@@ -30,6 +30,7 @@ public enum RepositoryType {
         idMap.put(BITBUCKET.id, BITBUCKET);
         idMap.put(BITBUCKET_CLOUD.id, BITBUCKET_CLOUD);
         idMap.put(AZURE_DEVOPS.id, AZURE_DEVOPS);
+        idMap.put(GITHUB_APP.id, GITHUB_APP);
     }
     private static Map<String, RepositoryType> namesMap = new HashMap<>();
     static {
@@ -38,6 +39,7 @@ public enum RepositoryType {
         namesMap.put(BITBUCKET.name(), BITBUCKET);
         namesMap.put(BITBUCKET_CLOUD.name(), BITBUCKET_CLOUD);
         namesMap.put(AZURE_DEVOPS.name(), AZURE_DEVOPS);
+        namesMap.put(GITHUB_APP.name(), GITHUB_APP);
     }
 
     RepositoryType(long id) {


### PR DESCRIPTION
relates to #4374

The current PR provides implementation for a new pipeline repository type `GITHUB_APP`.

If pipeline has `GITHUB_APP` repository type the access token shall be generated from  GitHub Apps authentication flow. 

If pipeline has `GITHUB` repository type the `repositoryToken` shall be provided explicitly for each pipeline.