### PR TITLE
Issue #4400: [API] Persist “Share with” on tool/pipeline and lock per-run sharing when configured - fix for run as

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/PipelineRunManager.java
@@ -309,7 +309,7 @@ public class PipelineRunManager {
         checkRunLaunchLimits(runVO);
         final Tool tool = toolManager.loadByNameOrId(runVO.getDockerImage());
         final PipelineConfiguration configuration = configurationManager.getPipelineConfiguration(runVO, tool);
-        runVO.setRunSids(mergeRunSidsWithParent(configuration, runVO.getRunSids()));
+        runVO.setRunSids(mergeRunSidsWithParent(configuration, runVO.getRunSids(), resolveOriginalOwner(runVO)));
         final boolean clusterRun = configurationManager.initClusterConfiguration(configuration, true);
 
         final PipelineRun run = launchPipeline(configuration, null, null,
@@ -357,7 +357,7 @@ public class PipelineRunManager {
         run.setTimeout(runVO.getTimeout());
         run.setCommitStatus(CommitStatus.NOT_COMMITTED);
         run.setLastChangeCommitTime(DateUtils.now());
-        run.setRunSids(mergeRunSidsWithParent(configuration, runVO.getRunSids()));
+        run.setRunSids(mergeRunSidsWithParent(configuration, runVO.getRunSids(), resolveOriginalOwner(runVO)));
         run.setOwner(parentRun.getOwner());
         final String launchedCommand = pipelineLauncher.launch(
                 run, configuration, endpoints, false, parentRun.getPodId(), null
@@ -386,7 +386,7 @@ public class PipelineRunManager {
         final Pipeline pipeline = pipelineManager.load(pipelineId);
         final PipelineConfiguration configuration = configurationManager
                 .getPipelineConfigurationForPipeline(pipeline, runVO);
-        runVO.setRunSids(mergeRunSidsWithParents(configuration, runVO.getRunSids()));
+        runVO.setRunSids(mergeRunSidsWithParents(configuration, runVO.getRunSids(), resolveOriginalOwner(runVO)));
         final boolean isClusterRun = configurationManager.initClusterConfiguration(configuration, true);
 
         permissionManager.checkToolRunPermission(configuration.getDockerImage());
@@ -2101,39 +2101,72 @@ public class PipelineRunManager {
         validateToolSharing(run.getDockerImage());
     }
 
+    private String resolveOriginalOwner(final PipelineStart runVO) {
+        final String originalOwnerParam = preferenceManager.getPreference(
+                SystemPreferences.LAUNCH_ORIGINAL_OWNER_PARAMETER);
+        return Optional.ofNullable(runVO.getParams())
+                .map(params -> params.get(originalOwnerParam))
+                .map(PipeConfValueVO::getValue)
+                .filter(StringUtils::isNotBlank)
+                .orElse(null);
+    }
+
     private List<RunSid> mergeRunSidsWithParent(final PipelineConfiguration configuration,
-                                                final List<RunSid> externalRunSids) {
+                                                final List<RunSid> externalRunSids,
+                                                final String originalOwner) {
         if (hasNotSharedUsersOrRoles(configuration)) {
             return new ArrayList<>(ListUtils.emptyIfNull(externalRunSids));
         }
-        Assert.state(CollectionUtils.isEmpty(externalRunSids),
+        final List<RunSid> allowedExternalRunSids = validateAndFilterExternalRunSids(externalRunSids, originalOwner);
+        return configuration.mergeRunSids(allowedExternalRunSids);
+    }
+
+    private List<RunSid> validateAndFilterExternalRunSids(final List<RunSid> externalRunSids,
+                                                          final String originalOwner) {
+        if (CollectionUtils.isEmpty(externalRunSids)) {
+            return Collections.emptyList();
+        }
+        final List<RunSid> disallowedRunSids = externalRunSids.stream()
+                .filter(runSid -> !isOriginalOwnerRunSid(runSid, originalOwner))
+                .collect(Collectors.toList());
+        Assert.state(disallowedRunSids.isEmpty(),
                 messageHelper.getMessage(MessageConstants.ERROR_RUN_SIDS_NOT_ALLOWED_FOR_CONFIGURATION));
-        return configuration.mergeRunSids(new ArrayList<>());
+        return new ArrayList<>(externalRunSids);
+    }
+
+    private boolean isOriginalOwnerRunSid(final RunSid runSid, final String originalOwner) {
+        return StringUtils.isNotBlank(originalOwner)
+                && Boolean.TRUE.equals(runSid.getIsPrincipal())
+                && StringUtils.equalsIgnoreCase(runSid.getName(), originalOwner);
     }
 
     /**
      * Merges RunSids from pipeline configuration and parent tool configuration.
      * Logic:
-     * - If tool or pipeline contains shared roles/users, raise an error when runSids provided to run VO
+     * - If tool or pipeline contains shared roles/users, raise an error when runSids other than the original
+     *   owner are provided to run VO (original owner is allowed for run-as launches)
      * - If no tool or pipeline contains shared roles/users, apply runSids from run VO if present
      * - If user is present in both configurations with different access types, use SSH
      *
      * @param configuration       Current pipeline configuration
      * @param externalRunSids     RunSids from the launch request
+     * @param originalOwner       User who initiated the launch (for run-as), or null
      * @return Merged list of RunSids
      */
     List<RunSid> mergeRunSidsWithParents(final PipelineConfiguration configuration,
-                                         final List<RunSid> externalRunSids) {
-        final List<RunSid> pipelineSids = mergeRunSidsWithParent(configuration, externalRunSids);
+                                         final List<RunSid> externalRunSids,
+                                         final String originalOwner) {
+        final List<RunSid> pipelineSids = mergeRunSidsWithParent(configuration, externalRunSids, originalOwner);
 
         final Tool tool = getToolForRun(configuration);
         final PipelineConfiguration toolConfiguration = configurationManager
                 .getConfigurationForTool(tool, configuration);
 
-        final List<RunSid> toolSids = mergeRunSidsWithParent(toolConfiguration, externalRunSids);
+        final List<RunSid> toolSids = mergeRunSidsWithParent(toolConfiguration, externalRunSids, originalOwner);
 
-        if (CollectionUtils.isNotEmpty(externalRunSids)) {
-            // if "shared with" were specified for one of the parent configuration, an error would occur
+        if (CollectionUtils.isNotEmpty(externalRunSids)
+                && hasNotSharedUsersOrRoles(configuration)
+                && hasNotSharedUsersOrRoles(toolConfiguration)) {
             return externalRunSids;
         }
 

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunManagerUnitTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/PipelineRunManagerUnitTest.java
@@ -126,6 +126,7 @@ public class PipelineRunManagerUnitTest {
     private static final String USER1 = "USER1";
     private static final String USER2 = "USER2";
     private static final String USER3 = "USER3";
+    private static final String ORIGINAL_OWNER = "RUNNER";
     private static final String GROUP1 = "GROUP1";
     private static final String GROUP2 = "GROUP2";
     private static final String PARAM_NAME_1 = "param-1";
@@ -806,7 +807,8 @@ public class PipelineRunManagerUnitTest {
         when(pipelineConfigurationManager.getConfigurationForTool(eq(tool), any(PipelineConfiguration.class)))
                 .thenReturn(toolConfig);
 
-        final List<RunSid> result = pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, Collections.emptyList());
+        final List<RunSid> result = pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, Collections.emptyList(),
+                null);
 
         // Then: Both users should be present
         assertThat(result).hasSize(2);
@@ -827,7 +829,8 @@ public class PipelineRunManagerUnitTest {
         when(pipelineConfigurationManager.getConfigurationForTool(eq(tool), any(PipelineConfiguration.class)))
                 .thenReturn(toolConfig);
 
-        final List<RunSid> result = pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, null);
+        final List<RunSid> result = pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, null,
+                null);
 
         assertThat(result).hasSize(0);
     }
@@ -850,7 +853,8 @@ public class PipelineRunManagerUnitTest {
         when(pipelineConfigurationManager.getConfigurationForTool(eq(tool), any(PipelineConfiguration.class)))
                 .thenReturn(toolConfig);
 
-        final List<RunSid> result = pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, Collections.emptyList());
+        final List<RunSid> result = pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, Collections.emptyList(),
+                null);
 
         // Then: Single user with SSH access
         assertThat(result).hasSize(1);
@@ -875,7 +879,8 @@ public class PipelineRunManagerUnitTest {
         when(pipelineConfigurationManager.getConfigurationForTool(eq(tool), any(PipelineConfiguration.class)))
                 .thenReturn(toolConfig);
 
-        final List<RunSid> result = pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, Collections.emptyList());
+        final List<RunSid> result = pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, Collections.emptyList(),
+                null);
 
         // Then: Single user with ENDPOINT access
         assertThat(result).hasSize(1);
@@ -900,7 +905,8 @@ public class PipelineRunManagerUnitTest {
         when(pipelineConfigurationManager.getConfigurationForTool(eq(tool), any(PipelineConfiguration.class)))
                 .thenReturn(toolConfig);
 
-        final List<RunSid> result = pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, Collections.emptyList());
+        final List<RunSid> result = pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, Collections.emptyList(),
+                null);
 
         // Then: Both roles should be present
         assertThat(result).hasSize(2);
@@ -926,7 +932,8 @@ public class PipelineRunManagerUnitTest {
         when(pipelineConfigurationManager.getConfigurationForTool(eq(tool), any(PipelineConfiguration.class)))
                 .thenReturn(toolConfig);
 
-        final List<RunSid> result = pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, Collections.emptyList());
+        final List<RunSid> result = pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, Collections.emptyList(),
+                null);
 
         // Then: All users and roles should be present
         assertThat(result).hasSize(4);
@@ -954,7 +961,7 @@ public class PipelineRunManagerUnitTest {
                 .thenReturn(toolConfig);
 
         assertThrows(IllegalStateException.class, () ->
-                pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, externalRunSids));
+                pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, externalRunSids, null));
     }
 
     @Test
@@ -975,7 +982,7 @@ public class PipelineRunManagerUnitTest {
                 .thenReturn(toolConfig);
 
         assertThrows(IllegalStateException.class, () ->
-                pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, externalRunSids));
+                pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, externalRunSids, null));
     }
 
     @Test
@@ -996,7 +1003,7 @@ public class PipelineRunManagerUnitTest {
                 .thenReturn(toolConfig);
 
         assertThrows(IllegalStateException.class, () ->
-                pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, externalRunSids));
+                pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, externalRunSids, null));
     }
 
     @Test
@@ -1014,11 +1021,33 @@ public class PipelineRunManagerUnitTest {
         when(pipelineConfigurationManager.getConfigurationForTool(eq(tool), any(PipelineConfiguration.class)))
                 .thenReturn(toolConfig);
 
-        final List<RunSid> result = pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, externalRunSids);
+        final List<RunSid> result = pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, externalRunSids,
+                null);
 
         // Then: External USER3 should be present
         assertThat(result).hasSize(1);
         assertContainsUser(result, USER3, RunAccessType.ENDPOINT);
+    }
+
+    @Test
+    public void shouldApplyOriginalOwnerWhenNoConfigurationHasSharing() {
+        final List<RunSid> externalRunSids = singletonList(createUserSid(ORIGINAL_OWNER, RunAccessType.ENDPOINT));
+
+        final PipelineConfiguration pipelineConfig = new PipelineConfiguration();
+        pipelineConfig.setDockerImage(DOCKER_IMAGE);
+        final PipelineConfiguration toolConfig = new PipelineConfiguration();
+
+        final Tool tool = getTool(ID, OWNER);
+        tool.setImage(DOCKER_IMAGE);
+        when(toolManager.resolveSymlinks(eq(DOCKER_IMAGE))).thenReturn(tool);
+        when(pipelineConfigurationManager.getConfigurationForTool(eq(tool), any(PipelineConfiguration.class)))
+                .thenReturn(toolConfig);
+
+        final List<RunSid> result = pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, externalRunSids,
+                ORIGINAL_OWNER);
+
+        assertThat(result).hasSize(1);
+        assertContainsUser(result, ORIGINAL_OWNER, RunAccessType.ENDPOINT);
     }
 
     @Test
@@ -1040,7 +1069,124 @@ public class PipelineRunManagerUnitTest {
                 .thenReturn(toolConfig);
 
         assertThrows(IllegalStateException.class, () ->
-                pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, externalRunSids));
+                pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, externalRunSids, null));
+    }
+
+    @Test
+    public void shouldAllowOriginalOwnerWhenConfigurationHasSharedUsers() {
+        final List<RunSid> externalRunSids = singletonList(createUserSid(ORIGINAL_OWNER, RunAccessType.ENDPOINT));
+
+        final PipelineConfiguration pipelineConfig = new PipelineConfiguration();
+        pipelineConfig.setSharedWithUsers(singletonList(createUserSid(USER1, RunAccessType.ENDPOINT)));
+        pipelineConfig.setDockerImage(DOCKER_IMAGE);
+
+        final PipelineConfiguration toolConfig = new PipelineConfiguration();
+
+        final Tool tool = getTool(ID, OWNER);
+        tool.setImage(DOCKER_IMAGE);
+        when(toolManager.resolveSymlinks(eq(DOCKER_IMAGE))).thenReturn(tool);
+        when(pipelineConfigurationManager.getConfigurationForTool(eq(tool), any(PipelineConfiguration.class)))
+                .thenReturn(toolConfig);
+
+        final List<RunSid> result = pipelineRunManager.mergeRunSidsWithParents(
+                pipelineConfig, externalRunSids, ORIGINAL_OWNER);
+
+        assertThat(result).hasSize(2);
+        assertContainsUser(result, USER1, RunAccessType.ENDPOINT);
+        assertContainsUser(result, ORIGINAL_OWNER, RunAccessType.ENDPOINT);
+    }
+
+    @Test
+    public void shouldFailWhenExternalContainsOtherUserWithOriginalOwnerSet() {
+        final List<RunSid> externalRunSids = singletonList(createUserSid(USER3, RunAccessType.ENDPOINT));
+
+        final PipelineConfiguration pipelineConfig = new PipelineConfiguration();
+        pipelineConfig.setSharedWithUsers(singletonList(createUserSid(USER1, RunAccessType.ENDPOINT)));
+        pipelineConfig.setDockerImage(DOCKER_IMAGE);
+
+        final PipelineConfiguration toolConfig = new PipelineConfiguration();
+
+        final Tool tool = getTool(ID, OWNER);
+        tool.setImage(DOCKER_IMAGE);
+        when(toolManager.resolveSymlinks(eq(DOCKER_IMAGE))).thenReturn(tool);
+        when(pipelineConfigurationManager.getConfigurationForTool(eq(tool), any(PipelineConfiguration.class)))
+                .thenReturn(toolConfig);
+
+        assertThrows(IllegalStateException.class, () ->
+                pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, externalRunSids, ORIGINAL_OWNER));
+    }
+
+    @Test
+    public void shouldFailWhenExternalContainsOtherUserAndOriginalOwner() {
+        final List<RunSid> externalRunSids = Arrays.asList(
+                createUserSid(ORIGINAL_OWNER, RunAccessType.ENDPOINT),
+                createUserSid(USER3, RunAccessType.ENDPOINT)
+        );
+
+        final PipelineConfiguration pipelineConfig = new PipelineConfiguration();
+        pipelineConfig.setSharedWithUsers(singletonList(createUserSid(USER1, RunAccessType.ENDPOINT)));
+        pipelineConfig.setDockerImage(DOCKER_IMAGE);
+
+        final PipelineConfiguration toolConfig = new PipelineConfiguration();
+
+        final Tool tool = getTool(ID, OWNER);
+        tool.setImage(DOCKER_IMAGE);
+        when(toolManager.resolveSymlinks(eq(DOCKER_IMAGE))).thenReturn(tool);
+        when(pipelineConfigurationManager.getConfigurationForTool(eq(tool), any(PipelineConfiguration.class)))
+                .thenReturn(toolConfig);
+
+        assertThrows(IllegalStateException.class, () ->
+                pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, externalRunSids, ORIGINAL_OWNER));
+    }
+
+    @Test
+    public void shouldMergeOriginalOwnerWhenOnlyToolHasSharing() {
+        final List<RunSid> externalRunSids = singletonList(createUserSid(ORIGINAL_OWNER, RunAccessType.SSH));
+
+        final PipelineConfiguration pipelineConfig = new PipelineConfiguration();
+        pipelineConfig.setDockerImage(DOCKER_IMAGE);
+
+        final PipelineConfiguration toolConfig = new PipelineConfiguration();
+        toolConfig.setSharedWithUsers(singletonList(createUserSid(USER2, RunAccessType.ENDPOINT)));
+
+        final Tool tool = getTool(ID, OWNER);
+        tool.setImage(DOCKER_IMAGE);
+        when(toolManager.resolveSymlinks(eq(DOCKER_IMAGE))).thenReturn(tool);
+        when(pipelineConfigurationManager.getConfigurationForTool(eq(tool), any(PipelineConfiguration.class)))
+                .thenReturn(toolConfig);
+
+        final List<RunSid> result = pipelineRunManager.mergeRunSidsWithParents(
+                pipelineConfig, externalRunSids, ORIGINAL_OWNER);
+
+        assertThat(result).hasSize(2);
+        assertContainsUser(result, USER2, RunAccessType.ENDPOINT);
+        assertContainsUser(result, ORIGINAL_OWNER, RunAccessType.SSH);
+    }
+
+    @Test
+    public void shouldMergeOriginalOwnerWhenDuplicates() {
+        final List<RunSid> externalRunSids = Arrays.asList(
+                createUserSid(ORIGINAL_OWNER, RunAccessType.SSH),
+                createUserSid(ORIGINAL_OWNER, RunAccessType.ENDPOINT));
+
+        final PipelineConfiguration pipelineConfig = new PipelineConfiguration();
+        pipelineConfig.setDockerImage(DOCKER_IMAGE);
+
+        final PipelineConfiguration toolConfig = new PipelineConfiguration();
+        toolConfig.setSharedWithUsers(singletonList(createUserSid(USER2, RunAccessType.ENDPOINT)));
+
+        final Tool tool = getTool(ID, OWNER);
+        tool.setImage(DOCKER_IMAGE);
+        when(toolManager.resolveSymlinks(eq(DOCKER_IMAGE))).thenReturn(tool);
+        when(pipelineConfigurationManager.getConfigurationForTool(eq(tool), any(PipelineConfiguration.class)))
+                .thenReturn(toolConfig);
+
+        final List<RunSid> result = pipelineRunManager.mergeRunSidsWithParents(
+                pipelineConfig, externalRunSids, ORIGINAL_OWNER);
+
+        assertThat(result).hasSize(2);
+        assertContainsUser(result, USER2, RunAccessType.ENDPOINT);
+        assertContainsUser(result, ORIGINAL_OWNER, RunAccessType.SSH);
     }
 
     @Test
@@ -1058,7 +1204,8 @@ public class PipelineRunManagerUnitTest {
         when(pipelineConfigurationManager.getConfigurationForTool(eq(tool), any(PipelineConfiguration.class)))
                 .thenReturn(toolConfig);
 
-        final List<RunSid> result = pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, Collections.emptyList());
+        final List<RunSid> result = pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, Collections.emptyList(),
+                null);
 
         // Then: Only pipeline user should be present
         assertThat(result).hasSize(1);
@@ -1089,7 +1236,8 @@ public class PipelineRunManagerUnitTest {
         when(pipelineConfigurationManager.getConfigurationForTool(eq(tool), any(PipelineConfiguration.class)))
                 .thenReturn(toolConfig);
 
-        final List<RunSid> result = pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, Collections.emptyList());
+        final List<RunSid> result = pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, Collections.emptyList(),
+                null);
 
         // Then: Merged result with correct access types
         assertThat(result).hasSize(5);
@@ -1118,7 +1266,8 @@ public class PipelineRunManagerUnitTest {
         when(pipelineConfigurationManager.getConfigurationForTool(eq(tool), any(PipelineConfiguration.class)))
                 .thenReturn(toolConfig);
 
-        final List<RunSid> result = pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, Collections.emptyList());
+        final List<RunSid> result = pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, Collections.emptyList(),
+                null);
 
         // Then: Result should be empty
         assertThat(result).isEmpty();
@@ -1140,7 +1289,8 @@ public class PipelineRunManagerUnitTest {
         when(pipelineConfigurationManager.getConfigurationForTool(eq(tool), any(PipelineConfiguration.class)))
                 .thenReturn(toolConfig);
 
-        final List<RunSid> result = pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, Collections.emptyList());
+        final List<RunSid> result = pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, Collections.emptyList(),
+                null);
 
         // Then: User should have isPrincipal = true
         assertThat(result).hasSize(1);
@@ -1165,7 +1315,8 @@ public class PipelineRunManagerUnitTest {
         when(pipelineConfigurationManager.getConfigurationForTool(eq(tool), any(PipelineConfiguration.class)))
                 .thenReturn(toolConfig);
 
-        final List<RunSid> result = pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, Collections.emptyList());
+        final List<RunSid> result = pipelineRunManager.mergeRunSidsWithParents(pipelineConfig, Collections.emptyList(),
+                null);
 
         // Then: Role should have isPrincipal = false
         assertThat(result).hasSize(1);


### PR DESCRIPTION
retales to #4400 

When `runAs` provided for “Shared with” tool or pipeline, the original owner shall be added to run's sids and run shall be successfully launched. 