### PR TITLE
Issue #4408: Some of the task for completed runs stay running when pipeline run logs on data storage transfer is enabled - NPE fix

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/pipeline/RunLogManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/pipeline/RunLogManager.java
@@ -23,6 +23,7 @@ import java.io.OutputStreamWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import com.epam.pipeline.common.MessageHelper;
@@ -182,25 +183,25 @@ public class RunLogManager {
         final List<PipelineTask> tasks = new ArrayList<>(ListUtils.emptyIfNull(loadRunTasks(run, runId)));
 
         tasks.forEach(task -> {
-            if (run.getStatus().isFinal() && !task.getStatus().isFinal()) {
+            if (run.getStatus().isFinal() && statusNullOrNotFinal(task)) {
                 task.setStatus(run.getStatus());
                 if (task.getFinished() == null) {
                     task.setFinished(run.getEndDate());
                 }
             }
             if ((StringUtils.isEmpty(task.getInstance()) || task.getInstance().equals(run.getPodId()))
-                    && !task.getStatus().isFinal()) {
+                    && statusNullOrNotFinal(task)) {
                 task.setStatus(run.getStatus());
             }
             if (task.getStarted() == null &&
                     (StringUtils.isEmpty(task.getInstance()) || task.getInstance().equals(run.getPodId())
-                            || task.getStatus().isFinal())) {
+                            || !statusNullOrNotFinal(task))) {
                 task.setStarted(task.getCreated());
             }
-            if (!task.getStatus().isFinal()) {
+            if (statusNullOrNotFinal(task)) {
                 task.setFinished(null);
             }
-            if (task.getName().equals(run.getPipelineName())) {
+            if (Objects.equals(task.getName(), run.getPipelineName())) {
                 task.setCreated(run.getStartDate());
                 task.setStarted(tasks.get(0).getCreated());
             }
@@ -288,5 +289,9 @@ public class RunLogManager {
             }
         }
         return runLogDao.loadTasksForRun(runId);
+    }
+
+    private boolean statusNullOrNotFinal(final PipelineTask task) {
+        return Objects.isNull(task.getStatus()) || !task.getStatus().isFinal();
     }
 }

--- a/api/src/test/java/com/epam/pipeline/manager/pipeline/RunLogManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/pipeline/RunLogManagerTest.java
@@ -292,6 +292,28 @@ public class RunLogManagerTest extends AbstractManagerTest {
     }
 
     @Test
+    public void loadTasksByRunIdShouldNormalizeStorageTaskWithNullStatus() {
+        final PipelineRun run = buildRun(RUN_ID, TaskStatus.STOPPED);
+        run.setLogsStoragePath(LOGS_STORAGE_PREFIX + RUN_ID);
+        run.setStartDate(new Date(System.currentTimeMillis() - DURATION1));
+        run.setEndDate(new Date());
+        run.setPodId(POD_NAME);
+
+        when(runCRUDServiceMock.loadRunById(RUN_ID)).thenReturn(run);
+
+        final PipelineTask storageTask = buildPipelineTask(TASK_NAME, null);
+        storageTask.setCreated(new Date(System.currentTimeMillis() - DURATION2));
+        storageTask.setInstance(POD_NAME);
+        when(runLogStorageManager.loadTasksFromStorage(RUN_ID))
+                .thenReturn(Collections.singletonList(storageTask));
+
+        final List<PipelineTask> result = logManager.loadTasksByRunId(RUN_ID);
+
+        assertEquals(1, result.size());
+        assertEquals(TaskStatus.STOPPED, result.get(0).getStatus());
+    }
+
+    @Test
     public void loadTasksByRunIdShouldNormalizeDatabaseTasks() {
         // Given: A final run without storage path and non-final task in database
         final PipelineRun run = buildRun(RUN_ID, TaskStatus.FAILURE);
@@ -495,7 +517,9 @@ public class RunLogManagerTest extends AbstractManagerTest {
     private static PipelineTask buildPipelineTask(final String name, final TaskStatus status) {
         final PipelineTask task = new PipelineTask();
         task.setName(name);
-        task.setStatus(status);
+        if (status != null) {
+            task.setStatus(status);
+        }
         return task;
     }
 


### PR DESCRIPTION
relates to #4408

If the task has no status, treat it like a non-final task and apply run-level normalization.