### PR TITLE
Issue #4349: [CLI] Support json output option to pipe command - users instances

### DIFF
--- a/pipe-cli/pipe.py
+++ b/pipe-cli/pipe.py
@@ -2059,12 +2059,14 @@ def import_users(file_path, create_user, create_group, create_metadata):
 
 @users.command(name='instances')
 @click.option('-v', '--verbose', required=False, is_flag=True, default=False, help='Show all active limits in a table')
+@click.option('-of', '--output-format', type=click.Choice(['json']), default=None,
+              help=OUTPUT_FORMAT_OPTION_DESCRIPTION)
 @common_options
-def list_instance_limits(verbose):
+def list_instance_limits(verbose, output_format):
     """
     Shows information on user's instance limits
     """
-    UserOperationsManager().get_instance_limits(verbose)
+    UserOperationsManager().get_instance_limits(verbose, output_format)
 
 
 @cli.group()

--- a/pipe-cli/src/utilities/printing/acl.py
+++ b/pipe-cli/src/utilities/printing/acl.py
@@ -23,6 +23,8 @@ from abc import ABCMeta, abstractmethod
 import click
 from prettytable import prettytable
 
+from src.utilities.printing.utils import to_json
+
 
 def _build_name_by_type(entity, entity_type):
     """Build display name based on entity type."""
@@ -128,11 +130,6 @@ class PrettyTableAclPrintService(AclPrintService):
 class JsonAclPrintService(AclPrintService):
     """ACL print service using JSON format with camelCase fields."""
 
-    @staticmethod
-    def _to_json(obj):
-        """Convert object to JSON string with proper formatting."""
-        return json.dumps(obj, indent=2, default=str, ensure_ascii=False)
-
     def print_acl(self, permissions_list, owner):
         """Print ACL permissions in JSON format."""
         acl_dict = {
@@ -149,7 +146,7 @@ class JsonAclPrintService(AclPrintService):
             }
             acl_dict['permissions'].append(perm_dict)
         
-        click.echo(self._to_json(acl_dict))
+        click.echo(to_json(acl_dict))
 
     def print_sid_objects(self, sid_name, available_entities):
         """Print accessible objects in JSON format."""
@@ -168,7 +165,7 @@ class JsonAclPrintService(AclPrintService):
                 }
                 objects_list.append(obj_dict)
         
-        click.echo(self._to_json(objects_list))
+        click.echo(to_json(objects_list))
 
     def error(self, message, err=True):
         click.echo(json.dumps({'error': message}), err=err)

--- a/pipe-cli/src/utilities/printing/cluster.py
+++ b/pipe-cli/src/utilities/printing/cluster.py
@@ -14,13 +14,13 @@
 
 """Cluster printing services for different output formats."""
 
-import json
 from abc import ABCMeta, abstractmethod
 
 import click
 from prettytable import prettytable
 
 from src.utilities import state_utilities
+from src.utilities.printing.utils import to_json
 
 
 class ClusterPrintService:
@@ -241,21 +241,9 @@ class PrettyTableClusterPrintService(ClusterPrintService):
 class JsonClusterPrintService(ClusterPrintService):
     """JSON implementation for cluster node printing."""
 
-    @staticmethod
-    def _to_json(obj):
-        """Convert object to formatted JSON string.
-        
-        Args:
-            obj: Object to convert to JSON
-            
-        Returns:
-            Formatted JSON string
-        """
-        return json.dumps(obj, default=str, indent=2, ensure_ascii=False)
-
     def empty_nodes(self):
         """Print empty JSON array when no nodes are available."""
-        click.echo(self._to_json([]))
+        click.echo(to_json([]))
 
     def print_nodes_list(self, nodes):
         """Print list of all cluster nodes in JSON format.
@@ -278,7 +266,7 @@ class JsonClusterPrintService(ClusterPrintService):
             }
             nodes_data.append(node_dict)
 
-        click.echo(self._to_json(nodes_data))
+        click.echo(to_json(nodes_data))
 
     def print_node_details(self, node):
         """Print detailed information about a specific node in JSON format.
@@ -304,7 +292,7 @@ class JsonClusterPrintService(ClusterPrintService):
             ] if node.pods else []
         }
 
-        click.echo(self._to_json(node_dict))
+        click.echo(to_json(node_dict))
 
 
 def create_cluster_print_service(output_format):

--- a/pipe-cli/src/utilities/printing/pipeline.py
+++ b/pipe-cli/src/utilities/printing/pipeline.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 from abc import ABCMeta, abstractmethod
 
 import click
 from prettytable import prettytable
+
+from src.utilities.printing.utils import to_json
 
 """
 Pipeline printing utilities for different output formats.
@@ -177,11 +178,6 @@ class PrettyTablePipelinePrintService(PipelinePrintService):
 class JsonPipelinePrintService(PipelinePrintService):
     """Pipeline print service using JSON format with camelCase fields."""
 
-    @staticmethod
-    def _to_json(obj):
-        """Convert object to JSON string with proper formatting."""
-        return json.dumps(obj, indent=2, default=str, ensure_ascii=False)
-
     def print_pipelines_list(self, pipelines):
         """Print a list of pipelines in JSON format."""
         pipelines_json = []
@@ -194,7 +190,7 @@ class JsonPipelinePrintService(PipelinePrintService):
                 'sourceRepo': pipeline_model.repository
             }
             pipelines_json.append(pipeline_dict)
-        click.echo(self._to_json(pipelines_json))
+        click.echo(to_json(pipelines_json))
 
     def print_pipeline_details(self, pipeline_model, include_parameters=False,
                                include_versions=False, include_storage_rules=False,
@@ -256,11 +252,11 @@ class JsonPipelinePrintService(PipelinePrintService):
                 }
                 pipeline_dict['permissions'].append(perm_dict)
 
-        click.echo(self._to_json(pipeline_dict))
+        click.echo(to_json(pipeline_dict))
 
     def print_empty_pipelines(self):
         """Print empty array when no pipelines are available."""
-        click.echo(self._to_json([]))
+        click.echo(to_json([]))
 
 
 def create_pipeline_print_service(output_format):

--- a/pipe-cli/src/utilities/printing/print_service.py
+++ b/pipe-cli/src/utilities/printing/print_service.py
@@ -12,14 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
-
 from abc import abstractmethod, ABCMeta
 import click
 from prettytable import prettytable
 
 from src.model.pipeline_run_model import PriceType
 from src.utilities import state_utilities
+from src.utilities.printing.utils import to_json
 
 
 def _to_int_value(value):
@@ -241,13 +240,9 @@ class JsonPrintService(PrintService):
     def __init__(self):
         self.__buffer = {}
 
-    @staticmethod
-    def _to_json(obj):
-        return json.dumps(obj, default=str, indent=2, ensure_ascii=False)
-
     def flush(self):
         if self.__buffer:
-            click.echo(self._to_json(self.__buffer))
+            click.echo(to_json(self.__buffer))
 
     def launch_run_id(self, run_id):
         self.__buffer['runId'] = _to_int_value(run_id)
@@ -266,7 +261,7 @@ class JsonPrintService(PrintService):
             if parameter.value is not None:
                 run_param['value'] = parameter.value
             run_params.append(run_param)
-        click.echo(self._to_json(run_params))
+        click.echo(to_json(run_params))
 
     def error(self, message, err=False, buf=False):
         if buf:
@@ -274,7 +269,7 @@ class JsonPrintService(PrintService):
                 self.__buffer['error'] = [message]
             else:
                 self.__buffer['error'].append(message)
-        click.echo(self._to_json({'error': message}), err=err)
+        click.echo(to_json({'error': message}), err=err)
 
     def empty_runs(self, run_filter=None):
         payload = {
@@ -284,7 +279,7 @@ class JsonPrintService(PrintService):
         if run_filter is not None:
             payload['page'] = run_filter.page
             payload['pageSize'] = run_filter.page_size
-        click.echo(self._to_json(payload))
+        click.echo(to_json(payload))
 
     def runs(self, run_filter):
         runs = []
@@ -305,7 +300,7 @@ class JsonPrintService(PrintService):
             'truncated': run_filter.total_count > run_filter.page_size,
             'runs': runs,
         }
-        click.echo(self._to_json(payload))
+        click.echo(to_json(payload))
 
     def _node_instance_dict(self, run_model):
         node = {}

--- a/pipe-cli/src/utilities/printing/share.py
+++ b/pipe-cli/src/utilities/printing/share.py
@@ -18,6 +18,8 @@ import click
 from abc import abstractmethod, ABCMeta
 from prettytable import prettytable
 
+from src.utilities.printing.utils import to_json
+
 
 class SharePrintService(object):
     """Formats and prints the sharing state of a pipeline run."""
@@ -76,17 +78,13 @@ class JsonSharePrintService(SharePrintService):
         {"error": "<message>"}
     """
 
-    @staticmethod
-    def _to_json(obj):
-        return json.dumps(obj, default=str, indent=2, ensure_ascii=False)
-
     def not_shared(self):
-        click.echo(self._to_json([]))
+        click.echo(to_json([]))
 
     def print_sids(self, run_sids):
         result = [{'name': sid.name, 'isPrincipal': sid.is_principal, 'accessType': sid.access_type}
                   for sid in run_sids]
-        click.echo(self._to_json(result))
+        click.echo(to_json(result))
 
     def error(self, message):
         click.echo(json.dumps({'error': message}), err=True)

--- a/pipe-cli/src/utilities/printing/storage.py
+++ b/pipe-cli/src/utilities/printing/storage.py
@@ -22,6 +22,7 @@ from future.utils import iteritems
 from prettytable import prettytable
 
 from src.model.data_storage_wrapper_type import WrapperType
+from src.utilities.printing.utils import to_json
 
 STORAGE_DETAILS_SEPARATOR = ', '
 
@@ -189,10 +190,6 @@ class JsonStoragePrintService(StoragePrintService):
         self.__buffer = []
         self.__item = {}
 
-    @staticmethod
-    def _to_json(obj):
-        return json.dumps(obj, default=str, indent=2, ensure_ascii=False)
-
     def disable_header(self):
         # no-op
         pass
@@ -207,7 +204,7 @@ class JsonStoragePrintService(StoragePrintService):
 
     def flush(self):
         if self.__buffer:
-            click.echo(self._to_json(self.__buffer))
+            click.echo(to_json(self.__buffer))
 
     def error(self, message, err=False, buf=False):
         click.echo(json.dumps({'error': message}), err=err)
@@ -268,7 +265,7 @@ class JsonStoragePrintService(StoragePrintService):
         self.__buffer.append({'name': item.path})
 
     def empty_items(self):
-        click.echo(self._to_json([]))
+        click.echo(to_json([]))
 
 
 class StorageObjectTagPrintService(object):
@@ -296,16 +293,12 @@ class PrettyTableStorageObjectTagPrintService(StorageObjectTagPrintService):
 
 class JsonStorageObjectTagPrintService(StorageObjectTagPrintService):
 
-    @staticmethod
-    def _to_json(obj):
-        return json.dumps(obj, indent=2, default=str, ensure_ascii=False)
-
     def print_tags(self, path, tags):
         if not tags:
-            click.echo(self._to_json([]))
+            click.echo(to_json([]))
             return
         result = [{'tagName': key, 'value': value} for key, value in iteritems(tags)]
-        click.echo(self._to_json(result))
+        click.echo(to_json(result))
 
 
 def create_storage_object_tag_print_service(output_format):

--- a/pipe-cli/src/utilities/printing/storage_du.py
+++ b/pipe-cli/src/utilities/printing/storage_du.py
@@ -19,6 +19,7 @@ import click
 from prettytable import prettytable
 
 from src.utilities.datastorage_du_operation import DuOutput
+from src.utilities.printing.utils import to_json
 
 
 class StorageDuPrintService(object):
@@ -192,10 +193,6 @@ class JsonStorageDuPrintService(StorageDuPrintService):
     def __init__(self):
         self._buffer = []
 
-    @staticmethod
-    def _to_json(obj):
-        return json.dumps(obj, default=str, indent=2, ensure_ascii=False)
-
     def add_item(self, du_command, item):
         self._buffer.append(self._build_entry(du_command, item))
 
@@ -204,7 +201,7 @@ class JsonStorageDuPrintService(StorageDuPrintService):
             self._buffer.append(self._build_entry(du_command, item))
 
     def flush(self):
-        click.echo(self._to_json(self._buffer))
+        click.echo(to_json(self._buffer))
 
     def error(self, message):
         click.echo(json.dumps({'error': message}), err=True)

--- a/pipe-cli/src/utilities/printing/tag.py
+++ b/pipe-cli/src/utilities/printing/tag.py
@@ -19,6 +19,8 @@ import click
 import prettytable
 from future.utils import iteritems
 
+from src.utilities.printing.utils import to_json
+
 
 class TagPrintService(object):
     __metaclass__ = ABCMeta
@@ -52,17 +54,13 @@ class PrettyTableTagPrintService(TagPrintService):
 
 class JsonTagPrintService(TagPrintService):
 
-    @staticmethod
-    def _to_json(obj):
-        return json.dumps(obj, indent=2, default=str, ensure_ascii=False)
-
     def print_tags(self, entity_class, entity_id, data):
         if not data:
-            click.echo(self._to_json([]))
+            click.echo(to_json([]))
             return
         tags = [{'tagName': key, 'value': entry.get('value'), 'type': entry.get('type')}
                 for key, entry in iteritems(data)]
-        click.echo(self._to_json(tags))
+        click.echo(to_json(tags))
 
     def error(self, message, err=True):
         click.echo(json.dumps({'error': message}), err=err)

--- a/pipe-cli/src/utilities/printing/tool.py
+++ b/pipe-cli/src/utilities/printing/tool.py
@@ -22,6 +22,7 @@ from abc import ABCMeta, abstractmethod
 import click
 from prettytable import prettytable
 
+from src.utilities.printing.utils import to_json
 
 MB = 1024 * 1024
 
@@ -250,11 +251,6 @@ class PrettyTableToolPrintService(ToolPrintService):
 class JsonToolPrintService(ToolPrintService):
     """Print service using JSON format for structured output."""
 
-    @staticmethod
-    def _to_json(obj):
-        """Convert object to JSON string."""
-        return json.dumps(obj, default=str, indent=2, ensure_ascii=False)
-
     def print_registry(self, registry_model, groups):
         """Print registry information with its groups."""
         registry_data = {
@@ -272,7 +268,7 @@ class JsonToolPrintService(ToolPrintService):
                 'description': group_model.description
             })
 
-        click.echo(self._to_json(registry_data))
+        click.echo(to_json(registry_data))
 
     def print_group(self, group_model, tools, group_name):
         """Print tool group information with its tools."""
@@ -294,7 +290,7 @@ class JsonToolPrintService(ToolPrintService):
                 'description': tool_model.short_description
             })
 
-        click.echo(self._to_json(group_data))
+        click.echo(to_json(group_data))
 
     def print_tool(self, tool_model, group, tags):
         """Print detailed tool information."""
@@ -310,7 +306,7 @@ class JsonToolPrintService(ToolPrintService):
             'versions': tags if tags else []
         }
 
-        click.echo(self._to_json(tool_data))
+        click.echo(to_json(tool_data))
 
     def print_version(self, tool_model, group, registry_path, version, tool_settings, scan_results):
         """Print detailed tool version information."""
@@ -383,7 +379,7 @@ class JsonToolPrintService(ToolPrintService):
                         for d in scan_result.dependencies
                     ]
 
-        click.echo(self._to_json(version_data))
+        click.echo(to_json(version_data))
 
     def print_error(self, message):
         """Print error message in JSON format."""

--- a/pipe-cli/src/utilities/printing/user.py
+++ b/pipe-cli/src/utilities/printing/user.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 from abc import ABCMeta, abstractmethod
 
 import click
 from prettytable import prettytable
+
+from src.utilities.printing.utils import to_json
 
 
 class UserInstancesPrintService:
@@ -34,7 +35,7 @@ class UserInstancesPrintService:
 
     @abstractmethod
     def print_single_limits(self, username, active_runs_count, source, value):
-        """Report aa single active instance limits applied to the user.
+        """Report a single active instance limits applied to the user.
 
         :param username: the name of the logged user.
         :param active_runs_count: number of runs in RUNNING or RESUMING state.
@@ -100,10 +101,6 @@ class JsonUserInstancesPrintService(UserInstancesPrintService):
     """
 
     @staticmethod
-    def _to_json(obj):
-        return json.dumps(obj, default=str, indent=2, ensure_ascii=False)
-
-    @staticmethod
     def _to_dict(username, runs_count, limits):
         return {
             'userName': username,
@@ -112,21 +109,21 @@ class JsonUserInstancesPrintService(UserInstancesPrintService):
         }
 
     def print_no_limits(self, username, active_runs_count):
-        click.echo(self._to_json(self._to_dict(
+        click.echo(to_json(self._to_dict(
             username=username,
             runs_count=active_runs_count,
             limits=[]
         )))
 
     def print_single_limits(self, username, active_runs_count, source, value):
-        click.echo(self._to_json(self._to_dict(
+        click.echo(to_json(self._to_dict(
             username=username,
             runs_count=active_runs_count,
             limits=[{'source': source, 'value': value}]
         )))
 
     def print_limits(self, username, active_runs_count, limits_dict):
-        click.echo(self._to_json(self._to_dict(
+        click.echo(to_json(self._to_dict(
             username=username,
             runs_count=active_runs_count,
             limits=[{'source': s, 'value': v} for s, v in limits_dict.items()]

--- a/pipe-cli/src/utilities/printing/user.py
+++ b/pipe-cli/src/utilities/printing/user.py
@@ -1,0 +1,139 @@
+# Copyright 2026 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from abc import ABCMeta, abstractmethod
+
+import click
+from prettytable import prettytable
+
+
+class UserInstancesPrintService:
+
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def print_no_limits(self, username, active_runs_count):
+        """Report that no instance limits are configured for the user.
+
+        :param username: the name of the logged user.
+        :param active_runs_count: number of runs in RUNNING or RESUMING state.
+        """
+        pass
+
+    @abstractmethod
+    def print_single_limits(self, username, active_runs_count, source, value):
+        """Report aa single active instance limits applied to the user.
+
+        :param username: the name of the logged user.
+        :param active_runs_count: number of runs in RUNNING or RESUMING state.
+        :param source: source to display.
+        :param value: value to display.
+        """
+        pass
+
+    @abstractmethod
+    def print_limits(self, username, active_runs_count, limits_dict):
+        """Report active instance limits applied to the user.
+
+        :param username: the name of the logged user.
+        :param active_runs_count: number of runs in RUNNING or RESUMING state.
+        :param limits_dict: ordered mapping of ``source -> value`` to display.
+        """
+        pass
+
+
+class PrettyTableUserInstancesPrintService(UserInstancesPrintService):
+
+    @staticmethod
+    def _print_active_runs(username, active_runs_count):
+        click.echo('Active runs detected for a user: [{}: {}]'.format(username, active_runs_count))
+
+    def print_no_limits(self, username, active_runs_count):
+        self._print_active_runs(username, active_runs_count)
+        click.echo('No restrictions on runs launching configured')
+
+    def print_single_limits(self, username, active_runs_count, source, value):
+        self._print_active_runs(username, active_runs_count)
+        click.echo('The following restriction applied on runs launching: [{}: {}]'.format(source, value))
+
+    def print_limits(self, username, active_runs_count, limits_dict):
+        self._print_active_runs(username, active_runs_count)
+        click.echo('The following restrictions applied on runs launching:\n')
+        table = prettytable.PrettyTable()
+        table.field_names = ['Source', 'Value']
+        table.align = 'l'
+        for source, value in limits_dict.items():
+            table.add_row([source, value])
+        click.echo(table)
+
+
+class JsonUserInstancesPrintService(UserInstancesPrintService):
+    """JSON implementation of :class:`UserInstancesPrintService`.
+
+    All methods emit a single JSON object to stdout. Schema::
+
+        {
+          "userName":       string,          // the name of the logged user
+          "activeRunsCount": integer,        // number of currently active runs
+          "instanceLimits": [                // empty array when no limits are configured
+            {
+              "source": string,             // limit origin, e.g. "USER" or group name
+              "value":  integer             // maximum allowed concurrent runs
+            }
+          ]
+        }
+
+    Note: without ``-v`` / ``--verbose`` only the single most restrictive limit
+    is included in ``instanceLimits``. Pass ``-v`` to receive all configured limits.
+    """
+
+    @staticmethod
+    def _to_json(obj):
+        return json.dumps(obj, default=str, indent=2, ensure_ascii=False)
+
+    @staticmethod
+    def _to_dict(username, runs_count, limits):
+        return {
+            'userName': username,
+            'activeRunsCount': runs_count,
+            'instanceLimits': limits
+        }
+
+    def print_no_limits(self, username, active_runs_count):
+        click.echo(self._to_json(self._to_dict(
+            username=username,
+            runs_count=active_runs_count,
+            limits=[]
+        )))
+
+    def print_single_limits(self, username, active_runs_count, source, value):
+        click.echo(self._to_json(self._to_dict(
+            username=username,
+            runs_count=active_runs_count,
+            limits=[{'source': source, 'value': value}]
+        )))
+
+    def print_limits(self, username, active_runs_count, limits_dict):
+        click.echo(self._to_json(self._to_dict(
+            username=username,
+            runs_count=active_runs_count,
+            limits=[{'source': s, 'value': v} for s, v in limits_dict.items()]
+        )))
+
+
+def create_user_instances_print_service(output_format):
+    if output_format == 'json':
+        return JsonUserInstancesPrintService()
+    return PrettyTableUserInstancesPrintService()

--- a/pipe-cli/src/utilities/printing/utils.py
+++ b/pipe-cli/src/utilities/printing/utils.py
@@ -1,0 +1,19 @@
+# Copyright 2026 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+
+def to_json(obj):
+    return json.dumps(obj, default=str, indent=2, ensure_ascii=False)

--- a/pipe-cli/src/utilities/user_operations_manager.py
+++ b/pipe-cli/src/utilities/user_operations_manager.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 import os
 import sys
+from itertools import islice
 
 import click
-
-from prettytable import prettytable
 
 from src.api.entity import Entity
 from src.api.pipeline_run import PipelineRun
 from src.api.user import User
+from src.utilities.printing.user import create_user_instances_print_service
 
 
 class UserOperationsManager:
@@ -41,31 +41,20 @@ class UserOperationsManager:
         for event in events:
             click.echo("[%s] %s" % (event.get('status', ''), event.get('message', '')))
 
-    def get_instance_limits(self, verbose=False):
+    def get_instance_limits(self, verbose=False, output_format=None):
+        print_service = create_user_instances_print_service(output_format)
         username = self.user['userName']
         active_runs_count = PipelineRun.count_user_runs(target_statuses=['RUNNING', 'RESUMING'], owner=username)
-        click.echo('Active runs detected for a user: [{}: {}]'.format(username, active_runs_count))
         active_limits = User.load_launch_limits(verbose)
         if len(active_limits) == 0:
-            click.echo('No restrictions on runs launching configured')
+            print_service.print_no_limits(username, active_runs_count)
             return
+        sorted_limits = dict(sorted(active_limits.items(), key=lambda x: x[1]))
         if not verbose:
-            limit_entry = active_limits.items()[0]
-            source = limit_entry[0]
-            limit = limit_entry[1]
-            click.echo('The following restriction applied on runs launching: [{}: {}]'.format(source, limit))
-        else:
-            self.print_limits_table(active_limits)
-
-    def print_limits_table(self, limits_dict):
-        click.echo('The following restrictions applied on runs launching:\n')
-        limit_details_table = prettytable.PrettyTable()
-        limit_details_table.field_names = ['Source', 'Value']
-        limit_details_table.sortby = 'Value'
-        limit_details_table.align = 'l'
-        for source, value in limits_dict.items():
-            limit_details_table.add_row([source, value])
-        click.echo(limit_details_table)
+            source, value = next(iter(sorted_limits.items()))
+            print_service.print_single_limits(username, active_runs_count, source, value)
+            return
+        print_service.print_limits(username, active_runs_count, sorted_limits)
 
     def is_admin(self):
         return 'ROLE_ADMIN' in self.get_all_user_roles()


### PR DESCRIPTION
relates to #4349 

- support `-of | --output-format json` for `pipe users instances`
- small refactor for common `to_json` method usage