### PR TITLE
Issue #4450: Versioned Storages: Clone a Versioned Storage into the run gives error unexpected http status code: 404 - fsbrowser fix

### DIFF
--- a/fs-browser/fsbrowser/src/api/cloud_pipeline_api_provider.py
+++ b/fs-browser/fsbrowser/src/api/cloud_pipeline_api_provider.py
@@ -87,7 +87,7 @@ class CloudPipelineAPI:
         url = '/pipeline/git/credentials'
         if duration:
             url += '?duration=%d' % duration
-        result = self._get('/pipeline/git/credentials', token)
+        result = self._get(url, token)
         return result or {}
 
     def _get(self, url, token=None):


### PR DESCRIPTION
related to #4450 

The bug was found into `fsbrowser`: `duration` field was not provided for `pipeline/git/credentials` query.