### PR TITLE
feature/docker images build workflow

### DIFF
--- a/.github/workflows/build-dockers-matrix.yml
+++ b/.github/workflows/build-dockers-matrix.yml
@@ -1,0 +1,446 @@
+name: Build and Push Docker Images (matrix)
+
+on:
+  workflow_dispatch:
+    inputs:
+      cp_api_dist_url:
+        description: 'URL to cloud-pipeline distribution tarball'
+        required: true
+      sources_path:
+        description: 'Path to docker sources directory'
+        required: false
+        default: 'deploy/docker'
+
+env:
+  DOCKERS_SOURCES_PATH: ${{ github.event.inputs.sources_path }}
+
+##############################################################
+# Jobs:
+#   prebuild      – parses version from dist URL
+#   build         – all services via matrix (parallel)
+#   build-pipectl – generates dockers-manifest, assembles and
+#                   packages the pipectl binary, uploads as
+#                   a GitHub Actions artifact
+#
+# build-push-action with push: true sends directly to the
+# registry without loading to the local daemon, so no
+# docker rmi cleanup is needed.
+##############################################################
+
+jobs:
+
+  ##############################################################
+  # Parse version from dist URL filename:
+  # cloud-pipeline.{major}.{minor}.{patch}.{build}.{commit}.tgz
+  ##############################################################
+  prebuild:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.parse.outputs.version }}
+      version_full: ${{ steps.parse.outputs.version_full }}
+    steps:
+      - name: Parse version from dist URL
+        id: parse
+        run: |
+          FILENAME="${{ github.event.inputs.cp_api_dist_url }}"
+          FILENAME="${FILENAME##*/}"
+          IFS='.' read -ra V <<< "$FILENAME"
+          VERSION="${V[1]}.${V[2]}"
+          if [[ -z "${V[1]}" || -z "${V[2]}" ]]; then
+            echo "Failed to parse version from URL: ${{ github.event.inputs.cp_api_dist_url }}"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "version_full=${V[1]}.${V[2]}.${V[3]}.${V[4]}.${V[5]}" >> "$GITHUB_OUTPUT"
+
+  ##############################################################
+  # Build docker images
+  ##############################################################
+  build:
+    name: build docker (${{ matrix.service }})
+    needs: prebuild
+    runs-on: ubuntu-latest
+    env:
+      DOCKERS_VERSION: ${{ needs.prebuild.outputs.version }}
+    strategy:
+      fail-fast: false
+      max-parallel: 20
+      matrix:
+        include:
+
+          - service: cp-api-srv
+            context: cp-api-srv
+            needs_dist_url: true
+            tag: api-srv-$DOCKERS_VERSION
+
+          - service: cp-idp
+            context: cp-idp
+            tag: idp-$DOCKERS_VERSION
+
+          - service: cp-edge
+            context: cp-edge
+            tag: edge-$DOCKERS_VERSION
+
+          - service: cp-docker-comp
+            context: cp-docker-comp
+            needs_dist_url: true
+            tag: docker-comp-$DOCKERS_VERSION
+
+          - service: cp-clair
+            context: cp-clair
+            tag: clair-$DOCKERS_VERSION
+
+          - service: cp-clair-v4
+            context: cp-clair-v4
+            tag: clair-v4-$DOCKERS_VERSION
+
+          - service: cp-docker-registry-default
+            context: cp-docker-registry/v2.7.0+aws_imds2
+            tag: registry-$DOCKERS_VERSION-default
+
+          - service: cp-docker-registry-2.7.0-aws-imds2
+            context: cp-docker-registry/v2.7.0+aws_imds2
+            tag: registry-$DOCKERS_VERSION-2.7.0-aws-imds2
+
+          - service: cp-docker-registry-2.7.1
+            context: cp-docker-registry/v2.7.1
+            tag: registry-$DOCKERS_VERSION-2.7.1
+
+          - service: cp-docker-registry-3.0.0
+            context: cp-docker-registry/v3.0.0
+            tag: registry-$DOCKERS_VERSION-3.0.0
+
+          - service: cp-git-9
+            context: cp-git
+            dockerfile: cp-git/Dockerfile.9.4
+            tag: git-9-$DOCKERS_VERSION
+
+          - service: cp-git-15
+            context: cp-git
+            dockerfile: cp-git/Dockerfile.15.5
+            base_image: gitlab/gitlab-ce:15.5.4-ce.0
+            tag: git-15-$DOCKERS_VERSION
+
+          - service: cp-git-17
+            context: cp-git
+            dockerfile: cp-git/Dockerfile.17.4
+            base_image: gitlab/gitlab-ce:17.4.1-ce.0
+            tag: git-17-$DOCKERS_VERSION
+
+          - service: cp-notifier
+            context: cp-notifier
+            needs_dist_url: true
+            tag: notifier-$DOCKERS_VERSION
+
+          - service: cp-search
+            context: cp-search
+            needs_dist_url: true
+            tag: search-$DOCKERS_VERSION
+
+          - service: cp-search-elk
+            context: cp-search-elk
+            tag: search-elk-$DOCKERS_VERSION
+
+          - service: cp-search-elk-curator
+            context: cp-search-elk-curator
+            tag: search-elk-curator-$DOCKERS_VERSION
+
+          - service: cp-heapster-elk
+            context: cp-heapster-elk
+            tag: heapster-elk-$DOCKERS_VERSION
+
+          - service: cp-node-logger
+            context: cp-node-logger
+            tag: node-logger-$DOCKERS_VERSION
+
+          - service: cp-node-reporter
+            context: cp-node-reporter
+            needs_dist_url: true
+            tag: node-reporter-$DOCKERS_VERSION
+
+          - service: cp-bkp-worker
+            context: cp-bkp-worker
+            tag: cp-bkp-worker-$DOCKERS_VERSION
+
+          - service: cp-vm-monitor
+            context: cp-vm-monitor
+            needs_dist_url: true
+            tag: vm-monitor-$DOCKERS_VERSION
+
+          - service: cp-share-srv
+            context: cp-share-srv
+            needs_dist_url: true
+            tag: share-srv-$DOCKERS_VERSION
+
+          - service: cp-billing-srv
+            context: cp-billing-srv
+            needs_dist_url: true
+            tag: billing-srv-$DOCKERS_VERSION
+
+          - service: cp-gitlab-reader
+            context: cp-gitlab-reader
+            needs_dist_url: true
+            tag: gitlab-reader-$DOCKERS_VERSION
+
+          - service: cp-tinyproxy
+            context: cp-tinyproxy
+            tag: tinyproxy-$DOCKERS_VERSION
+
+          - service: cp-leader-elector
+            context: cp-leader-elector
+            tag: leader-elector-$DOCKERS_VERSION
+
+          - service: cp-run-policy-manager
+            context: cp-run-policy-manager
+            tag: run-policy-manager-$DOCKERS_VERSION
+
+          - service: cp-dns-hosts-sync
+            context: cp-dns-hosts-sync
+            tag: dns-hosts-sync-$DOCKERS_VERSION
+
+          - service: cp-monitoring-srv
+            context: cp-monitoring-srv
+            needs_dist_url: true
+            tag: monitoring-service-$DOCKERS_VERSION
+
+          - service: cp-deployment-autoscaler
+            context: cp-deployment-autoscaler
+            needs_dist_url: true
+            tag: deployment-autoscaler-$DOCKERS_VERSION
+
+          - service: cp-storage-lifecycle-service
+            context: cp-storage-lifecycle-service
+            needs_dist_url: true
+            tag: storage-lifecycle-service-$DOCKERS_VERSION
+
+          - service: cp-mlflow-server
+            context: cp-mlflow-server
+            tag: mlflow-server-$DOCKERS_VERSION
+
+          - service: cp-run-cleanup-job
+            context: cp-run-cleanup-job
+            needs_dist_url: true
+            tag: cp-run-cleanup-job-$DOCKERS_VERSION
+
+          - service: cp-tools-base-centos-vanilla
+            context: cp-tools/base/centos/vanilla
+            tag: tools-base-centos-7-$DOCKERS_VERSION
+            manifest_pretty_names: "library/centos:7|library/centos:latest"
+            manifest_spec_path: cp-tools/base/centos/vanilla
+
+          - service: cp-tools-base-centos-vanilla-optimized
+            context: cp-tools/base/centos/vanilla
+            dockerfile: cp-tools/base/centos/vanilla/Dockerfile.optimized
+            needs_dist_url: true
+            tag: tools-base-centos-7-optimized-$DOCKERS_VERSION
+            manifest_pretty_names: "library/centos:7-optimized"
+            manifest_spec_path: cp-tools/base/centos/vanilla
+
+          - service: cp-tools-base-centos-cuda-11
+            context: cp-tools/base/centos/cuda
+            base_image: nvidia/cuda:11.3.1-cudnn8-runtime-centos7
+            tag: tools-base-centos-7-cuda11-$DOCKERS_VERSION
+            manifest_pretty_names: "library/centos-cuda:7-cuda11"
+            manifest_spec_path: cp-tools/base/centos/cuda
+
+          - service: cp-tools-base-centos-cuda
+            context: cp-tools/base/centos/cuda
+            base_image: nvidia/cuda:11.3.1-cudnn8-runtime-centos7
+            tag: tools-base-centos-7-cuda-$DOCKERS_VERSION
+            manifest_pretty_names: "library/centos-cuda:latest"
+            manifest_spec_path: cp-tools/base/centos/cuda
+
+          - service: cp-tools-base-ubuntu-vanilla-16.04
+            context: cp-tools/base/ubuntu/vanilla
+            base_image: library/ubuntu:16.04
+            tag: tools-base-ubuntu-16.04-$DOCKERS_VERSION
+            manifest_pretty_names: "library/ubuntu:16.04"
+            manifest_spec_path: cp-tools/base/ubuntu/vanilla
+
+          - service: cp-tools-base-ubuntu-vanilla-18.04
+            context: cp-tools/base/ubuntu/vanilla
+            base_image: library/ubuntu:18.04
+            tag: tools-base-ubuntu-18.04-$DOCKERS_VERSION
+            manifest_pretty_names: "library/ubuntu:18.04|library/ubuntu:latest"
+            manifest_spec_path: cp-tools/base/ubuntu/vanilla
+
+          - service: cp-tools-base-ubuntu-cuda-11
+            context: cp-tools/base/ubuntu/cuda
+            base_image: nvidia/cuda:11.3.1-cudnn8-runtime-ubuntu18.04
+            tag: tools-base-ubuntu-18.04-cuda11-$DOCKERS_VERSION
+            manifest_pretty_names: "library/ubuntu-cuda:18.04-cuda11"
+            manifest_spec_path: cp-tools/base/ubuntu/cuda
+
+          - service: cp-tools-base-ubuntu-cuda
+            context: cp-tools/base/ubuntu/cuda
+            base_image: nvidia/cuda:11.3.1-cudnn8-runtime-ubuntu18.04
+            tag: tools-base-ubuntu-18.04-cuda-$DOCKERS_VERSION
+            manifest_pretty_names: "library/ubuntu-cuda:latest"
+            manifest_spec_path: cp-tools/base/ubuntu/cuda
+
+          - service: cp-tools-base-rockylinux-vanilla
+            context: cp-tools/base/rockylinux/vanilla
+            tag: tools-base-rockylinux-8-$DOCKERS_VERSION
+            manifest_pretty_names: "library/rockylinux:8|library/rockylinux:latest"
+            manifest_spec_path: cp-tools/base/rockylinux/vanilla
+
+          - service: cp-tools-base-cromwell
+            context: cp-tools/base/cromwell
+            tag: tools-base-cromwell-$DOCKERS_VERSION
+            manifest_pretty_names: "library/cromwell:latest"
+            manifest_spec_path: cp-tools/base/cromwell
+
+          - service: cp-tools-base-nextflow
+            context: cp-tools/base/nextflow
+            base_image: library/rockylinux:8.7
+            tag: tools-base-nextflow-$DOCKERS_VERSION
+            manifest_pretty_names: "library/nextflow:latest"
+            manifest_spec_path: cp-tools/base/nextflow
+
+          - service: cp-tools-mlops-cp-mlflow
+            context: cp-tools/mlops/cp-mlflow
+            tag: tools-mlops-mlflow-$DOCKERS_VERSION
+            manifest_pretty_names: "library/mlflow:latest"
+            manifest_spec_path: cp-tools/mlops/cp-mlflow
+
+          - service: cp-tools-system-system-job
+            context: cp-tools/system/system-job
+            tag: tools-system-system-job-$DOCKERS_VERSION
+            manifest_pretty_names: "system/system-job-launcher:latest"
+            manifest_spec_path: cp-tools/system/system-job
+
+          - service: cp-dav
+            context: cp-dav
+            tag: dav-$DOCKERS_VERSION
+            pre_build_commands: cp -r scripts/nfs-roles-management $DOCKERS_SOURCES_PATH/cp-dav/
+            post_build_commands: rm -rf $DOCKERS_SOURCES_PATH/cp-dav/nfs-roles-management
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ secrets.DOCKER_DIST_SRV }}
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Pre-build
+        if: ${{ matrix.pre_build_commands != '' }}
+        run: ${{ matrix.pre_build_commands }}
+
+      - name: Compute tag
+        id: tag
+        run: |
+          echo "value=$(eval echo "${{ matrix.tag }}")" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push ${{ matrix.service }}
+        uses: docker/build-push-action@v7
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: "false"
+        with:
+          context: ${{ env.DOCKERS_SOURCES_PATH }}/${{ matrix.context }}
+          file: ${{ matrix.dockerfile && format('{0}/{1}', env.DOCKERS_SOURCES_PATH, matrix.dockerfile) || '' }}
+          push: true
+          tags: ${{ secrets.DOCKER_DIST_SRV }}:${{ steps.tag.outputs.value }}
+          cache-from: type=registry,ref=${{ secrets.DOCKER_DIST_SRV }}:${{ steps.tag.outputs.value }}-cache
+          cache-to: type=registry,ref=${{ secrets.DOCKER_DIST_SRV }}:${{ steps.tag.outputs.value }}-cache,mode=max
+          build-args: |
+            ${{ matrix.needs_dist_url && format('CP_API_DIST_URL={0}', github.event.inputs.cp_api_dist_url) || '' }}
+            ${{ matrix.base_image && format('BASE_IMAGE={0}', matrix.base_image) || '' }}
+
+      - name: Post-build
+        if: ${{ always() && matrix.post_build_commands != '' }}
+        run: ${{ matrix.post_build_commands }}
+
+
+  ##############################################################
+  # Generate dockers-manifest, assemble and package pipectl
+  # Runs after all matrix builds succeed.
+  # Binary is uploaded as a GitHub Actions artifact.
+  ##############################################################
+  build-pipectl:
+    needs: [prebuild, build]
+    runs-on: ubuntu-latest
+    env:
+      CP_VERSION_SHORT: ${{ needs.prebuild.outputs.version }}
+      CP_VERSION_FULL: ${{ needs.prebuild.outputs.version_full }}
+      CP_DIST_REPO_NAME: ${{ secrets.DOCKER_DIST_SRV }}
+      BUILD_DIR: /tmp/cp-deploy-build
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Generate dockers manifest
+        run: |
+          python3 - <<'EOF'
+          import yaml, os, shutil
+
+          workflow_file = ".github/workflows/build-dockers-matrix.yml"
+          with open(workflow_file) as f:
+              wf = yaml.safe_load(f)
+
+          matrix   = wf["jobs"]["build"]["strategy"]["matrix"]["include"]
+          tools    = [e for e in matrix if e.get("manifest_pretty_names")]
+
+          repo     = os.environ["CP_DIST_REPO_NAME"]
+          version  = os.environ["CP_VERSION_SHORT"]
+          sources  = os.environ["DOCKERS_SOURCES_PATH"]
+          mdir     = os.environ["BUILD_DIR"] + "/dockers-manifest"
+
+          os.makedirs(mdir, exist_ok=True)
+          with open(f"{mdir}/manifest.txt", "w") as mf:
+              for tool in tools:
+                  tag        = tool["tag"].replace("$DOCKERS_VERSION", version)
+                  full_tag   = f"{repo}:{tag}"
+                  spec_path  = tool["manifest_spec_path"]
+                  for pretty in tool["manifest_pretty_names"].split("|"):
+                      mf.write(f"{full_tag},{pretty}\n")
+                      pdir = f"{mdir}/{pretty}"
+                      os.makedirs(pdir, exist_ok=True)
+                      for fname in ("icon.png", "README.md", "spec.json"):
+                          src = f"{sources}/{spec_path}/{fname}"
+                          if os.path.exists(src):
+                              shutil.copy(src, f"{pdir}/{fname}")
+          EOF
+
+      - name: Assemble pipectl contents
+        run: |
+          CONTENTS_DIR="${BUILD_DIR}/contents"
+          OTHER_PKGS="${CONTENTS_DIR}/other-packages"
+
+          # Static install scripts, k8s configs, preferences, etc.
+          cp -r deploy/contents/. "${CONTENTS_DIR}/"
+
+          # Dockers manifest built in the previous step
+          cp -r "${BUILD_DIR}/dockers-manifest" "${CONTENTS_DIR}/"
+
+          cp deploy/contents/install/cloud-images/cloud-images-manifest.txt "${CONTENTS_DIR}/"
+
+          # Additional workflow packages (mirrors -p flags in Jenkins build-pipectl.sh)
+          mkdir -p "${OTHER_PKGS}"
+          cp -r workflows/pipe-templates/__SYSTEM/data_loader "${OTHER_PKGS}/"
+          cp -r workflows/pipe-templates/__SYSTEM/system_jobs "${OTHER_PKGS}/"
+          cp -r e2e/prerequisites                             "${OTHER_PKGS}/"
+          cp -r workflows/pipe-demo                           "${OTHER_PKGS}/"
+
+          echo "${CP_VERSION_SHORT}" > "${CONTENTS_DIR}/version.txt"
+
+      - name: Build pipectl binary
+        run: |
+          DIST_FILE="pipectl.${CP_VERSION_FULL}"
+          export DEPLOY_BUILD_OUTPUT_PATH="${BUILD_DIR}/${DIST_FILE}"
+          bash deploy/pipectl/build-pipectl.sh --base64 "${BUILD_DIR}/contents/"
+          echo "DIST_FILE=${DIST_FILE}" >> "$GITHUB_ENV"
+
+      - name: Upload pipectl artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pipectl-${{ env.CP_VERSION_FULL }}
+          path: ${{ env.BUILD_DIR }}/pipectl.${{ env.CP_VERSION_FULL }}
+          retention-days: 3

--- a/.github/workflows/build-dockers-matrix.yml
+++ b/.github/workflows/build-dockers-matrix.yml
@@ -63,7 +63,7 @@ jobs:
     env:
       DOCKERS_VERSION: ${{ needs.prebuild.outputs.version }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       max-parallel: 20
       matrix:
         include:
@@ -325,9 +325,9 @@ jobs:
       - name: Log in to registry
         uses: docker/login-action@v4
         with:
-          registry: ${{ secrets.DOCKER_DIST_SRV }}
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ${{ secrets.CP_DOCKER_DIST_SRV }}
+          username: ${{ secrets.CP_DOCKER_USER }}
+          password: ${{ secrets.CP_DOCKER_PASSWORD }}
 
       - name: Pre-build
         if: ${{ matrix.pre_build_commands != '' }}
@@ -346,9 +346,9 @@ jobs:
           context: ${{ env.DOCKERS_SOURCES_PATH }}/${{ matrix.context }}
           file: ${{ matrix.dockerfile && format('{0}/{1}', env.DOCKERS_SOURCES_PATH, matrix.dockerfile) || '' }}
           push: true
-          tags: ${{ secrets.DOCKER_DIST_SRV }}:${{ steps.tag.outputs.value }}
-          cache-from: type=registry,ref=${{ secrets.DOCKER_DIST_SRV }}:${{ steps.tag.outputs.value }}-cache
-          cache-to: type=registry,ref=${{ secrets.DOCKER_DIST_SRV }}:${{ steps.tag.outputs.value }}-cache,mode=max
+          tags: ${{ secrets.CP_DOCKER_DIST_SRV }}:${{ steps.tag.outputs.value }}
+          cache-from: type=registry,ref=${{ secrets.CP_DOCKER_DIST_SRV }}:${{ steps.tag.outputs.value }}-cache
+          cache-to: type=registry,ref=${{ secrets.CP_DOCKER_DIST_SRV }}:${{ steps.tag.outputs.value }}-cache,mode=max
           build-args: |
             ${{ matrix.needs_dist_url && format('CP_API_DIST_URL={0}', github.event.inputs.cp_api_dist_url) || '' }}
             ${{ matrix.base_image && format('BASE_IMAGE={0}', matrix.base_image) || '' }}
@@ -369,7 +369,7 @@ jobs:
     env:
       CP_VERSION_SHORT: ${{ needs.prebuild.outputs.version }}
       CP_VERSION_FULL: ${{ needs.prebuild.outputs.version_full }}
-      CP_DIST_REPO_NAME: ${{ secrets.DOCKER_DIST_SRV }}
+      CP_DIST_REPO_NAME: ${{ secrets.CP_DOCKER_DIST_SRV }}
       BUILD_DIR: /tmp/cp-deploy-build
 
     steps:

--- a/.github/workflows/build-dockers.yml
+++ b/.github/workflows/build-dockers.yml
@@ -361,7 +361,7 @@ jobs:
   ##############################################################
   # Generate dockers-manifest, assemble and package pipectl
   # Runs after all matrix builds succeed.
-  # Binary is uploaded as a GitHub Actions artifact.
+  # Binary is uploaded to s3://cloud-pipeline-oss-builds/builds/<branch>/
   ##############################################################
   build-pipectl:
     needs: [prebuild, build]
@@ -431,6 +431,13 @@ jobs:
 
           echo "${CP_VERSION_SHORT}" > "${CONTENTS_DIR}/version.txt"
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6.2.2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+
       - name: Build pipectl binary
         run: |
           DIST_FILE="pipectl.${CP_VERSION_FULL}"
@@ -438,9 +445,7 @@ jobs:
           bash deploy/pipectl/build-pipectl.sh --base64 "${BUILD_DIR}/contents/"
           echo "DIST_FILE=${DIST_FILE}" >> "$GITHUB_ENV"
 
-      - name: Upload pipectl artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: pipectl-${{ env.CP_VERSION_FULL }}
-          path: ${{ env.BUILD_DIR }}/pipectl.${{ env.CP_VERSION_FULL }}
-          retention-days: 3
+      - name: Upload pipectl to S3
+        run: |
+          aws s3 cp --no-progress "${BUILD_DIR}/${DIST_FILE}" \
+            "s3://cloud-pipeline-oss-builds/builds/${GITHUB_REF_NAME}/${DIST_FILE}"

--- a/api/src/main/java/com/epam/pipeline/manager/git/bitbucketcloud/BitbucketCloudService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/bitbucketcloud/BitbucketCloudService.java
@@ -211,9 +211,13 @@ public class BitbucketCloudService implements GitClientService {
                                               final boolean issueToken, final Long duration) {
         final GitRepositoryUrl repositoryUrl = GitRepositoryUrl.fromBitbucketCloud(pipeline.getRepository());
         final String token = pipeline.getRepositoryToken();
-        final String username = repositoryUrl.getUsername()
-                .flatMap(this::trimUsername)
-                .orElse(preferenceManager.getPreference(SystemPreferences.BITBUCKET_CLOUD_STATIC_USERNAME));
+        final String staticUsername = preferenceManager
+                .getPreference(SystemPreferences.BITBUCKET_CLOUD_STATIC_USERNAME);
+        final String username = StringUtils.isBlank(staticUsername)
+                ? repositoryUrl.getUsername()
+                  .flatMap(this::trimUsername)
+                  .orElseThrow(() -> buildUrlParseError(USER_NAME))
+                : staticUsername;
         final String host = repositoryUrl.getHost();
         return GitCredentials.builder()
                 .url(GitRepositoryUrl.asString(repositoryUrl.getProtocol(), username, token, host,

--- a/api/src/main/java/com/epam/pipeline/manager/git/bitbucketcloud/BitbucketCloudService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/git/bitbucketcloud/BitbucketCloudService.java
@@ -53,6 +53,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
@@ -75,7 +77,8 @@ public class BitbucketCloudService implements GitClientService {
     private static final String USER_NAME = "user name";
     private static final String BITBUCKET_CLOUD_FOLDER_MARKER = "commit_directory";
     private static final String BITBUCKET_CLOUD_FILE_MARKER = "commit_file";
-    private static final String PAGE_PARAMETER = "page=";
+    private static final String PAGE_PARAMETER = "page";
+    private static final String QUERY_PARAM_SEPARATOR = "&";
     private static final String AT_SIGN_ENCODED = "%40";
     private static final int MAX_DEPTH = 20;
 
@@ -255,11 +258,11 @@ public class BitbucketCloudService implements GitClientService {
         BitbucketCloudPagedResponse<BitbucketCloudSource> response = client.getFiles(path, version, null, maxDepth);
         final List<BitbucketCloudSource> values = response.getValues();
         while (response.getNext() != null) {
-            String[] params = response.getNext().split(PAGE_PARAMETER);
-            if (params.length < 2) {
+            final Optional<String> pageToken = extractPageToken(response.getNext());
+            if (!pageToken.isPresent()) {
                 break;
             }
-            response = client.getFiles(path, version, params[1], maxDepth);
+            response = client.getFiles(path, version, pageToken.get(), maxDepth);
             values.addAll(response.getValues());
         }
 
@@ -358,7 +361,7 @@ public class BitbucketCloudService implements GitClientService {
         return buildClient(repositoryPath, token);
     }
 
-    private BitbucketCloudClient buildClient(final String repositoryPath, final String token) {
+    protected BitbucketCloudClient buildClient(final String repositoryPath, final String token) {
         final GitRepositoryUrl repositoryUrl = GitRepositoryUrl.fromBitbucketCloud(repositoryPath);
         final String projectName = repositoryUrl.getNamespace().orElseThrow(() -> buildUrlParseError(PROJECT_NAME));
         final String repositoryName = repositoryUrl.getProject().orElseThrow(() -> buildUrlParseError(REPOSITORY_NAME));
@@ -411,6 +414,24 @@ public class BitbucketCloudService implements GitClientService {
 
     private boolean fileExists(final BitbucketCloudClient client, final String path, final Pipeline pipeline) {
         return client.searchFile(pipeline.getBranch(), path).getValues().size() > 0;
+    }
+
+    private Optional<String> extractPageToken(final String url) {
+        try {
+            final String query = new URI(url).getQuery();
+            if (query == null) {
+                return Optional.empty();
+            }
+            for (final String param : query.split(QUERY_PARAM_SEPARATOR)) {
+                final int eq = param.indexOf('=');
+                if (eq > 0 && param.substring(0, eq).equals(PAGE_PARAMETER)) {
+                    return Optional.of(param.substring(eq + 1));
+                }
+            }
+        } catch (URISyntaxException e) {
+            log.warn("Failed to parse next page URL: {}", url);
+        }
+        return Optional.empty();
     }
 
     private Optional<String> decodeUsername(final String username) {

--- a/api/src/test/java/com/epam/pipeline/manager/git/bitbucketcloud/BitbucketCloudServicePagingTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/git/bitbucketcloud/BitbucketCloudServicePagingTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.git.bitbucketcloud;
+
+import com.epam.pipeline.common.MessageHelper;
+import com.epam.pipeline.entity.git.GitRepositoryEntry;
+import com.epam.pipeline.entity.git.bitbucketcloud.BitbucketCloudPagedResponse;
+import com.epam.pipeline.entity.git.bitbucketcloud.BitbucketCloudSource;
+import com.epam.pipeline.entity.pipeline.Pipeline;
+import com.epam.pipeline.manager.preference.PreferenceManager;
+import com.epam.pipeline.mapper.git.BitbucketCloudMapper;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class BitbucketCloudServicePagingTest {
+
+    private static final String VERSION = "abc123";
+    private static final String PATH = "src";
+    private static final int MAX_DEPTH = 20;
+    private static final String FILE_A = "src/A.java";
+    private static final String FILE_B = "src/B.java";
+
+    @Mock
+    private BitbucketCloudMapper mapper;
+    @Mock
+    private MessageHelper messageHelper;
+    @Mock
+    private PreferenceManager preferenceManager;
+    @Mock
+    private BitbucketCloudClient mockClient;
+
+    private BitbucketCloudService service;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        service = new BitbucketCloudService(mapper, messageHelper, preferenceManager) {
+            @Override
+            protected BitbucketCloudClient buildClient(final String repositoryPath, final String token) {
+                return mockClient;
+            }
+        };
+    }
+
+    @Test
+    public void shouldReturnSinglePageResultsWhenNextIsNull() {
+        when(mockClient.getFiles(PATH, VERSION, null, MAX_DEPTH))
+                .thenReturn(page(Arrays.asList(file(FILE_A), file(FILE_B)), null));
+
+        final List<GitRepositoryEntry> result = service.getRepositoryContents(
+                pipeline(), PATH, VERSION, true, false);
+
+        Assert.assertEquals(2, result.size());
+        verify(mockClient, times(1)).getFiles(any(), any(), any(), any());
+    }
+
+    @Test
+    public void shouldFollowPaginationWhenNextUrlHasSinglePageParam() {
+        when(mockClient.getFiles(PATH, VERSION, null, MAX_DEPTH))
+                .thenReturn(page(Collections.singletonList(file(FILE_A)),
+                        "https://api.bitbucket.org/2.0/repos/ws/r/src?page=cursor2"));
+        when(mockClient.getFiles(PATH, VERSION, "cursor2", MAX_DEPTH))
+                .thenReturn(page(Collections.singletonList(file(FILE_B)), null));
+
+        final List<GitRepositoryEntry> result = service.getRepositoryContents(
+                pipeline(), PATH, VERSION, true, false);
+
+        Assert.assertEquals(2, result.size());
+        verify(mockClient).getFiles(PATH, VERSION, "cursor2", MAX_DEPTH);
+    }
+
+    @Test
+    public void shouldExtractOnlyPageTokenWhenNextUrlHasMultipleQueryParams() {
+        // Regression: splitting on "page=" would produce "cursor123&foo=bar" instead of "cursor123"
+        when(mockClient.getFiles(PATH, VERSION, null, MAX_DEPTH))
+                .thenReturn(page(Collections.singletonList(file(FILE_A)),
+                        "https://api.bitbucket.org/2.0/repos/ws/r/src?maxdepth=20&page=cursor123&foo=bar"));
+        when(mockClient.getFiles(PATH, VERSION, "cursor123", MAX_DEPTH))
+                .thenReturn(page(Collections.singletonList(file(FILE_B)), null));
+
+        final List<GitRepositoryEntry> result = service.getRepositoryContents(
+                pipeline(), PATH, VERSION, true, false);
+
+        Assert.assertEquals(2, result.size());
+        verify(mockClient).getFiles(PATH, VERSION, "cursor123", MAX_DEPTH);
+    }
+
+    @Test
+    public void shouldStopPaginationWhenNextUrlHasNoPageParam() {
+        when(mockClient.getFiles(PATH, VERSION, null, MAX_DEPTH))
+                .thenReturn(page(Collections.singletonList(file(FILE_A)),
+                        "https://api.bitbucket.org/2.0/repos/ws/r/src?maxdepth=20"));
+
+        final List<GitRepositoryEntry> result = service.getRepositoryContents(
+                pipeline(), PATH, VERSION, true, false);
+
+        Assert.assertEquals(1, result.size());
+        verify(mockClient, times(1)).getFiles(any(), any(), any(), any());
+    }
+
+    private Pipeline pipeline() {
+        final Pipeline p = new Pipeline();
+        p.setRepository("https://user@bitbucket.org/workspace/repo.git");
+        p.setRepositoryToken("token");
+        p.setBranch("main");
+        return p;
+    }
+
+    private static BitbucketCloudSource file(final String path) {
+        return BitbucketCloudSource.builder().path(path).type("commit_file").build();
+    }
+
+    private static BitbucketCloudPagedResponse<BitbucketCloudSource> page(
+            final List<BitbucketCloudSource> values, final String next) {
+        final BitbucketCloudPagedResponse<BitbucketCloudSource> response = new BitbucketCloudPagedResponse<>();
+        response.setValues(new ArrayList<>(values));
+        response.setNext(next);
+        return response;
+    }
+}


### PR DESCRIPTION
Introduces .github/workflows/build-dockers.yml
A workflow that builds approximately 40 Docker service images in parallel (up to 20 concurrent jobs) and follows up with a build-pipectl job that:

1. Auto-generates the dockers-manifest by reading the matrix definition directly from the workflow YAML, ensuring the manifest and builds remain in sync.
2. Assembles pipectl contents, including install scripts, Kubernetes configurations, and workflow templates.
3. Builds the pipectl.<version> binary and uploads it to s3 bucket.

Inputs:
- cp_api_dist_url (required): The distribution tarball URL.
- sources_path (default: deploy/docker): The path to the source files.