### PR TITLE
changed the way how docker tag builds from secrets

### DIFF
--- a/.github/workflows/build-pipectl.yml
+++ b/.github/workflows/build-pipectl.yml
@@ -338,7 +338,8 @@ jobs:
       - name: Compute tag
         id: tag
         run: |
-          echo "value=$(eval echo "${{ matrix.tag }}")" >> "$GITHUB_OUTPUT"
+          TAG_SUFFIX=$(eval echo "${{ matrix.tag }}")
+          echo "value=${{ secrets.CP_DOCKER_DIST_SRV }}${{ secrets.CP_DOCKER_USER }}/cloud-pipeline:${TAG_SUFFIX}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push ${{ matrix.service }}
         uses: docker/build-push-action@v7
@@ -348,9 +349,9 @@ jobs:
           context: ${{ env.DOCKERS_SOURCES_PATH }}/${{ matrix.context }}
           file: ${{ matrix.dockerfile && format('{0}/{1}', env.DOCKERS_SOURCES_PATH, matrix.dockerfile) || '' }}
           push: true
-          tags: ${{ secrets.CP_DOCKER_DIST_SRV }}:${{ steps.tag.outputs.value }}
-          cache-from: type=registry,ref=${{ secrets.CP_DOCKER_DIST_SRV }}:${{ steps.tag.outputs.value }}-cache
-          cache-to: type=registry,ref=${{ secrets.CP_DOCKER_DIST_SRV }}:${{ steps.tag.outputs.value }}-cache,mode=max
+          tags: ${{ steps.tag.outputs.value }}
+          cache-from: type=registry,ref=${{ steps.tag.outputs.value }}-cache
+          cache-to: type=registry,ref=${{ steps.tag.outputs.value }}-cache,mode=max
           build-args: |
             ${{ matrix.needs_dist_url && format('CP_API_DIST_URL={0}', inputs.cp_dist_url) || '' }}
             ${{ matrix.base_image && format('BASE_IMAGE={0}', matrix.base_image) || '' }}
@@ -371,7 +372,7 @@ jobs:
     env:
       CP_VERSION_SHORT: ${{ needs.prebuild.outputs.version }}
       CP_VERSION_FULL: ${{ needs.prebuild.outputs.version_full }}
-      CP_DIST_REPO_NAME: ${{ secrets.CP_DOCKER_DIST_SRV }}
+      CP_DIST_REPO_NAME: "${{ secrets.CP_DOCKER_DIST_SRV }}${{ secrets.CP_DOCKER_USER }}/cloud-pipeline"
       BUILD_DIR: /tmp/cp-deploy-build
 
     steps:
@@ -390,7 +391,7 @@ jobs:
           matrix   = wf["jobs"]["build"]["strategy"]["matrix"]["include"]
           tools    = [e for e in matrix if e.get("manifest_pretty_names")]
 
-          repo     = os.environ["CP_DIST_REPO_NAME"]
+          repo     = os.environ["CP_DIST_REPO_NAME"].rstrip("/")
           version  = os.environ["CP_VERSION_SHORT"]
           sources  = os.environ["DOCKERS_SOURCES_PATH"]
           mdir     = os.environ["BUILD_DIR"] + "/dockers-manifest"


### PR DESCRIPTION
CP_DOCKER_DIST_SRV ends with a trailing / and is a registry prefix only. The previous tag format {CP_DOCKER_DIST_SRV}:{tag} produced  registry.io/:search-0.25 — invalid Docker reference.