### PR TITLE
Optimize Docker build cache usage across services

### DIFF
--- a/deploy/docker/cp-api-srv/Dockerfile
+++ b/deploy/docker/cp-api-srv/Dockerfile
@@ -100,33 +100,7 @@ RUN pip install -I google-api-core==1.32.0 \
                    google-auth-httplib2==0.1.0 \
                    googleapis-common-protos==1.52.0
 
-# API distribution
-ARG CP_API_DIST_URL=""
 ENV CP_API_HOME="/opt/api"
-ARG REQUIRED_JARS_REGEX="pipeline|jwt-generator|data-transfer-service"
-
-RUN cd /tmp && \
-    wget -q "$CP_API_DIST_URL" -O cloud-pipeline.tgz && \
-    tar -zxf cloud-pipeline.tgz && \
-    rm -rf bin/pipe-templates/__SYSTEM && \
-    mkdir -p $CP_API_HOME && \
-    ls -dp bin/* \
-        | grep '\.jar$' \
-        | grep -v -E "/($REQUIRED_JARS_REGEX)\.jar$" \
-        | xargs rm -f && \
-    mv bin/* $CP_API_HOME/ && \
-    rm -f cloud-pipeline.tgz && \
-    rm -rf bin
-ADD config $CP_API_HOME/config
-
-# Install pipe-common package
-RUN mkdir -p /tmp/pipe-temp && \
-    cp /opt/api/pipeline.jar /tmp/pipe-temp/ && \
-    cd /tmp/pipe-temp/ && \
-    unzip -qq pipeline.jar && \
-    pip install -I /tmp/pipe-temp/BOOT-INF/classes/static/pipe-common.tar.gz && \
-    cd / && \
-    rm -rf /tmp/pipe-temp
 
 # Install projects templates
 ADD folder-templates /opt/api/folder-templates
@@ -156,6 +130,33 @@ RUN cd /tmp \
     && mv /opt/filebeat-7.10.0-linux-x86_64 /opt/filebeat-oss
 
 COPY filebeat/opensearch/filebeat-template.yml /opt/filebeat-oss/
+
+# API distribution
+ARG CP_API_DIST_URL=""
+ARG REQUIRED_JARS_REGEX="pipeline|jwt-generator|data-transfer-service"
+
+RUN cd /tmp && \
+    wget -q "$CP_API_DIST_URL" -O cloud-pipeline.tgz && \
+    tar -zxf cloud-pipeline.tgz && \
+    rm -rf bin/pipe-templates/__SYSTEM && \
+    mkdir -p $CP_API_HOME && \
+    ls -dp bin/* \
+        | grep '\.jar$' \
+        | grep -v -E "/($REQUIRED_JARS_REGEX)\.jar$" \
+        | xargs rm -f && \
+    mv bin/* $CP_API_HOME/ && \
+    rm -f cloud-pipeline.tgz && \
+    rm -rf bin
+ADD config $CP_API_HOME/config
+
+# Install pipe-common package
+RUN mkdir -p /tmp/pipe-temp && \
+    cp /opt/api/pipeline.jar /tmp/pipe-temp/ && \
+    cd /tmp/pipe-temp/ && \
+    unzip -qq pipeline.jar && \
+    pip install -I /tmp/pipe-temp/BOOT-INF/classes/static/pipe-common.tar.gz && \
+    cd / && \
+    rm -rf /tmp/pipe-temp
 
 WORKDIR /opt/api
 

--- a/deploy/docker/cp-api-srv/Dockerfile
+++ b/deploy/docker/cp-api-srv/Dockerfile
@@ -101,12 +101,12 @@ RUN pip install -I google-api-core==1.32.0 \
                    googleapis-common-protos==1.52.0
 
 ENV CP_API_HOME="/opt/api"
-
+RUN mkdir -p $CP_API_HOME 
 # Install projects templates
-ADD folder-templates /opt/api/folder-templates
+ADD folder-templates $CP_API_HOME/folder-templates
 
 # Install error-pages templates
-ADD error-pages /opt/api/static/error
+ADD error-pages $CP_API_HOME/static/error
 
 # Add initialization scripts (api jar and git-sync)
 ADD init-api /init-api
@@ -139,7 +139,6 @@ RUN cd /tmp && \
     wget -q "$CP_API_DIST_URL" -O cloud-pipeline.tgz && \
     tar -zxf cloud-pipeline.tgz && \
     rm -rf bin/pipe-templates/__SYSTEM && \
-    mkdir -p $CP_API_HOME && \
     ls -dp bin/* \
         | grep '\.jar$' \
         | grep -v -E "/($REQUIRED_JARS_REGEX)\.jar$" \
@@ -151,13 +150,13 @@ ADD config $CP_API_HOME/config
 
 # Install pipe-common package
 RUN mkdir -p /tmp/pipe-temp && \
-    cp /opt/api/pipeline.jar /tmp/pipe-temp/ && \
+    cp $CP_API_HOME/pipeline.jar /tmp/pipe-temp/ && \
     cd /tmp/pipe-temp/ && \
     unzip -qq pipeline.jar && \
     pip install -I /tmp/pipe-temp/BOOT-INF/classes/static/pipe-common.tar.gz && \
     cd / && \
     rm -rf /tmp/pipe-temp
 
-WORKDIR /opt/api
+WORKDIR $CP_API_HOME
 
 CMD ["/init-api"]

--- a/deploy/docker/cp-billing-srv/Dockerfile
+++ b/deploy/docker/cp-billing-srv/Dockerfile
@@ -26,7 +26,8 @@ RUN yum install -y \
                 java-1.8.0-openjdk \
                 unzip
 
-ENV CP_BILLING_HOME="/opt/billing"                
+ENV CP_BILLING_HOME="/opt/billing"
+RUN mkdir -p $CP_BILLING_HOME
 ADD config $CP_BILLING_HOME/config
 
 ADD init /init
@@ -37,7 +38,6 @@ ARG CP_API_DIST_URL=""
 RUN cd /tmp && \
     wget -q "$CP_API_DIST_URL" -O cloud-pipeline.tgz && \
     tar -zxf cloud-pipeline.tgz && \
-    mkdir -p $CP_BILLING_HOME && \
     mv bin/billing-report-agent.jar $CP_BILLING_HOME/ && \
     rm -rf /tmp/*
 

--- a/deploy/docker/cp-billing-srv/Dockerfile
+++ b/deploy/docker/cp-billing-srv/Dockerfile
@@ -26,20 +26,19 @@ RUN yum install -y \
                 java-1.8.0-openjdk \
                 unzip
 
+ENV CP_BILLING_HOME="/opt/billing"                
+ADD config $CP_BILLING_HOME/config
+
+ADD init /init
+RUN chmod +x /init
+
 # API distribution
 ARG CP_API_DIST_URL=""
-ENV CP_BILLING_HOME="/opt/billing"
-
 RUN cd /tmp && \
     wget -q "$CP_API_DIST_URL" -O cloud-pipeline.tgz && \
     tar -zxf cloud-pipeline.tgz && \
     mkdir -p $CP_BILLING_HOME && \
     mv bin/billing-report-agent.jar $CP_BILLING_HOME/ && \
     rm -rf /tmp/*
-
-ADD config $CP_BILLING_HOME/config
-
-ADD init /init
-RUN chmod +x /init
 
 CMD ["/init"]

--- a/deploy/docker/cp-docker-comp/Dockerfile
+++ b/deploy/docker/cp-docker-comp/Dockerfile
@@ -28,6 +28,7 @@ RUN yum install -y \
                 unzip
 
 ENV CP_DOCKER_COMP_HOME="/opt/docker-comp"
+RUN mkdir -p $CP_DOCKER_COMP_HOME
 ADD config $CP_DOCKER_COMP_HOME/config
 
 ADD init /init
@@ -38,7 +39,6 @@ ARG CP_API_DIST_URL=""
 RUN cd /tmp && \
     wget -q "$CP_API_DIST_URL" -O cloud-pipeline.tgz && \
     tar -zxf cloud-pipeline.tgz && \
-    mkdir -p $CP_DOCKER_COMP_HOME && \
     mv bin/docker-comp-scan.jar $CP_DOCKER_COMP_HOME/ && \
     rm -rf /tmp/*
 

--- a/deploy/docker/cp-docker-comp/Dockerfile
+++ b/deploy/docker/cp-docker-comp/Dockerfile
@@ -27,19 +27,19 @@ RUN yum install -y \
                 python \
                 unzip
 
+ENV CP_DOCKER_COMP_HOME="/opt/docker-comp"
+ADD config $CP_DOCKER_COMP_HOME/config
+
+ADD init /init
+RUN chmod +x /init                
+
 # API distribution
 ARG CP_API_DIST_URL=""
-ENV CP_DOCKER_COMP_HOME="/opt/docker-comp"
 RUN cd /tmp && \
     wget -q "$CP_API_DIST_URL" -O cloud-pipeline.tgz && \
     tar -zxf cloud-pipeline.tgz && \
     mkdir -p $CP_DOCKER_COMP_HOME && \
     mv bin/docker-comp-scan.jar $CP_DOCKER_COMP_HOME/ && \
     rm -rf /tmp/*
-
-ADD config $CP_DOCKER_COMP_HOME/config
-
-ADD init /init
-RUN chmod +x /init
 
 CMD ["/init"]

--- a/deploy/docker/cp-gitlab-reader/Dockerfile
+++ b/deploy/docker/cp-gitlab-reader/Dockerfile
@@ -26,9 +26,13 @@ RUN apt update && \
 
 RUN python3 -m pip install --upgrade pip && pip3 install setuptools_rust==0.12.1
 
+ENV CP_GITLAB_READER_HOME="/opt/gitlab-reader"
+
+ADD init.sh /init.sh
+RUN chmod +x /init.sh
+
 # API distribution
 ARG CP_API_DIST_URL=""
-ENV CP_GITLAB_READER_HOME="/opt/gitlab-reader"
 
 RUN cd /tmp && \
     wget -q "$CP_API_DIST_URL" -O cloud-pipeline.tgz && \
@@ -46,9 +50,5 @@ RUN cd $CP_GITLAB_READER_HOME/gitreader && \
     python3 -m pip install wheel && \
     python3 -m pip install uwsgi==2.0.20 && \
     python3 setup.py install
-
-
-ADD init.sh /init.sh
-RUN chmod +x /init.sh
 
 CMD ["/init.sh"]

--- a/deploy/docker/cp-notifier/Dockerfile
+++ b/deploy/docker/cp-notifier/Dockerfile
@@ -27,22 +27,23 @@ RUN yum install -y \
                 python \
                 unzip
 
+ADD init /init
+RUN chmod +x /init
+
+ADD liveness.sh /liveness.sh
+RUN chmod +x /liveness.sh
+
+ENV CP_NOTIFIER_HOME="/opt/notifier"
+ADD config $CP_NOTIFIER_HOME/config
+
 # API distribution
 ARG CP_API_DIST_URL=""
-ENV CP_NOTIFIER_HOME="/opt/notifier"
+
 RUN cd /tmp && \
     wget -q "$CP_API_DIST_URL" -O cloud-pipeline.tgz && \
     tar -zxf cloud-pipeline.tgz && \
     mkdir -p $CP_NOTIFIER_HOME && \
     mv bin/notifier.jar $CP_NOTIFIER_HOME/ && \
     rm -rf /tmp/*
-
-ADD config $CP_NOTIFIER_HOME/config
-
-ADD init /init
-RUN chmod +x /init
-
-ADD liveness.sh /liveness.sh
-RUN chmod +x /liveness.sh
 
 CMD ["/init"]

--- a/deploy/docker/cp-notifier/Dockerfile
+++ b/deploy/docker/cp-notifier/Dockerfile
@@ -34,6 +34,7 @@ ADD liveness.sh /liveness.sh
 RUN chmod +x /liveness.sh
 
 ENV CP_NOTIFIER_HOME="/opt/notifier"
+RUN mkdir -p $CP_NOTIFIER_HOME
 ADD config $CP_NOTIFIER_HOME/config
 
 # API distribution
@@ -42,7 +43,6 @@ ARG CP_API_DIST_URL=""
 RUN cd /tmp && \
     wget -q "$CP_API_DIST_URL" -O cloud-pipeline.tgz && \
     tar -zxf cloud-pipeline.tgz && \
-    mkdir -p $CP_NOTIFIER_HOME && \
     mv bin/notifier.jar $CP_NOTIFIER_HOME/ && \
     rm -rf /tmp/*
 

--- a/deploy/docker/cp-search/Dockerfile
+++ b/deploy/docker/cp-search/Dockerfile
@@ -43,18 +43,8 @@ RUN cd /tmp && \
     package-cleanup --cleandupes -y && \
     rm -rf lustre-client*
 
-# API distribution
-ARG CP_API_DIST_URL=""
 ENV CP_SEARCH_HOME="/opt/search"
 ENV CP_SEARCH_MAPPINGS_LOCATION="$CP_SEARCH_HOME/search-mappings"
-RUN cd /tmp && \
-    wget -q "$CP_API_DIST_URL" -O cloud-pipeline.tgz && \
-    tar -zxf cloud-pipeline.tgz && \
-    mkdir -p $CP_SEARCH_HOME && \
-    mv bin/elasticsearch-agent.jar $CP_SEARCH_HOME/ && \
-    mv bin/search-mappings $CP_SEARCH_MAPPINGS_LOCATION && \
-    rm -rf /tmp/*
-
 ADD config $CP_SEARCH_HOME/config
 
 ADD init /init
@@ -62,5 +52,14 @@ RUN chmod +x /init
 
 ADD liveness.sh /liveness.sh
 RUN chmod +x /liveness.sh
+# API distribution
+ARG CP_API_DIST_URL=""
+RUN cd /tmp && \
+    wget -q "$CP_API_DIST_URL" -O cloud-pipeline.tgz && \
+    tar -zxf cloud-pipeline.tgz && \
+    mkdir -p $CP_SEARCH_HOME && \
+    mv bin/elasticsearch-agent.jar $CP_SEARCH_HOME/ && \
+    mv bin/search-mappings $CP_SEARCH_MAPPINGS_LOCATION && \
+    rm -rf /tmp/*
 
 CMD ["/init"]

--- a/deploy/docker/cp-search/Dockerfile
+++ b/deploy/docker/cp-search/Dockerfile
@@ -44,6 +44,7 @@ RUN cd /tmp && \
     rm -rf lustre-client*
 
 ENV CP_SEARCH_HOME="/opt/search"
+RUN mkdir -p $CP_SEARCH_HOME
 ENV CP_SEARCH_MAPPINGS_LOCATION="$CP_SEARCH_HOME/search-mappings"
 ADD config $CP_SEARCH_HOME/config
 
@@ -57,7 +58,6 @@ ARG CP_API_DIST_URL=""
 RUN cd /tmp && \
     wget -q "$CP_API_DIST_URL" -O cloud-pipeline.tgz && \
     tar -zxf cloud-pipeline.tgz && \
-    mkdir -p $CP_SEARCH_HOME && \
     mv bin/elasticsearch-agent.jar $CP_SEARCH_HOME/ && \
     mv bin/search-mappings $CP_SEARCH_MAPPINGS_LOCATION && \
     rm -rf /tmp/*

--- a/deploy/docker/cp-share-srv/Dockerfile
+++ b/deploy/docker/cp-share-srv/Dockerfile
@@ -32,11 +32,16 @@ RUN yum install -y \
                 unzip \
                 openssl
 
+ENV CP_SHARE_HOME="/opt/share-srv"
+ADD config $CP_SHARE_HOME/config
+ADD init /init
+ADD update-trust /update-trust
+
+RUN chmod +x /init* && \
+    chmod +x /update-trust
 
 # SHARE distribution
 ARG CP_API_DIST_URL=""
-ENV CP_SHARE_HOME="/opt/share-srv"
-
 RUN cd /tmp && \
      wget -q "$CP_API_DIST_URL" -O cloud-pipeline.tgz && \
      tar -zxf cloud-pipeline.tgz && \
@@ -44,13 +49,6 @@ RUN cd /tmp && \
      mv bin/data-sharing-service.jar $CP_SHARE_HOME/ && \
      rm -f cloud-pipeline.tgz && \
      rm -rf bin
-
-ADD config $CP_SHARE_HOME/config
-ADD init /init
-ADD update-trust /update-trust
-
-RUN chmod +x /init* && \
-    chmod +x /update-trust
 
 WORKDIR /opt/share-srv
 

--- a/deploy/docker/cp-share-srv/Dockerfile
+++ b/deploy/docker/cp-share-srv/Dockerfile
@@ -33,6 +33,7 @@ RUN yum install -y \
                 openssl
 
 ENV CP_SHARE_HOME="/opt/share-srv"
+RUN mkdir -p $CP_SHARE_HOME
 ADD config $CP_SHARE_HOME/config
 ADD init /init
 ADD update-trust /update-trust
@@ -45,11 +46,10 @@ ARG CP_API_DIST_URL=""
 RUN cd /tmp && \
      wget -q "$CP_API_DIST_URL" -O cloud-pipeline.tgz && \
      tar -zxf cloud-pipeline.tgz && \
-     mkdir -p $CP_SHARE_HOME && \
      mv bin/data-sharing-service.jar $CP_SHARE_HOME/ && \
      rm -f cloud-pipeline.tgz && \
      rm -rf bin
 
-WORKDIR /opt/share-srv
+WORKDIR $CP_SHARE_HOME
 
 CMD ["/init"]

--- a/deploy/docker/cp-vm-monitor/Dockerfile
+++ b/deploy/docker/cp-vm-monitor/Dockerfile
@@ -30,6 +30,7 @@ RUN yum install -y \
 ENV CP_VM_MONITOR_HOME="/opt/vm-monitor" \
     CP_VM_MONITOR_TEMPLATES_LOCATION="${CP_VM_MONITOR_HOME}/templates"
 
+RUN mkdir -p $CP_VM_MONITOR_HOME
 ADD config $CP_VM_MONITOR_HOME/config
 
 ADD init /init
@@ -39,7 +40,6 @@ ARG CP_API_DIST_URL=""
 RUN cd /tmp && \
     wget -q "$CP_API_DIST_URL" -O cloud-pipeline.tgz && \
     tar -zxf cloud-pipeline.tgz && \
-    mkdir -p $CP_VM_MONITOR_HOME && \
     mv bin/vm-monitor.jar $CP_VM_MONITOR_HOME/ && \
     mv bin/vm-monitor-templates ${CP_VM_MONITOR_TEMPLATES_LOCATION} && \
     rm -rf /tmp/*

--- a/deploy/docker/cp-vm-monitor/Dockerfile
+++ b/deploy/docker/cp-vm-monitor/Dockerfile
@@ -27,10 +27,15 @@ RUN yum install -y \
                 python \
                 unzip
 
-# API distribution
-ARG CP_API_DIST_URL=""
 ENV CP_VM_MONITOR_HOME="/opt/vm-monitor" \
     CP_VM_MONITOR_TEMPLATES_LOCATION="${CP_VM_MONITOR_HOME}/templates"
+
+ADD config $CP_VM_MONITOR_HOME/config
+
+ADD init /init
+RUN chmod +x /init                
+# API distribution
+ARG CP_API_DIST_URL=""
 RUN cd /tmp && \
     wget -q "$CP_API_DIST_URL" -O cloud-pipeline.tgz && \
     tar -zxf cloud-pipeline.tgz && \
@@ -38,10 +43,5 @@ RUN cd /tmp && \
     mv bin/vm-monitor.jar $CP_VM_MONITOR_HOME/ && \
     mv bin/vm-monitor-templates ${CP_VM_MONITOR_TEMPLATES_LOCATION} && \
     rm -rf /tmp/*
-
-ADD config $CP_VM_MONITOR_HOME/config
-
-ADD init /init
-RUN chmod +x /init
 
 CMD ["/init"]


### PR DESCRIPTION
Reorder Dockerfile layers in cp-api-srv, cp-billing-srv, cp-docker-comp, cp-gitlab-reader, cp-notifier, cp-search, cp-share-srv, and cp-vm-monitor to maximize cache hit rate.                                                                                                                                                          
Key changes:                                                                                                                                                        
  - Move static layers (config files, init scripts, templates, filebeat) before ARG CP_API_DIST_URL so they remain cached across builds when only the distribution URL changes                                                                                                                                                            
  - Move cp-search ENV CP_SEARCH_MAPPINGS_LOCATION before the ARG cache-bust point 