### PR TITLE
Issue #4461: Introduce Platform Usage Credits to optimize costs - users credits

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/credits/PlatformUsageCreditsUserBalanceApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/credits/PlatformUsageCreditsUserBalanceApiService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.acl.credits;
+
+import com.epam.pipeline.controller.PagedResult;
+import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalance;
+import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalanceFilterVO;
+import com.epam.pipeline.manager.credits.PlatformUsageCreditsUserBalanceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static com.epam.pipeline.security.acl.AclExpressions.ADMIN_ONLY;
+
+@Service
+@RequiredArgsConstructor
+public class PlatformUsageCreditsUserBalanceApiService {
+
+    private final PlatformUsageCreditsUserBalanceService manager;
+
+    @PreAuthorize(ADMIN_ONLY)
+    public PagedResult<List<PlatformUsageCreditsUserBalance>> filter(
+            final PlatformUsageCreditsUserBalanceFilterVO filter) {
+        return manager.filter(filter);
+    }
+
+    @PreAuthorize(ADMIN_ONLY)
+    public void reset(final int value, final Long userId) {
+        manager.reset(value, userId);
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/acl/credits/PlatformUsageCreditsUserBalanceApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/credits/PlatformUsageCreditsUserBalanceApiService.java
@@ -20,6 +20,7 @@ import com.epam.pipeline.controller.PagedResult;
 import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalance;
 import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalanceFilterVO;
 import com.epam.pipeline.manager.credits.PlatformUsageCreditsUserBalanceService;
+import io.reactivex.annotations.Nullable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
@@ -41,7 +42,7 @@ public class PlatformUsageCreditsUserBalanceApiService {
     }
 
     @PreAuthorize(ADMIN_ONLY)
-    public void reset(final int value, final Long userId) {
-        manager.reset(value, userId);
+    public void reset(final int value, @Nullable final List<Long> userIds) {
+        manager.reset(value, userIds);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/acl/credits/PlatformUsageCreditsUserBalanceApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/credits/PlatformUsageCreditsUserBalanceApiService.java
@@ -20,11 +20,11 @@ import com.epam.pipeline.controller.PagedResult;
 import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalance;
 import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalanceFilterVO;
 import com.epam.pipeline.manager.credits.PlatformUsageCreditsUserBalanceService;
-import io.reactivex.annotations.Nullable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 import static com.epam.pipeline.security.acl.AclExpressions.ADMIN_ONLY;

--- a/api/src/main/java/com/epam/pipeline/acl/user/UserApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/user/UserApiService.java
@@ -29,6 +29,7 @@ import com.epam.pipeline.entity.user.ImpersonationStatus;
 import com.epam.pipeline.entity.user.PipelineUser;
 import com.epam.pipeline.entity.user.PipelineUserEvent;
 import com.epam.pipeline.entity.user.RunnerSid;
+import com.epam.pipeline.manager.credits.PlatformUsageCreditsUserBalanceService;
 import com.epam.pipeline.manager.quota.RunLimitsService;
 import com.epam.pipeline.manager.security.AuthManager;
 import com.epam.pipeline.manager.security.JwtTokenRevocationManager;
@@ -79,6 +80,9 @@ public class UserApiService {
 
     @Autowired
     private JwtTokenRevocationManager jwtTokenRevocationManager;
+
+    @Autowired
+    private PlatformUsageCreditsUserBalanceService platformUsageCreditsUserBalanceService;
 
     /**
      * Registers a new user
@@ -137,8 +141,8 @@ public class UserApiService {
 
     @PreAuthorize(ADMIN_ONLY + OR_USER_READER + OR + USER_ADMIN_ONLY + OR + USER_READ_PERMISSION)
     @AclMask
-    public PipelineUser loadUser(Long id, final boolean quotas) {
-        return userManager.load(id, quotas);
+    public PipelineUser loadUser(final Long id, final boolean quotas, final boolean loadCredits) {
+        return userManager.load(id, quotas, loadCredits);
     }
 
     @PostAuthorize(ADMIN_ONLY+ OR + USER_ADMIN_ONLY + OR_USER_READER + OR + "hasPermission(returnObject, 'READ')")
@@ -159,14 +163,14 @@ public class UserApiService {
 
     @PostFilter(USER_READ_FILTER)
     @AclMaskList
-    public List<PipelineUser> loadUsers(final boolean loadQuotas) {
-        return new ArrayList<>(userManager.loadAllUsers(loadQuotas));
+    public List<PipelineUser> loadUsers(final boolean loadQuotas, final boolean loadCredits) {
+        return new ArrayList<>(userManager.loadAllUsers(loadQuotas, loadCredits));
     }
 
     @PostFilter(USER_READ_FILTER)
     @AclMaskList
-    public List<PipelineUser> loadUsersWithActivityStatus(final boolean loadQuotas) {
-        return new ArrayList<>(userManager.loadUsersWithActivityStatus(loadQuotas));
+    public List<PipelineUser> loadUsersWithActivityStatus(final boolean loadQuotas, final boolean loadCredits) {
+        return new ArrayList<>(userManager.loadUsersWithActivityStatus(loadQuotas, loadCredits));
     }
 
     //TODO
@@ -176,7 +180,12 @@ public class UserApiService {
     }
 
     public PipelineUser getCurrentUser() {
-        return userManager.getCurrentUser();
+        final PipelineUser user = userManager.getCurrentUser();
+        if (user != null) {
+            platformUsageCreditsUserBalanceService.findByUserId(user.getId())
+                    .ifPresent(user::setUsageCredits);
+        }
+        return user;
     }
 
     /**

--- a/api/src/main/java/com/epam/pipeline/app/MappersConfiguration.java
+++ b/api/src/main/java/com/epam/pipeline/app/MappersConfiguration.java
@@ -23,6 +23,7 @@ import com.epam.pipeline.mapper.cluster.pool.NodePoolUsageMapper;
 import com.epam.pipeline.mapper.cluster.pool.NodeScheduleMapper;
 import com.epam.pipeline.mapper.cluster.pool.NodePoolMapper;
 import com.epam.pipeline.mapper.credits.PlatformUsageCreditsRuleMapper;
+import com.epam.pipeline.mapper.credits.PlatformUsageCreditsUserBalanceMapper;
 import com.epam.pipeline.mapper.datastorage.lifecycle.StorageLifecycleEntityMapper;
 import com.epam.pipeline.mapper.git.AzureDevOpsMapper;
 import com.epam.pipeline.mapper.git.BitbucketCloudMapper;
@@ -195,5 +196,10 @@ public class MappersConfiguration {
     @Bean
     public PlatformUsageCreditsRuleMapper platformUsageCreditsRuleMapper() {
         return Mappers.getMapper(PlatformUsageCreditsRuleMapper.class);
+    }
+
+    @Bean
+    public PlatformUsageCreditsUserBalanceMapper platformUsageCreditsUserBalanceMapper() {
+        return Mappers.getMapper(PlatformUsageCreditsUserBalanceMapper.class);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/credits/PlatformUsageCreditsUserBalanceController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/credits/PlatformUsageCreditsUserBalanceController.java
@@ -61,7 +61,7 @@ public class PlatformUsageCreditsUserBalanceController extends AbstractRestContr
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
     public Result<Void> reset(@RequestParam final int value,
-                              @RequestParam(required = false) final List<Long> userIds) {
+                              @RequestBody(required = false) final List<Long> userIds) {
         apiService.reset(value, userIds);
         return Result.success(null);
     }

--- a/api/src/main/java/com/epam/pipeline/controller/credits/PlatformUsageCreditsUserBalanceController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/credits/PlatformUsageCreditsUserBalanceController.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017-2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.controller.credits;
+
+import com.epam.pipeline.acl.credits.PlatformUsageCreditsUserBalanceApiService;
+import com.epam.pipeline.controller.AbstractRestController;
+import com.epam.pipeline.controller.PagedResult;
+import com.epam.pipeline.controller.Result;
+import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalance;
+import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalanceFilterVO;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@Api(value = "Platform usage credits user balances management")
+@RequestMapping("/usage/credits/users")
+@RequiredArgsConstructor
+public class PlatformUsageCreditsUserBalanceController extends AbstractRestController {
+
+    private final PlatformUsageCreditsUserBalanceApiService apiService;
+
+    @PostMapping
+    @ApiOperation(
+            value = "Loads current user balances with optional filters. Admin only.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<PagedResult<List<PlatformUsageCreditsUserBalance>>> filter(
+            @RequestBody final PlatformUsageCreditsUserBalanceFilterVO filter) {
+        return Result.success(apiService.filter(filter));
+    }
+
+    @PostMapping("/reset")
+    @ApiOperation(
+            value = "Resets the credits balance for a specific user, or for all users if userId is omitted. "
+                    + "Admin only.",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
+    public Result<Void> reset(@RequestParam final int value,
+                              @RequestParam(required = false) final Long userId) {
+        apiService.reset(value, userId);
+        return Result.success(null);
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/controller/credits/PlatformUsageCreditsUserBalanceController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/credits/PlatformUsageCreditsUserBalanceController.java
@@ -56,13 +56,13 @@ public class PlatformUsageCreditsUserBalanceController extends AbstractRestContr
 
     @PostMapping("/reset")
     @ApiOperation(
-            value = "Resets the credits balance for a specific user, or for all users if userId is omitted. "
+            value = "Resets the credits balance for specific users, or for all users if userIds is omitted. "
                     + "Admin only.",
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
     public Result<Void> reset(@RequestParam final int value,
-                              @RequestParam(required = false) final Long userId) {
-        apiService.reset(value, userId);
+                              @RequestParam(required = false) final List<Long> userIds) {
+        apiService.reset(value, userIds);
         return Result.success(null);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/user/UserController.java
@@ -239,8 +239,9 @@ public class UserController extends AbstractRestController {
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
             })
     public Result<PipelineUser> loadUser(@PathVariable Long id,
-                                         @RequestParam(defaultValue = FALSE) final boolean quotas) {
-        return Result.success(userApiService.loadUser(id, quotas));
+                                         @RequestParam(defaultValue = FALSE) final boolean quotas,
+                                         @RequestParam(defaultValue = FALSE) final boolean credits) {
+        return Result.success(userApiService.loadUser(id, quotas, credits));
     }
 
     @GetMapping(value = "/user")
@@ -293,10 +294,11 @@ public class UserController extends AbstractRestController {
             value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)
             })
     public Result<List<PipelineUser>> loadUsers(@RequestParam(defaultValue = FALSE) final boolean activity,
-                                                @RequestParam(defaultValue = FALSE) final boolean quotas) {
+                                                @RequestParam(defaultValue = FALSE) final boolean quotas,
+                                                @RequestParam(defaultValue = FALSE) final boolean credits) {
         return Result.success(activity
-                ? userApiService.loadUsersWithActivityStatus(quotas)
-                : userApiService.loadUsers(quotas));
+                ? userApiService.loadUsersWithActivityStatus(quotas, credits)
+                : userApiService.loadUsers(quotas, credits));
     }
 
     @GetMapping(value = "/users/info")

--- a/api/src/main/java/com/epam/pipeline/controller/vo/PipelineUserExportVO.java
+++ b/api/src/main/java/com/epam/pipeline/controller/vo/PipelineUserExportVO.java
@@ -35,6 +35,7 @@ public class PipelineUserExportVO {
     private boolean includeFirstLoginDate;
     private boolean includeHeader;
     private boolean includeAttributes;
+    private boolean includeCredits;
     private List<String> metadataColumns;
     private LocalDate from;
     private LocalDate to;

--- a/api/src/main/java/com/epam/pipeline/entity/credits/PlatformUsageCreditsUserBalanceEntity.java
+++ b/api/src/main/java/com/epam/pipeline/entity/credits/PlatformUsageCreditsUserBalanceEntity.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.entity.credits;
+
+import com.epam.pipeline.entity.utils.TimestampConverter;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@Table(name = "usage_credits_user_balance", schema = "pipeline")
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlatformUsageCreditsUserBalanceEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false, unique = true)
+    private Long userId;
+
+    @Column(name = "current_value", nullable = false)
+    private int currentValue;
+
+    @Convert(converter = TimestampConverter.class)
+    @Column(name = "modified_date", nullable = false)
+    private LocalDateTime modifiedDate;
+}

--- a/api/src/main/java/com/epam/pipeline/entity/user/PipelineUserWithStoragePath.java
+++ b/api/src/main/java/com/epam/pipeline/entity/user/PipelineUserWithStoragePath.java
@@ -46,7 +46,8 @@ public class PipelineUserWithStoragePath {
         FIRST_LOGIN_DATE("firstLoginDate"),
         ATTRIBUTES("attributes"),
         DEFAULT_STORAGE_ID("defaultStorageId"),
-        DEFAULT_STORAGE_PATH("defaultStoragePath");
+        DEFAULT_STORAGE_PATH("defaultStoragePath"),
+        USAGE_CREDITS("usageCredits");
 
         private final String value;
 

--- a/api/src/main/java/com/epam/pipeline/manager/contextual/ContextualPreferenceManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/contextual/ContextualPreferenceManager.java
@@ -164,6 +164,29 @@ public class ContextualPreferenceManager {
     }
 
     /**
+     * Searches for a contextual preference using an explicit target user as the lookup context
+     * instead of the currently authenticated user.
+     *
+     * <p>Useful when the caller (e.g. a background monitoring service) is not the user whose
+     * preferences should be consulted. The USER- and ROLE-level resources are built from the
+     * target user's data, so any per-user or per-role overrides are correctly honoured.
+     *
+     * @param preferences list of preference key names to search
+     * @param userId      ID of the user whose USER- and ROLE-level overrides should be consulted
+     * @throws IllegalArgumentException if no preference is found
+     */
+    public ContextualPreference search(final List<String> preferences, final Long userId) {
+        validateNames(preferences);
+        final PipelineUser targetUser = userManager.load(userId);
+        final List<ContextualPreferenceExternalResource> allResources = new ArrayList<>();
+        allResources.add(userResource(targetUser));
+        allResources.addAll(rolesResources(targetUser.getRoles()));
+        return contextualPreferenceHandler.search(preferences, allResources)
+                .orElseThrow(() -> new IllegalArgumentException(messageHelper.getMessage(
+                        MessageConstants.ERROR_CONTEXTUAL_PREFERENCE_NOT_FOUND, preferences, userId)));
+    }
+
+    /**
      * Searches for a contextual preference with the given parameters
      *
      * Returns a first found preference from the list of preferences.

--- a/api/src/main/java/com/epam/pipeline/manager/contextual/ContextualPreferenceManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/contextual/ContextualPreferenceManager.java
@@ -164,26 +164,21 @@ public class ContextualPreferenceManager {
     }
 
     /**
-     * Searches for a contextual preference using an explicit target user as the lookup context
-     * instead of the currently authenticated user.
-     *
-     * <p>Useful when the caller (e.g. a background monitoring service) is not the user whose
-     * preferences should be consulted. The USER- and ROLE-level resources are built from the
-     * target user's data, so any per-user or per-role overrides are correctly honoured.
+     * Searches for a contextual preference using an already-loaded user as the lookup context.
+     * Prefer this overload when the caller has already loaded the user to avoid a redundant DB call.
      *
      * @param preferences list of preference key names to search
-     * @param userId      ID of the user whose USER- and ROLE-level overrides should be consulted
+     * @param user        the user whose USER- and ROLE-level overrides should be consulted
      * @throws IllegalArgumentException if no preference is found
      */
-    public ContextualPreference search(final List<String> preferences, final Long userId) {
+    public ContextualPreference search(final List<String> preferences, final PipelineUser user) {
         validateNames(preferences);
-        final PipelineUser targetUser = userManager.load(userId);
         final List<ContextualPreferenceExternalResource> allResources = new ArrayList<>();
-        allResources.add(userResource(targetUser));
-        allResources.addAll(rolesResources(targetUser.getRoles()));
+        allResources.add(userResource(user));
+        allResources.addAll(rolesResources(user.getRoles()));
         return contextualPreferenceHandler.search(preferences, allResources)
                 .orElseThrow(() -> new IllegalArgumentException(messageHelper.getMessage(
-                        MessageConstants.ERROR_CONTEXTUAL_PREFERENCE_NOT_FOUND, preferences, userId)));
+                        MessageConstants.ERROR_CONTEXTUAL_PREFERENCE_NOT_FOUND, preferences, user.getId())));
     }
 
     /**

--- a/api/src/main/java/com/epam/pipeline/manager/credits/PlatformUsageCreditsUserBalanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/credits/PlatformUsageCreditsUserBalanceService.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017-2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.credits;
+
+import com.epam.pipeline.controller.PagedResult;
+import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalance;
+import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalanceFilterVO;
+import com.epam.pipeline.entity.credits.PlatformUsageCreditsUserBalanceEntity;
+import com.epam.pipeline.entity.utils.DateUtils;
+import com.epam.pipeline.mapper.credits.PlatformUsageCreditsUserBalanceMapper;
+import com.epam.pipeline.repository.credits.PlatformUsageCreditsUserBalanceRepository;
+import com.epam.pipeline.repository.credits.PlatformUsageCreditsUserBalanceSpecification;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.Nullable;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Business-logic layer for platform usage credits user balances.
+ *
+ * <p>A user balance tracks the current credits held by a specific pipeline user and is updated
+ * whenever the monitoring service fires a credits event (increase or deduction).
+ *
+ */
+@Service
+@RequiredArgsConstructor
+public class PlatformUsageCreditsUserBalanceService {
+
+    private final PlatformUsageCreditsUserBalanceRepository repository;
+    private final PlatformUsageCreditsUserBalanceMapper mapper;
+
+    /**
+     * Returns a paged, optionally filtered list of user balances.
+     * This method supports three optional predicates, all
+     * translated to SQL so that paging counts are always accurate:
+     * <ul>
+     *   <li>{@code userIds} — restrict results to a specific set of users</li>
+     *   <li>{@code value} + {@code operation} ({@code "<"}, {@code ">"}, {@code "="}) — compare
+     *       the stored {@code current_value} against the given threshold at the database level</li>
+     * </ul>
+     * @param filter filter criteria; {@code page} and {@code pageSize} are always applied
+     * @return paged result containing matching balance DTOs and the total count
+     */
+    public PagedResult<List<PlatformUsageCreditsUserBalance>> filter(
+            final PlatformUsageCreditsUserBalanceFilterVO filter) {
+        final Page<PlatformUsageCreditsUserBalanceEntity> page =
+                repository.findAll(PlatformUsageCreditsUserBalanceSpecification.build(filter),
+                        new PageRequest(filter.getPage(), filter.getPageSize()));
+        final List<PlatformUsageCreditsUserBalance> elements = page.getContent().stream()
+                .map(mapper::toDto)
+                .collect(Collectors.toList());
+        return new PagedResult<>(elements, (int) page.getTotalElements());
+    }
+
+    /**
+     * Resets the credits balance to {@code value}.
+     * This method either updates one user's balance (when {@code userId} is
+     * supplied) or bulk-updates every row in the table (when {@code userId} is {@code null}).
+     * If the target user has no existing balance row it is created on the fly.
+     *
+     * <p>When {@code userId} is non-null, only that user's row is updated (created if absent).
+     * When {@code userId} is {@code null}, every existing balance row is updated in a single
+     * bulk statement.
+     *
+     * @param value  the new credits balance to set
+     * @param userId the target user, or {@code null} to reset all users
+     */
+    @Transactional
+    public void reset(final int value, @Nullable final Long userId) {
+        final LocalDateTime now = DateUtils.nowUTC();
+        if (userId != null) {
+            final PlatformUsageCreditsUserBalanceEntity entity = repository.findByUserId(userId)
+                    .orElseGet(() -> PlatformUsageCreditsUserBalanceEntity.builder().userId(userId).build());
+            entity.setCurrentValue(value);
+            entity.setModifiedDate(now);
+            repository.save(entity);
+        } else {
+            repository.resetAll(value, now);
+        }
+    }
+}

--- a/api/src/main/java/com/epam/pipeline/manager/credits/PlatformUsageCreditsUserBalanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/credits/PlatformUsageCreditsUserBalanceService.java
@@ -24,6 +24,7 @@ import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalanceFilterVO;
 import com.epam.pipeline.entity.credits.PlatformUsageCreditsUserBalanceEntity;
 import com.epam.pipeline.entity.utils.DateUtils;
 import com.epam.pipeline.manager.contextual.ContextualPreferenceManager;
+import com.epam.pipeline.manager.notification.NotificationManager;
 import com.epam.pipeline.manager.preference.AbstractSystemPreference;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.mapper.credits.PlatformUsageCreditsUserBalanceMapper;
@@ -31,6 +32,8 @@ import com.epam.pipeline.repository.credits.PlatformUsageCreditsUserBalanceRepos
 import com.epam.pipeline.repository.credits.PlatformUsageCreditsUserBalanceSpecification;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -63,6 +66,10 @@ public class PlatformUsageCreditsUserBalanceService {
     private final PlatformUsageCreditsUserBalanceRepository repository;
     private final PlatformUsageCreditsUserBalanceMapper mapper;
     private final ContextualPreferenceManager contextualPreferenceManager;
+
+    @Autowired
+    @Lazy
+    private NotificationManager notificationManager;
 
     /**
      * Returns a paged, optionally filtered list of user balances.
@@ -183,6 +190,10 @@ public class PlatformUsageCreditsUserBalanceService {
         entity.setModifiedDate(DateUtils.nowUTC());
         repository.save(entity);
 
+        if (!isNotificationThresholdExceeded(clampedBalance, event.getUserId())) {
+            notificationManager.notifyLowUsageCredits(event.getUserId(), clampedBalance);
+        }
+
         return event;
     }
 
@@ -206,5 +217,13 @@ public class PlatformUsageCreditsUserBalanceService {
         entity.setCurrentValue(value);
         entity.setModifiedDate(now);
         repository.save(entity);
+    }
+
+    private boolean isNotificationThresholdExceeded(final int currentValue, final Long userId) {
+        final int min = getIntPreference(SystemPreferences.USAGE_CREDITS_MIN, userId);
+        final int max = getIntPreference(SystemPreferences.USAGE_CREDITS_MAX, userId);
+        final int threshold = getIntPreference(SystemPreferences.USAGE_CREDITS_NOTIFICATION_THRESHOLD, userId);
+        final double absoluteValue = min + (threshold / 100.0) * (max - min);
+        return currentValue >= absoluteValue;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/credits/PlatformUsageCreditsUserBalanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/credits/PlatformUsageCreditsUserBalanceService.java
@@ -42,8 +42,11 @@ import javax.annotation.Nullable;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 /**
  * Business-logic layer for platform usage credits user balances.
@@ -82,6 +85,28 @@ public class PlatformUsageCreditsUserBalanceService {
                 .map(mapper::toDto)
                 .collect(Collectors.toList());
         return new PagedResult<>(elements, (int) page.getTotalElements());
+    }
+
+    /**
+     * Returns the credits balance for a single user, or empty if no record exists yet.
+     *
+     * @param userId the user whose balance to look up
+     * @return the balance DTO, or {@link Optional#empty()} if no row exists for the user
+     */
+    public Optional<PlatformUsageCreditsUserBalance> findByUserId(final Long userId) {
+        return repository.findByUserId(userId).map(mapper::toDto);
+    }
+
+    /**
+     * Returns all recorded balances keyed by {@code userId}.
+     * Intended for bulk enrichment to avoid N+1 queries.
+     *
+     * @return map from userId to the corresponding balance DTO
+     */
+    public Map<Long, PlatformUsageCreditsUserBalance> findAllAsMap() {
+        return StreamSupport.stream(repository.findAll().spliterator(), false)
+                .map(mapper::toDto)
+                .collect(Collectors.toMap(PlatformUsageCreditsUserBalance::getUserId, Function.identity()));
     }
 
     /**

--- a/api/src/main/java/com/epam/pipeline/manager/credits/PlatformUsageCreditsUserBalanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/credits/PlatformUsageCreditsUserBalanceService.java
@@ -17,22 +17,32 @@
 package com.epam.pipeline.manager.credits;
 
 import com.epam.pipeline.controller.PagedResult;
+import com.epam.pipeline.dto.credits.PlatformUsageCreditsUpdateAction.ActionType;
+import com.epam.pipeline.dto.credits.PlatformUsageCreditsUpdateEvent;
 import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalance;
 import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalanceFilterVO;
 import com.epam.pipeline.entity.credits.PlatformUsageCreditsUserBalanceEntity;
 import com.epam.pipeline.entity.utils.DateUtils;
+import com.epam.pipeline.manager.contextual.ContextualPreferenceManager;
+import com.epam.pipeline.manager.preference.AbstractSystemPreference;
+import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.mapper.credits.PlatformUsageCreditsUserBalanceMapper;
 import com.epam.pipeline.repository.credits.PlatformUsageCreditsUserBalanceRepository;
 import com.epam.pipeline.repository.credits.PlatformUsageCreditsUserBalanceSpecification;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import org.apache.commons.collections4.CollectionUtils;
+
 import javax.annotation.Nullable;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -42,12 +52,14 @@ import java.util.stream.Collectors;
  * whenever the monitoring service fires a credits event (increase or deduction).
  *
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PlatformUsageCreditsUserBalanceService {
 
     private final PlatformUsageCreditsUserBalanceRepository repository;
     private final PlatformUsageCreditsUserBalanceMapper mapper;
+    private final ContextualPreferenceManager contextualPreferenceManager;
 
     /**
      * Returns a paged, optionally filtered list of user balances.
@@ -73,29 +85,101 @@ public class PlatformUsageCreditsUserBalanceService {
     }
 
     /**
-     * Resets the credits balance to {@code value}.
-     * This method either updates one user's balance (when {@code userId} is
-     * supplied) or bulk-updates every row in the table (when {@code userId} is {@code null}).
-     * If the target user has no existing balance row it is created on the fly.
+     * Resets the credits balance to {@code value} for each user in {@code userIds}.
      *
-     * <p>When {@code userId} is non-null, only that user's row is updated (created if absent).
-     * When {@code userId} is {@code null}, every existing balance row is updated in a single
-     * bulk statement.
+     * <p>When {@code userIds} is non-empty, the value is first validated against each user's
+     * contextual {@code [usage.credits.min, usage.credits.max]} bounds. If the value falls outside
+     * the bounds for any user, an {@link IllegalArgumentException} is thrown and no rows are
+     * modified. When all validations pass, each user's balance row is upserted.
      *
-     * @param value  the new credits balance to set
-     * @param userId the target user, or {@code null} to reset all users
+     * <p>When {@code userIds} is {@code null} or empty, every existing balance row is updated in
+     * a single bulk statement with no per-user validation.
+     *
+     * @param value   the new credits balance to set
+     * @param userIds the target users, or {@code null}/empty to reset all users
+     * @throws IllegalArgumentException if {@code value} is outside the allowed bounds for any user
      */
     @Transactional
-    public void reset(final int value, @Nullable final Long userId) {
+    public void reset(final int value, @Nullable final List<Long> userIds) {
         final LocalDateTime now = DateUtils.nowUTC();
-        if (userId != null) {
-            final PlatformUsageCreditsUserBalanceEntity entity = repository.findByUserId(userId)
-                    .orElseGet(() -> PlatformUsageCreditsUserBalanceEntity.builder().userId(userId).build());
-            entity.setCurrentValue(value);
-            entity.setModifiedDate(now);
-            repository.save(entity);
+        if (CollectionUtils.isNotEmpty(userIds)) {
+            userIds.forEach(userId -> validateResetValue(value, userId));
+            userIds.forEach(userId -> upsertBalance(value, now, userId));
         } else {
-            repository.resetAll(value, now);
+            repository.resetAll(value);
         }
+    }
+
+    /**
+     * Applies a credits event to the user's balance and returns the event with the actual amount
+     * applied (which may be less than {@code event.getValue()} when the balance would otherwise
+     * exceed the configured bounds).
+     *
+     * <p>If the user has no balance row yet, the configured default ({@code usage.credits.default})
+     * is used as the starting value. The resulting balance is always clamped to
+     * [{@code usage.credits.min}, {@code usage.credits.max}].
+     *
+     * <p>If the actual amount applied is 0 (balance already at the boundary in the direction of the
+     * event), nothing is written to the database and the returned event has {@code value = 0}.
+     *
+     * @param event the event to apply; {@code value} must be positive; direction is {@code incidentType}
+     * @return a copy of the event with {@code value} set to the actual amount applied
+     */
+    @Transactional
+    public PlatformUsageCreditsUpdateEvent updateByEvent(final PlatformUsageCreditsUpdateEvent event) {
+        final Optional<PlatformUsageCreditsUserBalanceEntity> existing =
+                repository.findByUserId(event.getUserId());
+        final int currentBalance = existing
+                .map(PlatformUsageCreditsUserBalanceEntity::getCurrentValue)
+                .orElseGet(() -> getIntPreference(SystemPreferences.USAGE_CREDITS_DEFAULT, event.getUserId()));
+
+        final int minBalance = getIntPreference(SystemPreferences.USAGE_CREDITS_MIN, event.getUserId());
+        final int maxBalance = getIntPreference(SystemPreferences.USAGE_CREDITS_MAX, event.getUserId());
+
+        final int rawNewBalance = ActionType.INCREASE.equals(event.getIncidentType())
+                ? currentBalance + event.getValue()
+                : currentBalance - event.getValue();
+
+        final int clampedBalance = Math.max(minBalance, Math.min(maxBalance, rawNewBalance));
+        final int actualValue = Math.abs(clampedBalance - currentBalance);
+        event.setValue(actualValue);
+
+        if (actualValue == 0) {
+            log.info("Credits event for user {} has no effect: balance already at boundary {}",
+                    event.getUserId(), currentBalance);
+            return event;
+        }
+
+        final PlatformUsageCreditsUserBalanceEntity entity = existing
+                .orElseGet(() -> PlatformUsageCreditsUserBalanceEntity.builder()
+                        .userId(event.getUserId())
+                        .build());
+        entity.setCurrentValue(clampedBalance);
+        entity.setModifiedDate(DateUtils.nowUTC());
+        repository.save(entity);
+
+        return event;
+    }
+
+    private int getIntPreference(final AbstractSystemPreference.IntPreference intPreference, final Long userId) {
+        return Integer.parseInt(contextualPreferenceManager.search(
+                Collections.singletonList(intPreference.getKey()), userId).getValue());
+    }
+
+    private void validateResetValue(final int value, final Long userId) {
+        final int min = getIntPreference(SystemPreferences.USAGE_CREDITS_MIN, userId);
+        final int max = getIntPreference(SystemPreferences.USAGE_CREDITS_MAX, userId);
+        if (value < min || value > max) {
+            throw new IllegalArgumentException(String.format(
+                    "Reset value %d is out of allowed range [%d, %d] for user %d", value, min, max, userId));
+        }
+    }
+
+    private void upsertBalance(final int value, final LocalDateTime now, final Long userId) {
+        final PlatformUsageCreditsUserBalanceEntity entity = repository.findByUserId(userId)
+                .orElseGet(() -> PlatformUsageCreditsUserBalanceEntity.builder().userId(userId).build());
+        entity.setCurrentValue(value);
+        entity.setModifiedDate(now);
+        repository.save(entity);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/credits/PlatformUsageCreditsUserBalanceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/credits/PlatformUsageCreditsUserBalanceService.java
@@ -22,22 +22,23 @@ import com.epam.pipeline.dto.credits.PlatformUsageCreditsUpdateEvent;
 import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalance;
 import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalanceFilterVO;
 import com.epam.pipeline.entity.credits.PlatformUsageCreditsUserBalanceEntity;
+import com.epam.pipeline.entity.user.PipelineUser;
 import com.epam.pipeline.entity.utils.DateUtils;
 import com.epam.pipeline.manager.contextual.ContextualPreferenceManager;
 import com.epam.pipeline.manager.notification.NotificationManager;
 import com.epam.pipeline.manager.preference.AbstractSystemPreference;
 import com.epam.pipeline.manager.preference.SystemPreferences;
+import com.epam.pipeline.manager.user.UserManager;
 import com.epam.pipeline.mapper.credits.PlatformUsageCreditsUserBalanceMapper;
 import com.epam.pipeline.repository.credits.PlatformUsageCreditsUserBalanceRepository;
 import com.epam.pipeline.repository.credits.PlatformUsageCreditsUserBalanceSpecification;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.Assert;
 
 import org.apache.commons.collections4.CollectionUtils;
 
@@ -60,16 +61,26 @@ import java.util.stream.StreamSupport;
  */
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class PlatformUsageCreditsUserBalanceService {
 
     private final PlatformUsageCreditsUserBalanceRepository repository;
     private final PlatformUsageCreditsUserBalanceMapper mapper;
     private final ContextualPreferenceManager contextualPreferenceManager;
+    private final NotificationManager notificationManager;
+    private final UserManager userManager;
 
-    @Autowired
-    @Lazy
-    private NotificationManager notificationManager;
+    public PlatformUsageCreditsUserBalanceService(
+            final PlatformUsageCreditsUserBalanceRepository repository,
+            final PlatformUsageCreditsUserBalanceMapper mapper,
+            final ContextualPreferenceManager contextualPreferenceManager,
+            @Lazy final NotificationManager notificationManager,
+            @Lazy final UserManager userManager) {
+        this.repository = repository;
+        this.mapper = mapper;
+        this.contextualPreferenceManager = contextualPreferenceManager;
+        this.notificationManager = notificationManager;
+        this.userManager = userManager;
+    }
 
     /**
      * Returns a paged, optionally filtered list of user balances.
@@ -135,10 +146,17 @@ public class PlatformUsageCreditsUserBalanceService {
     public void reset(final int value, @Nullable final List<Long> userIds) {
         final LocalDateTime now = DateUtils.nowUTC();
         if (CollectionUtils.isNotEmpty(userIds)) {
-            userIds.forEach(userId -> validateResetValue(value, userId));
+            userIds.forEach(userId -> {
+                final PipelineUser user = userManager.load(userId);
+                final int min = getIntPreference(SystemPreferences.USAGE_CREDITS_MIN, user);
+                final int max = getIntPreference(SystemPreferences.USAGE_CREDITS_MAX, user);
+                validateResetValue(value, min, max, userId);
+            });
             userIds.forEach(userId -> upsertBalance(value, now, userId));
         } else {
+            log.debug("Resetting credits balance to {} for all users", value);
             repository.resetAll(value);
+            log.debug("Credits balance reset to {} completed for all users", value);
         }
     }
 
@@ -155,56 +173,63 @@ public class PlatformUsageCreditsUserBalanceService {
      * event), nothing is written to the database and the returned event has {@code value = 0}.
      *
      * @param event the event to apply; {@code value} must be positive; direction is {@code incidentType}
-     * @return a copy of the event with {@code value} set to the actual amount applied
+     * @return the event with {@code value} set to the actual amount applied
      */
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     @Transactional
     public PlatformUsageCreditsUpdateEvent updateByEvent(final PlatformUsageCreditsUpdateEvent event) {
-        final Optional<PlatformUsageCreditsUserBalanceEntity> existing =
-                repository.findByUserId(event.getUserId());
-        final int currentBalance = existing
+        Assert.notNull(event, "Credits event must not be null");
+        Assert.notNull(event.getUserId(), "Credits event userId must not be null");
+        Assert.notNull(event.getIncidentType(), "Credits event incidentType must not be null");
+        final Long userId = event.getUserId();
+        final PipelineUser user = userManager.load(userId);
+        final int minBalance = getIntPreference(SystemPreferences.USAGE_CREDITS_MIN, user);
+        final int maxBalance = getIntPreference(SystemPreferences.USAGE_CREDITS_MAX, user);
+        final int defaultBalance = getIntPreference(SystemPreferences.USAGE_CREDITS_DEFAULT, user);
+        final int threshold = getIntPreference(SystemPreferences.USAGE_CREDITS_NOTIFICATION_THRESHOLD, user);
+
+        final int oldBalance = repository.findByUserId(userId)
                 .map(PlatformUsageCreditsUserBalanceEntity::getCurrentValue)
-                .orElseGet(() -> getIntPreference(SystemPreferences.USAGE_CREDITS_DEFAULT, event.getUserId()));
+                .orElse(defaultBalance);
 
-        final int minBalance = getIntPreference(SystemPreferences.USAGE_CREDITS_MIN, event.getUserId());
-        final int maxBalance = getIntPreference(SystemPreferences.USAGE_CREDITS_MAX, event.getUserId());
+        final int delta = ActionType.INCREASE.equals(event.getIncidentType())
+                ? event.getValue() : -event.getValue();
 
-        final int rawNewBalance = ActionType.INCREASE.equals(event.getIncidentType())
-                ? currentBalance + event.getValue()
-                : currentBalance - event.getValue();
+        final int newBalance = repository.atomicUpdateBalance(
+                userId, delta, defaultBalance, minBalance, maxBalance);
 
-        final int clampedBalance = Math.max(minBalance, Math.min(maxBalance, rawNewBalance));
-        final int actualValue = Math.abs(clampedBalance - currentBalance);
+        final int actualValue = Math.abs(newBalance - oldBalance);
         event.setValue(actualValue);
 
         if (actualValue == 0) {
             log.info("Credits event for user {} has no effect: balance already at boundary {}",
-                    event.getUserId(), currentBalance);
+                    userId, oldBalance);
             return event;
         }
 
-        final PlatformUsageCreditsUserBalanceEntity entity = existing
-                .orElseGet(() -> PlatformUsageCreditsUserBalanceEntity.builder()
-                        .userId(event.getUserId())
-                        .build());
-        entity.setCurrentValue(clampedBalance);
-        entity.setModifiedDate(DateUtils.nowUTC());
-        repository.save(entity);
+        log.debug("Credits balance updated for user {}: {} -> {} (actual delta={})",
+                userId, oldBalance, newBalance, actualValue);
 
-        if (!isNotificationThresholdExceeded(clampedBalance, event.getUserId())) {
-            notificationManager.notifyLowUsageCredits(event.getUserId(), clampedBalance);
+        if (isBelowNotificationThreshold(newBalance, minBalance, maxBalance, threshold)) {
+            log.debug("Balance {} for user {} is below notification threshold, sending notification",
+                    newBalance, userId);
+            try {
+                notificationManager.notifyLowUsageCredits(userId, newBalance);
+            } catch (Exception e) {
+                log.warn("Failed to send low credits notification", e);
+            }
         }
 
         return event;
     }
 
-    private int getIntPreference(final AbstractSystemPreference.IntPreference intPreference, final Long userId) {
+    private int getIntPreference(final AbstractSystemPreference.IntPreference intPreference,
+                                  final PipelineUser user) {
         return Integer.parseInt(contextualPreferenceManager.search(
-                Collections.singletonList(intPreference.getKey()), userId).getValue());
+                Collections.singletonList(intPreference.getKey()), user).getValue());
     }
 
-    private void validateResetValue(final int value, final Long userId) {
-        final int min = getIntPreference(SystemPreferences.USAGE_CREDITS_MIN, userId);
-        final int max = getIntPreference(SystemPreferences.USAGE_CREDITS_MAX, userId);
+    private void validateResetValue(final int value, final int min, final int max, final Long userId) {
         if (value < min || value > max) {
             throw new IllegalArgumentException(String.format(
                     "Reset value %d is out of allowed range [%d, %d] for user %d", value, min, max, userId));
@@ -213,17 +238,19 @@ public class PlatformUsageCreditsUserBalanceService {
 
     private void upsertBalance(final int value, final LocalDateTime now, final Long userId) {
         final PlatformUsageCreditsUserBalanceEntity entity = repository.findByUserId(userId)
-                .orElseGet(() -> PlatformUsageCreditsUserBalanceEntity.builder().userId(userId).build());
+                .orElseGet(() -> {
+                    log.debug("No existing balance row for user {}, creating new", userId);
+                    return PlatformUsageCreditsUserBalanceEntity.builder().userId(userId).build();
+                });
         entity.setCurrentValue(value);
         entity.setModifiedDate(now);
         repository.save(entity);
+        log.debug("Saved credits balance {} for user {}", value, userId);
     }
 
-    private boolean isNotificationThresholdExceeded(final int currentValue, final Long userId) {
-        final int min = getIntPreference(SystemPreferences.USAGE_CREDITS_MIN, userId);
-        final int max = getIntPreference(SystemPreferences.USAGE_CREDITS_MAX, userId);
-        final int threshold = getIntPreference(SystemPreferences.USAGE_CREDITS_NOTIFICATION_THRESHOLD, userId);
+    private boolean isBelowNotificationThreshold(final int currentValue, final int min, final int max,
+                                                  final int threshold) {
         final double absoluteValue = min + (threshold / 100.0) * (max - min);
-        return currentValue >= absoluteValue;
+        return currentValue < absoluteValue;
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/notification/NotificationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/notification/NotificationManager.java
@@ -976,4 +976,21 @@ public class NotificationManager implements NotificationService { // TODO: rewri
                 return false;
         }
     }
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void notifyLowUsageCredits(final Long userId, final int creditsBalance) {
+        final NotificationType type = NotificationType.LOW_USAGE_CREDITS;
+        final NotificationSettings settings = settingsManager.load(type);
+        if (settings == null || !settings.isEnabled() || settings.getTemplateId() == 0) {
+            log.info("No template configured for {} notification or it was disabled!", type);
+            return;
+        }
+        final PipelineUser user = userManager.load(userId);
+        final NotificationMessage message = new NotificationMessage();
+        message.setTemplate(new NotificationTemplate(settings.getTemplateId()));
+        message.setTemplateParameters(parameterManager.build(type, user, creditsBalance));
+        message.setToUserId(userId);
+        message.setCopyUserIds(getCCUsers(settings));
+        saveNotification(message);
+    }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/notification/NotificationManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/notification/NotificationManager.java
@@ -739,6 +739,24 @@ public class NotificationManager implements NotificationService { // TODO: rewri
         monitoringNotificationDao.createMonitoringNotification(message);
     }
 
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void notifyLowUsageCredits(final Long userId, final int creditsBalance) {
+        final NotificationType type = NotificationType.LOW_USAGE_CREDITS;
+        final NotificationSettings settings = settingsManager.load(type);
+        if (settings == null || !settings.isEnabled() || settings.getTemplateId() == 0) {
+            log.info(messageHelper.getMessage(MessageConstants.INFO_NOTIFICATION_TEMPLATE_NOT_CONFIGURED,
+                    "usage credits"));
+            return;
+        }
+        final PipelineUser user = userManager.load(userId);
+        final NotificationMessage message = new NotificationMessage();
+        message.setTemplate(new NotificationTemplate(settings.getTemplateId()));
+        message.setTemplateParameters(parameterManager.build(type, user, creditsBalance));
+        message.setToUserId(userId);
+        message.setCopyUserIds(getCCUsers(settings));
+        saveNotification(message);
+    }
+
     private List<Long> mapRecipientsToUserIds(final List<? extends Sid> recipients) {
         final Stream<PipelineUser> plainUsersStream = recipients.stream()
                 .filter(Sid::isPrincipal)
@@ -975,22 +993,5 @@ public class NotificationManager implements NotificationService { // TODO: rewri
             default:
                 return false;
         }
-    }
-
-    @Transactional(propagation = Propagation.REQUIRED)
-    public void notifyLowUsageCredits(final Long userId, final int creditsBalance) {
-        final NotificationType type = NotificationType.LOW_USAGE_CREDITS;
-        final NotificationSettings settings = settingsManager.load(type);
-        if (settings == null || !settings.isEnabled() || settings.getTemplateId() == 0) {
-            log.info("No template configured for {} notification or it was disabled!", type);
-            return;
-        }
-        final PipelineUser user = userManager.load(userId);
-        final NotificationMessage message = new NotificationMessage();
-        message.setTemplate(new NotificationTemplate(settings.getTemplateId()));
-        message.setTemplateParameters(parameterManager.build(type, user, creditsBalance));
-        message.setToUserId(userId);
-        message.setCopyUserIds(getCCUsers(settings));
-        saveNotification(message);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/notification/NotificationParameterManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/notification/NotificationParameterManager.java
@@ -161,6 +161,15 @@ public class NotificationParameterManager {
         return parameters;
     }
 
+    public Map<String, Object> build(final NotificationType type,
+                                     final PipelineUser user,
+                                     final int creditsBalance) {
+        final Map<String, Object> parameters = build(type);
+        parameters.put("user", UserMapper.map(user, Collections.emptyMap()));
+        parameters.put("creditsBalance", creditsBalance);
+        return parameters;
+    }
+
     public Map<String, Object> build(final NotificationType type, final List<NodePool> pools) {
         final Map<String, Object> parameters = build(type);
         parameters.putAll(buildEntities(NotificationEntityClass.NODE_POOL, pools.stream()

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -149,6 +149,7 @@ public class SystemPreferences {
     private static final String LUSTRE_GROUP = "Lustre FS";
     private static final String LDAP_GROUP = "LDAP";
     private static final String BILLING_QUOTAS_GROUP= "Billing Quotas";
+    private static final String USAGE_CREDITS_GROUP = "Usage Credits";
     private static final String NGS_PREPROCESSING_GROUP = "NGS Preprocessing";
     private static final String MONITORING_GROUP = "Monitoring";
     private static final String CLOUD = "Cloud";
@@ -1552,6 +1553,19 @@ public class SystemPreferences {
     public static final IntPreference BILLING_QUOTAS_CLEARING_PERIOD_SECONDS = new IntPreference(
             "billing.quotas.clear.period.seconds", Constants.SECONDS_IN_DAY * 30,
             BILLING_QUOTAS_GROUP, isGreaterThan(10));
+
+    // Usage Credits
+    public static final IntPreference USAGE_CREDITS_DEFAULT = new IntPreference(
+            "usage.credits.default", 2000, USAGE_CREDITS_GROUP, isGreaterThan(0));
+    public static final IntPreference USAGE_CREDITS_MIN = new IntPreference(
+            "usage.credits.min", 24, USAGE_CREDITS_GROUP, isGreaterThan(0));
+    public static final IntPreference USAGE_CREDITS_MAX = new IntPreference(
+            "usage.credits.max", 3000, USAGE_CREDITS_GROUP, isGreaterThan(0));
+    public static final ObjectPreference<Map<String, Integer>> USAGE_CREDITS_RESOURCE_WEIGHTS =
+            new ObjectPreference<>("usage.credits.resource.weights",
+                    CommonUtils.toMap(Pair.of("CPU", 1), Pair.of("GPU", 100)),
+                    new TypeReference<Map<String, Integer>>() {}, USAGE_CREDITS_GROUP,
+                    isNullOrValidJson(new TypeReference<Map<String, Integer>>() {}));
 
     // Lustre FS
     public static final BooleanPreference LUSTRE_FS_SCALE_ENABLED = new BooleanPreference(

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -1566,6 +1566,8 @@ public class SystemPreferences {
                     CommonUtils.toMap(Pair.of("CPU", 1), Pair.of("GPU", 100)),
                     new TypeReference<Map<String, Integer>>() {}, USAGE_CREDITS_GROUP,
                     isNullOrValidJson(new TypeReference<Map<String, Integer>>() {}));
+    public static final IntPreference USAGE_CREDITS_NOTIFICATION_THRESHOLD = new IntPreference(
+            "usage.credits.notification.threshold", 25, USAGE_CREDITS_GROUP, isGreaterThan(0));
 
     // Lustre FS
     public static final BooleanPreference LUSTRE_FS_SCALE_ENABLED = new BooleanPreference(

--- a/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
+++ b/api/src/main/java/com/epam/pipeline/manager/preference/SystemPreferences.java
@@ -1555,17 +1555,25 @@ public class SystemPreferences {
             BILLING_QUOTAS_GROUP, isGreaterThan(10));
 
     // Usage Credits
+    /** Starting balance assigned to every new user (must be within [min, max]). Default: 2000 credits. */
     public static final IntPreference USAGE_CREDITS_DEFAULT = new IntPreference(
             "usage.credits.default", 2000, USAGE_CREDITS_GROUP, isGreaterThan(0));
+    /** Hard floor for any user's balance — no event can push it below this value. Default: 24 credits. */
     public static final IntPreference USAGE_CREDITS_MIN = new IntPreference(
             "usage.credits.min", 24, USAGE_CREDITS_GROUP, isGreaterThan(0));
+    /** Hard ceiling for any user's balance — no event can push it above this value. Default: 3000 credits. */
     public static final IntPreference USAGE_CREDITS_MAX = new IntPreference(
             "usage.credits.max", 3000, USAGE_CREDITS_GROUP, isGreaterThan(0));
+    /** Credits cost per single unit of each resource type. Default: CPU=1, GPU=100. */
     public static final ObjectPreference<Map<String, Integer>> USAGE_CREDITS_RESOURCE_WEIGHTS =
             new ObjectPreference<>("usage.credits.resource.weights",
                     CommonUtils.toMap(Pair.of("CPU", 1), Pair.of("GPU", 100)),
                     new TypeReference<Map<String, Integer>>() {}, USAGE_CREDITS_GROUP,
                     isNullOrValidJson(new TypeReference<Map<String, Integer>>() {}));
+    /**
+     * Percentage of the [min, max] range above min below which a low-balance notification is sent.
+     * E.g. 25 means notify when balance drops below {@code min + 0.25 * (max - min)}. Default: 25.
+     */
     public static final IntPreference USAGE_CREDITS_NOTIFICATION_THRESHOLD = new IntPreference(
             "usage.credits.notification.threshold", 25, USAGE_CREDITS_GROUP, isGreaterThan(0));
 

--- a/api/src/main/java/com/epam/pipeline/manager/user/UserExporter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/UserExporter.java
@@ -114,6 +114,9 @@ public class UserExporter {
             result.add(PipelineUserWithStoragePath.PipelineUserFields.DEFAULT_STORAGE_ID.getValue());
             result.add(PipelineUserWithStoragePath.PipelineUserFields.DEFAULT_STORAGE_PATH.getValue());
         }
+        if (exportSettings.isIncludeCredits()) {
+            result.add(PipelineUserWithStoragePath.PipelineUserFields.USAGE_CREDITS.getValue());
+        }
         return result.toArray(new String[0]);
     }
 
@@ -168,6 +171,11 @@ public class UserExporter {
         if (exportSettings.isIncludeDataStorage()) {
             result.add(formatNullable(user.getDefaultStorageId()));
             result.add(formatNullable(user.getDefaultStoragePath()));
+        }
+        if (exportSettings.isIncludeCredits()) {
+            result.add(user.getUsageCredits() != null
+                    ? String.valueOf(user.getUsageCredits().getCurrentValue())
+                    : StringUtils.EMPTY);
         }
         return result.toArray(new String[0]);
     }

--- a/api/src/main/java/com/epam/pipeline/manager/user/UserManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/user/UserManager.java
@@ -40,7 +40,9 @@ import com.epam.pipeline.entity.user.PipelineUserWithStoragePath;
 import com.epam.pipeline.entity.user.Role;
 import com.epam.pipeline.entity.utils.ControlEntry;
 import com.epam.pipeline.entity.utils.DateUtils;
+import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalance;
 import com.epam.pipeline.manager.cloud.credentials.CloudProfileCredentialsManagerProvider;
+import com.epam.pipeline.manager.credits.PlatformUsageCreditsUserBalanceService;
 import com.epam.pipeline.manager.datastorage.DataStorageManager;
 import com.epam.pipeline.manager.datastorage.DataStorageValidator;
 import com.epam.pipeline.manager.keypair.SshKeyPair;
@@ -147,6 +149,9 @@ public class UserManager implements SecuredEntityManager {
 
     @Autowired
     private QuotaService quotaService;
+
+    @Autowired
+    private PlatformUsageCreditsUserBalanceService platformUsageCreditsUserBalanceService;
 
     @Autowired
     private SshKeyPairManager sshKeyPairManager;
@@ -315,10 +320,18 @@ public class UserManager implements SecuredEntityManager {
     }
 
     public PipelineUser load(final Long id, final boolean quotas) {
+        return load(id, quotas, false);
+    }
+
+    public PipelineUser load(final Long id, final boolean quotas, final boolean loadCredits) {
         final PipelineUser user = userDao.loadUserById(id);
         Assert.notNull(user, messageHelper.getMessage(MessageConstants.ERROR_USER_ID_NOT_FOUND, id));
         if (quotas && !user.isAdmin()) {
             user.setActiveQuotas(quotaService.loadActiveQuotasForUser(user));
+        }
+        if (loadCredits) {
+            platformUsageCreditsUserBalanceService.findByUserId(user.getId())
+                    .ifPresent(user::setUsageCredits);
         }
         return user;
     }
@@ -337,16 +350,28 @@ public class UserManager implements SecuredEntityManager {
     }
 
     public Collection<PipelineUser> loadAllUsers(final boolean loadQuotas) {
-        final  Collection<PipelineUser> pipelineUsers = userDao.loadAllUsers();
+        return loadAllUsers(loadQuotas, false);
+    }
+
+    public Collection<PipelineUser> loadAllUsers(final boolean loadQuotas, final boolean loadCredits) {
+        final Collection<PipelineUser> pipelineUsers = userDao.loadAllUsers();
         final PipelineUser currentUser = getCurrentUser();
         if (loadQuotas && (currentUser.isAdmin() ||
                 UserUtils.hasRole(currentUser, DefaultRoles.ROLE_BILLING_MANAGER))) {
             attachQuotaInfo(pipelineUsers);
         }
+        if (loadCredits) {
+            attachCreditsInfo(pipelineUsers);
+        }
         return pipelineUsers;
     }
 
     public Collection<PipelineUser> loadUsersWithActivityStatus(final boolean loadQuotas) {
+        return loadUsersWithActivityStatus(loadQuotas, false);
+    }
+
+    public Collection<PipelineUser> loadUsersWithActivityStatus(final boolean loadQuotas,
+                                                                final boolean loadCredits) {
         final PipelineUser currentUser = getCurrentUser();
         final Collection<PipelineUser> pipelineUsers = currentUser.isAdmin()
                 || UserUtils.hasRole(currentUser, DefaultRoles.ROLE_USER_ADMIN)
@@ -354,6 +379,9 @@ public class UserManager implements SecuredEntityManager {
                 : loadAllUsers();
         if (loadQuotas) {
             attachQuotaInfo(pipelineUsers);
+        }
+        if (loadCredits) {
+            attachCreditsInfo(pipelineUsers);
         }
         return pipelineUsers;
     }
@@ -606,6 +634,12 @@ public class UserManager implements SecuredEntityManager {
     public byte[] exportUsers(final PipelineUserExportVO attr) {
         final Collection<PipelineUserWithStoragePath> users = loadAllUsersWithDataStoragePath();
         final Collection<PipelineUserWithStoragePath> filteredUsers = filterUsers(users, attr);
+        if (attr.isIncludeCredits()) {
+            final Map<Long, PlatformUsageCreditsUserBalance> balances =
+                    platformUsageCreditsUserBalanceService.findAllAsMap();
+            filteredUsers.forEach(user -> Optional.ofNullable(balances.get(user.getId()))
+                    .ifPresent(user::setUsageCredits));
+        }
         final List<String> sensitiveKeys = authManager.isAdmin() ? Collections.emptyList() :
                 preferenceManager.getPreference(SystemPreferences.MISC_METADATA_SENSITIVE_KEYS);
         return new UserExporter().exportUsers(attr, filteredUsers, sensitiveKeys).getBytes(Charset.defaultCharset());
@@ -755,5 +789,15 @@ public class UserManager implements SecuredEntityManager {
             return;
         }
         quotaService.attachQuotaInfo(pipelineUsers);
+    }
+
+    private void attachCreditsInfo(final Collection<PipelineUser> pipelineUsers) {
+        if (CollectionUtils.isEmpty(pipelineUsers)) {
+            return;
+        }
+        final Map<Long, PlatformUsageCreditsUserBalance> balances =
+                platformUsageCreditsUserBalanceService.findAllAsMap();
+        pipelineUsers.forEach(user -> Optional.ofNullable(balances.get(user.getId()))
+                .ifPresent(user::setUsageCredits));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/mapper/credits/PlatformUsageCreditsUserBalanceMapper.java
+++ b/api/src/main/java/com/epam/pipeline/mapper/credits/PlatformUsageCreditsUserBalanceMapper.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.mapper.credits;
+
+import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalance;
+import com.epam.pipeline.entity.credits.PlatformUsageCreditsUserBalanceEntity;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface PlatformUsageCreditsUserBalanceMapper {
+
+    PlatformUsageCreditsUserBalance toDto(PlatformUsageCreditsUserBalanceEntity entity);
+}

--- a/api/src/main/java/com/epam/pipeline/repository/credits/PlatformUsageCreditsUserBalanceRepository.java
+++ b/api/src/main/java/com/epam/pipeline/repository/credits/PlatformUsageCreditsUserBalanceRepository.java
@@ -23,16 +23,25 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface PlatformUsageCreditsUserBalanceRepository
         extends PagingAndSortingRepository<PlatformUsageCreditsUserBalanceEntity, Long>,
         JpaSpecificationExecutor<PlatformUsageCreditsUserBalanceEntity> {
 
+    String BATCH_RESET = "INSERT INTO pipeline.usage_credits_user_balance (user_id, current_value, modified_date) "
+            + "SELECT id, :value, NOW() FROM pipeline.user "
+            + "ON CONFLICT (user_id) DO UPDATE "
+            + "SET current_value = EXCLUDED.current_value, modified_date = EXCLUDED.modified_date";
+
     Optional<PlatformUsageCreditsUserBalanceEntity> findByUserId(Long userId);
 
+    /**
+     * Upserts a balance row for every user in {@code pipeline.user}.
+     * Users who already have a row get their balance updated; users with no row get one created.
+     * The timestamp is set by the database so all rows share a consistent {@code NOW()} value.
+     */
     @Modifying
-    @Query("UPDATE PlatformUsageCreditsUserBalanceEntity e SET e.currentValue = :value, e.modifiedDate = :now")
-    void resetAll(@Param("value") Integer value, @Param("now") LocalDateTime now);
+    @Query(value = BATCH_RESET, nativeQuery = true)
+    void resetAll(@Param("value") int value);
 }

--- a/api/src/main/java/com/epam/pipeline/repository/credits/PlatformUsageCreditsUserBalanceRepository.java
+++ b/api/src/main/java/com/epam/pipeline/repository/credits/PlatformUsageCreditsUserBalanceRepository.java
@@ -33,8 +33,40 @@ public interface PlatformUsageCreditsUserBalanceRepository
             + "SELECT id, :value, NOW() FROM pipeline.user "
             + "ON CONFLICT (user_id) DO UPDATE "
             + "SET current_value = EXCLUDED.current_value, modified_date = EXCLUDED.modified_date";
+    String ATOMIC_UPSERT = "WITH upsert AS ( "
+            + "INSERT INTO pipeline.usage_credits_user_balance (user_id, current_value, modified_date) "
+            + "VALUES (:userId, GREATEST(:min, LEAST(:max, :defaultBalance + :delta)), NOW()) "
+            + "ON CONFLICT (user_id) DO UPDATE "
+            + "SET current_value = GREATEST(:min, LEAST(:max, "
+            + "    pipeline.usage_credits_user_balance.current_value + :delta)), "
+            + "    modified_date = NOW() "
+            + "RETURNING current_value "
+            + ") SELECT current_value FROM upsert";
 
     Optional<PlatformUsageCreditsUserBalanceEntity> findByUserId(Long userId);
+
+    /**
+     * Atomically upserts the credits balance for a single user and returns the resulting value.
+     *
+     * <p>The arithmetic and clamping are performed entirely inside the database using a single SQL
+     * statement, so concurrent calls for the same user cannot race. The DML is wrapped in a CTE and
+     * exposed as a {@code SELECT} so that Spring Data JPA returns the {@code RETURNING} value
+     * directly without requiring a separate follow-up read.
+     *
+     * @param userId         the target user
+     * @param delta          signed delta: positive for INCREASE, negative for DEDUCTION
+     * @param defaultBalance starting balance when no row exists yet
+     * @param min            lower bound for clamping
+     * @param max            upper bound for clamping
+     * @return the new {@code current_value} after the update
+     */
+    @Query(value = ATOMIC_UPSERT, nativeQuery = true)
+    Integer atomicUpdateBalance(
+            @Param("userId") Long userId,
+            @Param("delta") int delta,
+            @Param("defaultBalance") int defaultBalance,
+            @Param("min") int min,
+            @Param("max") int max);
 
     /**
      * Upserts a balance row for every user in {@code pipeline.user}.

--- a/api/src/main/java/com/epam/pipeline/repository/credits/PlatformUsageCreditsUserBalanceRepository.java
+++ b/api/src/main/java/com/epam/pipeline/repository/credits/PlatformUsageCreditsUserBalanceRepository.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.repository.credits;
+
+import com.epam.pipeline.entity.credits.PlatformUsageCreditsUserBalanceEntity;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface PlatformUsageCreditsUserBalanceRepository
+        extends PagingAndSortingRepository<PlatformUsageCreditsUserBalanceEntity, Long>,
+        JpaSpecificationExecutor<PlatformUsageCreditsUserBalanceEntity> {
+
+    Optional<PlatformUsageCreditsUserBalanceEntity> findByUserId(Long userId);
+
+    @Modifying
+    @Query("UPDATE PlatformUsageCreditsUserBalanceEntity e SET e.currentValue = :value, e.modifiedDate = :now")
+    void resetAll(@Param("value") Integer value, @Param("now") LocalDateTime now);
+}

--- a/api/src/main/java/com/epam/pipeline/repository/credits/PlatformUsageCreditsUserBalanceSpecification.java
+++ b/api/src/main/java/com/epam/pipeline/repository/credits/PlatformUsageCreditsUserBalanceSpecification.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017-2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.repository.credits;
+
+import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalanceFilterVO;
+import com.epam.pipeline.entity.credits.PlatformUsageCreditsUserBalanceEntity;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.data.jpa.domain.Specification;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * JPA {@link Specification} factory for {@link PlatformUsageCreditsUserBalanceEntity} queries.
+ *
+ * <p>All predicates are pushed down to the database — no post-load filtering is performed.
+ * Use {@link #build(PlatformUsageCreditsUserBalanceFilterVO)} to obtain a combined spec, or call
+ * the individual factory methods and compose them manually.
+ *
+ * <p>Example:
+ * <pre>{@code
+ * repository.findAll(
+ *     PlatformUsageCreditsUserBalanceSpecification.build(filter),
+ *     new PageRequest(filter.getPage(), filter.getPageSize()));
+ * }</pre>
+ */
+public final class PlatformUsageCreditsUserBalanceSpecification {
+
+    private static final String USER_ID = "userId";
+    private static final String CURRENT_VALUE = "currentValue";
+
+    private PlatformUsageCreditsUserBalanceSpecification() {
+    }
+
+    /**
+     * Builds a combined specification from all filter fields.
+     * All predicates are AND-ed at the database level.
+     */
+    public static Specification<PlatformUsageCreditsUserBalanceEntity> build(
+            final PlatformUsageCreditsUserBalanceFilterVO filter) {
+        return (root, query, cb) -> {
+            final List<Predicate> predicates = new ArrayList<>();
+            if (!CollectionUtils.isEmpty(filter.getUserIds())) {
+                predicates.add(root.get(USER_ID).in(filter.getUserIds()));
+            }
+            if (filter.getValue() != null && StringUtils.isNotBlank(filter.getOperation())) {
+                predicates.add(balancePredicate(root, cb, filter.getValue(), filter.getOperation()));
+            }
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+
+    private static Predicate balancePredicate(final Root<PlatformUsageCreditsUserBalanceEntity> root,
+                                              final CriteriaBuilder cb,
+                                              final int value,
+                                              final String operation) {
+        switch (operation) {
+            case "<": return cb.lessThan(root.get(CURRENT_VALUE), value);
+            case ">": return cb.greaterThan(root.get(CURRENT_VALUE), value);
+            case "=": return cb.equal(root.get(CURRENT_VALUE), value);
+            default:  throw new IllegalArgumentException("Unsupported balance operation: " + operation);
+        }
+    }
+}

--- a/api/src/main/resources/db/migration/v2026.07.21_12.00__issue_4461_platform_usage_credits_user_balance.sql
+++ b/api/src/main/resources/db/migration/v2026.07.21_12.00__issue_4461_platform_usage_credits_user_balance.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS pipeline.usage_credits_user_balance (
+    id            BIGSERIAL    PRIMARY KEY,
+    user_id       BIGINT       NOT NULL UNIQUE REFERENCES pipeline.user(id),
+    current_value INTEGER      NOT NULL,
+    modified_date TIMESTAMPTZ  NOT NULL DEFAULT now()
+);

--- a/api/src/test/java/com/epam/pipeline/acl/credits/PlatformUsageCreditsUserBalanceApiServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/acl/credits/PlatformUsageCreditsUserBalanceApiServiceTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017-2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.acl.credits;
+
+import com.epam.pipeline.controller.PagedResult;
+import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalance;
+import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalanceFilterVO;
+import com.epam.pipeline.manager.credits.PlatformUsageCreditsUserBalanceService;
+import com.epam.pipeline.test.acl.AbstractAclTest;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import java.util.List;
+
+import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.RESET_VALUE;
+import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.USER_ID;
+import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.filterVO;
+import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.pagedResult;
+import static com.epam.pipeline.util.CustomAssertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+public class PlatformUsageCreditsUserBalanceApiServiceTest extends AbstractAclTest {
+
+    @Autowired
+    private PlatformUsageCreditsUserBalanceApiService apiService;
+
+    @Autowired
+    private PlatformUsageCreditsUserBalanceService mockPlatformUsageCreditsUserBalanceService;
+
+    @Test
+    @WithMockUser(roles = ADMIN_ROLE)
+    public void shouldFilterForAdmin() {
+        final PlatformUsageCreditsUserBalanceFilterVO filter = filterVO();
+        final PagedResult<List<PlatformUsageCreditsUserBalance>> expected = pagedResult();
+        doReturn(expected).when(mockPlatformUsageCreditsUserBalanceService).filter(filter);
+
+        assertThat(apiService.filter(filter)).isEqualTo(expected);
+        verify(mockPlatformUsageCreditsUserBalanceService).filter(filter);
+    }
+
+    @Test
+    @WithMockUser(username = SIMPLE_USER)
+    public void shouldDenyFilterForNonAdmin() {
+        assertThrows(AccessDeniedException.class, () -> apiService.filter(filterVO()));
+    }
+
+    @Test
+    @WithMockUser(roles = ADMIN_ROLE)
+    public void shouldResetForSpecificUserForAdmin() {
+        apiService.reset(RESET_VALUE, USER_ID);
+
+        verify(mockPlatformUsageCreditsUserBalanceService).reset(RESET_VALUE, USER_ID);
+    }
+
+    @Test
+    @WithMockUser(roles = ADMIN_ROLE)
+    public void shouldResetForAllUsersForAdmin() {
+        apiService.reset(RESET_VALUE, null);
+
+        verify(mockPlatformUsageCreditsUserBalanceService).reset(RESET_VALUE, null);
+    }
+
+    @Test
+    @WithMockUser(username = SIMPLE_USER)
+    public void shouldDenyResetForNonAdmin() {
+        assertThrows(AccessDeniedException.class, () -> apiService.reset(RESET_VALUE, USER_ID));
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/acl/credits/PlatformUsageCreditsUserBalanceApiServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/acl/credits/PlatformUsageCreditsUserBalanceApiServiceTest.java
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.test.context.support.WithMockUser;
 
+import java.util.Collections;
 import java.util.List;
 
 import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.RESET_VALUE;
@@ -65,9 +66,9 @@ public class PlatformUsageCreditsUserBalanceApiServiceTest extends AbstractAclTe
     @Test
     @WithMockUser(roles = ADMIN_ROLE)
     public void shouldResetForSpecificUserForAdmin() {
-        apiService.reset(RESET_VALUE, USER_ID);
+        apiService.reset(RESET_VALUE, Collections.singletonList(USER_ID));
 
-        verify(mockPlatformUsageCreditsUserBalanceService).reset(RESET_VALUE, USER_ID);
+        verify(mockPlatformUsageCreditsUserBalanceService).reset(RESET_VALUE, Collections.singletonList(USER_ID));
     }
 
     @Test
@@ -81,6 +82,7 @@ public class PlatformUsageCreditsUserBalanceApiServiceTest extends AbstractAclTe
     @Test
     @WithMockUser(username = SIMPLE_USER)
     public void shouldDenyResetForNonAdmin() {
-        assertThrows(AccessDeniedException.class, () -> apiService.reset(RESET_VALUE, USER_ID));
+        assertThrows(AccessDeniedException.class,
+                () -> apiService.reset(RESET_VALUE, Collections.singletonList(USER_ID)));
     }
 }

--- a/api/src/test/java/com/epam/pipeline/acl/credits/PlatformUsageCreditsUserBalanceApiServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/acl/credits/PlatformUsageCreditsUserBalanceApiServiceTest.java
@@ -83,6 +83,6 @@ public class PlatformUsageCreditsUserBalanceApiServiceTest extends AbstractAclTe
     @WithMockUser(username = SIMPLE_USER)
     public void shouldDenyResetForNonAdmin() {
         assertThrows(AccessDeniedException.class,
-                () -> apiService.reset(RESET_VALUE, Collections.singletonList(USER_ID)));
+            () -> apiService.reset(RESET_VALUE, Collections.singletonList(USER_ID)));
     }
 }

--- a/api/src/test/java/com/epam/pipeline/acl/user/UserApiServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/acl/user/UserApiServiceTest.java
@@ -24,6 +24,9 @@ import com.epam.pipeline.entity.user.CustomControl;
 import com.epam.pipeline.entity.user.GroupStatus;
 import com.epam.pipeline.entity.user.PipelineUser;
 import com.epam.pipeline.entity.user.PipelineUserEvent;
+import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalance;
+import com.epam.pipeline.manager.credits.PlatformUsageCreditsUserBalanceService;
+
 import com.epam.pipeline.manager.quota.RunLimitsService;
 import com.epam.pipeline.manager.user.UserManager;
 import com.epam.pipeline.manager.user.UsersFileImportManager;
@@ -39,6 +42,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -51,6 +55,7 @@ import static com.epam.pipeline.test.creator.CommonCreatorConstants.TEST_STRING_
 import static com.epam.pipeline.util.CustomAssertions.assertThrows;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 public class UserApiServiceTest extends AbstractAclTest {
@@ -79,6 +84,9 @@ public class UserApiServiceTest extends AbstractAclTest {
 
     @Autowired
     private RunLimitsService mockRunLimitsService;
+
+    @Autowired
+    private PlatformUsageCreditsUserBalanceService mockPlatformUsageCreditsUserBalanceService;
 
     @Test
     @WithMockUser(roles = ADMIN_ROLE)
@@ -235,25 +243,25 @@ public class UserApiServiceTest extends AbstractAclTest {
     @Test
     @WithMockUser(roles = ADMIN_ROLE)
     public void shouldLoadUserForAdmin() {
-        doReturn(pipelineUser).when(mockUserManager).load(ID, false);
+        doReturn(pipelineUser).when(mockUserManager).load(ID, false, false);
 
-        assertThat(userApiService.loadUser(ID, false)).isEqualTo(pipelineUser);
+        assertThat(userApiService.loadUser(ID, false, false)).isEqualTo(pipelineUser);
     }
 
     @Test
     @WithMockUser(roles = USER_ADMIN_ROLE)
     public void shouldLoadUserForUserAdmin() {
-        doReturn(pipelineUser).when(mockUserManager).load(ID, false);
+        doReturn(pipelineUser).when(mockUserManager).load(ID, false, false);
 
-        assertThat(userApiService.loadUser(ID, false)).isEqualTo(pipelineUser);
+        assertThat(userApiService.loadUser(ID, false, false)).isEqualTo(pipelineUser);
     }
 
     @Test
     @WithMockUser(roles = USER_READER_ROLE)
     public void shouldLoadUserForUserReader() {
-        doReturn(pipelineUser).when(mockUserManager).load(ID, false);
+        doReturn(pipelineUser).when(mockUserManager).load(ID, false, false);
 
-        assertThat(userApiService.loadUser(ID, false)).isEqualTo(pipelineUser);
+        assertThat(userApiService.loadUser(ID, false, false)).isEqualTo(pipelineUser);
     }
 
     @Test
@@ -261,7 +269,16 @@ public class UserApiServiceTest extends AbstractAclTest {
     public void shouldDenyLoadUserForNotUserReader() {
         doReturn(pipelineUser).when(mockUserManager).load(ID);
         initAclEntity(pipelineUser);
-        assertThrows(AccessDeniedException.class, () -> userApiService.loadUser(ID, false));
+        assertThrows(AccessDeniedException.class, () -> userApiService.loadUser(ID, false, false));
+    }
+
+    @Test
+    @WithMockUser(roles = ADMIN_ROLE)
+    public void shouldLoadUserWithCreditsForAdmin() {
+        doReturn(pipelineUser).when(mockUserManager).load(ID, false, true);
+
+        assertThat(userApiService.loadUser(ID, false, true)).isEqualTo(pipelineUser);
+        verify(mockUserManager).load(ID, false, true);
     }
 
     @Test
@@ -359,32 +376,51 @@ public class UserApiServiceTest extends AbstractAclTest {
     @Test
     @WithMockUser(roles = ADMIN_ROLE)
     public void shouldLoadUsersForAdmin() {
-        doReturn(pipelineUserList).when(mockUserManager).loadAllUsers(false);
+        doReturn(pipelineUserList).when(mockUserManager).loadAllUsers(false, false);
 
-        assertThat(userApiService.loadUsers(false)).isEqualTo(pipelineUserList);
+        assertThat(userApiService.loadUsers(false, false)).isEqualTo(pipelineUserList);
     }
 
     @Test
     @WithMockUser(roles = USER_ADMIN_ROLE)
     public void shouldLoadUsersForUserAdmin() {
-        doReturn(pipelineUserList).when(mockUserManager).loadAllUsers(false);
+        doReturn(pipelineUserList).when(mockUserManager).loadAllUsers(false, false);
 
-        assertThat(userApiService.loadUsers(false)).isEqualTo(pipelineUserList);
+        assertThat(userApiService.loadUsers(false, false)).isEqualTo(pipelineUserList);
     }
 
     @Test
     @WithMockUser(roles = USER_READER_ROLE)
     public void shouldLoadUsersForUserReader() {
-        doReturn(pipelineUserList).when(mockUserManager).loadAllUsers(false);
+        doReturn(pipelineUserList).when(mockUserManager).loadAllUsers(false, false);
 
-        assertThat(userApiService.loadUsers(false)).isEqualTo(pipelineUserList);
+        assertThat(userApiService.loadUsers(false, false)).isEqualTo(pipelineUserList);
     }
 
     @Test
     @WithMockUser
     public void shouldDenyLoadUsersForNotUserReader() {
         doReturn(pipelineUserList).when(mockUserManager).loadAllUsers();
-        assertThat(userApiService.loadUsers(false)).isEmpty();
+        assertThat(userApiService.loadUsers(false, false)).isEmpty();
+    }
+
+    @Test
+    @WithMockUser(roles = ADMIN_ROLE)
+    public void shouldLoadUsersWithCreditsForAdmin() {
+        doReturn(pipelineUserList).when(mockUserManager).loadAllUsers(false, true);
+
+        assertThat(userApiService.loadUsers(false, true)).isEqualTo(pipelineUserList);
+        verify(mockUserManager).loadAllUsers(false, true);
+    }
+
+    @Test
+    @WithMockUser(roles = ADMIN_ROLE)
+    public void shouldNotEnrichCreditsWhenFlagIsFalse() {
+        doReturn(pipelineUserList).when(mockUserManager).loadAllUsers(false, false);
+
+        userApiService.loadUsers(false, false);
+
+        verify(mockUserManager).loadAllUsers(false, false);
     }
 
     @Test
@@ -430,8 +466,32 @@ public class UserApiServiceTest extends AbstractAclTest {
     @Test
     public void shouldGetCurrentUser() {
         doReturn(pipelineUser).when(mockUserManager).getCurrentUser();
+        doReturn(Optional.empty())
+                .when(mockPlatformUsageCreditsUserBalanceService).findByUserId(pipelineUser.getId());
 
         assertThat(userApiService.getCurrentUser()).isEqualTo(pipelineUser);
+    }
+
+    @Test
+    public void shouldSetUsageCreditsOnGetCurrentUser() {
+        final PlatformUsageCreditsUserBalance balance =
+                new PlatformUsageCreditsUserBalance(pipelineUser.getId(), 1500, null);
+        doReturn(pipelineUser).when(mockUserManager).getCurrentUser();
+        doReturn(Optional.of(balance))
+                .when(mockPlatformUsageCreditsUserBalanceService).findByUserId(pipelineUser.getId());
+
+        final PipelineUser result = userApiService.getCurrentUser();
+
+        assertThat(result.getUsageCredits()).isEqualTo(balance);
+    }
+
+    @Test
+    public void shouldLeaveUsageCreditsNullWhenNoBalanceExists() {
+        doReturn(pipelineUser).when(mockUserManager).getCurrentUser();
+        doReturn(Optional.empty())
+                .when(mockPlatformUsageCreditsUserBalanceService).findByUserId(pipelineUser.getId());
+
+        assertThat(userApiService.getCurrentUser().getUsageCredits()).isNull();
     }
 
     @Test

--- a/api/src/test/java/com/epam/pipeline/acl/user/UserApiServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/acl/user/UserApiServiceTest.java
@@ -55,7 +55,6 @@ import static com.epam.pipeline.test.creator.CommonCreatorConstants.TEST_STRING_
 import static com.epam.pipeline.util.CustomAssertions.assertThrows;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 public class UserApiServiceTest extends AbstractAclTest {

--- a/api/src/test/java/com/epam/pipeline/app/TestApplication.java
+++ b/api/src/test/java/com/epam/pipeline/app/TestApplication.java
@@ -30,6 +30,7 @@ import com.epam.pipeline.manager.cluster.InstanceOfferScheduler;
 import com.epam.pipeline.manager.cluster.performancemonitoring.ESMonitoringManager;
 import com.epam.pipeline.manager.cluster.pool.NodePoolUsageService;
 import com.epam.pipeline.manager.credits.PlatformUsageCreditsRuleService;
+import com.epam.pipeline.manager.credits.PlatformUsageCreditsUserBalanceService;
 import com.epam.pipeline.manager.datastorage.lifecycle.DataStorageLifecycleManager;
 import com.epam.pipeline.manager.datastorage.providers.StorageEventCollector;
 import com.epam.pipeline.manager.ldap.LdapManager;
@@ -210,6 +211,9 @@ public class TestApplication {
 
     @MockBean
     public PlatformUsageCreditsRuleService platformUsageCreditsRuleService;
+
+    @MockBean
+    public PlatformUsageCreditsUserBalanceService platformUsageCreditsUserBalanceService;
 
     @Bean
     public EmbeddedServletContainerCustomizer containerCustomizer() throws FileNotFoundException {

--- a/api/src/test/java/com/epam/pipeline/controller/credits/PlatformUsageCreditsUserBalanceControllerTest.java
+++ b/api/src/test/java/com/epam/pipeline/controller/credits/PlatformUsageCreditsUserBalanceControllerTest.java
@@ -27,6 +27,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
+import java.util.Collections;
 import java.util.List;
 
 import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.BALANCE_PAGED_TYPE;
@@ -78,9 +79,9 @@ public class PlatformUsageCreditsUserBalanceControllerTest extends AbstractContr
         final MvcResult result = performRequest(
                 post(RESET_URL)
                         .param("value", String.valueOf(RESET_VALUE))
-                        .param("userId", String.valueOf(USER_ID)));
+                        .param("userIds", String.valueOf(USER_ID)));
 
-        verify(mockApiService).reset(RESET_VALUE, USER_ID);
+        verify(mockApiService).reset(RESET_VALUE, Collections.singletonList(USER_ID));
         assertResponse(result, null, VOID_TYPE);
     }
 

--- a/api/src/test/java/com/epam/pipeline/controller/credits/PlatformUsageCreditsUserBalanceControllerTest.java
+++ b/api/src/test/java/com/epam/pipeline/controller/credits/PlatformUsageCreditsUserBalanceControllerTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017-2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.controller.credits;
+
+import com.epam.pipeline.acl.credits.PlatformUsageCreditsUserBalanceApiService;
+import com.epam.pipeline.controller.PagedResult;
+import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalance;
+import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalanceFilterVO;
+import com.epam.pipeline.test.web.AbstractControllerTest;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.List;
+
+import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.BALANCE_PAGED_TYPE;
+import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.RESET_VALUE;
+import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.USER_ID;
+import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.VOID_TYPE;
+import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.filterVO;
+import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.pagedResult;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+@WebMvcTest(controllers = PlatformUsageCreditsUserBalanceController.class)
+public class PlatformUsageCreditsUserBalanceControllerTest extends AbstractControllerTest {
+
+    private static final String BASE_URL = SERVLET_PATH + "/usage/credits/users";
+    private static final String RESET_URL = BASE_URL + "/reset";
+
+    @Autowired
+    private PlatformUsageCreditsUserBalanceApiService mockApiService;
+
+    @Test
+    public void shouldFailFilterForUnauthorizedUser() {
+        performUnauthorizedRequest(post(BASE_URL));
+    }
+
+    @Test
+    @WithMockUser
+    public void shouldFilter() throws Exception {
+        final PlatformUsageCreditsUserBalanceFilterVO filter = filterVO();
+        final PagedResult<List<PlatformUsageCreditsUserBalance>> expected = pagedResult();
+        doReturn(expected).when(mockApiService).filter(filter);
+        final String content = getObjectMapper().writeValueAsString(filter);
+
+        final MvcResult result = performRequest(post(BASE_URL).content(content));
+
+        verify(mockApiService).filter(filter);
+        assertResponse(result, expected, BALANCE_PAGED_TYPE);
+    }
+
+    @Test
+    public void shouldFailResetForUnauthorizedUser() {
+        performUnauthorizedRequest(post(RESET_URL).param("value", String.valueOf(RESET_VALUE)));
+    }
+
+    @Test
+    @WithMockUser
+    public void shouldResetForSpecificUser() {
+        final MvcResult result = performRequest(
+                post(RESET_URL)
+                        .param("value", String.valueOf(RESET_VALUE))
+                        .param("userId", String.valueOf(USER_ID)));
+
+        verify(mockApiService).reset(RESET_VALUE, USER_ID);
+        assertResponse(result, null, VOID_TYPE);
+    }
+
+    @Test
+    @WithMockUser
+    public void shouldResetForAllUsers() {
+        final MvcResult result = performRequest(
+                post(RESET_URL).param("value", String.valueOf(RESET_VALUE)));
+
+        verify(mockApiService).reset(RESET_VALUE, null);
+        assertResponse(result, null, VOID_TYPE);
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/controller/credits/PlatformUsageCreditsUserBalanceControllerTest.java
+++ b/api/src/test/java/com/epam/pipeline/controller/credits/PlatformUsageCreditsUserBalanceControllerTest.java
@@ -75,11 +75,13 @@ public class PlatformUsageCreditsUserBalanceControllerTest extends AbstractContr
 
     @Test
     @WithMockUser
-    public void shouldResetForSpecificUser() {
+    public void shouldResetForSpecificUser() throws Exception {
+        final String content = getObjectMapper().writeValueAsString(Collections.singletonList(USER_ID));
+
         final MvcResult result = performRequest(
                 post(RESET_URL)
                         .param("value", String.valueOf(RESET_VALUE))
-                        .param("userIds", String.valueOf(USER_ID)));
+                        .content(content));
 
         verify(mockApiService).reset(RESET_VALUE, Collections.singletonList(USER_ID));
         assertResponse(result, null, VOID_TYPE);

--- a/api/src/test/java/com/epam/pipeline/controller/user/UserControllerTest.java
+++ b/api/src/test/java/com/epam/pipeline/controller/user/UserControllerTest.java
@@ -275,11 +275,11 @@ public class UserControllerTest extends AbstractControllerTest {
     @Test
     @WithMockUser
     public void shouldLoadUser() {
-        doReturn(pipelineUser).when(mockUserApiService).loadUser(ID, false);
+        doReturn(pipelineUser).when(mockUserApiService).loadUser(ID, false, false);
 
         final MvcResult mvcResult = performRequest(get(String.format(USER_ID_URL, ID)));
 
-        verify(mockUserApiService).loadUser(ID, false);
+        verify(mockUserApiService).loadUser(ID, false, false);
         assertResponse(mvcResult, pipelineUser, UserCreatorUtils.PIPELINE_USER_INSTANCE_TYPE);
     }
 
@@ -338,11 +338,11 @@ public class UserControllerTest extends AbstractControllerTest {
     @Test
     @WithMockUser
     public void shouldLoadUsers() {
-        doReturn(pipelineUserList).when(mockUserApiService).loadUsers(false);
+        doReturn(pipelineUserList).when(mockUserApiService).loadUsers(false, false);
 
         final MvcResult mvcResult = performRequest(get(USERS_URL));
 
-        verify(mockUserApiService).loadUsers(false);
+        verify(mockUserApiService).loadUsers(false, false);
         assertResponse(mvcResult, pipelineUserList, UserCreatorUtils.PIPELINE_USER_LIST_INSTANCE_TYPE);
     }
 

--- a/api/src/test/java/com/epam/pipeline/manager/contextual/ContextualPreferenceManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/contextual/ContextualPreferenceManagerTest.java
@@ -267,7 +267,8 @@ public class ContextualPreferenceManagerTest {
         when(authManager.getCurrentUser()).thenReturn(USER_WITHOUT_ROLES);
         when(userManager.load(eq(USER_WITHOUT_ROLES.getId()))).thenReturn(USER);
 
-        final ContextualPreference searchedPreference = manager.search(NAMES, (ContextualPreferenceExternalResource) null);
+        final ContextualPreference searchedPreference = manager.search(NAMES,
+                (ContextualPreferenceExternalResource) null);
 
         assertThat(searchedPreference, is(preference));
     }

--- a/api/src/test/java/com/epam/pipeline/manager/contextual/ContextualPreferenceManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/contextual/ContextualPreferenceManagerTest.java
@@ -267,7 +267,7 @@ public class ContextualPreferenceManagerTest {
         when(authManager.getCurrentUser()).thenReturn(USER_WITHOUT_ROLES);
         when(userManager.load(eq(USER_WITHOUT_ROLES.getId()))).thenReturn(USER);
 
-        final ContextualPreference searchedPreference = manager.search(NAMES, null);
+        final ContextualPreference searchedPreference = manager.search(NAMES, (ContextualPreferenceExternalResource) null);
 
         assertThat(searchedPreference, is(preference));
     }

--- a/api/src/test/java/com/epam/pipeline/manager/contextual/ContextualPreferenceManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/contextual/ContextualPreferenceManagerTest.java
@@ -66,13 +66,13 @@ public class ContextualPreferenceManagerTest {
     private static final String USER_NAME = "userName";
     private static final PipelineUser USER = new PipelineUser(1L, null, Arrays.asList(ROLE_1, ROLE_2),
             Collections.emptyList(), false, false, null, null, null, null, null, null,
-            Collections.emptyMap(), Collections.emptyList(), null, Collections.emptyList(), null, null);
+            Collections.emptyMap(), Collections.emptyList(), null, Collections.emptyList(), null, null, null);
     private static final PipelineUser USER_WITHOUT_ROLES = new PipelineUser(USER.getId(), null, null,
             Collections.emptyList(), false, false, null, null, null, null, null, null,
-            Collections.emptyMap(), Collections.emptyList(), null, Collections.emptyList(), null, null);
+            Collections.emptyMap(), Collections.emptyList(), null, Collections.emptyList(), null, null, null);
     private static final PipelineUser USER_WITHOUT_ID = new PipelineUser(null, USER_NAME, Collections.emptyList(),
             Collections.emptyList(), false, false, null, null, null, null, null, null,
-            Collections.emptyMap(), Collections.emptyList(), null, Collections.emptyList(), null, null);
+            Collections.emptyMap(), Collections.emptyList(), null, Collections.emptyList(), null, null, null);
 
     private final ContextualPreferenceExternalResource toolResource =
             new ContextualPreferenceExternalResource(LEVEL, TOOL_ID);

--- a/api/src/test/java/com/epam/pipeline/manager/credits/PlatformUsageCreditsUserBalanceServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/credits/PlatformUsageCreditsUserBalanceServiceTest.java
@@ -22,12 +22,13 @@ import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalance;
 import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalanceFilterVO;
 import com.epam.pipeline.entity.contextual.ContextualPreference;
 import com.epam.pipeline.entity.credits.PlatformUsageCreditsUserBalanceEntity;
+import com.epam.pipeline.entity.user.PipelineUser;
 import com.epam.pipeline.manager.contextual.ContextualPreferenceManager;
 import com.epam.pipeline.manager.notification.NotificationManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
+import com.epam.pipeline.manager.user.UserManager;
 import com.epam.pipeline.mapper.credits.PlatformUsageCreditsUserBalanceMapper;
 import com.epam.pipeline.repository.credits.PlatformUsageCreditsUserBalanceRepository;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.data.domain.PageImpl;
@@ -42,7 +43,11 @@ import java.util.Optional;
 
 import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.BALANCE_ABOVE_THRESHOLD;
 import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.BALANCE_BELOW_THRESHOLD;
+import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.BALANCE_NEAR_MAX;
+import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.BALANCE_NEAR_MIN;
 import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.BALANCE_VALUE;
+import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.CURRENT_BALANCE;
+import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.EVENT_VALUE;
 import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.DEFAULT_BALANCE;
 import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.MAX_BALANCE;
 import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.MIN_BALANCE;
@@ -50,6 +55,7 @@ import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBal
 import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.RESET_VALUE;
 import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.USER_ID;
 import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.balanceDto;
+import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.pipelineUser;
 import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.balanceEntity;
 import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.deductionEvent;
 import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.filterVO;
@@ -75,12 +81,11 @@ public class PlatformUsageCreditsUserBalanceServiceTest {
             mock(ContextualPreferenceManager.class);
     private final NotificationManager notificationManager =
             mock(NotificationManager.class);
-    private final PlatformUsageCreditsUserBalanceService service;
-
-    {
-        service = new PlatformUsageCreditsUserBalanceService(repository, mapper, contextualPreferenceManager);
-        ReflectionTestUtils.setField(service, "notificationManager", notificationManager);
-    }
+    private final UserManager userManager =
+            mock(UserManager.class);
+    private final PlatformUsageCreditsUserBalanceService service =
+            new PlatformUsageCreditsUserBalanceService(
+                    repository, mapper, contextualPreferenceManager, notificationManager, userManager);
 
     @Test
     public void shouldReturnPagedBalancesOnFilter() {
@@ -235,147 +240,131 @@ public class PlatformUsageCreditsUserBalanceServiceTest {
     @Test
     public void shouldIncreaseBalanceWithinBounds() {
         mockPreferences(MIN_BALANCE, MAX_BALANCE, DEFAULT_BALANCE);
-        doReturn(Optional.of(entityWithValue(2000))).when(repository).findByUserId(USER_ID);
+        doReturn(Optional.of(entityWithValue(CURRENT_BALANCE))).when(repository).findByUserId(USER_ID);
+        mockJdbcUpdate(CURRENT_BALANCE + EVENT_VALUE);
 
-        final PlatformUsageCreditsUpdateEvent result = service.updateByEvent(increaseEvent(100));
+        final PlatformUsageCreditsUpdateEvent result = service.updateByEvent(increaseEvent(EVENT_VALUE));
 
-        assertThat(result.getValue(), is(100));
-        final ArgumentCaptor<PlatformUsageCreditsUserBalanceEntity> captor =
-                ArgumentCaptor.forClass(PlatformUsageCreditsUserBalanceEntity.class);
-        verify(repository).save(captor.capture());
-        assertThat(captor.getValue().getCurrentValue(), is(2100));
+        assertThat(result.getValue(), is(EVENT_VALUE));
     }
 
     @Test
     public void shouldClampIncreaseToMax() {
         mockPreferences(MIN_BALANCE, MAX_BALANCE, DEFAULT_BALANCE);
-        doReturn(Optional.of(entityWithValue(2900))).when(repository).findByUserId(USER_ID);
+        doReturn(Optional.of(entityWithValue(BALANCE_NEAR_MAX))).when(repository).findByUserId(USER_ID);
+        mockJdbcUpdate(MAX_BALANCE);
 
         final PlatformUsageCreditsUpdateEvent result = service.updateByEvent(increaseEvent(200));
 
-        assertThat(result.getValue(), is(100));
-        final ArgumentCaptor<PlatformUsageCreditsUserBalanceEntity> captor =
-                ArgumentCaptor.forClass(PlatformUsageCreditsUserBalanceEntity.class);
-        verify(repository).save(captor.capture());
-        assertThat(captor.getValue().getCurrentValue(), is(MAX_BALANCE));
+        assertThat(result.getValue(), is(MAX_BALANCE - BALANCE_NEAR_MAX));
     }
 
     @Test
     public void shouldReturnZeroValueWhenAlreadyAtMax() {
         mockPreferences(MIN_BALANCE, MAX_BALANCE, DEFAULT_BALANCE);
         doReturn(Optional.of(entityWithValue(MAX_BALANCE))).when(repository).findByUserId(USER_ID);
+        mockJdbcUpdate(MAX_BALANCE);
 
         final PlatformUsageCreditsUpdateEvent result = service.updateByEvent(increaseEvent(200));
 
         assertThat(result.getValue(), is(0));
-        verify(repository, never()).save(any(PlatformUsageCreditsUserBalanceEntity.class));
     }
 
     @Test
     public void shouldDeductBalanceWithinBounds() {
         mockPreferences(MIN_BALANCE, MAX_BALANCE, DEFAULT_BALANCE);
-        doReturn(Optional.of(entityWithValue(2000))).when(repository).findByUserId(USER_ID);
+        doReturn(Optional.of(entityWithValue(CURRENT_BALANCE))).when(repository).findByUserId(USER_ID);
+        mockJdbcUpdate(CURRENT_BALANCE - EVENT_VALUE);
 
-        final PlatformUsageCreditsUpdateEvent result = service.updateByEvent(deductionEvent(100));
+        final PlatformUsageCreditsUpdateEvent result = service.updateByEvent(deductionEvent(EVENT_VALUE));
 
-        assertThat(result.getValue(), is(100));
-        final ArgumentCaptor<PlatformUsageCreditsUserBalanceEntity> captor =
-                ArgumentCaptor.forClass(PlatformUsageCreditsUserBalanceEntity.class);
-        verify(repository).save(captor.capture());
-        assertThat(captor.getValue().getCurrentValue(), is(1900));
+        assertThat(result.getValue(), is(EVENT_VALUE));
     }
 
     @Test
     public void shouldClampDeductionToMin() {
         mockPreferences(MIN_BALANCE, MAX_BALANCE, DEFAULT_BALANCE);
-        doReturn(Optional.of(entityWithValue(50))).when(repository).findByUserId(USER_ID);
+        doReturn(Optional.of(entityWithValue(BALANCE_NEAR_MIN))).when(repository).findByUserId(USER_ID);
+        mockJdbcUpdate(MIN_BALANCE);
 
-        final PlatformUsageCreditsUpdateEvent result = service.updateByEvent(deductionEvent(100));
+        final PlatformUsageCreditsUpdateEvent result = service.updateByEvent(deductionEvent(EVENT_VALUE));
 
-        assertThat(result.getValue(), is(26));
-        final ArgumentCaptor<PlatformUsageCreditsUserBalanceEntity> captor =
-                ArgumentCaptor.forClass(PlatformUsageCreditsUserBalanceEntity.class);
-        verify(repository).save(captor.capture());
-        assertThat(captor.getValue().getCurrentValue(), is(MIN_BALANCE));
+        assertThat(result.getValue(), is(BALANCE_NEAR_MIN - MIN_BALANCE));
     }
 
     @Test
     public void shouldReturnZeroValueWhenAlreadyAtMin() {
         mockPreferences(MIN_BALANCE, MAX_BALANCE, DEFAULT_BALANCE);
         doReturn(Optional.of(entityWithValue(MIN_BALANCE))).when(repository).findByUserId(USER_ID);
+        mockJdbcUpdate(MIN_BALANCE);
 
         final PlatformUsageCreditsUpdateEvent result = service.updateByEvent(deductionEvent(100));
 
         assertThat(result.getValue(), is(0));
-        verify(repository, never()).save(any(PlatformUsageCreditsUserBalanceEntity.class));
     }
 
     @Test
     public void shouldUseDefaultBalanceWhenNoRowExists() {
         mockPreferences(MIN_BALANCE, MAX_BALANCE, DEFAULT_BALANCE);
         doReturn(Optional.empty()).when(repository).findByUserId(USER_ID);
+        mockJdbcUpdate(DEFAULT_BALANCE + EVENT_VALUE);
 
-        final PlatformUsageCreditsUpdateEvent result = service.updateByEvent(increaseEvent(100));
+        final PlatformUsageCreditsUpdateEvent result = service.updateByEvent(increaseEvent(EVENT_VALUE));
 
-        assertThat(result.getValue(), is(100));
-        final ArgumentCaptor<PlatformUsageCreditsUserBalanceEntity> captor =
-                ArgumentCaptor.forClass(PlatformUsageCreditsUserBalanceEntity.class);
-        verify(repository).save(captor.capture());
-        assertThat(captor.getValue().getCurrentValue(), is(DEFAULT_BALANCE + 100));
-        assertThat(captor.getValue().getUserId(), is(USER_ID));
+        assertThat(result.getValue(), is(EVENT_VALUE));
     }
 
     @Test
     public void shouldUpdateExistingRowOnEvent() {
         mockPreferences(MIN_BALANCE, MAX_BALANCE, DEFAULT_BALANCE);
-        final PlatformUsageCreditsUserBalanceEntity entity = entityWithValue(2000);
-        doReturn(Optional.of(entity)).when(repository).findByUserId(USER_ID);
+        doReturn(Optional.of(entityWithValue(CURRENT_BALANCE))).when(repository).findByUserId(USER_ID);
+        mockJdbcUpdate(CURRENT_BALANCE + EVENT_VALUE);
 
-        service.updateByEvent(increaseEvent(100));
+        service.updateByEvent(increaseEvent(EVENT_VALUE));
 
-        verify(repository).save(entity);
+        verify(repository).atomicUpdateBalance(any(), anyInt(), anyInt(), anyInt(), anyInt());
     }
 
     @Test
     public void shouldCreateNewRowWhenNoBalanceExists() {
         mockPreferences(MIN_BALANCE, MAX_BALANCE, DEFAULT_BALANCE);
         doReturn(Optional.empty()).when(repository).findByUserId(USER_ID);
+        mockJdbcUpdate(DEFAULT_BALANCE + EVENT_VALUE);
 
-        service.updateByEvent(increaseEvent(100));
+        service.updateByEvent(increaseEvent(EVENT_VALUE));
 
-        final ArgumentCaptor<PlatformUsageCreditsUserBalanceEntity> captor =
-                ArgumentCaptor.forClass(PlatformUsageCreditsUserBalanceEntity.class);
-        verify(repository).save(captor.capture());
-        assertThat(captor.getValue().getUserId(), is(USER_ID));
-        assertThat(captor.getValue().getModifiedDate(), notNullValue());
+        verify(repository).atomicUpdateBalance(any(), anyInt(), anyInt(), anyInt(), anyInt());
     }
 
     private void mockPreferences(final int min, final int max, final int defaultValue) {
+        final PipelineUser user = pipelineUser();
+        doReturn(user).when(userManager).load(USER_ID);
         doReturn(new ContextualPreference(SystemPreferences.USAGE_CREDITS_MIN.getKey(), String.valueOf(min)))
                 .when(contextualPreferenceManager)
-                .search(Collections.singletonList(SystemPreferences.USAGE_CREDITS_MIN.getKey()), USER_ID);
+                .search(Collections.singletonList(SystemPreferences.USAGE_CREDITS_MIN.getKey()), user);
         doReturn(new ContextualPreference(SystemPreferences.USAGE_CREDITS_MAX.getKey(), String.valueOf(max)))
                 .when(contextualPreferenceManager)
-                .search(Collections.singletonList(SystemPreferences.USAGE_CREDITS_MAX.getKey()), USER_ID);
+                .search(Collections.singletonList(SystemPreferences.USAGE_CREDITS_MAX.getKey()), user);
         doReturn(new ContextualPreference(SystemPreferences.USAGE_CREDITS_DEFAULT.getKey(),
                         String.valueOf(defaultValue)))
                 .when(contextualPreferenceManager)
-                .search(Collections.singletonList(SystemPreferences.USAGE_CREDITS_DEFAULT.getKey()), USER_ID);
+                .search(Collections.singletonList(SystemPreferences.USAGE_CREDITS_DEFAULT.getKey()), user);
         doReturn(new ContextualPreference(SystemPreferences.USAGE_CREDITS_NOTIFICATION_THRESHOLD.getKey(),
                         String.valueOf(NOTIFICATION_THRESHOLD)))
                 .when(contextualPreferenceManager)
                 .search(Collections.singletonList(
-                        SystemPreferences.USAGE_CREDITS_NOTIFICATION_THRESHOLD.getKey()), USER_ID);
+                        SystemPreferences.USAGE_CREDITS_NOTIFICATION_THRESHOLD.getKey()), user);
     }
 
     @Test
     public void shouldNotifyWhenBalanceDropsBelowThreshold() {
         // BALANCE_BELOW_THRESHOLD=700 < absoluteValue=768 → notify
         mockPreferences(MIN_BALANCE, MAX_BALANCE, DEFAULT_BALANCE);
-        doReturn(Optional.of(entityWithValue(BALANCE_BELOW_THRESHOLD + 100)))
+        doReturn(Optional.of(entityWithValue(BALANCE_BELOW_THRESHOLD + EVENT_VALUE)))
                 .when(repository).findByUserId(USER_ID);
+        mockJdbcUpdate(BALANCE_BELOW_THRESHOLD);
 
-        service.updateByEvent(deductionEvent(100));
+        service.updateByEvent(deductionEvent(EVENT_VALUE));
 
         verify(notificationManager).notifyLowUsageCredits(USER_ID, BALANCE_BELOW_THRESHOLD);
     }
@@ -384,23 +373,30 @@ public class PlatformUsageCreditsUserBalanceServiceTest {
     public void shouldNotNotifyWhenBalanceIsAboveThreshold() {
         // BALANCE_ABOVE_THRESHOLD=800 >= absoluteValue=768 → no notify
         mockPreferences(MIN_BALANCE, MAX_BALANCE, DEFAULT_BALANCE);
-        doReturn(Optional.of(entityWithValue(BALANCE_ABOVE_THRESHOLD - 100)))
+        doReturn(Optional.of(entityWithValue(BALANCE_ABOVE_THRESHOLD - EVENT_VALUE)))
                 .when(repository).findByUserId(USER_ID);
+        mockJdbcUpdate(BALANCE_ABOVE_THRESHOLD);
 
-        service.updateByEvent(increaseEvent(100));
+        service.updateByEvent(increaseEvent(EVENT_VALUE));
 
         verify(notificationManager, never()).notifyLowUsageCredits(any(), anyInt());
     }
 
     @Test
     public void shouldNotNotifyWhenEventHasNoEffect() {
-        // balance already at MAX, INCREASE → actualValue=0, no save, no notify
+        // balance already at MAX, INCREASE → actualValue=0, no notify
         mockPreferences(MIN_BALANCE, MAX_BALANCE, DEFAULT_BALANCE);
         doReturn(Optional.of(entityWithValue(MAX_BALANCE))).when(repository).findByUserId(USER_ID);
+        mockJdbcUpdate(MAX_BALANCE);
 
-        service.updateByEvent(increaseEvent(100));
+        service.updateByEvent(increaseEvent(EVENT_VALUE));
 
         verify(notificationManager, never()).notifyLowUsageCredits(any(), anyInt());
+    }
+
+    private void mockJdbcUpdate(final int newBalance) {
+        doReturn(newBalance).when(repository)
+                .atomicUpdateBalance(any(), anyInt(), anyInt(), anyInt(), anyInt());
     }
 
     private PlatformUsageCreditsUserBalanceEntity entityWithValue(final int value) {

--- a/api/src/test/java/com/epam/pipeline/manager/credits/PlatformUsageCreditsUserBalanceServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/credits/PlatformUsageCreditsUserBalanceServiceTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2017-2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.credits;
+
+import com.epam.pipeline.controller.PagedResult;
+import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalance;
+import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalanceFilterVO;
+import com.epam.pipeline.entity.credits.PlatformUsageCreditsUserBalanceEntity;
+import com.epam.pipeline.mapper.credits.PlatformUsageCreditsUserBalanceMapper;
+import com.epam.pipeline.repository.credits.PlatformUsageCreditsUserBalanceRepository;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.BALANCE_VALUE;
+import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.RESET_VALUE;
+import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.USER_ID;
+import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.balanceDto;
+import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.balanceEntity;
+import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.filterVO;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@SuppressWarnings("unchecked")
+public class PlatformUsageCreditsUserBalanceServiceTest {
+
+    private final PlatformUsageCreditsUserBalanceRepository repository =
+            mock(PlatformUsageCreditsUserBalanceRepository.class);
+    private final PlatformUsageCreditsUserBalanceMapper mapper =
+            mock(PlatformUsageCreditsUserBalanceMapper.class);
+    private final PlatformUsageCreditsUserBalanceService service =
+            new PlatformUsageCreditsUserBalanceService(repository, mapper);
+
+    @Test
+    public void shouldReturnPagedBalancesOnFilter() {
+        final PlatformUsageCreditsUserBalanceEntity entity = balanceEntity();
+        final PlatformUsageCreditsUserBalance dto = balanceDto();
+        doReturn(new PageImpl<>(Collections.singletonList(entity)))
+                .when(repository).findAll(any(Specification.class), any(Pageable.class));
+        doReturn(dto).when(mapper).toDto(entity);
+
+        final PagedResult<List<PlatformUsageCreditsUserBalance>> result = service.filter(filterVO());
+
+        assertThat(result.getElements().size(), is(1));
+        assertThat(result.getElements().get(0), is(dto));
+        assertThat(result.getTotalCount(), is(1));
+    }
+
+    @Test
+    public void shouldPassPageRequestToRepository() {
+        final PlatformUsageCreditsUserBalanceFilterVO filter = filterVO();
+        doReturn(new PageImpl<>(Collections.emptyList()))
+                .when(repository).findAll(any(Specification.class), any(Pageable.class));
+
+        service.filter(filter);
+
+        final ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+        verify(repository).findAll(any(Specification.class), captor.capture());
+        assertThat(captor.getValue().getPageNumber(), is(filter.getPage()));
+        assertThat(captor.getValue().getPageSize(), is(filter.getPageSize()));
+    }
+
+    @Test
+    public void shouldUpdateExistingEntityOnResetForUser() {
+        final PlatformUsageCreditsUserBalanceEntity entity = balanceEntity();
+        doReturn(Optional.of(entity)).when(repository).findByUserId(USER_ID);
+
+        service.reset(RESET_VALUE, USER_ID);
+
+        final ArgumentCaptor<PlatformUsageCreditsUserBalanceEntity> captor =
+                ArgumentCaptor.forClass(PlatformUsageCreditsUserBalanceEntity.class);
+        verify(repository).save(captor.capture());
+        assertThat(captor.getValue().getCurrentValue(), is(RESET_VALUE));
+        assertThat(captor.getValue().getModifiedDate(), notNullValue());
+        assertThat(captor.getValue().getUserId(), is(USER_ID));
+    }
+
+    @Test
+    public void shouldCreateEntityWhenUserHasNoBalanceOnReset() {
+        doReturn(Optional.empty()).when(repository).findByUserId(USER_ID);
+
+        service.reset(RESET_VALUE, USER_ID);
+
+        final ArgumentCaptor<PlatformUsageCreditsUserBalanceEntity> captor =
+                ArgumentCaptor.forClass(PlatformUsageCreditsUserBalanceEntity.class);
+        verify(repository).save(captor.capture());
+        assertThat(captor.getValue().getCurrentValue(), is(RESET_VALUE));
+        assertThat(captor.getValue().getModifiedDate(), notNullValue());
+        assertThat(captor.getValue().getUserId(), is(USER_ID));
+    }
+
+    @Test
+    public void shouldBulkResetAllWhenUserIdIsNull() {
+        service.reset(RESET_VALUE, null);
+
+        verify(repository).resetAll(anyInt(), any());
+        verify(repository, never()).findByUserId(any());
+        verify(repository, never()).save(any(PlatformUsageCreditsUserBalanceEntity.class));
+    }
+
+    @Test
+    public void shouldFilterByBalanceGreaterThan() {
+        final PlatformUsageCreditsUserBalanceFilterVO filter = PlatformUsageCreditsUserBalanceFilterVO.builder()
+                .value(BALANCE_VALUE)
+                .operation(">")
+                .page(0)
+                .pageSize(10)
+                .build();
+        doReturn(new PageImpl<>(Collections.emptyList()))
+                .when(repository).findAll(any(Specification.class), any(Pageable.class));
+
+        service.filter(filter);
+
+        verify(repository).findAll(any(Specification.class), any(Pageable.class));
+    }
+
+    @Test
+    public void shouldFilterByBalanceLessThan() {
+        final PlatformUsageCreditsUserBalanceFilterVO filter = PlatformUsageCreditsUserBalanceFilterVO.builder()
+                .value(BALANCE_VALUE)
+                .operation("<")
+                .page(0)
+                .pageSize(10)
+                .build();
+        doReturn(new PageImpl<>(Collections.emptyList()))
+                .when(repository).findAll(any(Specification.class), any(Pageable.class));
+
+        service.filter(filter);
+
+        verify(repository).findAll(any(Specification.class), any(Pageable.class));
+    }
+
+    @Test
+    public void shouldFilterByBalanceEqualTo() {
+        final PlatformUsageCreditsUserBalanceFilterVO filter = PlatformUsageCreditsUserBalanceFilterVO.builder()
+                .value(BALANCE_VALUE)
+                .operation("=")
+                .page(0)
+                .pageSize(10)
+                .build();
+        doReturn(new PageImpl<>(Collections.emptyList()))
+                .when(repository).findAll(any(Specification.class), any(Pageable.class));
+
+        service.filter(filter);
+
+        verify(repository).findAll(any(Specification.class), any(Pageable.class));
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/manager/credits/PlatformUsageCreditsUserBalanceServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/credits/PlatformUsageCreditsUserBalanceServiceTest.java
@@ -17,9 +17,13 @@
 package com.epam.pipeline.manager.credits;
 
 import com.epam.pipeline.controller.PagedResult;
+import com.epam.pipeline.dto.credits.PlatformUsageCreditsUpdateEvent;
 import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalance;
 import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalanceFilterVO;
+import com.epam.pipeline.entity.contextual.ContextualPreference;
 import com.epam.pipeline.entity.credits.PlatformUsageCreditsUserBalanceEntity;
+import com.epam.pipeline.manager.contextual.ContextualPreferenceManager;
+import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.mapper.credits.PlatformUsageCreditsUserBalanceMapper;
 import com.epam.pipeline.repository.credits.PlatformUsageCreditsUserBalanceRepository;
 import org.junit.Test;
@@ -28,16 +32,23 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 
+import java.util.Arrays;
 import java.util.Collections;
+
 import java.util.List;
 import java.util.Optional;
 
 import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.BALANCE_VALUE;
+import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.DEFAULT_BALANCE;
+import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.MAX_BALANCE;
+import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.MIN_BALANCE;
 import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.RESET_VALUE;
 import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.USER_ID;
 import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.balanceDto;
 import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.balanceEntity;
+import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.deductionEvent;
 import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.filterVO;
+import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.increaseEvent;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
@@ -55,8 +66,10 @@ public class PlatformUsageCreditsUserBalanceServiceTest {
             mock(PlatformUsageCreditsUserBalanceRepository.class);
     private final PlatformUsageCreditsUserBalanceMapper mapper =
             mock(PlatformUsageCreditsUserBalanceMapper.class);
+    private final ContextualPreferenceManager contextualPreferenceManager =
+            mock(ContextualPreferenceManager.class);
     private final PlatformUsageCreditsUserBalanceService service =
-            new PlatformUsageCreditsUserBalanceService(repository, mapper);
+            new PlatformUsageCreditsUserBalanceService(repository, mapper, contextualPreferenceManager);
 
     @Test
     public void shouldReturnPagedBalancesOnFilter() {
@@ -89,10 +102,11 @@ public class PlatformUsageCreditsUserBalanceServiceTest {
 
     @Test
     public void shouldUpdateExistingEntityOnResetForUser() {
+        mockPreferences(MIN_BALANCE, MAX_BALANCE, DEFAULT_BALANCE);
         final PlatformUsageCreditsUserBalanceEntity entity = balanceEntity();
         doReturn(Optional.of(entity)).when(repository).findByUserId(USER_ID);
 
-        service.reset(RESET_VALUE, USER_ID);
+        service.reset(RESET_VALUE, Collections.singletonList(USER_ID));
 
         final ArgumentCaptor<PlatformUsageCreditsUserBalanceEntity> captor =
                 ArgumentCaptor.forClass(PlatformUsageCreditsUserBalanceEntity.class);
@@ -104,9 +118,10 @@ public class PlatformUsageCreditsUserBalanceServiceTest {
 
     @Test
     public void shouldCreateEntityWhenUserHasNoBalanceOnReset() {
+        mockPreferences(MIN_BALANCE, MAX_BALANCE, DEFAULT_BALANCE);
         doReturn(Optional.empty()).when(repository).findByUserId(USER_ID);
 
-        service.reset(RESET_VALUE, USER_ID);
+        service.reset(RESET_VALUE, Collections.singletonList(USER_ID));
 
         final ArgumentCaptor<PlatformUsageCreditsUserBalanceEntity> captor =
                 ArgumentCaptor.forClass(PlatformUsageCreditsUserBalanceEntity.class);
@@ -120,8 +135,41 @@ public class PlatformUsageCreditsUserBalanceServiceTest {
     public void shouldBulkResetAllWhenUserIdIsNull() {
         service.reset(RESET_VALUE, null);
 
-        verify(repository).resetAll(anyInt(), any());
+        verify(repository).resetAll(RESET_VALUE);
         verify(repository, never()).findByUserId(any());
+        verify(repository, never()).save(any(PlatformUsageCreditsUserBalanceEntity.class));
+    }
+
+    @Test
+    public void shouldBulkResetAllWhenUserIdsIsEmpty() {
+        service.reset(RESET_VALUE, Collections.emptyList());
+
+        verify(repository).resetAll(RESET_VALUE);
+        verify(repository, never()).findByUserId(any());
+        verify(repository, never()).save(any(PlatformUsageCreditsUserBalanceEntity.class));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailResetWhenValueBelowMin() {
+        mockPreferences(MIN_BALANCE, MAX_BALANCE, DEFAULT_BALANCE);
+
+        service.reset(MIN_BALANCE - 1, Collections.singletonList(USER_ID));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailResetWhenValueAboveMax() {
+        mockPreferences(MIN_BALANCE, MAX_BALANCE, DEFAULT_BALANCE);
+
+        service.reset(MAX_BALANCE + 1, Collections.singletonList(USER_ID));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailResetOnFirstInvalidUserAndSkipRemaining() {
+        final Long secondUserId = USER_ID + 1;
+        mockPreferences(MIN_BALANCE, MAX_BALANCE, DEFAULT_BALANCE);
+
+        service.reset(MAX_BALANCE + 1, Arrays.asList(USER_ID, secondUserId));
+
         verify(repository, never()).save(any(PlatformUsageCreditsUserBalanceEntity.class));
     }
 
@@ -172,4 +220,144 @@ public class PlatformUsageCreditsUserBalanceServiceTest {
 
         verify(repository).findAll(any(Specification.class), any(Pageable.class));
     }
+
+    @Test
+    public void shouldIncreaseBalanceWithinBounds() {
+        mockPreferences(MIN_BALANCE, MAX_BALANCE, DEFAULT_BALANCE);
+        doReturn(Optional.of(entityWithValue(2000))).when(repository).findByUserId(USER_ID);
+
+        final PlatformUsageCreditsUpdateEvent result = service.updateByEvent(increaseEvent(100));
+
+        assertThat(result.getValue(), is(100));
+        final ArgumentCaptor<PlatformUsageCreditsUserBalanceEntity> captor =
+                ArgumentCaptor.forClass(PlatformUsageCreditsUserBalanceEntity.class);
+        verify(repository).save(captor.capture());
+        assertThat(captor.getValue().getCurrentValue(), is(2100));
+    }
+
+    @Test
+    public void shouldClampIncreaseToMax() {
+        mockPreferences(MIN_BALANCE, MAX_BALANCE, DEFAULT_BALANCE);
+        doReturn(Optional.of(entityWithValue(2900))).when(repository).findByUserId(USER_ID);
+
+        final PlatformUsageCreditsUpdateEvent result = service.updateByEvent(increaseEvent(200));
+
+        assertThat(result.getValue(), is(100));
+        final ArgumentCaptor<PlatformUsageCreditsUserBalanceEntity> captor =
+                ArgumentCaptor.forClass(PlatformUsageCreditsUserBalanceEntity.class);
+        verify(repository).save(captor.capture());
+        assertThat(captor.getValue().getCurrentValue(), is(MAX_BALANCE));
+    }
+
+    @Test
+    public void shouldReturnZeroValueWhenAlreadyAtMax() {
+        mockPreferences(MIN_BALANCE, MAX_BALANCE, DEFAULT_BALANCE);
+        doReturn(Optional.of(entityWithValue(MAX_BALANCE))).when(repository).findByUserId(USER_ID);
+
+        final PlatformUsageCreditsUpdateEvent result = service.updateByEvent(increaseEvent(200));
+
+        assertThat(result.getValue(), is(0));
+        verify(repository, never()).save(any(PlatformUsageCreditsUserBalanceEntity.class));
+    }
+
+    @Test
+    public void shouldDeductBalanceWithinBounds() {
+        mockPreferences(MIN_BALANCE, MAX_BALANCE, DEFAULT_BALANCE);
+        doReturn(Optional.of(entityWithValue(2000))).when(repository).findByUserId(USER_ID);
+
+        final PlatformUsageCreditsUpdateEvent result = service.updateByEvent(deductionEvent(100));
+
+        assertThat(result.getValue(), is(100));
+        final ArgumentCaptor<PlatformUsageCreditsUserBalanceEntity> captor =
+                ArgumentCaptor.forClass(PlatformUsageCreditsUserBalanceEntity.class);
+        verify(repository).save(captor.capture());
+        assertThat(captor.getValue().getCurrentValue(), is(1900));
+    }
+
+    @Test
+    public void shouldClampDeductionToMin() {
+        mockPreferences(MIN_BALANCE, MAX_BALANCE, DEFAULT_BALANCE);
+        doReturn(Optional.of(entityWithValue(50))).when(repository).findByUserId(USER_ID);
+
+        final PlatformUsageCreditsUpdateEvent result = service.updateByEvent(deductionEvent(100));
+
+        assertThat(result.getValue(), is(26));
+        final ArgumentCaptor<PlatformUsageCreditsUserBalanceEntity> captor =
+                ArgumentCaptor.forClass(PlatformUsageCreditsUserBalanceEntity.class);
+        verify(repository).save(captor.capture());
+        assertThat(captor.getValue().getCurrentValue(), is(MIN_BALANCE));
+    }
+
+    @Test
+    public void shouldReturnZeroValueWhenAlreadyAtMin() {
+        mockPreferences(MIN_BALANCE, MAX_BALANCE, DEFAULT_BALANCE);
+        doReturn(Optional.of(entityWithValue(MIN_BALANCE))).when(repository).findByUserId(USER_ID);
+
+        final PlatformUsageCreditsUpdateEvent result = service.updateByEvent(deductionEvent(100));
+
+        assertThat(result.getValue(), is(0));
+        verify(repository, never()).save(any(PlatformUsageCreditsUserBalanceEntity.class));
+    }
+
+    @Test
+    public void shouldUseDefaultBalanceWhenNoRowExists() {
+        mockPreferences(MIN_BALANCE, MAX_BALANCE, DEFAULT_BALANCE);
+        doReturn(Optional.empty()).when(repository).findByUserId(USER_ID);
+
+        final PlatformUsageCreditsUpdateEvent result = service.updateByEvent(increaseEvent(100));
+
+        assertThat(result.getValue(), is(100));
+        final ArgumentCaptor<PlatformUsageCreditsUserBalanceEntity> captor =
+                ArgumentCaptor.forClass(PlatformUsageCreditsUserBalanceEntity.class);
+        verify(repository).save(captor.capture());
+        assertThat(captor.getValue().getCurrentValue(), is(DEFAULT_BALANCE + 100));
+        assertThat(captor.getValue().getUserId(), is(USER_ID));
+    }
+
+    @Test
+    public void shouldUpdateExistingRowOnEvent() {
+        mockPreferences(MIN_BALANCE, MAX_BALANCE, DEFAULT_BALANCE);
+        final PlatformUsageCreditsUserBalanceEntity entity = entityWithValue(2000);
+        doReturn(Optional.of(entity)).when(repository).findByUserId(USER_ID);
+
+        service.updateByEvent(increaseEvent(100));
+
+        verify(repository).save(entity);
+    }
+
+    @Test
+    public void shouldCreateNewRowWhenNoBalanceExists() {
+        mockPreferences(MIN_BALANCE, MAX_BALANCE, DEFAULT_BALANCE);
+        doReturn(Optional.empty()).when(repository).findByUserId(USER_ID);
+
+        service.updateByEvent(increaseEvent(100));
+
+        final ArgumentCaptor<PlatformUsageCreditsUserBalanceEntity> captor =
+                ArgumentCaptor.forClass(PlatformUsageCreditsUserBalanceEntity.class);
+        verify(repository).save(captor.capture());
+        assertThat(captor.getValue().getUserId(), is(USER_ID));
+        assertThat(captor.getValue().getModifiedDate(), notNullValue());
+    }
+
+    private void mockPreferences(final int min, final int max, final int defaultValue) {
+        doReturn(new ContextualPreference(SystemPreferences.USAGE_CREDITS_MIN.getKey(), String.valueOf(min)))
+                .when(contextualPreferenceManager)
+                .search(Collections.singletonList(SystemPreferences.USAGE_CREDITS_MIN.getKey()), USER_ID);
+        doReturn(new ContextualPreference(SystemPreferences.USAGE_CREDITS_MAX.getKey(), String.valueOf(max)))
+                .when(contextualPreferenceManager)
+                .search(Collections.singletonList(SystemPreferences.USAGE_CREDITS_MAX.getKey()), USER_ID);
+        doReturn(new ContextualPreference(SystemPreferences.USAGE_CREDITS_DEFAULT.getKey(),
+                        String.valueOf(defaultValue)))
+                .when(contextualPreferenceManager)
+                .search(Collections.singletonList(SystemPreferences.USAGE_CREDITS_DEFAULT.getKey()), USER_ID);
+    }
+
+    private PlatformUsageCreditsUserBalanceEntity entityWithValue(final int value) {
+        return PlatformUsageCreditsUserBalanceEntity.builder()
+                .id(1L)
+                .userId(USER_ID)
+                .currentValue(value)
+                .build();
+    }
+
 }

--- a/api/src/test/java/com/epam/pipeline/manager/credits/PlatformUsageCreditsUserBalanceServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/credits/PlatformUsageCreditsUserBalanceServiceTest.java
@@ -23,9 +23,11 @@ import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalanceFilterVO;
 import com.epam.pipeline.entity.contextual.ContextualPreference;
 import com.epam.pipeline.entity.credits.PlatformUsageCreditsUserBalanceEntity;
 import com.epam.pipeline.manager.contextual.ContextualPreferenceManager;
+import com.epam.pipeline.manager.notification.NotificationManager;
 import com.epam.pipeline.manager.preference.SystemPreferences;
 import com.epam.pipeline.mapper.credits.PlatformUsageCreditsUserBalanceMapper;
 import com.epam.pipeline.repository.credits.PlatformUsageCreditsUserBalanceRepository;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.data.domain.PageImpl;
@@ -38,10 +40,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.BALANCE_ABOVE_THRESHOLD;
+import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.BALANCE_BELOW_THRESHOLD;
 import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.BALANCE_VALUE;
 import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.DEFAULT_BALANCE;
 import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.MAX_BALANCE;
 import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.MIN_BALANCE;
+import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.NOTIFICATION_THRESHOLD;
 import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.RESET_VALUE;
 import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.USER_ID;
 import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.balanceDto;
@@ -68,8 +73,14 @@ public class PlatformUsageCreditsUserBalanceServiceTest {
             mock(PlatformUsageCreditsUserBalanceMapper.class);
     private final ContextualPreferenceManager contextualPreferenceManager =
             mock(ContextualPreferenceManager.class);
-    private final PlatformUsageCreditsUserBalanceService service =
-            new PlatformUsageCreditsUserBalanceService(repository, mapper, contextualPreferenceManager);
+    private final NotificationManager notificationManager =
+            mock(NotificationManager.class);
+    private final PlatformUsageCreditsUserBalanceService service;
+
+    {
+        service = new PlatformUsageCreditsUserBalanceService(repository, mapper, contextualPreferenceManager);
+        ReflectionTestUtils.setField(service, "notificationManager", notificationManager);
+    }
 
     @Test
     public void shouldReturnPagedBalancesOnFilter() {
@@ -350,6 +361,46 @@ public class PlatformUsageCreditsUserBalanceServiceTest {
                         String.valueOf(defaultValue)))
                 .when(contextualPreferenceManager)
                 .search(Collections.singletonList(SystemPreferences.USAGE_CREDITS_DEFAULT.getKey()), USER_ID);
+        doReturn(new ContextualPreference(SystemPreferences.USAGE_CREDITS_NOTIFICATION_THRESHOLD.getKey(),
+                        String.valueOf(NOTIFICATION_THRESHOLD)))
+                .when(contextualPreferenceManager)
+                .search(Collections.singletonList(
+                        SystemPreferences.USAGE_CREDITS_NOTIFICATION_THRESHOLD.getKey()), USER_ID);
+    }
+
+    @Test
+    public void shouldNotifyWhenBalanceDropsBelowThreshold() {
+        // BALANCE_BELOW_THRESHOLD=700 < absoluteValue=768 → notify
+        mockPreferences(MIN_BALANCE, MAX_BALANCE, DEFAULT_BALANCE);
+        doReturn(Optional.of(entityWithValue(BALANCE_BELOW_THRESHOLD + 100)))
+                .when(repository).findByUserId(USER_ID);
+
+        service.updateByEvent(deductionEvent(100));
+
+        verify(notificationManager).notifyLowUsageCredits(USER_ID, BALANCE_BELOW_THRESHOLD);
+    }
+
+    @Test
+    public void shouldNotNotifyWhenBalanceIsAboveThreshold() {
+        // BALANCE_ABOVE_THRESHOLD=800 >= absoluteValue=768 → no notify
+        mockPreferences(MIN_BALANCE, MAX_BALANCE, DEFAULT_BALANCE);
+        doReturn(Optional.of(entityWithValue(BALANCE_ABOVE_THRESHOLD - 100)))
+                .when(repository).findByUserId(USER_ID);
+
+        service.updateByEvent(increaseEvent(100));
+
+        verify(notificationManager, never()).notifyLowUsageCredits(any(), anyInt());
+    }
+
+    @Test
+    public void shouldNotNotifyWhenEventHasNoEffect() {
+        // balance already at MAX, INCREASE → actualValue=0, no save, no notify
+        mockPreferences(MIN_BALANCE, MAX_BALANCE, DEFAULT_BALANCE);
+        doReturn(Optional.of(entityWithValue(MAX_BALANCE))).when(repository).findByUserId(USER_ID);
+
+        service.updateByEvent(increaseEvent(100));
+
+        verify(notificationManager, never()).notifyLowUsageCredits(any(), anyInt());
     }
 
     private PlatformUsageCreditsUserBalanceEntity entityWithValue(final int value) {

--- a/api/src/test/java/com/epam/pipeline/manager/user/UserExporterTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/user/UserExporterTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017-2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.user;
+
+import com.epam.pipeline.controller.vo.PipelineUserExportVO;
+import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalance;
+import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.entity.user.PipelineUserWithStoragePath;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static com.epam.pipeline.test.creator.CommonCreatorConstants.ID;
+import static com.epam.pipeline.test.creator.user.UserCreatorUtils.getPipelineUser;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UserExporterTest {
+
+    private static final int CREDITS_VALUE = 1500;
+    private static final String USAGE_CREDITS_HEADER = "usageCredits";
+
+    private final UserExporter exporter = new UserExporter();
+
+    @Test
+    public void shouldIncludeUsageCreditsColumnInHeaderWhenFlagIsSet() {
+        final PipelineUserExportVO settings = new PipelineUserExportVO();
+        settings.setIncludeHeader(true);
+        settings.setIncludeCredits(true);
+
+        final String csv = exporter.exportUsers(settings, Collections.emptyList(), Collections.emptyList());
+
+        assertThat(csv).contains(USAGE_CREDITS_HEADER);
+    }
+
+    @Test
+    public void shouldNotIncludeUsageCreditsColumnWhenFlagIsNotSet() {
+        final PipelineUserExportVO settings = new PipelineUserExportVO();
+        settings.setIncludeHeader(true);
+        settings.setIncludeCredits(false);
+
+        final String csv = exporter.exportUsers(settings, Collections.emptyList(), Collections.emptyList());
+
+        assertThat(csv).doesNotContain(USAGE_CREDITS_HEADER);
+    }
+
+    @Test
+    public void shouldWriteCreditsValueWhenBalanceIsPresent() {
+        final PipelineUserExportVO settings = exportSettingsWithCredits();
+        final PipelineUser user = getPipelineUser("USER1", ID);
+        user.setUsageCredits(new PlatformUsageCreditsUserBalance(ID, CREDITS_VALUE, null));
+        final List<PipelineUserWithStoragePath> users = Collections.singletonList(wrap(user));
+
+        final String csv = exporter.exportUsers(settings, users, Collections.emptyList());
+
+        assertThat(csv).contains(String.valueOf(CREDITS_VALUE));
+    }
+
+    @Test
+    public void shouldWriteEmptyStringWhenBalanceIsNull() {
+        final PipelineUserExportVO settings = exportSettingsWithCredits();
+        final PipelineUser user = getPipelineUser("USER1", ID);
+        // usageCredits intentionally left null
+        final List<PipelineUserWithStoragePath> users = Collections.singletonList(wrap(user));
+
+        final String csv = exporter.exportUsers(settings, users, Collections.emptyList());
+
+        // header present but no numeric value on the data row
+        assertThat(csv).contains(USAGE_CREDITS_HEADER);
+        assertThat(csv).doesNotContain(String.valueOf(CREDITS_VALUE));
+    }
+
+    private static PipelineUserExportVO exportSettingsWithCredits() {
+        final PipelineUserExportVO settings = new PipelineUserExportVO();
+        settings.setIncludeHeader(true);
+        settings.setIncludeCredits(true);
+        return settings;
+    }
+
+    private static PipelineUserWithStoragePath wrap(final PipelineUser user) {
+        return PipelineUserWithStoragePath.builder().pipelineUser(user).build();
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/mapper/credits/PlatformUsageCreditsUserBalanceMapperTest.java
+++ b/api/src/test/java/com/epam/pipeline/mapper/credits/PlatformUsageCreditsUserBalanceMapperTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.mapper.credits;
+
+import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalance;
+import com.epam.pipeline.entity.credits.PlatformUsageCreditsUserBalanceEntity;
+import org.junit.Test;
+import org.mapstruct.factory.Mappers;
+
+import static com.epam.pipeline.test.creator.credits.PlatformUsageCreditsUserBalanceCreatorUtils.balanceEntity;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class PlatformUsageCreditsUserBalanceMapperTest {
+
+    private final PlatformUsageCreditsUserBalanceMapper mapper =
+            Mappers.getMapper(PlatformUsageCreditsUserBalanceMapper.class);
+
+    @Test
+    public void shouldMapAllFieldsFromEntityToDto() {
+        final PlatformUsageCreditsUserBalanceEntity entity = balanceEntity();
+
+        final PlatformUsageCreditsUserBalance dto = mapper.toDto(entity);
+
+        assertThat(dto.getUserId(), is(entity.getUserId()));
+        assertThat(dto.getCurrentValue(), is(entity.getCurrentValue()));
+        assertThat(dto.getModifiedDate(), is(entity.getModifiedDate()));
+    }
+
+    @Test
+    public void shouldPreserveModifiedDate() {
+        final PlatformUsageCreditsUserBalanceEntity entity = balanceEntity();
+
+        final PlatformUsageCreditsUserBalance dto = mapper.toDto(entity);
+
+        assertThat(dto.getModifiedDate(), notNullValue());
+        assertThat(dto.getModifiedDate(), is(entity.getModifiedDate()));
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/repository/credits/PlatformUsageCreditsUserBalanceRepositoryTest.java
+++ b/api/src/test/java/com/epam/pipeline/repository/credits/PlatformUsageCreditsUserBalanceRepositoryTest.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2017-2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.repository.credits;
+
+import com.epam.pipeline.dao.user.UserDao;
+import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalanceFilterVO;
+import com.epam.pipeline.entity.credits.PlatformUsageCreditsUserBalanceEntity;
+import com.epam.pipeline.entity.user.PipelineUser;
+import com.epam.pipeline.entity.utils.DateUtils;
+import com.epam.pipeline.test.repository.AbstractJpaTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+
+import static com.epam.pipeline.test.creator.user.UserCreatorUtils.getPipelineUser;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@Transactional
+public class PlatformUsageCreditsUserBalanceRepositoryTest extends AbstractJpaTest {
+
+    private static final String USER1 = "BALANCE_USER1";
+    private static final String USER2 = "BALANCE_USER2";
+    private static final int VALUE_HIGH = 2000;
+    private static final int VALUE_LOW = 500;
+    private static final int RESET_VALUE = 1500;
+
+    @Autowired
+    private PlatformUsageCreditsUserBalanceRepository repository;
+
+    @Autowired
+    private UserDao userDao;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    private PipelineUser user1;
+    private PipelineUser user2;
+
+    @Before
+    public void setUp() {
+        user1 = userDao.createUser(getPipelineUser(USER1), Collections.emptyList());
+        user2 = userDao.createUser(getPipelineUser(USER2), Collections.emptyList());
+    }
+
+    @Test
+    public void shouldSaveAndFindByUserId() {
+        final PlatformUsageCreditsUserBalanceEntity entity = entity(user1.getId(), VALUE_HIGH);
+        repository.save(entity);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        final Optional<PlatformUsageCreditsUserBalanceEntity> loaded = repository.findByUserId(user1.getId());
+        assertThat(loaded.isPresent(), is(true));
+        assertThat(loaded.get().getUserId(), is(user1.getId()));
+        assertThat(loaded.get().getCurrentValue(), is(VALUE_HIGH));
+        assertThat(loaded.get().getModifiedDate(), notNullValue());
+    }
+
+    @Test
+    public void shouldReturnEmptyWhenUserHasNoBalance() {
+        assertThat(repository.findByUserId(user1.getId()).isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldUpdateBalance() {
+        final PlatformUsageCreditsUserBalanceEntity entity = entity(user1.getId(), VALUE_LOW);
+        repository.save(entity);
+        entityManager.flush();
+        entityManager.clear();
+
+        final PlatformUsageCreditsUserBalanceEntity loaded = repository.findByUserId(user1.getId()).get();
+        loaded.setCurrentValue(VALUE_HIGH);
+        repository.save(loaded);
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(repository.findByUserId(user1.getId()).get().getCurrentValue(), is(VALUE_HIGH));
+    }
+
+    @Test
+    public void shouldDeleteBalance() {
+        final PlatformUsageCreditsUserBalanceEntity entity = entity(user1.getId(), VALUE_HIGH);
+        repository.save(entity);
+        entityManager.flush();
+        entityManager.clear();
+
+        repository.delete(entity.getId());
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(repository.findByUserId(user1.getId()).isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldFilterByUserIds() {
+        repository.save(entity(user1.getId(), VALUE_HIGH));
+        repository.save(entity(user2.getId(), VALUE_LOW));
+        entityManager.flush();
+        entityManager.clear();
+
+        final PlatformUsageCreditsUserBalanceFilterVO filter = filterVO(
+                Collections.singletonList(user1.getId()), null, null);
+        final Page<PlatformUsageCreditsUserBalanceEntity> page =
+                repository.findAll(PlatformUsageCreditsUserBalanceSpecification.build(filter),
+                        new PageRequest(0, 10));
+
+        assertThat(page.getTotalElements(), is(1L));
+        assertThat(page.getContent().get(0).getUserId(), is(user1.getId()));
+    }
+
+    @Test
+    public void shouldFilterByBalanceGreaterThan() {
+        repository.save(entity(user1.getId(), VALUE_HIGH));
+        repository.save(entity(user2.getId(), VALUE_LOW));
+        entityManager.flush();
+        entityManager.clear();
+
+        final PlatformUsageCreditsUserBalanceFilterVO filter = filterVO(null, VALUE_LOW, ">");
+        final Page<PlatformUsageCreditsUserBalanceEntity> page =
+                repository.findAll(PlatformUsageCreditsUserBalanceSpecification.build(filter),
+                        new PageRequest(0, 10));
+
+        assertThat(page.getTotalElements(), is(1L));
+        assertThat(page.getContent().get(0).getCurrentValue(), is(VALUE_HIGH));
+    }
+
+    @Test
+    public void shouldFilterByBalanceLessThan() {
+        repository.save(entity(user1.getId(), VALUE_HIGH));
+        repository.save(entity(user2.getId(), VALUE_LOW));
+        entityManager.flush();
+        entityManager.clear();
+
+        final PlatformUsageCreditsUserBalanceFilterVO filter = filterVO(null, VALUE_HIGH, "<");
+        final Page<PlatformUsageCreditsUserBalanceEntity> page =
+                repository.findAll(PlatformUsageCreditsUserBalanceSpecification.build(filter),
+                        new PageRequest(0, 10));
+
+        assertThat(page.getTotalElements(), is(1L));
+        assertThat(page.getContent().get(0).getCurrentValue(), is(VALUE_LOW));
+    }
+
+    @Test
+    public void shouldFilterByBalanceEqualTo() {
+        repository.save(entity(user1.getId(), VALUE_HIGH));
+        repository.save(entity(user2.getId(), VALUE_LOW));
+        entityManager.flush();
+        entityManager.clear();
+
+        final PlatformUsageCreditsUserBalanceFilterVO filter = filterVO(null, VALUE_HIGH, "=");
+        final Page<PlatformUsageCreditsUserBalanceEntity> page =
+                repository.findAll(PlatformUsageCreditsUserBalanceSpecification.build(filter),
+                        new PageRequest(0, 10));
+
+        assertThat(page.getTotalElements(), is(1L));
+        assertThat(page.getContent().get(0).getCurrentValue(), is(VALUE_HIGH));
+    }
+
+    @Test
+    public void shouldCombineUserIdsAndBalanceFilter() {
+        repository.save(entity(user1.getId(), VALUE_HIGH));
+        repository.save(entity(user2.getId(), VALUE_HIGH));
+        entityManager.flush();
+        entityManager.clear();
+
+        final PlatformUsageCreditsUserBalanceFilterVO filter = filterVO(
+                Collections.singletonList(user1.getId()), VALUE_LOW, ">");
+        final Page<PlatformUsageCreditsUserBalanceEntity> page =
+                repository.findAll(PlatformUsageCreditsUserBalanceSpecification.build(filter),
+                        new PageRequest(0, 10));
+
+        assertThat(page.getTotalElements(), is(1L));
+        assertThat(page.getContent().get(0).getUserId(), is(user1.getId()));
+    }
+
+    @Test
+    public void shouldReturnAllWhenNoFiltersApplied() {
+        repository.save(entity(user1.getId(), VALUE_HIGH));
+        repository.save(entity(user2.getId(), VALUE_LOW));
+        entityManager.flush();
+        entityManager.clear();
+
+        final PlatformUsageCreditsUserBalanceFilterVO filter = filterVO(null, null, null);
+        final Page<PlatformUsageCreditsUserBalanceEntity> page =
+                repository.findAll(PlatformUsageCreditsUserBalanceSpecification.build(filter),
+                        new PageRequest(0, 10));
+
+        assertThat(page.getTotalElements(), is(2L));
+    }
+
+    @Test
+    public void shouldResetAll() {
+        repository.save(entity(user1.getId(), VALUE_HIGH));
+        repository.save(entity(user2.getId(), VALUE_LOW));
+        entityManager.flush();
+        entityManager.clear();
+
+        repository.resetAll(RESET_VALUE, DateUtils.nowUTC());
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(repository.findByUserId(user1.getId()).get().getCurrentValue(), is(RESET_VALUE));
+        assertThat(repository.findByUserId(user2.getId()).get().getCurrentValue(), is(RESET_VALUE));
+    }
+
+    @Test
+    public void shouldSupportPaging() {
+        repository.save(entity(user1.getId(), VALUE_HIGH));
+        repository.save(entity(user2.getId(), VALUE_LOW));
+        entityManager.flush();
+        entityManager.clear();
+
+        final PlatformUsageCreditsUserBalanceFilterVO filter = filterVO(null, null, null);
+        final Page<PlatformUsageCreditsUserBalanceEntity> firstPage =
+                repository.findAll(PlatformUsageCreditsUserBalanceSpecification.build(filter),
+                        new PageRequest(0, 1));
+
+        assertThat(firstPage.getTotalElements(), is(2L));
+        assertThat(firstPage.getContent().size(), is(1));
+
+        final Page<PlatformUsageCreditsUserBalanceEntity> secondPage =
+                repository.findAll(PlatformUsageCreditsUserBalanceSpecification.build(filter),
+                        new PageRequest(1, 1));
+
+        assertThat(secondPage.getContent().size(), is(1));
+    }
+
+    @Test
+    public void shouldFilterMultipleUserIds() {
+        repository.save(entity(user1.getId(), VALUE_HIGH));
+        repository.save(entity(user2.getId(), VALUE_LOW));
+        entityManager.flush();
+        entityManager.clear();
+
+        final PlatformUsageCreditsUserBalanceFilterVO filter = filterVO(
+                Arrays.asList(user1.getId(), user2.getId()), null, null);
+        final Page<PlatformUsageCreditsUserBalanceEntity> page =
+                repository.findAll(PlatformUsageCreditsUserBalanceSpecification.build(filter),
+                        new PageRequest(0, 10));
+
+        assertThat(page.getTotalElements(), is(2L));
+    }
+
+    private static PlatformUsageCreditsUserBalanceEntity entity(final Long userId, final int value) {
+        return PlatformUsageCreditsUserBalanceEntity.builder()
+                .userId(userId)
+                .currentValue(value)
+                .modifiedDate(DateUtils.nowUTC())
+                .build();
+    }
+
+    private static PlatformUsageCreditsUserBalanceFilterVO filterVO(
+            final java.util.List<Long> userIds, final Integer value, final String operation) {
+        return PlatformUsageCreditsUserBalanceFilterVO.builder()
+                .userIds(userIds)
+                .value(value)
+                .operation(operation)
+                .page(0)
+                .pageSize(10)
+                .build();
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/repository/credits/PlatformUsageCreditsUserBalanceRepositoryTest.java
+++ b/api/src/test/java/com/epam/pipeline/repository/credits/PlatformUsageCreditsUserBalanceRepositoryTest.java
@@ -47,6 +47,12 @@ public class PlatformUsageCreditsUserBalanceRepositoryTest extends AbstractJpaTe
     private static final int VALUE_HIGH = 2000;
     private static final int VALUE_LOW = 500;
     private static final int RESET_VALUE = 1500;
+    private static final int MIN_BALANCE = 24;
+    private static final int MAX_BALANCE = 3000;
+    private static final int DEFAULT_BALANCE = 2000;
+    private static final int DELTA = 100;
+    private static final int BALANCE_NEAR_MAX = 2950;
+    private static final int BALANCE_NEAR_MIN = 50;
 
     @Autowired
     private PlatformUsageCreditsUserBalanceRepository repository;
@@ -279,6 +285,91 @@ public class PlatformUsageCreditsUserBalanceRepositoryTest extends AbstractJpaTe
                         new PageRequest(0, 10));
 
         assertThat(page.getTotalElements(), is(2L));
+    }
+
+    @Test
+    public void shouldIncreaseBalanceAtomicallyAndReturnNewValue() {
+        repository.save(entity(user1.getId(), VALUE_HIGH));
+        entityManager.flush();
+        entityManager.clear();
+
+        final int result = repository.atomicUpdateBalance(
+                user1.getId(), DELTA, DEFAULT_BALANCE, MIN_BALANCE, MAX_BALANCE);
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(result, is(VALUE_HIGH + DELTA));
+        assertThat(repository.findByUserId(user1.getId()).get().getCurrentValue(), is(VALUE_HIGH + DELTA));
+    }
+
+    @Test
+    public void shouldDeductBalanceAtomicallyAndReturnNewValue() {
+        repository.save(entity(user1.getId(), VALUE_HIGH));
+        entityManager.flush();
+        entityManager.clear();
+
+        final int result = repository.atomicUpdateBalance(
+                user1.getId(), -DELTA, DEFAULT_BALANCE, MIN_BALANCE, MAX_BALANCE);
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(result, is(VALUE_HIGH - DELTA));
+        assertThat(repository.findByUserId(user1.getId()).get().getCurrentValue(), is(VALUE_HIGH - DELTA));
+    }
+
+    @Test
+    public void shouldClampIncreaseToMax() {
+        repository.save(entity(user1.getId(), BALANCE_NEAR_MAX));
+        entityManager.flush();
+        entityManager.clear();
+
+        final int result = repository.atomicUpdateBalance(
+                user1.getId(), DELTA * 2, DEFAULT_BALANCE, MIN_BALANCE, MAX_BALANCE);
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(result, is(MAX_BALANCE));
+        assertThat(repository.findByUserId(user1.getId()).get().getCurrentValue(), is(MAX_BALANCE));
+    }
+
+    @Test
+    public void shouldClampDeductionToMin() {
+        repository.save(entity(user1.getId(), BALANCE_NEAR_MIN));
+        entityManager.flush();
+        entityManager.clear();
+
+        final int result = repository.atomicUpdateBalance(
+                user1.getId(), -DELTA, DEFAULT_BALANCE, MIN_BALANCE, MAX_BALANCE);
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(result, is(MIN_BALANCE));
+        assertThat(repository.findByUserId(user1.getId()).get().getCurrentValue(), is(MIN_BALANCE));
+    }
+
+    @Test
+    public void shouldCreateRowFromDefaultBalanceWhenNoRowExists() {
+        // user1 has no balance row
+        final int result = repository.atomicUpdateBalance(
+                user1.getId(), DELTA, DEFAULT_BALANCE, MIN_BALANCE, MAX_BALANCE);
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(result, is(DEFAULT_BALANCE + DELTA));
+        assertThat(repository.findByUserId(user1.getId()).get().getCurrentValue(), is(DEFAULT_BALANCE + DELTA));
+    }
+
+    @Test
+    public void shouldClampDefaultPlusDeltaToMaxOnFirstInsert() {
+        // no row; default + delta would exceed max
+        final int highDefault = MAX_BALANCE - DELTA / 2;
+        final int result = repository.atomicUpdateBalance(
+                user1.getId(), DELTA, highDefault, MIN_BALANCE, MAX_BALANCE);
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(result, is(MAX_BALANCE));
+        assertThat(repository.findByUserId(user1.getId()).get().getCurrentValue(), is(MAX_BALANCE));
     }
 
     private static PlatformUsageCreditsUserBalanceEntity entity(final Long userId, final int value) {

--- a/api/src/test/java/com/epam/pipeline/repository/credits/PlatformUsageCreditsUserBalanceRepositoryTest.java
+++ b/api/src/test/java/com/epam/pipeline/repository/credits/PlatformUsageCreditsUserBalanceRepositoryTest.java
@@ -220,7 +220,22 @@ public class PlatformUsageCreditsUserBalanceRepositoryTest extends AbstractJpaTe
         entityManager.flush();
         entityManager.clear();
 
-        repository.resetAll(RESET_VALUE, DateUtils.nowUTC());
+        repository.resetAll(RESET_VALUE);
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(repository.findByUserId(user1.getId()).get().getCurrentValue(), is(RESET_VALUE));
+        assertThat(repository.findByUserId(user2.getId()).get().getCurrentValue(), is(RESET_VALUE));
+    }
+
+    @Test
+    public void shouldCreateMissingBalanceRowsOnResetAll() {
+        repository.save(entity(user1.getId(), VALUE_HIGH));
+        // user2 has no balance row
+        entityManager.flush();
+        entityManager.clear();
+
+        repository.resetAll(RESET_VALUE);
         entityManager.flush();
         entityManager.clear();
 

--- a/api/src/test/java/com/epam/pipeline/test/acl/AclTestBeans.java
+++ b/api/src/test/java/com/epam/pipeline/test/acl/AclTestBeans.java
@@ -137,6 +137,7 @@ import com.epam.pipeline.manager.pipeline.runner.ConfigurationRunner;
 import com.epam.pipeline.manager.preference.PreferenceManager;
 import com.epam.pipeline.manager.preprocessing.NgsPreprocessingManager;
 import com.epam.pipeline.manager.credits.PlatformUsageCreditsRuleService;
+import com.epam.pipeline.manager.credits.PlatformUsageCreditsUserBalanceService;
 import com.epam.pipeline.manager.quota.QuotaService;
 import com.epam.pipeline.manager.quota.RunLimitsService;
 import com.epam.pipeline.manager.region.CloudRegionManager;
@@ -581,6 +582,9 @@ public class AclTestBeans {
 
     @MockBean
     protected PlatformUsageCreditsRuleService mockPlatformUsageCreditsRuleService;
+
+    @MockBean
+    protected PlatformUsageCreditsUserBalanceService mockPlatformUsageCreditsUserBalanceService;
 
     @MockBean
     protected UsersUsageReportService usersUsageReportService;

--- a/api/src/test/java/com/epam/pipeline/test/aspect/AspectTestBeans.java
+++ b/api/src/test/java/com/epam/pipeline/test/aspect/AspectTestBeans.java
@@ -73,6 +73,7 @@ import com.epam.pipeline.manager.cluster.InstanceOfferScheduler;
 import com.epam.pipeline.manager.cluster.PodMonitor;
 import com.epam.pipeline.manager.credits.PlatformUsageCreditsRuleService;
 import com.epam.pipeline.manager.contextual.handler.ContextualPreferenceHandler;
+import com.epam.pipeline.manager.credits.PlatformUsageCreditsUserBalanceService;
 import com.epam.pipeline.manager.datastorage.StorageQuotaTriggersManager;
 import com.epam.pipeline.manager.datastorage.lifecycle.DataStorageLifecycleManager;
 import com.epam.pipeline.manager.datastorage.lifecycle.DataStorageLifecycleRestoreManager;
@@ -553,4 +554,7 @@ public class AspectTestBeans {
 
     @MockBean
     protected PlatformUsageCreditsRuleService platformUsageCreditsRuleService;
+
+    @MockBean
+    protected PlatformUsageCreditsUserBalanceService platformUsageCreditsUserBalanceService;
 }

--- a/api/src/test/java/com/epam/pipeline/test/creator/credits/PlatformUsageCreditsUserBalanceCreatorUtils.java
+++ b/api/src/test/java/com/epam/pipeline/test/creator/credits/PlatformUsageCreditsUserBalanceCreatorUtils.java
@@ -41,6 +41,10 @@ public interface PlatformUsageCreditsUserBalanceCreatorUtils {
     int DEFAULT_BALANCE = 2000;
     int MIN_BALANCE = 24;
     int MAX_BALANCE = 3000;
+    // threshold 25% → absoluteValue = 24 + 0.25*(3000-24) = 768
+    int NOTIFICATION_THRESHOLD = 25;
+    int BALANCE_BELOW_THRESHOLD = 700;
+    int BALANCE_ABOVE_THRESHOLD = 800;
     String OPERATION_GT = ">";
     String OPERATION_LT = "<";
     String OPERATION_EQ = "=";

--- a/api/src/test/java/com/epam/pipeline/test/creator/credits/PlatformUsageCreditsUserBalanceCreatorUtils.java
+++ b/api/src/test/java/com/epam/pipeline/test/creator/credits/PlatformUsageCreditsUserBalanceCreatorUtils.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017-2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.test.creator.credits;
+
+import com.epam.pipeline.controller.PagedResult;
+import com.epam.pipeline.controller.Result;
+import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalance;
+import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalanceFilterVO;
+import com.epam.pipeline.entity.credits.PlatformUsageCreditsUserBalanceEntity;
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+public interface PlatformUsageCreditsUserBalanceCreatorUtils {
+
+    TypeReference<Result<PagedResult<List<PlatformUsageCreditsUserBalance>>>> BALANCE_PAGED_TYPE =
+            new TypeReference<Result<PagedResult<List<PlatformUsageCreditsUserBalance>>>>() {};
+    TypeReference<Result<Void>> VOID_TYPE = new TypeReference<Result<Void>>() {};
+
+    Long USER_ID = 1L;
+    int BALANCE_VALUE = 1000;
+    int RESET_VALUE = 2000;
+    String OPERATION_GT = ">";
+    String OPERATION_LT = "<";
+    String OPERATION_EQ = "=";
+
+    static PlatformUsageCreditsUserBalanceEntity balanceEntity() {
+        return PlatformUsageCreditsUserBalanceEntity.builder()
+                .id(1L)
+                .userId(USER_ID)
+                .currentValue(BALANCE_VALUE)
+                .modifiedDate(LocalDateTime.now())
+                .build();
+    }
+
+    static PlatformUsageCreditsUserBalance balanceDto() {
+        return new PlatformUsageCreditsUserBalance(USER_ID, BALANCE_VALUE, LocalDateTime.now());
+    }
+
+    static PlatformUsageCreditsUserBalanceFilterVO filterVO() {
+        return PlatformUsageCreditsUserBalanceFilterVO.builder()
+                .userIds(Collections.singletonList(USER_ID))
+                .value(BALANCE_VALUE)
+                .operation(OPERATION_GT)
+                .page(0)
+                .pageSize(10)
+                .build();
+    }
+
+    static PagedResult<List<PlatformUsageCreditsUserBalance>> pagedResult() {
+        return new PagedResult<>(Collections.singletonList(balanceDto()), 1);
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/test/creator/credits/PlatformUsageCreditsUserBalanceCreatorUtils.java
+++ b/api/src/test/java/com/epam/pipeline/test/creator/credits/PlatformUsageCreditsUserBalanceCreatorUtils.java
@@ -23,6 +23,7 @@ import com.epam.pipeline.dto.credits.PlatformUsageCreditsUpdateEvent;
 import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalance;
 import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalanceFilterVO;
 import com.epam.pipeline.entity.credits.PlatformUsageCreditsUserBalanceEntity;
+import com.epam.pipeline.entity.user.PipelineUser;
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import java.time.LocalDateTime;
@@ -45,9 +46,18 @@ public interface PlatformUsageCreditsUserBalanceCreatorUtils {
     int NOTIFICATION_THRESHOLD = 25;
     int BALANCE_BELOW_THRESHOLD = 700;
     int BALANCE_ABOVE_THRESHOLD = 800;
+    int CURRENT_BALANCE = 2000;
+    int EVENT_VALUE = 100;
+    int BALANCE_NEAR_MAX = 2900;
+    int BALANCE_NEAR_MIN = 50;
     String OPERATION_GT = ">";
-    String OPERATION_LT = "<";
-    String OPERATION_EQ = "=";
+
+    static PipelineUser pipelineUser() {
+        final PipelineUser user = new PipelineUser();
+        user.setId(USER_ID);
+        user.setRoles(Collections.emptyList());
+        return user;
+    }
 
     static PlatformUsageCreditsUserBalanceEntity balanceEntity() {
         return PlatformUsageCreditsUserBalanceEntity.builder()

--- a/api/src/test/java/com/epam/pipeline/test/creator/credits/PlatformUsageCreditsUserBalanceCreatorUtils.java
+++ b/api/src/test/java/com/epam/pipeline/test/creator/credits/PlatformUsageCreditsUserBalanceCreatorUtils.java
@@ -18,6 +18,8 @@ package com.epam.pipeline.test.creator.credits;
 
 import com.epam.pipeline.controller.PagedResult;
 import com.epam.pipeline.controller.Result;
+import com.epam.pipeline.dto.credits.PlatformUsageCreditsUpdateAction;
+import com.epam.pipeline.dto.credits.PlatformUsageCreditsUpdateEvent;
 import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalance;
 import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalanceFilterVO;
 import com.epam.pipeline.entity.credits.PlatformUsageCreditsUserBalanceEntity;
@@ -36,6 +38,9 @@ public interface PlatformUsageCreditsUserBalanceCreatorUtils {
     Long USER_ID = 1L;
     int BALANCE_VALUE = 1000;
     int RESET_VALUE = 2000;
+    int DEFAULT_BALANCE = 2000;
+    int MIN_BALANCE = 24;
+    int MAX_BALANCE = 3000;
     String OPERATION_GT = ">";
     String OPERATION_LT = "<";
     String OPERATION_EQ = "=";
@@ -65,5 +70,21 @@ public interface PlatformUsageCreditsUserBalanceCreatorUtils {
 
     static PagedResult<List<PlatformUsageCreditsUserBalance>> pagedResult() {
         return new PagedResult<>(Collections.singletonList(balanceDto()), 1);
+    }
+
+    static PlatformUsageCreditsUpdateEvent increaseEvent(final int value) {
+        return PlatformUsageCreditsUpdateEvent.builder()
+                .userId(USER_ID)
+                .incidentType(PlatformUsageCreditsUpdateAction.ActionType.INCREASE)
+                .value(value)
+                .build();
+    }
+
+    static PlatformUsageCreditsUpdateEvent deductionEvent(final int value) {
+        return PlatformUsageCreditsUpdateEvent.builder()
+                .userId(USER_ID)
+                .incidentType(PlatformUsageCreditsUpdateAction.ActionType.DEDUCTION)
+                .value(value)
+                .build();
     }
 }

--- a/api/src/test/java/com/epam/pipeline/test/web/ControllerTestBeans.java
+++ b/api/src/test/java/com/epam/pipeline/test/web/ControllerTestBeans.java
@@ -35,6 +35,7 @@ import com.epam.pipeline.acl.plugin.PluginAssignmentService;
 import com.epam.pipeline.acl.plugin.PluginService;
 import com.epam.pipeline.acl.preprocessing.NgsPreprocessingApiService;
 import com.epam.pipeline.acl.credits.PlatformUsageCreditsRuleApiService;
+import com.epam.pipeline.acl.credits.PlatformUsageCreditsUserBalanceApiService;
 import com.epam.pipeline.acl.quota.QuotaApiService;
 import com.epam.pipeline.acl.report.ReportApiService;
 import com.epam.pipeline.acl.resource.StaticResourceApiService;
@@ -278,6 +279,9 @@ public class ControllerTestBeans {
 
     @MockBean
     protected PlatformUsageCreditsRuleApiService platformUsageCreditsRuleApiService;
+
+    @MockBean
+    protected PlatformUsageCreditsUserBalanceApiService platformUsageCreditsUserBalanceApiService;
 
     @MockBean
     protected ReportApiService reportApiService;

--- a/core/src/main/java/com/epam/pipeline/dto/credits/PlatformUsageCreditsUserBalanceFilterVO.java
+++ b/core/src/main/java/com/epam/pipeline/dto/credits/PlatformUsageCreditsUserBalanceFilterVO.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.dto.credits;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlatformUsageCreditsUserBalanceFilterVO {
+
+    private List<Long> userIds;
+    private Integer value;
+    private String operation;
+    private int page;
+    private int pageSize;
+}

--- a/core/src/main/java/com/epam/pipeline/entity/notification/NotificationGroup.java
+++ b/core/src/main/java/com/epam/pipeline/entity/notification/NotificationGroup.java
@@ -26,5 +26,6 @@ public enum NotificationGroup {
     LONG_PAUSED,
     USER,
     NODE_POOL,
-    DATASTORAGE_LIFECYCLE
+    DATASTORAGE_LIFECYCLE,
+    USAGE_CREDITS
 }

--- a/core/src/main/java/com/epam/pipeline/entity/notification/NotificationType.java
+++ b/core/src/main/java/com/epam/pipeline/entity/notification/NotificationType.java
@@ -72,7 +72,9 @@ public enum NotificationType {
     LDAP_BLOCKED_POSTPONED_USERS(20, -1L, -1L, Collections.emptyList(), true,
             NotificationGroup.USER),
     HIGH_CONSUMED_NETWORK_BANDWIDTH(21, -1L, -1L, Collections.emptyList(), true,
-            NotificationGroup.RESOURCE_CONSUMING);
+            NotificationGroup.RESOURCE_CONSUMING),
+    LOW_USAGE_CREDITS(22, -1L, -1L, Collections.emptyList(), true,
+            NotificationGroup.USAGE_CREDITS);
 
     private static final Map<Long, NotificationType> BY_ID;
 

--- a/core/src/main/java/com/epam/pipeline/entity/user/PipelineUser.java
+++ b/core/src/main/java/com/epam/pipeline/entity/user/PipelineUser.java
@@ -16,6 +16,7 @@
 
 package com.epam.pipeline.entity.user;
 
+import com.epam.pipeline.dto.credits.PlatformUsageCreditsUserBalance;
 import com.epam.pipeline.dto.quota.Quota;
 import com.epam.pipeline.entity.AbstractSecuredEntity;
 import com.epam.pipeline.entity.cloud.credentials.CloudProfileCredentialsEntity;
@@ -125,6 +126,9 @@ public class PipelineUser extends AbstractSecuredEntity implements StorageContai
 
     @Transient
     private List<Quota> activeQuotas;
+
+    @Transient
+    private PlatformUsageCreditsUserBalance usageCredits;
 
     public PipelineUser() {
         this.admin = false;

--- a/deploy/contents/install/email-templates/configs/LOW_USAGE_CREDITS.json
+++ b/deploy/contents/install/email-templates/configs/LOW_USAGE_CREDITS.json
@@ -1,0 +1,6 @@
+{
+  "keepInformedAdmins":false,
+  "keepInformedOwner":false,
+  "enabled":true,
+  "subject":"Your usage credits balance is running low"
+}

--- a/deploy/contents/install/email-templates/contents/LOW_USAGE_CREDITS.html
+++ b/deploy/contents/install/email-templates/contents/LOW_USAGE_CREDITS.html
@@ -1,0 +1,36 @@
+<!--
+  ~ Copyright 2017-2026 EPAM Systems, Inc. (https://www.epam.com/)
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
+</head>
+
+<body>
+<p>Dear ${CP_DOLLAR}templateParameters.get("user").name,</p>
+<p>*** This is a system generated email, do not reply to this email ***</p>
+<p>Please be informed that your current usage credits balance has dropped to
+    <b>${CP_DOLLAR}templateParameters.get("creditsBalance")</b> CPU units.</p>
+<p>A low balance may restrict your ability to launch new compute jobs or expand existing clusters.
+    To restore your balance, consider completing or stopping idle runs and using resources more efficiently.</p>
+<br/>
+
+<p>Best regards,</p>
+<p>$CP_PREF_UI_PIPELINE_DEPLOYMENT_NAME Platform</p>
+</body>
+
+</html>


### PR DESCRIPTION
relates to #4461


A new API method shall be implemented to manage users credits:
- `POST /usage/credits/users/reset?value=<new credits>` — [Admin only] reset the balance for a specified users, or for all users if request body is empty.
```json
[] # (Optional) userIds 
```
- `POST /usage/credits/users` — [Admin only] load current user balances with filters:
```json
{
    "userIds": [ ... ],
    "balance": <>,
    "operation": "> | < | =",
    "page": <>,  # starts from 0
    "pageSize": <>
}
```

Response:
```json
{
"elements": [
    {
        "userId": <userId>,
        "modifiedDate": "<last update datetime>",
        "currentValue": 1000
    }
],
"totalCount": <>
}
```

The following existing Users API methods shall be updated to support usage credits loading for users:
- `GET /whoami` - returns current user rating:
```json
{
    .. ,
    "usageCredits": {
      "currentValue": <>,
      "modifiedDate": "2026-07-23T14:59:28.211Z",
      "userId": <>
    }
}
```
- `GET /user/{id}?credits=true` - returns credits if requested
- `GET /users?credits=true` - returns credits if requested
- `GET /user/export` - includes user's usage credits to report if requested (via new column `usageCredits`).
```json
{
      .. ,
      "includeCredits": <true | false>
}
```