### PR TITLE
Azure price list loaders: do not do partial update

### DIFF
--- a/api/src/main/java/com/epam/pipeline/dao/cluster/InstanceOfferDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/cluster/InstanceOfferDao.java
@@ -52,6 +52,8 @@ public class InstanceOfferDao extends NamedParameterJdbcDaoSupport {
     private final String loadFirstInstanceOffer;
     private final String loadInstanceTypesQuery;
     private final String removeInstanceOffersForRegionQuery;
+    private final String removeInstanceOffersForInactiveRegionsQuery;
+    private final String getPriceListPublishDateForRegionQuery;
 
     @Transactional(propagation = Propagation.MANDATORY)
     @SuppressWarnings("unchecked")
@@ -72,6 +74,11 @@ public class InstanceOfferDao extends NamedParameterJdbcDaoSupport {
     @Transactional(propagation = Propagation.MANDATORY)
     public void removeInstanceOffersForRegion(Long regionId) {
         getJdbcTemplate().update(removeInstanceOffersForRegionQuery, regionId);
+    }
+
+    @Transactional
+    public void removeInstanceOffersForInactiveRegions() {
+        getJdbcTemplate().update(removeInstanceOffersForInactiveRegionsQuery);
     }
 
     @Transactional
@@ -99,6 +106,15 @@ public class InstanceOfferDao extends NamedParameterJdbcDaoSupport {
         String query = wherePattern.matcher(loadInstanceTypesQuery)
             .replaceFirst("");
         return getNamedParameterJdbcTemplate().query(query, params, InstanceTypeParameters.getRowMapper());
+    }
+
+    public Date getPriceListPublishDateForRegion(final Long regionId) {
+        final List<Date> dates = getNamedParameterJdbcTemplate().query(
+                getPriceListPublishDateForRegionQuery,
+                new MapSqlParameterSource(InstanceOfferParameters.REGION.name(), regionId),
+                (rs, rowNum) -> new Date(
+                        rs.getTimestamp(InstanceOfferParameters.PRICE_LIST_PUBLISH_DATE.name()).getTime()));
+        return CollectionUtils.isNotEmpty(dates) ? dates.get(0) : null;
     }
 
     public Date getPriceListPublishDate() {

--- a/api/src/main/java/com/epam/pipeline/dao/cluster/InstanceOfferDao.java
+++ b/api/src/main/java/com/epam/pipeline/dao/cluster/InstanceOfferDao.java
@@ -109,11 +109,12 @@ public class InstanceOfferDao extends NamedParameterJdbcDaoSupport {
     }
 
     public Date getPriceListPublishDateForRegion(final Long regionId) {
+        final RowMapper<Date> dateMapper = (rs, rowNum) ->
+                new Date(rs.getTimestamp(InstanceOfferParameters.PRICE_LIST_PUBLISH_DATE.name()).getTime());
         final List<Date> dates = getNamedParameterJdbcTemplate().query(
                 getPriceListPublishDateForRegionQuery,
                 new MapSqlParameterSource(InstanceOfferParameters.REGION.name(), regionId),
-                (rs, rowNum) -> new Date(
-                        rs.getTimestamp(InstanceOfferParameters.PRICE_LIST_PUBLISH_DATE.name()).getTime()));
+                dateMapper);
         return CollectionUtils.isNotEmpty(dates) ? dates.get(0) : null;
     }
 

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AbstractAzurePriceListLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AbstractAzurePriceListLoader.java
@@ -101,7 +101,7 @@ public abstract class AbstractAzurePriceListLoader {
 
     }
 
-    public List<InstanceOffer> load(final AzureRegion region) throws IOException {
+    public List<InstanceOffer> load(final AzureRegion region, final boolean useFallback) throws IOException {
         final AzureCredentials credential = AzureHelper.getAzureCredentials(region);
         final AzureResourceManager client = AzureHelper.buildClient(credential);
 
@@ -120,7 +120,12 @@ public abstract class AbstractAzurePriceListLoader {
                 .filter(sku -> Objects.nonNull(sku.size()) && isAvailableForSubscription(sku))
                 .collect(Collectors.toMap(ResourceSkuInner::size, Function.identity(), (o1, o2) -> o1));
 
-        return getInstanceOffers(region, credential.getCredential(), client, vmSkusByName, diskSkusByName);
+        final List<InstanceOffer> offers =
+                getInstanceOffers(region, credential.getCredential(), client, vmSkusByName, diskSkusByName);
+        if (offers == null && useFallback) {
+            return getOffersFromSku(vmSkusByName, diskSkusByName, region.getId());
+        }
+        return offers;
     }
 
     protected abstract List<InstanceOffer> getInstanceOffers(AzureRegion region,
@@ -359,7 +364,7 @@ public abstract class AbstractAzurePriceListLoader {
         return retrofit.create(AzurePricingClient.class);
     }
 
-    private String buildVMKey(final String input) {
+    String buildVMKey(final String input) {
         return input.replaceAll("_|-|\\s+", "")
                 .toLowerCase();
     }

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzureEAPriceListLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzureEAPriceListLoader.java
@@ -58,10 +58,11 @@ public class AzureEAPriceListLoader extends AbstractAzurePriceListLoader {
                                                     final Map<String, ResourceSkuInner> diskSkusByName)
                                                     throws IOException {
         final Optional<AzureEAPricingResult> prices = getPricing(client.subscriptionId(), credentials);
-        return prices.filter(p -> CollectionUtils.isNotEmpty(p.getProperties().getPricesheets()))
-                .map(p -> mergeSkusWithPrices(p.getProperties().getPricesheets(), vmSkusByName, diskSkusByName,
-                        meterRegionName, region.getId()))
-                .orElseGet(() -> getOffersFromSku(vmSkusByName, diskSkusByName, region.getId()));
+        if (!prices.isPresent() || CollectionUtils.isEmpty(prices.get().getProperties().getPricesheets())) {
+            return null;
+        }
+        return mergeSkusWithPrices(prices.get().getProperties().getPricesheets(), vmSkusByName, diskSkusByName,
+                meterRegionName, region.getId());
     }
 
     @Override
@@ -70,12 +71,13 @@ public class AzureEAPriceListLoader extends AbstractAzurePriceListLoader {
     }
 
     private Optional<AzureEAPricingResult> getPricing(final String subscription,
-                                                      final TokenCredential credentials) {
+                                                      final TokenCredential credentials) throws IOException {
         Assert.isTrue(StringUtils.isNotBlank(subscription), "Could not find subscription ID");
         return Optional.of(getPriceSheet(subscription, credentials));
     }
 
-    private AzureEAPricingResult getPriceSheet(final String subscription, final TokenCredential credentials) {
+    private AzureEAPricingResult getPriceSheet(final String subscription, final TokenCredential credentials)
+            throws IOException {
         return AzureEAPricingResult.builder().properties(
                 AzureEAPricingResult.PricingProperties.builder().pricesheets(
                     getPriceSheet(new ArrayList<>(), subscription, credentials, null)
@@ -87,20 +89,22 @@ public class AzureEAPriceListLoader extends AbstractAzurePriceListLoader {
     }
 
     private List<AzureEAPricingMeter> getPriceSheet(final List<AzureEAPricingMeter> buffer, final String subscription,
-                                                    final TokenCredential credentials, String skiptoken) {
+                                                    final TokenCredential credentials, String skiptoken)
+            throws IOException {
         final String token = AzureHelper.getBearerToken(credentials);
         Assert.isTrue(StringUtils.isNotBlank(token), "Could not find access token");
         final AzureEAPricingResult meterDetails = executeRequest(azurePricingClient.getPricesheet(
                 "Bearer " + token, subscription, getAPIVersion(), "meterDetails", BATCH_SIZE, skiptoken));
-        if (meterDetails != null && meterDetails.getProperties() != null) {
-            buffer.addAll(meterDetails.getProperties().getPricesheets());
-            if (StringUtils.isNotBlank(meterDetails.getProperties().getNextLink())) {
-                Pattern pattern = Pattern.compile(".*skiptoken=([^&]+).*");
-                Matcher matcher = pattern.matcher(meterDetails.getProperties().getNextLink());
-                if (matcher.matches()) {
-                    skiptoken = matcher.group(1);
-                    return getPriceSheet(buffer, subscription, credentials, skiptoken);
-                }
+        if (meterDetails == null || meterDetails.getProperties() == null) {
+            throw new IOException("Azure EA price sheet response body is empty");
+        }
+        buffer.addAll(meterDetails.getProperties().getPricesheets());
+        if (StringUtils.isNotBlank(meterDetails.getProperties().getNextLink())) {
+            Pattern pattern = Pattern.compile(".*skiptoken=([^&]+).*");
+            Matcher matcher = pattern.matcher(meterDetails.getProperties().getNextLink());
+            if (matcher.matches()) {
+                skiptoken = matcher.group(1);
+                return getPriceSheet(buffer, subscription, credentials, skiptoken);
             }
         }
         return buffer;

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzureInstancePriceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzureInstancePriceService.java
@@ -28,8 +28,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.ListUtils;
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
@@ -51,19 +49,33 @@ public class AzureInstancePriceService implements CloudInstancePriceService<Azur
     @Override
     public List<InstanceOffer> refreshPriceListForRegion(final AzureRegion region) {
         try {
-            final String authPath = region.getAuthFile();
-            if (region.isEnterpriseAgreements()) {
-                return new AzureEAPriceListLoader(authPath, region.getMeterRegionName(), region.getAzureApiUrl())
-                        .load(region);
-            } else {
-                return new AzureRateCardPriceListLoader(authPath, region.getPriceOfferId(),
-                        region.getMeterRegionName(), region.getAzureApiUrl())
-                        .load(region);
+            final List<InstanceOffer> result = getLoaderForRegion(region).load(
+                    region, !hasExistingOffersInDb(region.getId())
+            );
+            if (result != null) {
+                return result;
             }
-        } catch (IOException e) {
-            log.error(e.getMessage(), e);
-            return Collections.emptyList();
+            log.warn("Azure prices not available for region {}, keeping existing offers", region.getId());
+            return null;
+        } catch (Exception e) {
+            log.error("Failed to load Azure prices for region {}, keeping existing offers",
+                    region.getId(), e);
+            return null;
         }
+    }
+
+    private static AbstractAzurePriceListLoader getLoaderForRegion(final AzureRegion region) {
+        if (region.isEnterpriseAgreements()) {
+            return new AzureEAPriceListLoader(region.getAuthFile(),
+                    region.getMeterRegionName(), region.getAzureApiUrl());
+        } else {
+            return new AzureRateCardPriceListLoader(region.getAuthFile(), region.getPriceOfferId(),
+                    region.getMeterRegionName(), region.getAzureApiUrl());
+        }
+    }
+
+    private boolean hasExistingOffersInDb(final Long regionId) {
+        return instanceOfferDao.getPriceListPublishDateForRegion(regionId) != null;
     }
 
     @Override

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzureInstancePriceService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzureInstancePriceService.java
@@ -28,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.ListUtils;
 import org.springframework.stereotype.Service;
 
+import java.io.IOException;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
@@ -57,7 +58,7 @@ public class AzureInstancePriceService implements CloudInstancePriceService<Azur
             }
             log.warn("Azure prices not available for region {}, keeping existing offers", region.getId());
             return null;
-        } catch (Exception e) {
+        } catch (IOException e) {
             log.error("Failed to load Azure prices for region {}, keeping existing offers",
                     region.getId(), e);
             return null;

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzurePricingClient.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzurePricingClient.java
@@ -18,8 +18,7 @@ package com.epam.pipeline.manager.cloud.azure;
 
 import com.epam.pipeline.entity.pricing.azure.AzureEAPricingResult;
 import com.epam.pipeline.entity.pricing.azure.AzureRateCardPricingResult;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.lang.StringUtils;
 import retrofit2.Call;
 import retrofit2.Response;
 import retrofit2.http.GET;
@@ -28,9 +27,9 @@ import retrofit2.http.Path;
 import retrofit2.http.Query;
 
 import java.io.IOException;
+import java.util.Optional;
 
 public interface AzurePricingClient {
-    Logger LOGGER = LoggerFactory.getLogger(AzurePricingClient.class);
 
     String AUTH_HEADER = "Authorization";
 
@@ -48,18 +47,18 @@ public interface AzurePricingClient {
                                              @Query("$top") int top,
                                              @Query(value = "$skiptoken", encoded = true) String skiptoken);
 
-    static <T> T executeRequest(Call<T> request) {
-        try {
-            Response<T> response = request.execute();
-            if (response.isSuccessful()) {
-                return response.body();
-            } else {
-                LOGGER.error("Failed to execute Azure request: {}", response.message());
-                return null;
-            }
-        } catch (IOException e) {
-            LOGGER.error(e.getMessage(), e);
-            return null;
+    static <T> T executeRequest(Call<T> request) throws IOException {
+        final Response<T> response = request.execute();
+        if (response.isSuccessful()) {
+            return response.body();
         }
+        final String errorBody = Optional.ofNullable(response.errorBody()).map(body -> {
+            try {
+                return body.string();
+            } catch (IOException e) {
+                return "Failed to read error body";
+            }
+        }).orElse(StringUtils.EMPTY);
+        throw new IOException(String.format("Azure request failed: %s %s", response.message(), errorBody));
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzureRateCardPriceListLoader.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cloud/azure/AzureRateCardPriceListLoader.java
@@ -29,6 +29,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.util.Assert;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -52,12 +53,14 @@ public class AzureRateCardPriceListLoader extends AbstractAzurePriceListLoader {
                                                     final TokenCredential credential,
                                                     final AzureResourceManager client,
                                                     final Map<String, ResourceSkuInner> vmSkusByName,
-                                                    final Map<String, ResourceSkuInner> diskSkusByName) {
+                                                    final Map<String, ResourceSkuInner> diskSkusByName)
+                                                    throws IOException {
         final Optional<AzureRateCardPricingResult> prices = getPricing(client.subscriptionId(), credential);
-        return prices.filter(p -> CollectionUtils.isNotEmpty(p.getMeters()))
-                .map(p -> mergeSkusWithPrices(p.getMeters(), vmSkusByName, diskSkusByName,
-                        meterRegionName, region.getId()))
-                .orElseGet(() -> getOffersFromSku(vmSkusByName, diskSkusByName, region.getId()));
+        if (!prices.isPresent() || CollectionUtils.isEmpty(prices.get().getMeters())) {
+            return null;
+        }
+        return mergeSkusWithPrices(prices.get().getMeters(), vmSkusByName, diskSkusByName,
+                meterRegionName, region.getId());
     }
 
     @Override
@@ -66,7 +69,7 @@ public class AzureRateCardPriceListLoader extends AbstractAzurePriceListLoader {
     }
 
     private Optional<AzureRateCardPricingResult> getPricing(final String subscription,
-                                                            final TokenCredential credential) {
+                                                            final TokenCredential credential) throws IOException {
         if (StringUtils.isBlank(offerId)) {
             return Optional.empty();
         }

--- a/api/src/main/java/com/epam/pipeline/manager/cluster/InstanceOfferManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/InstanceOfferManager.java
@@ -397,6 +397,7 @@ public class InstanceOfferManager {
 
     public void refreshPriceList() {
         LOGGER.debug(messageHelper.getMessage(MessageConstants.DEBUG_INSTANCE_OFFERS_UPDATE_STARTED));
+        instanceOfferDao.removeInstanceOffersForInactiveRegions();
         List<InstanceOffer> offers = cloudRegionManager.loadAll()
                 .stream()
                 .map(this::updatePriceList)
@@ -420,6 +421,11 @@ public class InstanceOfferManager {
     private List<InstanceOffer> updatePriceList(final AbstractCloudRegion region) {
         try {
             final List<InstanceOffer> offers = retrievePriceList(region);
+            if (offers == null) {
+                LOGGER.warn("Price list refresh for region {} {} #{} returned no data, keeping existing offers",
+                        region.getProvider(), region.getRegionCode(), region.getId());
+                return Collections.emptyList();
+            }
             if (offers.isEmpty()) {
                 LOGGER.warn("Skipping instance offers update for region {} {} #{} " +
                                 "because no instance offers have been retrieved...",
@@ -439,8 +445,10 @@ public class InstanceOfferManager {
         LOGGER.debug("Retrieving instance offers for region {} {} #{}...",
                 region.getProvider(), region.getRegionCode(), region.getId());
         final List<InstanceOffer> offers = cloudFacade.refreshPriceListForRegion(region.getId());
-        LOGGER.debug("Retrieved {} instance offers for region {} {} #{}.",
-                offers.size(), region.getProvider(), region.getRegionCode(), region.getId());
+        if (offers != null) {
+            LOGGER.debug("Retrieved {} instance offers for region {} {} #{}.",
+                    offers.size(), region.getProvider(), region.getRegionCode(), region.getId());
+        }
         return offers;
     }
 

--- a/api/src/main/resources/dao/instance-offer-dao.xml
+++ b/api/src/main/resources/dao/instance-offer-dao.xml
@@ -84,6 +84,17 @@
                 ]]>
             </value>
         </constructor-arg>
+        <constructor-arg name="removeInstanceOffersForInactiveRegionsQuery">
+            <value>
+                <![CDATA[
+                    WITH active_regions AS (
+                        SELECT region_id FROM pipeline.cloud_region
+                    )
+                    DELETE FROM pipeline.instance_offer
+                    WHERE region NOT IN (SELECT region_id FROM active_regions)
+                ]]>
+            </value>
+        </constructor-arg>
         <constructor-arg name="loadInstanceOfferQuery">
             <value>
                 <![CDATA[
@@ -175,6 +186,16 @@
                     FROM
                         pipeline.instance_offer i
                     INNER JOIN pipeline.cloud_region r ON r.region_id = i.region
+                    LIMIT 1
+                ]]>
+            </value>
+        </constructor-arg>
+        <constructor-arg name="getPriceListPublishDateForRegionQuery">
+            <value>
+                <![CDATA[
+                    SELECT i.price_list_publish_date
+                    FROM pipeline.instance_offer i
+                    WHERE i.region = :REGION
                     LIMIT 1
                 ]]>
             </value>

--- a/api/src/test/java/com/epam/pipeline/manager/cloud/azure/AzurePriceListLoaderTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cloud/azure/AzurePriceListLoaderTest.java
@@ -116,7 +116,9 @@ public class AzurePriceListLoaderTest {
 
         final AzureRateCardPriceListLoader loader = new AzureRateCardPriceListLoader(ANY, ANY, "",
                 "https://any.com/");
-        final List<InstanceOffer> actualOffers = loader.mergeSkusWithPrices(prices, vmSkus, diskSkus,
+        final Map<String, ResourceSkuInner> normalizedVmSkus = new HashMap<>();
+        vmSkus.forEach((k, v) -> normalizedVmSkus.put(loader.buildVMKey(k), v));
+        final List<InstanceOffer> actualOffers = loader.mergeSkusWithPrices(prices, normalizedVmSkus, diskSkus,
                 METER_REGION, REGION_ID);
 
         final Map<String, InstanceOffer> expectedOffers = new HashMap<>();
@@ -205,7 +207,9 @@ public class AzurePriceListLoaderTest {
 
         final AzureEAPriceListLoader loader = new AzureEAPriceListLoader(ANY, "",
                 "https://any.com/");
-        final List<InstanceOffer> actualOffers = loader.mergeSkusWithPrices(prices, vmSkus, diskSkus,
+        final Map<String, ResourceSkuInner> normalizedVmSkus = new HashMap<>();
+        vmSkus.forEach((k, v) -> normalizedVmSkus.put(loader.buildVMKey(k), v));
+        final List<InstanceOffer> actualOffers = loader.mergeSkusWithPrices(prices, normalizedVmSkus, diskSkus,
                 METER_REGION, REGION_ID);
 
         final Map<String, InstanceOffer> expectedOffers = new HashMap<>();
@@ -294,7 +298,9 @@ public class AzurePriceListLoaderTest {
 
         final AzureEAPriceListLoader loader = new AzureEAPriceListLoader(ANY, "",
                 "https://any.com/");
-        final List<InstanceOffer> actualOffers = loader.mergeSkusWithPrices(prices, vmSkus, diskSkus,
+        final Map<String, ResourceSkuInner> normalizedVmSkus = new HashMap<>();
+        vmSkus.forEach((k, v) -> normalizedVmSkus.put(loader.buildVMKey(k), v));
+        final List<InstanceOffer> actualOffers = loader.mergeSkusWithPrices(prices, normalizedVmSkus, diskSkus,
                 METER_REGION, REGION_ID);
 
         final Map<String, InstanceOffer> expectedOffers = new HashMap<>();

--- a/api/src/test/java/com/epam/pipeline/manager/cloud/azure/AzurePricingClientTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cloud/azure/AzurePricingClientTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.cloud.azure;
+
+import okhttp3.MediaType;
+import okhttp3.ResponseBody;
+import org.junit.Test;
+import retrofit2.Call;
+import retrofit2.Response;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AzurePricingClientTest {
+
+    @Test
+    public void executeRequestShouldReturnBodyOnSuccessfulResponse() throws IOException {
+        final Call<String> call = mock(Call.class);
+        when(call.execute()).thenReturn(Response.success("body"));
+
+        final String result = AzurePricingClient.executeRequest(call);
+
+        assertThat(result, is("body"));
+    }
+
+    @Test(expected = IOException.class)
+    public void executeRequestShouldThrowIOExceptionOnNonSuccessfulResponse() throws IOException {
+        final Call<String> call = mock(Call.class);
+        when(call.execute()).thenReturn(
+                Response.error(500, ResponseBody.create(MediaType.parse("text/plain"), "server error")));
+
+        AzurePricingClient.executeRequest(call);
+    }
+
+    @Test(expected = IOException.class)
+    public void executeRequestShouldPropagateIOExceptionFromCallExecute() throws IOException {
+        final Call<String> call = mock(Call.class);
+        when(call.execute()).thenThrow(new IOException("network error"));
+
+        AzurePricingClient.executeRequest(call);
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/manager/cloud/azure/AzurePricingClientTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cloud/azure/AzurePricingClientTest.java
@@ -31,6 +31,8 @@ import static org.mockito.Mockito.when;
 
 public class AzurePricingClientTest {
 
+    public static final int CODE_500 = 500;
+
     @Test
     public void executeRequestShouldReturnBodyOnSuccessfulResponse() throws IOException {
         final Call<String> call = mock(Call.class);
@@ -45,7 +47,7 @@ public class AzurePricingClientTest {
     public void executeRequestShouldThrowIOExceptionOnNonSuccessfulResponse() throws IOException {
         final Call<String> call = mock(Call.class);
         when(call.execute()).thenReturn(
-                Response.error(500, ResponseBody.create(MediaType.parse("text/plain"), "server error")));
+                Response.error(CODE_500, ResponseBody.create(MediaType.parse("text/plain"), "server error")));
 
         AzurePricingClient.executeRequest(call);
     }

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/InstanceOfferManagerUnitTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/InstanceOfferManagerUnitTest.java
@@ -40,6 +40,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
+import org.mockito.InOrder;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -50,7 +51,10 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -340,6 +344,38 @@ public class InstanceOfferManagerUnitTest {
 
         assertTrue(instanceOfferManager.isPriceTypeAllowed(SPOT));
         verify(contextualPreferenceManager).searchList(eq(PRICE_TYPES_PREFERENCES), eq(null));
+    }
+
+    @Test
+    public void updatePriceListShouldNotUpdateDbWhenCloudFacadeReturnsNull() {
+        when(cloudFacade.refreshPriceListForRegion(REGION_ID)).thenReturn(null);
+
+        instanceOfferManager.refreshPriceList(defaultRegion);
+
+        verify(instanceOfferDao, never()).replaceInstanceOffersForRegion(any(), any(), anyInt());
+    }
+
+    @Test
+    public void updatePriceListShouldReplaceOffersWhenCloudFacadeReturnsOffers() {
+        final List<InstanceOffer> offers = Collections.singletonList(new InstanceOffer());
+        when(cloudFacade.refreshPriceListForRegion(REGION_ID)).thenReturn(offers);
+
+        instanceOfferManager.refreshPriceList(defaultRegion);
+
+        verify(instanceOfferDao).replaceInstanceOffersForRegion(eq(REGION_ID), anyList(), anyInt());
+    }
+
+    @Test
+    public void refreshPriceListShouldRemoveOffersForInactiveRegionsBeforeUpdatingRegions() {
+        doReturn(Collections.singletonList(defaultRegion)).when(cloudRegionManager).loadAll();
+        when(cloudFacade.refreshPriceListForRegion(REGION_ID)).thenReturn(null);
+        when(cloudFacade.getAllInstanceTypes(any(), anyBoolean())).thenReturn(Collections.emptyList());
+
+        instanceOfferManager.refreshPriceList();
+
+        final InOrder inOrder = inOrder(instanceOfferDao, cloudFacade);
+        inOrder.verify(instanceOfferDao).removeInstanceOffersForInactiveRegions();
+        inOrder.verify(cloudFacade).refreshPriceListForRegion(REGION_ID);
     }
 
     private InstanceType instanceType(final String name, final AbstractCloudRegion region) {


### PR DESCRIPTION
With current implementation of AzureEAPriceListLoader, if Azure will fail to responde with part of the price list - we will update it anyway, that will lead to partial data load. Since each time we overwrite pricelist entirely - it is possible to lose some prices and instance types.
This PR solves it by:
 - We will fail if some data can't be loaded, and keep existing pricelist
 - We will construct "fallback" pricelist from only SKUs only if there is no previously loaded pricelist, otherwise - we will keep previous version 