### PR TITLE
Issue 4461: fix some founded issues

### DIFF
--- a/api/src/main/java/com/epam/pipeline/acl/credits/PlatformUsageCreditsEventApiService.java
+++ b/api/src/main/java/com/epam/pipeline/acl/credits/PlatformUsageCreditsEventApiService.java
@@ -24,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
+import java.io.OutputStream;
 import java.util.List;
 
 import static com.epam.pipeline.security.acl.AclExpressions.ADMIN_ONLY;
@@ -47,7 +48,7 @@ public class PlatformUsageCreditsEventApiService {
     }
 
     @PreAuthorize(ADMIN_OR_GENERAL_USER)
-    public byte[] export(final PlatformUsageCreditsEventFilterVO filter) {
-        return platformUsageCreditsUpdateEventService.export(filter);
+    public void export(final PlatformUsageCreditsEventFilterVO filter, final OutputStream outputStream) {
+        platformUsageCreditsUpdateEventService.export(filter, outputStream);
     }
 }

--- a/api/src/main/java/com/epam/pipeline/controller/credits/PlatformUsageCreditsEventController.java
+++ b/api/src/main/java/com/epam/pipeline/controller/credits/PlatformUsageCreditsEventController.java
@@ -75,6 +75,8 @@ public class PlatformUsageCreditsEventController extends AbstractRestController 
     @ApiResponses(value = {@ApiResponse(code = HTTP_STATUS_OK, message = API_STATUS_DESCRIPTION)})
     public void export(@RequestBody final PlatformUsageCreditsEventFilterVO filter,
                        final HttpServletResponse response) throws IOException {
-        writeFileToResponse(response, apiService.export(filter), "credits_events.csv");
+        response.setContentType(MediaType.APPLICATION_OCTET_STREAM_VALUE);
+        response.setHeader("Content-Disposition", "attachment;filename=credits_events.csv");
+        apiService.export(filter, response.getOutputStream());
     }
 }

--- a/api/src/main/java/com/epam/pipeline/manager/credits/PlatformUsageCreditsEventExporter.java
+++ b/api/src/main/java/com/epam/pipeline/manager/credits/PlatformUsageCreditsEventExporter.java
@@ -19,32 +19,24 @@ package com.epam.pipeline.manager.credits;
 import com.epam.pipeline.config.Constants;
 import com.epam.pipeline.dto.credits.PlatformUsageCreditsUpdateEvent;
 import com.epam.pipeline.vo.SecuredEntityVO;
-import com.opencsv.CSVWriter;
 import org.apache.commons.lang.StringUtils;
 
-import java.io.IOException;
-import java.io.StringWriter;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class PlatformUsageCreditsEventExporter {
 
-    private static final String[] HEADER = {
-        "Timestamp", "User ID", "Rule ID", "Entity Class", "Entity ID", "Type", "Value", "Message"
-    };
     private static final DateTimeFormatter DATE_FORMATTER =
             DateTimeFormatter.ofPattern(Constants.EXPORT_DATE_TIME_FORMAT);
 
-    public String export(final List<PlatformUsageCreditsUpdateEvent> events) {
-        final StringWriter writer = new StringWriter();
-        try (CSVWriter csvWriter = new CSVWriter(writer)) {
-            csvWriter.writeNext(HEADER, false);
-            events.forEach(event -> csvWriter.writeNext(toLine(event), false));
-        } catch (IOException e) {
-            throw new IllegalStateException("Failed to export credits events to CSV", e);
-        }
-        return writer.toString();
+    public String[] header() {
+        return new String[]{"Timestamp", "User ID", "Rule ID", "Entity Class", "Entity ID", "Type", "Value", "Message"};
+    }
+
+    public List<String[]> lines(final List<PlatformUsageCreditsUpdateEvent> events) {
+        return events.stream().map(this::toLine).collect(Collectors.toList());
     }
 
     private String[] toLine(final PlatformUsageCreditsUpdateEvent event) {

--- a/api/src/main/java/com/epam/pipeline/manager/credits/PlatformUsageCreditsEventService.java
+++ b/api/src/main/java/com/epam/pipeline/manager/credits/PlatformUsageCreditsEventService.java
@@ -42,8 +42,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
+import com.opencsv.CSVWriter;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -133,26 +137,32 @@ public class PlatformUsageCreditsEventService {
     }
 
     /**
-     * Exports all credits events matching the filter as a UTF-8 encoded CSV byte array.
+     * Streams all credits events matching the filter as UTF-8 CSV directly to the given output stream.
      * The filter body is identical to {@link #filter}; the {@code page} and {@code pageSize}
      * fields are ignored — all matching rows are fetched page by page at {@value EXPORT_PAGE_SIZE}
      * records per page. Non-admin callers are restricted to their own events.
      *
-     * @param filter query criteria (pagination fields ignored)
-     * @return UTF-8 CSV bytes with a header row followed by one row per event
+     * <p>The output stream is flushed but not closed — the caller owns the stream lifecycle.
+     *
+     * @param filter       query criteria (pagination fields ignored)
+     * @param outputStream destination stream; must be open and writable for the duration of this call
      */
     @Transactional(readOnly = true)
-    public byte[] export(final PlatformUsageCreditsEventFilterVO filter) {
-        final List<PlatformUsageCreditsUpdateEvent> all = new ArrayList<>();
-        int page = 1;
-        List<PlatformUsageCreditsUpdateEvent> batch;
-        do {
-            final PlatformUsageCreditsEventFilterVO pageFilter =
-                    filter.toBuilder().page(page++).pageSize(EXPORT_PAGE_SIZE).build();
-            batch = filter(pageFilter).getElements();
-            all.addAll(batch);
-        } while (batch.size() == EXPORT_PAGE_SIZE);
-        return new PlatformUsageCreditsEventExporter().export(all).getBytes(StandardCharsets.UTF_8);
+    public void export(final PlatformUsageCreditsEventFilterVO filter, final OutputStream outputStream) {
+        final PlatformUsageCreditsEventExporter exporter = new PlatformUsageCreditsEventExporter();
+        try (CSVWriter csvWriter = new CSVWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8))) {
+            csvWriter.writeNext(exporter.header(), false);
+            int page = 1;
+            List<PlatformUsageCreditsUpdateEvent> batch;
+            do {
+                final PlatformUsageCreditsEventFilterVO pageFilter =
+                        filter.toBuilder().page(page++).pageSize(EXPORT_PAGE_SIZE).build();
+                batch = filter(pageFilter).getElements();
+                exporter.lines(batch).forEach(line -> csvWriter.writeNext(line, false));
+            } while (batch.size() == EXPORT_PAGE_SIZE);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to export credits events to CSV", e);
+        }
     }
 
     /**

--- a/api/src/main/resources/db/migration/v2026.07.28_15.00__issue_4461_platform_usage_credits.sql
+++ b/api/src/main/resources/db/migration/v2026.07.28_15.00__issue_4461_platform_usage_credits.sql
@@ -27,6 +27,7 @@ CREATE TABLE IF NOT EXISTS pipeline.usage_credits_update_event (
 
 CREATE INDEX usage_credits_update_event_user_idx ON pipeline.usage_credits_update_event (user_id);
 CREATE INDEX usage_credits_update_event_rule_idx ON pipeline.usage_credits_update_event (rule_id);
+CREATE INDEX usage_credits_update_event_created_date_idx ON pipeline.usage_credits_update_event (created_date);
 
 CREATE TABLE IF NOT EXISTS pipeline.usage_credits_user_balance (
     id            BIGSERIAL    PRIMARY KEY,

--- a/api/src/test/java/com/epam/pipeline/controller/credits/PlatformUsageCreditsEventControllerTest.java
+++ b/api/src/test/java/com/epam/pipeline/controller/credits/PlatformUsageCreditsEventControllerTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017-2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.controller.credits;
+
+import com.epam.pipeline.acl.credits.PlatformUsageCreditsEventApiService;
+import com.epam.pipeline.dto.credits.PlatformUsageCreditsEventFilterVO;
+import com.epam.pipeline.test.web.AbstractControllerTest;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+@WebMvcTest(controllers = PlatformUsageCreditsEventController.class)
+public class PlatformUsageCreditsEventControllerTest extends AbstractControllerTest {
+
+    private static final String EXPORT_URL = SERVLET_PATH + "/usage/credits/events/export";
+    private static final String CSV_FILE_NAME = "credits_events.csv";
+    private static final byte[] CSV_BYTES = "Timestamp,data\n".getBytes(StandardCharsets.UTF_8);
+
+    @Autowired
+    private PlatformUsageCreditsEventApiService mockApiService;
+
+    @Test
+    public void shouldFailExportForUnauthorizedUser() {
+        performUnauthorizedRequest(post(EXPORT_URL));
+    }
+
+    @Test
+    @WithMockUser
+    public void shouldExport() throws Exception {
+        doAnswer(invocation -> {
+            final OutputStream os = invocation.getArgumentAt(1, OutputStream.class);
+            os.write(CSV_BYTES);
+            return null;
+        }).when(mockApiService).export(any(PlatformUsageCreditsEventFilterVO.class), any(OutputStream.class));
+        final String content = getObjectMapper()
+                .writeValueAsString(PlatformUsageCreditsEventFilterVO.builder().build());
+
+        final MvcResult result = performRequest(
+                post(EXPORT_URL).content(content),
+                EXPECTED_CONTENT_TYPE,
+                MediaType.APPLICATION_OCTET_STREAM_VALUE);
+
+        verify(mockApiService).export(any(PlatformUsageCreditsEventFilterVO.class), any(OutputStream.class));
+        assertResponseHeader(result, CSV_FILE_NAME);
+        assertContent(result, CSV_BYTES);
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/manager/credits/PlatformUsageCreditsEventExporterTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/credits/PlatformUsageCreditsEventExporterTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2017-2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.manager.credits;
+
+import com.epam.pipeline.dto.credits.PlatformUsageCreditsUpdateAction;
+import com.epam.pipeline.dto.credits.PlatformUsageCreditsUpdateEvent;
+import com.epam.pipeline.vo.SecuredEntityVO;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PlatformUsageCreditsEventExporterTest {
+
+    private static final LocalDateTime DATE = LocalDateTime.of(2026, 1, 15, 10, 30, 0);
+    private static final long ENTITY_ID = 42L;
+    private static final String ENTITY_CLASS = "PipelineRun";
+    private static final Long USER_ID = 1L;
+    private static final Long RULE_ID = 2L;
+    private static final int VALUE = 100;
+    private static final String MESSAGE = "test message";
+
+    private final PlatformUsageCreditsEventExporter exporter = new PlatformUsageCreditsEventExporter();
+
+    @Test
+    public void headerReturnsEightNamedColumns() {
+        final String[] header = exporter.header();
+
+        assertThat(header).containsExactly(
+                "Timestamp", "User ID", "Rule ID", "Entity Class", "Entity ID", "Type", "Value", "Message");
+    }
+
+    @Test
+    public void linesReturnsOneLinePerEvent() {
+        final List<String[]> lines = exporter.lines(Arrays.asList(minimalEvent(), minimalEvent()));
+
+        assertThat(lines).hasSize(2);
+    }
+
+    @Test
+    public void linesReturnsEmptyListForEmptyInput() {
+        assertThat(exporter.lines(Collections.emptyList())).isEmpty();
+    }
+
+    @Test
+    public void linesFormatsAllFieldsForFullyPopulatedEvent() {
+        final PlatformUsageCreditsUpdateEvent event = PlatformUsageCreditsUpdateEvent.builder()
+                .createdDate(DATE)
+                .userId(USER_ID)
+                .ruleId(RULE_ID)
+                .entity(new SecuredEntityVO(ENTITY_ID, ENTITY_CLASS))
+                .incidentType(PlatformUsageCreditsUpdateAction.ActionType.DEDUCTION)
+                .value(VALUE)
+                .message(MESSAGE)
+                .build();
+
+        final String[] line = exporter.lines(Collections.singletonList(event)).get(0);
+
+        assertThat(line).hasSize(8);
+        assertThat(line[0]).isEqualTo("2026-01-15 10:30:00");
+        assertThat(line[1]).isEqualTo(String.valueOf(USER_ID));
+        assertThat(line[2]).isEqualTo(String.valueOf(RULE_ID));
+        assertThat(line[3]).isEqualTo(ENTITY_CLASS);
+        assertThat(line[4]).isEqualTo(String.valueOf(ENTITY_ID));
+        assertThat(line[5]).isEqualTo(PlatformUsageCreditsUpdateAction.ActionType.DEDUCTION.name());
+        assertThat(line[6]).isEqualTo(String.valueOf(VALUE));
+        assertThat(line[7]).isEqualTo(MESSAGE);
+    }
+
+    @Test
+    public void linesReplacesNullFieldsWithEmptyStrings() {
+        final PlatformUsageCreditsUpdateEvent event = PlatformUsageCreditsUpdateEvent.builder()
+                .value(VALUE)
+                .build();
+
+        final String[] line = exporter.lines(Collections.singletonList(event)).get(0);
+
+        assertThat(line[0]).isEmpty();  // null createdDate
+        assertThat(line[1]).isEmpty();  // null userId
+        assertThat(line[2]).isEmpty();  // null ruleId
+        assertThat(line[3]).isEmpty();  // null entity → empty entityClass
+        assertThat(line[4]).isEmpty();  // null entity → empty entityId
+        assertThat(line[5]).isEmpty();  // null incidentType
+        assertThat(line[6]).isEqualTo(String.valueOf(VALUE));
+        assertThat(line[7]).isEmpty();  // null message
+    }
+
+    private PlatformUsageCreditsUpdateEvent minimalEvent() {
+        return PlatformUsageCreditsUpdateEvent.builder().value(VALUE).build();
+    }
+}

--- a/api/src/test/java/com/epam/pipeline/manager/credits/PlatformUsageCreditsEventServiceTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/credits/PlatformUsageCreditsEventServiceTest.java
@@ -29,6 +29,8 @@ import com.epam.pipeline.manager.user.UserManager;
 import com.epam.pipeline.vo.SecuredEntityVO;
 import com.epam.pipeline.mapper.credits.PlatformUsageCreditsEventMapper;
 import com.epam.pipeline.repository.credits.PlatformUsageCreditsEventRepository;
+import com.opencsv.CSVReader;
+import lombok.SneakyThrows;
 import org.junit.Test;
 import org.junit.Before;
 import org.mapstruct.factory.Mappers;
@@ -37,6 +39,10 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
@@ -51,6 +57,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @SuppressWarnings("unchecked")
@@ -324,6 +331,58 @@ public class PlatformUsageCreditsEventServiceTest {
                 .value(value)
                 .createdDate(DATE)
                 .build();
+    }
+
+    // export
+
+    @Test
+    public void exportWritesHeaderAndEvents() {
+        doReturn(true).when(authManager).isAdmin();
+        doReturn(new PageImpl<>(Collections.singletonList(entity(USER_ID_1, VALUE))))
+                .when(repository).findAll(any(Specification.class), any(Pageable.class));
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        service.export(PlatformUsageCreditsEventFilterVO.builder().build(), output);
+
+        final List<String[]> rows = parseCsv(output.toByteArray());
+        assertThat(rows).hasSize(2);
+        assertThat(rows.get(0)).containsExactly(
+                "Timestamp", "User ID", "Rule ID", "Entity Class", "Entity ID", "Type", "Value", "Message");
+        assertThat(rows.get(1)[1]).isEqualTo(String.valueOf(USER_ID_1));
+    }
+
+    @Test
+    public void exportPaginatesUntilPartialPage() {
+        doReturn(true).when(authManager).isAdmin();
+        final List<PlatformUsageCreditsUpdateEventEntity> fullPage =
+                Collections.nCopies(1000, entity(USER_ID_1, VALUE));
+        doReturn(new PageImpl<>(fullPage))
+                .doReturn(new PageImpl<>(Collections.emptyList()))
+                .when(repository).findAll(any(Specification.class), any(Pageable.class));
+
+        service.export(PlatformUsageCreditsEventFilterVO.builder().build(), new ByteArrayOutputStream());
+
+        verify(repository, times(2)).findAll(any(Specification.class), any(Pageable.class));
+    }
+
+    @Test
+    public void exportNonAdminRestrictsToCurrentUser() {
+        doReturn(false).when(authManager).isAdmin();
+        doReturn(USERNAME).when(authManager).getAuthorizedUser();
+        doReturn(user(USER_ID_1)).when(userManager).loadUserByName(USERNAME);
+        doReturn("error").when(messageHelper).getMessage(any(String.class), any(Object[].class));
+        doReturn(new PageImpl<>(Collections.emptyList()))
+                .when(repository).findAll(any(Specification.class), any(Pageable.class));
+
+        service.export(PlatformUsageCreditsEventFilterVO.builder().build(), new ByteArrayOutputStream());
+
+        verify(userManager).loadUserByName(USERNAME);
+    }
+
+    @SneakyThrows
+    private static List<String[]> parseCsv(final byte[] bytes) {
+        return new CSVReader(
+                new InputStreamReader(new ByteArrayInputStream(bytes), StandardCharsets.UTF_8)).readAll();
     }
 
     private static PipelineUser user(final Long id) {

--- a/monitoring-service/src/main/java/com/epam/pipeline/monitor/monitoring/credits/handler/PipelineRunUsageCreditsRuleHandler.java
+++ b/monitoring-service/src/main/java/com/epam/pipeline/monitor/monitoring/credits/handler/PipelineRunUsageCreditsRuleHandler.java
@@ -19,6 +19,7 @@ package com.epam.pipeline.monitor.monitoring.credits.handler;
 import com.epam.pipeline.entity.pipeline.PipelineRun;
 import com.epam.pipeline.entity.pipeline.TaskStatus;
 import com.epam.pipeline.monitor.monitoring.credits.PlatformUsageCreditsUpdateRuleEvaluator;
+import com.epam.pipeline.monitor.monitoring.utils.LazyCache;
 import com.epam.pipeline.vo.credits.PlatformUsageCreditsEventFilterVO;
 import com.epam.pipeline.entity.credits.PlatformUsageCreditsUpdateEvent;
 import com.epam.pipeline.entity.credits.PlatformUsageCreditsUpdateRule;
@@ -83,6 +84,14 @@ public class PipelineRunUsageCreditsRuleHandler implements PlatformUsageCreditsR
         log.info("Evaluating {} RUN_STATE rule(s) against {} run(s) across {} user(s)",
                 rules.size(), runs.size(), runsByOwner.size());
 
+        final LazyCache<String, PipelineUser> userCache = new LazyCache<>(username -> {
+            final PipelineUser user = client.loadUserByName(username);
+            if (user == null) {
+                log.warn("Cannot resolve user '{}', skipping", username);
+            }
+            return user;
+        });
+
         final List<PlatformUsageCreditsUpdateEvent> newEvents = new ArrayList<>();
 
         for (final PlatformUsageCreditsUpdateRule rule : rules) {
@@ -91,11 +100,11 @@ public class PipelineRunUsageCreditsRuleHandler implements PlatformUsageCreditsR
                 final String owner = entry.getKey();
                 final List<PipelineRun> userRuns = entry.getValue();
 
-                final PipelineUser user = client.loadUserByName(owner);
-                if (user == null) {
-                    log.warn("Cannot resolve user '{}', skipping", owner);
+                final Optional<PipelineUser> cachedUser = userCache.get(owner);
+                if (!cachedUser.isPresent()) {
                     continue;
                 }
+                final PipelineUser user = cachedUser.get();
 
                 final List<PipelineRun> matchingRuns = userRuns.stream()
                         .filter(run -> evaluator.matches(rule, run, till))

--- a/monitoring-service/src/main/java/com/epam/pipeline/monitor/monitoring/utils/LazyCache.java
+++ b/monitoring-service/src/main/java/com/epam/pipeline/monitor/monitoring/utils/LazyCache.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2026 EPAM Systems, Inc. (https://www.epam.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.pipeline.monitor.monitoring.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Lazy key-value cache backed by a caller-supplied loader function.
+ * Each key is resolved at most once per instance; null results are memoized
+ * so a missing key does not trigger repeated loader calls.
+ *
+ * @param <K> key type
+ * @param <V> value type
+ */
+public class LazyCache<K, V> {
+
+    private final Function<K, V> loader;
+    private final Map<K, Optional<V>> cache = new HashMap<>();
+
+    public LazyCache(final Function<K, V> loader) {
+        this.loader = loader;
+    }
+
+    public Optional<V> get(final K key) {
+        return cache.computeIfAbsent(key, k -> Optional.ofNullable(loader.apply(k)));
+    }
+}


### PR DESCRIPTION
1. DB index on created_date — added usage_credits_update_event_created_date_idx to the migration file; event filter and export queries sort/filter on this column and would degrade at scale without it.
2. User-lookup caching in monitoring — loadUserByName was called once per rule × owner (N×M API calls per cycle); replaced with a LazyCache that resolves each unique username at most once per cycle regardless of how many rules are configured.
3. In-memory CSV export — export() buffered all pages into a List then a StringWriter before returning bytes, risking OOM on large datasets; replaced with streaming directly to HttpServletResponse.getOutputStream() page by page via CSVWriter, with no intermediate accumulation.