### PR TITLE
Fix init_multicloud_install_docker.sh S3 path for Amazon Linux 2023 worker bootstrap

### DIFF
--- a/scripts/autoscaling/init_multicloud_v1.15.4_al2023.sh
+++ b/scripts/autoscaling/init_multicloud_v1.15.4_al2023.sh
@@ -116,7 +116,7 @@ echo "> [$(date)] custom_script_pre"
 echo "> [$(date)] Start docker install"
 _DOCKER_INSTALL_SH="@SYSTEM_DOCKER_INSTALL_SH@"
 if [ ! "$_DOCKER_INSTALL_SH" ] || [[ "$_DOCKER_INSTALL_SH" == "@"*"@" ]]; then
-  _DOCKER_INSTALL_SH="${GLOBAL_DISTRIBUTION_URL}/scripts/init_multicloud_install_docker.sh"
+  _DOCKER_INSTALL_SH="${GLOBAL_DISTRIBUTION_URL}tools/scripts/init_multicloud_install_docker.sh"
 fi
 wget $_WO "${_DOCKER_INSTALL_SH}" -O /tmp/init_multicloud_install_docker.sh
 if check_gpu_available; then

--- a/scripts/autoscaling/init_multicloud_v1.15.4_al2023.sh
+++ b/scripts/autoscaling/init_multicloud_v1.15.4_al2023.sh
@@ -102,7 +102,9 @@ GLOBAL_DISTRIBUTION_URL="@GLOBAL_DISTRIBUTION_URL@"
 if [ ! "$GLOBAL_DISTRIBUTION_URL" ] || [[ "$GLOBAL_DISTRIBUTION_URL" == "@"*"@" ]]; then
   GLOBAL_DISTRIBUTION_URL="https://cloud-pipeline-oss-builds.s3.us-east-1.amazonaws.com/"
 fi
-[[ "$GLOBAL_DISTRIBUTION_URL" != */ ]] && GLOBAL_DISTRIBUTION_URL="${GLOBAL_DISTRIBUTION_URL}/"
+if [[ "$GLOBAL_DISTRIBUTION_URL" != */ ]]; then
+  GLOBAL_DISTRIBUTION_URL="${GLOBAL_DISTRIBUTION_URL}/"
+fi
 export GLOBAL_DISTRIBUTION_URL
 
 echo "> [$(date)] Download nvme"

--- a/scripts/autoscaling/init_multicloud_v1.15.4_al2023.sh
+++ b/scripts/autoscaling/init_multicloud_v1.15.4_al2023.sh
@@ -102,6 +102,7 @@ GLOBAL_DISTRIBUTION_URL="@GLOBAL_DISTRIBUTION_URL@"
 if [ ! "$GLOBAL_DISTRIBUTION_URL" ] || [[ "$GLOBAL_DISTRIBUTION_URL" == "@"*"@" ]]; then
   GLOBAL_DISTRIBUTION_URL="https://cloud-pipeline-oss-builds.s3.us-east-1.amazonaws.com/"
 fi
+[[ "$GLOBAL_DISTRIBUTION_URL" != */ ]] && GLOBAL_DISTRIBUTION_URL="${GLOBAL_DISTRIBUTION_URL}/"
 export GLOBAL_DISTRIBUTION_URL
 
 echo "> [$(date)] Download nvme"


### PR DESCRIPTION
  - Fixes the fallback download URL for init_multicloud_install_docker.sh in init_multicloud_v1.15.4_al2023.sh: path was /scripts/ but the script is published at tools/scripts/ in the OSS builds S3 bucket.