### PR TITLE
Add cp-gitlab-db-bkp.sh backup script for GitLab Postgres

### DIFF
--- a/deploy/docker/cp-bkp-worker/backupers/cp-gitlab-db-bkp.sh
+++ b/deploy/docker/cp-bkp-worker/backupers/cp-gitlab-db-bkp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+# Copyright 2017-2026 EPAM Systems, Inc. (https://www.epam.com/)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/deploy/docker/cp-bkp-worker/backupers/cp-gitlab-db-bkp.sh
+++ b/deploy/docker/cp-bkp-worker/backupers/cp-gitlab-db-bkp.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copyright 2017-2019 EPAM Systems, Inc. (https://www.epam.com/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+bkp_dir="${1:-/var/lib/postgresql/data/bkp/bkp-worker-wd}"
+mkdir -p "$bkp_dir"
+sql_bkp_file="$bkp_dir/cp-bkp-gitlab-db-dump-$(date +%Y%m%d).sql.gz"
+
+db_user="${GITLAB_DATABASE_USERNAME:-gitlab}"
+db_name="${GITLAB_DATABASE_DATABASE:-gitlabhq_production}"
+
+pg_dump -U "$db_user" "$db_name" | gzip > "$sql_bkp_file"


### PR DESCRIPTION
  - Adds deploy/docker/cp-bkp-worker/backupers/cp-gitlab-db-bkp.sh — a new backuper for the GitLab internal database                  
  - Follows the same pattern as the existing cp-api-db-bkp.sh: accepts an optional working-directory argument, writes a dated gzip-compressed pg_dump to  $bkp_dir/cp-bkp-gitlab-db-dump-<YYYYMMDD>.sql.gz.                                                                                                                        
  - Database user and database name are read from env vars GITLAB_DATABASE_USERNAME and GITLAB_DATABASE_DATABASE.