### PR TITLE
issue 4488 fix init_multicloud to be able to resume initially GPU node on non-GPU node

### DIFF
--- a/scripts/autoscaling/init_multicloud_v1.15.4.sh
+++ b/scripts/autoscaling/init_multicloud_v1.15.4.sh
@@ -547,12 +547,27 @@ fi
 
 enable_emergency_termination_service
 
+cat >> /etc/rc.local << 'RESUME_DOCKER_CONFIG_CLEANUP'
+function check_gpu_available {
+    command -v "nvidia-smi" >/dev/null 2>&1
+    if [ $? -ne 0 ]; then echo "nvidia-smi not found"; return 1; fi
+
+    nvidia-smi &> /dev/null
+    if [ $? -eq 9 ]; then echo "NVIDIA driver is not loaded"; return 1; fi
+
+    return 0
+}
 if check_gpu_available; then
-  cat >> /etc/rc.local << EOF
-nvidia-persistenced --persistence-mode
-nvidia-smi
-EOF
+    nvidia-persistenced --persistence-mode
+    nvidia-smi
+else
+    if [ -f /etc/docker/daemon.json ] && jq -e '."default-runtime" or .runtimes' /etc/docker/daemon.json > /dev/null 2>&1; then
+        jq 'del(."default-runtime", .runtimes)' /etc/docker/daemon.json > /tmp/daemon.json.tmp \
+            && mv /tmp/daemon.json.tmp /etc/docker/daemon.json
+    fi
 fi
+RESUME_DOCKER_CONFIG_CLEANUP
+
 cat >> /etc/rc.local << EOF
 systemctl start docker
 kubeadm join --token @KUBE_TOKEN@ @KUBE_IP@ --discovery-token-unsafe-skip-ca-verification --node-name $_KUBE_NODE_NAME --ignore-preflight-errors all

--- a/scripts/autoscaling/init_multicloud_v1.15.4_al2023.sh
+++ b/scripts/autoscaling/init_multicloud_v1.15.4_al2023.sh
@@ -488,9 +488,27 @@ echo "> [$(date)] Setup resume service"
 _RESUME_SCRIPT="/usr/local/bin/cloud-pipeline-resume.sh"
 printf '#!/bin/bash\nexec >> /var/log/cloud-pipeline-resume.log 2>&1\n' > "$_RESUME_SCRIPT"
 
+cat >> "$_RESUME_SCRIPT" << 'RESUME_DOCKER_CONFIG_CLEANUP'
+function check_gpu_available {
+    command -v "nvidia-smi" >/dev/null 2>&1
+    if [ $? -ne 0 ]; then echo "nvidia-smi not found"; return 1; fi
+
+    nvidia-smi &> /dev/null
+    if [ $? -eq 9 ]; then echo "NVIDIA driver is not loaded"; return 1; fi
+
+    return 0
+}
 if check_gpu_available; then
-    printf 'nvidia-persistenced --persistence-mode\nnvidia-smi\n' >> "$_RESUME_SCRIPT"
+    nvidia-persistenced --persistence-mode
+    nvidia-smi
+else
+    # deleting nvidia configuration if any, it is needed to cleanup docker config for GPU run that was resumed on non-GPU instance
+    if [ -f /etc/docker/daemon.json ] && jq -e '."default-runtime" or .runtimes' /etc/docker/daemon.json > /dev/null 2>&1; then
+        jq 'del(."default-runtime", .runtimes)' /etc/docker/daemon.json > /tmp/daemon.json.tmp \
+            && mv /tmp/daemon.json.tmp /etc/docker/daemon.json
+    fi
 fi
+RESUME_DOCKER_CONFIG_CLEANUP
 
 cat >> "$_RESUME_SCRIPT" << RESUME_MAIN
 systemctl start docker


### PR DESCRIPTION
#4488 

When user during resume of GPU instance define another instance type which is non-GPU, old version of init_multicloud script will fail to resume, because docker configured to enable nvidia runtime, which is wrong in case when we resume on non-GPU.

This PR fixes such behavior.  