### PR TITLE
issue 4513 fix ResourceMonitoringManager to correctly get db lock on run

### DIFF
--- a/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
+++ b/api/src/main/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManager.java
@@ -28,6 +28,7 @@ import net.javacrumbs.shedlock.core.SchedulerLock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
@@ -44,40 +45,56 @@ import java.util.stream.Collectors;
 @Slf4j
 public class ResourceMonitoringManager extends AbstractSchedulingManager {
 
-    private final PipelineRunManager pipelineRunManager;
-    private final MonitoringESDao monitoringDao;
-    private final PreferenceManager preferenceManager;
-    private final List<RunMonitor> monitors;
+    private final ResourceMonitoringManagerCore core;
 
     @Autowired
-    public ResourceMonitoringManager(final PipelineRunManager pipelineRunManager,
-                                      final MonitoringESDao monitoringDao,
-                                      final PreferenceManager preferenceManager,
-                                      final List<RunMonitor> monitors) {
-        this.pipelineRunManager = pipelineRunManager;
-        this.monitoringDao = monitoringDao;
-        this.preferenceManager = preferenceManager;
-        this.monitors = monitors.stream()
-                .sorted(Comparator.comparingInt(RunMonitor::order))
-                .collect(Collectors.toList());
+    public ResourceMonitoringManager(final ResourceMonitoringManagerCore core) {
+        this.core = core;
     }
 
     @PostConstruct
     public void init() {
-        scheduleFixedDelaySecured(this::monitorResourceUsage, SystemPreferences.SYSTEM_RESOURCE_MONITORING_PERIOD,
+        scheduleFixedDelaySecured(core::monitorResourceUsage, SystemPreferences.SYSTEM_RESOURCE_MONITORING_PERIOD,
                 "Resource Usage Monitoring");
     }
 
-    @Scheduled(cron = "0 0 0 ? * *")
-    @SchedulerLock(name = "ResourceMonitoringManager_removeOldIndices", lockAtMostForString = "PT1H")
-    public void removeOldIndices() {
-        monitoringDao.deleteIndices(preferenceManager.getPreference(
-                SystemPreferences.SYSTEM_RESOURCE_MONITORING_STATS_RETENTION_PERIOD));
+    public void monitorResourceUsage() {
+        core.monitorResourceUsage();
     }
 
-    @SchedulerLock(name = "ResourceMonitoringManager_monitorResourceUsage", lockAtMostForString = "PT10M")
-    public void monitorResourceUsage() {
-        final List<PipelineRun> runs = pipelineRunManager.loadRunningPipelineRuns();
-        monitors.forEach(m -> m.monitor(runs));
+    @Component
+    @ConditionalOnProperty("monitoring.elasticsearch.url")
+    static class ResourceMonitoringManagerCore {
+
+        private final PipelineRunManager pipelineRunManager;
+        private final MonitoringESDao monitoringDao;
+        private final PreferenceManager preferenceManager;
+        private final List<RunMonitor> monitors;
+
+        @Autowired
+        ResourceMonitoringManagerCore(final PipelineRunManager pipelineRunManager,
+                                      final MonitoringESDao monitoringDao,
+                                      final PreferenceManager preferenceManager,
+                                      final List<RunMonitor> monitors) {
+            this.pipelineRunManager = pipelineRunManager;
+            this.monitoringDao = monitoringDao;
+            this.preferenceManager = preferenceManager;
+            this.monitors = monitors.stream()
+                    .sorted(Comparator.comparingInt(RunMonitor::order))
+                    .collect(Collectors.toList());
+        }
+
+        @Scheduled(cron = "0 0 0 ? * *")
+        @SchedulerLock(name = "ResourceMonitoringManager_removeOldIndices", lockAtMostForString = "PT1H")
+        public void removeOldIndices() {
+            monitoringDao.deleteIndices(preferenceManager.getPreference(
+                    SystemPreferences.SYSTEM_RESOURCE_MONITORING_STATS_RETENTION_PERIOD));
+        }
+
+        @SchedulerLock(name = "ResourceMonitoringManager_monitorResourceUsage", lockAtMostForString = "PT10M")
+        public void monitorResourceUsage() {
+            final List<PipelineRun> runs = pipelineRunManager.loadRunningPipelineRuns();
+            monitors.forEach(m -> m.monitor(runs));
+        }
     }
 }

--- a/api/src/test/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManagerTest.java
+++ b/api/src/test/java/com/epam/pipeline/manager/cluster/performancemonitoring/ResourceMonitoringManagerTest.java
@@ -45,14 +45,14 @@ public class ResourceMonitoringManagerTest {
     @Mock private RunMonitor firstMonitor;
     @Mock private RunMonitor secondMonitor;
 
-    private ResourceMonitoringManager resourceMonitoringManager;
+    private ResourceMonitoringManager.ResourceMonitoringManagerCore core;
 
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         when(firstMonitor.order()).thenReturn(0);
         when(secondMonitor.order()).thenReturn(1);
-        resourceMonitoringManager = new ResourceMonitoringManager(
+        core = new ResourceMonitoringManager.ResourceMonitoringManagerCore(
                 pipelineRunManager, monitoringESDao, preferenceManager,
                 Arrays.asList(secondMonitor, firstMonitor));
     }
@@ -62,7 +62,7 @@ public class ResourceMonitoringManagerTest {
         final List<PipelineRun> runs = Collections.singletonList(new PipelineRun());
         when(pipelineRunManager.loadRunningPipelineRuns()).thenReturn(runs);
 
-        resourceMonitoringManager.monitorResourceUsage();
+        core.monitorResourceUsage();
 
         // setUp passes secondMonitor(order=1) before firstMonitor(order=0) — after sorting, first must precede second
         final InOrder ordered = inOrder(firstMonitor, secondMonitor);
@@ -75,7 +75,7 @@ public class ResourceMonitoringManagerTest {
         final List<PipelineRun> runs = Collections.singletonList(new PipelineRun());
         when(pipelineRunManager.loadRunningPipelineRuns()).thenReturn(runs);
 
-        resourceMonitoringManager.monitorResourceUsage();
+        core.monitorResourceUsage();
 
         verify(firstMonitor, times(1)).monitor(runs);
         verify(secondMonitor, times(1)).monitor(runs);


### PR DESCRIPTION
#4513 during refactoring we lost correct mechanism to lock in db to have exactly one ResourceMonitoringManager.monitorResourceUsage running at the same time